### PR TITLE
[ci] Add tt-lang-sim publishing to the pypi CI workflow

### DIFF
--- a/.github/scripts/smoke-test-wheel.py
+++ b/.github/scripts/smoke-test-wheel.py
@@ -16,22 +16,26 @@ import sys
 def main() -> int:
     import ttl
     import ttl.sim
-    import ttl.pykernel
 
-    from ttl import operation, compute, datamovement  # noqa: F401
-    from ttl.pykernel._src.kernel_ast import TTCompilerBase  # noqa: F401
     from ttl.sim.ttlang_sim import main as _ttlang_sim_entry  # noqa: F401
+
+    sim_only = getattr(ttl, "_SIM_ONLY_INSTALL", False)
+    package = "tt-lang-sim" if sim_only else "tt-lang"
+    if not sim_only:
+        import ttl.pykernel  # noqa: F401
+        from ttl import operation, compute, datamovement  # noqa: F401
+        from ttl.pykernel._src.kernel_ast import TTCompilerBase  # noqa: F401
 
     version = ttl.__version__
     if version == "0.0.0":
         print(
-            f"tt-lang version is the fallback {version!r}; "
-            "CMake-generated ttl/config.py was not bundled in the wheel.",
+            f"{package} version is the fallback {version!r}; "
+            "version metadata was not bundled in the wheel.",
             file=sys.stderr,
         )
         return 1
 
-    print(f"tt-lang {version}: imports OK")
+    print(f"{package} {version}: imports OK")
     return 0
 
 

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -49,24 +49,36 @@ jobs:
           source /opt/ttlang-toolchain/venv/bin/activate
           pip install auditwheel patchelf
 
-      - name: Build wheel
+      - name: Build tt-lang wheel
         run: |
           source /opt/ttlang-toolchain/venv/bin/activate
           pip wheel . --wheel-dir=dist-raw --no-deps --no-build-isolation
 
