### PR TITLE
Adjust demo_one on BH

### DIFF
--- a/examples/demo_one.py
+++ b/examples/demo_one.py
@@ -21,7 +21,7 @@ TILE_SIZE = 32
 GRANULARITY = 4
 
 
-# For BH extended grid: grid=(12, 8) with shape=(3072, 2048)
+# For BH extended grid: grid=(12, 10) with shape=(2560, 3072)
 @ttl.kernel(grid=(8, 8))  # (cols, rows)
 def __demo_kernel(a, b, c, y):
     row_tiles_per_block = GRANULARITY


### PR DESCRIPTION
Adjust demo_one on BH to use full 12 by 10 grid and fix the corresponding shape order.