### PR TITLE
ttlverifypipenetguards.cpp: fix false-positive cycle on mutually exclusive scf.if branches

### DIFF
--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -1431,6 +1431,74 @@ void emitPipeScheduleCycleDiagnostic(ArrayRef<PipeScheduleNode> nodes,
   state.sawError = true;
 }
 
+// Maps (funcOp, coord.x, coord.y) to the last pipe schedule node id seen
+// along the current execution path.
+using ProgramOrderFrontier = llvm::DenseMap<ProgramPointIdentity, unsigned>;
+
+static void buildProgramOrderEdgesInOps(
+    Block &block, SmallVectorImpl<PipeScheduleNode> &nodes,
+    const llvm::DenseMap<PipeNodeIdentity, unsigned> &nodeIds,
+    ProgramOrderFrontier &frontier, func::FuncOp funcOp);
+
+static void buildProgramOrderEdgesInRegion(
+    Region &region, SmallVectorImpl<PipeScheduleNode> &nodes,
+    const llvm::DenseMap<PipeNodeIdentity, unsigned> &nodeIds,
+    ProgramOrderFrontier &frontier, func::FuncOp funcOp) {
+  for (Block &block : region.getBlocks()) {
+    buildProgramOrderEdgesInOps(block, nodes, nodeIds, frontier, funcOp);
+  }
+}
+
+static void buildProgramOrderEdgesInOps(
+    Block &block, SmallVectorImpl<PipeScheduleNode> &nodes,
+    const llvm::DenseMap<PipeNodeIdentity, unsigned> &nodeIds,
+    ProgramOrderFrontier &frontier, func::FuncOp funcOp) {
+  for (Operation &op : block.getOperations()) {
+    // Give each branch its own frontier copy so no ProgramOrder edge is added
+    // between sibling regions. Merge both exits afterward.
+    if (auto ifOp = llvm::dyn_cast<scf::IfOp>(op)) {
+      ProgramOrderFrontier thenFrontier = frontier;
+      buildProgramOrderEdgesInRegion(ifOp.getThenRegion(), nodes, nodeIds,
+                                     thenFrontier, funcOp);
+      ProgramOrderFrontier elseFrontier = frontier;
+      if (!ifOp.getElseRegion().empty()) {
+        buildProgramOrderEdgesInRegion(ifOp.getElseRegion(), nodes, nodeIds,
+                                       elseFrontier, funcOp);
+      }
+      frontier = std::move(thenFrontier);
+      for (auto &[key, id] : elseFrontier) {
+        frontier.insert({key, id});
+      }
+      continue;
+    }
+
+    // Recurse into non-if regions with the shared frontier.
+    for (Region &nested : op.getRegions()) {
+      buildProgramOrderEdgesInRegion(nested, nodes, nodeIds, frontier, funcOp);
+    }
+
+    // Add ProgramOrder edges for each node owned by this op. An op can map to
+    // multiple nodes (one per active coord), so scan all three node kinds.
+    for (int k = 0; k < 3; ++k) {
+      auto kind = static_cast<PipeScheduleNodeKind>(k);
+      for (unsigned idx = 0, end = nodes.size(); idx < end; ++idx) {
+        PipeScheduleNode &node = nodes[idx];
+        if (node.op != &op || node.kind != kind) {
+          continue;
+        }
+        ProgramPointIdentity programPoint{funcOp.getOperation(), node.coord.x,
+                                          node.coord.y};
+        auto lastIt = frontier.find(programPoint);
+        if (lastIt != frontier.end() && lastIt->second != idx) {
+          addPipeScheduleEdge(nodes, lastIt->second, idx,
+                              PipeScheduleEdgeKind::ProgramOrder);
+        }
+        frontier[programPoint] = idx;
+      }
+    }
+  }
+}
+
 // Verify the hidden rendezvous introduced by receiver-advertised pipe lowering.
 // Receive-side ttl.copy publishes the address; ttl.wait on that handle waits
 // for completion. Modeling those as distinct events preserves async copy