-      - name: Repair wheel
+      - name: Repair tt-lang wheel
         run: |
           source /opt/ttlang-toolchain/venv/bin/activate
           auditwheel repair dist-raw/*.whl --wheel-dir=dist
 
-      - name: Test wheel
+      - name: Test tt-lang wheel
         run: |
-          python3.12 -m venv /tmp/test-venv
-          source /tmp/test-venv/bin/activate
-          pip install dist/*.whl --extra-index-url https://download.pytorch.org/whl/cpu
+          python3.12 -m venv /tmp/test-venv-hw
+          source /tmp/test-venv-hw/bin/activate
+          pip install dist/tt_lang-*.whl --extra-index-url https://download.pytorch.org/whl/cpu
           python .github/scripts/smoke-test-wheel.py
 
-      - name: Report wheel size
+      - name: Build tt-lang-sim wheel
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          pip wheel packaging/sim --wheel-dir=dist --no-deps --no-build-isolation
+
+      - name: Test tt-lang-sim wheel
+        run: |
+          python3.12 -m venv /tmp/test-venv-sim
+          source /tmp/test-venv-sim/bin/activate
+          pip install dist/tt_lang_sim-*.whl --extra-index-url https://download.pytorch.org/whl/cpu
+          python .github/scripts/smoke-test-wheel.py
+
+      - name: Report wheel sizes
         run: ls -lh dist-raw/*.whl dist/*.whl
 
       - name: Upload wheels

--- a/packaging/rewrite_readme.py
+++ b/packaging/rewrite_readme.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for preparing README content for PyPI long_description.
+
+PyPI renders Markdown without access to the repository file tree, so relative
+image references (`docs/...`, `./assets/...`) never resolve. This module
+rewrites such references to absolute raw.githubusercontent.com URLs anchored
+at a specific git ref so the rendered project page shows the correct images
+for that release.
+"""
+
+import pathlib
+import re
+
+_REPO_RAW_BASE = "https://raw.githubusercontent.com/tenstorrent/tt-lang"
+
+_HTML_IMG_SRC_RE = re.compile(
+    r'(<img\b[^>]*\bsrc=")(?!https?://|/|data:)([^"]+)"',
+    flags=re.IGNORECASE,
+)
+
+_MD_IMAGE_RE = re.compile(r"(!\[[^\]]*\]\()(?!https?://|/|data:)([^)\s]+)")
+
+# Release tags in this repo are strictly vMAJOR.MINOR.PATCH; any other shape
+# (dev/pre/post/local segments, TTLANG_PRETEND_VERSION garbage, etc.) has no
+# corresponding git ref so it must fall back to a branch.
+_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def ref_for_version(version: str) -> str:
+    """Pick the git ref that holds the assets for this wheel.
+
+    Returns `vX.Y.Z` only when `version` is exactly three numeric segments;
+    anything else (dev wheels, pre/post-release identifiers, malformed
+    `TTLANG_PRETEND_VERSION` overrides, empty strings) falls back to `main`.
+    """
+    if _RELEASE_VERSION_RE.match(version):
+        return f"v{version}"
+    return "main"
+
+
+def _collect_relative_image_paths(text: str) -> list[str]:
+    paths: list[str] = []
+    paths.extend(m.group(2) for m in _HTML_IMG_SRC_RE.finditer(text))
+    paths.extend(m.group(2) for m in _MD_IMAGE_RE.finditer(text))
+    return paths
+
+
+def absolutize_readme_images(text: str, ref: str, repo_root: pathlib.Path) -> str:
+    """Rewrite relative image URLs in `text` to absolute GitHub raw URLs.
+
+    Every relative path is verified against `repo_root`; missing files raise
+    `FileNotFoundError` so a broken README aborts the wheel build instead of
+    shipping a 404 to PyPI.
+    """
+    missing = [
+        path
+        for path in _collect_relative_image_paths(text)
+        if not (repo_root / path).is_file()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"README image paths do not resolve under {repo_root}: {missing}"
+        )
+
+    base = f"{_REPO_RAW_BASE}/{ref}/"
+    text = _HTML_IMG_SRC_RE.sub(lambda m: f'{m.group(1)}{base}{m.group(2)}"', text)
+    text = _MD_IMAGE_RE.sub(lambda m: f"{m.group(1)}{base}{m.group(2)}", text)
+    return text

--- a/packaging/sim/setup.py
+++ b/packaging/sim/setup.py
@@ -12,8 +12,12 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 
 from setuptools import setup
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from rewrite_readme import absolutize_readme_images, ref_for_version  # noqa: E402
 
 PKG_ROOT = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = PKG_ROOT.parent.parent
@@ -92,7 +96,7 @@ stage()
 
 readme_path = REPO_ROOT / "README.md"
 with open(readme_path, "r", encoding="utf-8") as f:
-    readme = f.read()
+    readme = absolutize_readme_images(f.read(), ref_for_version(VERSION), REPO_ROOT)
 
 
 def read_runtime_requirements() -> list[str]:

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ import pathlib
 import platform
 import shutil
 import subprocess
+import sys
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
@@ -255,12 +256,19 @@ class CMakeBuild(build_ext):
 
 ttlang_c = TTLangExtension("ttl")
 
+sys.path.insert(0, str(REPO_ROOT / "packaging"))
+from rewrite_readme import absolutize_readme_images, ref_for_version  # noqa: E402
+
+_version = get_version_from_git()
+
 readme_path = REPO_ROOT / "README.md"
 with open(str(readme_path), "r", encoding="utf-8") as readme_file:
-    readme = readme_file.read()
+    readme = absolutize_readme_images(
+        readme_file.read(), ref_for_version(_version), REPO_ROOT
+    )
 
 setup(
-    version=get_version_from_git(),
+    version=_version,
     install_requires=_read_install_requires(),
     packages=[
         "ttl",

--- a/test/python/packaging/test_rewrite_readme.py
+++ b/test/python/packaging/test_rewrite_readme.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the README-rewrite helpers used by both wheel setup scripts."""
+
+import pathlib
+import sys
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "packaging"))
+
+from rewrite_readme import (  # noqa: E402
+    absolutize_readme_images,
+    ref_for_version,
+)
+
+
+# ---------------------------------------------------------------------------
+# ref_for_version
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("1.2.3", "v1.2.3"),
+        ("0.0.1", "v0.0.1"),
+        ("10.20.30", "v10.20.30"),
+    ],
+)
+def test_ref_for_version_release(version, expected):
+    assert ref_for_version(version) == expected
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        # dev/local segments produced by get_version_from_git
+        "1.2.3.dev5",
+        "1.2.3.dev0",
+        "1.2.3+local",
+        "1.2.3.dev2+local",
+        # PEP 440 pre/post-release identifiers — not in this repo's tag scheme
+        "1.2.3rc1",
+        "1.2.3a1",
+        "1.2.3b2",
+        "1.2.3.post1",
+        # Malformed TTLANG_PRETEND_VERSION overrides
+        "1.2.3-rc1",
+        "foo",
+        "",
+        "1",
+        "1.2",
+        "v1.2.3",
+        "1.2.3.4",
+        "1.2.3 ",
+    ],
+)
+def test_ref_for_version_non_release_falls_back_to_main(version):
+    assert ref_for_version(version) == "main"
+
+
+# ---------------------------------------------------------------------------
+# absolutize_readme_images
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def repo(tmp_path):
+    (tmp_path / "docs" / "img").mkdir(parents=True)
+    (tmp_path / "docs" / "img" / "a.png").write_bytes(b"\x89PNG")
+    (tmp_path / "docs" / "img" / "b.png").write_bytes(b"\x89PNG")
+    return tmp_path
+
+
+_BASE = "https://raw.githubusercontent.com/tenstorrent/tt-lang/v1.2.3"
+
+
+def test_rewrites_html_img_relative_src(repo):
+    text = '<img alt="logo" src="docs/img/a.png" height="100">'
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == f'<img alt="logo" src="{_BASE}/docs/img/a.png" height="100">'
+
+
+def test_rewrites_markdown_image_relative_path(repo):
+    text = "![alt text](docs/img/a.png)"
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == f"![alt text]({_BASE}/docs/img/a.png)"
+
+
+def test_preserves_https_urls(repo):
+    text = (
+        '<img src="https://img.shields.io/badge/x.svg">\n'
+        "![badge](https://example.com/y.png)\n"
+    )
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == text
+
+
+def test_preserves_absolute_path_and_data_uri(repo):
+    text = '<img src="/static/abs.png">\n' '<img src="data:image/png;base64,AAAA">\n'
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == text
+
+
+def test_handles_uppercase_img_tag(repo):
+    text = '<IMG SRC="docs/img/a.png">'
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == f'<IMG SRC="{_BASE}/docs/img/a.png">'
+
+
+def test_preserves_markdown_image_title(repo):
+    text = '![alt](docs/img/a.png "caption")'
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == f'![alt]({_BASE}/docs/img/a.png "caption")'
+
+
+def test_does_not_match_plain_markdown_link(repo):
+    # A link (no leading '!') with a relative path must remain untouched even
+    # if the target does not exist on disk.
+    text = "[click](docs/img/does_not_exist.html)"
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == text
+
+
+def test_does_not_match_image_tag_variant(repo):
+    # <image> is SVG, not HTML <img>; leave it alone even if src is relative.
+    text = '<image src="docs/img/does_not_exist.png" />'
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert out == text
+
+
+def test_missing_file_aborts_and_lists_all_paths(repo):
+    text = (
+        '<img src="docs/img/a.png">\n'
+        '<img src="docs/img/missing_html.png">\n'
+        "![alt](docs/img/missing_md.png)\n"
+    )
+    with pytest.raises(FileNotFoundError) as info:
+        absolutize_readme_images(text, "v1.2.3", repo)
+    message = str(info.value)
+    assert "missing_html.png" in message
+    assert "missing_md.png" in message
+    # Files that do exist must not appear in the error list.
+    assert "docs/img/a.png" not in message.replace("missing_html.png", "").replace(
+        "missing_md.png", ""
+    )
+
+
+def test_rewrites_multiple_images_in_one_document(repo):
+    text = (
+        "<picture>\n"
+        '  <img alt="A" src="docs/img/a.png" height="220">\n'
+        "</picture>\n"
+        "\n"
+        "Body text.\n"
+        "\n"
+        "![B](docs/img/b.png)\n"
+    )
+    out = absolutize_readme_images(text, "v1.2.3", repo)
+    assert f'src="{_BASE}/docs/img/a.png"' in out
+    assert f"({_BASE}/docs/img/b.png)" in out
+
+
+def test_ref_is_threaded_through(repo):
+    text = '<img src="docs/img/a.png">'
+    out = absolutize_readme_images(text, "main", repo)
+    assert (
+        "https://raw.githubusercontent.com/tenstorrent/tt-lang/main/docs/img/a.png"
+        in out
+    )


### PR DESCRIPTION
- add tt-lang-sim publishing to the CI workflow
- Add a README.md transformation script to ensure that absolute links (to images, etc) are used instead of local paths in the pypi published version.