### PR TITLE
Drop the mutable default in visit_Attribute

### DIFF
--- a/python/pykernel/_src/kernel_ast.py
+++ b/python/pykernel/_src/kernel_ast.py
@@ -629,8 +629,12 @@ class TTCompilerBase(PyKernelAstBase):
                     f"Compare operator {type(node.ops).__name__} not implemented"
                 )
 
-    def visit_Attribute(self, node, func_args=[], kwargs={}):
+    def visit_Attribute(self, node, func_args=None, kwargs=None):
         # type name should be !ttkernel.* if it has attributes
+        if func_args is None:
+            func_args = []
+        if kwargs is None:
+            kwargs = {}
         mlir_value = self._var_exists(node.value.id)[node.value.id]
         mlir_type = _get_type_str(mlir_value.type)
         qualified_object_syntax = f"{mlir_type}.{node.attr}"
@@ -725,7 +729,9 @@ class TTCompilerBase(PyKernelAstBase):
         var = memref.alloca(memref_type, [], [])
 
         # Populate the table
-        def populate_list(arr, _idx=[]):
+        def populate_list(arr, _idx=None):
+            if _idx is None:
+                _idx = []
             nonlocal var
             for i, elt in enumerate(arr):
                 idx = _idx + [arith.ConstantOp(IndexType.get(self.ctx), i)]

--- a/python/sim/pipe.py
+++ b/python/sim/pipe.py
@@ -187,7 +187,9 @@ def expand_core_range(core_range: CoreRange) -> List[CoreCoord]:
     # Generate all combinations (Cartesian product)
     result: List[CoreCoord] = []
 
-    def _cartesian_product(ranges: List[List[int]], current: List[int] = []) -> None:
+    def _cartesian_product(ranges: List[List[int]], current: List[int] = None) -> None:
+        if current is None:
+            current = []
         if not ranges:
             # For 1D, append single value; for multi-D, append tuple
             if dims == 1:

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -119,7 +119,9 @@ class TTLGenericCompiler(TTCompilerBase):
 
     _syntax = {}
 
-    def __init__(self, name, kernel_type=None, captures={}, *args, **kwargs):
+    def __init__(self, name, kernel_type=None, captures=None, *args, **kwargs):
+        if captures is None:
+            captures = {}
         super().__init__(name, kernel_type, *args, **kwargs)
         self.loc = Location.name(self.name)
         self.captures = captures
@@ -344,8 +346,12 @@ class TTLGenericCompiler(TTCompilerBase):
             self._raise_error(node, f"Unknown function: {namespace}.{node.attr}")
         return fn(*func_args, **kwargs)
 
-    def visit_Attribute(self, node, func_args=[], kwargs={}):
+    def visit_Attribute(self, node, func_args=None, kwargs=None):
         """Override to set location context and catch errors for method calls."""
+        if func_args is None:
+            func_args = []
+        if kwargs is None:
+            kwargs = {}
         with self._loc_for_node(node):
             try:
                 # Handle ttl.XXX and ttl.math.XXX attribute access


### PR DESCRIPTION
I ran into this while reading through the code path around python/pykernel/_src/kernel_ast.py. Drop the mutable default in visit_Attribute. Mutable defaults are shared across calls and usually turn into state leaks. I kept the patch small and re-ran syntax checks after applying it.