@@ -1441,36 +1509,29 @@ void verifyPipeScheduleCycles(ModuleOp module, ModuleState &state) {
   llvm::DenseMap<PipeNodeIdentity, unsigned> nodeIds;
   llvm::DenseMap<PipeCoordIdentity, SmallVector<unsigned>> receivePostNodes;
   llvm::DenseMap<PipeCoordIdentity, SmallVector<unsigned>> receiveWaitNodes;
-  llvm::DenseMap<ProgramPointIdentity, unsigned> lastCompletionNodes;
 
+  // Pass 1: collect all pipe schedule nodes using a flat walk. No ProgramOrder
+  // edges are built here so that the CFG-aware pass can add them correctly.
   module.walk([&](Operation *op) {
     auto eventIt = state.pipeEventIndices.find(op);
     if (eventIt == state.pipeEventIndices.end()) {
       return;
     }
-    PipeEvent event = state.pipeEvents[eventIt->second];
+    const PipeEvent &event = state.pipeEvents[eventIt->second];
     if (!event.domain.known || event.domain.nodes.empty()) {
       return;
     }
-
-    auto funcOp = op->getParentOfType<func::FuncOp>();
-    if (!funcOp) {
-      return;
-    }
-
     for (Coord coord : event.domain.nodes) {
-      PipeScheduleNodeKind nodeKind;
+      PipeScheduleNodeKind kind;
       if (event.kind == PipeEventKind::Send) {
-        nodeKind = PipeScheduleNodeKind::Send;
+        kind = PipeScheduleNodeKind::Send;
       } else if (event.kind == PipeEventKind::ReceivePost) {
-        nodeKind = PipeScheduleNodeKind::ReceivePost;
+        kind = PipeScheduleNodeKind::ReceivePost;
       } else {
-        nodeKind = PipeScheduleNodeKind::ReceiveWait;
+        kind = PipeScheduleNodeKind::ReceiveWait;
       }
-
-      unsigned nodeId = addPipeScheduleNode(nodes, nodeIds, op, event.pipeType,
-                                            coord, nodeKind);
-
+      unsigned nodeId =
+          addPipeScheduleNode(nodes, nodeIds, op, event.pipeType, coord, kind);
       if (event.kind == PipeEventKind::Send) {
         sendNodes.push_back({nodeId, event.pipeType});
       } else if (event.kind == PipeEventKind::ReceivePost) {
@@ -1480,16 +1541,15 @@ void verifyPipeScheduleCycles(ModuleOp module, ModuleState &state) {
         receiveWaitNodes[getPipeCoordIdentity(event.pipeType, coord)].push_back(
             nodeId);
       }
-
-      ProgramPointIdentity programPoint{funcOp.getOperation(), coord.x,
-                                        coord.y};
-      auto lastIt = lastCompletionNodes.find(programPoint);
-      if (lastIt != lastCompletionNodes.end()) {
-        addPipeScheduleEdge(nodes, lastIt->second, nodeId,
-                            PipeScheduleEdgeKind::ProgramOrder);
-      }
-      lastCompletionNodes[programPoint] = nodeId;
     }
+  });
+
+  // Pass 2: CFG-aware traversal to add ProgramOrder edges. Each function
+  // gets a fresh frontier so order is local to each kernel-thread function.
+  module.walk([&](func::FuncOp funcOp) {
+    ProgramOrderFrontier frontier;
+    buildProgramOrderEdgesInRegion(funcOp.getBody(), nodes, nodeIds, frontier,
+                                   funcOp);
   });
 
   for (auto [sendNode, pipeType] : sendNodes) {

--- a/test/python/test_pipenet_scf_if_branch.py
+++ b/test/python/test_pipenet_scf_if_branch.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: %python -m pytest %s -v
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl
+
+
+@ttl.operation(grid=(1, 1))
+def _if_branch_pipe(inp, out):
+    """
+    Creates a loopback pipe and places send/recv wait operations in
+    mutually exclusive scf.if branches to test the PipeNet verifier
+    false-positive cycle bug.
+    """
+    net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(0, 0))])
+
+    inp_cb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        with inp_cb.wait() as t, out_cb.reserve() as o:
+            o.store(t)
+
+    @ttl.datamovement()
+    def dm_read():
+        x, y = ttl.node(dims=2)
+
+        # Generates an scf.if in the MLIR.
+        if x == 0:
+
+            def send(pipe):
+                with inp_cb.reserve() as blk:
+                    ttl.copy(inp[0, 0], blk).wait()
+                    ttl.copy(blk, pipe).wait()
+
+            net.if_src(send)
+
+            def recv(pipe):
+                with out_cb.reserve() as blk:
+                    ttl.copy(pipe, blk).wait()
+                    ttl.copy(blk, out[0, 0]).wait()
+
+            net.if_dst(recv)
+        else:
+
+            def send(pipe):
+                with inp_cb.reserve() as blk:
+                    ttl.copy(inp[0, 0], blk).wait()
+                    ttl.copy(blk, pipe).wait()
+
+            net.if_src(send)
+
+            def recv(pipe):
+                with out_cb.reserve() as blk:
+                    ttl.copy(pipe, blk).wait()
+                    ttl.copy(blk, out[0, 0]).wait()
+
+            net.if_dst(recv)
+
+    @ttl.datamovement()
+    def dm_write():
+        pass
+
+
+def test_pipenet_scf_if_no_cycle(device):
+    """
+    Ensures that compiling a kernel with pipe operations inside
+    sibling scf.if branches does not fail the verifier cycle check.
+    """
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    out = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Just defining/compiling the operation triggers the verifier pass.
+    # The fix ensures this does not throw a compile error.
+    _if_branch_pipe(inp, out)

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_if_branch.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_if_branch.mlir
@@ -1,0 +1,127 @@
+// RUN: ttlang-opt %s --split-input-file -ttl-verify-pipenet-guards | FileCheck %s
+
+// Summary: Verifies that ttl-verify-pipenet-guards does not report a false
+// wait-for cycle when pipe events appear in mutually exclusive scf.if branches.
+
+// -----
+
+// A runtime-flag scf.if has a locally valid loopback schedule in each branch.
+// No ProgramOrder edge should cross sibling branches, so no cycle is formed.
+//
+// CHECK-LABEL: func.func @if_branch_no_false_cycle
+// CHECK-NOT: pipe schedule contains a wait-for cycle
+// CHECK-NOT: receive wait occurs before the send that completes it
+// CHECK-NOT: pipe send occurs before the receiver publishes a destination address
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @if_branch_no_false_cycle(%runtime_flag: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %pipe = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 0) net 0
+        {pipeNetName = "net"}
+        : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>
+    %send_cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %recv_cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %runtime_flag {
+      %recv_reserve = ttl.cb_reserve %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %recv_view = ttl.attach_cb %recv_reserve, %recv_cb
+          : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %recv = ttl.copy %pipe, %recv_view
+          : (!ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>,
+             tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> !ttl.transfer_handle
+      %send = ttl.copy %send_cb, %pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+             !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+      ttl.wait %recv : !ttl.transfer_handle
+    } else {
+      %recv_reserve = ttl.cb_reserve %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %recv_view = ttl.attach_cb %recv_reserve, %recv_cb
+          : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %recv = ttl.copy %pipe, %recv_view
+          : (!ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>,
+             tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> !ttl.transfer_handle
+      %send = ttl.copy %send_cb, %pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+             !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+      ttl.wait %recv : !ttl.transfer_handle
+    }
+    func.return
+  }
+}
+
+// -----
+
+// Nested scf.if: the fix extends to multiple nesting levels.
+//
+// CHECK-LABEL: func.func @nested_if_no_false_cycle
+// CHECK-NOT: pipe schedule contains a wait-for cycle
+// CHECK-NOT: receive wait occurs before the send that completes it
+// CHECK-NOT: pipe send occurs before the receiver publishes a destination address
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @nested_if_no_false_cycle(%flag_a: i1, %flag_b: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %pipe = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 0) net 0
+        {pipeNetName = "net"}
+        : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>
+    %send_cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %recv_cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %flag_a {
+      scf.if %flag_b {
+        %recv_reserve = ttl.cb_reserve %recv_cb
+            : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        %recv_view = ttl.attach_cb %recv_reserve, %recv_cb
+            : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+               !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        %recv = ttl.copy %pipe, %recv_view
+            : (!ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>,
+               tensor<1x1x!ttcore.tile<32x32, bf16>>)
+            -> !ttl.transfer_handle
+        %send = ttl.copy %send_cb, %pipe
+            : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+               !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>)
+            -> !ttl.transfer_handle<write>
+        ttl.wait %send : !ttl.transfer_handle<write>
+        ttl.wait %recv : !ttl.transfer_handle
+      } else {
+        %recv_reserve = ttl.cb_reserve %recv_cb
+            : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        %recv_view = ttl.attach_cb %recv_reserve, %recv_cb
+            : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+               !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        %recv = ttl.copy %pipe, %recv_view
+            : (!ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>,
+               tensor<1x1x!ttcore.tile<32x32, bf16>>)
+            -> !ttl.transfer_handle
+        %send = ttl.copy %send_cb, %pipe
+            : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+               !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>)
+            -> !ttl.transfer_handle<write>
+        ttl.wait %send : !ttl.transfer_handle<write>
+        ttl.wait %recv : !ttl.transfer_handle
+      }
+    }
+    func.return
+  }
+}


