### PR TITLE
[ttl] Add ttl.compute verifier checks to catch malformed indexing maps

### DIFF
--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -413,13 +413,18 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
            << expectedMaps << " indexing maps but got " << mapsAttr.size();
   }
 
-  // Verify iterator_types contains only "parallel" or "reduction".
-  for (mlir::Attribute attr : getIteratorTypes()) {
+  // Verify iterator_types and track reduction dims for map validation.
+  // Reduction dims may appear in input maps but must not appear in output maps.
+  SmallVector<bool> isReductionDim(getIteratorTypes().size(), false);
+  for (auto [idx, attr] : llvm::enumerate(getIteratorTypes())) {
     auto strAttr = mlir::dyn_cast<mlir::StringAttr>(attr);
     if (!strAttr || (strAttr.getValue() != "parallel" &&
                      strAttr.getValue() != "reduction")) {
       return emitOpError(
           "iterator_types must contain only 'parallel' or 'reduction'");
+    }
+    if (strAttr.getValue() == "reduction") {
+      isReductionDim[idx] = true;
     }
   }
 
@@ -472,12 +477,45 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
              << expectedResults << " results to match operand rank, but got "
              << map.getNumResults();
     }
-    return mlir::success();
+    return success();
+  };
+
+  // Unlike linalg.generic (which allows arbitrary affine maps), ttl.compute
+  // requires projected-permutation indexing maps: each result is a unique
+  // dimension or a constant 0 (broadcast). This is sufficient for all spec
+  // operations (element-wise, broadcast, matmul, reductions, transpose) and
+  // enables downstream tiling and loop lowering to assume a direct
+  // iteration-to-element mapping. Constant-0 results encode broadcast and
+  // require the corresponding tensor dimension to be 1.
+  // Examples of invalid maps: (d0, d1)->(d0 + d1), (d0, d1)->(1),
+  // (d0, d1, d2)->(d0, d0), (d0)[s0]->(d0 + s0).
+  auto validateMapStructure =
+      [&](AffineMap map, RankedTensorType tensorTy, StringRef kind, size_t idx,
+          SmallVectorImpl<bool> *dimsReferenced) -> mlir::LogicalResult {
+    if (!map.isProjectedPermutation(/*allowZeroInResults=*/true)) {
+      return emitOpError() << kind << " " << idx
+                           << " indexing map must be a projected permutation"
+                              " (unique dims or 0 constants)";
+    }
+    for (auto [resIdx, expr] : llvm::enumerate(map.getResults())) {
+      if (auto dimExpr = mlir::dyn_cast<mlir::AffineDimExpr>(expr)) {
+        if (dimsReferenced) {
+          (*dimsReferenced)[dimExpr.getPosition()] = true;
+        }
+      } else if (auto cstExpr =
+                     mlir::dyn_cast<mlir::AffineConstantExpr>(expr)) {
+        if (tensorTy.getDimSize(resIdx) != 1) {
+          return emitOpError() << kind << " " << idx << " broadcast dim "
+                               << resIdx << " must have size 1";
+        }
+      }
+    }
+    return success();
   };
 
   // Ensure every tensor operand has an attached CB (via ttl.attach_cb).
   auto requireAttachedCB = [&](Value tensor, size_t idx,
-                               StringRef kind) -> LogicalResult {
+                               StringRef kind) -> mlir::LogicalResult {
     Value cb = getAttachedCB(tensor);
     if (!cb) {
       return emitOpError() << kind << " " << idx
@@ -488,6 +526,7 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
   };
 
   // Inputs.
+  SmallVector<bool> dimsReferencedByInputs(iteratorCount, false);
   for (size_t i = 0; i < numInputs; ++i) {
     auto tensorTy = mlir::cast<RankedTensorType>(getInputs()[i].getType());
     if (failed(requireAttachedCB(getInputs()[i], i, "input"))) {
@@ -498,7 +537,11 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
     }
     auto map = mlir::cast<AffineMapAttr>(maps[i]).getValue();
     if (failed(verifyMapCommon(map, tensorTy.getRank()))) {
-      return mlir::failure();
+      return failure();
+    }
+    if (failed(validateMapStructure(map, tensorTy, "input", i,
+                                    &dimsReferencedByInputs))) {
+      return failure();
     }
   }
 
@@ -515,7 +558,35 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
     }
     auto map = mlir::cast<AffineMapAttr>(maps[mapIdx]).getValue();
     if (failed(verifyMapCommon(map, tensorTy.getRank()))) {
-      return mlir::failure();
+      return failure();
+    }
+    if (failed(validateMapStructure(map, tensorTy, "output", i,
+                                    /*dimsReferenced=*/nullptr))) {
+      return failure();
+    }
+
+    // Reduction dims must not appear in output maps. Like linalg.generic,
+    // reduction dimensions are contracted: the body accumulates into the
+    // output along these dims, so they do not index the output tensor.
+    for (AffineExpr expr : map.getResults()) {
+      if (auto dimExpr = mlir::dyn_cast<mlir::AffineDimExpr>(expr)) {
+        if (isReductionDim[dimExpr.getPosition()]) {
+          return emitOpError() << "output " << i
+                               << " indexing map cannot reference reduction "
+                                  "dimension "
+                               << dimExpr.getPosition();
+        }
+      }
+    }
+  }
+
+  // Every reduction dim must be referenced by at least one input map,
+  // otherwise the reduction iterator has no operand to traverse.
+  for (size_t d = 0; d < iteratorCount; ++d) {
+    if (isReductionDim[d] && !dimsReferencedByInputs[d]) {
+      return emitOpError()
+             << "reduction dimension " << d
+             << " must be referenced by at least one input indexing map";
     }
   }
 

