### PR TITLE
[ttl] Fix copy_dest_values arg order causing wrong results (#443)

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -634,7 +634,7 @@ def TTL_CopyDstOp : TTL_Op<"copy_dst",
     The dst_idx attribute specifies the destination DST register index. The
     source DST register is determined by the src_tile's dst_idx attribute.
 
-    Lowering: ttl.copy_dst -> ttkernel.copy_dest_values(dst_idx, src.dst_idx)
+    Lowering: ttl.copy_dst -> ttkernel.copy_dest_values(src.dst_idx, dst_idx)
 
     Example:
     ```mlir

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -521,8 +521,9 @@ struct TTLCopyDstToTTKernel : OpConversionPattern<CopyDstOp> {
     Value srcIdx = arith::ConstantIndexOp::create(rewriter, loc, *srcDstIdx);
     Value dstIdx = arith::ConstantIndexOp::create(rewriter, loc, dstDstIdx);
 
-    // Emit copy_dest_values(dst0, dst1): copies DST[dst1] → DST[dst0].
-    ttk::CopyDestValuesOp::create(rewriter, loc, dstIdx, srcIdx);
+    // Emit copy_dest_values(idst_in, idst_out): copies DST[idst_in] ->
+    // DST[idst_out].
+    ttk::CopyDestValuesOp::create(rewriter, loc, srcIdx, dstIdx);
 
     // Replace with an unrealized conversion cast to preserve the tile value.
     // The tile is now in DST[dstIdx].

--- a/test/python/test_copy_dst.py
+++ b/test/python/test_copy_dst.py
@@ -7,10 +7,11 @@ Test for copy_dst legalization when a DST intermediate is reused.
 
 When a computed intermediate (DST register value) is referenced multiple times
 in a single store expression, the compiler emits ttl.copy_dst to preserve
-the value before a destructive unary. This test validates that copy_dst is
-correctly lowered through the pipeline.
+the value before a destructive unary. These tests validate that copy_dst is
+correctly lowered through the pipeline and produces numerically correct results.
 
 Reproduces: https://github.com/tenstorrent/tt-lang/issues/384
+Regression: https://github.com/tenstorrent/tt-lang/issues/443
 """
 
 # REQUIRES: ttnn
@@ -61,11 +62,68 @@ def dst_intermediate_reuse_kernel(a, b, out):
 
 
 def test_dst_intermediate_reuse(device):
-    """Compile kernel where DST intermediate is reused (triggers copy_dst)."""
+    """Validate x * rsqrt(abs(x)) where x is a DST intermediate (a*b)."""
+    # Use uniform [0.5, 2.0] to avoid zeros (rsqrt(0) = inf -> NaN).
+    torch.manual_seed(42)
+    a_t = torch.empty(32, 32, dtype=torch.bfloat16).uniform_(0.5, 2.0)
+    b_t = torch.empty(32, 32, dtype=torch.bfloat16).uniform_(0.5, 2.0)
+    out_t = torch.zeros(32, 32, dtype=torch.bfloat16)
+
+    out_dev = to_dram(out_t, device)
+    dst_intermediate_reuse_kernel(to_dram(a_t, device), to_dram(b_t, device), out_dev)
+
+    x = a_t.float() * b_t.float()
+    expected = x * torch.rsqrt(torch.abs(x))
+    result = ttnn.to_torch(out_dev)
+    assert_allclose(result.float(), expected.float(), rtol=1e-2, atol=1e-2)
+
+
+@ttl.operation(grid=(1, 1))
+def silu_on_intermediate_kernel(a, b, out):
+    """SiLU on computed intermediate: y = a+b, then y * sigmoid(y).
+
+    Regression test for https://github.com/tenstorrent/tt-lang/issues/443.
+    The intermediate y lives in DST. sigmoid(y) is a destructive unary that
+    clobbers its DST input. The compiler must emit copy_dst to preserve y
+    for the outer multiply. With copy_dest_values args swapped, the copy
+    goes the wrong direction and the multiply reads stale data.
+    """
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), buffer_factor=2)
+    b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), buffer_factor=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), buffer_factor=2)
+
+    @ttl.compute()
+    def compute():
+        with a_dfb.wait() as av, b_dfb.wait() as bv, out_dfb.reserve() as o:
+            y = av + bv
+            o.store(y * ttl.math.sigmoid(y))
+
+    @ttl.datamovement()
+    def dm_read():
+        with a_dfb.reserve() as blk:
+            tx = ttl.copy(a[0, 0], blk)
+            tx.wait()
+        with b_dfb.reserve() as blk:
+            tx = ttl.copy(b[0, 0], blk)
+            tx.wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with out_dfb.wait() as blk:
+            tx = ttl.copy(blk, out[0, 0])
+            tx.wait()
+
+
+def test_silu_on_intermediate(device):
+    """SiLU on computed intermediate must match torch reference (issue #443)."""
     a_t = torch.randn(32, 32, dtype=torch.bfloat16)
     b_t = torch.randn(32, 32, dtype=torch.bfloat16)
     out_t = torch.zeros(32, 32, dtype=torch.bfloat16)
 
-    dst_intermediate_reuse_kernel(
-        to_dram(a_t, device), to_dram(b_t, device), to_dram(out_t, device)
-    )
+    out_dev = to_dram(out_t, device)
+    silu_on_intermediate_kernel(to_dram(a_t, device), to_dram(b_t, device), out_dev)
+
+    y = a_t.float() + b_t.float()
+    expected = y * torch.sigmoid(y)
+    result = ttnn.to_torch(out_dev)
+    assert_allclose(result.float(), expected.float(), rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
copy_dest_values(idst_in, idst_out) copies DST[in] -> DST[out], but the CopyDstOp lowering had the args swapped. Fixed arg order and added numerical validation to test_copy_dst.py plus a SiLU-on-intermediate regression test.