### PR TITLE
Remove block_factors (#185)

### DIFF
--- a/test/python/invalid/invalid_3d_grid.py
+++ b/test/python/invalid/invalid_3d_grid.py
@@ -32,7 +32,7 @@ except ImportError:
 
 
 # CHECK: ValueError: Only 2D grids supported, got grid
-@pykernel_gen(grid=(1, 1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1, 1))
 def invalid_3d_grid_kernel(lhs, rhs, out):
     """This kernel should fail because 3D grids are not supported."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_copy_no_cb.py
+++ b/test/python/invalid/invalid_copy_no_cb.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 # CHECK: ValueError: copy() requires exactly one CB argument
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def invalid_copy_no_cb_kernel(lhs, rhs, out):
     """This kernel should fail because copy() needs exactly one CB."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_grid_divisibility.py
+++ b/test/python/invalid/invalid_grid_divisibility.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 # CHECK: must be divisible by grid dim
-@pykernel_gen(grid=(2, 3), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(2, 3))
 def invalid_divisibility_kernel(lhs, rhs, out):
     """This kernel should fail because 32 is not divisible by 3."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_memory_space.py
+++ b/test/python/invalid/invalid_memory_space.py
@@ -34,9 +34,7 @@ except ImportError:
 
 # CHECK: ValueError: Invalid memory_space: 'INVALID'
 # CHECK: Must be one of:
-@pykernel_gen(
-    grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)], memory_space="INVALID"
-)
+@pykernel_gen(grid=(1, 1), memory_space="INVALID")
 def invalid_memory_space_kernel(lhs, rhs, out):
     """This kernel should fail because memory_space='INVALID' is not supported."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_multicore_grid.py
+++ b/test/python/invalid/invalid_multicore_grid.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 # CHECK: TTNN interop only supports single-core grid (1, 1)
-@pykernel_gen(grid=(2, 2), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(2, 2))
 def invalid_multicore_kernel(lhs, rhs, out):
     """This kernel should fail because multi-core grids are not supported."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_non_2d_cb.py
+++ b/test/python/invalid/invalid_non_2d_cb.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 # CHECK: ValueError: Only 2D CBs supported, got shape
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1, 1), (1, 1, 1), (1, 1, 1)])
+@pykernel_gen(grid=(1, 1))
 def invalid_3d_cb_kernel(lhs, rhs, out):
     """This kernel should fail because 3D tensors create 3D CBs which are not supported."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_non_tiled.py
+++ b/test/python/invalid/invalid_non_tiled.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 # CHECK: ValueError: Only tiled CBs supported
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)], tiled=False)
+@pykernel_gen(grid=(1, 1), tiled=False)
 def invalid_non_tiled_kernel(lhs, rhs, out):
     """This kernel should fail because tiled=False is not supported."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_sharded_tensor.py
+++ b/test/python/invalid/invalid_sharded_tensor.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 # CHECK: ValueError: TTNN interop requires interleaved tensors
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def invalid_sharded_kernel(lhs, rhs, out):
     """This kernel should fail because sharded tensors are not supported."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/invalid/invalid_with_non_cb.py
+++ b/test/python/invalid/invalid_with_non_cb.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 # CHECK: Expected CircularBufferType, got
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def invalid_with_non_cb_kernel(lhs, rhs, out):
     """This kernel should fail because 'with' is used on a TensorBlock, not a CB."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/simple_add.py
+++ b/test/python/simple_add.py
@@ -33,7 +33,7 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def add_kernel(lhs, rhs, out):
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)

--- a/test/python/simple_add_dram.py
+++ b/test/python/simple_add_dram.py
@@ -34,7 +34,7 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def add_dram_kernel(lhs, rhs, out):
     """Add kernel that reads/writes directly from/to DRAM."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/simple_add_loop.py
+++ b/test/python/simple_add_loop.py
@@ -34,7 +34,7 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def add_loop_kernel(lhs, rhs, out):
     """Add kernel with loop in compute to accumulate results."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/simple_add_multitile.py
+++ b/test/python/simple_add_multitile.py
@@ -36,7 +36,7 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1), block_factors=[(2, 2), (2, 2), (2, 2)])
+@pykernel_gen(grid=(1, 1))
 def add_multitile_kernel(lhs, rhs, out):
     """Add kernel processing 2x2 tile grid (4 tiles total)."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/simple_add_with_stmt.py
+++ b/test/python/simple_add_with_stmt.py
@@ -37,7 +37,7 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def add_with_kernel(lhs, rhs, out):
     """Add kernel using 'with' pattern for automatic CB lifecycle."""
     lhs_accessor = TensorAccessor(lhs)

--- a/test/python/test_dram_interleaved_add.py
+++ b/test/python/test_dram_interleaved_add.py
@@ -21,10 +21,7 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(
-    grid=(1, 1),
-    block_factors=[(1, 1), (1, 1), (1, 1)],
-)
+@pykernel_gen(grid=(1, 1))
 def add_dram_direct(lhs, rhs, out):
     """
     Add kernel that reads directly from DRAM interleaved tensors.

--- a/test/python/test_elementwise_ops.py
+++ b/test/python/test_elementwise_ops.py
@@ -49,7 +49,7 @@ from ttlang.ttl_api import (
 )
 from ttlang.operators import copy
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def {name}_kernel(lhs, rhs, out):
     """Binary {name} kernel."""
     lhs_accessor = TensorAccessor(lhs)
@@ -107,7 +107,7 @@ from ttlang.ttl_api import (
 from ttlang.operators import copy
 from ttlang import {op}
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def {name}_kernel(lhs, rhs, out):
     """Binary {name} kernel (function call)."""
     lhs_accessor = TensorAccessor(lhs)
@@ -165,7 +165,7 @@ from ttlang.ttl_api import (
 from ttlang.operators import copy
 from ttlang import {op}
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def {name}_kernel(inp, out):
     """Unary {name} kernel."""
     inp_accessor = TensorAccessor(inp)

--- a/test/python/test_ttnn_interop_add.py
+++ b/test/python/test_ttnn_interop_add.py
@@ -21,7 +21,7 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1), block_factors=[(1, 1), (1, 1), (1, 1)])
+@pykernel_gen(grid=(1, 1))
 def test_ttnn_interop_add(lhs, rhs, out):
     """Simple add kernel compiled for TTNN interop (C++ output)."""
     lhs_accessor = TensorAccessor(lhs)


### PR DESCRIPTION
The title. Resolved #185. In explicit data movement mode (the only mode we are currently focused on), the user is expected to generate loops for block factors manually. 