### PR TITLE
[ttl] Update python bindings to point at ttl ops (instead of d2m)

### DIFF
--- a/lib/Dialect/TTL/Transforms/TTLEraseDeadOps.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLEraseDeadOps.cpp
@@ -4,6 +4,7 @@
 
 #include "ttlang/Dialect/TTL/Passes.h"
 
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
@@ -29,6 +30,18 @@ static bool eraseDeadOpsIteration(ModuleOp mod) {
 
     // Erase dead unrealized_conversion_cast ops.
     if (llvm::isa<UnrealizedConversionCastOp>(op) && op->use_empty()) {
+      toErase.push_back(op);
+      return;
+    }
+
+    // Erase dead tensor.extract ops (used as CB->tile placeholder).
+    if (llvm::isa<tensor::ExtractOp>(op) && op->use_empty()) {
+      toErase.push_back(op);
+      return;
+    }
+
+    // Erase dead tensor.from_elements ops (used as tile result placeholder).
+    if (llvm::isa<tensor::FromElementsOp>(op) && op->use_empty()) {
       toErase.push_back(op);
       return;
     }

--- a/python/TTLangModule.cpp
+++ b/python/TTLangModule.cpp
@@ -6,6 +6,7 @@
 #include "mlir/CAPI/IR.h"
 #include "ttlang/Dialect/D2M/Passes.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/Passes.h"
 
 namespace nb = nanobind;
 using namespace mlir;
@@ -16,6 +17,7 @@ NB_MODULE(_ttlang, m) {
 
   // Local ttlang pass registration
   mlir::tt::d2m::registerD2MPasses();
+  mlir::tt::ttl::registerTTLPasses();
 
   // Register TTL dialect with any Context that loads this module
   m.def(


### PR DESCRIPTION
* ttnn interop support for ttl
* removes metal runtime path  + dead d2m code.

Now `test/python/test_ttnn_interop_add.py` runs! 

This is very much a draft PR that needs serious work:
* ttnn layout is super hard coded/hacked
* init_sfpu is completely hacked
* we need to delete a bunch of d2m code and rename some files (pending the real compute ops impl)
* once we have the real compute op impl, replace the runtime tests with pytests (+ better infra)
* replace random parsing logic
* identify any other assumptions / limitations / hard coded things and break them into errors / todos / gh issues 

