### PR TITLE
[NFC] Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,47 +1,20 @@
-## Description
-<!-- Provide a clear description of your changes -->
+### Title: [Subsystem/Area/NFC] Short, clear summary of change
 
-## Type of Change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Code refactoring
-- [ ] Build/CI changes
+### What?
+Briefly describe the *what* (e.g., Fix bug in `X` pass, add optimization for
+`Y`).
 
-## Related Issues
-<!-- Link to related issues: Fixes #123, Relates to #456 -->
+### Why?
+Explain the *why* (e.g., Fixes issue #1234, improves performance, addresses design
+flaw).
 
-## Testing
-<!-- Describe the tests you ran and how to reproduce them -->
+### How?
+Key changes made (e.g., "Introduced new operator," "Modified simulator component").
 
-### Test Configuration
-- **OS:**
-- **Python version:**
-- **Compiler:**
+### How to Test?
+Steps/commands to verify (e.g., `ttlang-opt --ttl-convert-...`).
 
-### Tests Added/Modified
-- [ ] Unit tests added
-- [ ] Integration tests added
-- [ ] Existing tests updated
-- [ ] All tests pass locally
-
-## MLIR Changes (if applicable)
-<!-- If this changes MLIR generation, describe the changes -->
-- [ ] Verified with TTLANG_VERBOSE_PASSES=1
-- [ ] Checked initial and final MLIR outputs
-- [ ] No unexpected IR transformations
-
-## Checklist
-- [ ] Code follows the project's style guidelines
-- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
-- [ ] Self-review completed
-- [ ] Comments added for complex code
-- [ ] Documentation updated (if needed)
-- [ ] No new compiler warnings
-- [ ] Breaking changes documented (if any)
-- [ ] CHANGELOG.md updated (if needed)
-
-## Additional Notes
-<!-- Any additional information that reviewers should know -->
+### Checklist:
+*   [ ] Self-reviewed (style, logic)
+*   [ ] Added tests (or justified none needed)
+*   [ ] PR is small and focused (one task)


### PR DESCRIPTION
### What?
Update the template to include only essential information and organize based on the LLVM suggested PR template.

### Why?
The current template is too long and excessively checkboxy. 

Not a functional change, no tests needed.

### Checklist:
*   [x] Self-reviewed (style, logic)
*   [x] Added tests (or justified none needed)
*   [x] PR is small and focused (one task)
