### PR TITLE
Fixed a test with tight bounds

### DIFF
--- a/test/sim/test_cbapi.py
+++ b/test/sim/test_cbapi.py
@@ -86,14 +86,14 @@ def test_circular_buffer_basic_flow(configured_cb8: Tuple[CBAPI, CBID]):
 
 def test_per_instance_timeout_effect():
     # consumer should timeout based on instance timeout
-    api = CBAPI(timeout=0.01)
+    api = CBAPI(timeout=0.2)
     cb = 3
     api.host_configure_cb(cb, 4)
-    start = time.time()
-    with pytest.raises(CBTimeoutError, match="timed out after 0.01s"):
+    start = time.perf_counter()
+    with pytest.raises(CBTimeoutError, match="timed out after 0.2s"):
         api.cb_wait_front(cb, 1)
-    elapsed = time.time() - start
-    assert elapsed < 0.1
+    elapsed = time.perf_counter() - start
+    assert elapsed < 0.4
 
 
 def test_threaded_produce_consume(configured_cb: Tuple[CBAPI, CBID]):


### PR DESCRIPTION
The problem here was that the defined timeout was too tight and other tasks from within the cb_wait_front code would take over most of the execution time (e.g pydantic checks)


