### PR TITLE
[fix] Emit error for exceeded dst capacity with matmul

### DIFF
--- a/lib/Dialect/TTL/Transforms/TTLSubblockComputeForDST.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLSubblockComputeForDST.cpp
@@ -106,7 +106,8 @@ struct TTLSubblockComputeForDSTPass
     funcOp.walk([&](ComputeOp computeOp) {
       auto unrollAttr =
           computeOp->getAttrOfType<IntegerAttr>(kUnrollFactorAttrName);
-      if (unrollAttr && unrollAttr.getInt() > 1) {
+      if (unrollAttr && unrollAttr.getInt() > 1 &&
+          !computeOp.containsOp<TileMatmulBlockOp>()) {
         opsToSubblock.push_back(computeOp);
       }
     });

--- a/test/python/invalid/invalid_matmul_exceeds_dst.py
+++ b/test/python/invalid/invalid_matmul_exceeds_dst.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: tt-device
+# RUN: not %python %s 2>&1 | FileCheck %s
+
+"""
+Validation test: matmul output exceeding DST capacity is rejected.
+
+A 4x4 tile matmul produces 16 output tiles, which exceeds the bf16 DST
+capacity of 8. The compiler must reject this with a clear error rather
+than silently generating incorrect code via subblocking.
+"""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import ttnn
+import ttl
+
+
+# CHECK: matmul output 4x4 = 16 tiles exceeds DST capacity of 8
+@ttl.kernel(grid=(1, 1))
+def matmul_exceeds_dst(a, b, y):
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(4, 1), buffer_factor=2)
+    b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 4), buffer_factor=2)
+    y_dfb = ttl.make_dataflow_buffer_like(y, shape=(4, 4), buffer_factor=2)
+
+    @ttl.compute()
+    def compute_fn():
+        with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
+            with y_dfb.reserve() as y_blk:
+                y_blk.store(a_blk @ b_blk)
+
+    @ttl.datamovement()
+    def dm_read():
+        with a_dfb.reserve() as blk:
+            tx = ttl.copy(a[0:4, 0], blk)
+            tx.wait()
+        with b_dfb.reserve() as blk:
+            tx = ttl.copy(b[0, 0:4], blk)
+            tx.wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with y_dfb.wait() as blk:
+            tx = ttl.copy(blk, y[0:4, 0:4])
+            tx.wait()
+
+
+if __name__ == "__main__":
+    import torch
+    from ttlang_test_utils import to_dram
+
+    device = ttnn.open_device(device_id=0)
+    try:
+        make = lambda: to_dram(torch.randn(128, 128, dtype=torch.bfloat16), device)
+        matmul_exceeds_dst(make(), make(), make())
+
+        print("ERROR: Expected error was not raised!")
+        exit(1)
+    finally:
+        ttnn.close_device(device)

--- a/test/ttlang/Conversion/TTLToTTKernel/matmul_block_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/matmul_block_invalid.mlir
@@ -2,6 +2,13 @@
 // RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-assign-dst{enable-fpu-binary-ops=0}, ttl-insert-tile-regs-sync, ttl-lower-matmul-block))' \
 // RUN:   --split-input-file 2>&1 | FileCheck %s
 
+// Verify the error still fires when the subblock pass is in the pipeline.
+// The subblock pass must skip matmul computes rather than silently subblocking
+// them (matmul subblocking requires accumulation that is not yet implemented).
+// RUN: not ttlang-opt %s \
+// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-assign-dst{enable-fpu-binary-ops=0}, ttl-subblock-compute-for-dst, ttl-insert-tile-regs-sync, ttl-lower-matmul-block))' \
+// RUN:   --split-input-file 2>&1 | FileCheck %s
+
 // bf16 DST capacity exceeded.
 // CHECK: matmul output 3x3 = 9 tiles exceeds DST capacity of 8
 func.func @matmul_3x3_bf16_dst_overflow(


### PR DESCRIPTION
### Problem description

When `maximize_dst=True` (the default), the `ttl-subblock-compute-for-dst` pass runs before `ttl-lower-matmul-block` and silently subblocks matmul computes that exceed DST capacity. This prevents the DST capacity validation from seeing the original oversized output dimensions, so the error is never emitted and incorrect code is generated.

For example, a 4x4 bf16 matmul (16 tiles, DST capacity 8) would compile without error, producing tile stores that overwrite the same output positions each subblock iteration.

### What's changed

The subblock pass now skips `ComputeOp`s containing `TileMatmulBlockOp`. Matmul computes that exceed DST capacity pass through to `ttl-lower-matmul-block`, which emits the expected error:

```
error: matmul output 4x4 = 16 tiles exceeds DST capacity of 8;
       automatic subblocking is not yet implemented
  --> test.py:45:29
   |
45 |                     y_blk.store(a_blk @ b_blk)
   |                             ^
```