### PR TITLE
[ttl] Move tensor accessor ops to function level

### DIFF
--- a/python/ttlang/ttl_api.py
+++ b/python/ttlang/ttl_api.py
@@ -35,7 +35,7 @@ from ._src.tensor_registry import (
     register_tensor_source,
 )
 from ._src.ttl_ast import TTLGenericCompiler
-from .circular_buffer import CircularBuffer
+from .circular_buffer import CircularBuffer, get_cb_count
 from .constants import SUPPORTED_MEMORY_SPACES
 from .diagnostics import (
     TTLangCompileError,

--- a/python/ttlang/utils/block_allocation.py
+++ b/python/ttlang/utils/block_allocation.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import itertools
 import math
+import sympy
+from collections import namedtuple
 from typing import List, Tuple
 
 

--- a/test/python/simple_add_dram.py
+++ b/test/python/simple_add_dram.py
@@ -103,7 +103,7 @@ def add_dram_kernel(lhs, rhs, out):
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: %arg0: tensor<{{[^>]+}}!ttcore.tile<32x32, bf16>, #ttnn_layout>
 # CHECK-SAME: %arg1: tensor<{{[^>]+}}!ttcore.tile<32x32, bf16>, #ttnn_layout>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>}
 
 # Bind CBs (alphabetical order: lhs_cb, rhs_cb)
 # CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0
@@ -123,7 +123,7 @@ def add_dram_kernel(lhs, rhs, out):
 
 # CHECK-LABEL: func.func @dm_write
 # CHECK-SAME: %arg0: tensor<{{[^>]+}}!ttcore.tile<32x32, bf16>, #ttnn_layout>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2], ttl.kernel_thread = #ttkernel.thread<noc>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>}
 
 # Wait for output CB, copy to device, pop
 # CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2
@@ -165,23 +165,26 @@ def add_dram_kernel(lhs, rhs, out):
 # CHECK-CPP: // dm_read
 # CHECK-CPP: void kernel_main()
 
+# Function entry: create tensor accessors
+# CHECK-CPP: auto {{.*}} = TensorAccessorArgs<3, 0>();
+# CHECK-CPP-NEXT: TensorAccessor {{.*}} = TensorAccessor(
+# Second tensor accessor at index 3+1=4, CRTA=1
+# CHECK-CPP: auto {{.*}} = TensorAccessorArgs<4, 1>();
+# CHECK-CPP-NEXT: TensorAccessor {{.*}} = TensorAccessor(
+
 # First input: reserve CB, read tile, push CB
 # CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(0),
-# CHECK-CPP: auto {{.*}} = TensorAccessorArgs<3, 0>();
-# CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_write_ptr(get_compile_time_arg_val(0))
-# CHECK-CPP: noc_async_read_tile(
-# CHECK-CPP: noc_async_read_barrier();
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(0),
+# CHECK-CPP-NEXT: int32_t {{.*}} = get_write_ptr(get_compile_time_arg_val(0))
+# CHECK-CPP-NEXT: noc_async_read_tile(
+# CHECK-CPP-NEXT: noc_async_read_barrier();
+# CHECK-CPP-NEXT: cb_push_back(get_compile_time_arg_val(0),
 
 # Second input: reserve CB, read tile, push CB
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(1),
-# CHECK-CPP: auto {{.*}} = TensorAccessorArgs<4, 1>();
-# CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_write_ptr(get_compile_time_arg_val(1))
-# CHECK-CPP: noc_async_read_tile(
-# CHECK-CPP: noc_async_read_barrier();
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(1),
+# CHECK-CPP-NEXT: cb_reserve_back(get_compile_time_arg_val(1),
+# CHECK-CPP-NEXT: int32_t {{.*}} = get_write_ptr(get_compile_time_arg_val(1))
+# CHECK-CPP-NEXT: noc_async_read_tile(
+# CHECK-CPP-NEXT: noc_async_read_barrier();
+# CHECK-CPP-NEXT: cb_push_back(get_compile_time_arg_val(1),
 
 # =============================================================================
 # C++ Kernel Checks - Verify generated dm_write kernel (DRAM access)
@@ -190,14 +193,16 @@ def add_dram_kernel(lhs, rhs, out):
 # CHECK-CPP: // dm_write
 # CHECK-CPP: void kernel_main()
 
+# Function entry: create tensor accessor
+# CHECK-CPP: auto {{.*}} = TensorAccessorArgs<5, 0>();
+# CHECK-CPP-NEXT: TensorAccessor {{.*}} = TensorAccessor(
+
 # Wait for output CB, write tile, pop CB
 # CHECK-CPP: cb_wait_front(get_compile_time_arg_val(2),
-# CHECK-CPP: auto {{.*}} = TensorAccessorArgs<5, 0>();
-# CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_read_ptr(get_compile_time_arg_val(2))
-# CHECK-CPP: noc_async_write_tile(
-# CHECK-CPP: noc_async_write_barrier();
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(2),
+# CHECK-CPP-NEXT: int32_t {{.*}} = get_read_ptr(get_compile_time_arg_val(2))
+# CHECK-CPP-NEXT: noc_async_write_tile(
+# CHECK-CPP-NEXT: noc_async_write_barrier();
+# CHECK-CPP-NEXT: cb_pop_front(get_compile_time_arg_val(2),
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add_f32.py
+++ b/test/python/simple_add_f32.py
@@ -71,11 +71,11 @@ def add_kernel_f32(lhs, rhs, out):
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: %arg0: tensor<{{[^>]+}}!ttcore.tile<32x32, f32>, #ttnn_layout>
 # CHECK-SAME: %arg1: tensor<{{[^>]+}}!ttcore.tile<32x32, f32>, #ttnn_layout>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>}
 
 # CHECK-LABEL: func.func @dm_write
 # CHECK-SAME: %arg0: tensor<{{[^>]+}}!ttcore.tile<32x32, f32>, #ttnn_layout>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2], ttl.kernel_thread = #ttkernel.thread<noc>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>}
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add_with_stmt.py
+++ b/test/python/simple_add_with_stmt.py
@@ -107,7 +107,7 @@ def add_with_kernel(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @dm_read
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>}
 
 # First CB: reserve (with CB association), copy, push
 # CHECK: ttl.cb_reserve
@@ -124,7 +124,7 @@ def add_with_kernel(lhs, rhs, out):
 # CHECK: ttl.cb_push
 
 # CHECK-LABEL: func.func @dm_write
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2], ttl.kernel_thread = #ttkernel.thread<noc>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>}
 
 # Output CB: wait (with CB association), copy, pop
 # CHECK: ttl.cb_wait