--- a/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
@@ -93,6 +93,120 @@ func.func @compute_invalid_iterator(
 
 // -----
 
+// Test: Indexing map is not a projected permutation
+func.func @compute_invalid_map_expr(
+    %a: tensor<2x2x!ttcore.tile<32x32, f32>>,
+    %cba: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+    %cbout: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_att = ttl.attach_cb %a, %cba
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %init_att = ttl.attach_cb %init, %cbout
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{input 0 indexing map must be a projected permutation (unique dims or 0 constants)}}
+  %0 = ttl.compute
+      ins(%a_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      outs(%init_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0 + d1, d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>):
+    ttl.yield %arg0 : !ttcore.tile<32x32, f32>
+  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Test: Broadcast constant on non-1 dimension
+func.func @compute_broadcast_dim_not_one(
+    %a: tensor<2x2x!ttcore.tile<32x32, f32>>,
+    %cba: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+    %cbout: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_att = ttl.attach_cb %a, %cba
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %init_att = ttl.attach_cb %init, %cbout
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{input 0 broadcast dim 0 must have size 1}}
+  %0 = ttl.compute
+      ins(%a_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      outs(%init_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (0, d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>):
+    ttl.yield %arg0 : !ttcore.tile<32x32, f32>
+  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Test: Reduction dimension referenced in output indexing map.
+func.func @compute_reduction_in_output(
+    %a: tensor<2x3x!ttcore.tile<32x32, f32>>,
+    %cba: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+    %cbout: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+    -> tensor<2x3x!ttcore.tile<32x32, f32>> {
+  %init = tensor.empty() : tensor<2x3x!ttcore.tile<32x32, f32>>
+  %a_att = ttl.attach_cb %a, %cba
+      : (tensor<2x3x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x3x!ttcore.tile<32x32, f32>>
+  %init_att = ttl.attach_cb %init, %cbout
+      : (tensor<2x3x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x3x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{output 0 indexing map cannot reference reduction dimension 1}}
+  %0 = ttl.compute
+      ins(%a_att : tensor<2x3x!ttcore.tile<32x32, f32>>)
+      outs(%init_att : tensor<2x3x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "reduction"]} {
+  ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>):
+    ttl.yield %arg0 : !ttcore.tile<32x32, f32>
+  } -> tensor<2x3x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<2x3x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Test: Reduction dimension not referenced by any input map. d1 is marked
+// "reduction" but both maps broadcast it (constant 0), so no input traverses
+// the reduction iterator.
+func.func @compute_unreferenced_reduction(
+    %a: tensor<2x1x!ttcore.tile<32x32, f32>>,
+    %cba: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+    %cbout: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+    -> tensor<2x1x!ttcore.tile<32x32, f32>> {
+  %init = tensor.empty() : tensor<2x1x!ttcore.tile<32x32, f32>>
+  %a_att = ttl.attach_cb %a, %cba
+      : (tensor<2x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x1x!ttcore.tile<32x32, f32>>
+  %init_att = ttl.attach_cb %init, %cbout
+      : (tensor<2x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{reduction dimension 1 must be referenced by at least one input indexing map}}
+  %0 = ttl.compute
+      ins(%a_att : tensor<2x1x!ttcore.tile<32x32, f32>>)
+      outs(%init_att : tensor<2x1x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, 0)>,
+                        affine_map<(d0, d1) -> (d0, 0)>],
+       iterator_types = ["parallel", "reduction"]} {
+  ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>):
+    ttl.yield %arg0 : !ttcore.tile<32x32, f32>
+  } -> tensor<2x1x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<2x1x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
 // Test: Missing terminator
 func.func @compute_no_terminator(
     %a: tensor<2x2x!ttcore.tile<32x32, f32>>,


### PR DESCRIPTION
Add verifier checks to `ttl.compute` that validate indexing map structure and reduction dimension semantics, catching malformed IR before downstream passes.                                                                                      

- Require indexing maps to be projected permutations (via `AffineMap::isProjectedPermutation`), rejecting affine expressions, duplicate dims, and non-zero constants.
- Validate that broadcast constants (constant-0 map results) correspond to size-1 tensor dimensions.
- Reject reduction dimensions in output maps (reduction dims are contracted, not indexed).
- Require every reduction dimension to be referenced by at least one input map.
- Add negative lit tests for each new error path.

These new constraints do not limit expressible functionality. Every compute operation in the TT-Lang spec (element-wise, broadcast, matmul, reductions, transpose) and every tt-metal compute kernel uses tile access patterns that are projected permutations with optional broadcast -- simple dimension references and constant-0 results for size-1 dimensions. No spec operation requires affine expressions, duplicate dimensions, or non-zero constants in indexing maps. Specifically:

1. Element-wise (add, sub, mul, sqrt, relu, etc.) — identity maps `(d0, d1) -> (d0, d1)` on all operands.                                             
2. Element-wise with broadcast (`ttl.math.broadcast(a, dims=[0])`) — input map uses constant `0` for broadcast dims, e.g., `(d0, d1) -> (0, d1)` or `(d0, d1) -> (d0, 1)` with size-1 tensor dim. Projected-permutation-with-zeros pattern.
3. Matmul (a @ b) — `(d0, d1, d2) -> (d0, d2)`, `(d0, d1, d2) -> (d2, d1)`, `(d0, d1, d2)
  -> (d0, d1)` with d2 as reduction. All are projected permutations.
4. Reductions (reduce_sum, reduce_max) — input uses identity map, output drops the reduction dim, e.g., sum over `d1`: input `(d0, d1) -> (d0, d1)`, output `(d0, d1) -> (d0)` with `d1` as reduction.
5. Transpose (`ttl.math.transpose`) — permuted map `(d0, d1) -> (d1, d0)`. 
6. Fill, where, mask — element-wise or broadcast variants.