### PR TITLE
Add trigonometry OPs

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -632,6 +632,9 @@ defm TTL_Abs : TTL_UnaryElementwisePair<"abs", "abs_tile">;
 defm TTL_Relu : TTL_UnaryElementwisePair<"relu", "relu_tile">;
 defm TTL_Floor : TTL_UnaryElementwisePair<"floor", "floor_tile">;
 defm TTL_Recip : TTL_UnaryElementwisePair<"recip", "recip_tile">;
+defm TTL_Sin : TTL_UnaryElementwisePair<"sin", "sin_tile">;
+defm TTL_Cos : TTL_UnaryElementwisePair<"cos", "cos_tile">;
+defm TTL_Tan : TTL_UnaryElementwisePair<"tan", "tan_tile">;
 
 //===----------------------------------------------------------------------===//
 // Broadcast Operation

--- a/include/ttlang/Dialect/TTL/TTLElementwiseOps.def
+++ b/include/ttlang/Dialect/TTL/TTLElementwiseOps.def
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -90,6 +90,9 @@ TTL_UNARY_TILE_OP(Relu, ReluTileOp, ReluTileInitOp, ReluTileOp)
 TTL_UNARY_TILE_OP(Sigmoid, SigmoidTileOp, SigmoidTileInitOp, SigmoidTileOp)
 TTL_UNARY_TILE_OP(Floor, FloorTileOp, RoundingTileInitOp, FloorTileOp)
 TTL_UNARY_TILE_OP(Recip, RecipTileOp, RecipTileInitOp, RecipTileOp)
+TTL_UNARY_TILE_OP(Sin, SinTileOp, SinTileInitOp, SinTileOp)
+TTL_UNARY_TILE_OP(Cos, CosTileOp, CosTileInitOp, CosTileOp)
+TTL_UNARY_TILE_OP(Tan, TanTileOp, TanTileInitOp, TanTileOp)
 
 // CB -> DST ops with attribute
 TTL_CB_UNARY_ATTR_OP(Bcast, TileBcastOp, UnaryBcastInitOp, UnaryBcastTileOp)

--- a/test/python/test_elementwise_ops.py
+++ b/test/python/test_elementwise_ops.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -233,6 +233,9 @@ UNARY_OPS = {
     "sigmoid": (make_unary_kernel("sigmoid", "sigmoid"), torch.sigmoid),
     "floor": (make_unary_kernel("floor", "floor"), torch.floor),
     "recip": (make_unary_kernel("recip", "recip"), torch.reciprocal),
+    "sin": (make_unary_kernel("sin", "sin"), torch.sin),
+    "cos": (make_unary_kernel("cos", "cos"), torch.cos),
+    "tan": (make_unary_kernel("tan", "tan"), torch.tan),
 }
 
 


### PR DESCRIPTION
### Title: Add trigonometry OPs

### What?
Add sin, cos, tan OPs to tt-lang.

### Why?
These OPs existed in MLIR, but were absent in tt-lang.

### How?
Add these OPs in TableGen file.

### How to Test?
`test/python/test_elementwise_ops.py` tests were updated. They should cover the change.

### Checklist:
*   [x] Self-reviewed (style, logic)
*   [x] Added tests (or justified none needed)
*   [x] PR is small and focused (one task)
