### PR TITLE
[nfc] Enforce `numpy` 1.x to align with `ttnn` (Also fixes #606)

### DIFF
--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,7 +1,7 @@
 # Runtime dependencies for the tt-lang wheel; also read by pyproject.toml.
 pydantic<3
 torch>=1.9.0
-numpy>=1.20.0
+numpy>=1.24.4,<2
 greenlet>=3.0.0
 PyYAML>=5.4.0
 typing_extensions>=4.12.2


### PR DESCRIPTION
Also fixes #606:

- Prevents `tt-lang-sim` to upgrade to `numpy` 2.x in absence of `ttnn` dependency;
- On Intel Macs `torch` 2.2.2 is the last supported version and is compatible only with `numpy` 1.x (but does not specify it as dependency).