### PR TITLE
Simulator: Refined kernel ids

### DIFF
--- a/python/sim/diagnostics.py
+++ b/python/sim/diagnostics.py
@@ -133,20 +133,21 @@ def format_core_ranges(core_numbers: list[int]) -> str:
 def extract_core_id_from_thread_name(thread_name: Optional[str]) -> str:
     """Extract core ID from a scheduled kernel name.
 
-    Names follow the pattern "coreN-type" where N is the core number
-    and type is the kernel role (e.g., "dm", "compute").
+    Names follow the pattern ``coreN-<func_name>`` where N is the core number
+    and ``<func_name>`` is the kernel function's ``__name__``
+    (see :func:`sim.greenlet_scheduler.kernel_display_name`).
 
     Args:
-        thread_name: Scheduled kernel display name like "core0-dm" or "core0-compute"
-            (see :func:`sim.greenlet_scheduler.kernel_thread_display_name`).
+        thread_name: Scheduled kernel display name like ``core0-mm_reader`` or
+            ``core15-mm_compute``.
 
     Returns:
         Core ID like "core0", or "unknown" if extraction fails
 
     Examples:
-        >>> extract_core_id_from_thread_name("core0-dm")
+        >>> extract_core_id_from_thread_name("core0-mm_reader")
         'core0'
-        >>> extract_core_id_from_thread_name("core15-compute")
+        >>> extract_core_id_from_thread_name("core15-mm_compute")
         'core15'
         >>> extract_core_id_from_thread_name(None)
         'unknown'

--- a/python/sim/greenlet_scheduler.py
+++ b/python/sim/greenlet_scheduler.py
@@ -26,31 +26,33 @@ from .trace import get_dfb_name, trace
 
 
 @dataclass(frozen=True)
-class KernelThreadId:
+class KernelId:
     """Stable identity for a cooperative scheduled kernel (scheduler dict key).
 
-    ``linear_core`` is the linear core index used by ``program`` when registering
-    threads. ``suffix`` is the kernel template name (e.g. ``compute``, ``dm0``).
-
-    User-visible strings match the historical format ``core{linear_core}-{suffix}``;
-    use :func:`kernel_thread_display_name` for traces and diagnostics.
+    Identity is ``(linear_core, kind, func_name)``: the linear core index, the
+    kernel role (compute or data movement), and the decorated function's
+    ``__name__``. The function name is part of identity because a core can host
+    up to two data movement kernels; their ``__name__`` distinguishes them. The
+    scheduler enforces uniqueness on registration -- two kernels with the same
+    triple on the same core is rejected with a user-facing error.
     """
 
     linear_core: int
-    suffix: str
+    kind: ThreadType
+    func_name: str
 
     def __post_init__(self) -> None:
         if self.linear_core < 0:
             raise ValueError(
                 f"linear_core must be non-negative; got {self.linear_core!r}"
             )
-        if not self.suffix:
-            raise ValueError("suffix must be a non-empty string")
+        if not self.func_name:
+            raise ValueError("func_name must be a non-empty string")
 
 
-def kernel_thread_display_name(thread_id: KernelThreadId) -> str:
-    """Return the user-facing kernel label (``core0-compute`` style)."""
-    return f"core{thread_id.linear_core}-{thread_id.suffix}"
+def kernel_display_name(kernel_id: KernelId) -> str:
+    """Return the user-facing kernel label (``core0-mm_compute`` style)."""
+    return f"core{kernel_id.linear_core}-{kernel_id.func_name}"
 
 
 def set_scheduler_algorithm(algorithm: str) -> None:
@@ -80,38 +82,52 @@ class GreenletScheduler:
 
     def __init__(self) -> None:
         """Initialize the scheduler."""
-        # Active greenlets: thread_id -> (greenlet, blocking_obj, operation, thread_type, block_location, raw_loc)
+        # Active greenlets: kernel_id -> (greenlet, blocking_obj, operation, thread_type, block_location, raw_loc)
         # raw_loc is Optional[Tuple[str, int]] = (filename, lineno) for pretty-printing
         self._active: Dict[
-            KernelThreadId,
+            KernelId,
             Tuple[greenlet, Any, str, ThreadType, str, Optional[Tuple[str, int]]],
         ] = {}
         # Completed greenlets (internal bookkeeping)
-        self._completed: List[KernelThreadId] = []
+        self._completed: List[KernelId] = []
         # Main greenlet for the scheduler
         self._main_greenlet: Optional[greenlet] = None
         # Currently executing scheduled kernel
-        self._current_thread_id: Optional[KernelThreadId] = None
-        # Last run timestamp for fair scheduling (thread_id -> timestamp)
-        self._last_run: Dict[KernelThreadId, int] = {}
+        self._current_kernel_id: Optional[KernelId] = None
+        # Last run timestamp for fair scheduling (kernel_id -> timestamp)
+        self._last_run: Dict[KernelId, int] = {}
         # Global timestamp counter
         self._timestamp: int = 0
         # Track if thread has ever made progress (passed at least one block_if_needed check)
-        self._has_made_progress: Dict[KernelThreadId, bool] = {}
+        self._has_made_progress: Dict[KernelId, bool] = {}
 
     def add_thread(
         self,
-        thread_id: KernelThreadId,
+        kernel_id: KernelId,
         func: Callable[[], None],
-        thread_type: ThreadType,
     ) -> None:
         """Add a scheduled kernel (greenlet) to the scheduler.
 
         Args:
-            thread_id: Stable kernel identity (linear core index and template suffix).
-            func: Kernel entry function to execute
-            thread_type: Kernel role (COMPUTE or DM)
+            kernel_id: Stable kernel identity. Its ``kind`` field doubles as the
+                kernel role (COMPUTE or DM); two kernels with the same
+                ``(linear_core, kind, func_name)`` triple is rejected.
+            func: Kernel entry function to execute.
+
+        Raises:
+            RuntimeError: If a kernel with this identity is already registered.
+                Most commonly fired when two data movement kernels on the same
+                core have the same ``__name__``; rename one of them.
         """
+        if kernel_id in self._active:
+            label = kernel_display_name(kernel_id)
+            raise RuntimeError(
+                f"Duplicate kernel registration: {label!r} "
+                f"({kernel_id.kind.name}) is already scheduled on "
+                f"core{kernel_id.linear_core}. Two {kernel_id.kind.name} kernels "
+                f"on the same core must have distinct function names; rename "
+                f"one of them."
+            )
 
         # Create greenlet that wraps the function
         def wrapped_func() -> None:
@@ -119,15 +135,15 @@ class GreenletScheduler:
             func()
             trace("kernel_end")
             # Thread completed successfully
-            self._mark_completed(thread_id)
+            self._mark_completed(kernel_id)
 
         g = greenlet(wrapped_func)
         # Initially not blocked (will start when scheduled)
-        self._active[thread_id] = (g, None, "", thread_type, "", None)
+        self._active[kernel_id] = (g, None, "", kernel_id.kind, "", None)
         # Initialize last run time to 0 (never run)
-        self._last_run[thread_id] = 0
+        self._last_run[kernel_id] = 0
         # Thread hasn't made progress yet
-        self._has_made_progress[thread_id] = False
+        self._has_made_progress[kernel_id] = False
 
     def block_current_thread(self, blocking_obj: Any, operation: str) -> None:
         """Block the current scheduled kernel on an operation.
@@ -139,7 +155,7 @@ class GreenletScheduler:
             blocking_obj: Object being waited on (DataflowBuffer or CopyTransaction)
             operation: Operation name ("wait" or "reserve")
         """
-        if self._current_thread_id is None:
+        if self._current_kernel_id is None:
             raise RuntimeError(
                 "block_current_thread called outside of scheduler context "
                 "(no kernel is currently scheduled)"
@@ -151,8 +167,8 @@ class GreenletScheduler:
         raw_loc: Optional[Tuple[str, int]] = (filename, lineno)
 
         # Update active entry with blocking info and location
-        g, _, _, thread_type, _, _ = self._active[self._current_thread_id]
-        self._active[self._current_thread_id] = (
+        g, _, _, thread_type, _, _ = self._active[self._current_kernel_id]
+        self._active[self._current_kernel_id] = (
             g,
             blocking_obj,
             operation,
@@ -169,18 +185,18 @@ class GreenletScheduler:
         self._main_greenlet.switch()
         trace("kernel_unblock")
 
-    def _mark_completed(self, thread_id: KernelThreadId) -> None:
+    def _mark_completed(self, kernel_id: KernelId) -> None:
         """Mark a kernel as completed and remove from active set.
 
         Args:
-            thread_id: Kernel identity
+            kernel_id: Kernel identity
         """
-        if thread_id in self._active:
-            del self._active[thread_id]
-        self._completed.append(thread_id)
+        if kernel_id in self._active:
+            del self._active[kernel_id]
+        self._completed.append(kernel_id)
         # Clean up last run time
-        if thread_id in self._last_run:
-            del self._last_run[thread_id]
+        if kernel_id in self._last_run:
+            del self._last_run[kernel_id]
 
     def mark_thread_progress(self) -> None:
         """Mark that the current scheduled kernel has made progress.
@@ -191,32 +207,33 @@ class GreenletScheduler:
         Raises:
             RuntimeError: If no kernel is scheduled or the name is missing from progress tracking
         """
-        if self._current_thread_id is None:
+        if self._current_kernel_id is None:
             raise RuntimeError(
                 "mark_thread_progress called but no kernel is currently scheduled. "
                 "This indicates a bug in the scheduler."
             )
-        if self._current_thread_id not in self._has_made_progress:
-            label = kernel_thread_display_name(self._current_thread_id)
+        if self._current_kernel_id not in self._has_made_progress:
+            label = kernel_display_name(self._current_kernel_id)
             raise RuntimeError(
                 f"Kernel {label!r} not found in progress tracking. "
                 "This indicates a bug in the scheduler."
             )
-        self._has_made_progress[self._current_thread_id] = True
+        self._has_made_progress[self._current_kernel_id] = True
 
-    def get_current_kernel_thread_id(self) -> Optional[KernelThreadId]:
+    def get_current_kernel_id(self) -> Optional[KernelId]:
         """Return the identity of the currently executing kernel, if any."""
-        return self._current_thread_id
+        return self._current_kernel_id
 
-    def get_current_thread_name(self) -> Optional[str]:
-        """Get the name of the currently executing scheduled kernel.
+    def get_current_kernel_name(self) -> Optional[str]:
+        """Get the display name of the currently executing kernel.
 
         Returns:
-            Kernel name (e.g., core0-dm), or None if none is executing
+            Kernel display name (e.g., ``core0-mm_reader``), or None if none
+            is executing.
         """
-        if self._current_thread_id is None:
+        if self._current_kernel_id is None:
             return None
-        return kernel_thread_display_name(self._current_thread_id)
+        return kernel_display_name(self._current_kernel_id)
 
     @property
     def tick(self) -> int:
@@ -285,19 +302,19 @@ class GreenletScheduler:
         keep ts=0, giving them priority in fair scheduling.
         """
 
-        for thread_id in list(self._active.keys()):
-            g, blocking_obj, _, thread_type, _, _ = self._active[thread_id]
+        for kernel_id in list(self._active.keys()):
+            g, blocking_obj, _, thread_type, _, _ = self._active[kernel_id]
 
             # All threads should start unblocked in init phase
             if blocking_obj is not None:
-                label = kernel_thread_display_name(thread_id)
+                label = kernel_display_name(kernel_id)
                 raise RuntimeError(
                     f"Kernel {label!r} is already blocked at init phase start. "
                     "This indicates a bug in the scheduler."
                 )
 
             # Set current thread context
-            self._current_thread_id = thread_id
+            self._current_kernel_id = kernel_id
             set_current_thread_type(thread_type)
 
             try:
@@ -305,31 +322,29 @@ class GreenletScheduler:
                 g.switch()
 
                 # Update timestamp only if thread made progress
-                made_progress = self._has_made_progress.get(thread_id, False)
+                made_progress = self._has_made_progress.get(kernel_id, False)
 
                 if g.dead:
-                    self._mark_completed(thread_id)
+                    self._mark_completed(kernel_id)
                 elif made_progress:
                     # Thread passed one or more block_if_needed checks - give it a timestamp
                     self._timestamp += 1
-                    self._last_run[thread_id] = self._timestamp
+                    self._last_run[kernel_id] = self._timestamp
                 # Threads that blocked on their first check keep ts=0
 
             except Exception as e:
                 # Thread raised an error during initialization
                 clear_current_thread_type()
-                self._current_thread_id = None
+                self._current_kernel_id = None
 
                 # Format and raise error with source location
-                self._format_and_raise_thread_error(
-                    kernel_thread_display_name(thread_id), e
-                )
+                self._format_and_raise_thread_error(kernel_display_name(kernel_id), e)
 
             clear_current_thread_type()
 
-        self._current_thread_id = None
+        self._current_kernel_id = None
 
-    def _get_fair_thread_order(self) -> List[KernelThreadId]:
+    def _get_fair_thread_order(self) -> List[KernelId]:
         """Get threads sorted by least recently run.
 
         Threads that can potentially make progress (not blocked or can unblock)