### PR DESCRIPTION
### Problem description

`verifyPipeScheduleCycles` used a flat `module.walk` to build `ProgramOrder`
edges between pipe events. The frontier key `(funcOp, coord.x, coord.y)` had
no knowledge of control flow, so the last event in the then-branch of an
`scf.if` became the predecessor of the first event in the else-branch. That
spurious edge created a false cycle on loopback pipes where both branches
contained a locally valid schedule.

Reproducer: a 1x1 grid, single loopback pipe, both branches of `scf.if` do
post-receive / send / wait-send / wait-receive. Each branch is valid on its
own, but the verifier reported "receive wait occurs before the send that
completes it" because it incorrectly ordered the then-branch's wait before
the else-branch's send.

### What's changed

Split `verifyPipeScheduleCycles` into two passes:

1. Flat `module.walk` to collect `PipeScheduleNode` entries (unchanged
   behavior).
2. CFG-aware traversal (`buildProgramOrderEdgesInRegion`) that tracks a
   frontier map of `(funcOp, coord) -> last node id`. On `scf.if`, each
   branch receives an independent copy of the frontier so no `ProgramOrder`
   edge is ever added between sibling branches. The post-if frontier is the
   union of both branch exits.

Added `verify_pipenet_schedule_if_branch.mlir` with two positive tests
(the exact reproducer and a nested-if variant) using `CHECK-NOT` to confirm
no false-positive diagnostic is emitted.

### Checklist
- [x] New/Existing tests provide coverage for changes

THis will fix the issue #630 
