### PR TITLE
sim: fix deadlock reporter crash on non-standard core IDs

### DIFF
--- a/python/sim/greenlet_scheduler.py
+++ b/python/sim/greenlet_scheduler.py
@@ -434,11 +434,19 @@ class GreenletScheduler:
                     if len(unique_cores) == 1:
                         cores_label = unique_cores[0]
                     else:
-                        core_numbers: list[int] = [
-                            int(core_id[4:]) for core_id in unique_cores
-                        ]
-                        cores_label = f"cores: {format_core_ranges(core_numbers)}"
-
+                        try:
+                            core_numbers: list[int] = [
+                                int(core_id[4:])
+                                for core_id in unique_cores
+                                if core_id.startswith("core") and core_id[4:].isdigit()
+                            ]
+                            cores_label = (
+                                f"cores: {format_core_ranges(core_numbers)}"
+                                if core_numbers
+                                else f"cores: {', '.join(unique_cores)}"
+                            )
+                        except (ValueError, IndexError):
+                            cores_label = f"cores: {', '.join(unique_cores)}"
                     raw_loc = blocked_raw_locs.get((op, obj_desc, location))
                     if raw_loc:
                         filename, lineno = raw_loc


### PR DESCRIPTION
### Problem description
The deadlock reporter in `GreenletScheduler.run()` crashed with `ValueError` when any blocked thread had a non-standard core ID (e.g. `"unknown"`). `extract_core_id_from_thread_name` explicitly returns `"unknown"` when the thread name is `None` or contains no `-`, so this was a reachable crash path. Instead of a helpful deadlock message, the user got an internal traceback.

### What's changed
Mirrored the safe core ID parsing pattern already used in `diagnostics.warn_once_per_location` — added a `startswith("core") and isdigit()` guard on the list comprehension, a fallback to joining raw names when no numeric IDs are found, and a `try/except (ValueError, IndexError)` around the whole block.

### Ticket
N/A

### Checklist
- [ ] New/Existing tests provide coverage for changes