### PR TITLE
[nfc] Diagnostics: render every MLIR error with its attached notes

### DIFF
--- a/python/ttl/diagnostics.py
+++ b/python/ttl/diagnostics.py
@@ -243,9 +243,8 @@ def format_mlir_error(
             # context.
             if note_msg.startswith("see current operation"):
                 continue
-            # Drop duplicate notes (the verifier emits one
-            # `PipeNet <N> declared here` note per pipe; a multi-pipe
-            # PipeNet repeats the note at the same location).
+            # Drop duplicate notes (some passes emit the same note
+            # at the same location more than once).
             key = (note_loc, note_msg)
             if key in seen:
                 continue

--- a/python/ttl/diagnostics.py
+++ b/python/ttl/diagnostics.py
@@ -72,6 +72,7 @@ class SourceDiagnostic:
         label: str = "error",
         span_length: int = 1,
         note: Optional[str] = None,
+        indent: int = 0,
     ) -> str:
         """Format an error with source context.
 
@@ -82,34 +83,38 @@ class SourceDiagnostic:
             label: Error label (e.g., "error", "warning")
             span_length: Length of the underline (^^^)
             note: Optional additional note
+            indent: Number of leading spaces to prepend to every line
+                of the rendered block, used to visually subordinate
+                child notes under their parent error.
 
         Returns:
             Formatted error string with source context
         """
+        prefix = " " * indent
         # Build header
-        result = [f"{label}: {message}"]
-        result.append(f"  --> {self.filename}:{line}:{col}")
+        result = [f"{prefix}{label}: {message}"]
+        result.append(f"{prefix}  --> {self.filename}:{line}:{col}")
 
         # Get line number width for alignment
         line_num_width = len(str(line))
         gutter = " " * line_num_width
 
-        result.append(f"{gutter} |")
+        result.append(f"{prefix}{gutter} |")
 
         # Show source line if available
         if 0 < line <= len(self.source_lines):
             source_line = self.source_lines[line - 1].rstrip()
-            result.append(f"{line:>{line_num_width}} | {source_line}")
+            result.append(f"{prefix}{line:>{line_num_width}} | {source_line}")
 
             # Build underline with carets
             underline_padding = " " * (col - 1)
             underline = "^" * max(1, span_length)
-            result.append(f"{gutter} | {underline_padding}{underline}")
+            result.append(f"{prefix}{gutter} | {underline_padding}{underline}")
 
-        result.append(f"{gutter} |")
+        result.append(f"{prefix}{gutter} |")
 
         if note:
-            result.append(f"{gutter} = note: {note}")
+            result.append(f"{prefix}{gutter} = note: {note}")
 
         return "\n".join(result)
 
@@ -204,6 +209,12 @@ def format_mlir_error(
 ) -> str:
     """Format an MLIR error with source context if location is available.
 
+    Splits the diagnostic stream into one group per error (each error
+    plus the notes attached to it) and renders each group as its own
+    `error:` + `note:` blocks. Multiple unrelated violations therefore
+    surface as multiple errors, not a single primary with the rest
+    folded into notes.
+
     Args:
         error_msg: The MLIR error message
         source_lines: Original Python source lines (optional, will read from file if needed)
@@ -212,25 +223,42 @@ def format_mlir_error(
     Returns:
         Formatted error message, with source context if available
     """
-    loc_info = extract_location_from_mlir_error(error_msg)
+    groups = _extract_diagnostic_groups(error_msg)
 
-    if loc_info is None:
+    if not groups:
         return error_msg
 
