### PR TITLE
Attach cbs correctly when generating with stmt

### DIFF
--- a/python/ttlang/_src/ttl_ast.py
+++ b/python/ttlang/_src/ttl_ast.py
@@ -260,11 +260,14 @@ class TTLGenericCompiler(TTCompilerBase):
                 # Get tensor type from CB for reserve/wait result
                 tensor_type = self._get_cb_tensor_type(cb_val)
                 if method_name == "reserve":
-                    acquire_result = ttl.cb_reserve(tensor_type, cb_val)
+                    tensor = ttl.cb_reserve(tensor_type, cb_val)
                     releases.append((ttl.cb_push, cb_val))
                 else:  # wait
-                    acquire_result = ttl.cb_wait(tensor_type, cb_val)
+                    tensor = ttl.cb_wait(tensor_type, cb_val)
                     releases.append((ttl.cb_pop, cb_val))
+
+                # Attach CB to tensor so store() can find the CB association
+                acquire_result = ttl.attach_cb(tensor.type, tensor, cb_val)
 
                 if optional_vars is not None:
                     if not isinstance(optional_vars, ast.Name):

--- a/test/python/simple_add_with_stmt.py
+++ b/test/python/simple_add_with_stmt.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# XFAIL: *
-# https://github.com/tenstorrent/tt-lang/issues/164
 # RUN: %python %s > %t.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
@@ -85,13 +83,19 @@ def add_with_kernel(lhs, rhs, out):
 # CHECK: %[[CB1:.+]] = ttl.bind_cb{cb_index = 1
 # CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2
 
-# 'with' entry: wait for inputs, reserve output
-# CHECK: ttl.cb_wait %[[CB0]]
-# CHECK: ttl.cb_wait %[[CB1]]
-# CHECK: ttl.cb_reserve %[[CB2]]
+# 'with' entry: wait for inputs, reserve output (with CB association)
+# CHECK: %[[L:.+]] = ttl.cb_wait %[[CB0]]
+# CHECK: ttl.attach_cb %[[L]], %[[CB0]]
+# CHECK: %[[R:.+]] = ttl.cb_wait %[[CB1]]
+# CHECK: ttl.attach_cb %[[R]], %[[CB1]]
+# CHECK: %[[O:.+]] = ttl.cb_reserve %[[CB2]]
+# CHECK: ttl.attach_cb %[[O]], %[[CB2]]
 
 # Add operation
 # CHECK: ttl.add
+
+# store() attaches result to output CB
+# CHECK: ttl.attach_cb %{{.+}}, %[[CB2]]
 
 # 'with' exit: push output, pop inputs (reverse order)
 # CHECK: ttl.cb_push %[[CB2]]
@@ -105,14 +109,16 @@ def add_with_kernel(lhs, rhs, out):
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: attributes {ttl.kernel_thread = #ttkernel.thread<noc>}
 
-# First CB: reserve, copy, push
+# First CB: reserve (with CB association), copy, push
 # CHECK: ttl.cb_reserve
+# CHECK: ttl.attach_cb
 # CHECK: ttl.copy {{.*}} -> !ttl.transfer_handle<read>
 # CHECK: ttl.wait
 # CHECK: ttl.cb_push
 
-# Second CB: reserve, copy, push
+# Second CB: reserve (with CB association), copy, push
 # CHECK: ttl.cb_reserve
+# CHECK: ttl.attach_cb
 # CHECK: ttl.copy {{.*}} -> !ttl.transfer_handle<read>
 # CHECK: ttl.wait
 # CHECK: ttl.cb_push
@@ -120,8 +126,9 @@ def add_with_kernel(lhs, rhs, out):
 # CHECK-LABEL: func.func @dm_write
 # CHECK-SAME: attributes {ttl.kernel_thread = #ttkernel.thread<noc>}
 
-# Output CB: wait, copy, pop
+# Output CB: wait (with CB association), copy, pop
 # CHECK: ttl.cb_wait
+# CHECK: ttl.attach_cb
 # CHECK: ttl.copy {{.*}} -> !ttl.transfer_handle<write>
 # CHECK: ttl.wait
 # CHECK: ttl.cb_pop


### PR DESCRIPTION
In the with pattern, `visit_With` in `ttl_ast.py` was calling `ttl.cb_wait` and `ttl.cb_reserve` directly but NOT calling `ttl.attach_cb` to associate the tensor with the CB. The `store()` method in `operators.py` expects the tensor to be the result of an `attach_cb` operation so it can extract the CB via `ast_self.owner.operands[1]`.

Fixes #164