### PR TITLE
[fix][ci] Fix path in pip wheel test script

### DIFF
--- a/.github/scripts/smoke-test-wheel.py
+++ b/.github/scripts/smoke-test-wheel.py
@@ -15,6 +15,7 @@
 
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
 
@@ -46,7 +47,8 @@ def main() -> int:
     import sim_stats  # noqa: F401
     from sim_stats.__main__ import main as _sim_stats_main  # noqa: F401
 
-    scripts_dir = Path(sys.executable).resolve().parent
+    # venv-aware; sys.executable may be a symlink out of the venv.
+    scripts_dir = Path(sysconfig.get_path("scripts"))
     stats_name = (
         "ttlang-sim-stats.exe" if sys.platform == "win32" else "ttlang-sim-stats"
     )


### PR DESCRIPTION
Problem: pip wheel smoketest failed in CI (https://github.com/tenstorrent/tt-lang/actions/runs/25777889363/job/75717599221)

Fix: Use `sysconfig.get_path("scripts")` to locate the venv's scripts directory.
Example [workflow](https://github.com/tenstorrent/tt-lang/actions/runs/25796008854)