### PR TITLE
[ci] Minor S3 PyPI workflow enhancements

### DIFF
--- a/.github/scripts/check-tt-metal-version.sh
+++ b/.github/scripts/check-tt-metal-version.sh
@@ -20,6 +20,10 @@
 
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/tt-metal-version-utils.sh
+. "$script_dir/lib/tt-metal-version-utils.sh"
+
 ROOT=$(git rev-parse --show-toplevel)
 VERSION_FILE="$ROOT/third-party/tt-metal-version"
 DOCKERFILE="$ROOT/.github/containers/Dockerfile.base"
@@ -29,12 +33,7 @@ TT_METAL_REMOTE="https://github.com/tenstorrent/tt-metal"
 UPDATE=0
 [[ "${1:-}" == "--update" ]] && UPDATE=1
 
-[[ -f "$VERSION_FILE" ]] || { echo "missing $VERSION_FILE" >&2; exit 1; }
-# shellcheck source=../../third-party/tt-metal-version
-. "$VERSION_FILE"
-: "${TT_METAL_TAG:?$VERSION_FILE: TT_METAL_TAG not set}"
-: "${TTNN_PYPI:?$VERSION_FILE: TTNN_PYPI not set}"
-: "${TTNN_PYPI_TT_METAL_TAG:?$VERSION_FILE: TTNN_PYPI_TT_METAL_TAG not set}"
+load_tt_metal_version "$VERSION_FILE"
 TAG="$TT_METAL_TAG"
 PYPI="$TTNN_PYPI"
 PYPI_TAG="$TTNN_PYPI_TT_METAL_TAG"

--- a/.github/scripts/lib/tt-metal-version-utils.sh
+++ b/.github/scripts/lib/tt-metal-version-utils.sh
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sourceable helpers for reading third-party/tt-metal-version, the single
+# source of truth for the tt-metal release tag (TT_METAL_TAG), the public ttnn
+# wheel version (TTNN_PYPI), and the tt-metal tag that ttnn wheel was built from
+# (TTNN_PYPI_TT_METAL_TAG).
+#
+# This is library code for the workflow scripts; it is not the version file
+# itself. Source it; do not execute it. To change tt-metal pinning, edit
+# third-party/tt-metal-version instead.
+
+# Resolve the version-file path. Honors $TTLANG_TT_METAL_VERSION_FILE so tests
+# can point at a synthetic file; otherwise uses <repo-root>/third-party/tt-metal-version.
+tt_metal_version_file() {
+    if [[ -n "${TTLANG_TT_METAL_VERSION_FILE:-}" ]]; then
+        printf '%s\n' "$TTLANG_TT_METAL_VERSION_FILE"
+        return 0
+    fi
+    printf '%s/third-party/tt-metal-version\n' "$(git rev-parse --show-toplevel)"
+}
+
+# Source the version file and require its three fields, defining TT_METAL_TAG,
+# TTNN_PYPI, and TTNN_PYPI_TT_METAL_TAG in the caller's scope. Pass an explicit
+# file to bypass tt_metal_version_file resolution.
+load_tt_metal_version() {
+    local version_file="${1:-}"
+    [[ -n "$version_file" ]] || version_file="$(tt_metal_version_file)"
+    [[ -f "$version_file" ]] || { echo "missing $version_file" >&2; return 1; }
+    # shellcheck source=/dev/null
+    . "$version_file"
+    : "${TT_METAL_TAG:?$version_file: TT_METAL_TAG not set}"
+    : "${TTNN_PYPI:?$version_file: TTNN_PYPI not set}"
+    : "${TTNN_PYPI_TT_METAL_TAG:?$version_file: TTNN_PYPI_TT_METAL_TAG not set}"
+}
+
+# True when the public ttnn wheel was built from the same tt-metal tag this
+# release builds against. Requires load_tt_metal_version to have run.
+ttnn_pypi_aligned() {
+    [[ "$TTNN_PYPI_TT_METAL_TAG" == "$TT_METAL_TAG" ]]
+}

--- a/.github/scripts/prepare-s3-publish-dist.sh
+++ b/.github/scripts/prepare-s3-publish-dist.sh
@@ -2,17 +2,17 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Verify mode-specific wheel artifact directories and copy their wheels into a
-# single publish directory. A spec has the form <mode>[:no-sim]=<dist_dir>.
+# Verify variant-specific wheel artifact directories and copy their wheels into
+# a single publish directory. A spec has the form <variant>[:no-sim]=<dist_dir>.
 # Use `:no-sim` when the same workflow run publishes bundled wheels and the
-# external artifact intentionally omits the duplicate tt-lang-sim wheel.
+# light artifact intentionally omits the duplicate tt-lang-sim wheel.
 #
 # Usage: prepare-s3-publish-dist.sh <version_override> <publish_dir> <spec>...
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <version_override> <publish_dir> <mode[:no-sim]=dist_dir>..." >&2
+    echo "Usage: $0 <version_override> <publish_dir> <variant[:no-sim]=dist_dir>..." >&2
     exit 2
 }
 
@@ -39,21 +39,21 @@ for spec in "$@"; do
     if [[ "$spec" != *=* ]]; then
         usage
     fi
-    mode_spec="${spec%%=*}"
+    variant_spec="${spec%%=*}"
     artifact_dir="${spec#*=}"
     verify_args=()
 
-    if [[ "$mode_spec" == *:no-sim ]]; then
+    if [[ "$variant_spec" == *:no-sim ]]; then
         verify_args+=(--no-sim)
-        mode="${mode_spec%:no-sim}"
+        variant="${variant_spec%:no-sim}"
     else
-        mode="$mode_spec"
+        variant="$variant_spec"
     fi
 
-    case "$mode" in
-        pypi | external | bundled) ;;
+    case "$variant" in
+        pypi | light | bundled) ;;
         *)
-            echo "Unknown ttnn dependency mode: $mode" >&2
+            echo "Unknown wheel variant: $variant" >&2
             exit 2
             ;;
     esac
@@ -65,7 +65,7 @@ for spec in "$@"; do
 
     "$script_dir/verify-s3-wheel-versions.sh" \
         "${verify_args[@]}" \
-        "$mode" \
+        "$variant" \
         "$version" \
         "$artifact_dir"
 

--- a/.github/scripts/prepare-s3-publish-dist.sh
+++ b/.github/scripts/prepare-s3-publish-dist.sh
@@ -44,8 +44,12 @@ for spec in "$@"; do
     verify_args=()
 
     if [[ "$variant_spec" == *:no-sim ]]; then
-        verify_args+=(--no-sim)
         variant="${variant_spec%:no-sim}"
+        if [[ "$variant" != light ]]; then
+            echo ":no-sim is only valid for the light variant: $spec" >&2
+            exit 2
+        fi
+        verify_args+=(--no-sim)
     else
         variant="$variant_spec"
     fi