@@ -339,13 +354,20 @@ class GreenletScheduler:
             List of thread ids in least-recently-run order
         """
         # Get all active threads with their last run times
-        thread_times: List[Tuple[int, KernelThreadId]] = []
-        for thread_id in self._active.keys():
-            last_run = self._last_run.get(thread_id, 0)
-            thread_times.append((last_run, thread_id))
+        thread_times: List[Tuple[int, KernelId]] = []
+        for kernel_id in self._active.keys():
+            last_run = self._last_run.get(kernel_id, 0)
+            thread_times.append((last_run, kernel_id))
 
-        # Sort by timestamp (ascending), then by display name for stability
-        thread_times.sort(key=lambda x: (x[0], kernel_thread_display_name(x[1])))
+        # Sort by timestamp (ascending), then by core, kind, and name for stability
+        thread_times.sort(
+            key=lambda x: (
+                x[0],
+                x[1].linear_core,
+                x[1].kind.value,
+                x[1].func_name,
+            )
+        )
 
         return [tid for _, tid in thread_times]
 
@@ -376,13 +398,13 @@ class GreenletScheduler:
                 thread_candidates = list(self._active.keys())
 
             # Try to advance each thread in the selected order
-            for thread_id in thread_candidates:
-                if thread_id not in self._active:
+            for kernel_id in thread_candidates:
+                if kernel_id not in self._active:
                     # Thread may have completed during this iteration
                     continue
 
                 g, blocking_obj, blocked_op, thread_type, location, _ = self._active[
-                    thread_id
+                    kernel_id
                 ]
 
                 # If thread is blocked, check if it can proceed
@@ -393,10 +415,10 @@ class GreenletScheduler:
                         continue
 
                     # Unblocked! Clear blocking state
-                    self._active[thread_id] = (g, None, "", thread_type, "", None)
+                    self._active[kernel_id] = (g, None, "", thread_type, "", None)
 
                 # Set current thread for block_current_thread()
-                self._current_thread_id = thread_id
+                self._current_kernel_id = kernel_id
 
                 # Run thread until it blocks or completes
 
@@ -404,8 +426,8 @@ class GreenletScheduler:
                 try:
                     if g.dead:
                         # Thread already completed (marked by wrapped_func)
-                        if thread_id in self._active:
-                            del self._active[thread_id]
+                        if kernel_id in self._active:
+                            del self._active[kernel_id]
                         continue
 
                     # Switch to the greenlet
@@ -415,28 +437,28 @@ class GreenletScheduler:
                     # Always update timestamp after thread runs
                     # The pre-check already prevented threads that can't make progress from running
                     self._timestamp += 1
-                    self._last_run[thread_id] = self._timestamp
+                    self._last_run[kernel_id] = self._timestamp
 
                     # If greenlet is dead, it completed
-                    if g.dead and thread_id in self._active:
+                    if g.dead and kernel_id in self._active:
                         # Should have been marked by wrapped_func, but double-check
-                        self._mark_completed(thread_id)
+                        self._mark_completed(kernel_id)
                 except Exception as e:
                     # Thread raised an error - preserve traceback for debugging
                     clear_current_thread_type()
-                    self._current_thread_id = None
+                    self._current_kernel_id = None
 
                     # Format and raise error with source location
                     # Include full traceback for main loop errors (more debugging info)
                     self._format_and_raise_thread_error(
-                        kernel_thread_display_name(thread_id),
+                        kernel_display_name(kernel_id),
                         e,
                         include_traceback=True,
                     )
                 finally:
                     clear_current_thread_type()
 
-                self._current_thread_id = None
+                self._current_kernel_id = None
 
             # Deadlock detection
             if not any_progress and self._active:
@@ -451,7 +473,7 @@ class GreenletScheduler:
                     tuple[str, str, str], Optional[Tuple[str, int]]
                 ] = {}
 
-                for thread_id, (
+                for kernel_id, (
                     g,
                     blocking_obj,
                     op,
@@ -461,7 +483,7 @@ class GreenletScheduler:
                 ) in self._active.items():
                     obj_desc = self._get_obj_description(blocking_obj)
                     key = (op, obj_desc, location)
-                    core_id = f"core{thread_id.linear_core}"
+                    core_id = f"core{kernel_id.linear_core}"
                     blocked_groups[key].append(core_id)
                     if key not in blocked_raw_locs:
                         blocked_raw_locs[key] = raw_loc
@@ -557,7 +579,7 @@ def get_current_core_id() -> str:
             scheduled. That indicates a simulator bug, not user misuse.
     """
     scheduler = get_scheduler()
