### PR TITLE
Revise TT-Lang getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,63 +18,6 @@ Tenstorrent developers today face a choice between TT-NN which provides high-lev
 
 TT-Lang bridges this gap through progressive disclosure: simple kernels require minimal specification where the compiler infers compute API operations, NOC addressing, DST register allocation and more from high-level abstractions, while complex kernels allow developers to open the hood and craft pipelining and synchronization details directly. The primary use case is kernel fusion for model deployment. Engineers porting models through TT-NN quickly encounter operations that need to be fused for performance or patterns that TT-NN cannot express, and today this requires rewriting in TT-Metalium which takes weeks and demands undivided attention and hardware debugging expertise. TT-Lang makes this transition fast and correct: a developer can take a sequence of TT-NN operations, express the fused equivalent with explicit control over intermediate results and memory layout, validate correctness through simulation, and integrate the result as a drop-in replacement in their TT-NN graph.
 
-## Getting Started with TT-Lang
-
-> ⚠️ Skills are an experimental feature under active development; skills currently reference in-flight functionality that may not be available such as the matmul operator.
-
-The easiest way to get started is with [Claude Code](https://claude.com/claude-code) and an existing codebase. TT-Lang provides slash commands that guide Claude through kernel translation, testing, profiling, and optimization workflows.
-
-### Example Workflow
-
-```bash
-# Clone a model you want to port
-git clone https://github.com/karpathy/nanoGPT
-cd nanoGPT
-
-# Install TT-Lang slash commands (one-time setup)
-cd /path/to/tt-lang/claude-slash-commands
-./install.sh
-
-# Open Claude Code in your project
-cd /path/to/nanoGPT
-claude
-
-# Now type slash to use skills to translate kernels to TT-Lang:
-#   /ttl-import model.py    "translate the attention kernel to TT-Lang DSL"
-```
-
-### Available Commands
-
-Run `/ttl-help` in Claude Code to see all available commands. Here is a summary:
-
-```
-/ttl-import <kernel>
-    Translate a CUDA, Triton, or PyTorch kernel to TT-Lang DSL. Analyzes the
-    source kernel, maps GPU concepts to Tenstorrent equivalents, and iterates
-    on testing until the translated kernel matches the original behavior.
-
-/ttl-export <kernel>
-    Export a TT-Lang kernel to TT-Metal C++ code. Runs the compiler pipeline,
-    extracts the generated C++, and beautifies it by improving variable names
-    and removing unnecessary casts for readable, production-ready output.
-
-/ttl-optimize <kernel>
-    Profile a kernel and apply performance optimizations. Identifies bottlenecks,
-    suggests improvements like tiling, pipelining, and fusion, then validates
-    that optimizations preserve correctness while improving throughput.
-
-/ttl-profile <kernel>
-    Run the profiler and display per-line cycle counts. Shows exactly where time
-    is spent in the kernel with annotated source, hotspot highlighting, and
-    memory vs compute breakdown.
-
-/ttl-bug <reproducer>
-    File a bug report for TT-Lang with a reproducer.
-
-/ttl-help
-    List all available TT-Lang slash commands with descriptions and examples.
-```
-
 ## Prerequisites
 
 * [CMake](https://cmake.org/) 3.28+
@@ -147,6 +90,63 @@ Note: this project is currently in early prototype phase, examples are not final
 - [Simulator Quick Start](docs/SIMULATOR.md) - Run kernels in simulation without building the compiler
 - [Testing Guide](test/TESTING.md) - How to write and run tests using LLVM lit
 - [Sphinx docs](docs/README.md) - How to build, view, and extend the documentation (docs are disabled by default; enable with `-DTTLANG_ENABLE_DOCS=ON` and build with `cmake --build build --target ttlang-docs`)
+
+## Claude Skills
+
+> ⚠️ Skills are an experimental feature under active development; skills currently reference in-flight functionality that may not be available such as the matmul operator.
+
+One of the easiest way to get started with tt-lang is using [Claude Code](https://claude.com/claude-code) and an existing codebase. TT-Lang provides slash commands that guide Claude through kernel translation, testing, profiling, and optimization workflows.
+
+### Example Workflow
+
+```bash
+# Clone a model you want to port
+git clone https://github.com/karpathy/nanoGPT
+cd nanoGPT
+
+# Install TT-Lang slash commands (one-time setup)
+cd /path/to/tt-lang/claude-slash-commands
+./install.sh
+
+# Open Claude Code in your project
+cd /path/to/nanoGPT
+claude
+
+# Now type slash to use skills to translate kernels to TT-Lang:
+#   /ttl-import model.py    "translate the attention kernel to TT-Lang DSL"
+```
+
+### Available Commands
+
+Run `/ttl-help` in Claude Code to see all available commands. Here is a summary:
+
+```
+/ttl-import <kernel>
+    Translate a CUDA, Triton, or PyTorch kernel to TT-Lang DSL. Analyzes the
+    source kernel, maps GPU concepts to Tenstorrent equivalents, and iterates
+    on testing until the translated kernel matches the original behavior.
+
+/ttl-export <kernel>
+    Export a TT-Lang kernel to TT-Metal C++ code. Runs the compiler pipeline,
+    extracts the generated C++, and beautifies it by improving variable names
+    and removing unnecessary casts for readable, production-ready output.
+
+/ttl-optimize <kernel>
+    Profile a kernel and apply performance optimizations. Identifies bottlenecks,
+    suggests improvements like tiling, pipelining, and fusion, then validates
+    that optimizations preserve correctness while improving throughput.
+
+/ttl-profile <kernel>
+    Run the profiler and display per-line cycle counts. Shows exactly where time
+    is spent in the kernel with annotated source, hotspot highlighting, and
+    memory vs compute breakdown.
+
+/ttl-bug <reproducer>
+    File a bug report for TT-Lang with a reproducer.
+
+/ttl-help
+    List all available TT-Lang slash commands with descriptions and examples.
+```
 
 ## Auto-Profiling
 


### PR DESCRIPTION
My original PR put these near the top of the readme, but given that these are experimental, they should be closer to the bottom after other setup and quick start sections. 