-    filename, line, col = loc_info
-    display_file = source_file if source_file else filename
+    blocks: List[str] = []
+    for primary, notes in groups:
+        primary_loc, primary_msg = primary
+        block = _render_diagnostic_block(
+            primary_loc, primary_msg, "error", source_lines, source_file
+        )
+        if block is not None:
+            blocks.append(block)
+        seen: List[Tuple[Optional[Tuple[str, int, int]], str]] = []
+        for note_loc, note_msg in notes:
+            # Drop the MLIR-internal `see current operation` note,
+            # which echoes the failing op's IR rather than adding user
+            # context.
+            if note_msg.startswith("see current operation"):
+                continue
+            # Drop duplicate notes (the verifier emits one
+            # `PipeNet <N> declared here` note per pipe; a multi-pipe
+            # PipeNet repeats the note at the same location).
+            key = (note_loc, note_msg)
+            if key in seen:
+                continue
+            seen.append(key)
+            # Indent notes 2 spaces so they read as visually subordinate
+            # to their parent error.
+            note_block = _render_diagnostic_block(
+                note_loc, note_msg, "note", source_lines, source_file, indent=2
+            )
+            if note_block is not None:
+                blocks.append(note_block)
 
-    # Read source from file if not provided or if line number exceeds provided lines
-    if source_lines is None or line > len(source_lines):
-        source_lines = _read_file_lines(filename)
-
-    if source_lines is None:
-        return error_msg
-
-    diag = SourceDiagnostic(source_lines, display_file)
-    core_msg = _extract_core_message(error_msg)
-
-    formatted = diag.format_error(line=line, col=col, message=core_msg)
+    formatted = "\n\n".join(blocks)
 
     if _verbose_errors_enabled():
         formatted += f"\n\nMLIR diagnostic:\n{error_msg}"
