### PR TITLE
[tt-mlir] bump submodule and update lit tests for new CB interface

### DIFF
--- a/test/python/auto_profile_bcast_multitile.py
+++ b/test/python/auto_profile_bcast_multitile.py
@@ -83,24 +83,28 @@ def bcast_multitile_kernel(
 
 # CHECK:          // demo_compute
 # CHECK:          void kernel_main()
+# CHECK-DAG:          experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-DAG:          experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-DAG:          experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-DAG:          experimental::CircularBuffer [[CB3:.*]](get_compile_time_arg_val(3));
 
 # CHECK-NOT:      DeviceZoneScopedN(
 # CHECK:          DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_wait");
-# CHECK-NEXT:     cb_wait_front(get_compile_time_arg_val(2), {{.*}});
+# CHECK-NEXT:     [[CB2]].wait_front({{.*}});
 # CHECK:          }
 # CHECK-NEXT:     for (size_t [[I:.*]] = [[V6:.*]]; [[I]] < [[V7:.*]]; [[I]] += [[V5:.*]]) {
 # CHECK-NEXT:       for (size_t [[J:.*]] = [[V6]]; [[J]] < [[V7]]; [[J]] += [[V5]]) {
 # CHECK-NEXT:         {
 # CHECK-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_wait");
-# CHECK-NEXT:         cb_wait_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-NEXT:         [[CB0]].wait_front({{.*}});
 # CHECK-NEXT:         }
 # CHECK-NEXT:         {
 # CHECK-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_wait");
-# CHECK-NEXT:         cb_wait_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-NEXT:         [[CB1]].wait_front({{.*}});
 # CHECK-NEXT:         }
 # CHECK-NEXT:         {
 # CHECK-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-NEXT:         cb_reserve_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-NEXT:         [[CB3]].reserve_back({{.*}});
 # CHECK-NEXT:         }
 # CHECK-NEXT:         {
 # CHECK-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}");
@@ -130,21 +134,21 @@ def bcast_multitile_kernel(
 # CHECK-NEXT:         }
 # CHECK-NEXT:         {
 # CHECK-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-NEXT:         cb_push_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-NEXT:         [[CB3]].push_back({{.*}});
 # CHECK-NEXT:         }
 # CHECK-NEXT:         {
 # CHECK-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-NEXT:         cb_pop_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-NEXT:         [[CB1]].pop_front({{.*}});
 # CHECK-NEXT:         }
 # CHECK-NEXT:         {
 # CHECK-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-NEXT:         cb_pop_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-NEXT:         [[CB0]].pop_front({{.*}});
 # CHECK-NEXT:         }
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }
 # CHECK-NEXT:     {
 # CHECK-NEXT:     DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-NEXT:     cb_pop_front(get_compile_time_arg_val(2), {{.*}});
+# CHECK-NEXT:     [[CB2]].pop_front({{.*}});
 # CHECK-NEXT:     }
 # CHECK-NEXT:     return;
 # CHECK-NEXT:   }
@@ -157,24 +161,28 @@ def bcast_multitile_kernel(
 
 # CHECK-FPU:          // demo_compute
 # CHECK-FPU:          void kernel_main()
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB3:.*]](get_compile_time_arg_val(3));
 
 # CHECK-FPU-NOT:      DeviceZoneScopedN(
 # CHECK-FPU:          DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_wait");
-# CHECK-FPU-NEXT:     cb_wait_front(get_compile_time_arg_val(2), {{.*}});
+# CHECK-FPU-NEXT:     [[CB2]].wait_front({{.*}});
 # CHECK-FPU:          }
 # CHECK-FPU-NEXT:     for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-FPU-NEXT:       for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-FPU-NEXT:         {
 # CHECK-FPU-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_wait");
-# CHECK-FPU-NEXT:         cb_wait_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-FPU-NEXT:         [[CB0]].wait_front({{.*}});
 # CHECK-FPU-NEXT:         }
 # CHECK-FPU-NEXT:         {
 # CHECK-FPU-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_wait");
-# CHECK-FPU-NEXT:         cb_wait_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-FPU-NEXT:         [[CB1]].wait_front({{.*}});
 # CHECK-FPU-NEXT:         }
 # CHECK-FPU-NEXT:         {
 # CHECK-FPU-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-FPU-NEXT:         cb_reserve_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-FPU-NEXT:         [[CB3]].reserve_back({{.*}});
 # CHECK-FPU-NEXT:         }
 # CHECK-FPU-NEXT:         {
 # CHECK-FPU-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}");
@@ -231,21 +239,21 @@ def bcast_multitile_kernel(
 # CHECK-FPU-NEXT:         }
 # CHECK-FPU-NEXT:         {
 # CHECK-FPU-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-FPU-NEXT:         cb_push_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-FPU-NEXT:         [[CB3]].push_back({{.*}});
 # CHECK-FPU-NEXT:         }
 # CHECK-FPU-NEXT:         {
 # CHECK-FPU-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-FPU-NEXT:         cb_pop_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-FPU-NEXT:         [[CB1]].pop_front({{.*}});
 # CHECK-FPU-NEXT:         }
 # CHECK-FPU-NEXT:         {
 # CHECK-FPU-NEXT:         DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-FPU-NEXT:         cb_pop_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-FPU-NEXT:         [[CB0]].pop_front({{.*}});
 # CHECK-FPU-NEXT:         }
 # CHECK-FPU-NEXT:       }
 # CHECK-FPU-NEXT:     }
 # CHECK-FPU-NEXT:     {
 # CHECK-FPU-NEXT:     DeviceZoneScopedN("demo_compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-FPU-NEXT:     cb_pop_front(get_compile_time_arg_val(2), {{.*}});
+# CHECK-FPU-NEXT:     [[CB2]].pop_front({{.*}});
 # CHECK-FPU-NEXT:     }
 # CHECK-FPU-NEXT:     return;
 # CHECK-FPU-NEXT:   }

--- a/test/python/auto_profile_multi_store.py
+++ b/test/python/auto_profile_multi_store.py
@@ -60,19 +60,24 @@ def multi_store_kernel(a, b, out1, out2, out3):
 
 # CHECK:          // compute
 # CHECK:          void kernel_main()
+# CHECK-DAG:          experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-DAG:          experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-DAG:          experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-DAG:          experimental::CircularBuffer [[CB3:.*]](get_compile_time_arg_val(3));
+# CHECK-DAG:          experimental::CircularBuffer [[CB4:.*]](get_compile_time_arg_val(4));
 
 # CB waits and reserves wrapped in auto-profile scopes
 # CHECK-NOT:      DeviceZoneScopedN(
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_wait");
-# CHECK-NEXT:     cb_wait_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-NEXT:     [[CB0]].wait_front({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_wait");
-# CHECK-NEXT:     cb_wait_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-NEXT:     [[CB1]].wait_front({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-NEXT:     cb_reserve_back(get_compile_time_arg_val(2), {{.*}});
+# CHECK-NEXT:     [[CB2]].reserve_back({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-NEXT:     cb_reserve_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-NEXT:     [[CB3]].reserve_back({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-NEXT:     cb_reserve_back(get_compile_time_arg_val(4), {{.*}});
+# CHECK-NEXT:     [[CB4]].reserve_back({{.*}});
 
 # Compute body with add and 3 pack_tiles (stores) in a single scope
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}");
@@ -87,15 +92,15 @@ def multi_store_kernel(a, b, out1, out2, out3):
 
 # 3 cb_push_back and 2 cb_pop_front with auto-profile scopes
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-NEXT:     cb_push_back(get_compile_time_arg_val(4), {{.*}});
+# CHECK-NEXT:     [[CB4]].push_back({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-NEXT:     cb_push_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-NEXT:     [[CB3]].push_back({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-NEXT:     cb_push_back(get_compile_time_arg_val(2), {{.*}});
+# CHECK-NEXT:     [[CB2]].push_back({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-NEXT:     cb_pop_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-NEXT:     [[CB1]].pop_front({{.*}});
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-NEXT:     cb_pop_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-NEXT:     [[CB0]].pop_front({{.*}});
 # CHECK-NOT:      DeviceZoneScopedN(
 
 # =============================================================================
