### PR TITLE
Update decorators to be spelled @ttl.kernel(), @ttl.compute(), @ttl.datamovement() instead of @pykernel_gen(), @compute(), @datamovement() (#186).

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -95,6 +95,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Main
     __init__.py
     circular_buffer.py
     constants.py
+    ttl.py
     ttl_api.py
     dtype_utils.py
     ir.py

--- a/python/ttlang/__init__.py
+++ b/python/ttlang/__init__.py
@@ -6,14 +6,14 @@
 
 __version__ = "0.1.0"
 
+# Export TTL DSL API module (decorators)
+from ttlang import ttl
+
 # Export TTL DSL API
 from ttlang.ttl_api import (
-    pykernel_gen,
     Program,
     CircularBuffer,
     TensorAccessor,
-    compute,
-    datamovement,
     TensorBlock,
     Semaphore,
     CopyTransferHandler,
@@ -24,12 +24,10 @@ from ttlang._generated_elementwise import *  # noqa: F401,F403
 from ttlang._generated_elementwise import __all__ as _elementwise_all
 
 __all__ = [
-    "pykernel_gen",
+    "ttl",
     "Program",
     "CircularBuffer",
     "TensorAccessor",
-    "compute",
-    "datamovement",
     "TensorBlock",
     "Semaphore",
     "CopyTransferHandler",

--- a/python/ttlang/ttl.py
+++ b/python/ttlang/ttl.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTL DSL module providing decorator APIs (@ttl.kernel(), @ttl.compute(), @ttl.datamovement())
+"""
+
+from ttlang.ttl_api import (
+    pykernel_gen as kernel,
+    compute,
+    datamovement,
+)
+
+__all__ = [
+    "kernel",
+    "compute",
+    "datamovement",
+]

--- a/test/python/invalid/invalid_3d_grid.py
+++ b/test/python/invalid/invalid_3d_grid.py
@@ -14,14 +14,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -32,14 +26,14 @@ except ImportError:
 
 
 # CHECK: ValueError: Only 2D grids supported, got grid
-@pykernel_gen(grid=(1, 1, 1))
+@ttl.kernel(grid=(1, 1, 1))
 def invalid_3d_grid_kernel(lhs, rhs, out):
     """This kernel should fail because 3D grids are not supported."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -52,7 +46,7 @@ def invalid_3d_grid_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -64,7 +58,7 @@ def invalid_3d_grid_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/invalid/invalid_copy_no_cb.py
+++ b/test/python/invalid/invalid_copy_no_cb.py
@@ -15,14 +15,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -33,14 +27,14 @@ except ImportError:
 
 
 # CHECK: ValueError: copy() requires exactly one CB argument
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def invalid_copy_no_cb_kernel(lhs, rhs, out):
     """This kernel should fail because copy() needs exactly one CB."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -53,13 +47,13 @@ def invalid_copy_no_cb_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         # INVALID: copy() between two tensor accessors (no CB)
         tx = copy(lhs_accessor[0, 0], rhs_accessor[0, 0])
         tx.wait()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/invalid/invalid_grid_divisibility.py
+++ b/test/python/invalid/invalid_grid_divisibility.py
@@ -15,14 +15,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -33,14 +27,14 @@ except ImportError:
 
 
 # CHECK: must be divisible by grid dim
-@pykernel_gen(grid=(2, 3))
+@ttl.kernel(grid=(2, 3))
 def invalid_divisibility_kernel(lhs, rhs, out):
     """This kernel should fail because 32 is not divisible by 3."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -53,7 +47,7 @@ def invalid_divisibility_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -65,7 +59,7 @@ def invalid_divisibility_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/invalid/invalid_non_2d_cb.py
+++ b/test/python/invalid/invalid_non_2d_cb.py
@@ -15,14 +15,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -33,14 +27,14 @@ except ImportError:
 
 
 # CHECK: ValueError: Only 2D CBs supported, got shape
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def invalid_3d_cb_kernel(lhs, rhs, out):
     """This kernel should fail because 3D tensors create 3D CBs which are not supported."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -53,7 +47,7 @@ def invalid_3d_cb_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -65,7 +59,7 @@ def invalid_3d_cb_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/invalid/invalid_non_tiled.py
+++ b/test/python/invalid/invalid_non_tiled.py
@@ -15,14 +15,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -33,14 +27,14 @@ except ImportError:
 
 
 # CHECK: ValueError: Only tiled CBs supported
-@pykernel_gen(grid=(1, 1), tiled=False)
+@ttl.kernel(grid=(1, 1), tiled=False)
 def invalid_non_tiled_kernel(lhs, rhs, out):
     """This kernel should fail because tiled=False is not supported."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -53,7 +47,7 @@ def invalid_non_tiled_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -65,7 +59,7 @@ def invalid_non_tiled_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/invalid/invalid_sharded_tensor.py
+++ b/test/python/invalid/invalid_sharded_tensor.py
@@ -15,14 +15,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -33,14 +27,14 @@ except ImportError:
 
 
 # CHECK: ValueError: TTNN interop requires interleaved tensors
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def invalid_sharded_kernel(lhs, rhs, out):
     """This kernel should fail because sharded tensors are not supported."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -53,7 +47,7 @@ def invalid_sharded_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -65,7 +59,7 @@ def invalid_sharded_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/invalid/invalid_with_non_cb.py
+++ b/test/python/invalid/invalid_with_non_cb.py
@@ -15,14 +15,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -33,14 +27,14 @@ except ImportError:
 
 
 # CHECK: Expected CircularBufferType, got
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def invalid_with_non_cb_kernel(lhs, rhs, out):
     """This kernel should fail because 'with' is used on a TensorBlock, not a CB."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -57,7 +51,7 @@ def invalid_with_non_cb_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -69,7 +63,7 @@ def invalid_with_non_cb_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/simple_add.py
+++ b/test/python/simple_add.py
@@ -16,14 +16,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -33,13 +27,13 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def add_kernel(lhs, rhs, out):
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -52,7 +46,7 @@ def add_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         # Reserve CB space before reading into it
         lhs_cb.reserve()
@@ -65,7 +59,7 @@ def add_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/simple_add_loop.py
+++ b/test/python/simple_add_loop.py
@@ -17,14 +17,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -34,14 +28,14 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def add_loop_kernel(lhs, rhs, out):
     """Add kernel with loop in compute to accumulate results."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -66,7 +60,7 @@ def add_loop_kernel(lhs, rhs, out):
         rhs_cb.pop()
         # Final value already pushed, DM will handle it
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -78,7 +72,7 @@ def add_loop_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/simple_add_multitile.py
+++ b/test/python/simple_add_multitile.py
@@ -19,14 +19,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -36,14 +30,14 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def add_multitile_kernel(lhs, rhs, out):
     """Add kernel processing 2x2 tile grid (4 tiles total)."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -56,7 +50,7 @@ def add_multitile_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         lhs_cb.reserve()
         tx_lhs = copy(lhs_accessor[0, 0], lhs_cb)
@@ -68,7 +62,7 @@ def add_multitile_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/simple_add_with_stmt.py
+++ b/test/python/simple_add_with_stmt.py
@@ -20,14 +20,8 @@ import os
 
 os.environ["TTLANG_COMPILE_ONLY"] = "1"
 
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
 try:
@@ -37,14 +31,14 @@ except ImportError:
     exit(0)
 
 
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def add_with_kernel(lhs, rhs, out):
     """Add kernel using 'with' pattern for automatic CB lifecycle."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def add_compute(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -54,7 +48,7 @@ def add_with_kernel(lhs, rhs, out):
             o.store(result)
         # Automatic: out_cb.push(), rhs_cb.pop(), lhs_cb.pop() (reverse order)
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer):
         # 'with' for reserve/push pattern
         with lhs_cb.reserve() as lhs_block:
@@ -67,7 +61,7 @@ def add_with_kernel(lhs, rhs, out):
             tx_rhs.wait()
         # Automatic: rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):

--- a/test/python/test_elementwise_ops.py
+++ b/test/python/test_elementwise_ops.py
@@ -39,24 +39,18 @@ pytestmark = pytest.mark.skipif(not TTNN_AVAILABLE, reason="TTNN not available")
 # =============================================================================
 
 BINARY_KERNEL_TEMPLATE = '''
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def {name}_kernel(lhs, rhs, out):
     """Binary {name} kernel."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def compute_fn(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -69,7 +63,7 @@ def {name}_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -83,7 +77,7 @@ def {name}_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -96,25 +90,19 @@ def {name}_kernel(lhs, rhs, out):
 '''
 
 BINARY_FN_KERNEL_TEMPLATE = '''
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 from ttlang import {op}
 
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def {name}_kernel(lhs, rhs, out):
     """Binary {name} kernel (function call)."""
     lhs_accessor = TensorAccessor(lhs)
     rhs_accessor = TensorAccessor(rhs)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def compute_fn(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -127,7 +115,7 @@ def {name}_kernel(lhs, rhs, out):
         rhs_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -141,7 +129,7 @@ def {name}_kernel(lhs, rhs, out):
         tx_rhs.wait()
         rhs_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(
         lhs_cb: CircularBuffer, rhs_cb: CircularBuffer, out_cb: CircularBuffer
     ):
@@ -154,24 +142,18 @@ def {name}_kernel(lhs, rhs, out):
 '''
 
 UNARY_KERNEL_TEMPLATE = '''
-from ttlang.ttl_api import (
-    pykernel_gen,
-    Program,
-    CircularBuffer,
-    TensorAccessor,
-    compute,
-    datamovement,
-)
+from ttlang import ttl
+from ttlang.ttl_api import Program, CircularBuffer, TensorAccessor
 from ttlang.operators import copy
 from ttlang import {op}
 
-@pykernel_gen(grid=(1, 1))
+@ttl.kernel(grid=(1, 1))
 def {name}_kernel(inp, out):
     """Unary {name} kernel."""
     inp_accessor = TensorAccessor(inp)
     out_accessor = TensorAccessor(out)
 
-    @compute()
+    @ttl.compute()
     def compute_fn(inp_cb: CircularBuffer, out_cb: CircularBuffer):
         x = inp_cb.wait()
         o = out_cb.reserve()
@@ -180,14 +162,14 @@ def {name}_kernel(inp, out):
         inp_cb.pop()
         out_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_read(inp_cb: CircularBuffer, out_cb: CircularBuffer):
         inp_cb.reserve()
         tx_inp = copy(inp_accessor[0, 0], inp_cb)
         tx_inp.wait()
         inp_cb.push()
 
-    @datamovement()
+    @ttl.datamovement()
     def dm_write(inp_cb: CircularBuffer, out_cb: CircularBuffer):
         out_cb.wait()
         tx = copy(out_cb, out_accessor[0, 0])


### PR DESCRIPTION
New module exporting kernel, compute, datamovement as the renamed decorator API

Added _get_annotation_name() helper to handle both CircularBuffer and ttl.CircularBuffer type annotations

fixes #186