### PR TITLE
dfb: add DataflowBuffer.peek() for non-popping reads to enable multi-pass tile reuse without DRAM reloads or intermediate buffers

### DIFF
--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -1282,10 +1282,10 @@ class TTLGenericCompiler(TTCompilerBase):
             method_name = context_expr.func.attr
             cb_node = context_expr.func.value
 
-            if method_name not in ("reserve", "wait"):
+            if method_name not in ("reserve", "wait", "peek"):
                 self._raise_error(
                     context_expr,
-                    f"'with' only supports 'reserve()' or 'wait()', got '{method_name}'",
+                    f"'with' only supports 'reserve()', 'wait()', or 'peek()', got '{method_name}'",
                 )
 
             if not isinstance(cb_node, ast.Name):
@@ -1299,7 +1299,7 @@ class TTLGenericCompiler(TTCompilerBase):
                 self._raise_error(cb_node, f"'{cb_node.id}' not found in scope")
             cb_val = cb_table[cb_node.id]
 
-            # Get tensor type from CB for reserve/wait result
+            # Get tensor type from CB for reserve/wait/peek result
             tensor_type = self._get_cb_tensor_type(cb_val, node=context_expr)
             if method_name == "reserve":
                 tensor = self._emit_op_signposts(
@@ -1308,13 +1308,19 @@ class TTLGenericCompiler(TTCompilerBase):
                     lambda tt=tensor_type, cv=cb_val: ttl.cb_reserve(tt, cv),
                 )
                 releases.append(("cb_push", ttl.cb_push, cb_val, context_expr))
-            else:  # wait
+            elif method_name == "wait":
                 tensor = self._emit_op_signposts(
                     "cb_wait",
                     context_expr,
                     lambda tt=tensor_type, cv=cb_val: ttl.cb_wait(tt, cv),
                 )
                 releases.append(("cb_pop", ttl.cb_pop, cb_val, context_expr))
+            else:  # peek -- wait without releasing the slot
+                tensor = self._emit_op_signposts(
+                    "cb_wait",
+                    context_expr,
+                    lambda tt=tensor_type, cv=cb_val: ttl.cb_wait(tt, cv),
+                )
 
             # Attach CB to tensor so store() can find the CB association
             acquire_result = ttl.attach_cb(tensor.type, tensor, cb_val)

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -81,16 +81,39 @@ class DataflowBuffer:
         """
         Wait for data from the dataflow buffer (consumer acquire).
 
-        Use in consumer threads to acquire data. Must be followed by pop()
-        to signal consumption is complete.
+        Use in consumer threads to acquire data. Emits cb_pop when the
+        with-block exits, returning the slot to the producer.
+        Use peek() instead when the same block must be read more than once.
 
         Returns:
             TensorBlock: The acquired data with DFB association.
 
         Example:
-            block = dfb.wait()
-            result = compute(block)
-            block.pop()
+            with dfb.wait() as block:
+                result = compute(block)
+        """
+        tensor_type = _get_cb_tensor_type(ast_self)
+        tensor = ttl.cb_wait(tensor_type, ast_self)
+        return ttl.attach_cb(tensor.type, tensor, ast_self)
+
+    def peek(ast_self: "DataflowBuffer") -> "TensorBlock":
+        """
+        Wait for data from the dataflow buffer without releasing the slot.
+
+        Like wait(), but no cb_pop is emitted when the with-block exits.
+        Use this when the same block must be read more than once before
+        signalling consumption to the producer (e.g., reduce first, then
+        element-wise scale). The caller is responsible for eventually
+        calling pop() once all reads are complete.
+
+        Returns:
+            TensorBlock: The acquired data with DFB association.
+
+        Example:
+            with dfb.peek() as block:
+                scalar = ttl.reduce(block, ...)   # first pass
+            with dfb.wait() as block:             # second pass + auto pop
+                result = ttl.mul(block, scalar)
         """
         tensor_type = _get_cb_tensor_type(ast_self)
         tensor = ttl.cb_wait(tensor_type, ast_self)


### PR DESCRIPTION
### Problem description

Kernels that need to iterate over the same tiles more than once (e.g., rmsnorm backward: reduce_sum first, then element-wise
multiply each tile by the reciprocal) currently have two options: re-read the block from DRAM a second time, or allocate an intermediate buffer to hold the data. Both are wasteful.

On TT-Metal hardware, cb_wait_front(n) is idempotent -- calling it a second time without an intervening cb_pop_front simply returns immediately if the tiles are still present. This property can be exposed safely at the ttl level.

### What's changed

Added DataflowBuffer.peek(). Like wait(), it emits ttl.cb_wait. Unlike wait(), the with-block exit does not auto-insert ttl.cb_pop.
The slot is held until the caller issues a subsequent wait() (which does pop) or an explicit pop.

The typical pattern for a two-pass kernel:

    with inp_cb.peek() as blk:       # first pass, slot held
        scalar = ttl.reduce(blk, ...) 
    with inp_cb.wait() as blk:       # second pass, auto pop on exit
        o.store(ttl.mul(blk, scalar))

Changes:
- python/ttl/dataflow_buffer.py: add DataflowBuffer.peek()
- python/ttl/_src/ttl_ast.py: extend with-block handler to accept
  "peek" and skip the cb_pop release entry

### Checklist
- [ ] New/Existing tests provide coverage for changes