@@ -105,16 +110,21 @@ def multi_store_kernel(a, b, out1, out2, out3):
 
 # CHECK-FPU:          // compute
 # CHECK-FPU:          void kernel_main()
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB3:.*]](get_compile_time_arg_val(3));
+# CHECK-FPU-DAG:          experimental::CircularBuffer [[CB4:.*]](get_compile_time_arg_val(4));
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_wait");
-# CHECK-FPU-NEXT:     cb_wait_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-FPU-NEXT:     [[CB0]].wait_front({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_wait");
-# CHECK-FPU-NEXT:     cb_wait_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-FPU-NEXT:     [[CB1]].wait_front({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-FPU-NEXT:     cb_reserve_back(get_compile_time_arg_val(2), {{.*}});
+# CHECK-FPU-NEXT:     [[CB2]].reserve_back({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-FPU-NEXT:     cb_reserve_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-FPU-NEXT:     [[CB3]].reserve_back({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_reserve");
-# CHECK-FPU-NEXT:     cb_reserve_back(get_compile_time_arg_val(4), {{.*}});
+# CHECK-FPU-NEXT:     [[CB4]].reserve_back({{.*}});
 
 # Compute body: FPU binary add with 3 pack_tiles
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}");
@@ -131,15 +141,15 @@ def multi_store_kernel(a, b, out1, out2, out3):
 
 # 3 cb_push_back and 2 cb_pop_front with auto-profile scopes
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-FPU-NEXT:     cb_push_back(get_compile_time_arg_val(4), {{.*}});
+# CHECK-FPU-NEXT:     [[CB4]].push_back({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-FPU-NEXT:     cb_push_back(get_compile_time_arg_val(3), {{.*}});
+# CHECK-FPU-NEXT:     [[CB3]].push_back({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_push");
-# CHECK-FPU-NEXT:     cb_push_back(get_compile_time_arg_val(2), {{.*}});
+# CHECK-FPU-NEXT:     [[CB2]].push_back({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-FPU-NEXT:     cb_pop_front(get_compile_time_arg_val(1), {{.*}});
+# CHECK-FPU-NEXT:     [[CB1]].pop_front({{.*}});
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_pop");
-# CHECK-FPU-NEXT:     cb_pop_front(get_compile_time_arg_val(0), {{.*}});
+# CHECK-FPU-NEXT:     [[CB0]].pop_front({{.*}});
 # CHECK-FPU-NOT:      DeviceZoneScopedN(
 
 if __name__ == "__main__":

--- a/test/python/auto_profile_signposts.py
+++ b/test/python/auto_profile_signposts.py
@@ -66,19 +66,19 @@ def signpost_test_kernel(inp, out):
 
 # Check for cb_wait signpost (scoped around the operation)
 # CHECK: DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_wait")
-# CHECK: cb_wait_front(
+# CHECK: .wait_front(
 
 # Check for cb_reserve signpost (scoped around the operation)
 # CHECK: DeviceZoneScopedN("compute_L{{[0-9]+}}_cb_reserve")
-# CHECK: cb_reserve_back(
+# CHECK: .reserve_back(
 
 # Check for implicit cb_push signpost (from 'with' exit)
 # CHECK: DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_push")
-# CHECK: cb_push_back(
+# CHECK: .push_back(
 
 # Check for implicit cb_pop signpost (from 'with' exit)
 # CHECK: DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_pop")
-# CHECK: cb_pop_front(
+# CHECK: .pop_front(
 
 # Check dm_read kernel has signposts
 # CHECK: === dm_read kernel written to

--- a/test/python/elementwise_l1_acc.py
+++ b/test/python/elementwise_l1_acc.py
@@ -79,7 +79,7 @@ def elementwise_add_acc(a, b, out):
 # CHECK-CPP:        pack_tile
 # CHECK-CPP:        if (
 # CHECK-CPP-NEXT:   PACK((llk_pack_reconfig_l1_acc([[ENABLE]])));
-# CHECK-CPP:      cb_push_back(
+# CHECK-CPP:      .push_back(
 # CHECK-CPP:      PACK((llk_pack_reconfig_l1_acc([[DISABLE]])));
 
 # CHECK-RESULT: PASS

--- a/test/python/many_fused_ops.py
+++ b/test/python/many_fused_ops.py
@@ -129,14 +129,18 @@ def fused_chain_kernel(a, b, c, out):
 
 # CHECK-CPP: // fused_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB3:.*]](get_compile_time_arg_val(3));
 
 # Wait for input CBs
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
+# CHECK-CPP: [[CB2]].wait_front(
 
 # Reserve output DFB
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(3),
+# CHECK-CPP: [[CB3]].reserve_back(
 
 # DST register lifecycle
 # CHECK-CPP: tile_regs_acquire();
@@ -157,10 +161,10 @@ def fused_chain_kernel(a, b, c, out):
 # CHECK-CPP: pack_tile<true>(
 
 # Pop inputs, push output
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(2),
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(3),
+# CHECK-CPP: [[CB0]].pop_front(
+# CHECK-CPP: [[CB1]].pop_front(
+# CHECK-CPP: [[CB2]].pop_front(
+# CHECK-CPP: [[CB3]].push_back(
 
 
 if __name__ == "__main__":

--- a/test/python/matmul_l1_acc_multinode.py
+++ b/test/python/matmul_l1_acc_multinode.py
@@ -144,7 +144,7 @@ def matmul_l1_acc(a, b, out):
 # CHECK-CPP:        pack_tile
 # CHECK-CPP:        if (
 # CHECK-CPP-NEXT:   PACK((llk_pack_reconfig_l1_acc([[ENABLE]])));
-# CHECK-CPP:      cb_push_back(
+# CHECK-CPP:      .push_back(
 # CHECK-CPP:      PACK((llk_pack_reconfig_l1_acc([[DISABLE]])));
 
 # CHECK-RESULT: PASS

