### PR TITLE
[fix][ttl][pipe] Fix write pointer tracking on pipe sender across iterations + verifier for DFB single-producer/consumer

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -18,11 +18,14 @@ ttl-insert-cb-sync             (FuncOp)   Insert cb_push / cb_pop
   ... compute lowering, DST assignment, loop lowering ...
 ttl-finalize-dfb-indices       (Module)   Index reuse + limit check
 ttl-annotate-cb-associations   (FuncOp)   Copy CB indices to tile ops
+ttl-verify-dfb-spsc            (Module)   Reject DFBs shared across threads
 convert-ttl-to-ttkernel        (Module)   Lower to TTKernel dialect
 ttkernel-insert-inits          (Module)   Insert hardware init calls
 ```
 
 `ttl-finalize-dfb-indices` must precede `ttl-annotate-cb-associations` because annotation copies the `cb_index` attribute from `BindCBOp` onto tile operations (`bcast`, `reduce`, `transpose`). If annotation runs before finalization, the copied indices become stale after reuse rewrites them.
+
+`ttl-verify-dfb-spsc` must run after `ttl-finalize-dfb-indices` so every `bind_cb` carries its final `cb_index`. The pass asserts on unresolvable indices.
 
 ## DFB Lifecycle
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -45,6 +45,77 @@ For compiler-allocated DFBs, `InsertIntermediateDFBs` creates the full sequence 
 
 A DFB's L1 memory is reclaimable after its last `cb_pop`. This defines the interval used for index reuse.
 
+## Single-producer Single-consumer Semantics
+
+### Contract
+
+Each DFB has exactly one producer thread and exactly one consumer thread. A *thread* here is a `func.func` carrying the `ttl.kernel_thread` attribute (compute, noc, ethernet); ops in untagged functions are outside the contract.
+
+The rule is inherited from tt-metal: its CB protocol is not multi-writer safe on either side. Each CB has two shared counters in `dataflow_api.h`:
+
+- `pages_received`, incremented by `cb_push_back` (producer side),
+- `pages_acked`, incremented by `cb_pop_front` (consumer side).
+
+`cb_reserve_back` blocks until `pages_received - pages_acked < block_count`. `cb_wait_front` blocks until `pages_received > pages_acked`. The protocol is correct only when exactly one thread writes each counter; the counters are not atomic with respect to multiple writers and carry no per-thread identity.
+
+### Violation
+
+A two-consumer DFB inside a stripe loop:
+
+```python
+buf = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+@ttl.compute()
+def compute():
+    for _ in range(num_stripes):
+        with buf.reserve() as b:
+            b.store(...)
+        with buf.wait() as b:       # consumer A: compute
+            ...
+
+@ttl.datamovement()
+def dm_read():
+    for _ in range(num_stripes):
+        with buf.wait() as b:       # consumer B: dm_read
+            ...
+```
+
+Per iteration, the producer pushes once (`pages_received += 1`) and each consumer pops once (`pages_acked += 2`). After iteration 0, the producer's `cb_reserve_back` on iteration 1 sees two free slots when only one has actually been consumed; it writes slot 0 while the late consumer is still reading slot 0's old data. The symmetric failure occurs with two producers: each `cb_push_back` advances the shared write pointer, and a consumer reads a partially-written slot.
+
+A single-iteration test masks this — exactly one push and two over-pops do not corrupt data when the producer never refills — so the rule must be enforced statically rather than left to test coverage.
+
+### Correct form
+
+Allocate one DFB per consumer thread (and symmetrically per producer thread). The producer writes the value into each DFB; each consumer reads its own. The sketch below is illustrative (no `@ttl.operation` wrapper, no tensor shape); for a runnable example see `test/python/test_store_patterns.py::store_then_forward_kernel`:
+
+```python
+buf_for_compute = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+buf_for_dm     = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+@ttl.compute()
+def compute():
+    for _ in range(num_stripes):
+        val = ...
+        with buf_for_compute.reserve() as b: b.store(val)
+        with buf_for_dm.reserve()     as b: b.store(val)
+        with buf_for_compute.wait()   as b: ...
+
+@ttl.datamovement()
+def dm_read():
+    for _ in range(num_stripes):
+        with buf_for_dm.wait() as b: ...
+```
+
+Each `pages_received`/`pages_acked` pair is now driven by a single thread.
+
+### Verification
+
+The `ttl-verify-dfb-spsc` module-level pass runs after `ttl-annotate-cb-associations`. It walks every `cb_reserve` and `cb_wait` op, groups them by `cb_index` and enclosing `ttl.kernel_thread`-tagged `func.func`, and rejects any DFB whose producer or consumer set spans more than one thread. The diagnostic identifies the cb_index, the role (producer or consumer), each kernel thread site, and the originating `ttl.bind_cb`.
+
+See `test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir` for the rejected patterns and `verify_dfb_spsc.mlir` for the accepted ones.
+
+The compiler does not currently auto-split multi-consumer DFBs; users must duplicate explicitly via `make_dataflow_buffer_like`. Tracked in [tenstorrent/tt-lang#581](https://github.com/tenstorrent/tt-lang/issues/581).
+
 ## Intermediate DFB Insertion
 
 `TTLInsertIntermediateDFBs` walks all operations implementing `DFBInputOpInterface` (reduce, bcast, matmul, transpose). For each operand that the interface marks as requiring a CB-attached value, the pass checks whether the operand traces to an existing CB via `getAttachedCB`. If not, the pass materializes the value through a fresh DFB: `bind_cb`, `cb_reserve`, `store`, `cb_wait`, `attach_cb`. The new DFB receives the `ttl.compiler_allocated` marker attribute.

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -481,6 +481,28 @@ strictly `Tuple[int, int]` (the dialect is 2D), but the simulator's
 `matmul_1d_mcast` example uses them. The test pins the hardware-side
 rejection contract; it `pytest.skip`s on the simulator runner.
 
+## Lowering: sender/receiver DFB lockstep
+
+`PipeLowering.cpp::lowerCBToPipe` emits, around every sender-side
+`ttl.copy(cb, pipe)`, a `ttkernel.cb_reserve_back` before the NOC
+write and a `ttkernel.cb_push_back` after the barrier and semaphore
+signal, on the sender's local view of the destination DFB. This
+keeps the sender's `fifo_wr_ptr` advancing in lockstep with the
+receiver's per iteration: the destination address handed to
+`noc_async_write` is `cb_<recvIdx>.get_write_ptr()` on the sender,
+which is correct only while sender and receiver have issued the
+same number of reserves/pushes against that DFB. Without the
+bracket, multi-iteration kernels write to slot 0 every iteration
+while the receiver's `cb_<recvIdx>.fifo_wr_ptr` keeps advancing,
+and data lands in a slot the receiver never waits on (issue #574).
+
+Loopback exception: when the sender is also a destination of the
+pipe (`pipeType.srcInDstRange()`) and the destination DFB index
+coincides with the sender's source DFB index, the receive callback
+running on the sender core already issues `cb_reserve_back` /
+`cb_push_back` on that DFB; the lowering skips its sender-side
+pair to avoid double-advancing.
+
 ## Limitations
 
 * Work larger than launch: the verifier checks role containment but

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -71,6 +71,10 @@ enum class PipeRole : int64_t {
 constexpr llvm::StringLiteral
     kEnableFPUBinaryOpsAttrName("ttl.enable_fpu_binary_ops");
 
+/// Func-level: tags a func.func as a kernel thread (compute / dataflow);
+/// the attribute value is a `ttkernel.thread` enum.
+constexpr llvm::StringLiteral kKernelThreadAttrName("ttl.kernel_thread");
+
 /// Number of tiles per DST sync region.
 constexpr llvm::StringLiteral kUnrollFactorAttrName("ttl.unroll_factor");
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -24,6 +24,16 @@
 
 namespace mlir::tt::ttl {
 
+/// Return the enclosing kernel-thread `func.func` (tagged with
+/// `ttl.kernel_thread`), or null if `op` is not inside one.
+inline mlir::func::FuncOp getEnclosingKernelThread(mlir::Operation *op) {
+  auto func = op->getParentOfType<mlir::func::FuncOp>();
+  if (func && func->hasAttr(kKernelThreadAttrName)) {
+    return func;
+  }
+  return nullptr;
+}
+
 /// Trace through unrealized conversion casts to the original value
 /// (cycle-safe).
 inline mlir::Value traceUnrealizedCasts(mlir::Value value) {

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -8,6 +8,7 @@
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -49,13 +50,15 @@ inline mlir::tt::ttl::CBReserveOp findCBReserveForView(mlir::Value view) {
   return view.getDefiningOp<mlir::tt::ttl::CBReserveOp>();
 }
 
-/// Resolve the CB index attached to `cb` by tracing through unrealized
-/// conversion casts to its defining BindCBOp. Returns std::nullopt when the
-/// value does not trace to a BindCBOp.
+/// Resolve the CB index attached to `cb`, accepting either the pre-conversion
+/// BindCBOp or the post-conversion GetCompileArgValOp.
 inline std::optional<int64_t> getCBIndex(mlir::Value cb) {
   cb = traceUnrealizedCasts(cb);
   if (auto bindOp = cb.getDefiningOp<BindCBOp>()) {
     return bindOp.getCbIndex().getSExtValue();
+  }
+  if (auto argOp = cb.getDefiningOp<mlir::tt::ttkernel::GetCompileArgValOp>()) {
+    return argOp.getArgIndex();
   }
   return std::nullopt;
 }

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -534,6 +534,34 @@ def TTLVerifyPipeNetGuards
   ];
 }
 
+def TTLVerifyDFBSPSC
+    : Pass<"ttl-verify-dfb-spsc", "::mlir::ModuleOp"> {
+  let summary = "Reject DFBs whose producer or consumer set spans more than one kernel thread";
+  let description = [{
+    Walks every `ttl.cb_reserve` and `ttl.cb_wait`, groups them by `cb_index`
+    (resolved via `getCBIndex`) and enclosing `ttl.kernel_thread`-tagged
+    `func.func`, and emits an error for any DFB whose producer thread set or
+    consumer thread set has size greater than one. The diagnostic attaches a
+    note for each additional thread site and one note at the originating
+    `ttl.bind_cb`.
+
+    tt-metal circular buffers expose a counter pair (`pages_received`,
+    `pages_acked`) that is not multi-writer safe on either side, so the
+    structural single-producer single-consumer property is required for
+    correctness; see `docs/development/DFBManagement.md` for the runtime
+    contract.
+
+    Prerequisite: `ttl-finalize-dfb-indices` must run first so that every
+    `bind_cb` carries a concrete `cb_index`. The pass asserts on
+    unresolvable indices.
+  }];
+
+  let dependentDialects = [
+    "::mlir::func::FuncDialect",
+    "::mlir::tt::ttl::TTLDialect"
+  ];
+}
+
 def TTLErasePipeNetScopes
     : Pass<"ttl-erase-pipenet-scopes", "::mlir::ModuleOp"> {
   let summary = "Inline and erase `ttl.pipenet_scope` regions";

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -52,6 +52,7 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
   pm.addPass(createTTLFinalizeDFBIndices());
   pm.addPass(createTTLAnnotateCBAssociations());
   pm.addPass(createTTLVerifyPipeNetGuards());
+  pm.addPass(createTTLVerifyDFBSPSC());
   pm.addPass(createTTLErasePipeNetScopes());
   {
     TTLConvertTTLToTTKernelOptions ttkOpts;

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   TTLInsertCBSync.cpp
   TTLInsertCopyWait.cpp
   TTLInsertIntermediateDFBs.cpp
+  TTLVerifyDFBSPSC.cpp
   TTLVerifyPipeNetGuards.cpp
   TTLErasePipeNetScopes.cpp
   TTLAssignDST.cpp

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -101,8 +101,8 @@ static std::optional<ttk::ThreadType> convertThreadAttr(Operation *op) {
   if (auto a = op->getAttrOfType<ttk::ThreadTypeAttr>("ttkernel.thread")) {
     return a.getValue();
   }
-  if (auto a = op->getAttrOfType<ttk::ThreadTypeAttr>("ttl.kernel_thread")) {
-    op->removeAttr("ttl.kernel_thread");
+  if (auto a = op->getAttrOfType<ttk::ThreadTypeAttr>(kKernelThreadAttrName)) {
+    op->removeAttr(kKernelThreadAttrName);
     op->setAttr("ttkernel.thread", a);
     return a.getValue();
   }
@@ -960,11 +960,12 @@ struct FuncKernelFinalize : OpRewritePattern<FuncOp> {
 
   LogicalResult matchAndRewrite(FuncOp op,
                                 PatternRewriter &rewriter) const override {
-    auto ttlAttr = op->getAttrOfType<ttk::ThreadTypeAttr>("ttl.kernel_thread");
+    auto ttlAttr =
+        op->getAttrOfType<ttk::ThreadTypeAttr>(kKernelThreadAttrName);
     if (!ttlAttr || ttlAttr.getValue() != ttk::ThreadType::Noc) {
       return failure();
     }
-    op->removeAttr("ttl.kernel_thread");
+    op->removeAttr(kKernelThreadAttrName);
     op->removeAttr("ttl.noc_index");
     op->setAttr("ttkernel.thread", ttlAttr);
 

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -141,47 +141,53 @@ LogicalResult lowerCBToPipe(CopyOp op, Value srcCB, Value pipe,
     ttk::NocSemaphoreSetOp::create(rewriter, loc, senderSemPtr, zeroIdx);
   }
 
-  // Destination address: always use write_ptr. The receiver does
-  // cb_reserve_back, so the write pointer is the correct target.
-  // CB layout is uniform across cores, so the local write_ptr matches
-  // the remote core's write_ptr for the same CB index.
-  auto cbWritePtr = ttk::GetWritePtrOp::create(rewriter, loc, *cbConverted);
-  auto cbWritePtrIdx =
+  SmallVector<int64_t> cbBounds(cbShape.begin(), cbShape.end());
+  int64_t cbNumTiles = 1;
+  for (int64_t d : cbBounds) {
+    cbNumTiles *= d;
+  }
+  auto numTilesI32 = arith::ConstantOp::create(
+      rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(cbNumTiles));
+
+  // Destination DFB on the sender's local view: same as the source when both
+  // endpoints share a DFB index, otherwise a fresh handle on the receiver's
+  // index so the sender can advance its own fifo_wr_ptr.
+  std::optional<int64_t> senderCBIndex = getCBIndex(srcCB);
+  Value senderRecvCB = *cbConverted;
+  bool destDiffersFromSrc = false;
+  if (receiverInfo && senderCBIndex.has_value() &&
+      senderCBIndex.value() != receiverInfo->cbIndex) {
+    auto srcCBType = mlir::cast<ttk::CBType>(cbConverted->getType());
+    senderRecvCB = ttk::GetCompileArgValOp::create(
+        rewriter, loc, srcCBType,
+        static_cast<int32_t>(receiverInfo->cbIndex));
+    destDiffersFromSrc = true;
+  }
+
+  // In loopback, the receive callback on this same core already issues
+  // reserve_back / push_back on the destination DFB; do not double-advance.
+  bool skipSenderReserve = pipeType.srcInDstRange() && !destDiffersFromSrc;
+
+  if (!skipSenderReserve) {
+    ttk::CBReserveBackOp::create(rewriter, loc, senderRecvCB, numTilesI32);
+  }
+
+  // Sender's local write_ptr is advanced in lockstep with the receiver via
+  // the surrounding reserve_back / push_back.
+  auto cbWritePtr = ttk::GetWritePtrOp::create(rewriter, loc, senderRecvCB);
+  Value dstBaseIdx =
       arith::IndexCastOp::create(rewriter, loc, indexTy, cbWritePtr);
 
-  // Source address depends on CB access context:
-  //   Producer (cb_reserve/cb_push): data at write_ptr, before push.
-  //   Consumer (cb_wait/cb_pop):     data at read_ptr, after wait.
+  // Producer source address is at the source DFB's write_ptr (data is staged
+  // there before push_back); consumer source address is at its read_ptr.
   Value srcPtrIdx;
   if (isConsumerCB) {
     auto cbReadPtr = ttk::GetReadPtrOp::create(rewriter, loc, *cbConverted);
     srcPtrIdx = arith::IndexCastOp::create(rewriter, loc, indexTy, cbReadPtr);
   } else {
-    srcPtrIdx = cbWritePtrIdx;
-  }
-
-  Value dstBaseIdx = cbWritePtrIdx;
-  if (receiverInfo) {
-    // Determine sender CB index to check if it differs from receiver.
-    // The source CB may be pre- or post-conversion, so check both BindCBOp
-    // (pre-conversion) and GetCompileArgValOp (post-conversion).
-    std::optional<int64_t> senderCBIndex = getCBIndex(srcCB);
-    if (!senderCBIndex.has_value()) {
-      Value tracedSrc = traceUnrealizedCasts(srcCB);
-      if (auto argOp = tracedSrc.getDefiningOp<ttk::GetCompileArgValOp>()) {
-        senderCBIndex = argOp.getArgIndex();
-      }
-    }
-    if (senderCBIndex.has_value() &&
-        senderCBIndex.value() != receiverInfo->cbIndex) {
-      auto srcCBType = llvm::dyn_cast<ttk::CBType>(cbConverted->getType());
-      auto recvCB = ttk::GetCompileArgValOp::create(
-          rewriter, loc, srcCBType,
-          static_cast<int32_t>(receiverInfo->cbIndex));
-      auto recvWritePtr = ttk::GetWritePtrOp::create(rewriter, loc, recvCB);
-      dstBaseIdx =
-          arith::IndexCastOp::create(rewriter, loc, indexTy, recvWritePtr);
-    }
+    auto srcWritePtr =
+        ttk::GetWritePtrOp::create(rewriter, loc, *cbConverted);
+    srcPtrIdx = arith::IndexCastOp::create(rewriter, loc, indexTy, srcWritePtr);
   }
 
   // Destination coordinates for multicast - convert logical to virtual coords
@@ -205,16 +211,10 @@ LogicalResult lowerCBToPipe(CopyOp op, Value srcCB, Value pipe,
   auto numDestsVal = arith::ConstantOp::create(
       rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(numDests));
 
-  SmallVector<int64_t> cbBounds(cbShape.begin(), cbShape.end());
-
   // For gather patterns (multiple sources to one destination), each source
   // writes to a different slot in the destination CB to avoid overwrites.
   // Slot indices are assigned by PipeGraph based on actual destination sharing.
   int64_t slotIdx = receiverInfo ? receiverInfo->gatherSlotIdx : 0;
-  int64_t cbNumTiles = 1;
-  for (int64_t d : cbBounds) {
-    cbNumTiles *= d;
-  }
   int64_t slotByteOffset = slotIdx * pageSizeBytes * cbNumTiles;
 
   // Transfer the entire block in a single NOC write. Tiles are contiguous in
@@ -295,6 +295,10 @@ LogicalResult lowerCBToPipe(CopyOp op, Value srcCB, Value pipe,
           rewriter, loc, recvSemAddr, recvSemMcastAddr.getResult(), numDestsVal,
           /*linked=*/nullptr, /*multicast_path_reserve=*/nullptr);
     }
+  }
+
+  if (!skipSenderReserve) {
+    ttk::CBPushBackOp::create(rewriter, loc, senderRecvCB, numTilesI32);
   }
 
   rewriter.replaceOp(op, makeZeroI32(loc, rewriter));

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -154,19 +154,18 @@ LogicalResult lowerCBToPipe(CopyOp op, Value srcCB, Value pipe,
   // index so the sender can advance its own fifo_wr_ptr.
   std::optional<int64_t> senderCBIndex = getCBIndex(srcCB);
   Value senderRecvCB = *cbConverted;
-  bool destDiffersFromSrc = false;
   if (receiverInfo && senderCBIndex.has_value() &&
       senderCBIndex.value() != receiverInfo->cbIndex) {
     auto srcCBType = mlir::cast<ttk::CBType>(cbConverted->getType());
     senderRecvCB = ttk::GetCompileArgValOp::create(
-        rewriter, loc, srcCBType,
-        static_cast<int32_t>(receiverInfo->cbIndex));
-    destDiffersFromSrc = true;
+        rewriter, loc, srcCBType, static_cast<int32_t>(receiverInfo->cbIndex));
   }
 
-  // In loopback, the receive callback on this same core already issues
-  // reserve_back / push_back on the destination DFB; do not double-advance.
-  bool skipSenderReserve = pipeType.srcInDstRange() && !destDiffersFromSrc;
+  // In loopback the user's receive callback runs on the sender core and
+  // already issues reserve_back / push_back on the destination DFB; emitting
+  // the sender-side pair would double-advance regardless of whether the
+  // source and destination DFB indices coincide.
+  bool skipSenderReserve = pipeType.srcInDstRange();
 
   if (!skipSenderReserve) {
     ttk::CBReserveBackOp::create(rewriter, loc, senderRecvCB, numTilesI32);
@@ -185,8 +184,7 @@ LogicalResult lowerCBToPipe(CopyOp op, Value srcCB, Value pipe,
     auto cbReadPtr = ttk::GetReadPtrOp::create(rewriter, loc, *cbConverted);
     srcPtrIdx = arith::IndexCastOp::create(rewriter, loc, indexTy, cbReadPtr);
   } else {
-    auto srcWritePtr =
-        ttk::GetWritePtrOp::create(rewriter, loc, *cbConverted);
+    auto srcWritePtr = ttk::GetWritePtrOp::create(rewriter, loc, *cbConverted);
     srcPtrIdx = arith::IndexCastOp::create(rewriter, loc, indexTy, srcWritePtr);
   }
 

--- a/lib/Dialect/TTL/Transforms/TTLDumpCBFlowGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLDumpCBFlowGraph.cpp
@@ -86,7 +86,7 @@ static std::string getKernelName(func::FuncOp func) {
 /// Get the thread type from a function's ttl.kernel_thread attribute.
 static std::string getThreadType(func::FuncOp func) {
   if (auto threadAttr = func->getAttrOfType<tt::ttkernel::ThreadTypeAttr>(
-          "ttl.kernel_thread")) {
+          kKernelThreadAttrName)) {
     auto thread = threadAttr.getValue();
     switch (thread) {
     case tt::ttkernel::ThreadType::Noc:

--- a/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//===----------------------------------------------------------------------===//
+// TTL Verify DFB SPSC
+//===----------------------------------------------------------------------===//
+//
+// Rejects modules in which a dataflow buffer (identified by its `cb_index`)
+// is reserved or waited-on in more than one `ttl.kernel_thread`-tagged
+// `func.func`. tt-metal CBs are single-producer single-consumer at the
+// API level; see `docs/development/DFBManagement.md` for the rationale.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+#include "ttlang/Dialect/TTL/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttl {
+
+#define GEN_PASS_DEF_TTLVERIFYDFBSPSC
+#include "ttlang/Dialect/TTL/Passes.h.inc"
+
+namespace {
+
+// Per-DFB index, the first acquire op observed in each kernel thread. We only
+// keep the first op per thread because the diagnostic just needs one site per
+// participant.
+struct DFBThreadSet {
+  llvm::SmallMapVector<func::FuncOp, Operation *, 2> threads;
+};
+
+// Error at the first thread's site, notes at the rest and (when available) at
+// the `ttl.bind_cb` that declares this index.
+static void emitMultiThreadError(int64_t cbIndex, const DFBThreadSet &sites,
+                                 Operation *bindSite, llvm::StringRef role,
+                                 llvm::StringRef verbedHere) {
+  auto it = sites.threads.begin();
+  Operation *primary = it->second;
+  InFlightDiagnostic diag =
+      primary->emitError() << "dataflow buffer cb_index=" << cbIndex << " has "
+                           << sites.threads.size() << " " << role << " threads";
+  diag.attachNote() << "tt-metal CBs are single-producer single-consumer; "
+                       "allocate one DFB per "
+                    << role;
+  for (++it; it != sites.threads.end(); ++it) {
+    diag.attachNote(it->second->getLoc()) << "also " << verbedHere << " here";
+  }
+  if (bindSite) {
+    diag.attachNote(bindSite->getLoc()) << "dataflow buffer declared here";
+  }
+}
+
+struct TTLVerifyDFBSPSCPass
+    : public impl::TTLVerifyDFBSPSCBase<TTLVerifyDFBSPSCPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    llvm::MapVector<int64_t, DFBThreadSet> producers;
+    llvm::MapVector<int64_t, DFBThreadSet> consumers;
+    llvm::DenseMap<int64_t, Operation *> bindSites;
+
+    auto record = [&](llvm::MapVector<int64_t, DFBThreadSet> &perCB,
+                      Operation *op, Value cb) {
+      func::FuncOp thread = getEnclosingKernelThread(op);
+      if (!thread) {
+        return;
+      }
+      std::optional<int64_t> idx = getCBIndex(cb);
+      assert(idx.has_value() &&
+             "ttl-verify-dfb-spsc requires finalized cb_index; run "
+             "ttl-finalize-dfb-indices first");
+      perCB[*idx].threads.insert({thread, op});
+    };
+
+    module.walk([&](Operation *op) {
+      if (auto reserveOp = dyn_cast<CBReserveOp>(op)) {
+        record(producers, op, reserveOp.getCb());
+      } else if (auto waitOp = dyn_cast<CBWaitOp>(op)) {
+        record(consumers, op, waitOp.getCb());
+      } else if (auto bindOp = dyn_cast<BindCBOp>(op)) {
+        std::optional<int64_t> idx = getCBIndex(bindOp.getResult());
+        if (idx.has_value()) {
+          bindSites.try_emplace(*idx, op);
+        }
+      }
+    });
+
+    bool sawError = false;
+    for (auto &entry : producers) {
+      if (entry.second.threads.size() > 1) {
+        emitMultiThreadError(entry.first, entry.second,
+                             bindSites.lookup(entry.first), "producer",
+                             "reserved");
+        sawError = true;
+      }
+    }
+    for (auto &entry : consumers) {
+      if (entry.second.threads.size() > 1) {
+        emitMultiThreadError(entry.first, entry.second,
+                             bindSites.lookup(entry.first), "consumer",
+                             "waited on");
+        sawError = true;
+      }
+    }
+
+    if (sawError) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::ttl

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -287,6 +287,7 @@ add_mlir_python_modules(TTLangPythonModules
 
 # Ensure generated elementwise ops are created before Python modules are built
 add_dependencies(TTLangPythonModules TTLangGeneratedElementwise)
+add_custom_target(pyext DEPENDS TTLangPythonModules)
 
 # pykernel is a subpackage of ttl (ttl/__init__.py transitively imports
 # from ttl.pykernel._src.utils via ttl_api.py), so TTLangPythonModules is

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1448,6 +1448,7 @@ def _compile_kernel(
         pipeline_passes.append("ttl-finalize-dfb-indices")
         pipeline_passes.append("func.func(ttl-annotate-cb-associations)")
         pipeline_passes.append("ttl-verify-pipenet-guards")
+        pipeline_passes.append("ttl-verify-dfb-spsc")
         pipeline_passes.append("ttl-erase-pipenet-scopes")
 
         # Add CB flow graph dump if auto-profiling or perf dump is enabled

--- a/test/me2e/builder/pipeline.py
+++ b/test/me2e/builder/pipeline.py
@@ -63,6 +63,7 @@ def compile_ttl_to_ttkernel(
         f"ttl-finalize-dfb-indices,"
         f"func.func(ttl-annotate-cb-associations),"
         f"ttl-verify-pipenet-guards,"
+        f"ttl-verify-dfb-spsc,"
         f"ttl-erase-pipenet-scopes,"
         f"convert-ttl-to-ttkernel,"
         f"ttkernel-insert-inits,"

--- a/test/python/pipe/test_pipenet_multi_iter.py
+++ b/test/python/pipe/test_pipenet_multi_iter.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-iteration PipeNet gather + multicast (issue #574).
+
+Regression test for an error surfaced from rmsnorm-backward: a two-core
+stripe of the kernel needed a `gather_net` + `bcast_net` pair inside a
+`for _ in range(num_of_stripes)` loop, and stripes after the first produced
+garbage outputs on Blackhole.
+
+Mirrors `_bugs/repro_574.py`. The sender's `fifo_wr_ptr` for the destination
+DFB must advance in lockstep with the receiver's across iterations; before
+the fix the second stripe consumed an unwritten slot.
+"""
+
+import pytest
+import torch
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import to_dram
+
+TILE = 32
+NUM_OF_STRIPES = 2
+
+
+@ttl.operation(grid=(2, 1))
+def gather_bcast_loop(out):
+    out_rows = out.shape[0] // TILE
+    col_cores = min(2, out_rows)
+    row_cores = 1
+
+    rb = out_rows // NUM_OF_STRIPES
+    row_shape = (rb, 1)
+    partial_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    recv_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=col_cores)
+    sum_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    bcast_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    gather_net = ttl.PipeNet([
+        ttl.Pipe((x, y), (0, y))
+        for x in range(1, col_cores)
+        for y in range(row_cores)
+    ])
+    bcast_net = ttl.PipeNet([
+        ttl.Pipe((0, y), (slice(1, col_cores), y))
+        for y in range(row_cores)
+    ])
+
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+
+    @ttl.compute()
+    def compute():
+        node_col, _node_row = ttl.node(dims=2)
+        for _ri in range(NUM_OF_STRIPES):
+            with partial_cb.reserve() as partial_blk:
+                partial_blk.store(ttl.math.fill(partial_blk, 1.0))
+            if node_col == 0:
+                partial_blk = partial_cb.wait()
+                blk = recv_cb.wait()
+                with sum_cb.reserve() as sum_blk:
+                    sum_blk.store(blk + partial_blk)
+                sum_blk = sum_cb.wait()
+                with out_cb.reserve() as out_blk:
+                    out_blk.store(sum_blk)
+            else:
+                blk = bcast_cb.wait()
+                with out_cb.reserve() as out_blk:
+                    out_blk.store(blk)
+
+    @ttl.datamovement()
+    def dm_read():
+        node_col, _node_row = ttl.node(dims=2)
+        for _ri in range(NUM_OF_STRIPES):
+            if node_col > 0:
+                blk = partial_cb.wait()
+
+                def send(pipe):
+                    tx = ttl.copy(blk, pipe)
+                    tx.wait()
+
+                gather_net.if_src(send)
+
+                def recv(pipe):
+                    b = bcast_cb.reserve()
+                    tx = ttl.copy(pipe, b)
+                    tx.wait()
+
+                bcast_net.if_dst(recv)
+            else:
+                def recv(pipe):
+                    b = recv_cb.reserve()
+                    tx = ttl.copy(pipe, b)
+                    tx.wait()
+
+                gather_net.if_dst(recv)
+                blk = sum_cb.wait()
+
+                def send(pipe):
+                    tx = ttl.copy(blk, pipe)
+                    tx.wait()
+
+                bcast_net.if_src(send)
+
+    @ttl.datamovement()
+    def dm_write():
+        node_col, node_row = ttl.node(dims=2)
+        for _ri in range(NUM_OF_STRIPES):
+            r0 = node_row + _ri
+            out_blk = out_cb.wait()
+            ttl.copy(out_blk, out[r0 : r0 + 1, node_col : node_col + 1]).wait()
+
+
+def test_gather_bcast_multi_iter(device):
+    st = 64
+    out_torch = torch.full((st, st), -42.0, dtype=torch.bfloat16)
+    out_tt = to_dram(out_torch, device)
+    gather_bcast_loop(out_tt)
+    ttnn.synchronize_device(device)
+    result = ttnn.to_torch(out_tt)
+    expected = torch.full((st, st), 2.0, dtype=torch.bfloat16)
+    torch.testing.assert_close(result, expected)

--- a/test/python/pipe/test_pipenet_multi_iter.py
+++ b/test/python/pipe/test_pipenet_multi_iter.py
@@ -9,15 +9,20 @@ Two tests:
 1. `test_gather_multi_iter` — minimal two-core gather over two stripes.
    Verifies the sender-side `cb_reserve_back` / `cb_push_back` lockstep
    fix in `PipeLowering.cpp` without depending on any other DFB
-   patterns. This is the focused regression test for #574.
+   patterns. Part of the regression test for #574.
 
-2. `test_gather_bcast_multi_iter` — mirrors issue 574 reproducer, the
-   pattern surfaced by rmsnorm-backward. Exercises gather + multicast
-   inside a stripe loop and depends on the same lockstep fix, but also
-   uses a multi-consumer `sum_cb` (compute consumes it locally AND
-   dm_read consumes it for the bcast send). The framework must emit
-   matching pushes for both consumers; see issue [multi-consumer DFB]
-   for the supporting framework change.
+2. `test_gather_bcast_multi_iter` — mirrors the rmsnorm-backward pattern
+   surfaced by issue #574. Exercises gather + multicast inside a stripe
+   loop and depends on the same lockstep fix. Each dataflow buffer is
+   structured as single-producer single-consumer: partial and sum each
+   have separate copies for the local-compute and pipe-send consumers,
+   so the `ttl-verify-dfb-spsc` pass accepts the kernel.
+
+   TODO(#581): replace the manual `partial_for_sum_cb` /
+   `partial_for_send_cb` duplication once a compiler pass auto-splits
+   user-facing DFBs whose consumers span multiple kernel threads. The
+   shared compiler-allocated DFB helpers introduced by PR #540 would be
+   a reasonable foundation but do not themselves perform the split.
 """
 
 import pytest
@@ -38,20 +43,16 @@ def gather_multi_iter(out):
     row_cores = 1
     row_shape = (1, 1)
 
-    partial_cb = ttl.make_dataflow_buffer_like(
-        out, shape=row_shape, block_count=2
+    partial_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    recv_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    gather_net = ttl.PipeNet(
+        [
+            ttl.Pipe((x, y), (0, y))
+            for x in range(1, col_cores)
+            for y in range(row_cores)
+        ]
     )
-    recv_cb = ttl.make_dataflow_buffer_like(
-        out, shape=row_shape, block_count=2
-    )
-    out_cb = ttl.make_dataflow_buffer_like(
-        out, shape=row_shape, block_count=2
-    )
-    gather_net = ttl.PipeNet([
-        ttl.Pipe((x, y), (0, y))
-        for x in range(1, col_cores)
-        for y in range(row_cores)
-    ])
 
     @ttl.compute()
     def compute():
@@ -64,9 +65,8 @@ def gather_multi_iter(out):
                 with out_cb.reserve() as out_blk:
                     out_blk.store(blk)
             else:
-                partial_blk = partial_cb.wait()
                 with out_cb.reserve() as out_blk:
-                    out_blk.store(partial_blk)
+                    out_blk.store(ttl.math.fill(out_blk, 1.0))
 
     @ttl.datamovement()
     def dm_read():
@@ -81,6 +81,7 @@ def gather_multi_iter(out):
 
                 gather_net.if_src(send)
             else:
+
                 def recv(pipe):
                     b = recv_cb.reserve()
                     tx = ttl.copy(pipe, b)
@@ -104,19 +105,32 @@ def gather_bcast_loop(out):
 
     rb = out_rows // NUM_OF_STRIPES
     row_shape = (rb, 1)
-    partial_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    # SPSC split: each cb has at most one producer and one consumer thread.
+    # partial gets two copies (one for compute's local sum, one for the
+    # gather sender); sum gets two copies (one for compute's out write, one
+    # for the bcast sender).
+    partial_for_sum_cb = ttl.make_dataflow_buffer_like(
+        out, shape=row_shape, block_count=2
+    )
+    partial_for_send_cb = ttl.make_dataflow_buffer_like(
+        out, shape=row_shape, block_count=2
+    )
     recv_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=col_cores)
-    sum_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    sum_for_out_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
+    sum_for_bcast_cb = ttl.make_dataflow_buffer_like(
+        out, shape=row_shape, block_count=2
+    )
     bcast_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
-    gather_net = ttl.PipeNet([
-        ttl.Pipe((x, y), (0, y))
-        for x in range(1, col_cores)
-        for y in range(row_cores)
-    ])
-    bcast_net = ttl.PipeNet([
-        ttl.Pipe((0, y), (slice(1, col_cores), y))
-        for y in range(row_cores)
-    ])
+    gather_net = ttl.PipeNet(
+        [
+            ttl.Pipe((x, y), (0, y))
+            for x in range(1, col_cores)
+            for y in range(row_cores)
+        ]
+    )
+    bcast_net = ttl.PipeNet(
+        [ttl.Pipe((0, y), (slice(1, col_cores), y)) for y in range(row_cores)]
+    )
 
     out_cb = ttl.make_dataflow_buffer_like(out, shape=row_shape, block_count=2)
 
@@ -124,17 +138,28 @@ def gather_bcast_loop(out):
     def compute():
         node_col, _node_row = ttl.node(dims=2)
         for _ri in range(NUM_OF_STRIPES):
-            with partial_cb.reserve() as partial_blk:
-                partial_blk.store(ttl.math.fill(partial_blk, 1.0))
             if node_col == 0:
-                partial_blk = partial_cb.wait()
+                # Produce the local partial only on the core that consumes
+                # it. An unconditional reserve here would over-push on
+                # col>0 (no matching wait) and deadlock past block_count
+                # iterations.
+                with partial_for_sum_cb.reserve() as p_sum_blk:
+                    p_sum_blk.store(ttl.math.fill(p_sum_blk, 1.0))
+                partial_blk = partial_for_sum_cb.wait()
                 blk = recv_cb.wait()
-                with sum_cb.reserve() as sum_blk:
-                    sum_blk.store(blk + partial_blk)
-                sum_blk = sum_cb.wait()
+                sum_val = blk + partial_blk
+                with sum_for_out_cb.reserve() as sum_out_blk:
+                    sum_out_blk.store(sum_val)
+                with sum_for_bcast_cb.reserve() as sum_bcast_blk:
+                    sum_bcast_blk.store(sum_val)
+                sum_out = sum_for_out_cb.wait()
                 with out_cb.reserve() as out_blk:
-                    out_blk.store(sum_blk)
+                    out_blk.store(sum_out)
             else:
+                # Produce the send-side partial only on the cores whose
+                # dm_read consumes it (col>0). Same rationale as above.
+                with partial_for_send_cb.reserve() as p_send_blk:
+                    p_send_blk.store(ttl.math.fill(p_send_blk, 1.0))
                 blk = bcast_cb.wait()
                 with out_cb.reserve() as out_blk:
                     out_blk.store(blk)
@@ -144,7 +169,7 @@ def gather_bcast_loop(out):
         node_col, _node_row = ttl.node(dims=2)
         for _ri in range(NUM_OF_STRIPES):
             if node_col > 0:
-                blk = partial_cb.wait()
+                blk = partial_for_send_cb.wait()
 
                 def send(pipe):
                     tx = ttl.copy(blk, pipe)
@@ -159,13 +184,14 @@ def gather_bcast_loop(out):
 
                 bcast_net.if_dst(recv)
             else:
+
                 def recv(pipe):
                     b = recv_cb.reserve()
                     tx = ttl.copy(pipe, b)
                     tx.wait()
 
                 gather_net.if_dst(recv)
-                blk = sum_cb.wait()
+                blk = sum_for_bcast_cb.wait()
 
                 def send(pipe):
                     tx = ttl.copy(blk, pipe)
@@ -198,12 +224,6 @@ def test_gather_multi_iter(device):
     torch.testing.assert_close(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="Blocked on multi-consumer DFB bug: sum_cb has 1 producer push "
-    "and 2 consumer pops per iteration (compute + dm_read both consume), "
-    "racing on stripe 1's bcast destination tile. Follow-up PR will scale "
-    "the producer push count in ConvertTTLToTTKernel.cpp."
-)
 def test_gather_bcast_multi_iter(device):
     st = 64
     out_torch = torch.full((st, st), -42.0, dtype=torch.bfloat16)

--- a/test/python/pipe/test_pipenet_multi_iter.py
+++ b/test/python/pipe/test_pipenet_multi_iter.py
@@ -4,7 +4,7 @@
 
 """Multi-iteration PipeNet gather + multicast (issue #574).
 
-Two tests:
+Three tests:
 
 1. `test_gather_multi_iter` — minimal two-core gather over two stripes.
    Verifies the sender-side `cb_reserve_back` / `cb_push_back` lockstep
@@ -23,6 +23,16 @@ Two tests:
    user-facing DFBs whose consumers span multiple kernel threads. The
    shared compiler-allocated DFB helpers introduced by PR #540 would be
    a reasonable foundation but do not themselves perform the split.
+
+3. `test_cross_dfb_multicast_loopback` — four-core multicast where the
+   source core (0, 0) is inside the destination range (loopback) and
+   the source DFB index differs from the destination DFB index. The
+   IR-level loopback skip fix in this PR (`skipSenderReserve =
+   pipeType.srcInDstRange()`) is necessary for this pattern, but the
+   stripe-1 multicast write is not delivered: dm_write reads whatever
+   was already in the destination DFB's slot 1 at device init time
+   (zero if L1 was just cleared; otherwise stale data from a prior
+   run). Marked `xfail` pending #583.
 """
 
 import pytest
@@ -232,4 +242,72 @@ def test_gather_bcast_multi_iter(device):
     ttnn.synchronize_device(device)
     result = ttnn.to_torch(out_tt)
     expected = torch.full((st, st), 2.0, dtype=torch.bfloat16)
+    torch.testing.assert_close(result, expected)
+
+
+CROSS_DFB_COL_CORES = 4
+
+
+@ttl.operation(grid=(CROSS_DFB_COL_CORES, 1))
+def cross_dfb_multicast_loopback(out):
+    src_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+    dst_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+    # Source (0, 0) is inside the destination range slice(0, 4) — loopback.
+    bcast_net = ttl.PipeNet([ttl.Pipe((0, 0), (slice(0, CROSS_DFB_COL_CORES), 0))])
+
+    @ttl.compute()
+    def compute():
+        node_col, _node_row = ttl.node(dims=2)
+        for _ri in range(NUM_OF_STRIPES):
+            if node_col == 0:
+                with src_cb.reserve() as src_blk:
+                    src_blk.store(ttl.math.fill(src_blk, 7.0))
+
+    @ttl.datamovement()
+    def dm_read():
+        node_col, _node_row = ttl.node(dims=2)
+        for _ri in range(NUM_OF_STRIPES):
+            if node_col == 0:
+                blk = src_cb.wait()
+
+                def send(pipe):
+                    tx = ttl.copy(blk, pipe)
+                    tx.wait()
+
+                bcast_net.if_src(send)
+
+            def recv(pipe):
+                b = dst_cb.reserve()
+                tx = ttl.copy(pipe, b)
+                tx.wait()
+
+            bcast_net.if_dst(recv)
+
+    @ttl.datamovement()
+    def dm_write():
+        node_col, _node_row = ttl.node(dims=2)
+        for ri in range(NUM_OF_STRIPES):
+            out_blk = dst_cb.wait()
+            ttl.copy(out_blk, out[ri : ri + 1, node_col : node_col + 1]).wait()
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Cross-DFB multicast loopback does not deliver the stripe-1 write to "
+        "the destination DFB. With L1 cleared at device init, dm_write reads "
+        "zero for stripe 1; with stale L1 from a prior run, it reads that "
+        "prior data. The IR-level loopback skip fix in this PR is necessary "
+        "but not sufficient. See #583."
+    ),
+)
+def test_cross_dfb_multicast_loopback(device):
+    rows = NUM_OF_STRIPES * TILE
+    cols = CROSS_DFB_COL_CORES * TILE
+    out_torch = torch.full((rows, cols), -42.0, dtype=torch.bfloat16)
+    out_tt = to_dram(out_torch, device)
+    cross_dfb_multicast_loopback(out_tt)
+    ttnn.synchronize_device(device)
+    result = ttnn.to_torch(out_tt)
+    expected = torch.full((rows, cols), 7.0, dtype=torch.bfloat16)
     torch.testing.assert_close(result, expected)

--- a/test/python/pipe/test_pipenet_multi_iter.py
+++ b/test/python/pipe/test_pipenet_multi_iter.py
@@ -4,14 +4,20 @@
 
 """Multi-iteration PipeNet gather + multicast (issue #574).
 
-Regression test for an error surfaced from rmsnorm-backward: a two-core
-stripe of the kernel needed a `gather_net` + `bcast_net` pair inside a
-`for _ in range(num_of_stripes)` loop, and stripes after the first produced
-garbage outputs on Blackhole.
+Two tests:
 
-Mirrors `_bugs/repro_574.py`. The sender's `fifo_wr_ptr` for the destination
-DFB must advance in lockstep with the receiver's across iterations; before
-the fix the second stripe consumed an unwritten slot.
+1. `test_gather_multi_iter` — minimal two-core gather over two stripes.
+   Verifies the sender-side `cb_reserve_back` / `cb_push_back` lockstep
+   fix in `PipeLowering.cpp` without depending on any other DFB
+   patterns. This is the focused regression test for #574.
+
+2. `test_gather_bcast_multi_iter` — mirrors issue 574 reproducer, the
+   pattern surfaced by rmsnorm-backward. Exercises gather + multicast
+   inside a stripe loop and depends on the same lockstep fix, but also
+   uses a multi-consumer `sum_cb` (compute consumes it locally AND
+   dm_read consumes it for the bcast send). The framework must emit
+   matching pushes for both consumers; see issue [multi-consumer DFB]
+   for the supporting framework change.
 """
 
 import pytest
@@ -24,6 +30,70 @@ from ttlang_test_utils import to_dram
 
 TILE = 32
 NUM_OF_STRIPES = 2
+
+
+@ttl.operation(grid=(2, 1))
+def gather_multi_iter(out):
+    col_cores = 2
+    row_cores = 1
+    row_shape = (1, 1)
+
+    partial_cb = ttl.make_dataflow_buffer_like(
+        out, shape=row_shape, block_count=2
+    )
+    recv_cb = ttl.make_dataflow_buffer_like(
+        out, shape=row_shape, block_count=2
+    )
+    out_cb = ttl.make_dataflow_buffer_like(
+        out, shape=row_shape, block_count=2
+    )
+    gather_net = ttl.PipeNet([
+        ttl.Pipe((x, y), (0, y))
+        for x in range(1, col_cores)
+        for y in range(row_cores)
+    ])
+
+    @ttl.compute()
+    def compute():
+        node_col, _node_row = ttl.node(dims=2)
+        for _ri in range(NUM_OF_STRIPES):
+            with partial_cb.reserve() as partial_blk:
+                partial_blk.store(ttl.math.fill(partial_blk, 1.0))
+            if node_col == 0:
+                blk = recv_cb.wait()
+                with out_cb.reserve() as out_blk:
+                    out_blk.store(blk)
+            else:
+                partial_blk = partial_cb.wait()
+                with out_cb.reserve() as out_blk:
+                    out_blk.store(partial_blk)
+
+    @ttl.datamovement()
+    def dm_read():
+        node_col, _node_row = ttl.node(dims=2)
+        for _ri in range(NUM_OF_STRIPES):
+            if node_col > 0:
+                blk = partial_cb.wait()
+
+                def send(pipe):
+                    tx = ttl.copy(blk, pipe)
+                    tx.wait()
+
+                gather_net.if_src(send)
+            else:
+                def recv(pipe):
+                    b = recv_cb.reserve()
+                    tx = ttl.copy(pipe, b)
+                    tx.wait()
+
+                gather_net.if_dst(recv)
+
+    @ttl.datamovement()
+    def dm_write():
+        node_col, _node_row = ttl.node(dims=2)
+        for ri in range(NUM_OF_STRIPES):
+            out_blk = out_cb.wait()
+            ttl.copy(out_blk, out[ri : ri + 1, node_col : node_col + 1]).wait()
 
 
 @ttl.operation(grid=(2, 1))
@@ -112,6 +182,28 @@ def gather_bcast_loop(out):
             ttl.copy(out_blk, out[r0 : r0 + 1, node_col : node_col + 1]).wait()
 
 
+def test_gather_multi_iter(device):
+    # Both columns produce partial = 1.0 every iteration. With the #574 fix,
+    # the gather sender advances its local fifo_wr_ptr per iter and stripe 1
+    # receives fresh data (1.0); without the fix the receiver reads slot 1
+    # which the sender never wrote, yielding stale L1 (typically 0).
+    rows = NUM_OF_STRIPES * TILE
+    cols = 2 * TILE
+    out_torch = torch.full((rows, cols), -42.0, dtype=torch.bfloat16)
+    out_tt = to_dram(out_torch, device)
+    gather_multi_iter(out_tt)
+    ttnn.synchronize_device(device)
+    result = ttnn.to_torch(out_tt)
+    expected = torch.full((rows, cols), 1.0, dtype=torch.bfloat16)
+    torch.testing.assert_close(result, expected)
+
+
+@pytest.mark.xfail(
+    reason="Blocked on multi-consumer DFB bug: sum_cb has 1 producer push "
+    "and 2 consumer pops per iteration (compute + dm_read both consume), "
+    "racing on stripe 1's bcast destination tile. Follow-up PR will scale "
+    "the producer push count in ConvertTTLToTTKernel.cpp."
+)
 def test_gather_bcast_multi_iter(device):
     st = 64
     out_torch = torch.full((st, st), -42.0, dtype=torch.bfloat16)

--- a/test/python/simple_add_loop.py
+++ b/test/python/simple_add_loop.py
@@ -26,7 +26,7 @@ import ttl
 
 @ttl.operation(grid=(1, 1))
 def add_loop_kernel(lhs, rhs, out):
-    """Add kernel with loop in compute to accumulate results."""
+    """Add kernel with loop in compute to accumulate results via `+=`."""
     lhs_dfb = ttl.make_dataflow_buffer_like(lhs, shape=(1, 1), block_count=2)
     rhs_dfb = ttl.make_dataflow_buffer_like(rhs, shape=(1, 1), block_count=2)
     out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
@@ -34,14 +34,11 @@ def add_loop_kernel(lhs, rhs, out):
     @ttl.compute()
     def add_compute():
         with lhs_dfb.wait() as l, rhs_dfb.wait() as r:
-            # Initial: store l into output DFB
-            with out_dfb.reserve() as o:
-                o.store(l)
-
-            # Loop: read back, add r, store again (accumulate pattern)
+            out_blk = out_dfb.reserve()
+            out_blk.store(l)
             for i in range(4):
-                with out_dfb.wait() as accum, out_dfb.reserve() as o:
-                    o.store(accum + r)
+                out_blk += r
+            out_blk.push()
 
     @ttl.datamovement()
     def dm_read():
@@ -61,36 +58,23 @@ def add_loop_kernel(lhs, rhs, out):
 
 
 # =============================================================================
-# Initial IR Checks - Verify scf.for loop is generated in compute
+# Initial IR Checks
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
 # CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
-
-# DFB binding (alphabetical order of capture names: lhs_cb, out_cb, rhs_cb)
-# CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0
-# CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2
-# CHECK: %[[CB1:.+]] = ttl.bind_cb{cb_index = 1
-
-# Initial: wait for inputs, reserve output, store, push
-# CHECK: ttl.cb_wait %[[CB0]]
-# CHECK: ttl.cb_wait %[[CB1]]
-# CHECK: ttl.cb_reserve %[[CB2]]
+# CHECK: %[[LHS:.+]] = ttl.bind_cb{cb_index = 0
+# CHECK: %[[OUT:.+]] = ttl.bind_cb{cb_index = 2
+# CHECK: %[[RHS:.+]] = ttl.bind_cb{cb_index = 1
+# CHECK: ttl.cb_wait %[[LHS]]
+# CHECK: ttl.cb_wait %[[RHS]]
+# CHECK: ttl.cb_reserve %[[OUT]]
 # CHECK: ttl.store
-# CHECK: ttl.cb_push %[[CB2]]
-
-# For loop in compute (accumulate pattern)
 # CHECK: scf.for
-# CHECK: ttl.cb_wait %[[CB2]]
-# CHECK: ttl.cb_reserve %[[CB2]]
-# CHECK: ttl.add
-# CHECK: ttl.store
-# CHECK: ttl.cb_push %[[CB2]]
-# CHECK: ttl.cb_pop %[[CB2]]
-
-# Finalize: pop inputs (reverse order from with-statement LIFO)
-# CHECK: ttl.cb_pop %[[CB1]]
-# CHECK: ttl.cb_pop %[[CB0]]
+# CHECK: ttl.store {{.*}} {accumulate}
+# CHECK: ttl.cb_push %[[OUT]]
+# CHECK: ttl.cb_pop %[[RHS]]
+# CHECK: ttl.cb_pop %[[LHS]]
 
 # =============================================================================
 # C++ Kernel Checks - Verify for loop in generated compute code
@@ -98,65 +82,73 @@ def add_loop_kernel(lhs, rhs, out):
 
 # CHECK-CPP: // add_compute
 # CHECK-CPP: void kernel_main()
-# CHECK-CPP-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
-# CHECK-CPP-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
-# CHECK-CPP-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
-
-# Initial: wait for inputs, reserve and push output
-# CHECK-CPP: [[CB0]].wait_front(
-# CHECK-CPP: [[CB1]].wait_front(
-# CHECK-CPP: [[CB2]].reserve_back(
-# CHECK-CPP: [[CB2]].push_back(
-
-# For loop with accumulate pattern
+# CHECK-CPP-DAG: int32_t [[ZERO:v[0-9]+]] = 0;
+# CHECK-CPP-DAG: int32_t [[ONE:v[0-9]+]] = 1;
+# CHECK-CPP-DAG: experimental::CircularBuffer [[LHS:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[RHS:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-DAG: experimental::CircularBuffer [[OUT:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP: [[LHS]].wait_front(
+# CHECK-CPP: [[RHS]].wait_front(
+# CHECK-CPP: [[OUT]].reserve_back(
+# CHECK-CPP: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
+# CHECK-CPP: tile_regs_acquire();
+# CHECK-CPP: copy_tile_init(get_compile_time_arg_val(0));
+# CHECK-CPP: copy_tile(get_compile_time_arg_val(0),
+# CHECK-CPP: tile_regs_commit();
+# CHECK-CPP: tile_regs_wait();
+# CHECK-CPP: pack_tile<true>({{.*}}, get_compile_time_arg_val(2),
+# CHECK-CPP: tile_regs_release();
+# CHECK-CPP: init_sfpu(get_compile_time_arg_val(1), get_compile_time_arg_val(2));
+# CHECK-CPP: llk_pack_reconfig_l1_acc([[ONE]])
 # CHECK-CPP: for (size_t {{.*}} < {{.*}};
-# CHECK-CPP: [[CB2]].wait_front(
-# CHECK-CPP: [[CB2]].reserve_back(
-# CHECK-CPP: add_binary_tile_init();
-# CHECK-CPP: add_binary_tile(
-# CHECK-CPP: [[CB2]].push_back(
-# CHECK-CPP: [[CB2]].pop_front(
-
-# Finalize: pop inputs (reverse order from with-statement LIFO)
-# CHECK-CPP: [[CB1]].pop_front(
-# CHECK-CPP: [[CB0]].pop_front(
+# CHECK-CPP: tile_regs_acquire();
+# CHECK-CPP: copy_tile_init(get_compile_time_arg_val(1));
+# CHECK-CPP: copy_tile(get_compile_time_arg_val(1),
+# CHECK-CPP: tile_regs_commit();
+# CHECK-CPP: tile_regs_wait();
+# CHECK-CPP: pack_tile<true>({{.*}}, get_compile_time_arg_val(2),
+# CHECK-CPP: tile_regs_release();
+# CHECK-CPP: [[OUT]].push_back(
+# CHECK-CPP: llk_pack_reconfig_l1_acc([[ZERO]])
+# CHECK-CPP: [[RHS]].pop_front(
+# CHECK-CPP: [[LHS]].pop_front(
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
-# Initial store uses copy_tile (SFPU), loop add uses FPU add_tiles
 # =============================================================================
 
 # CHECK-CPP-FPU: // add_compute
 # CHECK-CPP-FPU: void kernel_main()
-# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB0:.*]](get_compile_time_arg_val(0));
-# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB1:.*]](get_compile_time_arg_val(1));
-# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[CB2:.*]](get_compile_time_arg_val(2));
-# CHECK-CPP-FPU: [[CB0]].wait_front(
-# CHECK-CPP-FPU: [[CB1]].wait_front(
-# CHECK-CPP-FPU: [[CB2]].reserve_back(
-
-# Initial store: copy lhs to output (SFPU path)
+# CHECK-CPP-FPU-DAG: int32_t [[ZERO:v[0-9]+]] = 0;
+# CHECK-CPP-FPU-DAG: int32_t [[ONE:v[0-9]+]] = 1;
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[LHS:.*]](get_compile_time_arg_val(0));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[RHS:.*]](get_compile_time_arg_val(1));
+# CHECK-CPP-FPU-DAG: experimental::CircularBuffer [[OUT:.*]](get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: [[LHS]].wait_front(
+# CHECK-CPP-FPU: [[RHS]].wait_front(
+# CHECK-CPP-FPU: [[OUT]].reserve_back(
 # CHECK-CPP-FPU: init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 # CHECK-CPP-FPU: tile_regs_acquire();
 # CHECK-CPP-FPU: copy_tile_init(get_compile_time_arg_val(0));
 # CHECK-CPP-FPU: copy_tile(get_compile_time_arg_val(0),
 # CHECK-CPP-FPU: tile_regs_commit();
 # CHECK-CPP-FPU: tile_regs_wait();
-# CHECK-CPP-FPU: pack_tile<true>(
+# CHECK-CPP-FPU: pack_tile<true>({{.*}}, get_compile_time_arg_val(2),
 # CHECK-CPP-FPU: tile_regs_release();
-# CHECK-CPP-FPU: [[CB2]].push_back(
-
-# Loop: accumulate with FPU add_tiles (both inputs from CBs)
+# CHECK-CPP-FPU: init_sfpu(get_compile_time_arg_val(1), get_compile_time_arg_val(2));
+# CHECK-CPP-FPU: llk_pack_reconfig_l1_acc([[ONE]])
 # CHECK-CPP-FPU: for (size_t {{.*}} < {{.*}};
-# CHECK-CPP-FPU: [[CB2]].wait_front(
-# CHECK-CPP-FPU: [[CB2]].reserve_back(
-# CHECK-CPP-FPU: binary_op_init_common(get_compile_time_arg_val(2), get_compile_time_arg_val(1), get_compile_time_arg_val(2));
-# CHECK-CPP-FPU: add_tiles_init(get_compile_time_arg_val(2), get_compile_time_arg_val(1));
-# CHECK-CPP-FPU: add_tiles(get_compile_time_arg_val(2), get_compile_time_arg_val(1),
-
-# Finalize
-# CHECK-CPP-FPU: [[CB1]].pop_front(
-# CHECK-CPP-FPU: [[CB0]].pop_front(
+# CHECK-CPP-FPU: tile_regs_acquire();
+# CHECK-CPP-FPU: copy_tile_init(get_compile_time_arg_val(1));
+# CHECK-CPP-FPU: copy_tile(get_compile_time_arg_val(1),
+# CHECK-CPP-FPU: tile_regs_commit();
+# CHECK-CPP-FPU: tile_regs_wait();
+# CHECK-CPP-FPU: pack_tile<true>({{.*}}, get_compile_time_arg_val(2),
+# CHECK-CPP-FPU: tile_regs_release();
+# CHECK-CPP-FPU: [[OUT]].push_back(
+# CHECK-CPP-FPU: llk_pack_reconfig_l1_acc([[ZERO]])
+# CHECK-CPP-FPU: [[RHS]].pop_front(
+# CHECK-CPP-FPU: [[LHS]].pop_front(
 
 
 if __name__ == "__main__":

--- a/test/python/test_store_patterns.py
+++ b/test/python/test_store_patterns.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for store patterns: passthrough, double store, multi-output, and
-store-then-forward (scratch DFB reuse within compute thread)."""
+store-then-forward (one producer fans out to two per-consumer DFBs)."""
 
 # REQUIRES: ttnn
 # UNSUPPORTED: system-darwin
@@ -201,16 +201,27 @@ def fused_bcast_two_outputs_kernel(a, b, out1, out2):
 def store_then_forward_kernel(a, b, out_main, out_copy):
     a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
     b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)
-    main_dfb = ttl.make_dataflow_buffer_like(out_main, shape=(1, 1), block_count=2)
+    # SPSC split: compute reads main back for the copy_dfb computation, and
+    # dm_write also reads main to forward to out_main. Each consumer gets
+    # its own DFB so the ttl-verify-dfb-spsc pass accepts the kernel.
+    main_for_compute_dfb = ttl.make_dataflow_buffer_like(
+        out_main, shape=(1, 1), block_count=2
+    )
+    main_for_write_dfb = ttl.make_dataflow_buffer_like(
+        out_main, shape=(1, 1), block_count=2
+    )
     copy_dfb = ttl.make_dataflow_buffer_like(out_copy, shape=(1, 1), block_count=2)
 
     @ttl.compute()
     def compute():
         with a_dfb.wait() as av, b_dfb.wait() as bv:
-            with main_dfb.reserve() as m:
-                m.store(av + bv)
+            main_val = av + bv
+            with main_for_compute_dfb.reserve() as m:
+                m.store(main_val)
+            with main_for_write_dfb.reserve() as m:
+                m.store(main_val)
 
-        with main_dfb.wait() as mv:
+        with main_for_compute_dfb.wait() as mv:
             with copy_dfb.reserve() as c:
                 c.store(mv + mv)
 
@@ -225,7 +236,7 @@ def store_then_forward_kernel(a, b, out_main, out_copy):
 
     @ttl.datamovement()
     def dm_write():
-        with main_dfb.wait() as blk:
+        with main_for_write_dfb.wait() as blk:
             tx = ttl.copy(blk, out_main[0, 0])
             tx.wait()
         with copy_dfb.wait() as blk:

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_multi_iter_reserve.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_multi_iter_reserve.mlir
@@ -1,0 +1,97 @@
+// RUN: ttlang-opt %s --split-input-file -convert-ttl-to-ttkernel | FileCheck %s
+
+// Sender-side unicast lowering must reserve and push the destination DFB on
+// the sender's local view so its fifo_wr_ptr stays in lockstep with the
+// receiver's across iterations. With no receiver in this module, the source
+// and destination DFB index coincide (both cb_index = 0).
+// CHECK-LABEL: func.func @sender_reserves_dest_dfb_unicast
+// CHECK: %[[N:.+]] = arith.constant 1 : i32
+// CHECK: %[[DFB:.+]] = ttkernel.get_compile_time_arg_val(0)
+// CHECK: ttkernel.cb_reserve_back(%[[DFB]], %[[N]])
+// CHECK: %[[WP:.+]] = ttkernel.get_write_ptr(%[[DFB]])
+// CHECK: ttkernel.get_noc_addr({{.*}}, %[[WP]])
+// CHECK: ttkernel.noc_async_write(
+// CHECK: ttkernel.noc_async_write_barrier
+// CHECK: ttkernel.noc_semaphore_inc
+// CHECK: ttkernel.cb_push_back(%[[DFB]], %[[N]])
+func.func @sender_reserves_dest_dfb_unicast() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  %xf = ttl.copy %cb, %p : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>) -> !ttl.transfer_handle<write>
+  ttl.wait %xf : !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
+// Multicast lowering: same bracketing pattern on the destination DFB.
+// CHECK-LABEL: func.func @sender_reserves_dest_dfb_multicast
+// CHECK: %[[N:.+]] = arith.constant 1 : i32
+// CHECK: %[[DFB:.+]] = ttkernel.get_compile_time_arg_val(0)
+// CHECK: ttkernel.experimental::semaphore_wait
+// CHECK: ttkernel.cb_reserve_back(%[[DFB]], %[[N]])
+// CHECK: %[[WP:.+]] = ttkernel.get_write_ptr(%[[DFB]])
+// CHECK: ttkernel.experimental::get_noc_multicast_addr({{.*}}, %[[WP]])
+// CHECK-NEXT: ttkernel.noc_async_write_multicast(
+// CHECK-NEXT: ttkernel.noc_async_write_barrier
+// CHECK: ttkernel.noc_semaphore_set_multicast
+// CHECK: ttkernel.cb_push_back(%[[DFB]], %[[N]])
+func.func @sender_reserves_dest_dfb_multicast() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 3) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 3) net 0>
+  %xf = ttl.copy %cb, %p : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, !ttl.pipe<src(0, 0) dst(1, 0) to(1, 3) net 0>) -> !ttl.transfer_handle<write>
+  ttl.wait %xf : !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
+// Gather: a pipe whose receiver uses a different DFB index than the sender.
+// The PipeGraph picks up the Pipe -> CB op in @receiver and the sender lowering
+// must reserve/push the *destination* DFB (cb_index = 5), not its own source
+// DFB (cb_index = 3).
+// CHECK-LABEL: func.func @sender
+// CHECK: %[[N:.+]] = arith.constant 1 : i32
+// CHECK: %[[SRC:.+]] = ttkernel.get_compile_time_arg_val(3)
+// CHECK: %[[DST:.+]] = ttkernel.get_compile_time_arg_val(5)
+// CHECK: ttkernel.cb_reserve_back(%[[DST]], %[[N]])
+// CHECK: %[[WP_DST:.+]] = ttkernel.get_write_ptr(%[[DST]])
+// CHECK: %[[WP_SRC:.+]] = ttkernel.get_write_ptr(%[[SRC]])
+// CHECK: ttkernel.get_noc_addr({{.*}}, %[[WP_DST]])
+// CHECK: ttkernel.noc_async_write(%[[WP_SRC]],
+// CHECK: ttkernel.cb_push_back(%[[DST]], %[[N]])
+func.func @sender() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
+  %src = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %p = ttl.create_pipe src(1, 0) dst(0, 0) to(0, 0) net 0 : !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0>
+  %xf = ttl.copy %src, %p : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0>) -> !ttl.transfer_handle<write>
+  ttl.wait %xf : !ttl.transfer_handle<write>
+  func.return
+}
+
+func.func @receiver() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
+  %dst = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %p = ttl.create_pipe src(1, 0) dst(0, 0) to(0, 0) net 0 : !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0>
+  %xf = ttl.copy %p, %dst : (!ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> !ttl.transfer_handle
+  ttl.wait %xf : !ttl.transfer_handle
+  func.return
+}
+
+// -----
+
+// Multicast loopback: the sender is in the destination range. The receive
+// callback on the sender core already issues reserve_back / push_back on the
+// destination DFB, so the lowering must NOT double-advance.
+// CHECK-LABEL: func.func @sender_skips_reserve_in_loopback
+// CHECK-NOT: ttkernel.cb_reserve_back
+// CHECK-NOT: ttkernel.cb_push_back
+// CHECK: ttkernel.noc_async_write_multicast_loopback_src
+// CHECK-NOT: ttkernel.cb_reserve_back
+// CHECK-NOT: ttkernel.cb_push_back
+// CHECK: return
+func.func @sender_skips_reserve_in_loopback() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %p = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 3) net 0 : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>
+  %xf = ttl.copy %cb, %p : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, !ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>) -> !ttl.transfer_handle<write>
+  ttl.wait %xf : !ttl.transfer_handle<write>
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_multi_iter_reserve.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_multi_iter_reserve.mlir
@@ -78,14 +78,21 @@ func.func @receiver() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> }
 
 // -----
 
-// Multicast loopback: the sender is in the destination range. The receive
-// callback on the sender core already issues reserve_back / push_back on the
-// destination DFB, so the lowering must NOT double-advance.
+// Multicast loopback (same-index): the sender is in the destination range
+// and reads/writes the same DFB index. The receive callback on the sender
+// core already issues reserve_back / push_back on the destination DFB, so
+// the lowering must not double-advance. Both the multicast destination
+// address and the source-data address come from `get_write_ptr` on the
+// single CB handle (two SSA values, same backing CB), and the call must
+// be `noc_async_write_multicast_loopback_src` to include the sender core.
 // CHECK-LABEL: func.func @sender_skips_reserve_in_loopback
 // CHECK-NOT: ttkernel.cb_reserve_back
-// CHECK-NOT: ttkernel.cb_push_back
-// CHECK: ttkernel.noc_async_write_multicast_loopback_src
-// CHECK-NOT: ttkernel.cb_reserve_back
+// CHECK: %[[CB:.+]] = ttkernel.get_compile_time_arg_val(0)
+// CHECK: %[[WP_DST:.+]] = ttkernel.get_write_ptr(%[[CB]])
+// CHECK: %[[WP_SRC:.+]] = ttkernel.get_write_ptr(%[[CB]])
+// CHECK: ttkernel.experimental::get_noc_multicast_addr({{.*}}, %[[WP_DST]])
+// CHECK-NEXT: ttkernel.noc_async_write_multicast_loopback_src(%[[WP_SRC]],
+// CHECK-NEXT: ttkernel.noc_async_write_barrier
 // CHECK-NOT: ttkernel.cb_push_back
 // CHECK: return
 func.func @sender_skips_reserve_in_loopback() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
@@ -93,5 +100,41 @@ func.func @sender_skips_reserve_in_loopback() attributes { "ttl.kernel_thread" =
   %p = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 3) net 0 : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>
   %xf = ttl.copy %cb, %p : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, !ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>) -> !ttl.transfer_handle<write>
   ttl.wait %xf : !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
+// Cross-DFB multicast loopback: sender is in the destination range but
+// reads from cb_index=3 (source DFB) while the receiver writes into
+// cb_index=5 (destination DFB). The receive callback on the sender core
+// advances the destination DFB; the sender path must NOT advance it again.
+// At the same time the NOC write must still target the destination DFB
+// (write_ptr of cb_index=5) and pull source data from the source DFB
+// (write_ptr of cb_index=3).
+// CHECK-LABEL: func.func @sender_skips_reserve_in_cross_dfb_loopback
+// CHECK-NOT: ttkernel.cb_reserve_back
+// CHECK: %[[SRC:.+]] = ttkernel.get_compile_time_arg_val(3)
+// CHECK: %[[DST:.+]] = ttkernel.get_compile_time_arg_val(5)
+// CHECK: %[[WP_DST:.+]] = ttkernel.get_write_ptr(%[[DST]])
+// CHECK: %[[WP_SRC:.+]] = ttkernel.get_write_ptr(%[[SRC]])
+// CHECK: ttkernel.experimental::get_noc_multicast_addr({{.*}}, %[[WP_DST]])
+// CHECK-NEXT: ttkernel.noc_async_write_multicast_loopback_src(%[[WP_SRC]],
+// CHECK-NEXT: ttkernel.noc_async_write_barrier
+// CHECK-NOT: ttkernel.cb_push_back
+// CHECK: return
+func.func @sender_skips_reserve_in_cross_dfb_loopback() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
+  %src = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %p = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 3) net 0 : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>
+  %xf = ttl.copy %src, %p : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, !ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>) -> !ttl.transfer_handle<write>
+  ttl.wait %xf : !ttl.transfer_handle<write>
+  func.return
+}
+
+func.func @receiver_cross_dfb_loopback() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
+  %dst = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %p = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 3) net 0 : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>
+  %xf = ttl.copy %p, %dst : (!ttl.pipe<src(0, 0) dst(0, 0) to(0, 3) net 0>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> !ttl.transfer_handle
+  ttl.wait %xf : !ttl.transfer_handle
   func.return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
@@ -1,0 +1,162 @@
+// RUN: ttlang-opt %s --split-input-file -ttl-verify-dfb-spsc | FileCheck %s
+
+// Producer in one thread, consumer in another: classic SPSC, accepted.
+// CHECK-LABEL: func.func @producer
+// CHECK-LABEL: func.func @consumer
+module {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %v = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Producer and consumer in the same thread: still SPSC (one producer thread,
+// one consumer thread); the verifier counts threads, not ops.
+// CHECK-LABEL: func.func @produce_and_consume
+module {
+  func.func @produce_and_consume() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 2, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %r = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %w = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Multiple `cb_wait` calls inside one thread are fine: only the thread set
+// matters, not the call count.
+// CHECK-LABEL: func.func @consumer_multi_wait
+module {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 1, block_count = 4}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+    %v = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @consumer_multi_wait() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 1, block_count = 4}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+    %a = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %b = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Ops not tagged with `ttl.kernel_thread` are ignored entirely. This matters
+// because helper or host funcs may share a CB declaration without participating
+// in the runtime push/pop protocol.
+// CHECK-LABEL: func.func @kernel_consumer
+// CHECK-LABEL: func.func @untagged_helper
+module {
+  func.func @kernel_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 4, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @untagged_helper() {
+    %cb = ttl.bind_cb {cb_index = 4, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Multiple `cb_reserve` calls inside one producer thread are fine: the verifier
+// counts threads per role, not ops.
+// CHECK-LABEL: func.func @producer_multi_reserve
+module {
+  func.func @producer_multi_reserve() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 6, block_count = 4}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+    %a = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %b = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @single_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 6, block_count = 4}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Two distinct CBs each correctly SPSC across the same two threads: the
+// verifier disambiguates by `cb_index` and accepts both.
+// CHECK-LABEL: func.func @two_cb_producer
+// CHECK-LABEL: func.func @two_cb_consumer
+module {
+  func.func @two_cb_producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb_a = ttl.bind_cb {cb_index = 10, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %cb_b = ttl.bind_cb {cb_index = 11, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %a = ttl.cb_reserve %cb_a
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %b = ttl.cb_reserve %cb_b
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @two_cb_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb_a = ttl.bind_cb {cb_index = 10, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %cb_b = ttl.bind_cb {cb_index = 11, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %a = ttl.cb_wait %cb_a
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %b = ttl.cb_wait %cb_b
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir
@@ -1,0 +1,140 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-dfb-spsc
+
+// Two kernel threads each call `cb_wait` on cb_index=0; the verifier rejects
+// because tt-metal CBs use a single `pages_acked` counter that races when
+// more than one thread pops. The diagnostic also attaches a "declared here"
+// note pointing at the first `ttl.bind_cb` for this index.
+
+module {
+  func.func @two_consumers_compute() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{dataflow buffer cb_index=0 has 2 consumer threads}}
+    // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per consumer}}
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @two_consumers_noc() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-note @below {{also waited on here}}
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Two kernel threads each call `cb_reserve`; rejected for the symmetric
+// reason on the producer side.
+
+module {
+  func.func @two_producers_compute() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %cb = ttl.bind_cb {cb_index = 3, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{dataflow buffer cb_index=3 has 2 producer threads}}
+    // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per producer}}
+    %v = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @two_producers_noc() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 3, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-note @below {{also reserved here}}
+    %v = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Three threads consume the same DFB; one error site, one note per other
+// thread.
+
+module {
+  func.func @consumer_a() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %cb = ttl.bind_cb {cb_index = 5, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{dataflow buffer cb_index=5 has 3 consumer threads}}
+    // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per consumer}}
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @consumer_b() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 5, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-note @below {{also waited on here}}
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @consumer_c() attributes {ttl.kernel_thread = #ttkernel.thread<ethernet>} {
+    %cb = ttl.bind_cb {cb_index = 5, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-note @below {{also waited on here}}
+    %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Same `cb_index` violates SPSC on BOTH the producer and consumer sides.
+// The pass emits one error per violated role and continues past the first.
+
+module {
+  func.func @both_sides_a() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // The pass attaches one "declared here" note per error (so two total
+    // here). MLIR's verify-diagnostics matches at most one expected-note
+    // per emitted note, so we assert only the producer-side note; the
+    // consumer-side note is exercised by the single-role cases above.
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %cb = ttl.bind_cb {cb_index = 8, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{dataflow buffer cb_index=8 has 2 producer threads}}
+    // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per producer}}
+    %r = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-error @below {{dataflow buffer cb_index=8 has 2 consumer threads}}
+    // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per consumer}}
+    %w = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @both_sides_b() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 8, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-note @below {{also reserved here}}
+    %r = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{also waited on here}}
+    %w = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #574: in a multi-iteration gather/multicast kernel, the pipe sender's local view of the destination DFB's write pointer did not advance, so iterations after the first wrote into stale DFB slots.

Also adds a new verifier (`ttl-verify-dfb-spsc`) that rejects any DFB used by more than one producer or consumer thread. tt-metal CBs maintain a single `pages_received` / `pages_acked` counter pair shared by both sides; two threads incrementing either counter over-count the available slots and let the producer reuse them while a consumer is still reading.
> Metal reference:  https://github.com/tenstorrent/tt-metal/blob/cf7232ab47227167f091c3c3cf6fdbed63c8b51c/tt_metal/hw/inc/internal/atomic_rwptr.h#L43
> ```// Atomic using only atomic load and store for single producer / single consumer FIFO read & write pointers.```)

## What changed

- Sender lockstep: the pipe sender now reserves and pushes on its local view of the destination DFB around each NOC write, keeping its write pointer in step with the receivers' across iterations. Loopback (sender is also a destination) is skipped because the user's receive callback on that core already advances the DFB.
- SPSC verifier: a module-level pass groups every `cb_reserve` / `cb_wait` by `cb_index` and enclosing kernel thread and emits a diagnostic when any DFB has more than one producer or consumer thread.
- Test refactors: a few existing tests shared a DFB across kernel threads. Before this PR nothing enforced SPSC, and those kernels worked at runtime because the threads happened to serialize their accesses on the small inputs the tests use. The new verifier rejects the structure regardless, so the tests are refactored to per-consumer DFBs (or, for `simple_add_loop.py`, to the spec-current `+=` accumulator).

## Follow-ups filed

- enhancement #580 — consolidate the three duplicated `ttl-to-ttkernel-pipeline` definitions.
- enhancement #581 — auto-split user DFBs whose consumers span multiple kernel threads.
- bug #582 — multi-source gather has a per-iteration write-pointer rate mismatch.
- bug #583 — cross-DFB multicast loopback still drops the stripe-1 write to the destination DFB; tracked by an `xfail` test in this PR.