### PR TITLE
[fix][ttl] Fix live interval boundary computation (#536)

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -63,23 +63,81 @@ correct DFB interval boundary.
 
 The pass treats every acquire as opening a DFB live interval. The interval
 starts at `cb_reserve` or `cb_wait` and ends after the last operation that can
-use the acquired slot. A later same-kind acquire on the same DFB bounds release
-matching and use discovery, because its release belongs to a different live
-interval.
+use the acquired slot. A later acquire in the same DFB sync class bounds
+release matching and use discovery, because its release belongs to a different
+live interval.
+
+DFB sync classes separate the producer side from the consumer side:
+`cb_reserve`/`cb_push` form producer intervals, and `cb_wait`/`cb_pop` form
+consumer intervals. Producer acquires bound other producer intervals; consumer
+acquires bound other consumer intervals.
 
 The pass finds owned uses from two sources:
 
 - Tensor-form uses follow the result of `cb_reserve` or `cb_wait` through
   `ttl.attach_cb`, `ttl.store`, and compute operations.
 - Direct DFB uses follow `ttl.copy` operations where the DFB operand direction
-  matches the acquire kind. `cb_reserve` live intervals include copies into the
-  DFB; `cb_wait` live intervals include copies from the DFB. This is required
-  for data movement kernels, where copies do not use the tensor value returned
-  by the acquire op.
+  matches the interval's DFB sync class. Producer intervals include copies into
+  the DFB; consumer intervals include copies from the DFB. This is required for
+  data movement kernels, where copies do not use the tensor value returned by
+  the acquire op.
 
 Uses inside descendant regions are projected to their ancestor operation in the
 acquire's block. This conservatively places the release after the enclosing
 structured op when the exact use is nested in an `scf.for` or `scf.if` body.
+
+### Slot State Model
+
+The pass models producer and consumer acquires as separate slot lifetimes:
+
+```
+Producer side:
+
+  free slot
+      |
+      | cb_reserve
+      v
+  reserved slot
+      |
+      | reserve-side writes
+      v
+  written slot
+      |
+      | cb_push
+      v
+  visible to consumer
+
+Consumer side:
+
+  visible to consumer
+      |
+      | cb_wait
+      v
+  acquired slot
+      |
+      | wait-side reads
+      v
+  consumed slot
+      |
+      | cb_pop
+      v
+  free slot
+```
+
+Each acquire owns exactly one interval. The release inserted for that interval
+must follow the last owned use and precede the next acquire in the same DFB sync
+class:
+
+```
+cb_wait A  ->  owned reads  ->  cb_pop A  ->  cb_wait B
+                                  ^
+                                  inserted release
+```
+
+Once a later acquire in the same DFB sync class starts, subsequent releases are
+considered part of that later interval. They cannot release the slot acquired by
+the earlier operation because the earlier slot must already be released before
+the DFB read or write pointer is reused.
 
 ### Algorithm
 
@@ -96,7 +154,7 @@ insertMissingReleases(func):
 insertReleases(acquires, releases, releaseOp):
   for acquire in acquires:
     dfb = acquire.cb
-    boundary = next same-kind acquire on dfb, projected to acquire.block
+    boundary = next acquire in the same DFB sync class, projected to acquire.block
 
     matching = same-block release on dfb after acquire and before boundary
     nested = nested releases on dfb after acquire and before boundary
@@ -110,7 +168,7 @@ insertReleases(acquires, releases, releaseOp):
 ```
 
 The same-block release check makes the pass idempotent. A release after the
-next same-kind acquire on the same DFB belongs to that later interval and does
+next acquire in the same DFB sync class belongs to that later interval and does
 not satisfy the earlier acquire.
 
 ## Index Reuse

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -53,6 +53,66 @@ When multiple `DFBInputOpInterface` operations consume the same non-CB-attached 
 
 Each DFB is created with `blockCount=2` (double-buffering) so the packer and unpacker can operate on different halves simultaneously within the same thread.
 
+## DFB Sync Insertion
+
+`TTLInsertCBSync` inserts missing releases for DFB acquire operations. A
+`cb_reserve` acquire requires a later `cb_push`; a `cb_wait` acquire requires a
+later `cb_pop`. The pass is also responsible for hoisting releases that were
+emitted inside structured regions to the acquire's block when that is the
+correct DFB interval boundary.
+
+The pass treats every acquire as opening a DFB live interval. The interval
+starts at `cb_reserve` or `cb_wait` and ends after the last operation that can
+use the acquired slot. A later same-kind acquire on the same DFB bounds release
+matching and use discovery, because its release belongs to a different live
+interval.
+
+The pass finds owned uses from two sources:
+
+- Tensor-form uses follow the result of `cb_reserve` or `cb_wait` through
+  `ttl.attach_cb`, `ttl.store`, and compute operations.
+- Direct DFB uses follow `ttl.copy` operations where the DFB operand direction
+  matches the acquire kind. `cb_reserve` live intervals include copies into the
+  DFB; `cb_wait` live intervals include copies from the DFB. This is required
+  for data movement kernels, where copies do not use the tensor value returned
+  by the acquire op.
+
+Uses inside descendant regions are projected to their ancestor operation in the
+acquire's block. This conservatively places the release after the enclosing
+structured op when the exact use is nested in an `scf.for` or `scf.if` body.
+
+### Algorithm
+
+```
+insertMissingReleases(func):
+  reserves = all cb_reserve ops in func
+  waits = all cb_wait ops in func
+  pushes = all cb_push ops in func
+  pops = all cb_pop ops in func
+
+  insertReleases(reserves, pushes, cb_push)
+  insertReleases(waits, pops, cb_pop)
+
+insertReleases(acquires, releases, releaseOp):
+  for acquire in acquires:
+    dfb = acquire.cb
+    boundary = next same-kind acquire on dfb, projected to acquire.block
+
+    matching = same-block release on dfb after acquire and before boundary
+    nested = nested releases on dfb after acquire and before boundary
+    if matching:
+      continue
+
+    erase nested releases
+    liveEnd = last transitive tensor or direction-matched direct DFB use
+              before boundary
+    insert releaseOp(dfb) after liveEnd
+```
+
+The same-block release check makes the pass idempotent. A release after the
+next same-kind acquire on the same DFB belongs to that later interval and does
+not satisfy the earlier acquire.
+
 ## Index Reuse
 
 `TTLFinalizeDFBIndices` reduces the physical DFB count by assigning the same index to compiler-allocated DFBs whose lifetimes do not overlap. The algorithm runs per function. Compiler-allocated DFBs are intra-thread (both producer and consumer are in the same compute function), so their lifetimes are independent across functions.

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -12,9 +12,10 @@ def TTLInsertCBSync
     missing release op after the last operation that accesses the CB's data.
 
     The pass computes a transitive use closure starting from the acquire op:
-    direct uses of the CB value and the acquire result, plus uses of values
-    those ops produce (e.g. copy -> transfer_handle -> wait). The release is
-    inserted after the last op in this closure.
+    direct uses of the DFB value and the acquire result, plus uses of values
+    those ops produce (e.g. copy -> transfer_handle -> wait). Direct DFB uses
+    are bounded by the next same-kind acquire on the same DFB because they do
+    not carry an SSA link to the acquire that owns the slot.
 
     Explicit push/pop calls and context-manager-generated push/pop are
     preserved: the pass only fills in what is missing.

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -14,7 +14,8 @@ def TTLInsertCBSync
     The pass computes a transitive use closure starting from the acquire op:
     direct uses of the DFB value and the acquire result, plus uses of values
     those ops produce (e.g. copy -> transfer_handle -> wait). Direct DFB uses
-    are bounded by the next same-kind acquire on the same DFB because they do
+    are bounded by the next acquire in the same DFB sync class (`cb_reserve`
+    for producer intervals, `cb_wait` for consumer intervals) because they do
     not carry an SSA link to the acquire that owns the slot.
 
     Explicit push/pop calls and context-manager-generated push/pop are

--- a/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
@@ -52,19 +52,21 @@ static bool isBefore(Operation *a, Operation *b) {
   return a->isBeforeInBlock(b);
 }
 
-/// Find releases on `cb` at or after `acquire` in the acquire's block.
+/// Find releases on `cb` at or after `acquire` and before `boundary`.
 /// Same-level releases are "matching" (the acquire is already handled).
 /// Nested releases are collected into `toHoist` for erasure.
 template <typename ReleaseOpTy>
 static bool findReleases(Value cb, Operation *acquire,
                          const SmallVectorImpl<ReleaseOpTy> &allReleases,
                          SmallVectorImpl<ReleaseOpTy> &toHoist,
-                         const DenseSet<Operation *> &erased) {
+                         const DenseSet<Operation *> &erased,
+                         Operation *boundary) {
   Block *block = acquire->getBlock();
   bool hasSameLevelRelease = false;
 
   for (auto release : allReleases) {
-    if (erased.contains(release)) {
+    Operation *releaseOp = release.getOperation();
+    if (erased.contains(releaseOp)) {
       continue;
     }
     if (release.getCb() != cb) {
@@ -72,8 +74,11 @@ static bool findReleases(Value cb, Operation *acquire,
     }
 
     // Same-level: release is directly in the acquire's block.
-    if (release->getBlock() == block) {
-      if (!isBefore(acquire, release)) {
+    if (releaseOp->getBlock() == block) {
+      if (!isBefore(acquire, releaseOp)) {
+        continue;
+      }
+      if (boundary && !isBefore(releaseOp, boundary)) {
         continue;
       }
       hasSameLevelRelease = true;
@@ -81,17 +86,49 @@ static bool findReleases(Value cb, Operation *acquire,
     }
 
     // Nested: release is inside a structured op in the acquire's block.
-    Operation *ancestor = block->findAncestorOpInBlock(*release);
+    Operation *ancestor = block->findAncestorOpInBlock(*releaseOp);
     if (!ancestor) {
       continue;
     }
     if (!isBefore(acquire, ancestor)) {
       continue;
     }
+    if (boundary && !isBefore(ancestor, boundary)) {
+      continue;
+    }
     toHoist.push_back(release);
   }
 
   return hasSameLevelRelease;
+}
+
+/// Return the next same-kind acquire on this DFB, projected into
+/// `acquire`'s block.
+template <typename AcquireOpTy>
+static Operation *findNextSameKindAcquire(Value cb, Operation *acquire,
+                                          ArrayRef<AcquireOpTy> acquires) {
+  Block *block = acquire->getBlock();
+  Operation *boundary = nullptr;
+  for (auto other : acquires) {
+    Operation *otherOp = other.getOperation();
+    if (otherOp == acquire) {
+      continue;
+    }
+    if (other.getCb() != cb) {
+      continue;
+    }
+    Operation *ancestor = block->findAncestorOpInBlock(*otherOp);
+    if (!ancestor || ancestor == acquire) {
+      continue;
+    }
+    if (!isBefore(acquire, ancestor)) {
+      continue;
+    }
+    if (!boundary || isBefore(ancestor, boundary)) {
+      boundary = ancestor;
+    }
+  }
+  return boundary;
 }
 
 /// Live-interval endpoint for the slot of `acquire`: the last op in
@@ -112,9 +149,12 @@ static bool findReleases(Value cb, Operation *acquire,
 /// Uses in descendant regions project up to their ancestor in the
 /// acquire's block.
 ///
+/// `boundary` excludes uses owned by a later same-DFB acquire interval.
+///
 /// Returns `acquire` itself when no tensor users exist; callers treat
 /// that as "insert the release immediately after the acquire".
-static Operation *findLastTensorUse(Value cb, Operation *acquire) {
+static Operation *findLastTensorUse(Value cb, Operation *acquire,
+                                    Operation *boundary) {
   Operation *last = acquire;
   Block *block = acquire->getBlock();
   DenseSet<Operation *> visited;
@@ -126,6 +166,9 @@ static Operation *findLastTensorUse(Value cb, Operation *acquire) {
     }
     Operation *ancestor = block->findAncestorOpInBlock(*user);
     if (!ancestor) {
+      return;
+    }
+    if (boundary && !isBefore(ancestor, boundary)) {
       return;
     }
     if (isBefore(last, ancestor)) {
@@ -195,15 +238,19 @@ struct TTLInsertCBSyncPass
     // check `erased.contains(...)` before touching any op wrapper method.
     DenseSet<Operation *> erased;
 
-    auto insertMissingReleases = [&](auto acquires, auto &releases,
+    auto insertMissingReleases = [&](auto &acquires, auto &releases,
                                      auto createRelease) {
+      using AcquireOpTy =
+          typename std::remove_reference_t<decltype(acquires)>::value_type;
+      using ReleaseOpTy =
+          typename std::remove_reference_t<decltype(releases)>::value_type;
+      ArrayRef<AcquireOpTy> acquiresRef(acquires);
       for (auto acquire : acquires) {
         Value cb = acquire.getCb();
 
-        using ReleaseOpTy =
-            typename std::remove_reference_t<decltype(releases)>::value_type;
+        Operation *boundary = findNextSameKindAcquire(cb, acquire, acquiresRef);
         SmallVector<ReleaseOpTy> nested;
-        if (findReleases(cb, acquire, releases, nested, erased)) {
+        if (findReleases(cb, acquire, releases, nested, erased, boundary)) {
           continue;
         }
 
@@ -212,7 +259,7 @@ struct TTLInsertCBSyncPass
           nestedOp.erase();
         }
 
-        Operation *last = findLastTensorUse(cb, acquire);
+        Operation *last = findLastTensorUse(cb, acquire, boundary);
         builder.setInsertionPointAfter(last);
         createRelease(builder, acquire.getLoc(), cb);
       }

--- a/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
@@ -38,13 +38,13 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-enum class AcquireKind { Reserve, Wait };
+enum class DFBSyncClass { Producer, Consumer };
 
 struct AcquireInterval {
   Operation *acquire;
   Value cb;
-  AcquireKind kind;
-  Operation *sameKindBoundary;
+  DFBSyncClass syncClass;
+  Operation *syncClassBoundary;
 };
 
 template <typename ReleaseOpTy>
@@ -59,13 +59,13 @@ static bool isBefore(Operation *a, Operation *b) {
 }
 
 template <typename AcquireOpTy>
-static AcquireKind getAcquireKind() {
+static DFBSyncClass getDFBSyncClass() {
   if constexpr (std::is_same_v<AcquireOpTy, CBReserveOp>) {
-    return AcquireKind::Reserve;
+    return DFBSyncClass::Producer;
   } else {
     static_assert(std::is_same_v<AcquireOpTy, CBWaitOp>,
                   "unsupported DFB acquire op");
-    return AcquireKind::Wait;
+    return DFBSyncClass::Consumer;
   }
 }
 
@@ -80,13 +80,13 @@ static bool directDFBUseMatchesAcquire(AcquireInterval interval,
     return true;
   }
 
-  switch (interval.kind) {
-  case AcquireKind::Reserve:
+  switch (interval.syncClass) {
+  case DFBSyncClass::Producer:
     return copy.getDst() == interval.cb;
-  case AcquireKind::Wait:
+  case DFBSyncClass::Consumer:
     return copy.getSrc() == interval.cb;
   }
-  llvm_unreachable("unknown acquire kind");
+  llvm_unreachable("unknown DFB sync class");
 }
 
 static bool projectToAcquireBlock(AcquireInterval interval, Operation *op,
@@ -99,8 +99,8 @@ static bool projectToAcquireBlock(AcquireInterval interval, Operation *op,
   if (!isBefore(interval.acquire, projected)) {
     return false;
   }
-  if (interval.sameKindBoundary &&
-      !isBefore(projected, interval.sameKindBoundary)) {
+  if (interval.syncClassBoundary &&
+      !isBefore(projected, interval.syncClassBoundary)) {
     return false;
   }
   return true;
@@ -163,7 +163,7 @@ static void updateBoundary(Value cb, Operation *acquire,
       continue;
     }
     Operation *ancestor = block->findAncestorOpInBlock(*otherOp);
-    if (!ancestor || ancestor == acquire) {
+    if (!ancestor) {
       continue;
     }
     if (!isBefore(acquire, ancestor)) {
@@ -175,11 +175,12 @@ static void updateBoundary(Value cb, Operation *acquire,
   }
 }
 
-/// Return the next same-kind acquire on this DFB, projected into `acquire`'s
-/// block.
+/// Return the closest later acquire in the same DFB sync class, projected into
+/// `acquire`'s block. Producer intervals use `cb_reserve` boundaries; consumer
+/// intervals use `cb_wait` boundaries.
 template <typename AcquireOpTy>
-static Operation *findNextSameKindAcquire(Value cb, Operation *acquire,
-                                          ArrayRef<AcquireOpTy> acquires) {
+static Operation *findNextSyncClassAcquire(Value cb, Operation *acquire,
+                                           ArrayRef<AcquireOpTy> acquires) {
   Operation *boundary = nullptr;
   updateBoundary(cb, acquire, acquires, boundary);
   return boundary;
@@ -187,7 +188,8 @@ static Operation *findNextSameKindAcquire(Value cb, Operation *acquire,
 
 /// Return the last op in `acquire`'s block that consumes the acquired slot.
 /// Tensor uses follow the acquire result; direct DFB copies use direction.
-/// `boundary` stops the scan at the next same-kind acquire.
+/// `boundary` stops the scan at the next `cb_reserve` for reserve intervals or
+/// the next `cb_wait` for wait intervals.
 static Operation *findLastOwnedUse(AcquireInterval interval) {
   Operation *last = interval.acquire;
   DenseSet<Operation *> visited;
@@ -244,8 +246,8 @@ static AcquireInterval makeAcquireInterval(AcquireOpTy acquire,
                                            ArrayRef<AcquireOpTy> acquires) {
   Value cb = acquire.getCb();
   Operation *acquireOp = acquire.getOperation();
-  return {acquireOp, cb, getAcquireKind<AcquireOpTy>(),
-          findNextSameKindAcquire(cb, acquireOp, acquires)};
+  return {acquireOp, cb, getDFBSyncClass<AcquireOpTy>(),
+          findNextSyncClassAcquire(cb, acquireOp, acquires)};
 }
 
 struct TTLInsertCBSyncPass

--- a/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
@@ -40,6 +40,11 @@ namespace {
 
 enum class DFBSyncClass { Producer, Consumer };
 
+struct ReleaseSearch {
+  bool hasSameLevelRelease = false;
+  SmallVector<Operation *> nestedReleases;
+};
+
 struct AcquireInterval {
   Operation *acquire;
   Value cb;
@@ -47,30 +52,41 @@ struct AcquireInterval {
   Operation *syncClassBoundary;
 };
 
-template <typename ReleaseOpTy>
-struct ReleaseSearch {
-  bool hasSameLevelRelease = false;
-  SmallVector<ReleaseOpTy> nestedReleases;
-};
-
 /// Return true if `a` is before `b` in their common block.
 static bool isBefore(Operation *a, Operation *b) {
   return a->isBeforeInBlock(b);
 }
 
-template <typename AcquireOpTy>
-static DFBSyncClass getDFBSyncClass() {
-  if constexpr (std::is_same_v<AcquireOpTy, CBReserveOp>) {
-    return DFBSyncClass::Producer;
-  } else {
-    static_assert(std::is_same_v<AcquireOpTy, CBWaitOp>,
-                  "unsupported DFB acquire op");
-    return DFBSyncClass::Consumer;
+static bool isAcquireOp(Operation *op) {
+  return isa<CBReserveOp, CBWaitOp>(op);
+}
+
+static bool isReleaseOp(Operation *op) { return isa<CBPushOp, CBPopOp>(op); }
+
+static Value getAcquireCB(Operation *op) {
+  if (auto reserve = dyn_cast<CBReserveOp>(op)) {
+    return reserve.getCb();
   }
+  return cast<CBWaitOp>(op).getCb();
+}
+
+static Value getReleaseCB(Operation *op) {
+  if (auto push = dyn_cast<CBPushOp>(op)) {
+    return push.getCb();
+  }
+  return cast<CBPopOp>(op).getCb();
+}
+
+static DFBSyncClass getDFBSyncClass(Operation *op) {
+  if (isa<CBReserveOp>(op)) {
+    return DFBSyncClass::Producer;
+  }
+  assert(isa<CBWaitOp>(op) && "unsupported DFB acquire op");
+  return DFBSyncClass::Consumer;
 }
 
 static bool isLifecycleOrAttachOp(Operation *op) {
-  return isa<CBPushOp, CBPopOp, CBReserveOp, CBWaitOp, AttachCBOp>(op);
+  return isAcquireOp(op) || isReleaseOp(op) || isa<AttachCBOp>(op);
 }
 
 static bool directDFBUseMatchesAcquire(AcquireInterval interval,
@@ -113,26 +129,23 @@ static void updateLatestUse(Operation *candidate, Operation *&latest) {
 }
 
 /// Find releases owned by this acquire interval.
-template <typename ReleaseOpTy>
-static ReleaseSearch<ReleaseOpTy>
-findOwnedReleases(AcquireInterval interval,
-                  const SmallVectorImpl<ReleaseOpTy> &allReleases,
-                  const DenseSet<Operation *> &erased) {
-  ReleaseSearch<ReleaseOpTy> result;
+static ReleaseSearch findOwnedReleases(AcquireInterval interval,
+                                       ArrayRef<Operation *> allReleases,
+                                       const DenseSet<Operation *> &erased) {
+  ReleaseSearch result;
   Block *block = interval.acquire->getBlock();
 
-  for (auto release : allReleases) {
-    Operation *releaseOp = release.getOperation();
-    if (erased.contains(releaseOp)) {
+  for (Operation *release : allReleases) {
+    if (erased.contains(release)) {
       continue;
     }
-    if (release.getCb() != interval.cb) {
+    if (getReleaseCB(release) != interval.cb) {
       continue;
     }
 
-    if (releaseOp->getBlock() == block) {
+    if (release->getBlock() == block) {
       Operation *projected = nullptr;
-      if (!projectToAcquireBlock(interval, releaseOp, projected)) {
+      if (!projectToAcquireBlock(interval, release, projected)) {
         continue;
       }
       result.hasSameLevelRelease = true;
@@ -140,7 +153,7 @@ findOwnedReleases(AcquireInterval interval,
     }
 
     Operation *projected = nullptr;
-    if (!projectToAcquireBlock(interval, releaseOp, projected)) {
+    if (!projectToAcquireBlock(interval, release, projected)) {
       continue;
     }
     result.nestedReleases.push_back(release);
@@ -149,20 +162,18 @@ findOwnedReleases(AcquireInterval interval,
   return result;
 }
 
-template <typename AcquireOpTy>
 static void updateBoundary(Value cb, Operation *acquire,
-                           ArrayRef<AcquireOpTy> acquires,
+                           ArrayRef<Operation *> acquires,
                            Operation *&boundary) {
   Block *block = acquire->getBlock();
-  for (auto other : acquires) {
-    Operation *otherOp = other.getOperation();
-    if (otherOp == acquire) {
+  for (Operation *other : acquires) {
+    if (other == acquire) {
       continue;
     }
-    if (other.getCb() != cb) {
+    if (getAcquireCB(other) != cb) {
       continue;
     }
-    Operation *ancestor = block->findAncestorOpInBlock(*otherOp);
+    Operation *ancestor = block->findAncestorOpInBlock(*other);
     if (!ancestor) {
       continue;
     }
@@ -178,9 +189,8 @@ static void updateBoundary(Value cb, Operation *acquire,
 /// Return the closest later acquire in the same DFB sync class, projected into
 /// `acquire`'s block. Producer intervals use `cb_reserve` boundaries; consumer
 /// intervals use `cb_wait` boundaries.
-template <typename AcquireOpTy>
 static Operation *findNextSyncClassAcquire(Value cb, Operation *acquire,
-                                           ArrayRef<AcquireOpTy> acquires) {
+                                           ArrayRef<Operation *> acquires) {
   Operation *boundary = nullptr;
   updateBoundary(cb, acquire, acquires, boundary);
   return boundary;
@@ -241,13 +251,35 @@ static Operation *findLastOwnedUse(AcquireInterval interval) {
   return last;
 }
 
-template <typename AcquireOpTy>
-static AcquireInterval makeAcquireInterval(AcquireOpTy acquire,
-                                           ArrayRef<AcquireOpTy> acquires) {
-  Value cb = acquire.getCb();
-  Operation *acquireOp = acquire.getOperation();
-  return {acquireOp, cb, getDFBSyncClass<AcquireOpTy>(),
-          findNextSyncClassAcquire(cb, acquireOp, acquires)};
+static AcquireInterval makeAcquireInterval(Operation *acquire,
+                                           ArrayRef<Operation *> acquires) {
+  Value cb = getAcquireCB(acquire);
+  return {acquire, cb, getDFBSyncClass(acquire),
+          findNextSyncClassAcquire(cb, acquire, acquires)};
+}
+
+template <typename CreateReleaseFn>
+static void insertMissingReleases(ArrayRef<Operation *> acquires,
+                                  ArrayRef<Operation *> releases,
+                                  DenseSet<Operation *> &erased,
+                                  OpBuilder &builder,
+                                  CreateReleaseFn createRelease) {
+  for (Operation *acquire : acquires) {
+    AcquireInterval interval = makeAcquireInterval(acquire, acquires);
+    ReleaseSearch releaseSearch = findOwnedReleases(interval, releases, erased);
+    if (releaseSearch.hasSameLevelRelease) {
+      continue;
+    }
+
+    for (Operation *nestedRelease : releaseSearch.nestedReleases) {
+      erased.insert(nestedRelease);
+      nestedRelease->erase();
+    }
+
+    Operation *last = findLastOwnedUse(interval);
+    builder.setInsertionPointAfter(last);
+    createRelease(builder, acquire->getLoc(), interval.cb);
+  }
 }
 
 struct TTLInsertCBSyncPass
@@ -255,63 +287,37 @@ struct TTLInsertCBSyncPass
   void runOnOperation() override {
     func::FuncOp func = getOperation();
 
-    SmallVector<CBReserveOp> reserves;
-    SmallVector<CBWaitOp> waits;
-    SmallVector<CBPushOp> pushes;
-    SmallVector<CBPopOp> pops;
+    SmallVector<Operation *> reserves;
+    SmallVector<Operation *> waits;
+    SmallVector<Operation *> pushes;
+    SmallVector<Operation *> pops;
 
     func.walk([&](Operation *op) {
-      if (auto r = dyn_cast<CBReserveOp>(op)) {
-        reserves.push_back(r);
-      } else if (auto w = dyn_cast<CBWaitOp>(op)) {
-        waits.push_back(w);
-      } else if (auto p = dyn_cast<CBPushOp>(op)) {
-        pushes.push_back(p);
-      } else if (auto p = dyn_cast<CBPopOp>(op)) {
-        pops.push_back(p);
+      if (isa<CBReserveOp>(op)) {
+        reserves.push_back(op);
+      } else if (isa<CBWaitOp>(op)) {
+        waits.push_back(op);
+      } else if (isa<CBPushOp>(op)) {
+        pushes.push_back(op);
+      } else if (isa<CBPopOp>(op)) {
+        pops.push_back(op);
       }
     });
 
     OpBuilder builder(func.getContext());
 
     // Track erased ops so later iterations skip them before any accessor
-    // call. The set holds raw pointers to freed ops; `findReleases` must
+    // call. The set holds raw pointers to freed ops; `findOwnedReleases` must
     // check `erased.contains(...)` before touching any op wrapper method.
     DenseSet<Operation *> erased;
 
-    auto insertMissingReleases = [&](auto &acquires, auto &releases,
-                                     auto createRelease) {
-      using ReleaseOpTy =
-          typename std::remove_reference_t<decltype(releases)>::value_type;
-      using AcquireOpTy =
-          typename std::remove_reference_t<decltype(acquires)>::value_type;
-      ArrayRef<AcquireOpTy> acquiresRef(acquires);
+    insertMissingReleases(reserves, pushes, erased, builder,
+                          [](OpBuilder &b, Location loc, Value cb) {
+                            CBPushOp::create(b, loc, cb,
+                                             /*num_tiles=*/IntegerAttr{});
+                          });
 
-      for (auto acquire : acquires) {
-        AcquireInterval interval = makeAcquireInterval(acquire, acquiresRef);
-        ReleaseSearch<ReleaseOpTy> releaseSearch =
-            findOwnedReleases(interval, releases, erased);
-        if (releaseSearch.hasSameLevelRelease) {
-          continue;
-        }
-
-        for (auto nestedOp : releaseSearch.nestedReleases) {
-          erased.insert(nestedOp);
-          nestedOp.erase();
-        }
-
-        Operation *last = findLastOwnedUse(interval);
-        builder.setInsertionPointAfter(last);
-        createRelease(builder, acquire.getLoc(), interval.cb);
-      }
-    };
-
-    insertMissingReleases(
-        reserves, pushes, [](OpBuilder &b, Location loc, Value cb) {
-          CBPushOp::create(b, loc, cb, /*num_tiles=*/IntegerAttr{});
-        });
-
-    insertMissingReleases(waits, pops,
+    insertMissingReleases(waits, pops, erased, builder,
                           [](OpBuilder &b, Location loc, Value cb) {
                             CBPopOp::create(b, loc, cb);
                           });

--- a/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
@@ -8,26 +8,17 @@
 //
 // Inserts missing cb_push / cb_pop for unmatched cb_reserve / cb_wait ops.
 //
-// Placement is driven by the live interval of the acquire's tensor result:
-// the SSA tensor value produced by cb_reserve / cb_wait flows through
-// attach_cb, ttl.store, and downstream compute ops. The last operation in
-// the acquire's block that transitively consumes the tensor marks the end
-// of the interval; the release is inserted immediately after it. Uses in
-// descendant regions (scf.for / scf.if bodies) project to their ancestor
-// in the acquire's block, so a tensor read inside a loop body correctly
-// extends the interval through the enclosing structured op.
+// Each acquire opens a DFB live interval. The pass finds owned uses from two
+// sources: SSA users of the acquire result, and direction-matched direct DFB
+// copy operands. Uses in descendant regions project to their ancestor in the
+// acquire block.
 //
-// Releases nested inside structured control flow are hoisted: the nested
-// release is erased and a single release is placed at the acquire's block
-// scope. Pre-existing same-level releases mark the acquire as already
-// handled and the pass leaves it alone (idempotency).
+// Nested releases are erased and reinserted at the acquire block scope.
+// Same-level releases make the pass idempotent.
 //
 // Legality invariants:
-//   P1. cb_push must follow the store into the reserved slot and precede
-//       any cb_wait that consumes the slot, including waits nested in
-//       descendant regions.
-//   P2. cb_pop must follow the last transitive use of the waited value,
-//       including uses nested in descendant regions.
+//   P1. cb_push follows reserve-side writes before write pointer reuse.
+//   P2. cb_pop follows wait-side reads before read pointer reuse.
 //
 //===----------------------------------------------------------------------===//
 
@@ -47,68 +38,122 @@ namespace mlir::tt::ttl {
 
 namespace {
 
+enum class AcquireKind { Reserve, Wait };
+
+struct AcquireInterval {
+  Operation *acquire;
+  Value cb;
+  AcquireKind kind;
+  Operation *sameKindBoundary;
+};
+
+template <typename ReleaseOpTy>
+struct ReleaseSearch {
+  bool hasSameLevelRelease = false;
+  SmallVector<ReleaseOpTy> nestedReleases;
+};
+
 /// Return true if `a` is before `b` in their common block.
 static bool isBefore(Operation *a, Operation *b) {
   return a->isBeforeInBlock(b);
 }
 
-/// Find releases on `cb` at or after `acquire` and before `boundary`.
-/// Same-level releases are "matching" (the acquire is already handled).
-/// Nested releases are collected into `toHoist` for erasure.
+template <typename AcquireOpTy>
+static AcquireKind getAcquireKind() {
+  if constexpr (std::is_same_v<AcquireOpTy, CBReserveOp>) {
+    return AcquireKind::Reserve;
+  } else {
+    static_assert(std::is_same_v<AcquireOpTy, CBWaitOp>,
+                  "unsupported DFB acquire op");
+    return AcquireKind::Wait;
+  }
+}
+
+static bool isLifecycleOrAttachOp(Operation *op) {
+  return isa<CBPushOp, CBPopOp, CBReserveOp, CBWaitOp, AttachCBOp>(op);
+}
+
+static bool directDFBUseMatchesAcquire(AcquireInterval interval,
+                                       Operation *user) {
+  auto copy = dyn_cast<CopyOp>(user);
+  if (!copy) {
+    return true;
+  }
+
+  switch (interval.kind) {
+  case AcquireKind::Reserve:
+    return copy.getDst() == interval.cb;
+  case AcquireKind::Wait:
+    return copy.getSrc() == interval.cb;
+  }
+  llvm_unreachable("unknown acquire kind");
+}
+
+static bool projectToAcquireBlock(AcquireInterval interval, Operation *op,
+                                  Operation *&projected) {
+  Block *block = interval.acquire->getBlock();
+  projected = op->getBlock() == block ? op : block->findAncestorOpInBlock(*op);
+  if (!projected) {
+    return false;
+  }
+  if (!isBefore(interval.acquire, projected)) {
+    return false;
+  }
+  if (interval.sameKindBoundary &&
+      !isBefore(projected, interval.sameKindBoundary)) {
+    return false;
+  }
+  return true;
+}
+
+static void updateLatestUse(Operation *candidate, Operation *&latest) {
+  if (isBefore(latest, candidate)) {
+    latest = candidate;
+  }
+}
+
+/// Find releases owned by this acquire interval.
 template <typename ReleaseOpTy>
-static bool findReleases(Value cb, Operation *acquire,
-                         const SmallVectorImpl<ReleaseOpTy> &allReleases,
-                         SmallVectorImpl<ReleaseOpTy> &toHoist,
-                         const DenseSet<Operation *> &erased,
-                         Operation *boundary) {
-  Block *block = acquire->getBlock();
-  bool hasSameLevelRelease = false;
+static ReleaseSearch<ReleaseOpTy>
+findOwnedReleases(AcquireInterval interval,
+                  const SmallVectorImpl<ReleaseOpTy> &allReleases,
+                  const DenseSet<Operation *> &erased) {
+  ReleaseSearch<ReleaseOpTy> result;
+  Block *block = interval.acquire->getBlock();
 
   for (auto release : allReleases) {
     Operation *releaseOp = release.getOperation();
     if (erased.contains(releaseOp)) {
       continue;
     }
-    if (release.getCb() != cb) {
+    if (release.getCb() != interval.cb) {
       continue;
     }
 
-    // Same-level: release is directly in the acquire's block.
     if (releaseOp->getBlock() == block) {
-      if (!isBefore(acquire, releaseOp)) {
+      Operation *projected = nullptr;
+      if (!projectToAcquireBlock(interval, releaseOp, projected)) {
         continue;
       }
-      if (boundary && !isBefore(releaseOp, boundary)) {
-        continue;
-      }
-      hasSameLevelRelease = true;
+      result.hasSameLevelRelease = true;
       continue;
     }
 
-    // Nested: release is inside a structured op in the acquire's block.
-    Operation *ancestor = block->findAncestorOpInBlock(*releaseOp);
-    if (!ancestor) {
+    Operation *projected = nullptr;
+    if (!projectToAcquireBlock(interval, releaseOp, projected)) {
       continue;
     }
-    if (!isBefore(acquire, ancestor)) {
-      continue;
-    }
-    if (boundary && !isBefore(ancestor, boundary)) {
-      continue;
-    }
-    toHoist.push_back(release);
+    result.nestedReleases.push_back(release);
   }
 
-  return hasSameLevelRelease;
+  return result;
 }
 
-/// Return the next same-kind acquire on this DFB, projected into
-/// `acquire`'s block.
 template <typename AcquireOpTy>
-static Operation *findNextSameKindAcquire(Value cb, Operation *acquire,
-                                          ArrayRef<AcquireOpTy> acquires) {
+static void updateBoundary(Value cb, Operation *acquire,
+                           ArrayRef<AcquireOpTy> acquires,
+                           Operation *&boundary) {
   Block *block = acquire->getBlock();
-  Operation *boundary = nullptr;
   for (auto other : acquires) {
     Operation *otherOp = other.getOperation();
     if (otherOp == acquire) {
@@ -128,76 +173,61 @@ static Operation *findNextSameKindAcquire(Value cb, Operation *acquire,
       boundary = ancestor;
     }
   }
+}
+
+/// Return the next same-kind acquire on this DFB, projected into `acquire`'s
+/// block.
+template <typename AcquireOpTy>
+static Operation *findNextSameKindAcquire(Value cb, Operation *acquire,
+                                          ArrayRef<AcquireOpTy> acquires) {
+  Operation *boundary = nullptr;
+  updateBoundary(cb, acquire, acquires, boundary);
   return boundary;
 }
 
-/// Live-interval endpoint for the slot of `acquire`: the last op in
-/// `acquire->getBlock()` that transitively consumes the reserved or
-/// waited slot. Two sources feed the interval:
-///
-///   1. SSA uses of `acquire->getResult(0)` — the acquire's tensor value
-///      (attach_cb -> ttl.store -> compute ops).
-///   2. Non-attach-cb users of the CB itself — e.g., `ttl.copy` in
-///      dm_read / dm_write takes the CB as an operand directly, bypassing
-///      the attach_cb chain.
-///
-/// attach_cb ops on the same CB for *other* acquires are deliberately
-/// excluded to avoid over-approximating across independent slots. They
-/// would be reached via (1) for this acquire's own tensor, and they
-/// belong to other acquires' intervals otherwise.
-///
-/// Uses in descendant regions project up to their ancestor in the
-/// acquire's block.
-///
-/// `boundary` excludes uses owned by a later same-DFB acquire interval.
-///
-/// Returns `acquire` itself when no tensor users exist; callers treat
-/// that as "insert the release immediately after the acquire".
-static Operation *findLastTensorUse(Value cb, Operation *acquire,
-                                    Operation *boundary) {
-  Operation *last = acquire;
-  Block *block = acquire->getBlock();
+/// Return the last op in `acquire`'s block that consumes the acquired slot.
+/// Tensor uses follow the acquire result; direct DFB copies use direction.
+/// `boundary` stops the scan at the next same-kind acquire.
+static Operation *findLastOwnedUse(AcquireInterval interval) {
+  Operation *last = interval.acquire;
   DenseSet<Operation *> visited;
   SmallVector<Value, 8> worklist;
 
   auto extend = [&](Operation *user) {
+    Operation *projected = nullptr;
+    if (!projectToAcquireBlock(interval, user, projected)) {
+      return false;
+    }
     if (!visited.insert(user).second) {
-      return;
+      return false;
     }
-    Operation *ancestor = block->findAncestorOpInBlock(*user);
-    if (!ancestor) {
-      return;
-    }
-    if (boundary && !isBefore(ancestor, boundary)) {
-      return;
-    }
-    if (isBefore(last, ancestor)) {
-      last = ancestor;
-    }
+    updateLatestUse(projected, last);
     for (Value result : user->getResults()) {
       worklist.push_back(result);
     }
+    return true;
   };
 
-  // Direct users of the CB value that aren't sync ops or attach_cb.
-  for (OpOperand &use : cb.getUses()) {
+  for (OpOperand &use : interval.cb.getUses()) {
     Operation *user = use.getOwner();
-    if (user == acquire) {
+    if (user == interval.acquire) {
       continue;
     }
-    if (isa<CBPushOp, CBPopOp, CBReserveOp, CBWaitOp, AttachCBOp>(user)) {
+    if (isLifecycleOrAttachOp(user)) {
+      continue;
+    }
+    if (!directDFBUseMatchesAcquire(interval, user)) {
       continue;
     }
     extend(user);
   }
 
-  // Tensor-value chain from this acquire's result.
-  if (acquire->getNumResults() > 0) {
-    worklist.push_back(acquire->getResult(0));
+  if (interval.acquire->getNumResults() > 0) {
+    worklist.push_back(interval.acquire->getResult(0));
   }
   while (!worklist.empty()) {
-    Value v = worklist.pop_back_val();
-    for (OpOperand &use : v.getUses()) {
+    Value value = worklist.pop_back_val();
+    for (OpOperand &use : value.getUses()) {
       Operation *user = use.getOwner();
       if (isa<CBPushOp, CBPopOp>(user)) {
         continue;
@@ -207,6 +237,15 @@ static Operation *findLastTensorUse(Value cb, Operation *acquire,
   }
 
   return last;
+}
+
+template <typename AcquireOpTy>
+static AcquireInterval makeAcquireInterval(AcquireOpTy acquire,
+                                           ArrayRef<AcquireOpTy> acquires) {
+  Value cb = acquire.getCb();
+  Operation *acquireOp = acquire.getOperation();
+  return {acquireOp, cb, getAcquireKind<AcquireOpTy>(),
+          findNextSameKindAcquire(cb, acquireOp, acquires)};
 }
 
 struct TTLInsertCBSyncPass
@@ -234,34 +273,34 @@ struct TTLInsertCBSyncPass
     OpBuilder builder(func.getContext());
 
     // Track erased ops so later iterations skip them before any accessor
-    // call. The set holds raw pointers to freed ops — `findReleases` must
+    // call. The set holds raw pointers to freed ops; `findReleases` must
     // check `erased.contains(...)` before touching any op wrapper method.
     DenseSet<Operation *> erased;
 
     auto insertMissingReleases = [&](auto &acquires, auto &releases,
                                      auto createRelease) {
-      using AcquireOpTy =
-          typename std::remove_reference_t<decltype(acquires)>::value_type;
       using ReleaseOpTy =
           typename std::remove_reference_t<decltype(releases)>::value_type;
+      using AcquireOpTy =
+          typename std::remove_reference_t<decltype(acquires)>::value_type;
       ArrayRef<AcquireOpTy> acquiresRef(acquires);
-      for (auto acquire : acquires) {
-        Value cb = acquire.getCb();
 
-        Operation *boundary = findNextSameKindAcquire(cb, acquire, acquiresRef);
-        SmallVector<ReleaseOpTy> nested;
-        if (findReleases(cb, acquire, releases, nested, erased, boundary)) {
+      for (auto acquire : acquires) {
+        AcquireInterval interval = makeAcquireInterval(acquire, acquiresRef);
+        ReleaseSearch<ReleaseOpTy> releaseSearch =
+            findOwnedReleases(interval, releases, erased);
+        if (releaseSearch.hasSameLevelRelease) {
           continue;
         }
 
-        for (auto nestedOp : nested) {
+        for (auto nestedOp : releaseSearch.nestedReleases) {
           erased.insert(nestedOp);
           nestedOp.erase();
         }
 
-        Operation *last = findLastTensorUse(cb, acquire, boundary);
+        Operation *last = findLastOwnedUse(interval);
         builder.setInsertionPointAfter(last);
-        createRelease(builder, acquire.getLoc(), cb);
+        createRelease(builder, acquire.getLoc(), interval.cb);
       }
     };
 

--- a/test/python/test_issue_536_cb_pop_between_waits.py
+++ b/test/python/test_issue_536_cb_pop_between_waits.py
@@ -16,95 +16,71 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 import ttl  # noqa: E402
 
 from ttlang_test_utils import to_dram  # noqa: E402
-from utils.correctness import assert_allclose  # noqa: E402
 
 TILE = 32
 
 
-def _make_kernel():
+def _make_kernel(*, explicit_pop_at_end=False):
     @ttl.operation(grid=(1, 1))
-    def repro(out):
+    def repro(inp, out):
         shape = (1, 1)
-        shared_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
+        inp_cb = ttl.make_dataflow_buffer_like(inp, shape=shape, block_count=2)
         out_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
 
         @ttl.compute()
         def compute():
-            with shared_cb.reserve() as v:
-                v.store(ttl.math.fill(v, 7.0))
-            with shared_cb.wait() as src, out_cb.reserve() as dst:
+            with inp_cb.wait() as src, out_cb.reserve() as dst:
                 dst.store(src)
 
-            with shared_cb.reserve() as v:
-                v.store(ttl.math.fill(v, 8.0))
-            with shared_cb.wait() as src, out_cb.reserve() as dst:
+            with inp_cb.wait() as src, out_cb.reserve() as dst:
                 dst.store(src)
 
         @ttl.datamovement()
         def dm_read():
-            pass
+            blk = inp_cb.reserve()
+            ttl.copy(inp[0, 0], blk).wait()
+            blk = inp_cb.reserve()
+            ttl.copy(inp[1, 0], blk).wait()
 
-        @ttl.datamovement()
-        def dm_write():
-            blk = out_cb.wait()
-            ttl.copy(blk, out[0:1, 0:1]).wait()
-            blk = out_cb.wait()
-            ttl.copy(blk, out[1:2, 0:1]).wait()
+        if explicit_pop_at_end:
 
-    return repro
+            @ttl.datamovement()
+            def dm_write():
+                blk = out_cb.wait()
+                ttl.copy(blk, out[0, 0]).wait()
+                blk = out_cb.wait()
+                ttl.copy(blk, out[1, 0]).wait()
+                blk.pop()
 
+        else:
 
-def _make_later_explicit_pop_kernel():
-    @ttl.operation(grid=(1, 1))
-    def repro(out):
-        shape = (1, 1)
-        shared_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
-        out_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
-
-        @ttl.compute()
-        def compute():
-            with shared_cb.reserve() as v:
-                v.store(ttl.math.fill(v, 7.0))
-            with shared_cb.wait() as src, out_cb.reserve() as dst:
-                dst.store(src)
-
-            with shared_cb.reserve() as v:
-                v.store(ttl.math.fill(v, 8.0))
-            with shared_cb.wait() as src, out_cb.reserve() as dst:
-                dst.store(src)
-
-        @ttl.datamovement()
-        def dm_read():
-            pass
-
-        @ttl.datamovement()
-        def dm_write():
-            blk = out_cb.wait()
-            ttl.copy(blk, out[0:1, 0:1]).wait()
-            blk = out_cb.wait()
-            ttl.copy(blk, out[1:2, 0:1]).wait()
-            blk.pop()
+            @ttl.datamovement()
+            def dm_write():
+                blk = out_cb.wait()
+                ttl.copy(blk, out[0, 0]).wait()
+                blk = out_cb.wait()
+                ttl.copy(blk, out[1, 0]).wait()
 
     return repro
-
-
-@pytest.mark.requires_device
-def test_two_waits_same_dfb_pops_between(device):
-    kernel = _make_kernel()
-    _run_kernel_and_check(device, kernel)
-
-
-@pytest.mark.requires_device
-def test_later_explicit_pop_does_not_satisfy_first_wait(device):
-    kernel = _make_later_explicit_pop_kernel()
-    _run_kernel_and_check(device, kernel)
 
 
 def _run_kernel_and_check(device, kernel):
+    torch.manual_seed(536)
+    inp = torch.randn((2 * TILE, TILE), dtype=torch.bfloat16)
+    inp_t = to_dram(inp, device)
     out_t = to_dram(torch.full((2 * TILE, TILE), -42.0, dtype=torch.bfloat16), device)
-    kernel(out_t)
+    kernel(inp_t, out_t)
     ttnn.synchronize_device(device)
-    expected = torch.empty((2 * TILE, TILE), dtype=torch.float32)
-    expected[:TILE, :] = 7.0
-    expected[TILE:, :] = 8.0
-    assert_allclose(ttnn.to_torch(out_t).float(), expected)
+    result = ttnn.to_torch(out_t)
+    assert torch.equal(result, inp), f"result:\n{result}\nexpected:\n{inp}"
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize(
+    "explicit_pop_at_end",
+    [False, True],
+    ids=["implicit-pops", "later-explicit-pop"],
+)
+def test_two_waits_same_dfb_pop_placement(device, explicit_pop_at_end):
+    kernel = _make_kernel(explicit_pop_at_end=explicit_pop_at_end)
+    _run_kernel_and_check(device, kernel)

--- a/test/python/test_issue_536_cb_pop_between_waits.py
+++ b/test/python/test_issue_536_cb_pop_between_waits.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression for #536: consecutive waits on one DFB need intervening pops."""
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v --tb=short
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+
+from ttlang_test_utils import to_dram  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+TILE = 32
+
+
+def _make_kernel():
+    @ttl.operation(grid=(1, 1))
+    def repro(out):
+        shape = (1, 1)
+        shared_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with shared_cb.reserve() as v:
+                v.store(ttl.math.fill(v, 7.0))
+            with shared_cb.wait() as src, out_cb.reserve() as dst:
+                dst.store(src)
+
+            with shared_cb.reserve() as v:
+                v.store(ttl.math.fill(v, 8.0))
+            with shared_cb.wait() as src, out_cb.reserve() as dst:
+                dst.store(src)
+
+        @ttl.datamovement()
+        def dm_read():
+            pass
+
+        @ttl.datamovement()
+        def dm_write():
+            blk = out_cb.wait()
+            ttl.copy(blk, out[0:1, 0:1]).wait()
+            blk = out_cb.wait()
+            ttl.copy(blk, out[1:2, 0:1]).wait()
+
+    return repro
+
+
+def _make_later_explicit_pop_kernel():
+    @ttl.operation(grid=(1, 1))
+    def repro(out):
+        shape = (1, 1)
+        shared_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=shape, block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with shared_cb.reserve() as v:
+                v.store(ttl.math.fill(v, 7.0))
+            with shared_cb.wait() as src, out_cb.reserve() as dst:
+                dst.store(src)
+
+            with shared_cb.reserve() as v:
+                v.store(ttl.math.fill(v, 8.0))
+            with shared_cb.wait() as src, out_cb.reserve() as dst:
+                dst.store(src)
+
+        @ttl.datamovement()
+        def dm_read():
+            pass
+
+        @ttl.datamovement()
+        def dm_write():
+            blk = out_cb.wait()
+            ttl.copy(blk, out[0:1, 0:1]).wait()
+            blk = out_cb.wait()
+            ttl.copy(blk, out[1:2, 0:1]).wait()
+            blk.pop()
+
+    return repro
+
+
+@pytest.mark.requires_device
+def test_two_waits_same_dfb_pops_between(device):
+    kernel = _make_kernel()
+    _run_kernel_and_check(device, kernel)
+
+
+@pytest.mark.requires_device
+def test_later_explicit_pop_does_not_satisfy_first_wait(device):
+    kernel = _make_later_explicit_pop_kernel()
+    _run_kernel_and_check(device, kernel)
+
+
+def _run_kernel_and_check(device, kernel):
+    out_t = to_dram(torch.full((2 * TILE, TILE), -42.0, dtype=torch.bfloat16), device)
+    kernel(out_t)
+    ttnn.synchronize_device(device)
+    expected = torch.empty((2 * TILE, TILE), dtype=torch.float32)
+    expected[:TILE, :] = 7.0
+    expected[TILE:, :] = 8.0
+    assert_allclose(ttnn.to_torch(out_t).float(), expected)

--- a/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
@@ -1,7 +1,9 @@
 // Verifies ttl-insert-cb-sync: missing cb_push/cb_pop are inserted after
-// the last transitive use of the CB data.
+// the last transitive use of the CB data. The second RUN verifies that
+// applying the pass twice does not insert duplicate releases.
 
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-insert-cb-sync))' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-insert-cb-sync,ttl-insert-cb-sync))' --split-input-file | FileCheck %s
 
 // Test 1: compute reserve without push, auto-insert after store.
 

--- a/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
@@ -574,3 +574,137 @@ func.func @reserve_then_if_else_branch_wait(
   }
   func.return
 }
+
+// -----
+
+// Test 21: consecutive DM waits on the same DFB need a pop between waits.
+
+// CHECK-LABEL: func.func @two_waits_same_cb_dm_write
+// CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
+// CHECK: ttl.cb_wait %[[CB]]
+// CHECK: ttl.copy %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_pop %[[CB]]
+// CHECK: ttl.cb_wait %[[CB]]
+// CHECK: ttl.copy %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_pop %[[CB]]
+// CHECK-NOT: ttl.cb_pop
+// CHECK: return
+func.func @two_waits_same_cb_dm_write(
+    %arg0: tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>)
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cb0 = ttl.bind_cb{cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice0 = ttl.tensor_slice %arg0[%c0, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx0 = ttl.copy %cb0, %slice0 : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>) -> !ttl.transfer_handle<write>
+  ttl.wait %tx0 : !ttl.transfer_handle<write>
+  %w1 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice1 = ttl.tensor_slice %arg0[%c1, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx1 = ttl.copy %cb0, %slice1 : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>) -> !ttl.transfer_handle<write>
+  ttl.wait %tx1 : !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
+// Test 22: consecutive DM reserves on the same DFB need a push between reserves.
+
+// CHECK-LABEL: func.func @two_reserves_same_cb_dm_read
+// CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
+// CHECK: ttl.cb_reserve %[[CB]]
+// CHECK: ttl.copy {{.*}}, %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_push %[[CB]]
+// CHECK: ttl.cb_reserve %[[CB]]
+// CHECK: ttl.copy {{.*}}, %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_push %[[CB]]
+// CHECK-NOT: ttl.cb_push
+// CHECK: return
+func.func @two_reserves_same_cb_dm_read(
+    %arg0: tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>)
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cb0 = ttl.bind_cb{cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice0 = ttl.tensor_slice %arg0[%c0, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx0 = ttl.copy %slice0, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> !ttl.transfer_handle<read>
+  ttl.wait %tx0 : !ttl.transfer_handle<read>
+  %r1 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice1 = ttl.tensor_slice %arg0[%c1, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx1 = ttl.copy %slice1, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> !ttl.transfer_handle<read>
+  ttl.wait %tx1 : !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+// Test 23: a later explicit pop does not satisfy an earlier wait.
+
+// CHECK-LABEL: func.func @same_cb_dm_write_later_explicit_pop
+// CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
+// CHECK: ttl.cb_wait %[[CB]]
+// CHECK: ttl.copy %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_pop %[[CB]]
+// CHECK: ttl.cb_wait %[[CB]]
+// CHECK: ttl.copy %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_pop %[[CB]]
+// CHECK-NOT: ttl.cb_pop
+// CHECK: return
+func.func @same_cb_dm_write_later_explicit_pop(
+    %arg0: tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>)
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cb0 = ttl.bind_cb{cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice0 = ttl.tensor_slice %arg0[%c0, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx0 = ttl.copy %cb0, %slice0 : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>) -> !ttl.transfer_handle<write>
+  ttl.wait %tx0 : !ttl.transfer_handle<write>
+  %w1 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice1 = ttl.tensor_slice %arg0[%c1, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx1 = ttl.copy %cb0, %slice1 : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>) -> !ttl.transfer_handle<write>
+  ttl.wait %tx1 : !ttl.transfer_handle<write>
+  ttl.cb_pop %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  func.return
+}
+
+// -----
+
+// Test 24: a later explicit push does not satisfy an earlier reserve.
+
+// CHECK-LABEL: func.func @same_cb_dm_read_later_explicit_push
+// CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
+// CHECK: ttl.cb_reserve %[[CB]]
+// CHECK: ttl.copy {{.*}}, %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_push %[[CB]]
+// CHECK: ttl.cb_reserve %[[CB]]
+// CHECK: ttl.copy {{.*}}, %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_push %[[CB]]
+// CHECK-NOT: ttl.cb_push
+// CHECK: return
+func.func @same_cb_dm_read_later_explicit_push(
+    %arg0: tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>)
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cb0 = ttl.bind_cb{cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice0 = ttl.tensor_slice %arg0[%c0, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx0 = ttl.copy %slice0, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> !ttl.transfer_handle<read>
+  ttl.wait %tx0 : !ttl.transfer_handle<read>
+  %r1 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %slice1 = ttl.tensor_slice %arg0[%c1, %c0] : tensor<2x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx1 = ttl.copy %slice1, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> !ttl.transfer_handle<read>
+  ttl.wait %tx1 : !ttl.transfer_handle<read>
+  ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
@@ -582,12 +582,12 @@ func.func @reserve_then_if_else_branch_wait(
 // CHECK-LABEL: func.func @two_waits_same_cb_dm_write
 // CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
 // CHECK: ttl.cb_wait %[[CB]]
-// CHECK: ttl.copy %[[CB]]
-// CHECK: ttl.wait
+// CHECK: %[[TX0:.+]] = ttl.copy %[[CB]],
+// CHECK-NEXT: ttl.wait %[[TX0]]
 // CHECK-NEXT: ttl.cb_pop %[[CB]]
-// CHECK: ttl.cb_wait %[[CB]]
-// CHECK: ttl.copy %[[CB]]
-// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_wait %[[CB]]
+// CHECK: %[[TX1:.+]] = ttl.copy %[[CB]],
+// CHECK-NEXT: ttl.wait %[[TX1]]
 // CHECK-NEXT: ttl.cb_pop %[[CB]]
 // CHECK-NOT: ttl.cb_pop
 // CHECK: return
@@ -615,12 +615,12 @@ func.func @two_waits_same_cb_dm_write(
 // CHECK-LABEL: func.func @two_reserves_same_cb_dm_read
 // CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
 // CHECK: ttl.cb_reserve %[[CB]]
-// CHECK: ttl.copy {{.*}}, %[[CB]]
-// CHECK: ttl.wait
+// CHECK: %[[TX0:.+]] = ttl.copy {{.*}}, %[[CB]]
+// CHECK-NEXT: ttl.wait %[[TX0]]
 // CHECK-NEXT: ttl.cb_push %[[CB]]
-// CHECK: ttl.cb_reserve %[[CB]]
-// CHECK: ttl.copy {{.*}}, %[[CB]]
-// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_reserve %[[CB]]
+// CHECK: %[[TX1:.+]] = ttl.copy {{.*}}, %[[CB]]
+// CHECK-NEXT: ttl.wait %[[TX1]]
 // CHECK-NEXT: ttl.cb_push %[[CB]]
 // CHECK-NOT: ttl.cb_push
 // CHECK: return
@@ -648,12 +648,12 @@ func.func @two_reserves_same_cb_dm_read(
 // CHECK-LABEL: func.func @same_cb_dm_write_later_explicit_pop
 // CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
 // CHECK: ttl.cb_wait %[[CB]]
-// CHECK: ttl.copy %[[CB]]
-// CHECK: ttl.wait
+// CHECK: %[[TX0:.+]] = ttl.copy %[[CB]],
+// CHECK-NEXT: ttl.wait %[[TX0]]
 // CHECK-NEXT: ttl.cb_pop %[[CB]]
-// CHECK: ttl.cb_wait %[[CB]]
-// CHECK: ttl.copy %[[CB]]
-// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_wait %[[CB]]
+// CHECK: %[[TX1:.+]] = ttl.copy %[[CB]],
+// CHECK-NEXT: ttl.wait %[[TX1]]
 // CHECK-NEXT: ttl.cb_pop %[[CB]]
 // CHECK-NOT: ttl.cb_pop
 // CHECK: return
@@ -682,12 +682,12 @@ func.func @same_cb_dm_write_later_explicit_pop(
 // CHECK-LABEL: func.func @same_cb_dm_read_later_explicit_push
 // CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
 // CHECK: ttl.cb_reserve %[[CB]]
-// CHECK: ttl.copy {{.*}}, %[[CB]]
-// CHECK: ttl.wait
+// CHECK: %[[TX0:.+]] = ttl.copy {{.*}}, %[[CB]]
+// CHECK-NEXT: ttl.wait %[[TX0]]
 // CHECK-NEXT: ttl.cb_push %[[CB]]
-// CHECK: ttl.cb_reserve %[[CB]]
-// CHECK: ttl.copy {{.*}}, %[[CB]]
-// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_reserve %[[CB]]
+// CHECK: %[[TX1:.+]] = ttl.copy {{.*}}, %[[CB]]
+// CHECK-NEXT: ttl.wait %[[TX1]]
 // CHECK-NEXT: ttl.cb_push %[[CB]]
 // CHECK-NOT: ttl.cb_push
 // CHECK: return
@@ -716,12 +716,12 @@ func.func @same_cb_dm_read_later_explicit_push(
 // CHECK-LABEL: func.func @dm_reserve_before_wait_same_dfb
 // CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
 // CHECK: ttl.cb_reserve %[[CB]]
-// CHECK: ttl.copy {{.*}}, %[[CB]]
-// CHECK: ttl.wait
+// CHECK: %[[TX0:.+]] = ttl.copy {{.*}}, %[[CB]]
+// CHECK-NEXT: ttl.wait %[[TX0]]
 // CHECK-NEXT: ttl.cb_push %[[CB]]
-// CHECK: ttl.cb_wait %[[CB]]
-// CHECK: ttl.copy %[[CB]]
-// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_wait %[[CB]]
+// CHECK: %[[TX1:.+]] = ttl.copy %[[CB]],
+// CHECK-NEXT: ttl.wait %[[TX1]]
 // CHECK-NEXT: ttl.cb_pop %[[CB]]
 // CHECK-NOT: ttl.cb_push
 // CHECK-NOT: ttl.cb_pop
@@ -750,12 +750,12 @@ func.func @dm_reserve_before_wait_same_dfb(
 // CHECK-LABEL: func.func @dm_wait_before_reserve_same_dfb
 // CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
 // CHECK: ttl.cb_wait %[[CB]]
-// CHECK: ttl.copy %[[CB]]
-// CHECK: ttl.wait
+// CHECK: %[[TX0:.+]] = ttl.copy %[[CB]],
+// CHECK-NEXT: ttl.wait %[[TX0]]
 // CHECK-NEXT: ttl.cb_pop %[[CB]]
-// CHECK: ttl.cb_reserve %[[CB]]
-// CHECK: ttl.copy {{.*}}, %[[CB]]
-// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_reserve %[[CB]]
+// CHECK: %[[TX1:.+]] = ttl.copy {{.*}}, %[[CB]]
+// CHECK-NEXT: ttl.wait %[[TX1]]
 // CHECK-NEXT: ttl.cb_push %[[CB]]
 // CHECK-NOT: ttl.cb_push
 // CHECK-NOT: ttl.cb_pop

--- a/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
@@ -473,7 +473,7 @@ func.func @reserve_before_loop_with_nested_wait(
 
 // Test 18: outer cb_wait whose attached-CB tensor value is consumed
 // inside a subsequent scf.for body. The pop must be placed AFTER the
-// scf.for — the live interval of the waited slot extends through the
+// scf.for because the live interval of the waited slot extends through the
 // loop because the value is still used on every iteration.
 
 // CHECK-LABEL: func.func @wait_before_loop_use_inside_loop
@@ -541,7 +541,7 @@ func.func @dm_reserve_copy_inside_loop(
 // Test 20: outer cb_reserve + store with a cb_wait on the same CB
 // consuming the slot in only the ELSE branch of a subsequent scf.if
 // (the then branch does nothing with this CB). The scf.if is a sibling
-// region — not a descendant of the reserve's block in the structured-
+// region, not a descendant of the reserve's block in the structured-
 // control-flow sense the bug originally exercised. Regardless, the
 // push must land before scf.if so the else branch's wait is satisfied
 // on the control-flow paths that reach it.
@@ -706,5 +706,73 @@ func.func @same_cb_dm_read_later_explicit_push(
   %tx1 = ttl.copy %slice1, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> !ttl.transfer_handle<read>
   ttl.wait %tx1 : !ttl.transfer_handle<read>
   ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  func.return
+}
+
+// -----
+
+// Test 25: wait-side copies do not extend a prior reserve interval.
+
+// CHECK-LABEL: func.func @dm_reserve_before_wait_same_dfb
+// CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
+// CHECK: ttl.cb_reserve %[[CB]]
+// CHECK: ttl.copy {{.*}}, %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_push %[[CB]]
+// CHECK: ttl.cb_wait %[[CB]]
+// CHECK: ttl.copy %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_pop %[[CB]]
+// CHECK-NOT: ttl.cb_push
+// CHECK-NOT: ttl.cb_pop
+// CHECK: return
+func.func @dm_reserve_before_wait_same_dfb(
+    %arg0: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>,
+    %arg1: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>)
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %c0 = arith.constant 0 : index
+  %cb0 = ttl.bind_cb{cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %src_slice = ttl.tensor_slice %arg0[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx0 = ttl.copy %src_slice, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> !ttl.transfer_handle<read>
+  ttl.wait %tx0 : !ttl.transfer_handle<read>
+  %w = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst_slice = ttl.tensor_slice %arg1[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx1 = ttl.copy %cb0, %dst_slice : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>) -> !ttl.transfer_handle<write>
+  ttl.wait %tx1 : !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
+// Test 26: reserve-side copies do not extend a prior wait interval.
+
+// CHECK-LABEL: func.func @dm_wait_before_reserve_same_dfb
+// CHECK: %[[CB:.+]] = ttl.bind_cb{cb_index = 0
+// CHECK: ttl.cb_wait %[[CB]]
+// CHECK: ttl.copy %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_pop %[[CB]]
+// CHECK: ttl.cb_reserve %[[CB]]
+// CHECK: ttl.copy {{.*}}, %[[CB]]
+// CHECK: ttl.wait
+// CHECK-NEXT: ttl.cb_push %[[CB]]
+// CHECK-NOT: ttl.cb_push
+// CHECK-NOT: ttl.cb_pop
+// CHECK: return
+func.func @dm_wait_before_reserve_same_dfb(
+    %arg0: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>,
+    %arg1: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>)
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %c0 = arith.constant 0 : index
+  %cb0 = ttl.bind_cb{cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst_slice = ttl.tensor_slice %arg1[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx0 = ttl.copy %cb0, %dst_slice : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>) -> !ttl.transfer_handle<write>
+  ttl.wait %tx0 : !ttl.transfer_handle<write>
+  %r = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %src_slice = ttl.tensor_slice %arg0[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>> -> tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
+  %tx1 = ttl.copy %src_slice, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> !ttl.transfer_handle<read>
+  ttl.wait %tx1 : !ttl.transfer_handle<read>
   func.return
 }

--- a/third-party/patches/ttmetal-disable-leak-warnings.patch
+++ b/third-party/patches/ttmetal-disable-leak-warnings.patch
@@ -11,3 +11,12 @@ index a0b002c0ca..2d3055f751 100644
 
      auto m_core = mod.def_submodule("core", "core operations");
      core::py_module_types(m_core);
+@@ -327,5 +327,6 @@ void py_module(nb::module_& mod) {
++    bool printLeakWarnings = nb::leak_warnings();
+     nb::set_leak_warnings(false);
+     mod.attr("CONFIG") = nb::cast(&ttnn::CONFIG, nb::rv_policy::reference);
+-    nb::set_leak_warnings(true);
++    nb::set_leak_warnings(printLeakWarnings);
+     mod.def(
+         "get_python_operation_id",
+         []() -> std::uint64_t { return ttnn::CoreIDs::instance().get_python_operation_id(); },


### PR DESCRIPTION
Bug:
Auto-inserted `cb_pop` / `cb_push` could be placed after a later acquire on the same DFB. In a DM writer with consecutive `cb_wait` calls, this left the read pointer on the first slot and caused both writes to read the same tile.

Changes:
- Bound DFB release matching and live-use analysis by the next same-kind acquire on the same DFB.
- Tightened `ttl-insert-cb-sync` documentation/comments around direct DFB uses.

Tests:
- Added MLIR coverage for consecutive waits/reserves and later explicit release cases.
- Added device pytest coverage for the issue 536 reproducer and the later explicit pop case.

Fixes #536