--- a/.github/scripts/prepare-s3-publish-dist.sh
+++ b/.github/scripts/prepare-s3-publish-dist.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify mode-specific wheel artifact directories and copy their wheels into a
+# single publish directory. A spec has the form <mode>[:no-sim]=<dist_dir>.
+# Use `:no-sim` when the same workflow run publishes bundled wheels and the
+# external artifact intentionally omits the duplicate tt-lang-sim wheel.
+#
+# Usage: prepare-s3-publish-dist.sh <version_override> <publish_dir> <spec>...
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <version_override> <publish_dir> <mode[:no-sim]=dist_dir>..." >&2
+    exit 2
+}
+
+if [[ $# -lt 3 ]]; then
+    usage
+fi
+
+version="$1"
+publish_dir="$2"
+shift 2
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$publish_dir" in
+    "" | "." | "/")
+        echo "Unsafe publish directory: $publish_dir" >&2
+        exit 2
+        ;;
+esac
+
+rm -rf "$publish_dir"
+mkdir -p "$publish_dir"
+
+for spec in "$@"; do
+    if [[ "$spec" != *=* ]]; then
+        usage
+    fi
+    mode_spec="${spec%%=*}"
+    artifact_dir="${spec#*=}"
+    verify_args=()
+
+    if [[ "$mode_spec" == *:no-sim ]]; then
+        verify_args+=(--no-sim)
+        mode="${mode_spec%:no-sim}"
+    else
+        mode="$mode_spec"
+    fi
+
+    case "$mode" in
+        pypi | external | bundled) ;;
+        *)
+            echo "Unknown ttnn dependency mode: $mode" >&2
+            exit 2
+            ;;
+    esac
+
+    if [[ ! -d "$artifact_dir" ]]; then
+        echo "Wheel artifact directory not found: $artifact_dir" >&2
+        exit 1
+    fi
+
+    "$script_dir/verify-s3-wheel-versions.sh" \
+        "${verify_args[@]}" \
+        "$mode" \
+        "$version" \
+        "$artifact_dir"
+
+    shopt -s nullglob
+    wheels=("$artifact_dir"/*.whl)
+    shopt -u nullglob
+    if [[ "${#wheels[@]}" -eq 0 ]]; then
+        echo "No wheels found under $artifact_dir" >&2
+        exit 1
+    fi
+
+    for wheel in "${wheels[@]}"; do
+        wheel_name="$(basename "$wheel")"
+        target="$publish_dir/$wheel_name"
+        if [[ -e "$target" ]]; then
+            echo "Duplicate wheel filename across S3 publish artifacts: $wheel_name" >&2
+            exit 1
+        fi
+        cp "$wheel" "$target"
+    done
+done

--- a/.github/scripts/publish-s3-summary.sh
+++ b/.github/scripts/publish-s3-summary.sh
@@ -30,6 +30,14 @@ if [[ "$dry_run" -eq 1 ]]; then
     summary_title="### Wheel publish dry run"
 fi
 
+case "$mode" in
+    external | bundled-and-external | bundled | pypi) ;;
+    *)
+        echo "Unknown S3 wheel selection: $mode" >&2
+        exit 2
+        ;;
+esac
+
 emit() {
     if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
         cat >> "$GITHUB_STEP_SUMMARY"
@@ -57,7 +65,26 @@ EOF
 
 emit_header
 
-if [[ "$mode" == "external" ]]; then
+emit_ttlang_install() {
+    local heading="$1"
+    local package_spec="$2"
+    if [[ -n "$heading" ]]; then
+        emit <<EOF
+$heading
+
+EOF
+    fi
+    emit <<EOF
+\`\`\`bash
+pip install \\
+  --extra-index-url $index_url \\
+  --extra-index-url $pytorch_url \\
+  $package_spec
+\`\`\`
+EOF
+}
+
+emit_light_install() {
     emit <<EOF
 Light install:
 
@@ -77,13 +104,20 @@ pip install \\
   tt-lang==$version+light
 \`\`\`
 EOF
-else
-    emit <<EOF
-\`\`\`bash
-pip install \\
-  --extra-index-url $index_url \\
-  --extra-index-url $pytorch_url \\
-  tt-lang==$version
-\`\`\`
+}
+
+case "$mode" in
+    external)
+        emit_light_install
+        ;;
+    bundled-and-external)
+        emit_ttlang_install "Bundled install:" "tt-lang==$version"
+        emit <<EOF
+
 EOF
-fi
+        emit_light_install
+        ;;
+    bundled | pypi)
+        emit_ttlang_install "" "tt-lang==$version"
+        ;;
+esac

--- a/.github/scripts/publish-s3-summary.sh
+++ b/.github/scripts/publish-s3-summary.sh
@@ -6,7 +6,7 @@
 # publish workflow. With --dry-run, record that no upload occurred. With no
 # $GITHUB_STEP_SUMMARY set, output goes to stdout for local invocations/tests.
 #
-# Usage: publish-s3-summary.sh [--dry-run] <ttnn_dep_mode> <version_override>
+# Usage: publish-s3-summary.sh [--dry-run] <wheel_variant> <version_override>
 
 set -euo pipefail
 
@@ -17,11 +17,11 @@ if [[ "${1:-}" == "--dry-run" ]]; then
 fi
 
 if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 [--dry-run] <ttnn_dep_mode> <version_override>" >&2
+    echo "Usage: $0 [--dry-run] <wheel_variant> <version_override>" >&2
     exit 2
 fi
 
-mode="$1"
+variant="$1"
 version="$2"
 index_url="https://pypi.eng.aws.tenstorrent.com/"
 pytorch_url="https://download.pytorch.org/whl/cpu"
@@ -30,10 +30,10 @@ if [[ "$dry_run" -eq 1 ]]; then
     summary_title="### Wheel publish dry run"
 fi
 
-case "$mode" in
-    external | bundled-and-external | bundled | pypi) ;;
+case "$variant" in
+    light | bundled-and-light | bundled | pypi) ;;
     *)
-        echo "Unknown S3 wheel selection: $mode" >&2
+        echo "Unknown S3 wheel variant: $variant" >&2
         exit 2
         ;;
 esac
@@ -95,7 +95,7 @@ pip install \\
   tt-lang-light==$version
 \`\`\`
 
-Underlying no-ttnn tt-lang wheel:
+Underlying light tt-lang wheel:
 
 \`\`\`bash
 pip install \\
@@ -106,11 +106,11 @@ pip install \\
 EOF
 }
 
-case "$mode" in
-    external)
+case "$variant" in
+    light)
         emit_light_install
         ;;
-    bundled-and-external)
+    bundled-and-light)
         emit_ttlang_install "Bundled install:" "tt-lang==$version"
         emit <<EOF
 

--- a/.github/scripts/require-pypi-ttnn-alignment.sh
+++ b/.github/scripts/require-pypi-ttnn-alignment.sh
@@ -7,18 +7,13 @@
 
 set -euo pipefail
 
-ROOT=$(git rev-parse --show-toplevel)
-VERSION_FILE="$ROOT/third-party/tt-metal-version"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/tt-metal-version-utils.sh
+. "$script_dir/lib/tt-metal-version-utils.sh"
 
-[[ -f "$VERSION_FILE" ]] || { echo "missing $VERSION_FILE" >&2; exit 1; }
+load_tt_metal_version
 
-# shellcheck source=../../third-party/tt-metal-version
-. "$VERSION_FILE"
-: "${TTNN_PYPI:?$VERSION_FILE: TTNN_PYPI not set}"
-: "${TTNN_PYPI_TT_METAL_TAG:?$VERSION_FILE: TTNN_PYPI_TT_METAL_TAG not set}"
-: "${TT_METAL_TAG:?$VERSION_FILE: TT_METAL_TAG not set}"
-
-if [[ "$TTNN_PYPI_TT_METAL_TAG" != "$TT_METAL_TAG" ]]; then
+if ! ttnn_pypi_aligned; then
   cat >&2 <<EOF
 Public PyPI publish requires ttnn provenance to match TT_METAL_TAG.
 TTNN_PYPI=$TTNN_PYPI was built from TTNN_PYPI_TT_METAL_TAG=$TTNN_PYPI_TT_METAL_TAG,

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -12,13 +12,14 @@
 #   DISPATCH_DRY_RUN             "true"|"false" (workflow_dispatch input).
 #   DISPATCH_OVERWRITE_RELEASES  "true"|"false" (workflow_dispatch input).
 #   DISPATCH_VERSION_OVERRIDE    PEP 440 string, may be empty.
-#   DISPATCH_TTNN_DEP_MODE       pypi|external|bundled.
+#   DISPATCH_TTNN_DEP_MODE       pypi|external|bundled|bundled-and-external.
 #   EVENT_NAME                   github.event_name.
 #   GITHUB_OUTPUT                Path that receives the resolved outputs.
 #                                Falls back to stdout when unset.
 #
 # Outputs (written to $GITHUB_OUTPUT):
-#   docker_tag, dry_run, overwrite_releases, version_override, ttnn_dep_mode
+#   docker_tag, dry_run, overwrite_releases, version_override, ttnn_dep_mode,
+#   ttnn_dep_modes
 
 set -euo pipefail
 
@@ -31,6 +32,19 @@ dry_run="$DISPATCH_DRY_RUN"
 overwrite_releases="$DISPATCH_OVERWRITE_RELEASES"
 version_override="${DISPATCH_VERSION_OVERRIDE:-}"
 ttnn_dep_mode="$DISPATCH_TTNN_DEP_MODE"
+
+case "$ttnn_dep_mode" in
+    pypi | external | bundled)
+        ttnn_dep_modes="[\"$ttnn_dep_mode\"]"
+        ;;
+    bundled-and-external)
+        ttnn_dep_modes='["bundled","external"]'
+        ;;
+    *)
+        echo "Unknown S3 wheel selection: $ttnn_dep_mode" >&2
+        exit 2
+        ;;
+esac
 
 if [[ "$EVENT_NAME" == "schedule" ]]; then
     overwrite_releases=true
@@ -48,9 +62,11 @@ output_file="${GITHUB_OUTPUT:-/dev/stdout}"
     echo "overwrite_releases=$overwrite_releases"
     echo "version_override=$version_override"
     echo "ttnn_dep_mode=$ttnn_dep_mode"
+    echo "ttnn_dep_modes=$ttnn_dep_modes"
 } >> "$output_file"
 
 echo "Resolved ttnn_dep_mode=$ttnn_dep_mode"
+echo "Resolved ttnn_dep_modes=$ttnn_dep_modes"
 echo "Resolved version_override=$version_override"
 echo "Resolved dry_run=$dry_run"
 echo "Resolved overwrite_releases=$overwrite_releases"

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -12,36 +12,46 @@
 #   DISPATCH_DRY_RUN             "true"|"false" (workflow_dispatch input).
 #   DISPATCH_OVERWRITE_RELEASES  "true"|"false" (workflow_dispatch input).
 #   DISPATCH_VERSION_OVERRIDE    PEP 440 string, may be empty.
-#   DISPATCH_TTNN_DEP_MODE       pypi|external|bundled|bundled-and-external.
+#   DISPATCH_WHEEL_VARIANT       pypi|light|bundled|bundled-and-light.
 #   EVENT_NAME                   github.event_name.
 #   GITHUB_OUTPUT                Path that receives the resolved outputs.
 #                                Falls back to stdout when unset.
 #
 # Outputs (written to $GITHUB_OUTPUT):
-#   docker_tag, dry_run, overwrite_releases, version_override, ttnn_dep_mode,
-#   ttnn_dep_modes
+#   docker_tag, dry_run, overwrite_releases, version_override, wheel_variant,
+#   wheel_variants, wheel_matrix
 
 set -euo pipefail
 
 : "${DISPATCH_DRY_RUN:?DISPATCH_DRY_RUN is required}"
 : "${DISPATCH_OVERWRITE_RELEASES:?DISPATCH_OVERWRITE_RELEASES is required}"
-: "${DISPATCH_TTNN_DEP_MODE:?DISPATCH_TTNN_DEP_MODE is required}"
+: "${DISPATCH_WHEEL_VARIANT:?DISPATCH_WHEEL_VARIANT is required}"
 : "${EVENT_NAME:?EVENT_NAME is required}"
 docker_tag="${DISPATCH_DOCKER_TAG:-}"
 dry_run="$DISPATCH_DRY_RUN"
 overwrite_releases="$DISPATCH_OVERWRITE_RELEASES"
 version_override="${DISPATCH_VERSION_OVERRIDE:-}"
-ttnn_dep_mode="$DISPATCH_TTNN_DEP_MODE"
+wheel_variant="$DISPATCH_WHEEL_VARIANT"
 
-case "$ttnn_dep_mode" in
-    pypi | external | bundled)
-        ttnn_dep_modes="[\"$ttnn_dep_mode\"]"
+case "$wheel_variant" in
+    bundled)
+        wheel_variants='["bundled"]'
+        wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
         ;;
-    bundled-and-external)
-        ttnn_dep_modes='["bundled","external"]'
+    light)
+        wheel_variants='["light"]'
+        wheel_matrix='{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
+        ;;
+    bundled-and-light)
+        wheel_variants='["bundled","light"]'
+        wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"},{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
+        ;;
+    pypi)
+        wheel_variants='["pypi"]'
+        wheel_matrix='{"include":[{"wheel_variant":"pypi","ttnn_dep_mode":"pypi"}]}'
         ;;
     *)
-        echo "Unknown S3 wheel selection: $ttnn_dep_mode" >&2
+        echo "Unknown S3 wheel variant: $wheel_variant" >&2
         exit 2
         ;;
 esac
@@ -61,12 +71,13 @@ output_file="${GITHUB_OUTPUT:-/dev/stdout}"
     echo "dry_run=$dry_run"
     echo "overwrite_releases=$overwrite_releases"
     echo "version_override=$version_override"
-    echo "ttnn_dep_mode=$ttnn_dep_mode"
-    echo "ttnn_dep_modes=$ttnn_dep_modes"
+    echo "wheel_variant=$wheel_variant"
+    echo "wheel_variants=$wheel_variants"
+    echo "wheel_matrix=$wheel_matrix"
 } >> "$output_file"
 
-echo "Resolved ttnn_dep_mode=$ttnn_dep_mode"
-echo "Resolved ttnn_dep_modes=$ttnn_dep_modes"
+echo "Resolved wheel_variant=$wheel_variant"
+echo "Resolved wheel_variants=$wheel_variants"
 echo "Resolved version_override=$version_override"
 echo "Resolved dry_run=$dry_run"
 echo "Resolved overwrite_releases=$overwrite_releases"

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -24,6 +24,10 @@
 
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/tt-metal-version-utils.sh
+. "$script_dir/lib/tt-metal-version-utils.sh"
+
 stable_tag_version() {
     local ref="$1"
 
@@ -44,17 +48,9 @@ variant_includes_bundled() {
     [[ "$1" == "bundled" || "$1" == "bundled-and-light" ]]
 }
 
-ttnn_pypi_aligned() {
-    local repo_root version_file
-    repo_root=$(git rev-parse --show-toplevel)
-    version_file="${TTLANG_TT_METAL_VERSION_FILE:-$repo_root/third-party/tt-metal-version}"
-
-    # shellcheck source=../../third-party/tt-metal-version
-    . "$version_file"
-    : "${TTNN_PYPI_TT_METAL_TAG:?$version_file: TTNN_PYPI_TT_METAL_TAG not set}"
-    : "${TT_METAL_TAG:?$version_file: TT_METAL_TAG not set}"
-
-    [[ "$TTNN_PYPI_TT_METAL_TAG" == "$TT_METAL_TAG" ]]
+pypi_aligned() {
+    load_tt_metal_version || exit 1
+    ttnn_pypi_aligned
 }
 
 : "${DISPATCH_DRY_RUN:?DISPATCH_DRY_RUN is required}"
@@ -70,7 +66,6 @@ if [[ -z "$version_override" ]]; then
     if [[ "$EVENT_NAME" == "push" ]]; then
         version_override=$(stable_tag_version "${GITHUB_REF:-}")
     else
-        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         version_override=$(python3 "$script_dir/compute-nightly-version.py")
     fi
 fi
@@ -78,7 +73,7 @@ fi
 if [[ -z "$wheel_variant" ]]; then
     case "$EVENT_NAME" in
         push)
-            if ttnn_pypi_aligned; then
+            if pypi_aligned; then
                 wheel_variant=light
             else
                 wheel_variant=bundled-and-light
@@ -117,7 +112,7 @@ case "$wheel_variant" in
         ;;
 esac
 
-if is_stable_version "$version_override" && variant_includes_bundled "$wheel_variant" && ttnn_pypi_aligned; then
+if is_stable_version "$version_override" && variant_includes_bundled "$wheel_variant" && pypi_aligned; then
     echo "Refusing to publish bundled tt-lang==$version_override to S3 because public PyPI publishing is aligned for this tt-metal tag." >&2
     echo "Use the light or pypi S3 variant, or use a distinct internal version." >&2
     exit 1

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -11,7 +11,8 @@
 #   DISPATCH_DRY_RUN             "true"|"false" (workflow_dispatch input).
 #   DISPATCH_OVERWRITE_RELEASES  "true"|"false" (workflow_dispatch input).
 #   DISPATCH_VERSION_OVERRIDE    PEP 440 string, may be empty.
-#   DISPATCH_WHEEL_VARIANT       pypi|light|bundled|bundled-and-light.
+#   DISPATCH_WHEEL_VARIANT       pypi|light|bundled|bundled-and-light, may be
+#                                empty for non-dispatch events.
 #   EVENT_NAME                   github.event_name.
 #   GITHUB_REF                   github.ref, required for push events.
 #   GITHUB_OUTPUT                Path that receives the resolved outputs.
@@ -19,7 +20,7 @@
 #
 # Outputs (written to $GITHUB_OUTPUT):
 #   docker_tag, dry_run, overwrite_releases, version_override, wheel_variant,
-#   wheel_variants, wheel_matrix
+#   wheel_variants, wheel_matrix, allow_final_internal_version
 
 set -euo pipefail
 
@@ -35,15 +36,63 @@ stable_tag_version() {
     return 1
 }
 
+is_stable_version() {
+    [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+variant_includes_bundled() {
+    [[ "$1" == "bundled" || "$1" == "bundled-and-light" ]]
+}
+
+ttnn_pypi_aligned() {
+    local repo_root version_file
+    repo_root=$(git rev-parse --show-toplevel)
+    version_file="${TTLANG_TT_METAL_VERSION_FILE:-$repo_root/third-party/tt-metal-version}"
+
+    # shellcheck source=../../third-party/tt-metal-version
+    . "$version_file"
+    : "${TTNN_PYPI_TT_METAL_TAG:?$version_file: TTNN_PYPI_TT_METAL_TAG not set}"
+    : "${TT_METAL_TAG:?$version_file: TT_METAL_TAG not set}"
+
+    [[ "$TTNN_PYPI_TT_METAL_TAG" == "$TT_METAL_TAG" ]]
+}
+
 : "${DISPATCH_DRY_RUN:?DISPATCH_DRY_RUN is required}"
 : "${DISPATCH_OVERWRITE_RELEASES:?DISPATCH_OVERWRITE_RELEASES is required}"
-: "${DISPATCH_WHEEL_VARIANT:?DISPATCH_WHEEL_VARIANT is required}"
 : "${EVENT_NAME:?EVENT_NAME is required}"
 docker_tag="${DISPATCH_DOCKER_TAG:-}"
 dry_run="$DISPATCH_DRY_RUN"
 overwrite_releases="$DISPATCH_OVERWRITE_RELEASES"
 version_override="${DISPATCH_VERSION_OVERRIDE:-}"
-wheel_variant="$DISPATCH_WHEEL_VARIANT"
+wheel_variant="${DISPATCH_WHEEL_VARIANT:-}"
+
+if [[ -z "$version_override" ]]; then
+    if [[ "$EVENT_NAME" == "push" ]]; then
+        version_override=$(stable_tag_version "${GITHUB_REF:-}")
+    else
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        version_override=$(python3 "$script_dir/compute-nightly-version.py")
+    fi
+fi
+
+if [[ -z "$wheel_variant" ]]; then
+    case "$EVENT_NAME" in
+        push)
+            if ttnn_pypi_aligned; then
+                wheel_variant=light
+            else
+                wheel_variant=bundled-and-light
+            fi
+            ;;
+        schedule)
+            wheel_variant=bundled-and-light
+            ;;
+        *)
+            echo "DISPATCH_WHEEL_VARIANT is required for $EVENT_NAME events" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 case "$wheel_variant" in
     bundled)
@@ -68,17 +117,19 @@ case "$wheel_variant" in
         ;;
 esac
 
-if [[ "$EVENT_NAME" == "schedule" ]]; then
-    overwrite_releases=true
+if is_stable_version "$version_override" && variant_includes_bundled "$wheel_variant" && ttnn_pypi_aligned; then
+    echo "Refusing to publish bundled tt-lang==$version_override to S3 because public PyPI publishing is aligned for this tt-metal tag." >&2
+    echo "Use the light or pypi S3 variant, or use a distinct internal version." >&2
+    exit 1
 fi
 
-if [[ -z "$version_override" ]]; then
-    if [[ "$EVENT_NAME" == "push" ]]; then
-        version_override=$(stable_tag_version "${GITHUB_REF:-}")
-    else
-        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        version_override=$(python3 "$script_dir/compute-nightly-version.py")
-    fi
+allow_final_internal_version=false
+if is_stable_version "$version_override"; then
+    allow_final_internal_version=true
+fi
+
+if [[ "$EVENT_NAME" == "schedule" ]]; then
+    overwrite_releases=true
 fi
 
 output_file="${GITHUB_OUTPUT:-/dev/stdout}"
@@ -90,11 +141,13 @@ output_file="${GITHUB_OUTPUT:-/dev/stdout}"
     echo "wheel_variant=$wheel_variant"
     echo "wheel_variants=$wheel_variants"
     echo "wheel_matrix=$wheel_matrix"
+    echo "allow_final_internal_version=$allow_final_internal_version"
 } >> "$output_file"
 
 echo "Resolved wheel_variant=$wheel_variant"
 echo "Resolved wheel_variants=$wheel_variants"
 echo "Resolved version_override=$version_override"
+echo "Resolved allow_final_internal_version=$allow_final_internal_version"
 echo "Resolved dry_run=$dry_run"
 echo "Resolved overwrite_releases=$overwrite_releases"
 if [[ -n "$docker_tag" ]]; then

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Resolve the inputs of the S3 PyPI publish workflow into a single set of
-# step outputs. Computes a nightly version when none was supplied, forces
-# `overwrite_releases=true` for scheduled runs, and prints a one-line
-# summary per resolved input.
+# step outputs. Stable tag pushes use the tag version, scheduled runs compute
+# a nightly version, and scheduled runs force `overwrite_releases=true`.
 #
 # Required env:
 #   DISPATCH_DOCKER_TAG          May be empty (workflow_dispatch input).
@@ -14,6 +13,7 @@
 #   DISPATCH_VERSION_OVERRIDE    PEP 440 string, may be empty.
 #   DISPATCH_WHEEL_VARIANT       pypi|light|bundled|bundled-and-light.
 #   EVENT_NAME                   github.event_name.
+#   GITHUB_REF                   github.ref, required for push events.
 #   GITHUB_OUTPUT                Path that receives the resolved outputs.
 #                                Falls back to stdout when unset.
 #
@@ -22,6 +22,18 @@
 #   wheel_variants, wheel_matrix
 
 set -euo pipefail
+
+stable_tag_version() {
+    local ref="$1"
+
+    if [[ "$ref" =~ ^refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        printf '%s.%s.%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+        return 0
+    fi
+
+    echo "S3 release-tag publish requires a stable tag like refs/tags/vX.Y.Z (got '$ref')." >&2
+    return 1
+}
 
 : "${DISPATCH_DRY_RUN:?DISPATCH_DRY_RUN is required}"
 : "${DISPATCH_OVERWRITE_RELEASES:?DISPATCH_OVERWRITE_RELEASES is required}"
@@ -61,8 +73,12 @@ if [[ "$EVENT_NAME" == "schedule" ]]; then
 fi
 
 if [[ -z "$version_override" ]]; then
-    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    version_override=$(python3 "$script_dir/compute-nightly-version.py")
+    if [[ "$EVENT_NAME" == "push" ]]; then
+        version_override=$(stable_tag_version "${GITHUB_REF:-}")
+    else
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        version_override=$(python3 "$script_dir/compute-nightly-version.py")
+    fi
 fi
 
 output_file="${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/tests/test_check_tt_metal_version.bats
+++ b/.github/scripts/tests/test_check_tt_metal_version.bats
@@ -43,9 +43,9 @@ EOF
 }
 
 @test "rejects missing TT_METAL_TAG" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.69.0"
-TTNN_PYPI_TT_METAL_TAG="v0.69.0"
+    cat > "$REPO/third-party/tt-metal-version" <<EOF
+TTNN_PYPI="$TEST_TTNN_PYPI_VERSION"
+TTNN_PYPI_TT_METAL_TAG="$TEST_TT_METAL_TAG"
 EOF
     commit_all "$REPO" "missing tag"
     run run_check_no_network
@@ -54,9 +54,9 @@ EOF
 }
 
 @test "rejects missing TTNN_PYPI" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI_TT_METAL_TAG="v0.69.0"
-TT_METAL_TAG="v0.69.0"
+    cat > "$REPO/third-party/tt-metal-version" <<EOF
+TTNN_PYPI_TT_METAL_TAG="$TEST_TT_METAL_TAG"
+TT_METAL_TAG="$TEST_TT_METAL_TAG"
 EOF
     commit_all "$REPO" "missing pypi"
     run run_check_no_network
@@ -65,9 +65,9 @@ EOF
 }
 
 @test "rejects missing TTNN_PYPI_TT_METAL_TAG" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.69.0"
-TT_METAL_TAG="v0.69.0"
+    cat > "$REPO/third-party/tt-metal-version" <<EOF
+TTNN_PYPI="$TEST_TTNN_PYPI_VERSION"
+TT_METAL_TAG="$TEST_TT_METAL_TAG"
 EOF
     commit_all "$REPO" "missing pypi tag"
     run run_check_no_network
@@ -76,11 +76,11 @@ EOF
 }
 
 @test "rejects malformed TT_METAL_TAG (no leading v)" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.69.0"
-TTNN_PYPI_TT_METAL_TAG="v0.69.0"
-TT_METAL_TAG="0.69.0"
-EOF
+    bad_tag="${TEST_TT_METAL_TAG#v}"
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$TEST_TT_METAL_TAG" \
+        "$bad_tag"
     commit_all "$REPO" "bad tag"
     run run_check_no_network
     assert_failure
@@ -88,23 +88,22 @@ EOF
 }
 
 @test "rejects malformed TTNN_PYPI_TT_METAL_TAG (no leading v)" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.69.0"
-TTNN_PYPI_TT_METAL_TAG="0.69.0"
-TT_METAL_TAG="v0.69.0"
-EOF
+    bad_tag="${TEST_TT_METAL_TAG#v}"
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$bad_tag" \
+        "$TEST_TT_METAL_TAG"
     commit_all "$REPO" "bad pypi tag"
     run run_check_no_network
     assert_failure
-    assert_output --partial "TTNN_PYPI_TT_METAL_TAG '0.69.0' does not look like vX.Y.Z"
+    assert_output --partial "TTNN_PYPI_TT_METAL_TAG '$bad_tag' does not look like vX.Y.Z"
 }
 
 @test "accepts valid version-file format" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.70.1"
-TTNN_PYPI_TT_METAL_TAG="v0.70.1-rc1"
-TT_METAL_TAG="v0.70.1-rc1"
-EOF
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$TEST_TT_METAL_RC1_TAG" \
+        "$TEST_TT_METAL_RC1_TAG"
     commit_all "$REPO" "valid"
     run run_check_no_network
     # ls-remote stub returns empty -> "tt-metal has no release tag" surfaces
@@ -114,14 +113,14 @@ EOF
 }
 
 @test "ignores '#' comment lines and blank lines" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
+    cat > "$REPO/third-party/tt-metal-version" <<EOF
 # leading comment about the file
 # describing fields
 
-TTNN_PYPI="0.70.1"
-TTNN_PYPI_TT_METAL_TAG="v0.70.1-rc1"
+TTNN_PYPI="$TEST_TTNN_PYPI_VERSION"
+TTNN_PYPI_TT_METAL_TAG="$TEST_TT_METAL_RC1_TAG"
 # inter-variable comment
-TT_METAL_TAG="v0.70.1-rc1"
+TT_METAL_TAG="$TEST_TT_METAL_RC1_TAG"
 
 # trailing comment
 EOF
@@ -132,11 +131,10 @@ EOF
 }
 
 @test "accepts rc-suffixed tag (vX.Y.Z-rcN)" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.70.1"
-TTNN_PYPI_TT_METAL_TAG="v0.70.1-rc2"
-TT_METAL_TAG="v0.70.1-rc2"
-EOF
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$TEST_TT_METAL_RC2_TAG" \
+        "$TEST_TT_METAL_RC2_TAG"
     commit_all "$REPO" "rc tag"
     run run_check_no_network
     # Regex ^vX.Y.Z accepts the prefix; -rcN passes through to ls-remote.

--- a/.github/scripts/tests/test_get_version_tag.bats
+++ b/.github/scripts/tests/test_get_version_tag.bats
@@ -107,11 +107,10 @@ uplift_one_path() {
     commit_all "$REPO" "uplift"
     first_tag=$(get_tag "$REPO")
     # Restore the exact content mkrepo() initialized so revert matches BASE_TAG.
-cat > "$REPO/third-party/tt-metal-version" <<'VERSION_EOF'
-TTNN_PYPI="0.69.0"
-TTNN_PYPI_TT_METAL_TAG="v0.69.0"
-TT_METAL_TAG="v0.69.0"
-VERSION_EOF
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$TEST_TT_METAL_TAG" \
+        "$TEST_TT_METAL_TAG"
     commit_all "$REPO" "revert"
     revert_tag=$(get_tag "$REPO")
     echo "uplift-state" > "$REPO/third-party/tt-metal-version"

--- a/.github/scripts/tests/test_helper.bash
+++ b/.github/scripts/tests/test_helper.bash
@@ -20,6 +20,21 @@ BIN_DIR="$(dirname "$SCRIPTS_DIR")/../bin"
 # Real tt-lang repo root (parent of .github/). Lets tests reach
 # scripts/ (top-level) without hard-coding a path.
 TTLANG_REPO_ROOT="$(dirname "$(dirname "$SCRIPTS_DIR")")"
+WHEEL_PYTAG="cp312-cp312-linux_x86_64"
+
+whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$WHEEL_PYTAG"; }
+whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }
+whl_light() { printf 'tt_lang_light-%s-py3-none-any.whl' "$1"; }
+whl_build() { printf 'tt_lang-%s-%s-%s.whl' "$1" "$2" "$WHEEL_PYTAG"; }
+
+make_wheel_dir() {
+    local dir
+    dir=$(mktemp -d "$BATS_TEST_TMPDIR/wheels.XXXXXX")
+    for name in "$@"; do
+        : > "$dir/$name"
+    done
+    echo "$dir"
+}
 
 # Build a synthetic git repo in $BATS_TEST_TMPDIR (auto-cleaned). Initialized
 # with one file at each UPLIFT_PATHS location, plus python/sim/example.py for

--- a/.github/scripts/tests/test_helper.bash
+++ b/.github/scripts/tests/test_helper.bash
@@ -21,6 +21,10 @@ BIN_DIR="$(dirname "$SCRIPTS_DIR")/../bin"
 # scripts/ (top-level) without hard-coding a path.
 TTLANG_REPO_ROOT="$(dirname "$(dirname "$SCRIPTS_DIR")")"
 WHEEL_PYTAG="cp312-cp312-linux_x86_64"
+TEST_TTNN_PYPI_VERSION="99.88.77"
+TEST_TT_METAL_TAG="v99.88.77"
+TEST_TT_METAL_RC1_TAG="v99.88.77-rc1"
+TEST_TT_METAL_RC2_TAG="v99.88.77-rc2"
 
 whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$WHEEL_PYTAG"; }
 whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }
@@ -34,6 +38,27 @@ make_wheel_dir() {
         : > "$dir/$name"
     done
     echo "$dir"
+}
+
+write_tt_metal_version_file() {
+    local version_file="$1"
+    local ttnn_pypi="$2"
+    local pypi_tag="$3"
+    local tt_metal_tag="$4"
+    cat > "$version_file" <<EOF
+TTNN_PYPI="$ttnn_pypi"
+TTNN_PYPI_TT_METAL_TAG="$pypi_tag"
+TT_METAL_TAG="$tt_metal_tag"
+EOF
+}
+
+make_tt_metal_version_file() {
+    local pypi_tag="$1"
+    local tt_metal_tag="$2"
+    local ttnn_pypi="${3:-$TEST_TTNN_PYPI_VERSION}"
+    local version_file="$BATS_TEST_TMPDIR/tt-metal-version.$pypi_tag.$tt_metal_tag"
+    write_tt_metal_version_file "$version_file" "$ttnn_pypi" "$pypi_tag" "$tt_metal_tag"
+    echo "$version_file"
 }
 
 # Build a synthetic git repo in $BATS_TEST_TMPDIR (auto-cleaned). Initialized
@@ -52,11 +77,10 @@ mkrepo() {
         mkdir -p third-party/llvm-project third-party/tt-metal .github/containers python/sim
         # Sourceable shell snippet matching the real third-party/tt-metal-version
         # schema.
-        cat > third-party/tt-metal-version <<'VERSION_EOF'
-TTNN_PYPI="0.69.0"
-TTNN_PYPI_TT_METAL_TAG="v0.69.0"
-TT_METAL_TAG="v0.69.0"
-VERSION_EOF
+        write_tt_metal_version_file third-party/tt-metal-version \
+            "$TEST_TTNN_PYPI_VERSION" \
+            "$TEST_TT_METAL_TAG" \
+            "$TEST_TT_METAL_TAG"
         echo "llvm-content-v1" > third-party/llvm-project/sentinel
         echo "tt-metal-content-v1" > third-party/tt-metal/sentinel
         cat > .github/containers/Dockerfile.base <<'EOF'

--- a/.github/scripts/tests/test_install_ttmetal.bats
+++ b/.github/scripts/tests/test_install_ttmetal.bats
@@ -7,7 +7,7 @@
 # Focus: the .so binaries (_ttnn.so, _ttnncpp.so) come from $BUILD/ttnn/,
 # never from $SRC/ttnn/ttnn/. install-ttmetal.sh used to copy from $SRC,
 # which silently installed stale extensions left in the source tree by a
-# previous tt-metal build (see the v0.71.0-rc2 uplift debugging session).
+# previous tt-metal uplift debugging session.
 
 load test_helper
 

--- a/.github/scripts/tests/test_prepare_s3_publish_dist.bats
+++ b/.github/scripts/tests/test_prepare_s3_publish_dist.bats
@@ -7,20 +7,6 @@
 load test_helper
 
 VER="99.99.99.dev20260515"
-PYTAG="cp312-cp312-linux_x86_64"
-
-whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$PYTAG"; }
-whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }
-whl_light() { printf 'tt_lang_light-%s-py3-none-any.whl' "$1"; }
-
-make_wheel_dir() {
-    local dir
-    dir=$(mktemp -d "$BATS_TEST_TMPDIR/wheels.XXXXXX")
-    for name in "$@"; do
-        : > "$dir/$name"
-    done
-    echo "$dir"
-}
 
 setup() {
     SCRIPT="$SCRIPTS_DIR/prepare-s3-publish-dist.sh"

--- a/.github/scripts/tests/test_prepare_s3_publish_dist.bats
+++ b/.github/scripts/tests/test_prepare_s3_publish_dist.bats
@@ -31,10 +31,10 @@ setup() {
     assert_output --partial "Unsafe publish directory: ."
 }
 
-@test "unknown mode -> usage error (exit 2)" {
+@test "unknown variant -> usage error (exit 2)" {
     dir=$(make_wheel_dir "$(whl "$VER")")
     run -2 "$SCRIPT" "$VER" "$PUBLISH_DIR" "garbage=$dir"
-    assert_output --partial "Unknown ttnn dependency mode: garbage"
+    assert_output --partial "Unknown wheel variant: garbage"
 }
 
 @test "missing artifact dir -> error" {
@@ -52,15 +52,15 @@ setup() {
     assert_output --partial "$(whl_sim "$VER")"
 }
 
-@test "combined bundled and external artifacts copy unique wheel set" {
+@test "combined bundled and light artifacts copy unique wheel set" {
     bundled_dir=$(make_wheel_dir "$(whl "$VER")" "$(whl_sim "$VER")")
-    external_dir=$(make_wheel_dir "$(whl "$VER+light")" "$(whl_light "$VER")")
+    light_dir=$(make_wheel_dir "$(whl "$VER+light")" "$(whl_light "$VER")")
 
     run -0 "$SCRIPT" \
         "$VER" \
         "$PUBLISH_DIR" \
         "bundled=$bundled_dir" \
-        "external:no-sim=$external_dir"
+        "light:no-sim=$light_dir"
 
     run ls "$PUBLISH_DIR"
     assert_output --partial "$(whl "$VER")"
@@ -69,13 +69,13 @@ setup() {
     assert_output --partial "$(whl_light "$VER")"
 }
 
-@test "external no-sim spec rejects unexpected sim wheel" {
-    external_dir=$(make_wheel_dir \
+@test "light no-sim spec rejects unexpected sim wheel" {
+    light_dir=$(make_wheel_dir \
         "$(whl "$VER+light")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
 
-    run -1 "$SCRIPT" "$VER" "$PUBLISH_DIR" "external:no-sim=$external_dir"
+    run -1 "$SCRIPT" "$VER" "$PUBLISH_DIR" "light:no-sim=$light_dir"
 
     assert_output --partial "No expected version configured for distribution 'tt_lang_sim'"
 }

--- a/.github/scripts/tests/test_prepare_s3_publish_dist.bats
+++ b/.github/scripts/tests/test_prepare_s3_publish_dist.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/prepare-s3-publish-dist.sh.
+
+load test_helper
+
+VER="99.99.99.dev20260515"
+PYTAG="cp312-cp312-linux_x86_64"
+
+whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$PYTAG"; }
+whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }
+whl_light() { printf 'tt_lang_light-%s-py3-none-any.whl' "$1"; }
+
+make_wheel_dir() {
+    local dir
+    dir=$(mktemp -d "$BATS_TEST_TMPDIR/wheels.XXXXXX")
+    for name in "$@"; do
+        : > "$dir/$name"
+    done
+    echo "$dir"
+}
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/prepare-s3-publish-dist.sh"
+    PUBLISH_DIR="$BATS_TEST_TMPDIR/publish-dist"
+}
+
+@test "no arguments -> usage error (exit 2)" {
+    run -2 "$SCRIPT"
+}
+
+@test "missing artifact spec -> usage error (exit 2)" {
+    run -2 "$SCRIPT" "$VER" "$PUBLISH_DIR"
+}
+
+@test "malformed artifact spec -> usage error (exit 2)" {
+    run -2 "$SCRIPT" "$VER" "$PUBLISH_DIR" bundled
+}
+
+@test "unsafe publish dir -> usage error (exit 2)" {
+    dir=$(make_wheel_dir "$(whl "$VER")")
+    run -2 "$SCRIPT" "$VER" "." "bundled=$dir"
+    assert_output --partial "Unsafe publish directory: ."
+}
+
+@test "unknown mode -> usage error (exit 2)" {
+    dir=$(make_wheel_dir "$(whl "$VER")")
+    run -2 "$SCRIPT" "$VER" "$PUBLISH_DIR" "garbage=$dir"
+    assert_output --partial "Unknown ttnn dependency mode: garbage"
+}
+
+@test "missing artifact dir -> error" {
+    run -1 "$SCRIPT" "$VER" "$PUBLISH_DIR" bundled="$BATS_TEST_TMPDIR/missing"
+    assert_output --partial "Wheel artifact directory not found"
+}
+
+@test "bundled artifact is verified and copied" {
+    bundled_dir=$(make_wheel_dir "$(whl "$VER")" "$(whl_sim "$VER")")
+
+    run -0 "$SCRIPT" "$VER" "$PUBLISH_DIR" "bundled=$bundled_dir"
+
+    run ls "$PUBLISH_DIR"
+    assert_output --partial "$(whl "$VER")"
+    assert_output --partial "$(whl_sim "$VER")"
+}
+
+@test "combined bundled and external artifacts copy unique wheel set" {
+    bundled_dir=$(make_wheel_dir "$(whl "$VER")" "$(whl_sim "$VER")")
+    external_dir=$(make_wheel_dir "$(whl "$VER+light")" "$(whl_light "$VER")")
+
+    run -0 "$SCRIPT" \
+        "$VER" \
+        "$PUBLISH_DIR" \
+        "bundled=$bundled_dir" \
+        "external:no-sim=$external_dir"
+
+    run ls "$PUBLISH_DIR"
+    assert_output --partial "$(whl "$VER")"
+    assert_output --partial "$(whl_sim "$VER")"
+    assert_output --partial "$(whl "$VER+light")"
+    assert_output --partial "$(whl_light "$VER")"
+}
+
+@test "external no-sim spec rejects unexpected sim wheel" {
+    external_dir=$(make_wheel_dir \
+        "$(whl "$VER+light")" \
+        "$(whl_light "$VER")" \
+        "$(whl_sim "$VER")")
+
+    run -1 "$SCRIPT" "$VER" "$PUBLISH_DIR" "external:no-sim=$external_dir"
+
+    assert_output --partial "No expected version configured for distribution 'tt_lang_sim'"
+}
+
+@test "duplicate wheel filename across artifacts -> error" {
+    first_dir=$(make_wheel_dir "$(whl "$VER")")
+    second_dir=$(make_wheel_dir "$(whl "$VER")")
+
+    run -1 "$SCRIPT" \
+        "$VER" \
+        "$PUBLISH_DIR" \
+        "bundled=$first_dir" \
+        "pypi=$second_dir"
+
+    assert_output --partial "Duplicate wheel filename across S3 publish artifacts"
+}

--- a/.github/scripts/tests/test_prepare_s3_publish_dist.bats
+++ b/.github/scripts/tests/test_prepare_s3_publish_dist.bats
@@ -37,6 +37,12 @@ setup() {
     assert_output --partial "Unknown wheel variant: garbage"
 }
 
+@test ":no-sim on a non-light variant -> usage error (exit 2)" {
+    dir=$(make_wheel_dir "$(whl "$VER")" "$(whl_sim "$VER")")
+    run -2 "$SCRIPT" "$VER" "$PUBLISH_DIR" "bundled:no-sim=$dir"
+    assert_output --partial ":no-sim is only valid for the light variant"
+}
+
 @test "missing artifact dir -> error" {
     run -1 "$SCRIPT" "$VER" "$PUBLISH_DIR" bundled="$BATS_TEST_TMPDIR/missing"
     assert_output --partial "Wheel artifact directory not found"

--- a/.github/scripts/tests/test_publish_s3_summary.bats
+++ b/.github/scripts/tests/test_publish_s3_summary.bats
@@ -49,6 +49,19 @@ setup() {
     assert_output --partial "Underlying no-ttnn tt-lang wheel:"
 }
 
+@test "bundled-and-external mode emits bundled and light install blocks" {
+    run -0 "$SCRIPT" bundled-and-external "$VER"
+    assert_output --partial "Bundled install:"
+    assert_output --partial "tt-lang==$VER"
+    assert_output --partial "tt-lang-light==$VER"
+    assert_output --partial "tt-lang==$VER+light"
+}
+
+@test "unknown mode -> usage error (exit 2)" {
+    run -2 "$SCRIPT" garbage "$VER"
+    assert_output --partial "Unknown S3 wheel selection: garbage"
+}
+
 @test "--dry-run marks summary as not uploaded" {
     run -0 "$SCRIPT" --dry-run bundled "$VER"
     assert_output --partial "### Wheel publish dry run"

--- a/.github/scripts/tests/test_publish_s3_summary.bats
+++ b/.github/scripts/tests/test_publish_s3_summary.bats
@@ -41,25 +41,25 @@ setup() {
     refute_output --partial "tt-lang-light"
 }
 
-@test "external mode emits both light and underlying install blocks" {
-    run -0 "$SCRIPT" external "$VER"
+@test "light variant emits both light and underlying install blocks" {
+    run -0 "$SCRIPT" light "$VER"
     assert_output --partial "tt-lang-light==$VER"
     assert_output --partial "tt-lang==$VER+light"
     assert_output --partial "Light install:"
-    assert_output --partial "Underlying no-ttnn tt-lang wheel:"
+    assert_output --partial "Underlying light tt-lang wheel:"
 }
 
-@test "bundled-and-external mode emits bundled and light install blocks" {
-    run -0 "$SCRIPT" bundled-and-external "$VER"
+@test "bundled-and-light variant emits bundled and light install blocks" {
+    run -0 "$SCRIPT" bundled-and-light "$VER"
     assert_output --partial "Bundled install:"
     assert_output --partial "tt-lang==$VER"
     assert_output --partial "tt-lang-light==$VER"
     assert_output --partial "tt-lang==$VER+light"
 }
 
-@test "unknown mode -> usage error (exit 2)" {
+@test "unknown variant -> usage error (exit 2)" {
     run -2 "$SCRIPT" garbage "$VER"
-    assert_output --partial "Unknown S3 wheel selection: garbage"
+    assert_output --partial "Unknown S3 wheel variant: garbage"
 }
 
 @test "--dry-run marks summary as not uploaded" {

--- a/.github/scripts/tests/test_require_pypi_ttnn_alignment.bats
+++ b/.github/scripts/tests/test_require_pypi_ttnn_alignment.bats
@@ -19,39 +19,37 @@ run_alignment_check() {
 }
 
 @test "accepts matching ttnn provenance and tt-metal tag" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.70.1"
-TTNN_PYPI_TT_METAL_TAG="v0.70.1-rc1"
-TT_METAL_TAG="v0.70.1-rc1"
-EOF
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$TEST_TT_METAL_RC1_TAG" \
+        "$TEST_TT_METAL_RC1_TAG"
     commit_all "$REPO" "aligned"
 
     run run_alignment_check
 
     assert_success
-    assert_output --partial "ok: ttnn==0.70.1 and tt-lang both use tt-metal v0.70.1-rc1"
+    assert_output --partial "ok: ttnn==$TEST_TTNN_PYPI_VERSION and tt-lang both use tt-metal $TEST_TT_METAL_RC1_TAG"
 }
 
 @test "rejects mismatched ttnn provenance and tt-metal tag" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.70.1"
-TTNN_PYPI_TT_METAL_TAG="v0.70.1-rc1"
-TT_METAL_TAG="v0.71.0-rc2"
-EOF
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$TEST_TT_METAL_RC1_TAG" \
+        "$TEST_TT_METAL_RC2_TAG"
     commit_all "$REPO" "mismatched"
 
     run run_alignment_check
 
     assert_failure
     assert_output --partial "Public PyPI publish requires ttnn provenance to match TT_METAL_TAG."
-    assert_output --partial "TTNN_PYPI=0.70.1 was built from TTNN_PYPI_TT_METAL_TAG=v0.70.1-rc1"
-    assert_output --partial "TT_METAL_TAG=v0.71.0-rc2"
+    assert_output --partial "TTNN_PYPI=$TEST_TTNN_PYPI_VERSION was built from TTNN_PYPI_TT_METAL_TAG=$TEST_TT_METAL_RC1_TAG"
+    assert_output --partial "TT_METAL_TAG=$TEST_TT_METAL_RC2_TAG"
 }
 
 @test "rejects missing ttnn provenance tag" {
-    cat > "$REPO/third-party/tt-metal-version" <<'EOF'
-TTNN_PYPI="0.70.1"
-TT_METAL_TAG="v0.70.1-rc1"
+    cat > "$REPO/third-party/tt-metal-version" <<EOF
+TTNN_PYPI="$TEST_TTNN_PYPI_VERSION"
+TT_METAL_TAG="$TEST_TT_METAL_RC1_TAG"
 EOF
     commit_all "$REPO" "missing provenance"
 

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -53,7 +53,21 @@ output_value() {
     assert_equal "$(output_value overwrite_releases)" "false"
     assert_equal "$(output_value version_override)" "1.2.3.dev20260101"
     assert_equal "$(output_value ttnn_dep_mode)" "external"
+    assert_equal "$(output_value ttnn_dep_modes)" '["external"]'
     assert_output --partial "Using existing docker_tag=mytag"
+}
+
+@test "bundled-and-external expands to both build modes" {
+    DISPATCH_TTNN_DEP_MODE=bundled-and-external run -0 "$SCRIPT"
+
+    assert_equal "$(output_value ttnn_dep_mode)" "bundled-and-external"
+    assert_equal "$(output_value ttnn_dep_modes)" '["bundled","external"]'
+    assert_output --partial 'Resolved ttnn_dep_modes=["bundled","external"]'
+}
+
+@test "unknown ttnn dependency selection -> error" {
+    DISPATCH_TTNN_DEP_MODE=garbage run -2 "$SCRIPT"
+    assert_output --partial "Unknown S3 wheel selection: garbage"
 }
 
 @test "empty docker_tag -> hint about build-docker" {
@@ -101,6 +115,7 @@ EOF
     run -0 "$SCRIPT"
     assert_output --partial "version_override=42.42.42.dev20260527"
     assert_output --partial "ttnn_dep_mode=bundled"
+    assert_output --partial 'ttnn_dep_modes=["bundled"]'
 }
 
 @test "appends rather than overwrites GITHUB_OUTPUT" {

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -168,8 +168,10 @@ output_value() {
     # ($script_dir/compute-nightly-version.py), so shadow that file specifically.
     shadow_dir="$BATS_TEST_TMPDIR/shadow-scripts"
     mkdir -p "$shadow_dir/tests"
-    # Copy real script (so its sibling import resolves) and override compute-nightly.
+    # Copy real script and its sibling lib (so the sourced helper resolves),
+    # then override compute-nightly.
     cp "$SCRIPT" "$shadow_dir/"
+    cp -r "$SCRIPTS_DIR/lib" "$shadow_dir/"
     cat > "$shadow_dir/compute-nightly-version.py" <<'EOF'
 #!/usr/bin/env python3
 print("9.9.9.dev20991231")

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -19,6 +19,7 @@ setup() {
     export DISPATCH_VERSION_OVERRIDE="42.42.42.dev20260527"
     export DISPATCH_WHEEL_VARIANT=bundled
     export EVENT_NAME=workflow_dispatch
+    export GITHUB_REF=refs/heads/main
 }
 
 # Read one `key=value` line from the captured GITHUB_OUTPUT file.
@@ -90,6 +91,26 @@ output_value() {
 @test "non-schedule event does not force overwrite_releases" {
     DISPATCH_OVERWRITE_RELEASES=false EVENT_NAME=workflow_dispatch run -0 "$SCRIPT"
     assert_equal "$(output_value overwrite_releases)" "false"
+}
+
+@test "stable tag push uses clean tag version" {
+    DISPATCH_VERSION_OVERRIDE="" \
+    EVENT_NAME=push \
+    GITHUB_REF=refs/tags/v1.2.3 \
+        run -0 "$SCRIPT"
+
+    assert_equal "$(output_value version_override)" "1.2.3"
+    assert_equal "$(output_value wheel_variant)" "bundled"
+    assert_equal "$(output_value overwrite_releases)" "false"
+}
+
+@test "push event rejects non-stable tag when version is unset" {
+    DISPATCH_VERSION_OVERRIDE="" \
+    EVENT_NAME=push \
+    GITHUB_REF=refs/tags/v1.2.3-rc1 \
+        run -1 "$SCRIPT"
+
+    assert_output --partial "S3 release-tag publish requires a stable tag"
 }
 
 @test "empty version_override invokes compute-nightly-version.py" {

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -28,6 +28,18 @@ output_value() {
     grep "^${key}=" "$GITHUB_OUTPUT_FILE" | sed "s/^${key}=//"
 }
 
+make_tt_metal_version_file() {
+    local pypi_tag="$1"
+    local tt_metal_tag="$2"
+    local version_file="$BATS_TEST_TMPDIR/tt-metal-version.$pypi_tag.$tt_metal_tag"
+    cat > "$version_file" <<EOF
+TTNN_PYPI="0.70.1"
+TTNN_PYPI_TT_METAL_TAG="$pypi_tag"
+TT_METAL_TAG="$tt_metal_tag"
+EOF
+    echo "$version_file"
+}
+
 @test "missing DISPATCH_DRY_RUN -> error" {
     unset DISPATCH_DRY_RUN
     run -1 "$SCRIPT"
@@ -83,6 +95,12 @@ output_value() {
     assert_equal "$(output_value overwrite_releases)" "true"
 }
 
+@test "schedule event defaults to bundled and light" {
+    DISPATCH_WHEEL_VARIANT="" EVENT_NAME=schedule run -0 "$SCRIPT"
+    assert_equal "$(output_value wheel_variant)" "bundled-and-light"
+    assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
+}
+
 @test "schedule event keeps overwrite_releases=true if already set" {
     DISPATCH_OVERWRITE_RELEASES=true EVENT_NAME=schedule run -0 "$SCRIPT"
     assert_equal "$(output_value overwrite_releases)" "true"
@@ -93,19 +111,54 @@ output_value() {
     assert_equal "$(output_value overwrite_releases)" "false"
 }
 
-@test "stable tag push uses clean tag version" {
+@test "stable tag push publishes bundled and light when public PyPI is blocked" {
+    version_file=$(make_tt_metal_version_file v0.70.1-rc1 v0.71.0-rc2)
+
     DISPATCH_VERSION_OVERRIDE="" \
+    DISPATCH_WHEEL_VARIANT="" \
     EVENT_NAME=push \
     GITHUB_REF=refs/tags/v1.2.3 \
+    TTLANG_TT_METAL_VERSION_FILE="$version_file" \
         run -0 "$SCRIPT"
 
     assert_equal "$(output_value version_override)" "1.2.3"
-    assert_equal "$(output_value wheel_variant)" "bundled"
+    assert_equal "$(output_value wheel_variant)" "bundled-and-light"
+    assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
     assert_equal "$(output_value overwrite_releases)" "false"
+    assert_equal "$(output_value allow_final_internal_version)" "true"
+}
+
+@test "stable tag push publishes only light when public PyPI is aligned" {
+    version_file=$(make_tt_metal_version_file v0.71.0-rc2 v0.71.0-rc2)
+
+    DISPATCH_VERSION_OVERRIDE="" \
+    DISPATCH_WHEEL_VARIANT="" \
+    EVENT_NAME=push \
+    GITHUB_REF=refs/tags/v1.2.3 \
+    TTLANG_TT_METAL_VERSION_FILE="$version_file" \
+        run -0 "$SCRIPT"
+
+    assert_equal "$(output_value version_override)" "1.2.3"
+    assert_equal "$(output_value wheel_variant)" "light"
+    assert_equal "$(output_value wheel_variants)" '["light"]'
+    assert_equal "$(output_value allow_final_internal_version)" "true"
+}
+
+@test "stable manual bundled publish is rejected when public PyPI is aligned" {
+    version_file=$(make_tt_metal_version_file v0.71.0-rc2 v0.71.0-rc2)
+
+    DISPATCH_VERSION_OVERRIDE="1.2.3" \
+    DISPATCH_WHEEL_VARIANT=bundled \
+    EVENT_NAME=workflow_dispatch \
+    TTLANG_TT_METAL_VERSION_FILE="$version_file" \
+        run -1 "$SCRIPT"
+
+    assert_output --partial "Refusing to publish bundled tt-lang==1.2.3 to S3"
 }
 
 @test "push event rejects non-stable tag when version is unset" {
     DISPATCH_VERSION_OVERRIDE="" \
+    DISPATCH_WHEEL_VARIANT="" \
     EVENT_NAME=push \
     GITHUB_REF=refs/tags/v1.2.3-rc1 \
         run -1 "$SCRIPT"
@@ -131,6 +184,7 @@ EOF
 
     DISPATCH_VERSION_OVERRIDE="" run -0 "$shadow_dir/resolve-s3-publish-inputs.sh"
     assert_equal "$(output_value version_override)" "9.9.9.dev20991231"
+    assert_equal "$(output_value allow_final_internal_version)" "false"
 }
 
 @test "GITHUB_OUTPUT unset -> writes to stdout" {
@@ -139,6 +193,7 @@ EOF
     assert_output --partial "version_override=42.42.42.dev20260527"
     assert_output --partial "wheel_variant=bundled"
     assert_output --partial 'wheel_variants=["bundled"]'
+    assert_output --partial "allow_final_internal_version=false"
 }
 
 @test "appends rather than overwrites GITHUB_OUTPUT" {

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -17,7 +17,7 @@ setup() {
     export DISPATCH_DRY_RUN=false
     export DISPATCH_OVERWRITE_RELEASES=false
     export DISPATCH_VERSION_OVERRIDE="42.42.42.dev20260527"
-    export DISPATCH_TTNN_DEP_MODE=bundled
+    export DISPATCH_WHEEL_VARIANT=bundled
     export EVENT_NAME=workflow_dispatch
 }
 
@@ -44,7 +44,7 @@ output_value() {
     DISPATCH_DRY_RUN=true \
     DISPATCH_OVERWRITE_RELEASES=false \
     DISPATCH_VERSION_OVERRIDE=1.2.3.dev20260101 \
-    DISPATCH_TTNN_DEP_MODE=external \
+    DISPATCH_WHEEL_VARIANT=light \
     EVENT_NAME=workflow_dispatch \
         run -0 "$SCRIPT"
 
@@ -52,22 +52,24 @@ output_value() {
     assert_equal "$(output_value dry_run)" "true"
     assert_equal "$(output_value overwrite_releases)" "false"
     assert_equal "$(output_value version_override)" "1.2.3.dev20260101"
-    assert_equal "$(output_value ttnn_dep_mode)" "external"
-    assert_equal "$(output_value ttnn_dep_modes)" '["external"]'
+    assert_equal "$(output_value wheel_variant)" "light"
+    assert_equal "$(output_value wheel_variants)" '["light"]'
+    assert_equal "$(output_value wheel_matrix)" '{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
     assert_output --partial "Using existing docker_tag=mytag"
 }
 
-@test "bundled-and-external expands to both build modes" {
-    DISPATCH_TTNN_DEP_MODE=bundled-and-external run -0 "$SCRIPT"
+@test "bundled-and-light expands to both build modes" {
+    DISPATCH_WHEEL_VARIANT=bundled-and-light run -0 "$SCRIPT"
 
-    assert_equal "$(output_value ttnn_dep_mode)" "bundled-and-external"
-    assert_equal "$(output_value ttnn_dep_modes)" '["bundled","external"]'
-    assert_output --partial 'Resolved ttnn_dep_modes=["bundled","external"]'
+    assert_equal "$(output_value wheel_variant)" "bundled-and-light"
+    assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
+    assert_equal "$(output_value wheel_matrix)" '{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"},{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
+    assert_output --partial 'Resolved wheel_variants=["bundled","light"]'
 }
 
-@test "unknown ttnn dependency selection -> error" {
-    DISPATCH_TTNN_DEP_MODE=garbage run -2 "$SCRIPT"
-    assert_output --partial "Unknown S3 wheel selection: garbage"
+@test "unknown wheel variant -> error" {
+    DISPATCH_WHEEL_VARIANT=garbage run -2 "$SCRIPT"
+    assert_output --partial "Unknown S3 wheel variant: garbage"
 }
 
 @test "empty docker_tag -> hint about build-docker" {
@@ -114,8 +116,8 @@ EOF
     unset GITHUB_OUTPUT
     run -0 "$SCRIPT"
     assert_output --partial "version_override=42.42.42.dev20260527"
-    assert_output --partial "ttnn_dep_mode=bundled"
-    assert_output --partial 'ttnn_dep_modes=["bundled"]'
+    assert_output --partial "wheel_variant=bundled"
+    assert_output --partial 'wheel_variants=["bundled"]'
 }
 
 @test "appends rather than overwrites GITHUB_OUTPUT" {

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -28,18 +28,6 @@ output_value() {
     grep "^${key}=" "$GITHUB_OUTPUT_FILE" | sed "s/^${key}=//"
 }
 
-make_tt_metal_version_file() {
-    local pypi_tag="$1"
-    local tt_metal_tag="$2"
-    local version_file="$BATS_TEST_TMPDIR/tt-metal-version.$pypi_tag.$tt_metal_tag"
-    cat > "$version_file" <<EOF
-TTNN_PYPI="0.70.1"
-TTNN_PYPI_TT_METAL_TAG="$pypi_tag"
-TT_METAL_TAG="$tt_metal_tag"
-EOF
-    echo "$version_file"
-}
-
 @test "missing DISPATCH_DRY_RUN -> error" {
     unset DISPATCH_DRY_RUN
     run -1 "$SCRIPT"
@@ -112,7 +100,9 @@ EOF
 }
 
 @test "stable tag push publishes bundled and light when public PyPI is blocked" {
-    version_file=$(make_tt_metal_version_file v0.70.1-rc1 v0.71.0-rc2)
+    version_file=$(make_tt_metal_version_file \
+        "$TEST_TT_METAL_RC1_TAG" \
+        "$TEST_TT_METAL_RC2_TAG")
 
     DISPATCH_VERSION_OVERRIDE="" \
     DISPATCH_WHEEL_VARIANT="" \
@@ -129,7 +119,9 @@ EOF
 }
 
 @test "stable tag push publishes only light when public PyPI is aligned" {
-    version_file=$(make_tt_metal_version_file v0.71.0-rc2 v0.71.0-rc2)
+    version_file=$(make_tt_metal_version_file \
+        "$TEST_TT_METAL_RC2_TAG" \
+        "$TEST_TT_METAL_RC2_TAG")
 
     DISPATCH_VERSION_OVERRIDE="" \
     DISPATCH_WHEEL_VARIANT="" \
@@ -145,7 +137,9 @@ EOF
 }
 
 @test "stable manual bundled publish is rejected when public PyPI is aligned" {
-    version_file=$(make_tt_metal_version_file v0.71.0-rc2 v0.71.0-rc2)
+    version_file=$(make_tt_metal_version_file \
+        "$TEST_TT_METAL_RC2_TAG" \
+        "$TEST_TT_METAL_RC2_TAG")
 
     DISPATCH_VERSION_OVERRIDE="1.2.3" \
     DISPATCH_WHEEL_VARIANT=bundled \

--- a/.github/scripts/tests/test_verify_s3_wheel_versions.bats
+++ b/.github/scripts/tests/test_verify_s3_wheel_versions.bats
@@ -7,20 +7,6 @@
 load test_helper
 
 VER="99.99.99.dev20260515"
-PYTAG="cp312-cp312-linux_x86_64"
-
-whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$PYTAG"; }
-whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }
-whl_light() { printf 'tt_lang_light-%s-py3-none-any.whl' "$1"; }
-
-make_wheel_dir() {
-    local dir
-    dir=$(mktemp -d "$BATS_TEST_TMPDIR/wheels.XXXXXX")
-    for name in "$@"; do
-        : > "$dir/$name"
-    done
-    echo "$dir"
-}
 
 setup() {
     SCRIPT="$SCRIPTS_DIR/verify-s3-wheel-versions.sh"

--- a/.github/scripts/tests/test_verify_s3_wheel_versions.bats
+++ b/.github/scripts/tests/test_verify_s3_wheel_versions.bats
@@ -38,6 +38,10 @@ setup() {
     run -2 "$SCRIPT" pypi "$VER" dist extra
 }
 
+@test "--no-sim without enough arguments -> usage error (exit 2)" {
+    run -2 "$SCRIPT" --no-sim external "$VER"
+}
+
 @test "unknown mode -> usage error (exit 2)" {
     dir=$(make_wheel_dir "$(whl "$VER")")
     run -2 "$SCRIPT" unknown "$VER" "$dir"
@@ -60,6 +64,22 @@ setup() {
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
     run -0 "$SCRIPT" external "$VER" "$dir"
+}
+
+@test "external mode with --no-sim accepts light wheels without sim" {
+    dir=$(make_wheel_dir \
+        "$(whl "$VER+light")" \
+        "$(whl_light "$VER")")
+    run -0 "$SCRIPT" --no-sim external "$VER" "$dir"
+}
+
+@test "external mode with --no-sim rejects a sim wheel" {
+    dir=$(make_wheel_dir \
+        "$(whl "$VER+light")" \
+        "$(whl_light "$VER")" \
+        "$(whl_sim "$VER")")
+    run -1 "$SCRIPT" --no-sim external "$VER" "$dir"
+    assert_output --partial "No expected version configured for distribution 'tt_lang_sim'"
 }
 
 @test "external mode rejects tt-lang without +light" {

--- a/.github/scripts/tests/test_verify_s3_wheel_versions.bats
+++ b/.github/scripts/tests/test_verify_s3_wheel_versions.bats
@@ -25,13 +25,13 @@ setup() {
 }
 
 @test "--no-sim without enough arguments -> usage error (exit 2)" {
-    run -2 "$SCRIPT" --no-sim external "$VER"
+    run -2 "$SCRIPT" --no-sim light "$VER"
 }
 
-@test "unknown mode -> usage error (exit 2)" {
+@test "unknown variant -> usage error (exit 2)" {
     dir=$(make_wheel_dir "$(whl "$VER")")
     run -2 "$SCRIPT" unknown "$VER" "$dir"
-    assert_output --partial "Unknown ttnn dependency mode"
+    assert_output --partial "Unknown wheel variant"
 }
 
 @test "pypi mode verifies every wheel against the requested version" {
@@ -44,41 +44,41 @@ setup() {
     run -0 "$SCRIPT" bundled "$VER" "$dir"
 }
 
-@test "external mode accepts +light tt-lang plus normal light and sim wheels" {
+@test "light variant accepts +light tt-lang plus normal light and sim wheels" {
     dir=$(make_wheel_dir \
         "$(whl "$VER+light")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
-    run -0 "$SCRIPT" external "$VER" "$dir"
+    run -0 "$SCRIPT" light "$VER" "$dir"
 }
 
-@test "external mode with --no-sim accepts light wheels without sim" {
+@test "light variant with --no-sim accepts light wheels without sim" {
     dir=$(make_wheel_dir \
         "$(whl "$VER+light")" \
         "$(whl_light "$VER")")
-    run -0 "$SCRIPT" --no-sim external "$VER" "$dir"
+    run -0 "$SCRIPT" --no-sim light "$VER" "$dir"
 }
 
-@test "external mode with --no-sim rejects a sim wheel" {
+@test "light variant with --no-sim rejects a sim wheel" {
     dir=$(make_wheel_dir \
         "$(whl "$VER+light")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
-    run -1 "$SCRIPT" --no-sim external "$VER" "$dir"
+    run -1 "$SCRIPT" --no-sim light "$VER" "$dir"
     assert_output --partial "No expected version configured for distribution 'tt_lang_sim'"
 }
 
-@test "external mode rejects tt-lang without +light" {
+@test "light variant rejects tt-lang without +light" {
     dir=$(make_wheel_dir \
         "$(whl "$VER")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
-    run -1 "$SCRIPT" external "$VER" "$dir"
+    run -1 "$SCRIPT" light "$VER" "$dir"
     assert_output --partial "does not match expected '$VER+light'"
 }
 
-@test "external mode requires the tt-lang-light wheel" {
+@test "light variant requires the tt-lang-light wheel" {
     dir=$(make_wheel_dir "$(whl "$VER+light")" "$(whl_sim "$VER")")
-    run -1 "$SCRIPT" external "$VER" "$dir"
+    run -1 "$SCRIPT" light "$VER" "$dir"
     assert_output --partial "No wheel found for expected distribution 'tt_lang_light'"
 }

--- a/.github/scripts/tests/test_verify_wheel_version.bats
+++ b/.github/scripts/tests/test_verify_wheel_version.bats
@@ -10,22 +10,6 @@ load test_helper
 # the literals can never be confused with a production version.
 VER="99.99.99"
 WRONG_VER="99.99.98"
-PYTAG="cp312-cp312-linux_x86_64"
-
-whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$PYTAG"; }
-whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }
-whl_light() { printf 'tt_lang_light-%s-py3-none-any.whl' "$1"; }
-whl_build() { printf 'tt_lang-%s-%s-%s.whl' "$1" "$2" "$PYTAG"; }  # <ver> <build>
-
-# Create a temp dir containing zero or more empty wheel files. Echoes the dir.
-make_wheel_dir() {
-    local dir
-    dir=$(mktemp -d "$BATS_TEST_TMPDIR/wheels.XXXXXX")
-    for name in "$@"; do
-        : > "$dir/$name"
-    done
-    echo "$dir"
-}
 
 setup() {
     SCRIPT="$SCRIPTS_DIR/verify-wheel-version.sh"

--- a/.github/scripts/tests/test_wheel_or_container_changed.bats
+++ b/.github/scripts/tests/test_wheel_or_container_changed.bats
@@ -119,7 +119,7 @@ setup() {
 }
 
 @test "diff only in third-party uplift path -> false (covered by detect-uplift, not this script)" {
-    echo "v0.70.0" > "$REPO/third-party/tt-metal-version"
+    printf '%s\n' "$TEST_TT_METAL_RC1_TAG" > "$REPO/third-party/tt-metal-version"
     commit_all "$REPO" "uplift only"
     head=$(cd "$REPO" && git rev-parse HEAD)
     assert_equal "$(run_changed "$BASE" "$head")" "false"

--- a/.github/scripts/verify-s3-wheel-versions.sh
+++ b/.github/scripts/verify-s3-wheel-versions.sh
@@ -7,14 +7,20 @@
 # tt-lang-light metapackage; bundled and pypi modes publish all wheels at the
 # requested internal version.
 #
-# Usage: verify-s3-wheel-versions.sh <ttnn_dep_mode> <version_override> <dist_dir>
+# Usage: verify-s3-wheel-versions.sh [--no-sim] <ttnn_dep_mode> <version_override> <dist_dir>
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <ttnn_dep_mode> <version_override> <dist_dir>" >&2
+    echo "Usage: $0 [--no-sim] <ttnn_dep_mode> <version_override> <dist_dir>" >&2
     exit 2
 }
+
+include_sim=1
+if [[ "${1:-}" == "--no-sim" ]]; then
+    include_sim=0
+    shift
+fi
 
 if [[ $# -ne 3 ]]; then
     usage
@@ -27,11 +33,14 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 case "$mode" in
     external)
-        "$script_dir/verify-wheel-version.sh" \
-            --expect "tt_lang=$version+light" \
-            --expect "tt_lang_light=$version" \
-            --expect "tt_lang_sim=$version" \
-            "$dist_dir"
+        verify_args=(
+            --expect "tt_lang=$version+light"
+            --expect "tt_lang_light=$version"
+        )
+        if [[ "$include_sim" -eq 1 ]]; then
+            verify_args+=(--expect "tt_lang_sim=$version")
+        fi
+        "$script_dir/verify-wheel-version.sh" "${verify_args[@]}" "$dist_dir"
         ;;
     bundled | pypi)
         "$script_dir/verify-wheel-version.sh" "$version" "$dist_dir"

--- a/.github/scripts/verify-s3-wheel-versions.sh
+++ b/.github/scripts/verify-s3-wheel-versions.sh
@@ -2,17 +2,17 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Verify the wheel versions produced by the S3 PyPI publish workflow. External
-# mode publishes a tt-lang wheel with a +light local version plus the
-# tt-lang-light metapackage; bundled and pypi modes publish all wheels at the
+# Verify the wheel versions produced by the S3 PyPI publish workflow. The light
+# variant publishes a tt-lang wheel with a +light local version plus the
+# tt-lang-light metapackage; bundled and pypi variants publish all wheels at the
 # requested internal version.
 #
-# Usage: verify-s3-wheel-versions.sh [--no-sim] <ttnn_dep_mode> <version_override> <dist_dir>
+# Usage: verify-s3-wheel-versions.sh [--no-sim] <wheel_variant> <version_override> <dist_dir>
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 [--no-sim] <ttnn_dep_mode> <version_override> <dist_dir>" >&2
+    echo "Usage: $0 [--no-sim] <wheel_variant> <version_override> <dist_dir>" >&2
     exit 2
 }
 
@@ -26,13 +26,13 @@ if [[ $# -ne 3 ]]; then
     usage
 fi
 
-mode="$1"
+variant="$1"
 version="$2"
 dist_dir="$3"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-case "$mode" in
-    external)
+case "$variant" in
+    light)
         verify_args=(
             --expect "tt_lang=$version+light"
             --expect "tt_lang_light=$version"
@@ -46,7 +46,7 @@ case "$mode" in
         "$script_dir/verify-wheel-version.sh" "$version" "$dist_dir"
         ;;
     *)
-        echo "Unknown ttnn dependency mode: $mode" >&2
+        echo "Unknown wheel variant: $variant" >&2
         exit 2
         ;;
 esac

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -41,6 +41,16 @@ on:
         type: string
         default: ""
         required: false
+      build_sim_wheel:
+        description: "Build and test the tt-lang-sim wheel."
+        type: boolean
+        default: true
+        required: false
+      artifact_name:
+        description: "Artifact name for uploaded wheels."
+        type: string
+        default: tt-lang-wheels
+        required: false
 
 permissions:
   contents: read
@@ -139,13 +149,14 @@ jobs:
           python .github/scripts/check-installed-ttnn.py --mode "${{ inputs.ttnn_dep_mode }}"
           python .github/scripts/smoke-test-wheel.py
 
-      - name: Free disk space before tt-lang-sim wheel test
+      - name: Free disk space before remaining wheel tests
         run: |
           rm -rf /tmp/test-venv-hw /tmp/ttlang-prefix build dist-raw
           python3.12 -m pip cache purge || true
           df -h
 
       - name: Build tt-lang-sim wheel
+        if: ${{ inputs.build_sim_wheel }}
         env:
           TTLANG_VERSION_OVERRIDE: ${{ inputs.version_override }}
         run: |
@@ -153,6 +164,7 @@ jobs:
           pip wheel packaging/sim --wheel-dir=dist --no-deps --no-build-isolation
 
       - name: Test tt-lang-sim wheel
+        if: ${{ inputs.build_sim_wheel }}
         run: |
           python3.12 -m venv /tmp/test-venv-sim
           source /tmp/test-venv-sim/bin/activate
@@ -186,6 +198,6 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: tt-lang-wheels
+          name: ${{ inputs.artifact_name }}
           path: dist/*.whl
           retention-days: 14

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -46,6 +46,11 @@ on:
         type: boolean
         default: true
         required: false
+      allow_final_internal_version:
+        description: "Allow bundled/external internal wheels to use a final release version."
+        type: boolean
+        default: false
+        required: false
       artifact_name:
         description: "Artifact name for uploaded wheels."
         type: string
@@ -108,6 +113,7 @@ jobs:
           TTLANG_EXTERNAL_TT_METAL_BUILD_DIR: ${{ inputs.external_tt_metal_build_dir }}
           TTLANG_BUNDLED_TT_METAL_DIR: ${{ inputs.bundled_tt_metal_dir }}
           TTLANG_PYTHON_VENV: ${{ inputs.external_python_venv }}
+          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ inputs.allow_final_internal_version }}
         run: |
           source /opt/ttlang-toolchain/venv/bin/activate
           pip wheel . --wheel-dir=dist-raw --no-deps --no-build-isolation
@@ -180,6 +186,7 @@ jobs:
         env:
           TTLANG_VERSION_OVERRIDE: ${{ inputs.version_override }}
           TTLANG_LIGHT_TTLANG_VERSION: ${{ steps.versions.outputs.light_version }}
+          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ inputs.allow_final_internal_version }}
         run: |
           source /opt/ttlang-toolchain/venv/bin/activate
           pip wheel packaging/light --wheel-dir=dist --no-deps --no-build-isolation

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -66,6 +66,7 @@ jobs:
       wheel_variant: ${{ steps.resolve.outputs.wheel_variant }}
       wheel_variants: ${{ steps.resolve.outputs.wheel_variants }}
       wheel_matrix: ${{ steps.resolve.outputs.wheel_matrix }}
+      allow_final_internal_version: ${{ steps.resolve.outputs.allow_final_internal_version }}
 
     steps:
       - name: Checkout tt-lang
@@ -81,7 +82,7 @@ jobs:
           DISPATCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.dry_run) || 'false' }}
           DISPATCH_OVERWRITE_RELEASES: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.overwrite_releases) || 'false' }}
           DISPATCH_VERSION_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.version_override || '' }}
-          DISPATCH_WHEEL_VARIANT: ${{ github.event_name == 'workflow_dispatch' && inputs.wheel_variant || 'bundled-and-light' }}
+          DISPATCH_WHEEL_VARIANT: ${{ github.event_name == 'workflow_dispatch' && inputs.wheel_variant || '' }}
           EVENT_NAME: ${{ github.event_name }}
         run: .github/scripts/resolve-s3-publish-inputs.sh
 
@@ -116,6 +117,7 @@ jobs:
       external_python_venv: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/venv' || '' }}
       bundled_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'bundled' && '/opt/ttlang-toolchain/tt-metal' || '' }}
       build_sim_wheel: ${{ !(needs.preflight.outputs.wheel_variant == 'bundled-and-light' && matrix.wheel_variant == 'light') }}
+      allow_final_internal_version: ${{ needs.preflight.outputs.allow_final_internal_version == 'true' }}
       artifact_name: tt-lang-wheels-${{ matrix.wheel_variant }}
 
   publish:

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -76,7 +76,7 @@ jobs:
           DISPATCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.dry_run) || 'false' }}
           DISPATCH_OVERWRITE_RELEASES: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.overwrite_releases) || 'false' }}
           DISPATCH_VERSION_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.version_override || '' }}
-          DISPATCH_TTNN_DEP_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.ttnn_dep_mode || 'bundled' }}
+          DISPATCH_TTNN_DEP_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.ttnn_dep_mode || 'bundled-and-external' }}
           EVENT_NAME: ${{ github.event_name }}
         run: .github/scripts/resolve-s3-publish-inputs.sh
 

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -21,11 +21,12 @@ on:
         default: ""
         required: false
       ttnn_dep_mode:
-        description: "ttnn dependency mode for the tt-lang wheel."
+        description: "ttnn dependency mode or S3 publish selection."
         type: choice
         options:
           - bundled
           - external
+          - bundled-and-external
           - pypi
         default: bundled
         required: true
@@ -59,6 +60,7 @@ jobs:
       overwrite_releases: ${{ steps.resolve.outputs.overwrite_releases }}
       version_override: ${{ steps.resolve.outputs.version_override }}
       ttnn_dep_mode: ${{ steps.resolve.outputs.ttnn_dep_mode }}
+      ttnn_dep_modes: ${{ steps.resolve.outputs.ttnn_dep_modes }}
 
     steps:
       - name: Checkout tt-lang
@@ -93,17 +95,24 @@ jobs:
   build-wheels:
     needs: [preflight, build-docker]
     if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') }}
+    name: "Build ${{ matrix.ttnn_dep_mode }} wheels"
+    strategy:
+      fail-fast: false
+      matrix:
+        ttnn_dep_mode: ${{ fromJSON(needs.preflight.outputs.ttnn_dep_modes) }}
     permissions:
       contents: read
       packages: read
     uses: ./.github/workflows/call-build-wheels.yml
     with:
       docker_tag: ${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}
-      ttnn_dep_mode: ${{ needs.preflight.outputs.ttnn_dep_mode }}
+      ttnn_dep_mode: ${{ matrix.ttnn_dep_mode }}
       version_override: ${{ needs.preflight.outputs.version_override }}
-      external_tt_metal_dir: ${{ needs.preflight.outputs.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/tt-metal' || '' }}
-      external_python_venv: ${{ needs.preflight.outputs.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/venv' || '' }}
-      bundled_tt_metal_dir: ${{ needs.preflight.outputs.ttnn_dep_mode == 'bundled' && '/opt/ttlang-toolchain/tt-metal' || '' }}
+      external_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/tt-metal' || '' }}
+      external_python_venv: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/venv' || '' }}
+      bundled_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'bundled' && '/opt/ttlang-toolchain/tt-metal' || '' }}
+      build_sim_wheel: ${{ !(needs.preflight.outputs.ttnn_dep_mode == 'bundled-and-external' && matrix.ttnn_dep_mode == 'external') }}
+      artifact_name: tt-lang-wheels-${{ matrix.ttnn_dep_mode }}
 
   publish:
     name: "Publish wheels to S3 PyPI"
@@ -124,19 +133,48 @@ jobs:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
 
-      - name: Download wheels
+      - name: Download bundled wheels
+        if: ${{ contains(fromJSON(needs.preflight.outputs.ttnn_dep_modes), 'bundled') }}
         uses: actions/download-artifact@v8
         with:
-          name: tt-lang-wheels
-          path: dist
+          name: tt-lang-wheels-bundled
+          path: wheel-artifacts/bundled
 
-      - name: Verify wheel versions
+      - name: Download external wheels
+        if: ${{ contains(fromJSON(needs.preflight.outputs.ttnn_dep_modes), 'external') }}
+        uses: actions/download-artifact@v8
+        with:
+          name: tt-lang-wheels-external
+          path: wheel-artifacts/external
+
+      - name: Download pypi wheels
+        if: ${{ contains(fromJSON(needs.preflight.outputs.ttnn_dep_modes), 'pypi') }}
+        uses: actions/download-artifact@v8
+        with:
+          name: tt-lang-wheels-pypi
+          path: wheel-artifacts/pypi
+
+      - name: Prepare publish dist
         run: |
           set -euo pipefail
-          .github/scripts/verify-s3-wheel-versions.sh \
-            "${{ needs.preflight.outputs.ttnn_dep_mode }}" \
+          prepare_args=()
+          if [ -d wheel-artifacts/bundled ]; then
+            prepare_args+=(bundled=wheel-artifacts/bundled)
+          fi
+          if [ -d wheel-artifacts/external ]; then
+            if [ -d wheel-artifacts/bundled ]; then
+              prepare_args+=(external:no-sim=wheel-artifacts/external)
+            else
+              prepare_args+=(external=wheel-artifacts/external)
+            fi
+          fi
+          if [ -d wheel-artifacts/pypi ]; then
+            prepare_args+=(pypi=wheel-artifacts/pypi)
+          fi
+          .github/scripts/prepare-s3-publish-dist.sh \
             "${{ needs.preflight.outputs.version_override }}" \
-            dist
+            dist \
+            "${prepare_args[@]}"
 
       - name: Configure AWS Credentials
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -5,6 +5,10 @@
 name: Publish S3 PyPI Wheels
 
 on:
+  push:
+    tags:
+      # Publish clean-version internal bundled/light wheels for stable releases.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   schedule:
     # Nightly S3-only internal wheel publish. GitHub cron uses UTC.
     - cron: "0 8 * * *"

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -117,7 +117,7 @@ jobs:
   publish:
     name: "Publish wheels to S3 PyPI"
     needs: [preflight, build-wheels]
-    if: ${{ needs.build-wheels.result == 'success' }}
+    if: ${{ always() && needs.preflight.result == 'success' && needs.build-wheels.result == 'success' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
 

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -20,13 +20,13 @@ on:
         type: string
         default: ""
         required: false
-      ttnn_dep_mode:
-        description: "ttnn dependency mode or S3 publish selection."
+      wheel_variant:
+        description: "Wheel variant set to publish to S3 PyPI."
         type: choice
         options:
           - bundled
-          - external
-          - bundled-and-external
+          - light
+          - bundled-and-light
           - pypi
         default: bundled
         required: true
@@ -59,8 +59,9 @@ jobs:
       dry_run: ${{ steps.resolve.outputs.dry_run }}
       overwrite_releases: ${{ steps.resolve.outputs.overwrite_releases }}
       version_override: ${{ steps.resolve.outputs.version_override }}
-      ttnn_dep_mode: ${{ steps.resolve.outputs.ttnn_dep_mode }}
-      ttnn_dep_modes: ${{ steps.resolve.outputs.ttnn_dep_modes }}
+      wheel_variant: ${{ steps.resolve.outputs.wheel_variant }}
+      wheel_variants: ${{ steps.resolve.outputs.wheel_variants }}
+      wheel_matrix: ${{ steps.resolve.outputs.wheel_matrix }}
 
     steps:
       - name: Checkout tt-lang
@@ -76,7 +77,7 @@ jobs:
           DISPATCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.dry_run) || 'false' }}
           DISPATCH_OVERWRITE_RELEASES: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.overwrite_releases) || 'false' }}
           DISPATCH_VERSION_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.version_override || '' }}
-          DISPATCH_TTNN_DEP_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.ttnn_dep_mode || 'bundled-and-external' }}
+          DISPATCH_WHEEL_VARIANT: ${{ github.event_name == 'workflow_dispatch' && inputs.wheel_variant || 'bundled-and-light' }}
           EVENT_NAME: ${{ github.event_name }}
         run: .github/scripts/resolve-s3-publish-inputs.sh
 
@@ -95,11 +96,10 @@ jobs:
   build-wheels:
     needs: [preflight, build-docker]
     if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') }}
-    name: "Build ${{ matrix.ttnn_dep_mode }} wheels"
+    name: "Build ${{ matrix.wheel_variant }} wheels"
     strategy:
       fail-fast: false
-      matrix:
-        ttnn_dep_mode: ${{ fromJSON(needs.preflight.outputs.ttnn_dep_modes) }}
+      matrix: ${{ fromJSON(needs.preflight.outputs.wheel_matrix) }}
     permissions:
       contents: read
       packages: read
@@ -111,8 +111,8 @@ jobs:
       external_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/tt-metal' || '' }}
       external_python_venv: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/venv' || '' }}
       bundled_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'bundled' && '/opt/ttlang-toolchain/tt-metal' || '' }}
-      build_sim_wheel: ${{ !(needs.preflight.outputs.ttnn_dep_mode == 'bundled-and-external' && matrix.ttnn_dep_mode == 'external') }}
-      artifact_name: tt-lang-wheels-${{ matrix.ttnn_dep_mode }}
+      build_sim_wheel: ${{ !(needs.preflight.outputs.wheel_variant == 'bundled-and-light' && matrix.wheel_variant == 'light') }}
+      artifact_name: tt-lang-wheels-${{ matrix.wheel_variant }}
 
   publish:
     name: "Publish wheels to S3 PyPI"
@@ -134,21 +134,21 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download bundled wheels
-        if: ${{ contains(fromJSON(needs.preflight.outputs.ttnn_dep_modes), 'bundled') }}
+        if: ${{ contains(fromJSON(needs.preflight.outputs.wheel_variants), 'bundled') }}
         uses: actions/download-artifact@v8
         with:
           name: tt-lang-wheels-bundled
           path: wheel-artifacts/bundled
 
-      - name: Download external wheels
-        if: ${{ contains(fromJSON(needs.preflight.outputs.ttnn_dep_modes), 'external') }}
+      - name: Download light wheels
+        if: ${{ contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light') }}
         uses: actions/download-artifact@v8
         with:
-          name: tt-lang-wheels-external
-          path: wheel-artifacts/external
+          name: tt-lang-wheels-light
+          path: wheel-artifacts/light
 
       - name: Download pypi wheels
-        if: ${{ contains(fromJSON(needs.preflight.outputs.ttnn_dep_modes), 'pypi') }}
+        if: ${{ contains(fromJSON(needs.preflight.outputs.wheel_variants), 'pypi') }}
         uses: actions/download-artifact@v8
         with:
           name: tt-lang-wheels-pypi
@@ -161,11 +161,11 @@ jobs:
           if [ -d wheel-artifacts/bundled ]; then
             prepare_args+=(bundled=wheel-artifacts/bundled)
           fi
-          if [ -d wheel-artifacts/external ]; then
+          if [ -d wheel-artifacts/light ]; then
             if [ -d wheel-artifacts/bundled ]; then
-              prepare_args+=(external:no-sim=wheel-artifacts/external)
+              prepare_args+=(light:no-sim=wheel-artifacts/light)
             else
-              prepare_args+=(external=wheel-artifacts/external)
+              prepare_args+=(light=wheel-artifacts/light)
             fi
           fi
           if [ -d wheel-artifacts/pypi ]; then
@@ -206,5 +206,5 @@ jobs:
           fi
           .github/scripts/publish-s3-summary.sh \
             "${summary_args[@]}" \
-            "${{ needs.preflight.outputs.ttnn_dep_mode }}" \
+            "${{ needs.preflight.outputs.wheel_variant }}" \
             "${{ needs.preflight.outputs.version_override }}"

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -565,19 +565,24 @@ pushes, runs nightly on a GitHub schedule, and can also be dispatched manually.
 It uses GitHub OIDC for AWS access, then uploads with
 `s3pypi upload --put-root-index --bucket tenstorrent-pypi`.
 
-Do not publish a bundled internal wheel with the same package name and version
-as the public PyPI wheel if the public wheel has different dependency metadata.
-For example, a public `tt-lang` release may depend on a separately published
-`ttnn` wheel, while an internal S3 `tt-lang` wheel at the same version may
-bundle `ttnn` directly.
-Those two artifacts are not interchangeable, and pip can see both indexes when
-`--extra-index-url` is used.
+The workflow prevents publishing a bundled internal `tt-lang` wheel with the
+same package name and version as the public PyPI wheel when public PyPI
+publishing is already valid for that tt-metal tag. This avoids having two
+indexes expose `tt-lang==X.Y.Z` artifacts with different dependency metadata.
 
 Automatic S3 publishing should use this policy:
 
 - Stable release tags (`vX.Y.Z`) publish clean-version bundled and light wheels
-  to S3. This does not require the public `ttnn` PyPI wheel to exist for the
-  current tt-metal tag.
+  to S3 only when public PyPI publishing is blocked because
+  `TTNN_PYPI_TT_METAL_TAG != TT_METAL_TAG`.
+- Stable release tags publish only light wheels to S3 when public PyPI
+  publishing is aligned. In that case public PyPI owns `tt-lang==X.Y.Z`, and S3
+  owns `tt-lang==X.Y.Z+light` plus `tt-lang-light==X.Y.Z`.
+- Manual stable-version S3 publishes that include the bundled variant are
+  rejected when public PyPI publishing is aligned for the same tt-metal tag.
+- The S3 resolver passes `TTLANG_ALLOW_FINAL_INTERNAL_VERSION=true` to the wheel
+  builder only after this conflict check has passed, so final-version internal
+  wheels cannot bypass the release guard.
 - Do not mix public PyPI and S3 indexes for a `tt-lang` version whose artifacts
   have different dependency semantics. Use the S3 install command emitted by the
   workflow summary for internal release wheels.
@@ -589,10 +594,11 @@ Automatic S3 publishing should use this policy:
   keeps nightly versions readable, but existing local pip caches may still hold
   the older wheel for that version.
 
-Stable tag pushes default to `wheel_variant: bundled-and-light`, derive
-`version_override` from the tag (`v1.1.2` -> `1.1.2`), build and push the
-matching IRD image, build bundled and light wheels from that image, verify the
-wheel versions, and publish the result to S3 PyPI.
+Stable tag pushes derive `version_override` from the tag (`v1.1.2` -> `1.1.2`),
+build and push the matching IRD image, build the selected wheel variants from
+that image, verify the wheel versions, and publish the result to S3 PyPI. The
+selected variant set is `bundled-and-light` when public PyPI publishing is
+blocked, and `light` when public PyPI publishing is aligned.
 
 The scheduled workflow also defaults to `wheel_variant: bundled-and-light`,
 builds and pushes the matching IRD image, builds bundled and light wheels from

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -586,9 +586,9 @@ Automatic S3 publishing should use this policy:
   keeps nightly versions readable, but existing local pip caches may still hold
   the older wheel for that version.
 
-The scheduled workflow defaults to `ttnn_dep_mode: bundled`, builds and pushes
-the matching IRD image, builds wheels from that image, verifies the wheel
-versions, and publishes the result to S3 PyPI.
+The scheduled workflow defaults to `ttnn_dep_mode: bundled-and-external`, builds
+and pushes the matching IRD image, builds bundled and light wheels from that
+image, verifies the wheel versions, and publishes the result to S3 PyPI.
 
 For a manual bundled internal wheel with an existing IRD image, dispatch the
 workflow with:

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -699,18 +699,34 @@ pip wheel packaging/light --wheel-dir=/tmp/ttlang-wheels/light/dist \
   --no-deps --no-build-isolation
 ```
 
-Install-test the light package from the local wheel directory, then configure
-the external tt-metal environment:
+Install-test the light package from the local wheel directory. The setup command
+copies tutorials into `./tutorials/` and skips sfpi installation for light
+installs because the external tt-metal tree provides sfpi:
 
 ```bash
 python3.12 -m venv /tmp/ttlang-light-test
 source /tmp/ttlang-light-test/bin/activate
 pip install --find-links=/tmp/ttlang-wheels/light/dist \
   "tt-lang-light==$TTLANG_VERSION"
-tt-lang-setup-external-tt-metal \
-  --tt-metal-dir /opt/ttlang-toolchain/tt-metal \
-  --check \
-  -- python -c 'import ttl, ttnn; print(ttl.__version__, ttnn.__file__)'
+tt-lang-setup
+```
+
+Configure the external tt-metal environment and validate imports:
+
+```bash
+external_tt_metal_env="$(
+  tt-lang-setup-external-tt-metal \
+    --tt-metal-dir /opt/ttlang-toolchain/tt-metal \
+    --check
+)" && eval "$external_tt_metal_env"
+python -c 'import ttl, ttnn; print(ttl.__version__, ttnn.__file__)'
+```
+
+The TT-Lang tutorial can then run from the local directory copied by
+`tt-lang-setup`:
+
+```bash
+python tutorials/elementwise/step_4_multinode_grid_full.py
 ```
 
 ## CMake Options

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -620,6 +620,19 @@ omits `Requires-Dist: ttnn`; the normal PyPI build keeps that requirement. The
 same build also emits `tt-lang-light==<version_override>`, a metapackage that
 depends on `tt-lang==<version_override>+light`.
 
+To publish bundled and light wheels from the same workflow run, dispatch with:
+
+```text
+ttnn_dep_mode: bundled-and-external
+version_override: <internal-version>
+```
+
+The workflow builds the bundled and external wheel sets separately, uploads
+mode-specific artifacts, verifies each artifact with the expected version rules,
+then publishes a single combined directory. The external build skips
+`tt-lang-sim` in this mode because the bundled build already provides the same
+`tt-lang-sim==<version_override>` package/version for the S3 index.
+
 #### Local internal wheel testing
 
 Use the same environment variables as the reusable workflow when validating the

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -560,9 +560,9 @@ ird image tag):
 #### Publishing to S3 PyPI
 
 `publish-s3-pypi.yml` publishes internal wheels to the Tenstorrent S3 PyPI
-index at `https://pypi.eng.aws.tenstorrent.com/`. It runs nightly on a GitHub
-schedule and can also be dispatched manually. It uses GitHub OIDC for AWS access,
-then uploads with
+index at `https://pypi.eng.aws.tenstorrent.com/`. It runs on stable release tag
+pushes, runs nightly on a GitHub schedule, and can also be dispatched manually.
+It uses GitHub OIDC for AWS access, then uploads with
 `s3pypi upload --put-root-index --bucket tenstorrent-pypi`.
 
 Do not publish a bundled internal wheel with the same package name and version
@@ -575,9 +575,12 @@ Those two artifacts are not interchangeable, and pip can see both indexes when
 
 Automatic S3 publishing should use this policy:
 
-- Release or RC tags may publish to S3 only when the S3 artifact version is
-  distinct from the public PyPI artifact version, or when the S3 artifact is
-  byte-for-byte equivalent in dependency semantics.
+- Stable release tags (`vX.Y.Z`) publish clean-version bundled and light wheels
+  to S3. This does not require the public `ttnn` PyPI wheel to exist for the
+  current tt-metal tag.
+- Do not mix public PyPI and S3 indexes for a `tt-lang` version whose artifacts
+  have different dependency semantics. Use the S3 install command emitted by the
+  workflow summary for internal release wheels.
 - Nightly builds do not create Git tags. The scheduled workflow computes a
   PEP 440 development version of the form `<MAJOR.MINOR.PATCH>.dev<YYYYMMDD>`,
   where the base version matches the latest stable tag reachable from `HEAD`,
@@ -586,9 +589,14 @@ Automatic S3 publishing should use this policy:
   keeps nightly versions readable, but existing local pip caches may still hold
   the older wheel for that version.
 
-The scheduled workflow defaults to `wheel_variant: bundled-and-light`, builds
-and pushes the matching IRD image, builds bundled and light wheels from that
-image, verifies the wheel versions, and publishes the result to S3 PyPI.
+Stable tag pushes default to `wheel_variant: bundled-and-light`, derive
+`version_override` from the tag (`v1.1.2` -> `1.1.2`), build and push the
+matching IRD image, build bundled and light wheels from that image, verify the
+wheel versions, and publish the result to S3 PyPI.
+
+The scheduled workflow also defaults to `wheel_variant: bundled-and-light`,
+builds and pushes the matching IRD image, builds bundled and light wheels from
+that image, verifies the wheel versions, and publishes the result to S3 PyPI.
 
 For a manual bundled internal wheel with an existing IRD image, dispatch the
 workflow with:

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -586,7 +586,7 @@ Automatic S3 publishing should use this policy:
   keeps nightly versions readable, but existing local pip caches may still hold
   the older wheel for that version.
 
-The scheduled workflow defaults to `ttnn_dep_mode: bundled-and-external`, builds
+The scheduled workflow defaults to `wheel_variant: bundled-and-light`, builds
 and pushes the matching IRD image, builds bundled and light wheels from that
 image, verifies the wheel versions, and publishes the result to S3 PyPI.
 
@@ -595,7 +595,7 @@ workflow with:
 
 ```text
 docker_tag: <existing-ird-tag>
-ttnn_dep_mode: bundled
+wheel_variant: bundled
 version_override: <internal-version>
 ```
 
@@ -610,11 +610,12 @@ For light wheels that must use a user-provided tt-metal build instead of a
 bundled or public `ttnn` wheel, dispatch the workflow with:
 
 ```text
-ttnn_dep_mode: external
+wheel_variant: light
 version_override: <internal-version>
 ```
 
-The reusable wheel build sets `TTLANG_TTNN_DEP_MODE=external` and
+The workflow maps this publish selection to the reusable wheel builder's
+`TTLANG_TTNN_DEP_MODE=external` build mode and sets
 `TTLANG_VERSION_OVERRIDE=<version_override>+light`. The resulting `tt-lang` wheel
 omits `Requires-Dist: ttnn`; the normal PyPI build keeps that requirement. The
 same build also emits `tt-lang-light==<version_override>`, a metapackage that
@@ -623,13 +624,13 @@ depends on `tt-lang==<version_override>+light`.
 To publish bundled and light wheels from the same workflow run, dispatch with:
 
 ```text
-ttnn_dep_mode: bundled-and-external
+wheel_variant: bundled-and-light
 version_override: <internal-version>
 ```
 
-The workflow builds the bundled and external wheel sets separately, uploads
+The workflow builds the bundled and light wheel sets separately, uploads
 mode-specific artifacts, verifies each artifact with the expected version rules,
-then publishes a single combined directory. The external build skips
+then publishes a single combined directory. The light build skips
 `tt-lang-sim` in this mode because the bundled build already provides the same
 `tt-lang-sim==<version_override>` package/version for the S3 index.
 

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -88,46 +88,43 @@ pip install \
 tt-lang-setup    # copies tutorials only; sfpi is provided by the external tt-metal
 ```
 
-Configure a native tt-metal source/build layout before running hardware
-programs. The `--check` option imports `ttnn` from the selected tree, so use it
-only with trusted tt-metal builds:
+The `tt-lang-setup` command above copies the tutorials into `./tutorials`.
+Configure a native tt-metal source/build layout before running those local
+hardware examples. The `--check` option imports `ttnn` from the selected tree,
+so use it only with trusted tt-metal builds:
 
 ```bash
-tt-lang-setup-external-tt-metal \
-  --tt-metal-dir /path/to/tt-metal \
-  --build-dir /path/to/tt-metal/build \
-  --check \
-  -- python tutorials/elementwise/step_4_multinode_grid_full.py
+external_tt_metal_env="$(
+  tt-lang-setup-external-tt-metal \
+    --tt-metal-dir /path/to/tt-metal \
+    --build-dir /path/to/tt-metal/build \
+    --check
+)" && eval "$external_tt_metal_env"
 ```
 
 Configure an install-layout tt-metal prefix similarly:
 
 ```bash
-tt-lang-setup-external-tt-metal \
-  --tt-metal-dir /path/to/tt-metal-install \
-  --check \
-  -- python tutorials/elementwise/step_4_multinode_grid_full.py
+external_tt_metal_env="$(
+  tt-lang-setup-external-tt-metal \
+    --tt-metal-dir /path/to/tt-metal-install \
+    --check
+)" && eval "$external_tt_metal_env"
+python tutorials/elementwise/step_4_multinode_grid_full.py
+python tutorials/matmul/step_3_multinode.py
 ```
-
-When no command is supplied, `tt-lang-setup-external-tt-metal` prints shell
-exports for interactive shell setup.
 
 Validate that Python resolves both packages from the intended environment:
 
 ```bash
-tt-lang-setup-external-tt-metal \
-  --tt-metal-dir /path/to/tt-metal-install \
-  --check \
-  -- python -c 'import ttnn, ttl; print(ttnn.__file__, ttl.__version__)'
+python -c 'import ttnn, ttl; print(ttnn.__file__, ttl.__version__)'
 ```
 
 Run a tutorial example:
 
 ```bash
 tt-lang-sim tutorials/elementwise/step_4_multinode_grid_full.py    # simulator (no compilation, runs on CPU)
-tt-lang-setup-external-tt-metal \
-  --tt-metal-dir /path/to/tt-metal-install \
-  -- python tutorials/elementwise/step_4_multinode_grid_full.py   # compiles and runs on hardware
+python tutorials/elementwise/step_4_multinode_grid_full.py        # compiles and runs on hardware
 ```
 
 ## Build from source for the simulator only

--- a/packaging/internal_wheel_metadata.py
+++ b/packaging/internal_wheel_metadata.py
@@ -13,10 +13,19 @@ import subprocess
 from packaging.version import InvalidVersion, Version
 
 VERSION_OVERRIDE_ENV = "TTLANG_VERSION_OVERRIDE"
+ALLOW_FINAL_INTERNAL_VERSION_ENV = "TTLANG_ALLOW_FINAL_INTERNAL_VERSION"
 
 
 def get_version_override() -> str:
     return os.environ.get(VERSION_OVERRIDE_ENV, "").strip()
+
+
+def allow_final_internal_version() -> bool:
+    return os.environ.get(ALLOW_FINAL_INTERNAL_VERSION_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
 
 def require_version_override(package_name: str) -> None:
@@ -66,7 +75,11 @@ def require_non_final_internal_version(package_name: str, version: str) -> None:
     except InvalidVersion as error:
         raise SystemExit(f"{package_name} has invalid version {version!r}") from error
 
-    if not parsed_version.is_devrelease and not parsed_version.is_prerelease:
+    if (
+        not parsed_version.is_devrelease
+        and not parsed_version.is_prerelease
+        and not allow_final_internal_version()
+    ):
         raise SystemExit(
             f"{package_name} requires a non-final version such as "
             "0.71.0.dev20260525 or 0.71.0rc1"

--- a/python/ttl/_setup/external_tt_metal.py
+++ b/python/ttl/_setup/external_tt_metal.py
@@ -151,8 +151,13 @@ def _check_import(settings: ExternalTTMetalEnv) -> int:
         [sys.executable, "-c", "import ttnn; print(ttnn.__file__)"],
         env=environment,
         text=True,
+        capture_output=True,
         check=False,
     )
+    if result.stdout:
+        print(result.stdout, end="", file=sys.stderr)
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
     return result.returncode
 
 

--- a/python/ttl/_setup/external_tt_metal.py
+++ b/python/ttl/_setup/external_tt_metal.py
@@ -196,13 +196,8 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
-        "tt_metal_dir",
-        nargs="?",
-        help="existing tt-metal source or install directory",
-    )
-    parser.add_argument(
         "--tt-metal-dir",
-        dest="tt_metal_dir_option",
+        required=True,
         help="existing tt-metal source or install directory",
     )
     parser.add_argument(
@@ -225,12 +220,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(parser_argv)
 
-    tt_metal_dir = args.tt_metal_dir_option or args.tt_metal_dir
-    if not tt_metal_dir:
-        parser.error("tt-metal directory is required")
-
     try:
-        settings = detect_external_tt_metal(tt_metal_dir, args.build_dir)
+        settings = detect_external_tt_metal(args.tt_metal_dir, args.build_dir)
     except ValueError as error:
         print(f"error: {error}", file=sys.stderr)
         return 2

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ class NoSdist(_sdist):
 REPO_ROOT = pathlib.Path(__file__).resolve().parent
 _TTNN_DEP_MODES = ("pypi", "external", "bundled")
 _VERSION_OVERRIDE_ENV = "TTLANG_VERSION_OVERRIDE"
+_ALLOW_FINAL_INTERNAL_VERSION_ENV = "TTLANG_ALLOW_FINAL_INTERNAL_VERSION"
 
 
 def _ttnn_dep_mode():
@@ -48,6 +49,14 @@ def _ttnn_dep_mode():
 
 def _version_override():
     return os.environ.get(_VERSION_OVERRIDE_ENV, "").strip()
+
+
+def _allow_final_internal_version():
+    return os.environ.get(_ALLOW_FINAL_INTERNAL_VERSION_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
 
 def _read_tt_metal_version_var(name):
@@ -175,7 +184,11 @@ def _validate_ttnn_dep_mode_version(version):
     except InvalidVersion as error:
         raise SystemExit(f"invalid {_VERSION_OVERRIDE_ENV} {version!r}") from error
 
-    if not parsed_version.is_devrelease and not parsed_version.is_prerelease:
+    if (
+        not parsed_version.is_devrelease
+        and not parsed_version.is_prerelease
+        and not _allow_final_internal_version()
+    ):
         raise SystemExit(
             f"TTLANG_TTNN_DEP_MODE={mode} requires a non-final version "
             "such as 0.71.0.dev20260525 or 0.71.0rc1"

--- a/test/packaging/test_external_tt_metal_setup.py
+++ b/test/packaging/test_external_tt_metal_setup.py
@@ -31,6 +31,9 @@ def _make_install_layout(tmp_path: Path) -> Path:
     install_root = tmp_path / "tt-metal-install"
     (install_root / "python_packages" / "ttnn" / "ttnn").mkdir(parents=True)
     (install_root / "python_packages" / "tools").mkdir(parents=True)
+    (install_root / "python_packages" / "ttnn" / "ttnn" / "__init__.py").write_text(
+        "print('ttnn import probe stdout')\n"
+    )
     (install_root / "python_packages" / "ttnn" / "ttnn" / "_ttnn.so").touch()
     (install_root / "lib").mkdir()
     return install_root
@@ -135,6 +138,22 @@ assert os.environ["LD_LIBRARY_PATH"].split(":")[0] == f"{install_root}/lib"
     )
 
     assert status == 0
+
+
+def test_checked_shell_export_form_keeps_stdout_eval_safe(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+    install_root = _make_install_layout(tmp_path)
+
+    status = module.main(["--tt-metal-dir", str(install_root), "--check"])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "export TT_METAL_HOME=" in captured.out
+    assert "ttnn import probe stdout" not in captured.out
+    assert "ttnn import probe stdout" in captured.err
 
 
 def test_cli_rejects_positional_tt_metal_dir(tmp_path: Path) -> None:

--- a/test/packaging/test_external_tt_metal_setup.py
+++ b/test/packaging/test_external_tt_metal_setup.py
@@ -27,13 +27,18 @@ def _load_module():
     return module
 
 
-def test_detects_install_layout_and_emits_shell_exports(tmp_path: Path) -> None:
-    module = _load_module()
+def _make_install_layout(tmp_path: Path) -> Path:
     install_root = tmp_path / "tt-metal-install"
     (install_root / "python_packages" / "ttnn" / "ttnn").mkdir(parents=True)
     (install_root / "python_packages" / "tools").mkdir(parents=True)
     (install_root / "python_packages" / "ttnn" / "ttnn" / "_ttnn.so").touch()
     (install_root / "lib").mkdir()
+    return install_root
+
+
+def test_detects_install_layout_and_emits_shell_exports(tmp_path: Path) -> None:
+    module = _load_module()
+    install_root = _make_install_layout(tmp_path)
 
     settings = module.detect_external_tt_metal(install_root)
     shell_exports = module.emit_shell_exports(settings)
@@ -101,11 +106,7 @@ def test_rejects_colon_in_path(tmp_path: Path) -> None:
 
 def test_command_form_runs_with_external_environment(tmp_path: Path) -> None:
     module = _load_module()
-    install_root = tmp_path / "tt-metal-install"
-    (install_root / "python_packages" / "ttnn" / "ttnn").mkdir(parents=True)
-    (install_root / "python_packages" / "tools").mkdir(parents=True)
-    (install_root / "python_packages" / "ttnn" / "ttnn" / "_ttnn.so").touch()
-    (install_root / "lib").mkdir()
+    install_root = _make_install_layout(tmp_path)
 
     check_environment = """
 import os
@@ -134,3 +135,13 @@ assert os.environ["LD_LIBRARY_PATH"].split(":")[0] == f"{install_root}/lib"
     )
 
     assert status == 0
+
+
+def test_cli_rejects_positional_tt_metal_dir(tmp_path: Path) -> None:
+    module = _load_module()
+    install_root = _make_install_layout(tmp_path)
+
+    with pytest.raises(SystemExit) as error:
+        module.main([str(install_root)])
+
+    assert error.value.code == 2

--- a/test/packaging/test_light_setup.py
+++ b/test/packaging/test_light_setup.py
@@ -81,6 +81,22 @@ def test_light_metadata_rejects_final_version(
     assert "requires a non-final version" in result.stderr
 
 
+def test_light_metadata_allows_final_version_when_release_guard_passed(
+    run_egg_info: Callable[..., object],
+    requires_text: Callable[[], str],
+) -> None:
+    result = run_egg_info(
+        {
+            "TTLANG_VERSION_OVERRIDE": "0.71.0",
+            "TTLANG_ALLOW_FINAL_INTERNAL_VERSION": "true",
+        },
+        cwd=LIGHT_ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "tt-lang==0.71.0+light" in requires_text()
+
+
 def test_light_metadata_rejects_base_version_mismatch(
     run_egg_info: Callable[..., object],
 ) -> None:

--- a/test/packaging/test_setup_ttnn_dep_mode.py
+++ b/test/packaging/test_setup_ttnn_dep_mode.py
@@ -89,6 +89,44 @@ def test_external_metadata_rejects_final_version(
     assert "requires a non-final version" in result.stderr
 
 
+def test_external_metadata_allows_final_version_when_release_guard_passed(
+    run_egg_info: Callable[..., object],
+    requires_text: Callable[[], str],
+) -> None:
+    result = run_egg_info(
+        {
+            "TTLANG_TTNN_DEP_MODE": "external",
+            "TTLANG_VERSION_OVERRIDE": "0.71.0+light",
+            "TTLANG_ALLOW_FINAL_INTERNAL_VERSION": "true",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ttnn==" not in requires_text()
+
+
+def test_bundled_metadata_allows_final_version_when_release_guard_passed(
+    run_egg_info: Callable[..., object],
+    requires_text: Callable[[], str],
+    make_fake_tt_metal_install: Callable[..., Path],
+) -> None:
+    tt_metal = make_fake_tt_metal_install()
+
+    result = run_egg_info(
+        {
+            "TTLANG_TTNN_DEP_MODE": "bundled",
+            "TTLANG_VERSION_OVERRIDE": "0.71.0",
+            "TTLANG_ALLOW_FINAL_INTERNAL_VERSION": "true",
+            "TTLANG_BUNDLED_TT_METAL_DIR": str(tt_metal),
+        },
+    )
+
+    requirements = requires_text()
+    assert result.returncode == 0, result.stderr
+    assert "ttnn==" not in requirements
+    assert "loguru>=0.6.0" in requirements
+
+
 def test_external_metadata_requires_light_label(
     run_egg_info: Callable[..., object],
 ) -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -51,12 +51,12 @@ def _write_wheel(dist_dir: Path, filename: str, metadata: str) -> Path:
     return wheel_path
 
 
-def test_s3_schedule_publishes_bundled_and_external_wheels() -> None:
+def test_s3_schedule_publishes_bundled_and_light_wheels() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
 
     assert (
-        "github.event_name == 'workflow_dispatch' && inputs.ttnn_dep_mode || "
-        "'bundled-and-external'"
+        "github.event_name == 'workflow_dispatch' && inputs.wheel_variant || "
+        "'bundled-and-light'"
     ) in workflow
 
 

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -55,9 +55,9 @@ def test_s3_schedule_publishes_bundled_and_light_wheels() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
 
     assert (
-        "github.event_name == 'workflow_dispatch' && inputs.wheel_variant || "
-        "'bundled-and-light'"
+        "github.event_name == 'workflow_dispatch' && inputs.wheel_variant || ''"
     ) in workflow
+    assert "EVENT_NAME: ${{ github.event_name }}" in workflow
 
 
 def test_s3_stable_tags_publish_clean_version_wheels() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -24,6 +24,7 @@ CHECK_LIGHT_METAPACKAGE = SCRIPTS_DIR / "check-light-metapackage.py"
 COMPUTE_NIGHTLY_VERSION = SCRIPTS_DIR / "compute-nightly-version.py"
 CHECK_INSTALLED_TTNN = SCRIPTS_DIR / "check-installed-ttnn.py"
 CHECK_BUNDLED_PAYLOAD = SCRIPTS_DIR / "check-wheel-bundled-payload.py"
+PUBLISH_S3_PYPI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-s3-pypi.yml"
 
 
 def _run_script(
@@ -48,6 +49,15 @@ def _write_wheel(dist_dir: Path, filename: str, metadata: str) -> Path:
     with zipfile.ZipFile(wheel_path, "w") as wheel:
         wheel.writestr(f"{dist_info}/METADATA", metadata)
     return wheel_path
+
+
+def test_s3_schedule_publishes_bundled_and_external_wheels() -> None:
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+
+    assert (
+        "github.event_name == 'workflow_dispatch' && inputs.ttnn_dep_mode || "
+        "'bundled-and-external'"
+    ) in workflow
 
 
 def test_check_wheel_ttnn_metadata_matches_requirement_name(tmp_path: Path) -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -60,6 +60,14 @@ def test_s3_schedule_publishes_bundled_and_light_wheels() -> None:
     ) in workflow
 
 
+def test_s3_stable_tags_publish_clean_version_wheels() -> None:
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+
+    assert "push:" in workflow
+    assert "tags:" in workflow
+    assert "- 'v[0-9]+.[0-9]+.[0-9]+'" in workflow
+
+
 def test_check_wheel_ttnn_metadata_matches_requirement_name(tmp_path: Path) -> None:
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir()


### PR DESCRIPTION
### Problem description

The S3 PyPI workflow could publish bundled wheels or light wheels, but not both in one run. Nightly publishing also only produced bundled wheels, manual runs with an existing `docker_tag` could skip the publish job, and stable release tags did not publish clean-version internal wheels to S3.

Public PyPI publishing can also be blocked while the released `ttnn` wheel catches up to the current tt-metal tag; the internal S3 release flow should still build and publish the clean-version bundled/light wheels.

### What's changed

Added `bundled-and-light` mode. The workflow now builds bundled and light wheel variants from one IRD image, verifies both artifacts, combines them, and publishes all wheels to S3 PyPI.

Nightly runs now default to `bundled-and-light`, so they publish both `tt-lang` and `tt-lang-light`. Stable release tag pushes also run the S3 workflow, derive `version_override` from the tag (`v1.1.2` -> `1.1.2`), and publish clean-version bundled/light wheels without depending on the public `ttnn` package. The publish job condition also handles skipped `build-docker` when reusing an existing image.

Also removed the positional `tt_metal_dir` CLI form; `tt-lang-setup-external-tt-metal` now requires `--tt-metal-dir`.

Refactored some common functions in test scripts.