-    tid = scheduler.get_current_kernel_thread_id()
+    tid = scheduler.get_current_kernel_id()
     if tid is None:
         raise RuntimeError(
             "get_current_core_id() called with no kernel "

--- a/python/sim/program.py
+++ b/python/sim/program.py
@@ -20,7 +20,11 @@ from .dfb import DataflowBuffer
 from .typedefs import BindableTemplate, Shape
 from .blockstate import ThreadType
 from .context import get_context
-from .greenlet_scheduler import GreenletScheduler, KernelThreadId, set_scheduler
+from .greenlet_scheduler import (
+    GreenletScheduler,
+    KernelId,
+    set_scheduler,
+)
 from .ttnnsim import Tensor
 from .analysis import (
     collect_reachable_analyses,
@@ -287,8 +291,11 @@ def Program(*funcs: BindableTemplate, grid: Shape, pipenets: Any = None) -> Any:
                     core_context = self._build_core_context(core)
                     all_core_contexts.append(core_context)
 
-                    # Add threads to scheduler
-                    for tmpl in [compute_func_tmpl, dm0_tmpl, dm1_tmpl]:
+                    # Add threads to scheduler (one compute + two DM per core).
+                    # Identity is (core, kind, __name__); the two DM kernels on
+                    # a core must have distinct __name__s -- the scheduler
+                    # rejects duplicates with a user-facing error.
+                    for tmpl in (compute_func_tmpl, dm0_tmpl, dm1_tmpl):
                         # Get ThreadType directly from template's thread_type attribute
                         thread_type = getattr(tmpl, "thread_type", None)
                         match thread_type:
@@ -321,9 +328,9 @@ def Program(*funcs: BindableTemplate, grid: Shape, pipenets: Any = None) -> Any:
                                     _val.auto_push_block()
                                     _val.auto_pop_block()
 
-                        # Add to scheduler (display name remains core{core}-{tmpl.__name__})
                         scheduler.add_thread(
-                            KernelThreadId(core, tmpl.__name__), _tagged, thread_type
+                            KernelId(core, thread_type, tmpl.__name__),
+                            _tagged,
                         )
 
                 # Install injection hooks for all discovered code objects (thread

--- a/python/sim/trace.py
+++ b/python/sim/trace.py
@@ -82,7 +82,7 @@ def trace(event: str, **data: Any) -> None:
         TraceEvent(
             event=event,
             tick=scheduler.tick,
-            kernel=scheduler.get_current_thread_name(),
+            kernel=scheduler.get_current_kernel_name(),
             data=data,
         )
     )

--- a/test/sim/conftest.py
+++ b/test/sim/conftest.py
@@ -47,7 +47,7 @@ from sim.blockstate import ThreadType
 from sim.context import set_current_thread_type, reset_context
 from sim.greenlet_scheduler import (
     GreenletScheduler,
-    KernelThreadId,
+    KernelId,
     set_scheduler,
     set_scheduler_algorithm,
 )
@@ -86,11 +86,13 @@ def setup_scheduler_and_thread_context(thread_type: ThreadType) -> GreenletSched
     # Set the main greenlet to the current greenlet (for switching back)
     scheduler._main_greenlet = greenlet.getcurrent()
 
-    # Simulate being within core 0 with a valid KernelThreadId so that
+    # Simulate being within core 0 with a valid KernelId so that
     # get_current_core_id() returns "core0" and shard-locality stats work in tests.
+    # ``kind`` mirrors ``thread_type``; ``func_name`` matches the chosen role
+    # for readable display in any test diagnostics.
     test_greenlet = greenlet(lambda: None)
-    tid = KernelThreadId(0, "compute")
-    scheduler._current_thread_id = tid
+    tid = KernelId(0, thread_type, thread_type.name.lower())
+    scheduler._current_kernel_id = tid
     scheduler._active[tid] = (
         test_greenlet,
         None,  # blocking_obj

--- a/test/sim/test_copyhandlers.py
+++ b/test/sim/test_copyhandlers.py
@@ -115,7 +115,7 @@ class TestPipeErrorHandling:
         """Test that receiving from pipe with no sender is detected as deadlock."""
         from sim.greenlet_scheduler import (
             GreenletScheduler,
-            KernelThreadId,
+            KernelId,
             set_scheduler,
         )
 
@@ -138,9 +138,7 @@ class TestPipeErrorHandling:
                     tx = copy(pipe, block)
                     tx.wait()
 
-            scheduler.add_thread(
-                KernelThreadId(0, "test-dm"), test_thread, ThreadType.DM
-            )
+            scheduler.add_thread(KernelId(0, ThreadType.DM, "test-dm"), test_thread)
 
             # With scheduler, waiting on pipe with no sender is detected as deadlock
             with pytest.raises(RuntimeError, match="Deadlock detected"):

--- a/test/sim/test_greenlet_scheduler.py
+++ b/test/sim/test_greenlet_scheduler.py
@@ -10,11 +10,11 @@ import pytest
 from sim.blockstate import ThreadType
 from sim.greenlet_scheduler import (
     GreenletScheduler,
-    KernelThreadId,
+    KernelId,
     block_if_needed,
     get_scheduler,
     get_scheduler_algorithm,
-    kernel_thread_display_name,
+    kernel_display_name,
     set_scheduler,
     set_scheduler_algorithm,
 )
@@ -62,8 +62,8 @@ class TestGreenletScheduler:
         def thread2() -> None:
             executed.append("thread2")
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-        scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
         set_scheduler(scheduler)
         try:
@@ -75,23 +75,49 @@ class TestGreenletScheduler:
         assert "thread2" in executed
 
     def test_kernel_thread_id_rejects_invalid_values(self) -> None:
-        """KernelThreadId validates linear core and suffix."""
+        """KernelId validates linear core and func_name."""
 
         def fn() -> None:
             pass
 
         with pytest.raises(ValueError, match="non-negative"):
-            KernelThreadId(-1, "a")
+            KernelId(-1, ThreadType.COMPUTE, "a")
 
         with pytest.raises(ValueError, match="non-empty"):
-            KernelThreadId(0, "")
+            KernelId(0, ThreadType.COMPUTE, "")
 
         scheduler = GreenletScheduler()
-        scheduler.add_thread(KernelThreadId(0, "role"), fn, ThreadType.COMPUTE)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "role"), fn)
 