@@ -238,34 +266,109 @@ def format_mlir_error(
     return formatted
 
 
-def _extract_core_message(error_msg: str) -> str:
-    """Extract the core error message from MLIR diagnostic output.
+def _render_diagnostic_block(
+    loc_info: Optional[Tuple[str, int, int]],
+    message: str,
+    label: str,
+    source_lines: Optional[List[str]],
+    source_file: Optional[str],
+    indent: int = 0,
+) -> Optional[str]:
+    """Render one diagnostic (primary or note) with a source block.
 
-    MLIR errors often look like:
-        error: 'ttl.copy' op expects transfer handle to be synchronized with ttl.wait
-
-    This extracts: "expects transfer handle to be synchronized with ttl.wait"
+    Falls back to a `<label>: <message>` line if location resolution
+    fails — better than dropping the note entirely.
     """
-    # Look for the pattern: 'op_name' op <message>
-    match = re.search(r"'[^']+' op (.+?)(?:\n|$)", error_msg)
-    if match:
-        return match.group(1).strip()
+    prefix = " " * indent
+    if loc_info is None:
+        return f"{prefix}{label}: {message}"
 
-    # Look for error: <message> pattern
-    match = re.search(r"error: (.+?)(?:\n|$)", error_msg)
-    if match:
-        return match.group(1).strip()
+    filename, line, col = loc_info
+    display_file = source_file if source_file else filename
 
-    # Fall back to first line
-    return error_msg.split("\n")[0].strip()
+    block_lines = source_lines
+    if block_lines is None or line > len(block_lines):
+        block_lines = _read_file_lines(filename)
+
+    if block_lines is None:
+        return f"{prefix}{label}: {message}\n{prefix}  --> {filename}:{line}:{col}"
+
+    diag = SourceDiagnostic(block_lines, display_file)
+    return diag.format_error(
+        line=line, col=col, message=message, label=label, indent=indent
+    )
 
 
-def _extract_note(error_msg: str) -> Optional[str]:
-    """Extract any note from the MLIR error message."""
-    match = re.search(r"note: (.+?)(?:\n|$)", error_msg)
-    if match:
-        return match.group(1).strip()
-    return None
+_Diagnostic = Tuple[Optional[Tuple[str, int, int]], str]
+_DiagnosticGroup = Tuple[_Diagnostic, List[_Diagnostic]]
+
+
+def _extract_diagnostic_groups(error_msg: str) -> List[_DiagnosticGroup]:
+    """Split an MLIR error string into groups of (error, [notes]).
+
+    MLIR emits one diagnostic per line in the form
+        <file>:<line>:<col>: <kind>: <message>
+    with `<kind>` in {error, note, warning}. Notes are attached to the
+    most recent error/warning that preceded them, so a stream like
+        error: A
+        note: about A
+        error: B
+        note: about B
+    parses as two groups: (A, [note about A]) and (B, [note about B]).
+    Continuation lines (e.g. the IR dump under `see current operation`)
+    don't start with a recognized kind keyword and are skipped.
+    """
+    groups: List[_DiagnosticGroup] = []
+    current_notes: List[_Diagnostic] = []
+
+    # MLIR diagnostics from the Python pass manager surface as
+    #     <kind>: "path":line:col: <message>
+    # (notes sometimes carry a leading space). Raw `ttlang-opt` runs
+    # use
+    #     path:line:col: <kind>: <message>
+    # We accept both. The location segment is optional so notes
+    # without locations still parse.
+    kind_first = re.compile(
+        r"^\s*(?P<kind>error|note|warning):\s*"
+        r"(?:\"?(?P<file>[^\"\n]+?)\"?:(?P<line>\d+):(?P<col>\d+):\s*)?"
+        r"(?P<msg>.*)$"
+    )
+    loc_first = re.compile(
+        r"^(?:\"?(?P<file>[^\"\n]+?)\"?:(?P<line>\d+):(?P<col>\d+):\s*)"
+        r"(?P<kind>error|note|warning):\s*(?P<msg>.*)$"
+    )
+
+    for raw in error_msg.splitlines():
+        match = loc_first.match(raw) or kind_first.match(raw)
+        if not match:
+            continue
+        kind = match.group("kind")
+        msg = match.group("msg").strip()
+        # Strip the leading `'op_name' op ` prefix MLIR adds for op-level
+        # diagnostics so the user sees the message we wrote.
+        op_match = re.match(r"'[^']+'\s+op\s+(.*)$", msg)
+        if op_match:
+            msg = op_match.group(1).strip()
+
+        if match.group("file"):
+            loc = (
+                match.group("file"),
+                int(match.group("line")),
+                int(match.group("col")),
+            )
+        else:
+            loc = None
+
+        if kind in ("error", "warning"):
+            current_notes = []
+            groups.append(((loc, msg), current_notes))
+        else:  # note
+            # Notes before any error are dropped — there's nothing for
+            # them to attach to. In practice MLIR doesn't emit those.
+            if groups:
+                current_notes.append((loc, msg))
+
+    return groups
 
 
 def format_python_error(

--- a/python/ttl/diagnostics.py
+++ b/python/ttl/diagnostics.py
@@ -138,61 +138,6 @@ class SourceDiagnostic:
         return "\n\n".join(results)
 
 
-def parse_mlir_location(loc_str: str) -> Optional[Tuple[str, int, int]]:
-    """Parse an MLIR location string to extract file, line, and column.
-
-    MLIR locations can appear in several formats:
-    - loc("filename":line:col)
-    - loc("filename":line:col to :line:col)
-    - loc(#loc1) with #loc1 = loc("filename":line:col)
-
-    Args:
-        loc_str: MLIR location string
-
-    Returns:
-        Tuple of (filename, line, col) or None if not parseable
-    """
-    # Match loc("filename":line:col)
-    match = re.search(r'loc\("([^"]+)":(\d+):(\d+)', loc_str)
-    if match:
-        return match.group(1), int(match.group(2)), int(match.group(3))
-
-    # Match standalone "filename":line:col pattern
-    match = re.search(r'"([^"]+)":(\d+):(\d+)', loc_str)
-    if match:
-        return match.group(1), int(match.group(2)), int(match.group(3))
-
-    return None
-
-
-def extract_location_from_mlir_error(error_msg: str) -> Optional[Tuple[str, int, int]]:
-    """Extract source location from an MLIR error message.
-
-    MLIR errors often include location information like:
-        error: 'op' op some error message
-        note: see current operation: %0 = "op"(...) loc("file.py":42:10)
-
-    Args:
-        error_msg: Full MLIR error message
-
-    Returns:
-        Tuple of (filename, line, col) or None if no location found
-    """
-    # Look for location patterns in the error message
-    loc_info = parse_mlir_location(error_msg)
-    if loc_info:
-        return loc_info
-
-    # Try to find location in "note: see current operation" lines
-    for line in error_msg.split("\n"):
-        if "loc(" in line:
-            loc_info = parse_mlir_location(line)
-            if loc_info:
-                return loc_info
-
-    return None
-
-
 def _read_file_lines(filepath: str) -> Optional[List[str]]:
     """Read source lines from a file if it exists."""
     try:
@@ -211,8 +156,8 @@ def format_mlir_error(
 
     Splits the diagnostic stream into one group per error (each error
     plus the notes attached to it) and renders each group as its own
-    `error:` + `note:` blocks. Multiple unrelated violations therefore
-    surface as multiple errors, not a single primary with the rest
+    `error:` + `note:` blocks. Multiple unrelated violations are
+    rendered as multiple errors, not a single primary with the rest
     folded into notes.
 
     Args:
@@ -301,6 +246,10 @@ def _render_diagnostic_block(
 _Diagnostic = Tuple[Optional[Tuple[str, int, int]], str]
 _DiagnosticGroup = Tuple[_Diagnostic, List[_Diagnostic]]
 
+# Strip the leading `'op_name' op ` prefix MLIR adds for op-level
+# diagnostics so the user sees the message we wrote.
+_OP_PREFIX = re.compile(r"'[^']+'\s+op\s+(.*)$")
+
 
 def _extract_diagnostic_groups(error_msg: str) -> List[_DiagnosticGroup]:
     """Split an MLIR error string into groups of (error, [notes]).
@@ -318,15 +267,16 @@ def _extract_diagnostic_groups(error_msg: str) -> List[_DiagnosticGroup]:
     don't start with a recognized kind keyword and are skipped.
     """
     groups: List[_DiagnosticGroup] = []
-    current_notes: List[_Diagnostic] = []
 
-    # MLIR diagnostics from the Python pass manager surface as
+    # MLIR diagnostics from the Python pass manager are emitted as
     #     <kind>: "path":line:col: <message>
     # (notes sometimes carry a leading space). Raw `ttlang-opt` runs
-    # use
+    # emit
     #     path:line:col: <kind>: <message>
-    # We accept both. The location segment is optional so notes
-    # without locations still parse.
+    # Both forms are accepted. `loc_first` is tried before `kind_first`
+    # because its location segment is mandatory (most-specific match
+    # wins); reordering would silently change behavior on the
+    # path-first variant.
     kind_first = re.compile(
         r"^\s*(?P<kind>error|note|warning):\s*"
         r"(?:\"?(?P<file>[^\"\n]+?)\"?:(?P<line>\d+):(?P<col>\d+):\s*)?"
@@ -343,9 +293,7 @@ def _extract_diagnostic_groups(error_msg: str) -> List[_DiagnosticGroup]:
             continue
         kind = match.group("kind")
         msg = match.group("msg").strip()
-        # Strip the leading `'op_name' op ` prefix MLIR adds for op-level
-        # diagnostics so the user sees the message we wrote.
-        op_match = re.match(r"'[^']+'\s+op\s+(.*)$", msg)
+        op_match = _OP_PREFIX.match(msg)
         if op_match:
             msg = op_match.group(1).strip()
 
@@ -359,7 +307,7 @@ def _extract_diagnostic_groups(error_msg: str) -> List[_DiagnosticGroup]:
             loc = None
 
         if kind in ("error", "warning"):
-            current_notes = []
+            current_notes: List[_Diagnostic] = []
             groups.append(((loc, msg), current_notes))
         else:  # note
             # Notes before any error are dropped — there's nothing for

--- a/test/python/diagnostics_multi_error.py
+++ b/test/python/diagnostics_multi_error.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+
+"""FileCheck test for `format_mlir_error` multi-error rendering.
+
+Feeds a synthetic MLIR diagnostic stream with two unrelated errors
+(each with attached notes) through the formatter and verifies the
+rendered output. Line numbers embedded in the diagnostic are surfaced
+via a preamble so CHECKs can capture them with `[[VAR]]` instead of
+hardcoding.
+"""
+
+import textwrap
+
+from ttl.diagnostics import format_mlir_error  # noqa: E402
+
+ANCHOR_FIRST = "FIRST_ERROR_ANCHOR"
+ANCHOR_FIRST_DECLARED = "FIRST_DECLARED_ANCHOR"
+ANCHOR_SECOND = "SECOND_ERROR_ANCHOR"
+ANCHOR_SECOND_DECLARED = "SECOND_DECLARED_ANCHOR"
+
+
+def _line_of(anchor: str) -> int:
+    with open(__file__, "r") as fd:
+        for idx, raw in enumerate(fd, start=1):
+            # Skip the constant definitions; we want the callsites below.
+            if raw.lstrip().startswith("ANCHOR_"):
+                continue
+            if anchor in raw:
+                return idx
+    raise RuntimeError(f"anchor {anchor!r} not found in {__file__}")
+
+
+def main() -> None:
+    first_line = _line_of(ANCHOR_FIRST)  # FIRST_ERROR_ANCHOR
+    first_decl_line = _line_of(ANCHOR_FIRST_DECLARED)  # FIRST_DECLARED_ANCHOR
+    second_line = _line_of(ANCHOR_SECOND)  # SECOND_ERROR_ANCHOR
+    second_decl_line = _line_of(ANCHOR_SECOND_DECLARED)  # SECOND_DECLARED_ANCHOR
+
+    print(f"FIRST_LINE={first_line}")
+    print(f"FIRST_DECL_LINE={first_decl_line}")
+    print(f"SECOND_LINE={second_line}")
+    print(f"SECOND_DECL_LINE={second_decl_line}")
+
+    diagnostic_stream = textwrap.dedent(
+        f"""\
+        Failure while executing pass pipeline:
+        error: "{__file__}":{first_line}:1: 'fake.op' op first violation
+         note: "{__file__}":{first_line}:1: see current operation: %0 = "fake.op"() : () -> ()
+         note: "{__file__}":{first_line}:1: first witness here
+         note: "{__file__}":{first_decl_line}:1: first thing declared here
+         note: "{__file__}":{first_decl_line}:1: first thing declared here
+        error: "{__file__}":{second_line}:1: 'fake.op' op second violation
+         note: "{__file__}":{second_line}:1: second witness here
+         note: "{__file__}":{second_decl_line}:1: second thing declared here
+        """
+    )
+    print(format_mlir_error(diagnostic_stream))
+
+
+if __name__ == "__main__":
+    main()
+
+
+# Capture the line numbers the script embedded.
+# CHECK: FIRST_LINE=[[FIRST_LINE:[0-9]+]]
+# CHECK: FIRST_DECL_LINE=[[FIRST_DECL_LINE:[0-9]+]]
+# CHECK: SECOND_LINE=[[SECOND_LINE:[0-9]+]]
+# CHECK: SECOND_DECL_LINE=[[SECOND_DECL_LINE:[0-9]+]]
+
+# First error: op-prefix stripped, source context shown.
+# CHECK: error: first violation
+# CHECK-NEXT: --> {{.*}}diagnostics_multi_error.py:[[FIRST_LINE]]:1
+# CHECK: FIRST_ERROR_ANCHOR
+
+# Notes indent two spaces; `see current operation` dropped; duplicate
+# `first thing declared here` rendered once.
+# CHECK: {{^  note: first witness here}}
+# CHECK-NOT: see current operation
+# CHECK: {{^  note: first thing declared here}}
+# CHECK: --> {{.*}}diagnostics_multi_error.py:[[FIRST_DECL_LINE]]:1
+# CHECK: FIRST_DECLARED_ANCHOR
+# CHECK-NOT: first thing declared here
+
+# Second error renders as its own `error:`, not as a note.
+# CHECK: error: second violation
+# CHECK-NEXT: --> {{.*}}diagnostics_multi_error.py:[[SECOND_LINE]]:1
+# CHECK: SECOND_ERROR_ANCHOR
+# CHECK: {{^  note: second witness here}}
+# CHECK: {{^  note: second thing declared here}}
+# CHECK: --> {{.*}}diagnostics_multi_error.py:[[SECOND_DECL_LINE]]:1
+# CHECK: SECOND_DECLARED_ANCHOR

--- a/test/python/diagnostics_multi_error.py
+++ b/test/python/diagnostics_multi_error.py
@@ -8,14 +8,14 @@
 
 Feeds a synthetic MLIR diagnostic stream with two unrelated errors
 (each with attached notes) through the formatter and verifies the
-rendered output. Line numbers embedded in the diagnostic are surfaced
-via a preamble so CHECKs can capture them with `[[VAR]]` instead of
+rendered output. Line numbers embedded in the diagnostic are printed
+in a preamble so CHECKs can capture them with `[[VAR]]` instead of
 hardcoding.
 """
 
 import textwrap
 
-from ttl.diagnostics import format_mlir_error  # noqa: E402
+from ttl.diagnostics import format_mlir_error
 
 ANCHOR_FIRST = "FIRST_ERROR_ANCHOR"
 ANCHOR_FIRST_DECLARED = "FIRST_DECLARED_ANCHOR"
@@ -60,6 +60,27 @@ def main() -> None:
     )
     print(format_mlir_error(diagnostic_stream))
 
+    # ===== single error, no notes =====
+    print("=== SINGLE ===")
+    print(
+        format_mlir_error(
+            f'error: "{__file__}":{first_line}:1: lone error with no notes'
+        )
+    )
+
+    # ===== error with no location prefix =====
+    print("=== NOLOC ===")
+    print(format_mlir_error("error: bare error message with no location"))
+
+    # ===== leading note (before any error) is dropped =====
+    print("=== LEADING_NOTE ===")
+    print(
+        format_mlir_error(
+            f'note: "{__file__}":{first_line}:1: orphan note with no parent\n'
+            f'error: "{__file__}":{first_line}:1: real error after orphan note'
+        )
+    )
+
 
 if __name__ == "__main__":
     main()
@@ -93,3 +114,18 @@ if __name__ == "__main__":
 # CHECK: {{^  note: second thing declared here}}
 # CHECK: --> {{.*}}diagnostics_multi_error.py:[[SECOND_DECL_LINE]]:1
 # CHECK: SECOND_DECLARED_ANCHOR
+
+# Single error, no notes — base case.
+# CHECK: === SINGLE ===
+# CHECK: error: lone error with no notes
+# CHECK-NEXT: --> {{.*}}diagnostics_multi_error.py:[[FIRST_LINE]]:1
+
+# Error with no location prefix falls back to the bare label-and-message line.
+# CHECK: === NOLOC ===
+# CHECK-NEXT: error: bare error message with no location
+
+# A note before any error is dropped (no parent to attach to); the
+# subsequent error still renders.
+# CHECK: === LEADING_NOTE ===
+# CHECK-NOT: orphan note with no parent
+# CHECK: error: real error after orphan note


### PR DESCRIPTION
`format_mlir_error` previously extracted only the first error's primary message and rendered one source-context block. When a pass emits multiple diagnostics, or attaches notes (witness, declared-here) to a diagnostic, those are dropped from the Python error banner.

This change parses the MLIR error stream into groups of `(error, [attached notes])` and renders each group as its own `error:` block with its notes underneath. Notes are indented two spaces so they read as visually subordinate to the parent error. `see current operation` MLIR-internal notes and duplicate notes are filtered out.

The public `format_mlir_error` signature is unchanged. Internal cleanup removes the now-unused `_extract_core_message` and `_extract_note` helpers.