--- a/test/python/simple_add.py
+++ b/test/python/simple_add.py
@@ -139,13 +139,16 @@ def add_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // add_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # Wait for input CBs
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
 
 # Reserve output DFB
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].reserve_back(
 
 # FPU binary init
 # CHECK-CPP: binary_op_init_common(get_compile_time_arg_val(0), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
@@ -168,9 +171,9 @@ def add_kernel(lhs, rhs, out):
 # CHECK-CPP: tile_regs_release();
 
 # Pop inputs, push output
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].pop_front(
+# CHECK-CPP: [[CB1]].pop_front(
+# CHECK-CPP: [[CB2]].push_back(
 
 # =============================================================================
 # C++ Kernel Checks - Verify generated dm_read kernel
@@ -178,27 +181,27 @@ def add_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // dm_read
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
 
 # First input: reserve DFB, read tile, push DFB
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB0]].reserve_back(
 # CHECK-CPP: auto {{.*}} = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 3>(), 0>();
 # CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_write_ptr(get_compile_time_arg_val(0))
-# CHECK-CPP: noc_async_read_tile(
+# CHECK-CPP: noc_async_read_tile({{.*}}[[CB0]].get_write_ptr()
 # CHECK-CPP: noc_async_read_barrier();
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB0]].push_back(
 
 # Second input: reserve DFB, read tile, push DFB
 # TensorAccessorArgs uses get_tensor_accessor_args_cta_offset<IDX, BASE_CTA> to
 # compute the compile-time arg index for tensor IDX, starting from BASE_CTA.
 # CRTA indexes buffer addresses in common runtime args, per-kernel (1 = second arg).
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB1]].reserve_back(
 # CHECK-CPP: auto {{.*}} = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 3>(), 1>();
 # CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_write_ptr(get_compile_time_arg_val(1))
-# CHECK-CPP: noc_async_read_tile(
+# CHECK-CPP: noc_async_read_tile({{.*}}[[CB1]].get_write_ptr()
 # CHECK-CPP: noc_async_read_barrier();
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB1]].push_back(
 
 # =============================================================================
 # C++ Kernel Checks - Verify generated dm_write kernel
@@ -206,15 +209,15 @@ def add_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // dm_write
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # Wait for output DFB, write tile, pop DFB
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].wait_front(
 # CHECK-CPP: auto {{.*}} = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<2, 3>(), 0>();
 # CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_read_ptr(get_compile_time_arg_val(2))
-# CHECK-CPP: noc_async_write_tile(
+# CHECK-CPP: noc_async_write_tile({{.*}}[[CB2]].get_read_ptr()
 # CHECK-CPP: noc_async_write_barrier();
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].pop_front(
 
 
 # =============================================================================
@@ -223,9 +226,12 @@ def add_kernel(lhs, rhs, out):
 
 # CHECK-CPP-SFPU: // add_compute
 # CHECK-CPP-SFPU: void kernel_main()
-# CHECK-CPP-SFPU: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP-SFPU: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP-SFPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-SFPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-SFPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-SFPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-SFPU: [[CB0]].wait_front(
+# CHECK-CPP-SFPU: [[CB1]].wait_front(
+# CHECK-CPP-SFPU: [[CB2]].reserve_back(
 # CHECK-CPP-SFPU: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 # CHECK-CPP-SFPU: tile_regs_acquire();
 # SFPU path loads tiles into DST via copy_tile before computing.
@@ -237,9 +243,9 @@ def add_kernel(lhs, rhs, out):
 # CHECK-CPP-SFPU: tile_regs_wait();
 # CHECK-CPP-SFPU: pack_tile<true>(
 # CHECK-CPP-SFPU: tile_regs_release();
-# CHECK-CPP-SFPU: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP-SFPU: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP-SFPU: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP-SFPU: [[CB0]].pop_front(
+# CHECK-CPP-SFPU: [[CB1]].pop_front(
+# CHECK-CPP-SFPU: [[CB2]].push_back(
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add_3d.py
+++ b/test/python/simple_add_3d.py
@@ -115,9 +115,12 @@ def add_3d_kernel(lhs, rhs, out):
 # Compute kernel: 3 nested loops over 2x2x2 tile grid
 # CHECK-CPP: // add_compute
 # CHECK-CPP: void kernel_main()
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
+# CHECK-CPP: [[CB2]].reserve_back(
 # CHECK-CPP: for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-CPP:   for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-CPP:     for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
@@ -133,7 +136,8 @@ def add_3d_kernel(lhs, rhs, out):
 # DM read kernel: 3 nested loops with noc_async_read_tile
 # CHECK-CPP: // dm_read
 # CHECK-CPP: void kernel_main()
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(0),
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP: [[CB0]].reserve_back(
 # CHECK-CPP: for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-CPP:   for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-CPP:     for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
@@ -142,7 +146,8 @@ def add_3d_kernel(lhs, rhs, out):
 # DM write kernel: 3 nested loops with noc_async_write_tile
 # CHECK-CPP: // dm_write
 # CHECK-CPP: void kernel_main()
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(2),
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP: [[CB2]].wait_front(
 # CHECK-CPP: for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-CPP:   for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-CPP:     for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
@@ -155,9 +160,12 @@ def add_3d_kernel(lhs, rhs, out):
 
 # CHECK-CPP-FPU: // add_compute
 # CHECK-CPP-FPU: void kernel_main()
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: [[CB0]].wait_front(
+# CHECK-CPP-FPU: [[CB1]].wait_front(
+# CHECK-CPP-FPU: [[CB2]].reserve_back(
 # CHECK-CPP-FPU: binary_op_init_common(get_compile_time_arg_val(0), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
 # CHECK-CPP-FPU: tile_regs_acquire();
 # CHECK-CPP-FPU: add_tiles_init(get_compile_time_arg_val(0), get_compile_time_arg_val(1));
@@ -166,14 +174,15 @@ def add_3d_kernel(lhs, rhs, out):
 # CHECK-CPP-FPU: tile_regs_wait();
 # CHECK-CPP-FPU: pack_tile<true>(
 # CHECK-CPP-FPU: tile_regs_release();
-# CHECK-CPP-FPU: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU: [[CB2]].push_back(
 # CHECK-CPP-FPU-NOT: pack_tile_block(
 
 # Default (combine-pack-tiles enabled): individual pack_tile ops combined.
+# CHECK-CPP-FPU-BLOCK-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 # CHECK-CPP-FPU-BLOCK: tile_regs_wait();
 # CHECK-CPP-FPU-BLOCK: pack_tile_block(
 # CHECK-CPP-FPU-BLOCK: tile_regs_release();
-# CHECK-CPP-FPU-BLOCK: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU-BLOCK: [[CB2]].push_back(
 # CHECK-CPP-FPU-BLOCK-NOT: pack_tile<true>(
 
 

--- a/test/python/simple_add_dram.py
+++ b/test/python/simple_add_dram.py
@@ -132,11 +132,14 @@ def add_dram_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // add_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # DFB operations
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
+# CHECK-CPP: [[CB2]].reserve_back(
 # CHECK-CPP: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 
 # DST register lifecycle and add
@@ -149,9 +152,9 @@ def add_dram_kernel(lhs, rhs, out):
 # CHECK-CPP: tile_regs_release();
 
 # DFB finalization
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].pop_front(
+# CHECK-CPP: [[CB1]].pop_front(
+# CHECK-CPP: [[CB2]].push_back(
 
 # =============================================================================
 # C++ Kernel Checks - Verify generated dm_read kernel (DRAM access)
@@ -159,24 +162,24 @@ def add_dram_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // dm_read
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
 
 # First input: reserve DFB, read tile, push DFB
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB0]].reserve_back(
 # CHECK-CPP: auto {{.*}} = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 3>(), 0>();
 # CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_write_ptr(get_compile_time_arg_val(0))
-# CHECK-CPP: noc_async_read_tile(
+# CHECK-CPP: noc_async_read_tile({{.*}}[[CB0]].get_write_ptr()
 # CHECK-CPP: noc_async_read_barrier();
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB0]].push_back(
 
 # Second input: reserve DFB, read tile, push DFB
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB1]].reserve_back(
 # CHECK-CPP: auto {{.*}} = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 3>(), 1>();
 # CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_write_ptr(get_compile_time_arg_val(1))
-# CHECK-CPP: noc_async_read_tile(
+# CHECK-CPP: noc_async_read_tile({{.*}}[[CB1]].get_write_ptr()
 # CHECK-CPP: noc_async_read_barrier();
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB1]].push_back(
 
 # =============================================================================
 # C++ Kernel Checks - Verify generated dm_write kernel (DRAM access)
@@ -184,15 +187,15 @@ def add_dram_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // dm_write
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # Wait for output DFB, write tile, pop DFB
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].wait_front(
 # CHECK-CPP: auto {{.*}} = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<2, 3>(), 0>();
 # CHECK-CPP: TensorAccessor{{.*}}= TensorAccessor(
-# CHECK-CPP: get_read_ptr(get_compile_time_arg_val(2))
-# CHECK-CPP: noc_async_write_tile(
+# CHECK-CPP: noc_async_write_tile({{.*}}[[CB2]].get_read_ptr()
 # CHECK-CPP: noc_async_write_barrier();
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].pop_front(
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -200,9 +203,12 @@ def add_dram_kernel(lhs, rhs, out):
 
 # CHECK-CPP-FPU: // add_compute
 # CHECK-CPP-FPU: void kernel_main()
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: [[CB0]].wait_front(
+# CHECK-CPP-FPU: [[CB1]].wait_front(
+# CHECK-CPP-FPU: [[CB2]].reserve_back(
 # CHECK-CPP-FPU: binary_op_init_common(get_compile_time_arg_val(0), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
 # CHECK-CPP-FPU: tile_regs_acquire();
 # CHECK-CPP-FPU: add_tiles_init(get_compile_time_arg_val(0), get_compile_time_arg_val(1));
@@ -211,9 +217,9 @@ def add_dram_kernel(lhs, rhs, out):
 # CHECK-CPP-FPU: tile_regs_wait();
 # CHECK-CPP-FPU: pack_tile<true>(
 # CHECK-CPP-FPU: tile_regs_release();
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU: [[CB0]].pop_front(
+# CHECK-CPP-FPU: [[CB1]].pop_front(
+# CHECK-CPP-FPU: [[CB2]].push_back(
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add_loop.py
+++ b/test/python/simple_add_loop.py
@@ -98,25 +98,28 @@ def add_loop_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // add_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # Initial: wait for inputs, reserve and push output
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
+# CHECK-CPP: [[CB2]].reserve_back(
+# CHECK-CPP: [[CB2]].push_back(
 
 # For loop with accumulate pattern
 # CHECK-CPP: for (size_t {{.*}} < {{.*}};
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(2),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].wait_front(
+# CHECK-CPP: [[CB2]].reserve_back(
 # CHECK-CPP: add_binary_tile_init();
 # CHECK-CPP: add_binary_tile(
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].push_back(
+# CHECK-CPP: [[CB2]].pop_front(
 
 # Finalize: pop inputs (reverse order from with-statement LIFO)
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB1]].pop_front(
+# CHECK-CPP: [[CB0]].pop_front(
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -125,9 +128,12 @@ def add_loop_kernel(lhs, rhs, out):
 
 # CHECK-CPP-FPU: // add_compute
 # CHECK-CPP-FPU: void kernel_main()
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: [[CB0]].wait_front(
+# CHECK-CPP-FPU: [[CB1]].wait_front(
+# CHECK-CPP-FPU: [[CB2]].reserve_back(
 
 # Initial store: copy lhs to output (SFPU path)
 # CHECK-CPP-FPU: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
@@ -138,19 +144,19 @@ def add_loop_kernel(lhs, rhs, out):
 # CHECK-CPP-FPU: tile_regs_wait();
 # CHECK-CPP-FPU: pack_tile<true>(
 # CHECK-CPP-FPU: tile_regs_release();
-# CHECK-CPP-FPU: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU: [[CB2]].push_back(
 
 # Loop: accumulate with FPU add_tiles (both inputs from CBs)
 # CHECK-CPP-FPU: for (size_t {{.*}} < {{.*}};
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(2),
-# CHECK-CPP-FPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU: [[CB2]].wait_front(
+# CHECK-CPP-FPU: [[CB2]].reserve_back(
 # CHECK-CPP-FPU: binary_op_init_common(get_compile_time_arg_val(2), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
 # CHECK-CPP-FPU: add_tiles_init(get_compile_time_arg_val(2), get_compile_time_arg_val(1));
 # CHECK-CPP-FPU: add_tiles(get_compile_time_arg_val(2), get_compile_time_arg_val(1),
 
 # Finalize
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(0),
+# CHECK-CPP-FPU: [[CB1]].pop_front(
+# CHECK-CPP-FPU: [[CB0]].pop_front(
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add_multitile.py
+++ b/test/python/simple_add_multitile.py
@@ -97,14 +97,18 @@ def add_multitile_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // add_compute
 # CHECK-CPP: void kernel_main()
-
-# Loop bound constant for 2x2 tile grid
-# CHECK-CPP: size_t [[BOUND:v[0-9]+]] = 2;
+# Loop bound constant for 2x2 tile grid, plus CB instance bindings.
+# Compiler emits both as immediate locals at kernel_main entry; their relative
+# order is not contractual so DAG-match them as a single group.
+# CHECK-CPP-DAG: size_t [[BOUND:v[0-9]+]] = 2;
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # DFB operations before loops
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
+# CHECK-CPP: [[CB2]].reserve_back(
 # CHECK-CPP: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 
 # Nested loops for 2x2 tile grid
@@ -124,9 +128,9 @@ def add_multitile_kernel(lhs, rhs, out):
 # CHECK-CPP: add_binary_tile_init();
 # CHECK-CPP: add_binary_tile(
 
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].pop_front(
+# CHECK-CPP: [[CB1]].pop_front(
+# CHECK-CPP: [[CB2]].push_back(
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -135,9 +139,12 @@ def add_multitile_kernel(lhs, rhs, out):
 
 # CHECK-CPP-FPU: // add_compute
 # CHECK-CPP-FPU: void kernel_main()
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: [[CB0]].wait_front(
+# CHECK-CPP-FPU: [[CB1]].wait_front(
+# CHECK-CPP-FPU: [[CB2]].reserve_back(
 # CHECK-CPP-FPU: binary_op_init_common(get_compile_time_arg_val(0), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
 # CHECK-CPP-FPU: tile_regs_acquire();
 # CHECK-CPP-FPU: add_tiles_init(get_compile_time_arg_val(0), get_compile_time_arg_val(1));
@@ -149,9 +156,9 @@ def add_multitile_kernel(lhs, rhs, out):
 # CHECK-CPP-FPU: tile_regs_wait();
 # CHECK-CPP-FPU: pack_tile_block(
 # CHECK-CPP-FPU: tile_regs_release();
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU: [[CB0]].pop_front(
+# CHECK-CPP-FPU: [[CB1]].pop_front(
+# CHECK-CPP-FPU: [[CB2]].push_back(
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add_with_stmt.py
+++ b/test/python/simple_add_with_stmt.py
@@ -134,13 +134,16 @@ def add_with_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // add_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # Wait for inputs
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
 
 # Reserve output
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].reserve_back(
 # CHECK-CPP: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 
 # Add operation
@@ -153,23 +156,23 @@ def add_with_kernel(lhs, rhs, out):
 # CHECK-CPP: tile_regs_release();
 
 # Push output, pop inputs (reverse order from 'with' exit)
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB2]].push_back(
+# CHECK-CPP: [[CB1]].pop_front(
+# CHECK-CPP: [[CB0]].pop_front(
 
 # CHECK-CPP: // dm_read
 # CHECK-CPP: void kernel_main()
-# CHECK-CPP: cb_reserve_back(
+# CHECK-CPP: .reserve_back(
 # CHECK-CPP: noc_async_read_tile(
 # CHECK-CPP: noc_async_read_barrier();
-# CHECK-CPP: cb_push_back(
+# CHECK-CPP: .push_back(
 
 # CHECK-CPP: // dm_write
 # CHECK-CPP: void kernel_main()
-# CHECK-CPP: cb_wait_front(
+# CHECK-CPP: .wait_front(
 # CHECK-CPP: noc_async_write_tile(
 # CHECK-CPP: noc_async_write_barrier();
-# CHECK-CPP: cb_pop_front(
+# CHECK-CPP: .pop_front(
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -177,9 +180,12 @@ def add_with_kernel(lhs, rhs, out):
 
 # CHECK-CPP-FPU: // add_compute
 # CHECK-CPP-FPU: void kernel_main()
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: [[CB0]].wait_front(
+# CHECK-CPP-FPU: [[CB1]].wait_front(
+# CHECK-CPP-FPU: [[CB2]].reserve_back(
 # CHECK-CPP-FPU: binary_op_init_common(get_compile_time_arg_val(0), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
 # CHECK-CPP-FPU: tile_regs_acquire();
 # CHECK-CPP-FPU: add_tiles_init(get_compile_time_arg_val(0), get_compile_time_arg_val(1));
@@ -188,9 +194,9 @@ def add_with_kernel(lhs, rhs, out):
 # CHECK-CPP-FPU: tile_regs_wait();
 # CHECK-CPP-FPU: pack_tile<true>(
 # CHECK-CPP-FPU: tile_regs_release();
-# CHECK-CPP-FPU: cb_push_back(get_compile_time_arg_val(2),
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(0),
+# CHECK-CPP-FPU: [[CB2]].push_back(
+# CHECK-CPP-FPU: [[CB1]].pop_front(
+# CHECK-CPP-FPU: [[CB0]].pop_front(
 
 
 if __name__ == "__main__":

--- a/test/python/simple_fill.py
+++ b/test/python/simple_fill.py
@@ -66,8 +66,9 @@ def fill_kernel(out):
 
 # CHECK-CPP: // fill_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
 
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB0]].reserve_back(
 
 # CHECK-CPP: tile_regs_acquire();
 
@@ -81,7 +82,7 @@ def fill_kernel(out):
 
 # CHECK-CPP: tile_regs_release();
 
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB0]].push_back(
 
 
 device = ttnn.open_device(device_id=0)

--- a/test/python/simple_fused.py
+++ b/test/python/simple_fused.py
@@ -94,13 +94,16 @@ def fused_kernel(inp, bias, out):
 
 # CHECK-CPP: // fused_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
 # Wait for input CBs
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
 
 # Reserve output DFB
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB2]].reserve_back(
 
 # DST register lifecycle
 # CHECK-CPP: tile_regs_acquire();
@@ -133,9 +136,9 @@ def fused_kernel(inp, bias, out):
 # CHECK-CPP: tile_regs_release();
 
 # Pop inputs, push output
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].pop_front(
+# CHECK-CPP: [[CB1]].pop_front(
+# CHECK-CPP: [[CB2]].push_back(
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -144,9 +147,12 @@ def fused_kernel(inp, bias, out):
 
 # CHECK-CPP-FPU: // fused_compute
 # CHECK-CPP-FPU: void kernel_main()
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: [[CB0]].wait_front(
+# CHECK-CPP-FPU: [[CB1]].wait_front(
+# CHECK-CPP-FPU: [[CB2]].reserve_back(
 # CHECK-CPP-FPU: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 # CHECK-CPP-FPU: tile_regs_acquire();
 
@@ -167,9 +173,9 @@ def fused_kernel(inp, bias, out):
 # CHECK-CPP-FPU: tile_regs_wait();
 # CHECK-CPP-FPU: pack_tile<true>(
 # CHECK-CPP-FPU: tile_regs_release();
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(0),
-# CHECK-CPP-FPU: cb_pop_front(get_compile_time_arg_val(1),
-# CHECK-CPP-FPU: cb_push_back(get_compile_time_arg_val(2),
+# CHECK-CPP-FPU: [[CB0]].pop_front(
+# CHECK-CPP-FPU: [[CB1]].pop_front(
+# CHECK-CPP-FPU: [[CB2]].push_back(
 
 
 if __name__ == "__main__":

--- a/test/python/simple_matmul_subblock.py
+++ b/test/python/simple_matmul_subblock.py
@@ -31,9 +31,12 @@ import ttl
 # per-subblock), so pack_tile_block's contiguous-from-0 requirement is
 # not met for subblocks after the first.
 # CHECK-CPP: void kernel_main()
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
+# CHECK-CPP: [[CB2]].reserve_back(
 # CHECK-CPP: mm_block_init(
 # CHECK-CPP: for (size_t {{.*}} = {{.*}}; {{.*}} < {{.*}}; {{.*}} += {{.*}}) {
 # CHECK-CPP:   tile_regs_acquire();

--- a/test/python/simple_reduce.py
+++ b/test/python/simple_reduce.py
@@ -80,10 +80,13 @@ def reduce_kernel(inp, scaler, out):
 
 # CHECK-CPP: // reduce_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
 
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(2),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].wait_front(
+# CHECK-CPP: [[CB2]].reserve_back(
 
 # CHECK-CPP: tile_regs_acquire();
 
@@ -97,8 +100,8 @@ def reduce_kernel(inp, scaler, out):
 
 # CHECK-CPP: tile_regs_release();
 
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(2),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB2]].push_back(
+# CHECK-CPP: [[CB0]].pop_front(
 
 
 device = ttnn.open_device(device_id=0)

--- a/test/python/simple_transpose.py
+++ b/test/python/simple_transpose.py
@@ -70,9 +70,11 @@ def transpose_kernel(inp, out):
 
 # CHECK-CPP: // transpose_compute
 # CHECK-CPP: void kernel_main()
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
 
-# CHECK-CPP: cb_wait_front(get_compile_time_arg_val(0),
-# CHECK-CPP: cb_reserve_back(get_compile_time_arg_val(1),
+# CHECK-CPP: [[CB0]].wait_front(
+# CHECK-CPP: [[CB1]].reserve_back(
 
 # CHECK-CPP: tile_regs_acquire();
 
@@ -86,8 +88,8 @@ def transpose_kernel(inp, out):
 
 # CHECK-CPP: tile_regs_release();
 
-# CHECK-CPP: cb_push_back(get_compile_time_arg_val(1),
-# CHECK-CPP: cb_pop_front(get_compile_time_arg_val(0),
+# CHECK-CPP: [[CB1]].push_back(
+# CHECK-CPP: [[CB0]].pop_front(
 
 
 if __name__ == "__main__":

--- a/test/python/softmax_compiler_allocated_dfb.py
+++ b/test/python/softmax_compiler_allocated_dfb.py
@@ -77,21 +77,21 @@ def softmax_kernel(inp, scaler, out):
 # reduce_max -> pack to intermediate DFB, push, wait for bcast.
 # CHECK-CPP: reduce_tile<PoolType::MAX
 # CHECK-CPP: pack_tile
-# CHECK-CPP: cb_push_back
-# CHECK-CPP: cb_wait_front
+# CHECK-CPP: .push_back
+# CHECK-CPP: .wait_front
 
 # bcast(max) + sub + exp -> pack to intermediate DFB, push, wait for reduce_sum.
 # CHECK-CPP: unary_bcast
 # CHECK-CPP: exp_tile
 # CHECK-CPP: pack_tile
-# CHECK-CPP: cb_push_back
-# CHECK-CPP: cb_wait_front
+# CHECK-CPP: .push_back
+# CHECK-CPP: .wait_front
 
 # reduce_sum -> pack to intermediate DFB, push, wait for final bcast.
 # CHECK-CPP: reduce_tile<PoolType::SUM
 # CHECK-CPP: pack_tile
-# CHECK-CPP: cb_push_back
-# CHECK-CPP: cb_wait_front
+# CHECK-CPP: .push_back
+# CHECK-CPP: .wait_front
 
 # bcast(sum) + recip + mul -> pack to output.
 # CHECK-CPP: unary_bcast

--- a/test/ttlang/Translate/TTLToCpp/cb_to_tensor_single_tile_write.mlir
+++ b/test/ttlang/Translate/TTLToCpp/cb_to_tensor_single_tile_write.mlir
@@ -13,11 +13,11 @@
 // CHECK: void kernel_main() {
 // CHECK-DAG:   int32_t [[ZERO:v[0-9]+]] = 0;
 // CHECK-DAG:   int32_t [[ADDR:v[0-9]+]] = 4096;
+// CHECK:   experimental::CircularBuffer [[CB:.*]](get_compile_time_arg_val(0));
 // CHECK:   int32_t [[RT_ARG:v[0-9]+]] = get_common_arg_val<uint32_t>([[RT_ARG_IDX:v[0-9]+]]);
 // CHECK:   auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // CHECK:   TensorAccessor [[ACCESSOR:v[0-9]+]] = TensorAccessor([[ARGS]], [[RT_ARG]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR:v[0-9]+]] = get_read_ptr(get_compile_time_arg_val(0));
-// CHECK-NEXT:   noc_async_write_tile([[ZERO]], [[ACCESSOR]], [[CB_PTR]]);
+// CHECK-NEXT:   noc_async_write_tile([[ZERO]], [[ACCESSOR]], [[CB]].get_read_ptr());
 // CHECK:   noc_async_write_barrier();
 // CHECK:   return;
 // CHECK-NEXT: }

--- a/test/ttlang/Translate/TTLToCpp/compute_fused_chain_to_cpp.mlir
+++ b/test/ttlang/Translate/TTLToCpp/compute_fused_chain_to_cpp.mlir
@@ -29,7 +29,11 @@
 // FPU-DAG:   size_t [[STEP:v[0-9]+]] = 1
 // FPU-DAG:   size_t [[ZERO:v[0-9]+]] = 0
 
-// FPU:       cb_reserve_back(get_compile_time_arg_val(2), [[TILES]]);
+// CB wrappers declared at top of kernel
+// FPU:       experimental::CircularBuffer [[FPU_CB0:.*]](get_compile_time_arg_val(0));
+// FPU:       experimental::CircularBuffer [[FPU_CB1:.*]](get_compile_time_arg_val(1));
+// FPU:       experimental::CircularBuffer [[FPU_CB2:.*]](get_compile_time_arg_val(2));
+// FPU:       [[FPU_CB2]].reserve_back([[TILES]]);
 // FPU:       binary_op_init_common(get_compile_time_arg_val(0), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
 
 // FPU:       for (size_t [[I:.*]] = [[ZERO]]; [[I]] < [[BOUND]]; [[I]] += [[STEP]]) {
@@ -68,7 +72,11 @@
 // SFPU-DAG:   size_t [[STEP:v[0-9]+]] = 1
 // SFPU-DAG:   size_t [[ZERO:v[0-9]+]] = 0
 
-// SFPU:       cb_reserve_back(get_compile_time_arg_val(2), [[TILES]]);
+// CB wrappers declared at top of kernel
+// SFPU:       experimental::CircularBuffer [[SFPU_CB0:.*]](get_compile_time_arg_val(0));
+// SFPU:       experimental::CircularBuffer [[SFPU_CB1:.*]](get_compile_time_arg_val(1));
+// SFPU:       experimental::CircularBuffer [[SFPU_CB2:.*]](get_compile_time_arg_val(2));
+// SFPU:       [[SFPU_CB2]].reserve_back([[TILES]]);
 // SFPU:       init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 
 // SFPU:       for (size_t [[I:.*]] = [[ZERO]]; [[I]] < [[BOUND]]; [[I]] += [[STEP]]) {

--- a/test/ttlang/Translate/TTLToCpp/compute_with_data_movement.mlir
+++ b/test/ttlang/Translate/TTLToCpp/compute_with_data_movement.mlir
@@ -32,13 +32,16 @@
 // FPU-DAG:   size_t [[PAGE_SIZE:v[0-9]+]] = 4096
 // FPU-DAG:   size_t [[ZERO:v[0-9]+]] = 0
 
+// CB wrappers declared at top of kernel
+// FPU:   experimental::CircularBuffer [[FPU_R_CB0:.*]](get_compile_time_arg_val(0));
+// FPU:   experimental::CircularBuffer [[FPU_R_CB1:.*]](get_compile_time_arg_val(1));
+
 // Read tensor A into CB0
 // FPU:   int32_t [[RT_ARG_A:.*]] = get_common_arg_val<uint32_t>([[ZERO]]);
 // FPU-NEXT:   auto [[ARGS_A:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 2>(), 0>();
 // FPU-NEXT:   TensorAccessor [[ACC_A:.*]] = TensorAccessor([[ARGS_A]], [[RT_ARG_A]],
-// CB pointer casting chain: int32_t -> ptrdiff_t -> size_t
-// FPU:   int32_t [[CB0_PTR:.*]] = get_write_ptr(get_compile_time_arg_val(0));
-// FPU-NEXT:   ptrdiff_t [[CB0_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB0_PTR]];
+// CB pointer casting chain: ptrdiff_t -> size_t
+// FPU-NEXT:   ptrdiff_t [[CB0_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[FPU_R_CB0]].get_write_ptr();
 // FPU-NEXT:   size_t [[CB0_PTR_IDX:v[0-9]+]] = (size_t) [[CB0_PTR_PTRDIFF]];
 // FPU:   for (size_t [[I_A:.*]] = [[ZERO]]; [[I_A]] < [[BOUND]]; [[I_A]] += [[ONE]]) {
 // FPU-NEXT:     for (size_t [[J_A:.*]] = [[ZERO]]; [[J_A]] < [[BOUND]]; [[J_A]] += [[ONE]]) {
@@ -62,9 +65,8 @@
 // FPU:   int32_t [[RT_ARG_B:.*]] = get_common_arg_val<uint32_t>([[ONE]]);
 // FPU-NEXT:   auto [[ARGS_B:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 2>(), 1>();
 // FPU-NEXT:   TensorAccessor [[ACC_B:.*]] = TensorAccessor([[ARGS_B]], [[RT_ARG_B]],
-// CB pointer casting chain: int32_t -> ptrdiff_t -> size_t
-// FPU:   int32_t [[CB1_PTR:.*]] = get_write_ptr(get_compile_time_arg_val(1));
-// FPU-NEXT:   ptrdiff_t [[CB1_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB1_PTR]];
+// CB pointer casting chain: ptrdiff_t -> size_t
+// FPU-NEXT:   ptrdiff_t [[CB1_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[FPU_R_CB1]].get_write_ptr();
 // FPU-NEXT:   size_t [[CB1_PTR_IDX:v[0-9]+]] = (size_t) [[CB1_PTR_PTRDIFF]];
 // FPU:   for (size_t [[I_B:.*]] = [[ZERO]]; [[I_B]] < [[BOUND]]; [[I_B]] += [[ONE]]) {
 // FPU-NEXT:     for (size_t [[J_B:.*]] = [[ZERO]]; [[J_B]] < [[BOUND]]; [[J_B]] += [[ONE]]) {
@@ -95,9 +97,13 @@
 // FPU-DAG:   size_t [[CBOUND:v[0-9]+]] = 2
 // FPU-DAG:   size_t [[CZERO:v[0-9]+]] = 0
 
-// FPU:       cb_wait_front(get_compile_time_arg_val(0), [[TILES]]);
-// FPU-NEXT:  cb_wait_front(get_compile_time_arg_val(1), [[TILES]]);
-// FPU-NEXT:  cb_reserve_back(get_compile_time_arg_val(2), [[TILES]]);
+// CB wrappers declared at top of kernel
+// FPU:       experimental::CircularBuffer [[FPU_C_CB0:.*]](get_compile_time_arg_val(0));
+// FPU:       experimental::CircularBuffer [[FPU_C_CB1:.*]](get_compile_time_arg_val(1));
+// FPU:       experimental::CircularBuffer [[FPU_C_CB2:.*]](get_compile_time_arg_val(2));
+// FPU:       [[FPU_C_CB0]].wait_front([[TILES]]);
+// FPU-NEXT:  [[FPU_C_CB1]].wait_front([[TILES]]);
+// FPU-NEXT:  [[FPU_C_CB2]].reserve_back([[TILES]]);
 // FPU-NEXT:  binary_op_init_common(get_compile_time_arg_val(0), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
 
 // FPU:       for (size_t [[CI:.*]] = [[CZERO]]; [[CI]] < [[CBOUND]]; [[CI]] += [[STEP]]) {
@@ -117,7 +123,7 @@
 // FPU-NEXT:      tile_regs_wait();
 // pack_tile reuses the same linearized CB index as add_tiles.
 // FPU:           pack_tile<true>([[CZERO]], get_compile_time_arg_val(2), [[CTILE_IDX]]);
-// FPU-NEXT:      cb_push_back(get_compile_time_arg_val(2), [[TILES]]);
+// FPU-NEXT:      [[FPU_C_CB2]].push_back([[TILES]]);
 // FPU-NEXT:      tile_regs_release();
 
 // FPU-NOT:   init_sfpu
@@ -132,12 +138,13 @@
 // FPU-DAG:   size_t [[WONE:v[0-9]+]] = 1
 // FPU-DAG:   size_t [[WPAGE:v[0-9]+]] = 4096
 // FPU-DAG:   size_t [[WZERO:v[0-9]+]] = 0
+// CB wrapper declared at top of kernel
+// FPU:   experimental::CircularBuffer [[FPU_W_CB2:.*]](get_compile_time_arg_val(2));
 // FPU:   int32_t [[WRT_ARG:.*]] = get_common_arg_val<uint32_t>([[WZERO]]);
 // FPU-NEXT:   auto [[WARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // FPU-NEXT:   TensorAccessor [[WACC:.*]] = TensorAccessor([[WARGS]], [[WRT_ARG]],
-// CB pointer casting chain: int32_t -> ptrdiff_t -> size_t
-// FPU:   int32_t [[WR_PTR:.*]] = get_read_ptr(get_compile_time_arg_val(2));
-// FPU-NEXT:   ptrdiff_t [[WR_PTR_PD:v[0-9]+]] = (ptrdiff_t) [[WR_PTR]];
+// CB pointer casting chain: ptrdiff_t -> size_t
+// FPU-NEXT:   ptrdiff_t [[WR_PTR_PD:v[0-9]+]] = (ptrdiff_t) [[FPU_W_CB2]].get_read_ptr();
 // FPU-NEXT:   size_t [[WR_PTR_IDX:v[0-9]+]] = (size_t) [[WR_PTR_PD]];
 // FPU:   for (size_t [[WI:.*]] = [[WZERO]]; [[WI]] < [[WBOUND]]; [[WI]] += [[WONE]]) {
 // FPU-NEXT:     for (size_t [[WJ:.*]] = [[WZERO]]; [[WJ]] < [[WBOUND]]; [[WJ]] += [[WONE]]) {
@@ -167,13 +174,16 @@
 // SFPU-DAG:   size_t [[PAGE_SIZE:v[0-9]+]] = 4096
 // SFPU-DAG:   size_t [[ZERO:v[0-9]+]] = 0
 
+// CB wrappers declared at top of kernel
+// SFPU:   experimental::CircularBuffer [[SFPU_R_CB0:.*]](get_compile_time_arg_val(0));
+// SFPU:   experimental::CircularBuffer [[SFPU_R_CB1:.*]](get_compile_time_arg_val(1));
+
 // Read tensor A into CB0
 // SFPU:   int32_t [[RT_ARG_A:.*]] = get_common_arg_val<uint32_t>([[ZERO]]);
 // SFPU-NEXT:   auto [[ARGS_A:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 2>(), 0>();
 // SFPU-NEXT:   TensorAccessor [[ACC_A:.*]] = TensorAccessor([[ARGS_A]], [[RT_ARG_A]],
-// CB pointer casting chain: int32_t -> ptrdiff_t -> size_t
-// SFPU:   int32_t [[CB0_PTR:.*]] = get_write_ptr(get_compile_time_arg_val(0));
-// SFPU-NEXT:   ptrdiff_t [[CB0_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB0_PTR]];
+// CB pointer casting chain: ptrdiff_t -> size_t
+// SFPU-NEXT:   ptrdiff_t [[CB0_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[SFPU_R_CB0]].get_write_ptr();
 // SFPU-NEXT:   size_t [[CB0_PTR_IDX:v[0-9]+]] = (size_t) [[CB0_PTR_PTRDIFF]];
 // SFPU:   for (size_t [[I_A:.*]] = [[ZERO]]; [[I_A]] < [[BOUND]]; [[I_A]] += [[ONE]]) {
 // SFPU-NEXT:     for (size_t [[J_A:.*]] = [[ZERO]]; [[J_A]] < [[BOUND]]; [[J_A]] += [[ONE]]) {
@@ -197,9 +207,8 @@
 // SFPU:   int32_t [[RT_ARG_B:.*]] = get_common_arg_val<uint32_t>([[ONE]]);
 // SFPU-NEXT:   auto [[ARGS_B:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 2>(), 1>();
 // SFPU-NEXT:   TensorAccessor [[ACC_B:.*]] = TensorAccessor([[ARGS_B]], [[RT_ARG_B]],
-// CB pointer casting chain: int32_t -> ptrdiff_t -> size_t
-// SFPU:   int32_t [[CB1_PTR:.*]] = get_write_ptr(get_compile_time_arg_val(1));
-// SFPU-NEXT:   ptrdiff_t [[CB1_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB1_PTR]];
+// CB pointer casting chain: ptrdiff_t -> size_t
+// SFPU-NEXT:   ptrdiff_t [[CB1_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[SFPU_R_CB1]].get_write_ptr();
 // SFPU-NEXT:   size_t [[CB1_PTR_IDX:v[0-9]+]] = (size_t) [[CB1_PTR_PTRDIFF]];
 // SFPU:   for (size_t [[I_B:.*]] = [[ZERO]]; [[I_B]] < [[BOUND]]; [[I_B]] += [[ONE]]) {
 // SFPU-NEXT:     for (size_t [[J_B:.*]] = [[ZERO]]; [[J_B]] < [[BOUND]]; [[J_B]] += [[ONE]]) {
@@ -230,9 +239,13 @@
 // SFPU-DAG:   size_t [[CBOUND:v[0-9]+]] = 2
 // SFPU-DAG:   size_t [[CZERO:v[0-9]+]] = 0
 
-// SFPU:       cb_wait_front(get_compile_time_arg_val(0), [[TILES]]);
-// SFPU-NEXT:  cb_wait_front(get_compile_time_arg_val(1), [[TILES]]);
-// SFPU-NEXT:  cb_reserve_back(get_compile_time_arg_val(2), [[TILES]]);
+// CB wrappers declared at top of kernel
+// SFPU:       experimental::CircularBuffer [[SFPU_C_CB0:.*]](get_compile_time_arg_val(0));
+// SFPU:       experimental::CircularBuffer [[SFPU_C_CB1:.*]](get_compile_time_arg_val(1));
+// SFPU:       experimental::CircularBuffer [[SFPU_C_CB2:.*]](get_compile_time_arg_val(2));
+// SFPU:       [[SFPU_C_CB0]].wait_front([[TILES]]);
+// SFPU-NEXT:  [[SFPU_C_CB1]].wait_front([[TILES]]);
+// SFPU-NEXT:  [[SFPU_C_CB2]].reserve_back([[TILES]]);
 // SFPU-NEXT:  init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 
 // SFPU:       for (size_t [[CI:.*]] = [[CZERO]]; [[CI]] < [[CBOUND]]; [[CI]] += [[STEP]]) {
@@ -252,7 +265,7 @@
 // SFPU-NEXT:      tile_regs_commit();
 // SFPU-NEXT:      tile_regs_wait();
 // SFPU-NEXT:      pack_tile<true>([[CZERO]], get_compile_time_arg_val(2), [[CTILE_IDX]]);
-// SFPU-NEXT:      cb_push_back(get_compile_time_arg_val(2), [[TILES]]);
+// SFPU-NEXT:      [[SFPU_C_CB2]].push_back([[TILES]]);
 // SFPU-NEXT:      tile_regs_release();
 
 // SFPU-NOT:   binary_op_init_common
@@ -267,12 +280,13 @@
 // SFPU-DAG:   size_t [[WONE:v[0-9]+]] = 1
 // SFPU-DAG:   size_t [[WPAGE:v[0-9]+]] = 4096
 // SFPU-DAG:   size_t [[WZERO:v[0-9]+]] = 0
+// CB wrapper declared at top of kernel
+// SFPU:   experimental::CircularBuffer [[SFPU_W_CB2:.*]](get_compile_time_arg_val(2));
 // SFPU:   int32_t [[WRT_ARG:.*]] = get_common_arg_val<uint32_t>([[WZERO]]);
 // SFPU-NEXT:   auto [[WARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // SFPU-NEXT:   TensorAccessor [[WACC:.*]] = TensorAccessor([[WARGS]], [[WRT_ARG]],
-// CB pointer casting chain: int32_t -> ptrdiff_t -> size_t
-// SFPU:   int32_t [[WR_PTR:.*]] = get_read_ptr(get_compile_time_arg_val(2));
-// SFPU-NEXT:   ptrdiff_t [[WR_PTR_PD:v[0-9]+]] = (ptrdiff_t) [[WR_PTR]];
+// CB pointer casting chain: ptrdiff_t -> size_t
+// SFPU-NEXT:   ptrdiff_t [[WR_PTR_PD:v[0-9]+]] = (ptrdiff_t) [[SFPU_W_CB2]].get_read_ptr();
 // SFPU-NEXT:   size_t [[WR_PTR_IDX:v[0-9]+]] = (size_t) [[WR_PTR_PD]];
 // SFPU:   for (size_t [[WI:.*]] = [[WZERO]]; [[WI]] < [[WBOUND]]; [[WI]] += [[WONE]]) {
 // SFPU-NEXT:     for (size_t [[WJ:.*]] = [[WZERO]]; [[WJ]] < [[WBOUND]]; [[WJ]] += [[WONE]]) {

--- a/test/ttlang/Translate/TTLToCpp/dma_batched_single_tile.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_batched_single_tile.mlir
@@ -13,18 +13,19 @@
 // CHECK: void kernel_main() {
 // CHECK-DAG:   int32_t [[ZERO:v[0-9]+]] = 0;
 // CHECK-DAG:   int32_t [[ADDR:v[0-9]+]] = 4096;
+// CB wrappers declared at top of kernel
+// CHECK:   experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+// CHECK:   experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
 // Tensor 0: get runtime arg, create accessor, get CB write ptr, cast chain, async read
 // CHECK:   int32_t [[RT_ARG0:v[0-9]+]] = get_common_arg_val<uint32_t>({{v[0-9]+}});
 // CHECK:   auto [[ARGS0:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 2>(), 0>();
 // CHECK:   TensorAccessor [[ACCESSOR0:v[0-9]+]] = TensorAccessor([[ARGS0]], [[RT_ARG0]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR0:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
-// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR0]], [[CB_PTR0]]);
+// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR0]], [[CB0]].get_write_ptr());
 // Tensor 1: get runtime arg, create accessor, get CB write ptr, cast chain, async read
 // CHECK:   int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>({{v[0-9]+}});
 // CHECK:   auto [[ARGS1:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 2>(), 1>();
 // CHECK:   TensorAccessor [[ACCESSOR1:v[0-9]+]] = TensorAccessor([[ARGS1]], [[RT_ARG1]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
-// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR1]], [[CB_PTR1]]);
+// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR1]], [[CB1]].get_write_ptr());
 // Consecutive barriers deduplicated to single barrier.
 // CHECK:   noc_async_read_barrier();
 // CHECK:   return;

--- a/test/ttlang/Translate/TTLToCpp/dma_loop_multi_tile_nontrivial_cb.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_loop_multi_tile_nontrivial_cb.mlir
@@ -40,14 +40,16 @@
 // CHECK-DAG:   size_t [[TILE_STEP:v[0-9]+]] = 1;
 // CHECK-DAG:   size_t [[USER_UB:v[0-9]+]] = 4;
 // CHECK-DAG:   size_t [[TILE_LB:v[0-9]+]] = 0;
+// CB wrappers declared at top of kernel
+// CHECK:   experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+// CHECK:   experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
 // CHECK:   for (size_t [[USER_ITER:[a-z][0-9]+]] = [[TILE_LB]]; [[USER_ITER]] < [[USER_UB]]; [[USER_ITER]] += [[TILE_STEP]]) {
 // First copy: arg0 (64x64) → CB0, accessor with runtime arg index 0
 // CHECK:     int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_LB]]);
 // CHECK:     auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 2>(), 0>();
 // CHECK:     TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:     ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR1]];
+// CHECK:     ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB0]].get_write_ptr();
 // CHECK:     size_t [[CB_PTR1_IDX:v[0-9]+]] = (size_t) [[CB_PTR1_PTRDIFF]];
 // CHECK:     for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_Y]] < [[TILES_2]]; [[TILE1_Y]] += [[TILE_STEP]]) {
 // CHECK:       for (size_t [[TILE1_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_X]] < [[TILES_2]]; [[TILE1_X]] += [[TILE_STEP]]) {
@@ -69,9 +71,8 @@
 // CHECK:     int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_STEP]]);
 // CHECK:     auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 2>(), 1>();
 // CHECK:     TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
+// CHECK:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB1]].get_write_ptr();
 // CHECK:     size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
 // CHECK:     for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_Y]] < [[TILES_3]]; [[TILE2_Y]] += [[TILE_STEP]]) {
 // CHECK:       for (size_t [[TILE2_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_X]] < [[TILES_2]]; [[TILE2_X]] += [[TILE_STEP]]) {

--- a/test/ttlang/Translate/TTLToCpp/dma_loop_single_tile.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_loop_single_tile.mlir
@@ -16,18 +16,17 @@
 // CHECK-DAG:   size_t [[STEP:v[0-9]+]] = 1;
 // CHECK-DAG:   size_t [[UB:v[0-9]+]] = 3;
 // CHECK-DAG:   size_t [[LB:v[0-9]+]] = 0;
+// CHECK:   experimental::CircularBuffer [[CB:.*]](get_compile_time_arg_val(0));
 // Pre-loop copy: create accessor with runtime arg, get CB write ptr, cast chain
 // CHECK:   int32_t [[RT_ARG0:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
 // CHECK:   auto [[ARGS0:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // CHECK:   TensorAccessor [[ACCESSOR0:v[0-9]+]] = TensorAccessor([[ARGS0]], [[RT_ARG0]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR0:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
-// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR0]], [[CB_PTR0]]);
+// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR0]], [[CB]].get_write_ptr());
 // CHECK:   for (size_t [[IV:i[0-9]+]] = [[LB]]; [[IV]] < [[UB]]; [[IV]] += [[STEP]]) {
 // In-loop copy: create accessor reusing hoisted runtime arg, get CB write ptr, cast chain
 // CHECK:     auto [[ARGS1:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // CHECK:     TensorAccessor [[ACCESSOR1:v[0-9]+]] = TensorAccessor([[ARGS1]], [[RT_ARG0]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
-// CHECK-NEXT:     noc_async_read_tile([[ZERO]], [[ACCESSOR1]], [[CB_PTR1]]);
+// CHECK-NEXT:     noc_async_read_tile([[ZERO]], [[ACCESSOR1]], [[CB]].get_write_ptr());
 // CHECK:     noc_async_read_barrier();
 // CHECK:   }
 // CHECK:   noc_async_read_barrier();

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_batched_in_user_loop.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_batched_in_user_loop.mlir
@@ -38,6 +38,10 @@
 // CHECK-DAG:   size_t [[USER_UB:v[0-9]+]] = 3;
 // CHECK-DAG:   size_t [[LB:v[0-9]+]] = 0;
 
+// CB wrappers declared at top of kernel
+// CHECK:   experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+// CHECK:   experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+
 // User loop from input MLIR (0..3)
 // CHECK:   for (size_t [[USER_ITER:[a-z][0-9]+]] = [[LB]]; [[USER_ITER]] < [[USER_UB]]; [[USER_ITER]] += [[STEP]]) {
 
@@ -45,9 +49,8 @@
 // CHECK:     int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
 // CHECK:     auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 2>(), 0>();
 // CHECK:     TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:     ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR1]];
+// CHECK:     ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB0]].get_write_ptr();
 // CHECK:     size_t [[CB_PTR1_IDX:v[0-9]+]] = (size_t) [[CB_PTR1_PTRDIFF]];
 // Tile loops: for tile_y in 0..2, for tile_x in 0..2
 // CHECK:     for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[LB]]; [[TILE1_Y]] < [[TILES_BOUND]]; [[TILE1_Y]] += [[STEP]]) {
@@ -70,9 +73,8 @@
 // CHECK:     int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[STEP]]);
 // CHECK:     auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 2>(), 1>();
 // CHECK:     TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
-// CHECK:     int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
+// CHECK:     ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB1]].get_write_ptr();
 // CHECK:     size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
 // Separate tile loops (same bounds 0..2 x 0..2 but not merged with first copy)
 // CHECK:     for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[LB]]; [[TILE2_Y]] < [[TILES_BOUND]]; [[TILE2_Y]] += [[STEP]]) {

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_read.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_read.mlir
@@ -19,12 +19,12 @@
 // CHECK-DAG:   size_t [[PAGE_SIZE:v[0-9]+]] = 4096;
 // CHECK-DAG:   int32_t [[ADDR:v[0-9]+]] = 4096;
 // CHECK-DAG:   size_t [[TILE_LB:v[0-9]+]] = 0;
+// CHECK:   experimental::CircularBuffer [[CB:.*]](get_compile_time_arg_val(0));
 // CHECK:   int32_t [[RT_ARG:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_LB]]);
 // CHECK:   auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // CHECK:   TensorAccessor [[ACCESSOR:v[0-9]+]] = TensorAccessor([[ARGS]], [[RT_ARG]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:   ptrdiff_t [[CB_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR]];
+// CHECK:   ptrdiff_t [[CB_PTR_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB]].get_write_ptr();
 // CHECK:   size_t [[CB_PTR_IDX:v[0-9]+]] = (size_t) [[CB_PTR_PTRDIFF]];
 // CHECK:   for (size_t [[TILE_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE_Y]] < [[TILES_BOUND]]; [[TILE_Y]] += [[TILE_STEP]]) {
 // CHECK:     for (size_t [[TILE_X:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE_X]] < [[TILES_BOUND]]; [[TILE_X]] += [[TILE_STEP]]) {

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_same_layout_different_cb.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_same_layout_different_cb.mlir
@@ -24,13 +24,16 @@
 // CHECK-DAG:   int32_t [[ADDR:v[0-9]+]] = 4096;
 // CHECK-DAG:   size_t [[TILE_LB:v[0-9]+]] = 0;
 
+// CB wrappers declared at top of kernel
+// CHECK:   experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
+// CHECK:   experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
+
 // First copy: 64x64 (2x2 tiles) → CB [2,2]
 // CHECK:   int32_t [[RT_ARG1:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_LB]]);
 // CHECK:   auto [[ACC1_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 2>(), 0>();
 // CHECK:   TensorAccessor [[ACC1:v[0-9]+]] = TensorAccessor([[ACC1_ARGS]], [[RT_ARG1]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR1:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:   ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR1]];
+// CHECK:   ptrdiff_t [[CB_PTR1_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB0]].get_write_ptr();
 // CHECK:   size_t [[CB_PTR1_IDX:v[0-9]+]] = (size_t) [[CB_PTR1_PTRDIFF]];
 // Generated tile loops iterate over tensor grid (2x2)
 // CHECK:   for (size_t [[TILE1_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE1_Y]] < [[TILES_BOUND]]; [[TILE1_Y]] += [[TILE_STEP]]) {
@@ -54,9 +57,8 @@
 // CHECK:   int32_t [[RT_ARG2:v[0-9]+]] = get_common_arg_val<uint32_t>([[TILE_STEP]]);
 // CHECK:   auto [[ACC2_ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 2>(), 1>();
 // CHECK:   TensorAccessor [[ACC2:v[0-9]+]] = TensorAccessor([[ACC2_ARGS]], [[RT_ARG2]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR2:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(1));
 // Cast CB ptr to size_t for index arithmetic
-// CHECK:   ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB_PTR2]];
+// CHECK:   ptrdiff_t [[CB_PTR2_PTRDIFF:v[0-9]+]] = (ptrdiff_t) [[CB1]].get_write_ptr();
 // CHECK:   size_t [[CB_PTR2_IDX:v[0-9]+]] = (size_t) [[CB_PTR2_PTRDIFF]];
 // Generated tile loops still iterate over tensor grid (2x2), not CB shape (4x1)
 // CHECK:   for (size_t [[TILE2_Y:[a-z][0-9]+]] = [[TILE_LB]]; [[TILE2_Y]] < [[TILES_BOUND]]; [[TILE2_Y]] += [[TILE_STEP]]) {

--- a/test/ttlang/Translate/TTLToCpp/dma_single_tile_read.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_single_tile_read.mlir
@@ -13,11 +13,11 @@
 // CHECK: void kernel_main() {
 // CHECK-DAG:   int32_t [[ZERO:v[0-9]+]] = 0;
 // CHECK-DAG:   int32_t [[ADDR:v[0-9]+]] = 4096;
+// CHECK:   experimental::CircularBuffer [[CB:.*]](get_compile_time_arg_val(0));
 // CHECK:   int32_t [[RT_ARG:v[0-9]+]] = get_common_arg_val<uint32_t>([[RT_ARG_IDX:v[0-9]+]]);
 // CHECK:   auto [[ARGS:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // CHECK:   TensorAccessor [[ACCESSOR:v[0-9]+]] = TensorAccessor([[ARGS]], [[RT_ARG]], [[ADDR]]);
-// CHECK:   int32_t [[CB_PTR:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
-// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR]], [[CB_PTR]]);
+// CHECK-NEXT:   noc_async_read_tile([[ZERO]], [[ACCESSOR]], [[CB]].get_write_ptr());
 // CHECK:   noc_async_read_barrier();
 // CHECK:   return;
 // CHECK-NEXT: }

--- a/test/ttlang/Translate/TTLToCpp/loopback_full_single_tile.mlir
+++ b/test/ttlang/Translate/TTLToCpp/loopback_full_single_tile.mlir
@@ -16,20 +16,20 @@
 // CHECK-DAG:   size_t [[STEP:v[0-9]+]] = 1;
 // CHECK-DAG:   size_t [[UB:v[0-9]+]] = 4;
 // CHECK-DAG:   size_t [[LB:v[0-9]+]] = 0;
+// CB wrapper declared at top of kernel
+// CHECK:   experimental::CircularBuffer [[CB:.*]](get_compile_time_arg_val(0));
 // CHECK:   for (size_t [[IV:i[0-9]+]] = [[LB]]; [[IV]] < [[UB]]; [[IV]] += [[STEP]]) {
-// Read: tensor -> CB (uses get_write_ptr for CB destination, with cast chain)
+// Read: tensor -> CB (uses get_write_ptr for CB destination)
 // CHECK:     int32_t [[RT_ARG_R:v[0-9]+]] = get_common_arg_val<uint32_t>([[LB]]);
 // CHECK:     auto [[ARGS_READ:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<0, 1>(), 0>();
 // CHECK:     TensorAccessor [[ACC_READ:v[0-9]+]] = TensorAccessor([[ARGS_READ]], [[RT_ARG_R]], [[ADDR]]);
-// CHECK:     int32_t [[CB_WRITE_PTR:v[0-9]+]] = get_write_ptr(get_compile_time_arg_val(0));
-// CHECK-NEXT:     noc_async_read_tile([[ZERO]], [[ACC_READ]], [[CB_WRITE_PTR]]);
+// CHECK-NEXT:     noc_async_read_tile([[ZERO]], [[ACC_READ]], [[CB]].get_write_ptr());
 // CHECK:     noc_async_read_barrier();
-// Write: CB -> tensor (uses get_read_ptr for CB source, with cast chain)
+// Write: CB -> tensor (uses get_read_ptr for CB source)
 // CHECK:     int32_t [[RT_ARG_W:v[0-9]+]] = get_common_arg_val<uint32_t>([[STEP]]);
 // CHECK:     auto [[ARGS_WRITE:tensor_accessor_args_[0-9]+]] = TensorAccessorArgs<tensor_accessor::detail::get_tensor_accessor_args_cta_offset<1, 1>(), 1>();
 // CHECK:     TensorAccessor [[ACC_WRITE:v[0-9]+]] = TensorAccessor([[ARGS_WRITE]], [[RT_ARG_W]], [[ADDR]]);
-// CHECK:     int32_t [[CB_READ_PTR:v[0-9]+]] = get_read_ptr(get_compile_time_arg_val(0));
-// CHECK-NEXT:     noc_async_write_tile([[ZERO]], [[ACC_WRITE]], [[CB_READ_PTR]]);
+// CHECK-NEXT:     noc_async_write_tile([[ZERO]], [[ACC_WRITE]], [[CB]].get_read_ptr());
 // CHECK:     noc_async_write_barrier();
 // CHECK:   }
 // CHECK:   return;


### PR DESCRIPTION
Bumps tt-mlir to f1f31b42 and adapts MLIR + Python lit tests to the new `experimental::CircularBuffer` EmitC interface (member-function CB ops replacing the free-function form keyed on CB id).