-    def test_kernel_thread_display_name_matches_program_convention(self) -> None:
+    def test_add_thread_rejects_duplicate_func_name_on_same_core(self) -> None:
+        """Two DM kernels with the same __name__ on the same core is rejected.
+
+        This is the registration-time enforcement of the uniqueness invariant
+        that ``KernelId`` relies on: identity is
+        ``(linear_core, kind, func_name)``, and two registrations with the same
+        triple would silently collide in the scheduler's dict otherwise.
+        """
+
+        def dm_a() -> None:
+            pass
+
+        def dm_b() -> None:
+            pass
+
+        scheduler = GreenletScheduler()
+        scheduler.add_thread(KernelId(0, ThreadType.DM, "reader"), dm_a)
+        with pytest.raises(RuntimeError, match="Duplicate kernel registration"):
+            scheduler.add_thread(KernelId(0, ThreadType.DM, "reader"), dm_b)
+
+        # Different core: allowed.
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "reader"), dm_b)
+        # Different kind on same core: allowed (compute vs DM).
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "reader"), dm_a)
+
+    def test_kernel_display_name_matches_program_convention(self) -> None:
         assert (
-            kernel_thread_display_name(KernelThreadId(3, "compute")) == "core3-compute"
+            kernel_display_name(KernelId(3, ThreadType.COMPUTE, "compute"))
+            == "core3-compute"
         )
 
     def test_thread_completion_tracking(self) -> None:
@@ -105,8 +131,8 @@ class TestGreenletScheduler:
         def thread2() -> None:
             completed.append("t2")
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-        scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
         set_scheduler(scheduler)
         try:
@@ -136,8 +162,8 @@ class TestGreenletScheduler:
             mock_obj.make_ready()
             execution_order.append("t2-end")
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-        scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
         set_scheduler(scheduler)
         try:
@@ -157,9 +183,7 @@ class TestGreenletScheduler:
             # This will block forever
             do_wait(mock_obj)
 
-        scheduler.add_thread(
-            KernelThreadId(0, "t1"), blocked_thread, ThreadType.COMPUTE
-        )
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), blocked_thread)
 
         set_scheduler(scheduler)
         try:
@@ -180,8 +204,8 @@ class TestGreenletScheduler:
         def thread2() -> None:
             do_reserve(mock2)
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-        scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
         set_scheduler(scheduler)
         try:
@@ -197,9 +221,7 @@ class TestGreenletScheduler:
         def failing_thread() -> None:
             raise ValueError("Test error")
 
-        scheduler.add_thread(
-            KernelThreadId(0, "t1"), failing_thread, ThreadType.COMPUTE
-        )
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), failing_thread)
 
         set_scheduler(scheduler)
         try:
@@ -229,8 +251,8 @@ class TestGreenletScheduler:
             do_wait(mock2)
             execution_order.append("t2-3")
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-        scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
         set_scheduler(scheduler)
         try:
@@ -262,7 +284,7 @@ class TestGreenletScheduler:
             do_wait(mock_obj)
             executed.append("after")
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread, ThreadType.COMPUTE)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread)
 
         set_scheduler(scheduler)
         try:
@@ -288,8 +310,8 @@ class TestGreenletScheduler:
             executed.append("t2")
             mock_obj.make_ready()
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-        scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
         set_scheduler(scheduler)
         try:
@@ -315,7 +337,7 @@ class TestGreenletScheduler:
                 do_wait(mock_obj)
                 count.append(i)
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread, ThreadType.COMPUTE)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread)
 
         set_scheduler(scheduler)
         try:
@@ -333,7 +355,7 @@ class TestGreenletScheduler:
             executed.append("done")
 
         scheduler = GreenletScheduler()
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread, ThreadType.COMPUTE)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread)
 
         set_scheduler(scheduler)
         try:
@@ -364,8 +386,8 @@ class TestBlockIfNeeded:
         def thread2() -> None:
             mock_obj.make_ready()
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-        scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+        scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
         set_scheduler(scheduler)
         try:
@@ -388,7 +410,7 @@ class TestBlockIfNeeded:
             do_reserve(mock_obj)
             executed.append(3)
 
-        scheduler.add_thread(KernelThreadId(0, "t1"), thread, ThreadType.COMPUTE)
+        scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread)
 
         set_scheduler(scheduler)
         try:
@@ -438,8 +460,8 @@ class TestSchedulerAlgorithm:
                 execution_order.append("t2-1")
                 execution_order.append("t2-2")
 
-            scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-            scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.DM)
+            scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+            scheduler.add_thread(KernelId(1, ThreadType.DM, "t2"), thread2)
 
             set_scheduler(scheduler)
             try:
@@ -477,9 +499,9 @@ class TestSchedulerAlgorithm:
                 mock_obj1.make_ready()
                 mock_obj2.make_ready()
 
-            scheduler.add_thread(KernelThreadId(0, "t1"), thread1, ThreadType.COMPUTE)
-            scheduler.add_thread(KernelThreadId(1, "t2"), thread2, ThreadType.COMPUTE)
-            scheduler.add_thread(KernelThreadId(2, "t3"), thread3, ThreadType.DM)
+            scheduler.add_thread(KernelId(0, ThreadType.COMPUTE, "t1"), thread1)
+            scheduler.add_thread(KernelId(1, ThreadType.COMPUTE, "t2"), thread2)
+            scheduler.add_thread(KernelId(2, ThreadType.DM, "t3"), thread3)
 
             set_scheduler(scheduler)
             try:


### PR DESCRIPTION
Kernel Ids now carry an enum for the type and the wrapped function's name