### PR TITLE
Support range slice syntax; validate against cb shape; pass in correct shape from cb for multitile slicing

### DIFF
--- a/test/python/invalid/invalid_copy_no_cb.py
+++ b/test/python/invalid/invalid_copy_no_cb.py
@@ -20,7 +20,7 @@ import ttnn
 from ttlang import ttl
 
 
-# CHECK: error: copy() requires exactly one block argument
+# CHECK: error: copy() with tensor subscript dst requires block src
 # CHECK-NEXT:   --> {{.*}}invalid_copy_no_cb.py:[[LINE:[0-9]+]]:10
 # CHECK-NEXT:    |
 # CHECK-NEXT: [[LINE]] |         tx = ttl.copy(lhs[0, 0], rhs[0, 0])

--- a/test/python/invalid/invalid_multitile_cb_index_syntax.py
+++ b/test/python/invalid/invalid_multitile_cb_index_syntax.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: not %python %s 2>&1 | FileCheck %s
+
+"""
+Validation test: multi-tile CB requires range syntax for tensor slices.
+
+When a CB has shape > 1x1, tensor indexing must use range syntax
+(e.g., tensor[0:2, 0:2]) rather than index syntax (e.g., tensor[0, 0]).
+"""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import ttnn
+from ttlang import ttl
+
+
+# CHECK: error: CB shape [2, 2] requires range syntax (e.g., tensor[0:2, 0:2]), but got index syntax (e.g., tensor[0, 0])
+@ttl.kernel(grid=(1, 1))
+def invalid_multitile_index_kernel(inp, out):
+    """This kernel should fail: 2x2 CB but using index syntax."""
+    inp_cb = ttl.make_circular_buffer_like(inp, shape=(2, 2), buffer_factor=2)
+    out_cb = ttl.make_circular_buffer_like(out, shape=(2, 2), buffer_factor=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = inp_cb.wait()
+        o = out_cb.reserve()
+        o.store(x)
+        inp_cb.pop()
+        out_cb.push()
+
+    @ttl.datamovement()
+    def dm_read():
+        inp_blk = inp_cb.reserve()
+        # INVALID: using index syntax with 2x2 CB
+        tx = ttl.copy(inp[0, 0], inp_blk)
+        tx.wait()
+        inp_cb.push()
+
+    @ttl.datamovement()
+    def dm_write():
+        out_blk = out_cb.wait()
+        tx = ttl.copy(out_blk, out[0:2, 0:2])
+        tx.wait()
+        out_cb.pop()
+
+    return ttl.Program(compute_fn, dm_read, dm_write)(inp, out)
+
+
+if __name__ == "__main__":
+    import torch
+
+    print("=== Multi-tile CB Index Syntax Validation Test ===")
+
+    device = ttnn.open_device(device_id=0)
+
+    try:
+        inp_torch = torch.full((64, 64), 1.0, dtype=torch.bfloat16)
+        out_torch = torch.zeros((64, 64), dtype=torch.bfloat16)
+
+        inp = ttnn.from_torch(
+            inp_torch,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        out = ttnn.from_torch(
+            out_torch,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        invalid_multitile_index_kernel(inp, out)
+
+        print("ERROR: Expected ValueError was not raised!")
+        exit(1)
+
+    finally:
+        ttnn.close_device(device)

--- a/test/python/invalid/invalid_singletile_cb_range_syntax.py
+++ b/test/python/invalid/invalid_singletile_cb_range_syntax.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: not %python %s 2>&1 | FileCheck %s
+
+"""
+Validation test: single-tile CB requires index syntax for tensor slices.
+
+When a CB has shape 1x1, tensor indexing must use index syntax
+(e.g., tensor[0, 0]) rather than range syntax (e.g., tensor[0:1, 0:1]).
+"""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import ttnn
+from ttlang import ttl
+
+
+# CHECK: error: CB shape [1, 1] requires index syntax (e.g., tensor[0, 0]), but got range syntax (e.g., tensor[0:2, 0:2])
+@ttl.kernel(grid=(1, 1))
+def invalid_singletile_range_kernel(inp, out):
+    """This kernel should fail: 1x1 CB but using range syntax."""
+    inp_cb = ttl.make_circular_buffer_like(inp, shape=(1, 1), buffer_factor=2)
+    out_cb = ttl.make_circular_buffer_like(out, shape=(1, 1), buffer_factor=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = inp_cb.wait()
+        o = out_cb.reserve()
+        o.store(x)
+        inp_cb.pop()
+        out_cb.push()
+
+    @ttl.datamovement()
+    def dm_read():
+        inp_blk = inp_cb.reserve()
+        # INVALID: using range syntax with 1x1 CB
+        tx = ttl.copy(inp[0:1, 0:1], inp_blk)
+        tx.wait()
+        inp_cb.push()
+
+    @ttl.datamovement()
+    def dm_write():
+        out_blk = out_cb.wait()
+        tx = ttl.copy(out_blk, out[0, 0])
+        tx.wait()
+        out_cb.pop()
+
+    return ttl.Program(compute_fn, dm_read, dm_write)(inp, out)
+
+
+if __name__ == "__main__":
+    import torch
+
+    print("=== Single-tile CB Range Syntax Validation Test ===")
+
+    device = ttnn.open_device(device_id=0)
+
+    try:
+        inp_torch = torch.full((32, 32), 1.0, dtype=torch.bfloat16)
+        out_torch = torch.zeros((32, 32), dtype=torch.bfloat16)
+
+        inp = ttnn.from_torch(
+            inp_torch,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        out = ttnn.from_torch(
+            out_torch,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        invalid_singletile_range_kernel(inp, out)
+
+        print("ERROR: Expected ValueError was not raised!")
+        exit(1)
+
+    finally:
+        ttnn.close_device(device)

--- a/test/python/simple_add_multitile.py
+++ b/test/python/simple_add_multitile.py
@@ -43,19 +43,19 @@ def add_multitile_kernel(lhs, rhs, out):
     @ttl.datamovement()
     def dm_read():
         lhs_blk = lhs_cb.reserve()
-        tx_lhs = ttl.copy(lhs[0, 0], lhs_blk)
+        tx_lhs = ttl.copy(lhs[0:2, 0:2], lhs_blk)
         tx_lhs.wait()
         lhs_cb.push()
 
         rhs_blk = rhs_cb.reserve()
-        tx_rhs = ttl.copy(rhs[0, 0], rhs_blk)
+        tx_rhs = ttl.copy(rhs[0:2, 0:2], rhs_blk)
         tx_rhs.wait()
         rhs_cb.push()
 
     @ttl.datamovement()
     def dm_write():
         out_blk = out_cb.wait()
-        tx = ttl.copy(out_blk, out[0, 0])
+        tx = ttl.copy(out_blk, out[0:2, 0:2])
         tx.wait()
         out_cb.pop()
 

--- a/test/python/test_elementwise_shapes.py
+++ b/test/python/test_elementwise_shapes.py
@@ -86,19 +86,19 @@ def {name}_kernel(lhs, rhs, out):
     @ttl.datamovement()
     def dm_read():
         lhs_blk = lhs_cb.reserve()
-        tx_lhs = ttl.copy(lhs[0, 0], lhs_blk)
+        tx_lhs = ttl.copy(lhs[{slice_syntax}], lhs_blk)
         tx_lhs.wait()
         lhs_cb.push()
 
         rhs_blk = rhs_cb.reserve()
-        tx_rhs = ttl.copy(rhs[0, 0], rhs_blk)
+        tx_rhs = ttl.copy(rhs[{slice_syntax}], rhs_blk)
         tx_rhs.wait()
         rhs_cb.push()
 
     @ttl.datamovement()
     def dm_write():
         out_blk = out_cb.wait()
-        tx = ttl.copy(out_blk, out[0, 0])
+        tx = ttl.copy(out_blk, out[{slice_syntax}])
         tx.wait()
         out_cb.pop()
 
@@ -129,19 +129,19 @@ def {name}_kernel(lhs, rhs, out):
     @ttl.datamovement()
     def dm_read():
         lhs_blk = lhs_cb.reserve()
-        tx_lhs = ttl.copy(lhs[0, 0], lhs_blk)
+        tx_lhs = ttl.copy(lhs[{slice_syntax}], lhs_blk)
         tx_lhs.wait()
         lhs_cb.push()
 
         rhs_blk = rhs_cb.reserve()
-        tx_rhs = ttl.copy(rhs[0, 0], rhs_blk)
+        tx_rhs = ttl.copy(rhs[{slice_syntax}], rhs_blk)
         tx_rhs.wait()
         rhs_cb.push()
 
     @ttl.datamovement()
     def dm_write():
         out_blk = out_cb.wait()
-        tx = ttl.copy(out_blk, out[0, 0])
+        tx = ttl.copy(out_blk, out[{slice_syntax}])
         tx.wait()
         out_cb.pop()
 
@@ -169,14 +169,14 @@ def {name}_kernel(inp, out):
     @ttl.datamovement()
     def dm_read():
         inp_blk = inp_cb.reserve()
-        tx_inp = ttl.copy(inp[0, 0], inp_blk)
+        tx_inp = ttl.copy(inp[{slice_syntax}], inp_blk)
         tx_inp.wait()
         inp_cb.push()
 
     @ttl.datamovement()
     def dm_write():
         out_blk = out_cb.wait()
-        tx = ttl.copy(out_blk, out[0, 0])
+        tx = ttl.copy(out_blk, out[{slice_syntax}])
         tx.wait()
         out_cb.pop()
 
@@ -187,6 +187,14 @@ def {name}_kernel(inp, out):
 # =============================================================================
 # Kernel Factories - generate kernels with specific shapes
 # =============================================================================
+
+
+def _get_slice_syntax(tile_rows: int, tile_cols: int) -> str:
+    """Return slice syntax for tensor indexing based on tile shape."""
+    if tile_rows == 1 and tile_cols == 1:
+        return "0, 0"
+    return f"0:{tile_rows}, 0:{tile_cols}"
+
 
 # Cache for generated kernels: (name, op, tile_rows, tile_cols) -> kernel
 _kernel_cache: dict[tuple, Callable] = {}
@@ -220,6 +228,7 @@ def make_binary_kernel(name: str, op: str, tile_rows: int, tile_cols: int) -> Ca
         tile_rows=tile_rows,
         tile_cols=tile_cols,
         buffer_factor=buffer_factor,
+        slice_syntax=_get_slice_syntax(tile_rows, tile_cols),
     )
 
     with tempfile.NamedTemporaryFile(
@@ -256,6 +265,7 @@ def make_binary_fn_kernel(
         tile_rows=tile_rows,
         tile_cols=tile_cols,
         buffer_factor=buffer_factor,
+        slice_syntax=_get_slice_syntax(tile_rows, tile_cols),
     )
 
     with tempfile.NamedTemporaryFile(
@@ -290,6 +300,7 @@ def make_unary_kernel(name: str, op: str, tile_rows: int, tile_cols: int) -> Cal
         tile_rows=tile_rows,
         tile_cols=tile_cols,
         buffer_factor=buffer_factor,
+        slice_syntax=_get_slice_syntax(tile_rows, tile_cols),
     )
 
     with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
  Adds range slice syntax support for tensor indexing (tensor[0:2, 0:2]) and enforces that slice syntax matches CB shape. This enables correct multi-tile transfers where CB shape determines block size.

    - Validate slice syntax against CB shape
    - Update `_make_tensor_slice()` to accept slice_shape parameter (now passes correct shape for multi-tile copies (extracted from cb shape))
    - Enforce: multi-tile CB (>1x1) requires range syntax; single-tile CB (1x1) requires index syntax

  TODO: Validate that range size (end - start) matches CB shape dimensions (requires constant folding or runtime check).