### PR TITLE
IGNORE (just testing something). Skip multicore pytests that fail on wormhole

### DIFF
--- a/test/python/test_adversarial_multicore.py
+++ b/test/python/test_adversarial_multicore.py
@@ -19,7 +19,7 @@ Evil features:
 import pytest
 import torch
 import ttnn
-from test_helpers import to_dram
+from test_helpers import to_dram, skip_if_wormhole
 
 import ttl
 
@@ -190,6 +190,7 @@ def compute_expected(a, b, c, d):
     return exp1, exp2, exp3, exp4
 
 
+@skip_if_wormhole()
 def test_adversarial_multicore(device):
     """Test adversarial kernel designed to break compiler optimizations."""
     # Random inputs

--- a/test/python/test_bcast_multicore.py
+++ b/test/python/test_bcast_multicore.py
@@ -22,7 +22,7 @@ Features:
 import pytest
 import torch
 import ttnn
-from test_helpers import to_dram, to_l1
+from test_helpers import to_dram, to_l1, skip_if_wormhole
 
 import ttl
 
@@ -202,6 +202,7 @@ def compute_expected_l1(c):
     return exp3
 
 
+@skip_if_wormhole()
 def test_bcast_multicore(device):
     """Test scoping-based broadcast: L1 tile reused across DRAM iterations."""
     # Random DRAM inputs

--- a/test/python/test_comprehensive_multicore.py
+++ b/test/python/test_comprehensive_multicore.py
@@ -15,7 +15,7 @@ Comprehensive multicore test combining multiple features:
 import pytest
 import torch
 import ttnn
-from test_helpers import to_dram, to_l1
+from test_helpers import to_dram, to_l1, skip_if_wormhole
 
 import ttl
 
@@ -162,6 +162,7 @@ def compute_expected(a, b, c):
     return exp1, exp2, exp3
 
 
+@skip_if_wormhole()
 def test_comprehensive_multicore(device):
     """Test comprehensive multicore kernel with mixed DRAM/L1 tensors."""
     # Random inputs


### PR DESCRIPTION
## Problem
On IRD wormhole machines (e.g., aus-wh-*), some of the pytests fail for me on main, e.g.,
```2026-01-17 19:19:55.614 | critical |          Always | TT_FATAL: Illegal kernel placement for ttlang_kernel_dm_write_b57abb08, Kernels cannot be placed on dispatch cores! (assert.hpp:103)
================================================== short test summary info ===================================================
FAILED test/python/test_adversarial_multicore.py::test_adversarial_multicore - RuntimeError: TT_FATAL @ /localdev/bnorris/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:13...
===================================================== 1 failed in 2.10s ======================================================
2026-01-17 19:19:56.961 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:447)```

This is just a quick check for CI. Although this issue does not actually exist on the CI wormhole machine.