### PR TITLE
[nfc] fix the ttlang env prompt updates for different shells

### DIFF
--- a/env/activate.in
+++ b/env/activate.in
@@ -16,15 +16,13 @@ if [ -n "${TTLANG_ENV_ACTIVATED}" ]; then
 fi
 
 # Activate the Python venv (provides correct Python version + packages).
-# Let the venv activate normally, then fix the double-wrapped PS1 by
-# overwriting PS1 and _OLD_VIRTUAL_PS1 (which deactivate restores).
+# Prompt customization is handled by ttlang_prompt_utils.sh, sourced after
+# the venv so it can wrap deactivate and cooperate with zsh themes.
 if [ -f "@TTLANG_PYTHON_VENV@/bin/activate" ]; then
-  _TTLANG_PRE_PS1="${PS1:-}"
+  VIRTUAL_ENV_DISABLE_PROMPT=1
   source "@TTLANG_PYTHON_VENV@/bin/activate"
-  PS1="(ᴛᴛʟᴀɴɢ) ${_TTLANG_PRE_PS1}"
-  export PS1
-  _OLD_VIRTUAL_PS1="${_TTLANG_PRE_PS1}"
-  unset _TTLANG_PRE_PS1
+  unset VIRTUAL_ENV_DISABLE_PROMPT
+  source "@TT_LANG_HOME@/env/ttlang_prompt_utils.sh"
 fi
 
 # Set tt-lang home directory.

--- a/env/ttlang_prompt_utils.sh
+++ b/env/ttlang_prompt_utils.sh
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# tt-lang prompt utilities — sourced by activate after the venv is loaded.
+#
+# Prepends "(ᴛᴛʟᴀɴɢ) " to PS1 without clobbering the user's shell theme,
+# and ensures the indicator disappears on `deactivate`.
+#
+# Usage (from activate):
+#   VIRTUAL_ENV_DISABLE_PROMPT=1
+#   source "<venv>/bin/activate"
+#   unset VIRTUAL_ENV_DISABLE_PROMPT
+#   source "<this-file>"
+
+if [ -n "${ZSH_VERSION:-}" ]; then
+  # --- zsh ---------------------------------------------------------------
+  # With prompt_subst (enabled by oh-my-zsh, powerlevel10k, etc.), parameter
+  # expansions inside single-quoted PROMPT are re-evaluated every prompt.
+  # ${TTLANG_ENV_ACTIVATED:+(ᴛᴛʟᴀɴɢ) } expands to the tag when the var is
+  # set and to nothing after `deactivate` unsets it.
+  #
+  # Guard against double-prepend on re-activation.
+  case "$PROMPT" in
+    *'${TTLANG_ENV_ACTIVATED:+'*) ;;
+    *) PROMPT='${TTLANG_ENV_ACTIVATED:+(ᴛᴛʟᴀɴɢ) }'$PROMPT ;;
+  esac
+
+  # Wrap deactivate to also unset TTLANG_ENV_ACTIVATED (venv's deactivate
+  # does not know about it).  The prompt tag disappears automatically on the
+  # next prompt evaluation.
+  _ttlang_orig_deactivate="$(functions deactivate)"
+  deactivate() {
+    unset TTLANG_ENV_ACTIVATED
+    eval "${_ttlang_orig_deactivate}" && deactivate "$@"
+    unset _ttlang_orig_deactivate
+  }
+else
+  # --- bash / POSIX ------------------------------------------------------
+  # bash does not re-evaluate PS1 parameter expansions, so save/restore.
+  _TTLANG_OLD_PS1="${PS1:-}"
+  PS1="(ᴛᴛʟᴀɴɢ) ${PS1:-}"
+  export PS1
+
+  _ttlang_orig_deactivate="$(type deactivate | tail -n +2)"
+  eval "deactivate() {
+    unset TTLANG_ENV_ACTIVATED
+    PS1=\"\${_TTLANG_OLD_PS1}\"
+    export PS1
+    unset _TTLANG_OLD_PS1
+    ${_ttlang_orig_deactivate}
+    deactivate \"\$@\"
+  }"
+fi


### PR DESCRIPTION
Previously the activate script improperly modified users' prompts when activated/deactivated. This PR cleans up the prompt setting/recovery for both bash and zsh; tested in docker as well.