### PR TITLE
Fix DST separate-output-region handling for merged sets with yielded values

### DIFF
--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/copy_insertion_multi_consumer.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/copy_insertion_multi_consumer.mlir
@@ -36,7 +36,7 @@
 // IR: %[[ABS:.*]] = ttl.tile_abs %[[COPY]]
 // Last consumer (exp) uses original
 // IR: %[[EXP:.*]] = ttl.tile_exp %[[MUL]]
-// SEPARATE: ttl.tile_exp {{.*}} {dst_idx = 0 : i32}
+// SEPARATE: ttl.tile_exp {{.*}} {dst_idx = 2 : i32}
 // IR: ttl.yield %[[ABS]], %[[EXP]]
 
 func.func @multi_consumer_two_unary(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_add_mul_exp_chain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_add_mul_exp_chain.mlir
@@ -33,7 +33,7 @@
 // CHECK-NEXT:   %[[DTOK2:.*]], %[[DTILE2:.*]] = ttl.copy_tile %[[C]], %[[LINIDX]], %[[C1]] : !ttcore.tile<32x32, f32>, index, index -> !ttl.dst, !ttcore.tile<32x32, f32>
 // CHECK-NEXT:   %[[MUL:.*]] = ttl.tile_mul %[[ADD]], %[[DTILE2]] {dst_idx = 0 : i32} : !ttcore.tile<32x32, f32>
 // CHECK-NEXT:   %[[EXP:.*]] = ttl.tile_exp %[[MUL]] {dst_idx = 0 : i32} : !ttcore.tile<32x32, f32>
-// SEPARATE: ttl.tile_exp {{.*}} {dst_idx = 0 : i32}
+// SEPARATE: ttl.tile_exp {{.*}} {dst_idx = 2 : i32}
 // CHECK-NEXT:   ttl.yield %[[EXP]] : !ttcore.tile<32x32, f32>
 // CHECK: } -> tensor<2x2x!ttcore.tile<32x32, f32>>
 // CHECK: return %[[RES]]

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_seven_op_chain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_seven_op_chain.mlir
@@ -30,7 +30,7 @@
 // CHECK-NEXT:        %[[LOG:.*]] = ttl.tile_log %[[EXP]] {dst_idx = 0 : i32}
 // CHECK-NEXT:        %[[NEG:.*]] = ttl.tile_neg %[[LOG]] {dst_idx = 0 : i32}
 // CHECK-NEXT:        %[[SQRT:.*]] = ttl.tile_sqrt %[[NEG]] {dst_idx = 0 : i32}
-// SEPARATE: ttl.tile_sqrt {{.*}} {dst_idx = 0 : i32}
+// SEPARATE: ttl.tile_sqrt {{.*}} {dst_idx = 2 : i32}
 // CHECK-NEXT:        ttl.tile_regs_commit
 // CHECK-NEXT:        ttl.tile_regs_wait
 // CHECK-NEXT:        %[[VIEW:.*]] = ttl.cb_reserve %[[CB2]]

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/separate_output_region_merged_set.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/separate_output_region_merged_set.mlir
@@ -1,0 +1,82 @@
+// Summary: Merged sets containing yielded values should be allocated in output region.
+// This test demonstrates the bug where Phase 3 allocates a merged set to the input
+// region when the leader value is not yielded, even though one of its merged partners
+// IS yielded. The fix ensures Phase 3 skips merged sets if ANY member is yielded.
+//
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-assign-dst{separate-output-region=1}))' -debug-only=ttl-assign-dst 2>&1 | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-assign-dst{separate-output-region=1}))' | FileCheck %s --check-prefix=IR
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// Test case: Binary operation followed by unary operation.
+// The binary result (%mul) is NOT yielded directly, but the unary result (%abs) IS yielded.
+// Phase 2 merges %mul and %abs (unary operations share DST with their input).
+// With the bug: Phase 3 sees %mul is not yielded, allocates the merged set to input region.
+// After fix: Phase 3 sees %abs (merged with %mul) is yielded, skips the merged set.
+//            Phase 4 allocates the entire merged set to output region.
+
+// Verify Phase 2 merges tile_mul and tile_abs
+// CHECK: === Phase 2: Build Live Intervals ===
+// CHECK: Phase 2: Merged
+// CHECK-SAME: tile_mul
+// CHECK-SAME: tile_abs
+// CHECK: Merged set interval: [0, 2] for 2 values
+
+// Verify Phase 3 only allocates block arguments (inputs)
+// CHECK: === Phase 3: Linear Scan Allocation ===
+// CHECK: Phase 3: Allocated DST[0]
+// CHECK-SAME: (merged set size: 1)
+// CHECK: Phase 3: Allocated DST[1]
+// CHECK-SAME: (merged set size: 1)
+// Phase 3 should NOT allocate the merged set (size 2) because one member is yielded
+// CHECK-NOT: Phase 3: Allocated DST{{.*}} (merged set size: 2)
+// CHECK: Phase 3 footprint: 2 registers
+
+// Verify Phase 4 allocates the merged set to output region (starting at DST[2])
+// CHECK: === Phase 4: Linear Scan Allocation ===
+// CHECK: Phase 4: Allocated DST[2]
+// CHECK-SAME: (merged set size: 2)
+
+// Verify final DST assignment: both merged values get output region index
+// CHECK: === Final DST Assignment ===
+// CHECK-DAG: tile_mul{{.*}} -> DST[2]
+// CHECK-DAG: tile_abs{{.*}} -> DST[2]
+// CHECK: Max DST usage: 3 / 8 registers
+
+// Verify IR has correct dst_idx attributes
+// IR-LABEL: func.func @binary_unary_merged_output
+// IR: ttl.compute
+// IR: ttl.tile_mul {{.*}} {dst_idx = 2 : i32}
+// IR: ttl.tile_abs {{.*}} {dst_idx = 2 : i32}
+
+func.func @binary_unary_merged_output(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
+                                      %b: tensor<2x2x!ttcore.tile<32x32, f32>>)
+    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+
+  %cb0 = ttl.bind_cb {cb_index = 0, buffer_factor = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, buffer_factor = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 16, buffer_factor = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+
+  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %b_cb = ttl.attach_cb %b, %cb1 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %init_cb = ttl.attach_cb %init, %cb2 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+
+  %result = ttl.compute
+      ins(%a_cb, %b_cb : tensor<2x2x!ttcore.tile<32x32, f32>>,
+                         tensor<2x2x!ttcore.tile<32x32, f32>>)
+      outs(%init_cb : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [#map, #map, #map],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
+       %b_tile: !ttcore.tile<32x32, f32>,
+       %out_tile: !ttcore.tile<32x32, f32>):
+    // Binary operation: creates intermediate value (not yielded)
+    %mul = ttl.tile_mul %a_tile, %b_tile : !ttcore.tile<32x32, f32>
+    // Unary operation: merges with %mul, result IS yielded
+    %abs = ttl.tile_abs %mul : !ttcore.tile<32x32, f32>
+    ttl.yield %abs : !ttcore.tile<32x32, f32>
+  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+
+  func.return %result : tensor<2x2x!ttcore.tile<32x32, f32>>
+}


### PR DESCRIPTION
### What?
Fix Phase 3 of the DST allocation pass to correctly defer merged sets containing yielded values to Phase 4 when `--separate-output-region=1` is enabled.

### Why?
Phase 3 filtered by checking if the current value is yielded, but when values are merged (unary ops share DST with their input), the entire merged set is allocated together. If any member is yielded, the set must be deferred to Phase 4 to maintain the separate output region invariant.

Example bug scenario:
```mlir
%0 = tile_mul(%in0, %in1)  // Intermediate (not yielded)
%1 = tile_abs(%0)          // Output (yielded), merged with %0
yield %1
```
Phase 3 saw `%0` wasn't yielded and allocated the merged set `{%0, %1}` to the input region (DST[0]), placing output value `%1` incorrectly. This can cause outputs to be overwritten during (future) loop unrolling.

### How?
Updated Phase 3 filter to check all members of a merged set using `llvm::none_of`. If any member is yielded, the entire set is skipped in Phase 3 and allocated by Phase 4 to the output region.

Changed files:
- `lib/Dialect/TTL/Transforms/TTLAssignDST.cpp`: Updated filter lambda (6 lines)
- Added test: `test/ttlang/Dialect/TTL/Transforms/AssignDST/separate_output_region_merged_set.mlir`
- Updated 3 existing test expectations for corrected `dst_idx` values

### How to Test?
```bash
cmake --build build --target check-ttlang
```


### Checklist:
*   [x] Self-reviewed (style, logic)
*   [x] Added tests (or justified none needed)
*   [x] PR is small and focused (one task)