--- a/test/python/utils/test_block_allocation.py
+++ b/test/python/utils/test_block_allocation.py
@@ -8,7 +8,7 @@ Test comparing split_work_to_cores with ttnn.split_work_to_cores
 get_large_matmul_params is compared with hard coded expected values
 """
 import pytest
-from ttlang.utils.block_allocation import split_work_to_cores
+from ttlang.utils.block_allocation import get_large_matmul_params, split_work_to_cores
 
 ttnn = pytest.importorskip("ttnn")
 

--- a/test/ttlang/Translate/TTLToCpp/compute_with_data_movement.mlir
+++ b/test/ttlang/Translate/TTLToCpp/compute_with_data_movement.mlir
@@ -20,10 +20,17 @@
 // CHECK-DAG:   size_t [[PAGE_SIZE:.*]] = 4096;
 // CHECK-DAG:   size_t [[ZERO:.*]] = 0;
 
-// Read tensor A into CB0
+// Function entry: materialize both accessors ONCE (function-level emission)
+// Accessor for tensor A (arg 0)
 // CHECK:   int32_t [[RT_ARG_A:.*]] = get_common_arg_val<uint32_t>([[ZERO]]);
 // CHECK-NEXT:   auto [[ARGS_A:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();
 // CHECK-NEXT:   TensorAccessor [[ACC_A:.*]] = TensorAccessor([[ARGS_A]], [[RT_ARG_A]],
+// Accessor for tensor B (arg 1)
+// CHECK:   int32_t [[RT_ARG_B:.*]] = get_common_arg_val<uint32_t>([[ONE]]);
+// CHECK-NEXT:   auto [[ARGS_B:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
+// CHECK-NEXT:   TensorAccessor [[ACC_B:.*]] = TensorAccessor([[ARGS_B]], [[RT_ARG_B]],
+
+// Read tensor A into CB0 using pre-materialized accessor
 // CHECK:   int32_t [[CB0_PTR:.*]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
 // CHECK-NEXT:   ptrdiff_t [[CB0_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB0_PTR]];
@@ -46,11 +53,8 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT:   noc_async_read_barrier();
 
-// Read tensor B into CB1
-// CHECK:   int32_t [[RT_ARG_B:.*]] = get_common_arg_val<uint32_t>([[ONE]]);
-// CHECK-NEXT:   auto [[ARGS_B:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
-// CHECK-NEXT:   TensorAccessor [[ACC_B:.*]] = TensorAccessor([[ARGS_B]], [[RT_ARG_B]],
-// CHECK:   int32_t [[CB1_PTR:.*]] = get_write_ptr(get_compile_time_arg_val(1));
+// Read tensor B into CB1 using pre-materialized accessor
+// CHECK-NEXT:   int32_t [[CB1_PTR:.*]] = get_write_ptr(get_compile_time_arg_val(1));
 // Cast CB ptr to size_t for index arithmetic
 // CHECK-NEXT:   ptrdiff_t [[CB1_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB1_PTR]];
 // CHECK-NEXT:   size_t [[CB1_PTR_IDX:v[0-9]+]] = (size_t) [[CB1_PTR_PTRDIFF]];

--- a/test/ttlang/Translate/TTLToCpp/dma_loop_multi_tile_nontrivial_cb.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_loop_multi_tile_nontrivial_cb.mlir
@@ -39,57 +39,59 @@
 // CHECK-DAG:   size_t [[TILE_STEP:v[0-9]+]] = 1;
 // CHECK-DAG:   size_t [[USER_UB:v[0-9]+]] = 4;
 // CHECK-DAG:   size_t [[TILE_LB:v[0-9]+]] = 0;
+// Function entry: create both tensor accessors (before user loop)
+// CHECK:   int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_LB]]);
+// CHECK-NEXT:   auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();
+// CHECK-NEXT:   TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
+// CHECK-NEXT:   int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_STEP]]);
+// CHECK-NEXT:   auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
+// CHECK-NEXT:   TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
+// User loop
 // CHECK:   for (size_t [[USER_ITER:[a-z][0-9]+]] = [[TILE_LB]]; [[USER_ITER]] < [[USER_UB]]; [[USER_ITER]] += [[TILE_STEP]]) {
-// First copy: arg0 (64x64) → CB0, accessor with runtime arg index 0
-// CHECK:     int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_LB]]);
-// CHECK:     auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();
-// CHECK:     TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
+// First copy: arg0 (64x64) → CB0, use pre-materialized accessor
 // CHECK:     int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:     ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR1]];
-// CHECK:     size_t [[CB_PTR1_IDX:v[0-9]+]] = (size_t) [[CB_PTR1_PTRDIFF]];
-// CHECK:     for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_Y]] < [[TILES_2]]; [[TILE1_Y]] += [[TILE_STEP]]) {
-// CHECK:       for (size_t [[TILE1_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_X]] < [[TILES_2]]; [[TILE1_X]] += [[TILE_STEP]]) {
-// CHECK:         size_t [[TILE1_OFFSET_Y:v[0-9]+]] = [[TILE1_Y]] * [[TILES_2]];
-// CHECK:         size_t [[TILE1_OFFSET_X:v[0-9]+]] = [[TILE1_OFFSET_Y]] + [[TILE1_X]];
+// CHECK-NEXT:     ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR1]];
+// CHECK-NEXT:     size_t [[CB_PTR1_IDX:v[0-9]+]] = (size_t) [[CB_PTR1_PTRDIFF]];
+// CHECK-NEXT:     for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_Y]] < [[TILES_2]]; [[TILE1_Y]] += [[TILE_STEP]]) {
+// CHECK-NEXT:       for (size_t [[TILE1_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_X]] < [[TILES_2]]; [[TILE1_X]] += [[TILE_STEP]]) {
+// CHECK-NEXT:         size_t [[TILE1_OFFSET_Y:v[0-9]+]] = [[TILE1_Y]] * [[TILES_2]];
+// CHECK-NEXT:         size_t [[TILE1_OFFSET_X:v[0-9]+]] = [[TILE1_OFFSET_Y]] + [[TILE1_X]];
 // CB address computation: cb_ptr + tile_offset * page_size (all size_t arithmetic)
-// CHECK:         size_t [[BYTE_OFF1:v[0-9]+]] = [[TILE1_OFFSET_X]] * [[PAGE_SIZE]];
-// CHECK:         size_t [[CB_ADDR1_IDX:v[0-9]+]] = [[CB_PTR1_IDX]] + [[BYTE_OFF1]];
+// CHECK-NEXT:         size_t [[BYTE_OFF1:v[0-9]+]] = [[TILE1_OFFSET_X]] * [[PAGE_SIZE]];
+// CHECK-NEXT:         size_t [[CB_ADDR1_IDX:v[0-9]+]] = [[CB_PTR1_IDX]] + [[BYTE_OFF1]];
 // Cast to i32 for NOC operation
-// CHECK:         ptrdiff_t [[TILE1_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE1_OFFSET_X]];
-// CHECK:         int32_t [[TILE1_OFFSET:v[0-9]+]] = (int32_t) [[TILE1_OFFSET_PTR]];
-// CHECK:         ptrdiff_t [[CB_ADDR1_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR1_IDX]];
-// CHECK:         int32_t [[CB_ADDR1:v[0-9]+]] = (int32_t) [[CB_ADDR1_PTR]];
-// CHECK:         noc_async_read_tile([[TILE1_OFFSET]], [[ACC1]], [[CB_ADDR1]]);
-// CHECK:       }
-// CHECK:     }
-// CHECK:     noc_async_read_barrier();
-// Second copy: arg1 (96x64) → CB1, accessor with runtime arg index 1
-// CHECK:     int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_STEP]]);
-// CHECK:     auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
-// CHECK:     TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
+// CHECK-NEXT:         ptrdiff_t [[TILE1_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE1_OFFSET_X]];
+// CHECK-NEXT:         int32_t [[TILE1_OFFSET:v[0-9]+]] = (int32_t) [[TILE1_OFFSET_PTR]];
+// CHECK-NEXT:         ptrdiff_t [[CB_ADDR1_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR1_IDX]];
+// CHECK-NEXT:         int32_t [[CB_ADDR1:v[0-9]+]] = (int32_t) [[CB_ADDR1_PTR]];
+// CHECK-NEXT:         noc_async_read_tile([[TILE1_OFFSET]], [[ACC1]], [[CB_ADDR1]]);
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     noc_async_read_barrier();
+// Second copy: arg1 (96x64) → CB1, use pre-materialized accessor
+// CHECK-NEXT:     int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
-// CHECK:     size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
-// CHECK:     for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_Y]] < [[TILES_3]]; [[TILE2_Y]] += [[TILE_STEP]]) {
-// CHECK:       for (size_t [[TILE2_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_X]] < [[TILES_2]]; [[TILE2_X]] += [[TILE_STEP]]) {
-// CHECK:         size_t [[TILE2_OFFSET_Y:v[0-9]+]] = [[TILE2_Y]] * [[TILES_2]];
-// CHECK:         size_t [[TILE2_OFFSET_X:v[0-9]+]] = [[TILE2_OFFSET_Y]] + [[TILE2_X]];
+// CHECK-NEXT:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
+// CHECK-NEXT:     size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
+// CHECK-NEXT:     for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_Y]] < [[TILES_3]]; [[TILE2_Y]] += [[TILE_STEP]]) {
+// CHECK-NEXT:       for (size_t [[TILE2_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_X]] < [[TILES_2]]; [[TILE2_X]] += [[TILE_STEP]]) {
+// CHECK-NEXT:         size_t [[TILE2_OFFSET_Y:v[0-9]+]] = [[TILE2_Y]] * [[TILES_2]];
+// CHECK-NEXT:         size_t [[TILE2_OFFSET_X:v[0-9]+]] = [[TILE2_OFFSET_Y]] + [[TILE2_X]];
 // CB address computation: cb_ptr + tile_offset * page_size (all size_t arithmetic)
-// CHECK:         size_t [[BYTE_OFF2:v[0-9]+]] = [[TILE2_OFFSET_X]] * [[PAGE_SIZE]];
-// CHECK:         size_t [[CB_ADDR2_IDX:v[0-9]+]] = [[CB_PTR2_IDX]] + [[BYTE_OFF2]];
+// CHECK-NEXT:         size_t [[BYTE_OFF2:v[0-9]+]] = [[TILE2_OFFSET_X]] * [[PAGE_SIZE]];
+// CHECK-NEXT:         size_t [[CB_ADDR2_IDX:v[0-9]+]] = [[CB_PTR2_IDX]] + [[BYTE_OFF2]];
 // Cast to i32 for NOC operation
-// CHECK:         ptrdiff_t [[TILE2_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE2_OFFSET_X]];
-// CHECK:         int32_t [[TILE2_OFFSET:v[0-9]+]] = (int32_t) [[TILE2_OFFSET_PTR]];
-// CHECK:         ptrdiff_t [[CB_ADDR2_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR2_IDX]];
-// CHECK:         int32_t [[CB_ADDR2:v[0-9]+]] = (int32_t) [[CB_ADDR2_PTR]];
-// CHECK:         noc_async_read_tile([[TILE2_OFFSET]], [[ACC2]], [[CB_ADDR2]]);
-// CHECK:       }
-// CHECK:     }
-// CHECK:     noc_async_read_barrier();
-// CHECK:   }
-// CHECK:   return;
+// CHECK-NEXT:         ptrdiff_t [[TILE2_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE2_OFFSET_X]];
+// CHECK-NEXT:         int32_t [[TILE2_OFFSET:v[0-9]+]] = (int32_t) [[TILE2_OFFSET_PTR]];
+// CHECK-NEXT:         ptrdiff_t [[CB_ADDR2_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR2_IDX]];
+// CHECK-NEXT:         int32_t [[CB_ADDR2:v[0-9]+]] = (int32_t) [[CB_ADDR2_PTR]];
+// CHECK-NEXT:         noc_async_read_tile([[TILE2_OFFSET]], [[ACC2]], [[CB_ADDR2]]);
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     noc_async_read_barrier();
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return;
 // CHECK-NEXT: }
 
 module {

--- a/test/ttlang/Translate/TTLToCpp/dma_loop_single_tile.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_loop_single_tile.mlir
@@ -16,23 +16,21 @@
 // CHECK-DAG:   size_t [[STEP:v[0-9]+]] = 1;
 // CHECK-DAG:   size_t [[UB:v[0-9]+]] = 3;
 // CHECK-DAG:   size_t [[LB:v[0-9]+]] = 0;
-// Pre-loop copy: create accessor with runtime arg, get CB write ptr
-// CHECK:   int32_t [[RT_ARG0:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
-// CHECK:   auto [[ARGS0:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<1, 0>();
-// CHECK:   TensorAccessor [[ACCESSOR0:v[0-9]+]] = TensorAccessor([[ARGS0]], [[RT_ARG0]], [[ADDR]]);
+// Function entry: create accessor ONCE with runtime arg (function-level emission)
+// CHECK:   int32_t [[RT_ARG:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
+// CHECK-NEXT:   auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<1, 0>();
+// CHECK-NEXT:   TensorAccessor [[ACCESSOR:v[0-9]+]] = TensorAccessor([[ARGS]], [[RT_ARG]], [[ADDR]]);
+// Pre-loop copy: use pre-materialized accessor
 // CHECK:   int32_t [[CB_PTR0:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
-// CHECK:   noc_async_read_tile([[ZERO]], [[ACCESSOR0]], [[CB_PTR0]]);
-// CHECK:   for (size_t [[IV:i[0-9]+]] = [[LB]]; [[IV]] < [[UB]]; [[IV]] += [[STEP]]) {
-// In-loop copy: create accessor with runtime arg, get CB write ptr
-// CHECK:     int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
-// CHECK:     auto [[ARGS1:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<1, 0>();
-// CHECK:     TensorAccessor [[ACCESSOR1:v[0-9]+]] = TensorAccessor([[ARGS1]], [[RT_ARG1]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
-// CHECK:     noc_async_read_tile([[ZERO]], [[ACCESSOR1]], [[CB_PTR1]]);
-// CHECK:     noc_async_read_barrier();
-// CHECK:   }
-// CHECK:   noc_async_read_barrier();
-// CHECK:   return;
+// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR]], [[CB_PTR0]]);
+// CHECK-NEXT:   for (size_t [[IV:i[0-9]+]] = [[LB]]; [[IV]] < [[UB]]; [[IV]] += [[STEP]]) {
+// In-loop copy: reuse pre-materialized accessor (no new accessor created)
+// CHECK-NEXT:     int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
+// CHECK-NEXT:     noc_async_read_tile([[ZERO]], [[ACCESSOR]], [[CB_PTR1]]);
+// CHECK-NEXT:     noc_async_read_barrier();
+// CHECK-NEXT:   }
+// CHECK-NEXT:   noc_async_read_barrier();
+// CHECK-NEXT:   return;
 // CHECK-NEXT: }
 module {
   func.func @dma_pipelined_loop(%t: tensor<32x32xf32, #layout>) attributes {ttl.base_cta_index = 1 : i32, ttl.crta_indices = [0], ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_batched_in_user_loop.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_batched_in_user_loop.mlir
@@ -37,64 +37,61 @@
 // CHECK-DAG:   size_t [[STEP:v[0-9]+]] = 1;
 // CHECK-DAG:   size_t [[USER_UB:v[0-9]+]] = 3;
 // CHECK-DAG:   size_t [[LB:v[0-9]+]] = 0;
-
+// Function entry: create both tensor accessors (before user loop)
+// CHECK:   int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
+// CHECK-NEXT:   auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();
+// CHECK-NEXT:   TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
+// CHECK-NEXT:   int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[STEP]]);
+// CHECK-NEXT:   auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
+// CHECK-NEXT:   TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
 // User loop from input MLIR (0..3)
 // CHECK:   for (size_t [[USER_ITER:[a-z][0-9]+]] = [[LB]]; [[USER_ITER]] < [[USER_UB]]; [[USER_ITER]] += [[STEP]]) {
-
-// First copy: 64x64 (2x2 tiles) → CB1
-// CHECK:     int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
-// CHECK:     auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();
-// CHECK:     TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
+// First copy: 64x64 (2x2 tiles) → CB1, use pre-materialized accessor
 // CHECK:     int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
 // CHECK:     ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR1]];
 // CHECK:     size_t [[CB_PTR1_IDX:v[0-9]+]] = (size_t) [[CB_PTR1_PTRDIFF]];
 // Tile loops: for tile_y in 0..2, for tile_x in 0..2
-// CHECK:     for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[LB]]; [[TILE1_Y]] < [[TILES_BOUND]]; [[TILE1_Y]] += [[STEP]]) {
-// CHECK:       for (size_t [[TILE1_X:[a-z][0-9]+]] = [[LB]]; [[TILE1_X]] < [[TILES_BOUND]]; [[TILE1_X]] += [[STEP]]) {
+// CHECK-NEXT:     for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[LB]]; [[TILE1_Y]] < [[TILES_BOUND]]; [[TILE1_Y]] += [[STEP]]) {
+// CHECK-NEXT:       for (size_t [[TILE1_X:[a-z][0-9]+]] = [[LB]]; [[TILE1_X]] < [[TILES_BOUND]]; [[TILE1_X]] += [[STEP]]) {
 // CHECK:         size_t [[TILE1_OFFSET_Y:v[0-9]+]] = [[TILE1_Y]] * [[TILES_BOUND]];
-// CHECK:         size_t [[TILE1_OFFSET_X:v[0-9]+]] = [[TILE1_OFFSET_Y]] + [[TILE1_X]];
+// CHECK-NEXT:         size_t [[TILE1_OFFSET_X:v[0-9]+]] = [[TILE1_OFFSET_Y]] + [[TILE1_X]];
 // CB address computation: cb_ptr + tile_offset * page_size (all size_t arithmetic)
-// CHECK:         size_t [[BYTE_OFF1:v[0-9]+]] = [[TILE1_OFFSET_X]] * [[PAGE_SIZE]];
-// CHECK:         size_t [[CB_ADDR1_IDX:v[0-9]+]] = [[CB_PTR1_IDX]] + [[BYTE_OFF1]];
+// CHECK-NEXT:         size_t [[BYTE_OFF1:v[0-9]+]] = [[TILE1_OFFSET_X]] * [[PAGE_SIZE]];
+// CHECK-NEXT:         size_t [[CB_ADDR1_IDX:v[0-9]+]] = [[CB_PTR1_IDX]] + [[BYTE_OFF1]];
 // Cast to i32 for NOC operation
-// CHECK:         ptrdiff_t [[TILE1_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE1_OFFSET_X]];
-// CHECK:         int32_t [[TILE1_OFFSET:v[0-9]+]] = (int32_t) [[TILE1_OFFSET_PTR]];
-// CHECK:         ptrdiff_t [[CB_ADDR1_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR1_IDX]];
-// CHECK:         int32_t [[CB_ADDR1:v[0-9]+]] = (int32_t) [[CB_ADDR1_PTR]];
-// CHECK:         noc_async_read_tile([[TILE1_OFFSET]], [[ACC1]], [[CB_ADDR1]]);
-// CHECK:       }
-// CHECK:     }
-
-// Second copy: 64x64 (2x2 tiles) → CB2
-// CHECK:     int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[STEP]]);
-// CHECK:     auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
-// CHECK:     TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
+// CHECK-NEXT:         ptrdiff_t [[TILE1_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE1_OFFSET_X]];
+// CHECK-NEXT:         int32_t [[TILE1_OFFSET:v[0-9]+]] = (int32_t) [[TILE1_OFFSET_PTR]];
+// CHECK-NEXT:         ptrdiff_t [[CB_ADDR1_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR1_IDX]];
+// CHECK-NEXT:         int32_t [[CB_ADDR1:v[0-9]+]] = (int32_t) [[CB_ADDR1_PTR]];
+// CHECK-NEXT:         noc_async_read_tile([[TILE1_OFFSET]], [[ACC1]], [[CB_ADDR1]]);
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// Second copy: 64x64 (2x2 tiles) → CB2, use pre-materialized accessor
+// CHECK-NEXT:     int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
-// CHECK:     size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
+// CHECK-NEXT:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
+// CHECK-NEXT:     size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
 // Separate tile loops (same bounds 0..2 x 0..2 but not merged with first copy)
-// CHECK:     for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[LB]]; [[TILE2_Y]] < [[TILES_BOUND]]; [[TILE2_Y]] += [[STEP]]) {
-// CHECK:       for (size_t [[TILE2_X:[a-z][0-9]+]] = [[LB]]; [[TILE2_X]] < [[TILES_BOUND]]; [[TILE2_X]] += [[STEP]]) {
+// CHECK-NEXT:     for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[LB]]; [[TILE2_Y]] < [[TILES_BOUND]]; [[TILE2_Y]] += [[STEP]]) {
+// CHECK-NEXT:       for (size_t [[TILE2_X:[a-z][0-9]+]] = [[LB]]; [[TILE2_X]] < [[TILES_BOUND]]; [[TILE2_X]] += [[STEP]]) {
 // CHECK:         size_t [[TILE2_OFFSET_Y:v[0-9]+]] = [[TILE2_Y]] * [[TILES_BOUND]];
-// CHECK:         size_t [[TILE2_OFFSET_X:v[0-9]+]] = [[TILE2_OFFSET_Y]] + [[TILE2_X]];
+// CHECK-NEXT:         size_t [[TILE2_OFFSET_X:v[0-9]+]] = [[TILE2_OFFSET_Y]] + [[TILE2_X]];
 // CB address computation: cb_ptr + tile_offset * page_size (all size_t arithmetic)
-// CHECK:         size_t [[BYTE_OFF2:v[0-9]+]] = [[TILE2_OFFSET_X]] * [[PAGE_SIZE]];
-// CHECK:         size_t [[CB_ADDR2_IDX:v[0-9]+]] = [[CB_PTR2_IDX]] + [[BYTE_OFF2]];
+// CHECK-NEXT:         size_t [[BYTE_OFF2:v[0-9]+]] = [[TILE2_OFFSET_X]] * [[PAGE_SIZE]];
+// CHECK-NEXT:         size_t [[CB_ADDR2_IDX:v[0-9]+]] = [[CB_PTR2_IDX]] + [[BYTE_OFF2]];
 // Cast to i32 for NOC operation
-// CHECK:         ptrdiff_t [[TILE2_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE2_OFFSET_X]];
-// CHECK:         int32_t [[TILE2_OFFSET:v[0-9]+]] = (int32_t) [[TILE2_OFFSET_PTR]];
-// CHECK:         ptrdiff_t [[CB_ADDR2_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR2_IDX]];
-// CHECK:         int32_t [[CB_ADDR2:v[0-9]+]] = (int32_t) [[CB_ADDR2_PTR]];
-// CHECK:         noc_async_read_tile([[TILE2_OFFSET]], [[ACC2]], [[CB_ADDR2]]);
-// CHECK:       }
-// CHECK:     }
-
-// Consecutive barriers deduplicated to single barrier.
-// CHECK:     noc_async_read_barrier();
-// CHECK:   }
-// CHECK:   return;
+// CHECK-NEXT:         ptrdiff_t [[TILE2_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE2_OFFSET_X]];
+// CHECK-NEXT:         int32_t [[TILE2_OFFSET:v[0-9]+]] = (int32_t) [[TILE2_OFFSET_PTR]];
+// CHECK-NEXT:         ptrdiff_t [[CB_ADDR2_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR2_IDX]];
+// CHECK-NEXT:         int32_t [[CB_ADDR2:v[0-9]+]] = (int32_t) [[CB_ADDR2_PTR]];
+// CHECK-NEXT:         noc_async_read_tile([[TILE2_OFFSET]], [[ACC2]], [[CB_ADDR2]]);
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// Consecutive barriers deduplicated to single barrier
+// CHECK-NEXT:     noc_async_read_barrier();
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return;
 // CHECK-NEXT: }
 
 module {

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_same_layout_different_cb.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_same_layout_different_cb.mlir
@@ -23,59 +23,58 @@
 // CHECK-DAG:   size_t [[PAGE_SIZE:v[0-9]+]] = 4096;
 // CHECK-DAG:   int32_t [[ADDR:v[0-9]+]] = 4096;
 // CHECK-DAG:   size_t [[TILE_LB:v[0-9]+]] = 0;
-
-// First copy: 64x64 (2x2 tiles) → CB [2,2]
+// Function entry: create both tensor accessors
 // CHECK:   int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_LB]]);
-// CHECK:   auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();
-// CHECK:   TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
+// CHECK-NEXT:   auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<2, 0>();
+// CHECK-NEXT:   TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
+// CHECK-NEXT:   int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_STEP]]);
+// CHECK-NEXT:   auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
+// CHECK-NEXT:   TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
+// First copy: 64x64 (2x2 tiles) → CB [2,2], use pre-materialized accessor
 // CHECK:   int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
 // CHECK:   ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR1]];
 // CHECK:   size_t [[CB_PTR1_IDX:v[0-9]+]] = (size_t) [[CB_PTR1_PTRDIFF]];
 // Generated tile loops iterate over tensor grid (2x2)
-// CHECK:   for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_Y]] < [[TILES_BOUND]]; [[TILE1_Y]] += [[TILE_STEP]]) {
-// CHECK:     for (size_t [[TILE1_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_X]] < [[TILES_BOUND]]; [[TILE1_X]] += [[TILE_STEP]]) {
+// CHECK-NEXT:   for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_Y]] < [[TILES_BOUND]]; [[TILE1_Y]] += [[TILE_STEP]]) {
+// CHECK-NEXT:     for (size_t [[TILE1_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_X]] < [[TILES_BOUND]]; [[TILE1_X]] += [[TILE_STEP]]) {
 // CHECK:       size_t [[TILE1_OFFSET_Y:v[0-9]+]] = [[TILE1_Y]] * [[TILES_BOUND]];
-// CHECK:       size_t [[TILE1_OFFSET_X:v[0-9]+]] = [[TILE1_OFFSET_Y]] + [[TILE1_X]];
+// CHECK-NEXT:       size_t [[TILE1_OFFSET_X:v[0-9]+]] = [[TILE1_OFFSET_Y]] + [[TILE1_X]];
 // CB address computation: cb_ptr + tile_offset * page_size (all size_t arithmetic)
-// CHECK:       size_t [[BYTE_OFF1:v[0-9]+]] = [[TILE1_OFFSET_X]] * [[PAGE_SIZE]];
-// CHECK:       size_t [[CB_ADDR1_IDX:v[0-9]+]] = [[CB_PTR1_IDX]] + [[BYTE_OFF1]];
+// CHECK-NEXT:       size_t [[BYTE_OFF1:v[0-9]+]] = [[TILE1_OFFSET_X]] * [[PAGE_SIZE]];
+// CHECK-NEXT:       size_t [[CB_ADDR1_IDX:v[0-9]+]] = [[CB_PTR1_IDX]] + [[BYTE_OFF1]];
 // Cast to i32 for NOC operation
-// CHECK:       ptrdiff_t [[TILE1_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE1_OFFSET_X]];
-// CHECK:       int32_t [[TILE1_OFFSET:v[0-9]+]] = (int32_t) [[TILE1_OFFSET_PTR]];
-// CHECK:       ptrdiff_t [[CB_ADDR1_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR1_IDX]];
-// CHECK:       int32_t [[CB_ADDR1:v[0-9]+]] = (int32_t) [[CB_ADDR1_PTR]];
-// CHECK:       noc_async_read_tile([[TILE1_OFFSET]], [[ACC1]], [[CB_ADDR1]]);
-// CHECK:     }
-// CHECK:   }
-// CHECK:   noc_async_read_barrier();
-
-// Second copy: 64x64 (2x2 tiles) → CB [4,1] - SAME tensor layout, DIFFERENT CB shape
-// CHECK:   int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_STEP]]);
-// CHECK:   auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<3, 1>();
-// CHECK:   TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
+// CHECK-NEXT:       ptrdiff_t [[TILE1_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE1_OFFSET_X]];
+// CHECK-NEXT:       int32_t [[TILE1_OFFSET:v[0-9]+]] = (int32_t) [[TILE1_OFFSET_PTR]];
+// CHECK-NEXT:       ptrdiff_t [[CB_ADDR1_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR1_IDX]];
+// CHECK-NEXT:       int32_t [[CB_ADDR1:v[0-9]+]] = (int32_t) [[CB_ADDR1_PTR]];
+// CHECK-NEXT:       noc_async_read_tile([[TILE1_OFFSET]], [[ACC1]], [[CB_ADDR1]]);
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   noc_async_read_barrier();
+// Second copy: 64x64 (2x2 tiles) → CB [4,1] - SAME tensor layout, DIFFERENT CB shape, use pre-materialized accessor
+// CHECK-NEXT:   int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:   ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
-// CHECK:   size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
+// CHECK-NEXT:   ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
+// CHECK-NEXT:   size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
 // Generated tile loops still iterate over tensor grid (2x2), not CB shape (4x1)
-// CHECK:   for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_Y]] < [[TILES_BOUND]]; [[TILE2_Y]] += [[TILE_STEP]]) {
-// CHECK:     for (size_t [[TILE2_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_X]] < [[TILES_BOUND]]; [[TILE2_X]] += [[TILE_STEP]]) {
+// CHECK-NEXT:   for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_Y]] < [[TILES_BOUND]]; [[TILE2_Y]] += [[TILE_STEP]]) {
+// CHECK-NEXT:     for (size_t [[TILE2_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_X]] < [[TILES_BOUND]]; [[TILE2_X]] += [[TILE_STEP]]) {
 // CHECK:       size_t [[TILE2_OFFSET_Y:v[0-9]+]] = [[TILE2_Y]] * [[TILES_BOUND]];
-// CHECK:       size_t [[TILE2_OFFSET_X:v[0-9]+]] = [[TILE2_OFFSET_Y]] + [[TILE2_X]];
+// CHECK-NEXT:       size_t [[TILE2_OFFSET_X:v[0-9]+]] = [[TILE2_OFFSET_Y]] + [[TILE2_X]];
 // CB address computation: cb_ptr + tile_offset * page_size (all size_t arithmetic)
-// CHECK:       size_t [[BYTE_OFF2:v[0-9]+]] = [[TILE2_OFFSET_X]] * [[PAGE_SIZE]];
-// CHECK:       size_t [[CB_ADDR2_IDX:v[0-9]+]] = [[CB_PTR2_IDX]] + [[BYTE_OFF2]];
+// CHECK-NEXT:       size_t [[BYTE_OFF2:v[0-9]+]] = [[TILE2_OFFSET_X]] * [[PAGE_SIZE]];
+// CHECK-NEXT:       size_t [[CB_ADDR2_IDX:v[0-9]+]] = [[CB_PTR2_IDX]] + [[BYTE_OFF2]];
 // Cast to i32 for NOC operation
-// CHECK:       ptrdiff_t [[TILE2_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE2_OFFSET_X]];
-// CHECK:       int32_t [[TILE2_OFFSET:v[0-9]+]] = (int32_t) [[TILE2_OFFSET_PTR]];
-// CHECK:       ptrdiff_t [[CB_ADDR2_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR2_IDX]];
-// CHECK:       int32_t [[CB_ADDR2:v[0-9]+]] = (int32_t) [[CB_ADDR2_PTR]];
-// CHECK:       noc_async_read_tile([[TILE2_OFFSET]], [[ACC2]], [[CB_ADDR2]]);
-// CHECK:     }
-// CHECK:   }
-// CHECK:   noc_async_read_barrier();
-// CHECK:   return;
+// CHECK-NEXT:       ptrdiff_t [[TILE2_OFFSET_PTR:v[0-9]+]] = (ptrdiff_t) [[TILE2_OFFSET_X]];
+// CHECK-NEXT:       int32_t [[TILE2_OFFSET:v[0-9]+]] = (int32_t) [[TILE2_OFFSET_PTR]];
+// CHECK-NEXT:       ptrdiff_t [[CB_ADDR2_PTR:v[0-9]+]] = (ptrdiff_t) [[CB_ADDR2_IDX]];
+// CHECK-NEXT:       int32_t [[CB_ADDR2:v[0-9]+]] = (int32_t) [[CB_ADDR2_PTR]];
+// CHECK-NEXT:       noc_async_read_tile([[TILE2_OFFSET]], [[ACC2]], [[CB_ADDR2]]);
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   noc_async_read_barrier();
+// CHECK-NEXT:   return;
 // CHECK-NEXT: }
 
 module {


### PR DESCRIPTION
Move tensor accessor ops to function level instead of per-copy (tt-metal use pattern). `check-ttlang-all` passes on qb. No new tests added, but made existing tests more specific.

(need to update for slices)

### Checklist:
*   [x] Self-reviewed (style, logic)
*   [x] Added tests (or justified none needed)
*   [x] PR is small and focused (one task)
