### PR TITLE
[ttl] Add TTL accumulation scope IR [acc-1]

### DIFF
--- a/docs/development/AccumulatingComputeLowering.md
+++ b/docs/development/AccumulatingComputeLowering.md
@@ -1,28 +1,21 @@
 # Accumulating Compute Lowering
 
 This document describes how the tt-lang compiler lowers operations that
-accumulate results across multiple invocations — reductions, matmul
-K-accumulation, and user-written `+=` loops — onto the Tenstorrent
+accumulate results across multiple invocations - reductions, matmul
+K-accumulation, and user-written `+=` loops - onto the Tenstorrent
 compute engines.
 
 ## Overview
 
-Tenstorrent hardware supports two accumulation mechanisms, and the
-compiler maps each accumulation source to one of them.
+An accumulation in tt-lang can be compiled in three ways with the same
+program semantics and different thread-local data movement:
 
-**DST register accumulation.** The compute engines hold partial results
-in a destination register file (DST) that persists across tile ops as
-long as it stays acquired (not released). Per-tile accumulation (matmul
-K-reduction, reduce across a reduction dim) happens inside one
-acquire/release cycle.
+1. Keep the partial value in the destination register file (DST).
+2. Add packed output tiles into L1 through the packer.
+3. Carry the partial value through an explicit compiler-managed dataflow
+   buffer (DFB).
 
-**L1 packer accumulation.** The pack unit can add each packed tile to
-the existing L1 value instead of overwriting, controlled by
-`pack_reconfig_l1_acc(1)` (enable) and `pack_reconfig_l1_acc(0)`
-(disable). Accumulation across separate acquire/release cycles uses
-this mechanism because DST is released between iterations.
-
-The compiler surface covers three accumulation sources:
+The current compiler lowering recognizes these accumulation forms:
 
 - `reduce_tile` and `matmul_tiles` accumulate per-tile over a reduction
   dim. The `dst-accumulation` pass option on `ttl-lower-to-loops`
@@ -40,10 +33,77 @@ The compiler surface covers three accumulation sources:
   prior-pack value rather than overwriting it. `precededByNonAccumulatingPack`
   detects the preceding non-accumulating pack.
 
-The rest of this document details each piece: `DstSectionOp` as the IR
-primitive that keeps DST live, the choice between DST and L1
-accumulation, the emitted loop structure, per-op init insertion, and
-the L1-acc guard placement (standard and prior-value variants).
+The accumulation-scope IR records semantic accumulation before storage
+selection. Later lowering can select DST, L1 packer accumulation, or
+explicit DFB state without reconstructing accumulation semantics from
+neighboring stores or DFB operations.
+
+The rest of this document details each piece: semantic accumulation
+scopes, `DstSectionOp` as the IR primitive that keeps DST live, the
+choice between DST and L1 accumulation, the emitted loop structure,
+per-op init insertion, and the L1-acc guard placement.
+
+## Semantic Accumulation IR
+
+`ttl.accumulation_scope` records accumulation semantics before storage
+selection. It has:
+
+- `outputs`: destination tensor views governed by the accumulation policy;
+- `explicit_inits`: initial tensors for outputs whose mode is `explicit`;
+- `combiners`: one accumulation combiner enum attribute per output
+  (`0 : i32` is add);
+- `initial_modes`: one accumulation initial-mode enum attribute per output
+  (`0 : i32` is overwrite, `1 : i32` is accumulate_existing, and
+  `2 : i32` is explicit);
+- `body`: a single-block region containing the loop or operations that
+  produce accumulated values.
+
+The op has `RecursiveMemoryEffects`; its effects are the effects of the body.
+It produces no tensor results. Tensor result support is deferred until the
+compiler needs value-style accumulation scopes.
+
+The verifier is structural:
+
+- combiner count equals output count;
+- initial-mode count equals output count;
+- explicit modes have matching explicit init operands;
+- explicit init types match their corresponding outputs;
+- nested `ttl.accumulation_scope` is rejected until nested accumulation
+  semantics are defined.
+
+The verifier does not prove that stores target the declared outputs or that
+control flow reaches an update. Those are nonlocal formation and strategy
+lowering responsibilities.
+
+Initial modes have these meanings:
+
+- `overwrite`: the first executed contribution defines the accumulator value.
+- `accumulate_existing`: an existing value in the output location
+  participates in the result.
+- `explicit`: an explicit init operand seeds the accumulator, independent of
+  the final output location.
+
+Example:
+
+```mlir
+ttl.accumulation_scope
+    outs(%out_view : tensor<...>)
+    inits(%init : tensor<...>)
+    {combiners = [0 : i32],
+     initial_modes = [2 : i32]} {
+  %result = scf.for ... iter_args(%acc = %init) -> tensor<...> {
+    %next = ttl.add %acc, %contribution : tensor<...>
+    scf.yield %next : tensor<...>
+  }
+  ttl.store %result, %out_view : tensor<...>, tensor<...>
+  ttl.yield
+}
+```
+
+`AccumulationScopeOpInterface` gives consumers a common contract for ops
+that carry accumulation semantics. The initial implementation is
+`ttl.accumulation_scope`; later PRs extend the same contract to structured
+reductions where the reduction body already represents accumulation.
 
 ## DstSectionOp
 

--- a/docs/development/AccumulatingComputeLowering.md
+++ b/docs/development/AccumulatingComputeLowering.md
@@ -33,20 +33,23 @@ The current compiler lowering recognizes these accumulation forms:
   prior-pack value rather than overwriting it. `precededByNonAccumulatingPack`
   detects the preceding non-accumulating pack.
 
-The accumulation-scope IR records semantic accumulation before storage
-selection. Later lowering can select DST, L1 packer accumulation, or
-explicit DFB state without reconstructing accumulation semantics from
-neighboring stores or DFB operations.
+The accumulation-scope IR declares which destination tensor views participate
+in an accumulation region, plus the combiner and initial-state policy for each
+output. Later lowering can select DST, L1 packer accumulation, or explicit DFB
+state without reconstructing that policy from neighboring stores or DFB
+operations.
 
-The rest of this document details each piece: semantic accumulation
-scopes, `DstSectionOp` as the IR primitive that keeps DST live, the
-choice between DST and L1 accumulation, the emitted loop structure,
-per-op init insertion, and the L1-acc guard placement.
+The rest of this document details each piece: accumulation scopes,
+`DstSectionOp` as the IR primitive that keeps DST live, the choice between DST
+and L1 accumulation, the emitted loop structure, per-op init insertion, and the
+L1-acc guard placement.
 
-## Semantic Accumulation IR
+## Accumulation Scope IR
 
-`ttl.accumulation_scope` records accumulation semantics before storage
-selection. It has:
+`ttl.accumulation_scope` declares the accumulation contract for one or more
+destination tensor views. It records which outputs share a region, how each
+output is initialized, and which combiner updates each output. The op does not
+select the storage mechanism used for partial values. It has:
 
 - `outputs`: destination tensor views governed by the accumulation policy;
 - `explicit_inits`: initial tensors for outputs whose mode is `explicit`;
@@ -68,6 +71,9 @@ The verifier is structural:
 - initial-mode count equals output count;
 - explicit modes have matching explicit init operands;
 - explicit init types match their corresponding outputs;
+- stateful bodies have one block argument and one yielded value per output;
+- stateful body arguments and yielded values match their output types;
+- stateful bodies use explicit initial mode for every output;
 - nested `ttl.accumulation_scope` is rejected until nested accumulation
   semantics are defined.
 
@@ -100,8 +106,26 @@ ttl.accumulation_scope
 }
 ```
 
-`AccumulationScopeOpInterface` gives consumers a common contract for ops
-that carry accumulation semantics. The initial implementation is
+Stateful accumulation scopes expose accumulator state as block arguments and
+return the updated state through `ttl.yield`. This form is used when multiple
+outputs must be analyzed or lowered as one group. Cross-output dependence is
+represented by ordinary SSA use-def edges between yielded values.
+
+```mlir
+ttl.accumulation_scope
+    outs(%out0, %out1 : tensor<...>, tensor<...>)
+    inits(%init0, %init1 : tensor<...>, tensor<...>)
+    {combiners = [0 : i32, 0 : i32],
+     initial_modes = [2 : i32, 2 : i32]} {
+^bb0(%acc0: tensor<...>, %acc1: tensor<...>):
+  %next0 = ttl.add %acc0, %acc1 : tensor<...>, tensor<...> -> tensor<...>
+  %next1 = ttl.add %acc1, %next0 : tensor<...>, tensor<...> -> tensor<...>
+  ttl.yield %next0, %next1 : tensor<...>, tensor<...>
+}
+```
+
+`AccumulationScopeOpInterface` gives consumers a common contract for ops that
+declare accumulation outputs and policies. The initial implementation is
 `ttl.accumulation_scope`; later PRs extend the same contract to structured
 reductions where the reduction body already represents accumulation.
 

--- a/docs/development/AccumulatingComputeLowering.md
+++ b/docs/development/AccumulatingComputeLowering.md
@@ -34,10 +34,9 @@ The current compiler lowering recognizes these accumulation forms:
   detects the preceding non-accumulating pack.
 
 The accumulation-scope IR declares which destination tensor views participate
-in an accumulation region, plus the combiner and initial-state policy for each
-output. Later lowering can select DST, L1 packer accumulation, or explicit DFB
-state without reconstructing that policy from neighboring stores or DFB
-operations.
+in an accumulation region, plus the initial-state policy for each output. Later
+lowering can select DST, L1 packer accumulation, or explicit DFB state without
+reconstructing that policy from neighboring stores or DFB operations.
 
 The rest of this document details each piece: accumulation scopes,
 `DstSectionOp` as the IR primitive that keeps DST live, the choice between DST
@@ -48,18 +47,16 @@ L1-acc guard placement.
 
 `ttl.accumulation_scope` declares the accumulation contract for one or more
 destination tensor views. It records which outputs share a region, how each
-output is initialized, and which combiner updates each output. The op does not
-select the storage mechanism used for partial values. It has:
+output is initialized, and which value returned by the region updates each
+output. The op does not select the storage mechanism used for partial values.
+It has:
 
 - `outputs`: destination tensor views governed by the accumulation policy;
-- `explicit_inits`: initial tensors for outputs whose mode is `explicit`;
-- `combiners`: one accumulation combiner enum attribute per output
-  (`0 : i32` is add);
-- `initial_modes`: one accumulation initial-mode enum attribute per output
-  (`0 : i32` is overwrite, `1 : i32` is accumulate_existing, and
-  `2 : i32` is explicit);
-- `body`: a single-block region containing the loop or operations that
-  produce accumulated values.
+- `inits`: init operands for outputs whose initial mode is `init`;
+- `initial_modes`: one accumulation initial-mode per output (`overwrite`,
+  `accumulate_existing`, or `init`);
+- `body`: a single-block region with one block argument and one yielded value
+  per output.
 
 The op has `RecursiveMemoryEffects`; its effects are the effects of the body.
 It produces no tensor results. Tensor result support is deferred until the
@@ -67,13 +64,11 @@ compiler needs value-style accumulation scopes.
 
 The verifier is structural:
 
-- combiner count equals output count;
 - initial-mode count equals output count;
-- explicit modes have matching explicit init operands;
-- explicit init types match their corresponding outputs;
-- stateful bodies have one block argument and one yielded value per output;
-- stateful body arguments and yielded values match their output types;
-- stateful bodies use explicit initial mode for every output;
+- init modes have matching init operands;
+- init operand types match their corresponding outputs;
+- the body has one block argument and one yielded value per output;
+- body arguments and yielded values match their output types;
 - nested `ttl.accumulation_scope` is rejected until nested accumulation
   semantics are defined.
 
@@ -86,8 +81,8 @@ Initial modes have these meanings:
 - `overwrite`: the first executed contribution defines the accumulator value.
 - `accumulate_existing`: an existing value in the output location
   participates in the result.
-- `explicit`: an explicit init operand seeds the accumulator, independent of
-  the final output location.
+- `init`: an init operand seeds the accumulator, independent of the final
+  output location.
 
 Example:
 
@@ -95,33 +90,27 @@ Example:
 ttl.accumulation_scope
     outs(%out_view : tensor<...>)
     inits(%init : tensor<...>)
-    {combiners = [0 : i32],
-     initial_modes = [2 : i32]} {
-  %result = scf.for ... iter_args(%acc = %init) -> tensor<...> {
-    %next = ttl.add %acc, %contribution : tensor<...>
-    scf.yield %next : tensor<...>
-  }
-  ttl.store %result, %out_view : tensor<...>, tensor<...>
-  ttl.yield
-}
+{
+^bb0(%acc: tensor<...>):
+  %next = ttl.add %acc, %contribution : tensor<...>, tensor<...> -> tensor<...>
+  ttl.yield %next : tensor<...>
+} initial_modes([init])
 ```
 
-Stateful accumulation scopes expose accumulator state as block arguments and
-return the updated state through `ttl.yield`. This form is used when multiple
-outputs must be analyzed or lowered as one group. Cross-output dependence is
-represented by ordinary SSA use-def edges between yielded values.
+Accumulation scopes expose accumulator state as block arguments and return the
+updated state through `ttl.yield`. Cross-output dependence is represented by
+ordinary SSA use-def edges between yielded values.
 
 ```mlir
 ttl.accumulation_scope
     outs(%out0, %out1 : tensor<...>, tensor<...>)
     inits(%init0, %init1 : tensor<...>, tensor<...>)
-    {combiners = [0 : i32, 0 : i32],
-     initial_modes = [2 : i32, 2 : i32]} {
+{
 ^bb0(%acc0: tensor<...>, %acc1: tensor<...>):
   %next0 = ttl.add %acc0, %acc1 : tensor<...>, tensor<...> -> tensor<...>
   %next1 = ttl.add %acc1, %next0 : tensor<...>, tensor<...> -> tensor<...>
   ttl.yield %next0, %next1 : tensor<...>, tensor<...>
-}
+} initial_modes([init, init])
 ```
 
 `AccumulationScopeOpInterface` gives consumers a common contract for ops that

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -56,6 +56,53 @@ def TTL_PipeNetPredicateOpInterface
   ];
 }
 
+def TTL_AccumulationScopeOpInterface
+    : OpInterface<"AccumulationScopeOpInterface"> {
+  let description = [{
+    Region-like operations that explicitly describe accumulation semantics.
+    The interface separates the accumulation policy from the storage mechanism,
+    so consumers can reason about the declared policy directly.
+  }];
+
+  let cppNamespace = "::mlir::tt::ttl";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/"Return true when this operation instance carries active "
+               "accumulation semantics.",
+      /*retTy=*/"bool",
+      /*methodName=*/"isAccumulation",
+      /*args=*/(ins)>,
+    InterfaceMethod<
+      /*desc=*/"Return the destination tensor operands governed by the "
+               "accumulation policy.",
+      /*retTy=*/"::mlir::ValueRange",
+      /*methodName=*/"getAccumulationOutputs",
+      /*args=*/(ins)>,
+    InterfaceMethod<
+      /*desc=*/"Return explicit initial values for outputs whose initial mode "
+               "requires one.",
+      /*retTy=*/"::mlir::ValueRange",
+      /*methodName=*/"getExplicitInitialValues",
+      /*args=*/(ins)>,
+    InterfaceMethod<
+      /*desc=*/"Return one combiner per accumulation output.",
+      /*retTy=*/"::llvm::SmallVector<::mlir::tt::ttl::AccumulationCombiner>",
+      /*methodName=*/"getAccumulationCombiners",
+      /*args=*/(ins)>,
+    InterfaceMethod<
+      /*desc=*/"Return one initial-value mode per accumulation output.",
+      /*retTy=*/"::llvm::SmallVector<::mlir::tt::ttl::AccumulationInitialMode>",
+      /*methodName=*/"getAccumulationInitialModes",
+      /*args=*/(ins)>,
+    InterfaceMethod<
+      /*desc=*/"Return the region containing the accumulation body.",
+      /*retTy=*/"::mlir::Region &",
+      /*methodName=*/"getAccumulationBody",
+      /*args=*/(ins)>,
+  ];
+}
+
 def TTL_DstAccessOpInterface : OpInterface<"DstAccessOpInterface"> {
   let description = [{
     Tile-level operations that expose concrete DST register reads, writes, and

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -80,15 +80,10 @@ def TTL_AccumulationScopeOpInterface
       /*methodName=*/"getAccumulationOutputs",
       /*args=*/(ins)>,
     InterfaceMethod<
-      /*desc=*/"Return explicit initial values for outputs whose initial mode "
-               "requires one.",
+      /*desc=*/"Return init operands for outputs whose initial mode requires "
+               "one.",
       /*retTy=*/"::mlir::ValueRange",
-      /*methodName=*/"getExplicitInitialValues",
-      /*args=*/(ins)>,
-    InterfaceMethod<
-      /*desc=*/"Return one combiner per accumulation output.",
-      /*retTy=*/"::llvm::SmallVector<::mlir::tt::ttl::AccumulationCombiner>",
-      /*methodName=*/"getAccumulationCombiners",
+      /*methodName=*/"getAccumulationInits",
       /*args=*/(ins)>,
     InterfaceMethod<
       /*desc=*/"Return one initial-value mode per accumulation output.",

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -331,10 +331,13 @@ def TTL_YieldOp : TTL_Op<"yield", [ReturnLike, Terminator,
   let description = [{
     `ttl.yield` terminates the body of `ttl.compute`, `ttl.dst_section`,
     `ttl.if_src`, `ttl.if_dst`, `ttl.pipenet_scope`, and
-    `ttl.accumulation_scope`. It carries no operands and produces no results;
-    the trait `SingleBlockImplicitTerminator` auto-inserts it.
+    `ttl.accumulation_scope`. In `ttl.accumulation_scope`, it may carry the
+    final accumulator values for scopes whose body exposes explicit accumulator
+    state as block arguments. Other TTL regions use an operand-less terminator.
   }];
-  let assemblyFormat = "attr-dict";
+  let arguments = (ins Variadic<AnyType>:$values);
+  let assemblyFormat = "attr-dict ($values^ `:` type($values))?";
+  let hasVerifier = 1;
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 }
 
@@ -346,7 +349,6 @@ def TTL_AccumulationScopeOp : TTL_Op<"accumulation_scope", [
     AttrSizedOperandSegments,
     SingleBlockImplicitTerminator<"YieldOp">,
     RecursiveMemoryEffects,
-    NoRegionArguments,
     DeclareOpInterfaceMethods<TTL_AccumulationScopeOpInterface>
   ]> {
   let summary = "Structured accumulation scope";
@@ -359,6 +361,13 @@ def TTL_AccumulationScopeOp : TTL_Op<"accumulation_scope", [
     The `combiners` and `initial_modes` attributes contain one entry per
     output. `explicit_inits` contains one operand for each output whose initial
     mode is `explicit`, in output order.
+
+    The body may use one block argument per output and yield one value per
+    output when all outputs use explicit initial values. This form makes
+    cross-accumulator dataflow an SSA property: if the yielded value for one
+    output uses another output's updated value, normal SSA use-def edges encode
+    that dependency. Scopes without body arguments and yielded values remain
+    policy-only wrappers for storage-strategy selection.
   }];
 
   let arguments = (ins

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -326,16 +326,55 @@ def TTL_ComputeOp : TTL_Op<"compute", [
 
 def TTL_YieldOp : TTL_Op<"yield", [ReturnLike, Terminator,
     ParentOneOf<["ComputeOp", "DstSectionOp", "IfSrcOp", "IfDstOp",
-                 "PipeNetScopeOp"]>]> {
+                 "PipeNetScopeOp", "AccumulationScopeOp"]>]> {
   let summary = "Terminate a TTL region body";
   let description = [{
     `ttl.yield` terminates the body of `ttl.compute`, `ttl.dst_section`,
-    `ttl.if_src`, `ttl.if_dst`, and `ttl.pipenet_scope`. It carries no
-    operands and produces no results; the trait
-    `SingleBlockImplicitTerminator` auto-inserts it.
+    `ttl.if_src`, `ttl.if_dst`, `ttl.pipenet_scope`, and
+    `ttl.accumulation_scope`. It carries no operands and produces no results;
+    the trait `SingleBlockImplicitTerminator` auto-inserts it.
   }];
   let assemblyFormat = "attr-dict";
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
+}
+
+//===----------------------------------------------------------------------===//
+// Accumulation scope
+//===----------------------------------------------------------------------===//
+
+def TTL_AccumulationScopeOp : TTL_Op<"accumulation_scope", [
+    AttrSizedOperandSegments,
+    SingleBlockImplicitTerminator<"YieldOp">,
+    RecursiveMemoryEffects,
+    NoRegionArguments,
+    DeclareOpInterfaceMethods<TTL_AccumulationScopeOpInterface>
+  ]> {
+  let summary = "Structured accumulation scope";
+  let description = [{
+    `ttl.accumulation_scope` records an accumulation policy for one or more
+    destination tensors. The operation does not prescribe whether the
+    accumulated value is stored in DST, a dataflow buffer, or another
+    target-specific storage mechanism.
+
+    The `combiners` and `initial_modes` attributes contain one entry per
+    output. `explicit_inits` contains one operand for each output whose initial
+    mode is `explicit`, in output order.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyRankedTensor>:$outputs,
+    Variadic<AnyRankedTensor>:$explicit_inits,
+    ArrayAttr:$combiners,
+    ArrayAttr:$initial_modes
+  );
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`inits` `(` $explicit_inits^ `:` type($explicit_inits) `)`)?
+    $body attr-dict
+  }];
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -331,9 +331,9 @@ def TTL_YieldOp : TTL_Op<"yield", [ReturnLike, Terminator,
   let description = [{
     `ttl.yield` terminates the body of `ttl.compute`, `ttl.dst_section`,
     `ttl.if_src`, `ttl.if_dst`, `ttl.pipenet_scope`, and
-    `ttl.accumulation_scope`. In `ttl.accumulation_scope`, it may carry the
-    final accumulator values for scopes whose body exposes explicit accumulator
-    state as block arguments. Other TTL regions use an operand-less terminator.
+    `ttl.accumulation_scope`. In `ttl.accumulation_scope`, it carries one
+    updated value per accumulation output. Other TTL regions use an
+    operand-less terminator.
   }];
   let arguments = (ins Variadic<AnyType>:$values);
   let assemblyFormat = "attr-dict ($values^ `:` type($values))?";
@@ -358,31 +358,25 @@ def TTL_AccumulationScopeOp : TTL_Op<"accumulation_scope", [
     accumulated value is stored in DST, a dataflow buffer, or another
     target-specific storage mechanism.
 
-    The `combiners` and `initial_modes` attributes contain one entry per
-    output. `explicit_inits` contains one operand for each output whose initial
-    mode is `explicit`, in output order.
+    The `initial_modes` attribute contains one entry per output. `inits`
+    contains one operand for each output whose initial mode is `init`, in output
+    order.
 
-    The body may use one block argument per output and yield one value per
-    output when all outputs use explicit initial values. This form makes
-    cross-accumulator dataflow an SSA property: if the yielded value for one
+    The body uses one block argument per output and yields one value per output.
+    This form makes
+    cross-output data dependence an SSA property: if the yielded value for one
     output uses another output's updated value, normal SSA use-def edges encode
-    that dependency. Scopes without body arguments and yielded values remain
-    policy-only wrappers for storage-strategy selection.
+    that dependency.
   }];
 
   let arguments = (ins
     Variadic<AnyRankedTensor>:$outputs,
-    Variadic<AnyRankedTensor>:$explicit_inits,
-    ArrayAttr:$combiners,
+    Variadic<AnyRankedTensor>:$inits,
     ArrayAttr:$initial_modes
   );
   let regions = (region SizedRegion<1>:$body);
 
-  let assemblyFormat = [{
-    `outs` `(` $outputs `:` type($outputs) `)`
-    (`inits` `(` $explicit_inits^ `:` type($explicit_inits) `)`)?
-    $body attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
@@ -58,6 +58,34 @@ def TTL_ReduceType : I32EnumAttr<"ReduceType", "TTL reduction function type",
   let cppNamespace = "::mlir::tt::ttl";
 }
 
+//===----------------------------------------------------------------------===//
+// Accumulation enums
+//===----------------------------------------------------------------------===//
+
+def TTL_AccumulationCombiner_Add : I32EnumAttrCase<"Add", 0, "add">;
+
+// TODO(#646): Add max/min combiners after strategy legality is defined for
+// each storage mechanism.
+def TTL_AccumulationCombiner : I32EnumAttr<"AccumulationCombiner",
+    "TTL accumulation combiner", [TTL_AccumulationCombiner_Add]> {
+  let cppNamespace = "::mlir::tt::ttl";
+}
+
+def TTL_AccumulationInitialMode_Overwrite
+    : I32EnumAttrCase<"Overwrite", 0, "overwrite">;
+def TTL_AccumulationInitialMode_AccumulateExisting
+    : I32EnumAttrCase<"AccumulateExisting", 1, "accumulate_existing">;
+def TTL_AccumulationInitialMode_Explicit
+    : I32EnumAttrCase<"Explicit", 2, "explicit">;
+
+def TTL_AccumulationInitialMode : I32EnumAttr<"AccumulationInitialMode",
+    "TTL accumulation initial-value mode",
+    [TTL_AccumulationInitialMode_Overwrite,
+     TTL_AccumulationInitialMode_AccumulateExisting,
+     TTL_AccumulationInitialMode_Explicit]> {
+  let cppNamespace = "::mlir::tt::ttl";
+}
+
 // Buffer type for tensor memory placement.
 // Values match TTNN BufferType enum for compatibility.
 def TTL_BufferType_DRAM       : I32EnumAttrCase<"DRAM",       0, "dram">;

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
@@ -58,31 +58,17 @@ def TTL_ReduceType : I32EnumAttr<"ReduceType", "TTL reduction function type",
   let cppNamespace = "::mlir::tt::ttl";
 }
 
-//===----------------------------------------------------------------------===//
-// Accumulation enums
-//===----------------------------------------------------------------------===//
-
-def TTL_AccumulationCombiner_Add : I32EnumAttrCase<"Add", 0, "add">;
-
-// TODO(#646): Add max/min combiners after strategy legality is defined for
-// each storage mechanism.
-def TTL_AccumulationCombiner : I32EnumAttr<"AccumulationCombiner",
-    "TTL accumulation combiner", [TTL_AccumulationCombiner_Add]> {
-  let cppNamespace = "::mlir::tt::ttl";
-}
-
 def TTL_AccumulationInitialMode_Overwrite
     : I32EnumAttrCase<"Overwrite", 0, "overwrite">;
 def TTL_AccumulationInitialMode_AccumulateExisting
     : I32EnumAttrCase<"AccumulateExisting", 1, "accumulate_existing">;
-def TTL_AccumulationInitialMode_Explicit
-    : I32EnumAttrCase<"Explicit", 2, "explicit">;
+def TTL_AccumulationInitialMode_Init : I32EnumAttrCase<"Init", 2, "init">;
 
 def TTL_AccumulationInitialMode : I32EnumAttr<"AccumulationInitialMode",
     "TTL accumulation initial-value mode",
     [TTL_AccumulationInitialMode_Overwrite,
      TTL_AccumulationInitialMode_AccumulateExisting,
-     TTL_AccumulationInitialMode_Explicit]> {
+     TTL_AccumulationInitialMode_Init]> {
   let cppNamespace = "::mlir::tt::ttl";
 }
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
@@ -95,9 +95,6 @@ def TTL_DSTRegister : TTL_Type<"DSTRegister", "dst"> {
 
 def TTL_BcastTypeAttr : EnumAttr<TTL_Dialect, TTL_BcastType, "bcast_type">;
 def TTL_ReduceTypeAttr : EnumAttr<TTL_Dialect, TTL_ReduceType, "reduce_type">;
-def TTL_AccumulationCombinerAttr
-    : EnumAttr<TTL_Dialect, TTL_AccumulationCombiner,
-               "accumulation_combiner">;
 def TTL_AccumulationInitialModeAttr
     : EnumAttr<TTL_Dialect, TTL_AccumulationInitialMode,
                "accumulation_initial_mode">;

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
@@ -95,6 +95,12 @@ def TTL_DSTRegister : TTL_Type<"DSTRegister", "dst"> {
 
 def TTL_BcastTypeAttr : EnumAttr<TTL_Dialect, TTL_BcastType, "bcast_type">;
 def TTL_ReduceTypeAttr : EnumAttr<TTL_Dialect, TTL_ReduceType, "reduce_type">;
+def TTL_AccumulationCombinerAttr
+    : EnumAttr<TTL_Dialect, TTL_AccumulationCombiner,
+               "accumulation_combiner">;
+def TTL_AccumulationInitialModeAttr
+    : EnumAttr<TTL_Dialect, TTL_AccumulationInitialMode,
+               "accumulation_initial_mode">;
 
 def TTL_Pipe : TTL_Type<"Pipe", "pipe"> {
   let summary = "Pipe for core-to-core data transfer";

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1017,6 +1017,21 @@ llvm::SmallVector<EnumT> getVerifiedEnumValues(mlir::ArrayAttr attrs) {
 } // namespace
 
 //===----------------------------------------------------------------------===//
+// YieldOp
+//===----------------------------------------------------------------------===//
+
+mlir::LogicalResult mlir::tt::ttl::YieldOp::verify() {
+  Operation *parent = getOperation()->getParentOp();
+  if (parent && mlir::isa<AccumulationScopeOp>(parent)) {
+    return mlir::success();
+  }
+  if (!getValues().empty()) {
+    return emitOpError("operands are only supported in ttl.accumulation_scope");
+  }
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // AccumulationScopeOp - AccumulationScopeOpInterface implementations
 //===----------------------------------------------------------------------===//
 
@@ -1126,14 +1141,53 @@ mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
   }
 
   mlir::Block &bodyBlock = getBody().front();
-  if (bodyBlock.getNumArguments() != 0) {
-    return emitOpError("body must not have block arguments");
-  }
   if (!bodyBlock.mightHaveTerminator()) {
     return emitOpError("body block must have a terminator");
   }
   if (!mlir::isa<YieldOp>(bodyBlock.getTerminator())) {
     return emitOpError("body block must be terminated with ttl.yield");
+  }
+  auto yield = mlir::cast<YieldOp>(bodyBlock.getTerminator());
+
+  size_t bodyArgCount = bodyBlock.getNumArguments();
+  size_t yieldedValueCount = yield.getValues().size();
+  if (bodyArgCount != 0 || yieldedValueCount != 0) {
+    if (bodyArgCount != outputCount) {
+      return emitOpError("stateful body requires one block argument per output, "
+                         "got ")
+             << bodyArgCount << " block arguments for " << outputCount
+             << " outputs";
+    }
+    if (yieldedValueCount != outputCount) {
+      return emitOpError("stateful body must yield one value per output, got ")
+             << yieldedValueCount << " yielded values for " << outputCount
+             << " outputs";
+    }
+
+    for (auto [outputIndex, mode] : llvm::enumerate(initialModes)) {
+      if (mode != AccumulationInitialMode::Explicit) {
+        return emitOpError("stateful body requires explicit initial mode for "
+                           "every output, but output ")
+               << outputIndex << " uses " << stringifyAccumulationInitialMode(mode);
+      }
+    }
+
+    for (auto [outputIndex, output] : llvm::enumerate(getOutputs())) {
+      mlir::Type expectedType = output.getType();
+      mlir::Type bodyArgType = bodyBlock.getArgument(outputIndex).getType();
+      if (bodyArgType != expectedType) {
+        return emitOpError("stateful body argument ")
+               << outputIndex << " type " << bodyArgType
+               << " must match output type " << expectedType;
+      }
+
+      mlir::Value yieldedValue = yield.getValues()[outputIndex];
+      if (yieldedValue.getType() != expectedType) {
+        return emitOpError("stateful yielded value ")
+               << outputIndex << " type " << yieldedValue.getType()
+               << " must match output type " << expectedType;
+      }
+    }
   }
 
   bool hasNestedAccumulationScope = false;

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1153,8 +1153,9 @@ mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
   size_t yieldedValueCount = yield.getValues().size();
   if (bodyArgCount != 0 || yieldedValueCount != 0) {
     if (bodyArgCount != outputCount) {
-      return emitOpError("stateful body requires one block argument per output, "
-                         "got ")
+      return emitOpError(
+                 "stateful body requires one block argument per output, "
+                 "got ")
              << bodyArgCount << " block arguments for " << outputCount
              << " outputs";
     }
@@ -1168,7 +1169,8 @@ mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
       if (mode != AccumulationInitialMode::Explicit) {
         return emitOpError("stateful body requires explicit initial mode for "
                            "every output, but output ")
-               << outputIndex << " uses " << stringifyAccumulationInitialMode(mode);
+               << outputIndex << " uses "
+               << stringifyAccumulationInitialMode(mode);
       }
     }
 

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1035,6 +1035,126 @@ mlir::LogicalResult mlir::tt::ttl::YieldOp::verify() {
 // AccumulationScopeOp - AccumulationScopeOpInterface implementations
 //===----------------------------------------------------------------------===//
 
+static mlir::ParseResult parseAccumulationScopeValueList(
+    mlir::OpAsmParser &parser, llvm::StringRef keyword,
+    llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand> &operands,
+    llvm::SmallVectorImpl<mlir::Type> &types) {
+  if (parser.parseKeyword(keyword) || parser.parseLParen()) {
+    return mlir::failure();
+  }
+  if (mlir::failed(parser.parseOptionalRParen()) &&
+      (parser.parseOperandList(operands) || parser.parseColon() ||
+       parser.parseTypeList(types) || parser.parseRParen())) {
+    return mlir::failure();
+  }
+  return mlir::success();
+}
+
+static mlir::ParseResult parseAccumulationInitialModeList(
+    mlir::OpAsmParser &parser, llvm::SmallVectorImpl<mlir::Attribute> &attrs) {
+  if (parser.parseKeyword("initial_modes") || parser.parseLParen()) {
+    return mlir::failure();
+  }
+  if (parser.parseCommaSeparatedList(
+          mlir::OpAsmParser::Delimiter::Square,
+          [&]() -> mlir::ParseResult {
+            llvm::StringRef keyword;
+            llvm::SMLoc loc = parser.getCurrentLocation();
+            if (parser.parseKeyword(&keyword)) {
+              return mlir::failure();
+            }
+            std::optional<mlir::tt::ttl::AccumulationInitialMode> mode =
+                mlir::tt::ttl::symbolizeAccumulationInitialMode(keyword);
+            if (!mode) {
+              return parser.emitError(loc)
+                     << "expected accumulation initial mode `overwrite`, "
+                        "`accumulate_existing`, or `init`";
+            }
+            attrs.push_back(mlir::tt::ttl::AccumulationInitialModeAttr::get(
+                parser.getContext(), *mode));
+            return mlir::success();
+          }) ||
+      parser.parseRParen()) {
+    return mlir::failure();
+  }
+  return mlir::success();
+}
+
+mlir::ParseResult
+mlir::tt::ttl::AccumulationScopeOp::parse(mlir::OpAsmParser &parser,
+                                          mlir::OperationState &result) {
+  llvm::SmallVector<mlir::OpAsmParser::UnresolvedOperand> outputs;
+  llvm::SmallVector<mlir::Type> outputTypes;
+  llvm::SmallVector<mlir::OpAsmParser::UnresolvedOperand> inits;
+  llvm::SmallVector<mlir::Type> initTypes;
+  if (parseAccumulationScopeValueList(parser, "outs", outputs, outputTypes)) {
+    return mlir::failure();
+  }
+  if (mlir::succeeded(parser.parseOptionalKeyword("inits")) &&
+      (parser.parseLParen() || parser.parseOperandList(inits) ||
+       parser.parseColon() || parser.parseTypeList(initTypes) ||
+       parser.parseRParen())) {
+    return mlir::failure();
+  }
+
+  if (parser.resolveOperands(outputs, outputTypes, parser.getNameLoc(),
+                             result.operands) ||
+      parser.resolveOperands(inits, initTypes, parser.getNameLoc(),
+                             result.operands)) {
+    return mlir::failure();
+  }
+  result.addAttribute("operandSegmentSizes",
+                      parser.getBuilder().getDenseI32ArrayAttr(
+                          {static_cast<int32_t>(outputs.size()),
+                           static_cast<int32_t>(inits.size())}));
+
+  mlir::Region *body = result.addRegion();
+  if (parser.parseRegion(*body, /*arguments=*/{}, /*argTypes=*/{})) {
+    return mlir::failure();
+  }
+
+  llvm::SmallVector<mlir::Attribute> initialModes;
+  if (parseAccumulationInitialModeList(parser, initialModes)) {
+    return mlir::failure();
+  }
+  result.addAttribute("initial_modes",
+                      parser.getBuilder().getArrayAttr(initialModes));
+
+  return parser.parseOptionalAttrDict(result.attributes);
+}
+
+void mlir::tt::ttl::AccumulationScopeOp::print(mlir::OpAsmPrinter &p) {
+  p << " outs(";
+  p.printOperands(getOutputs());
+  p << " : ";
+  llvm::interleaveComma(getOutputs().getTypes(), p);
+  p << ")";
+
+  if (!getInits().empty()) {
+    p << " inits(";
+    p.printOperands(getInits());
+    p << " : ";
+    llvm::interleaveComma(getInits().getTypes(), p);
+    p << ")";
+  }
+
+  p << ' ';
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/true,
+                /*printBlockTerminators=*/true);
+
+  p << " initial_modes([";
+  llvm::interleaveComma(getAccumulationInitialModes(), p,
+                        [&](mlir::tt::ttl::AccumulationInitialMode mode) {
+                          p << mlir::tt::ttl::stringifyAccumulationInitialMode(
+                              mode);
+                        });
+  p << "])";
+
+  llvm::SmallVector<llvm::StringRef> elidedAttrs = {"operandSegmentSizes",
+                                                    "initial_modes"};
+  p.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
+}
+
 /// Return true for all instances; the op has no non-accumulating form.
 bool mlir::tt::ttl::AccumulationScopeOp::isAccumulation() { return true; }
 
@@ -1043,17 +1163,9 @@ mlir::ValueRange mlir::tt::ttl::AccumulationScopeOp::getAccumulationOutputs() {
   return getOutputs();
 }
 
-/// Return explicit initial tensors, ordered by the explicit-mode outputs.
-mlir::ValueRange
-mlir::tt::ttl::AccumulationScopeOp::getExplicitInitialValues() {
-  return getExplicitInits();
-}
-
-/// Return one combiner per output tensor.
-llvm::SmallVector<mlir::tt::ttl::AccumulationCombiner>
-mlir::tt::ttl::AccumulationScopeOp::getAccumulationCombiners() {
-  return getVerifiedEnumValues<AccumulationCombinerAttr, AccumulationCombiner>(
-      getCombiners());
+/// Return init operands, ordered by the init-mode outputs.
+mlir::ValueRange mlir::tt::ttl::AccumulationScopeOp::getAccumulationInits() {
+  return getInits();
 }
 
 /// Return one initial-value mode per output tensor.
@@ -1068,18 +1180,12 @@ mlir::Region &mlir::tt::ttl::AccumulationScopeOp::getAccumulationBody() {
   return getBody();
 }
 
-/// Verify that `ttl.accumulation_scope` contains a complete, explicit
-/// accumulation policy without encoding a storage mechanism.
+/// Verify that `ttl.accumulation_scope` contains a complete accumulation
+/// policy without encoding a storage mechanism.
 mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
   size_t outputCount = getOutputs().size();
   if (outputCount == 0) {
     return emitOpError("requires at least one output");
-  }
-
-  if (getCombiners().size() != outputCount) {
-    return emitOpError("requires one combiner per output, got ")
-           << getCombiners().size() << " combiners for " << outputCount
-           << " outputs";
   }
 
   if (getInitialModes().size() != outputCount) {
@@ -1088,14 +1194,7 @@ mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
            << " outputs";
   }
 
-  for (mlir::Attribute attr : getCombiners()) {
-    if (!mlir::isa<AccumulationCombinerAttr>(attr)) {
-      return emitOpError(
-          "combiners must contain accumulation combiner enum attributes");
-    }
-  }
-
-  size_t explicitModeCount = 0;
+  size_t initModeCount = 0;
   llvm::SmallVector<AccumulationInitialMode> initialModes;
   for (mlir::Attribute attr : getInitialModes()) {
     auto modeAttr = mlir::dyn_cast<AccumulationInitialModeAttr>(attr);
@@ -1106,31 +1205,30 @@ mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
     }
     AccumulationInitialMode mode = modeAttr.getValue();
     initialModes.push_back(mode);
-    if (mode == AccumulationInitialMode::Explicit) {
-      ++explicitModeCount;
+    if (mode == AccumulationInitialMode::Init) {
+      ++initModeCount;
     }
   }
 
-  if (getExplicitInits().size() != explicitModeCount) {
-    return emitOpError("requires one explicit init per explicit initial mode, "
-                       "got ")
-           << getExplicitInits().size() << " inits for " << explicitModeCount
-           << " explicit modes";
+  if (getInits().size() != initModeCount) {
+    return emitOpError("requires one init operand per init mode, got ")
+           << getInits().size() << " inits for " << initModeCount
+           << " init modes";
   }
 
-  // The operand segment contains only explicit initial values. This preserves
-  // the output-to-policy correspondence without unused operands for overwrite
-  // and accumulate-existing outputs.
-  size_t explicitInitIndex = 0;
+  // The operand segment contains only init operands. This preserves the
+  // output-to-policy correspondence without unused operands for overwrite and
+  // accumulate-existing outputs.
+  size_t initIndex = 0;
   for (auto [outputIndex, mode] : llvm::enumerate(initialModes)) {
-    if (mode != AccumulationInitialMode::Explicit) {
+    if (mode != AccumulationInitialMode::Init) {
       continue;
     }
     mlir::Value output = getOutputs()[outputIndex];
-    mlir::Value explicitInit = getExplicitInits()[explicitInitIndex++];
-    if (output.getType() != explicitInit.getType()) {
-      return emitOpError("explicit init ")
-             << (explicitInitIndex - 1) << " type " << explicitInit.getType()
+    mlir::Value init = getInits()[initIndex++];
+    if (output.getType() != init.getType()) {
+      return emitOpError("init operand ")
+             << (initIndex - 1) << " type " << init.getType()
              << " must match output " << outputIndex << " type "
              << output.getType();
     }
@@ -1151,44 +1249,31 @@ mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
 
   size_t bodyArgCount = bodyBlock.getNumArguments();
   size_t yieldedValueCount = yield.getValues().size();
-  if (bodyArgCount != 0 || yieldedValueCount != 0) {
-    if (bodyArgCount != outputCount) {
-      return emitOpError(
-                 "stateful body requires one block argument per output, "
-                 "got ")
-             << bodyArgCount << " block arguments for " << outputCount
-             << " outputs";
-    }
-    if (yieldedValueCount != outputCount) {
-      return emitOpError("stateful body must yield one value per output, got ")
-             << yieldedValueCount << " yielded values for " << outputCount
-             << " outputs";
-    }
+  if (bodyArgCount != outputCount) {
+    return emitOpError("body requires one block argument per output, got ")
+           << bodyArgCount << " block arguments for " << outputCount
+           << " outputs";
+  }
+  if (yieldedValueCount != outputCount) {
+    return emitOpError("body must yield one value per output, got ")
+           << yieldedValueCount << " yielded values for " << outputCount
+           << " outputs";
+  }
 
-    for (auto [outputIndex, mode] : llvm::enumerate(initialModes)) {
-      if (mode != AccumulationInitialMode::Explicit) {
-        return emitOpError("stateful body requires explicit initial mode for "
-                           "every output, but output ")
-               << outputIndex << " uses "
-               << stringifyAccumulationInitialMode(mode);
-      }
+  for (auto [outputIndex, output] : llvm::enumerate(getOutputs())) {
+    mlir::Type expectedType = output.getType();
+    mlir::Type bodyArgType = bodyBlock.getArgument(outputIndex).getType();
+    if (bodyArgType != expectedType) {
+      return emitOpError("body argument ")
+             << outputIndex << " type " << bodyArgType
+             << " must match output type " << expectedType;
     }
 
-    for (auto [outputIndex, output] : llvm::enumerate(getOutputs())) {
-      mlir::Type expectedType = output.getType();
-      mlir::Type bodyArgType = bodyBlock.getArgument(outputIndex).getType();
-      if (bodyArgType != expectedType) {
-        return emitOpError("stateful body argument ")
-               << outputIndex << " type " << bodyArgType
-               << " must match output type " << expectedType;
-      }
-
-      mlir::Value yieldedValue = yield.getValues()[outputIndex];
-      if (yieldedValue.getType() != expectedType) {
-        return emitOpError("stateful yielded value ")
-               << outputIndex << " type " << yieldedValue.getType()
-               << " must match output type " << expectedType;
-      }
+    mlir::Value yieldedValue = yield.getValues()[outputIndex];
+    if (yieldedValue.getType() != expectedType) {
+      return emitOpError("yielded value ")
+             << outputIndex << " type " << yieldedValue.getType()
+             << " must match output type " << expectedType;
     }
   }
 

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -999,6 +999,159 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
   return success();
 }
 
+namespace {
+
+/// Convert a verified enum-attribute list to enum values for interface
+/// consumers. The verifier enforces the attribute class before this helper
+/// runs, so callers read a typed policy without rechecking.
+template <typename AttrT, typename EnumT>
+llvm::SmallVector<EnumT> getVerifiedEnumValues(mlir::ArrayAttr attrs) {
+  llvm::SmallVector<EnumT> values;
+  values.reserve(attrs.size());
+  for (mlir::Attribute attr : attrs) {
+    values.push_back(mlir::cast<AttrT>(attr).getValue());
+  }
+  return values;
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// AccumulationScopeOp - AccumulationScopeOpInterface implementations
+//===----------------------------------------------------------------------===//
+
+/// Return true for all instances; the op has no non-accumulating form.
+bool mlir::tt::ttl::AccumulationScopeOp::isAccumulation() { return true; }
+
+/// Return destination tensors whose stores are governed by the scope policy.
+mlir::ValueRange mlir::tt::ttl::AccumulationScopeOp::getAccumulationOutputs() {
+  return getOutputs();
+}
+
+/// Return explicit initial tensors, ordered by the explicit-mode outputs.
+mlir::ValueRange
+mlir::tt::ttl::AccumulationScopeOp::getExplicitInitialValues() {
+  return getExplicitInits();
+}
+
+/// Return one combiner per output tensor.
+llvm::SmallVector<mlir::tt::ttl::AccumulationCombiner>
+mlir::tt::ttl::AccumulationScopeOp::getAccumulationCombiners() {
+  return getVerifiedEnumValues<AccumulationCombinerAttr, AccumulationCombiner>(
+      getCombiners());
+}
+
+/// Return one initial-value mode per output tensor.
+llvm::SmallVector<mlir::tt::ttl::AccumulationInitialMode>
+mlir::tt::ttl::AccumulationScopeOp::getAccumulationInitialModes() {
+  return getVerifiedEnumValues<AccumulationInitialModeAttr,
+                               AccumulationInitialMode>(getInitialModes());
+}
+
+/// Return the region containing the accumulation body.
+mlir::Region &mlir::tt::ttl::AccumulationScopeOp::getAccumulationBody() {
+  return getBody();
+}
+
+/// Verify that `ttl.accumulation_scope` contains a complete, explicit
+/// accumulation policy without encoding a storage mechanism.
+mlir::LogicalResult mlir::tt::ttl::AccumulationScopeOp::verify() {
+  size_t outputCount = getOutputs().size();
+  if (outputCount == 0) {
+    return emitOpError("requires at least one output");
+  }
+
+  if (getCombiners().size() != outputCount) {
+    return emitOpError("requires one combiner per output, got ")
+           << getCombiners().size() << " combiners for " << outputCount
+           << " outputs";
+  }
+
+  if (getInitialModes().size() != outputCount) {
+    return emitOpError("requires one initial mode per output, got ")
+           << getInitialModes().size() << " modes for " << outputCount
+           << " outputs";
+  }
+
+  for (mlir::Attribute attr : getCombiners()) {
+    if (!mlir::isa<AccumulationCombinerAttr>(attr)) {
+      return emitOpError(
+          "combiners must contain accumulation combiner enum attributes");
+    }
+  }
+
+  size_t explicitModeCount = 0;
+  llvm::SmallVector<AccumulationInitialMode> initialModes;
+  for (mlir::Attribute attr : getInitialModes()) {
+    auto modeAttr = mlir::dyn_cast<AccumulationInitialModeAttr>(attr);
+    if (!modeAttr) {
+      return emitOpError(
+          "initial_modes must contain accumulation initial-mode enum "
+          "attributes");
+    }
+    AccumulationInitialMode mode = modeAttr.getValue();
+    initialModes.push_back(mode);
+    if (mode == AccumulationInitialMode::Explicit) {
+      ++explicitModeCount;
+    }
+  }
+
+  if (getExplicitInits().size() != explicitModeCount) {
+    return emitOpError("requires one explicit init per explicit initial mode, "
+                       "got ")
+           << getExplicitInits().size() << " inits for " << explicitModeCount
+           << " explicit modes";
+  }
+
+  // The operand segment contains only explicit initial values. This preserves
+  // the output-to-policy correspondence without unused operands for overwrite
+  // and accumulate-existing outputs.
+  size_t explicitInitIndex = 0;
+  for (auto [outputIndex, mode] : llvm::enumerate(initialModes)) {
+    if (mode != AccumulationInitialMode::Explicit) {
+      continue;
+    }
+    mlir::Value output = getOutputs()[outputIndex];
+    mlir::Value explicitInit = getExplicitInits()[explicitInitIndex++];
+    if (output.getType() != explicitInit.getType()) {
+      return emitOpError("explicit init ")
+             << (explicitInitIndex - 1) << " type " << explicitInit.getType()
+             << " must match output " << outputIndex << " type "
+             << output.getType();
+    }
+  }
+
+  if (getBody().getBlocks().size() != 1) {
+    return emitOpError("body must have exactly one block");
+  }
+
+  mlir::Block &bodyBlock = getBody().front();
+  if (bodyBlock.getNumArguments() != 0) {
+    return emitOpError("body must not have block arguments");
+  }
+  if (!bodyBlock.mightHaveTerminator()) {
+    return emitOpError("body block must have a terminator");
+  }
+  if (!mlir::isa<YieldOp>(bodyBlock.getTerminator())) {
+    return emitOpError("body block must be terminated with ttl.yield");
+  }
+
+  bool hasNestedAccumulationScope = false;
+  getBody().walk([&](AccumulationScopeOp) {
+    hasNestedAccumulationScope = true;
+    return mlir::WalkResult::interrupt();
+  });
+  // TODO(#648): Define nested and conditional accumulation scope semantics
+  // before accepting nested ttl.accumulation_scope operations.
+  if (hasNestedAccumulationScope) {
+    return emitOpError(
+        "nested ttl.accumulation_scope is not supported (#648); split nested "
+        "accumulations into separate scopes");
+  }
+
+  return mlir::success();
+}
+
 // Verify a `num_tiles`-bearing acquire (cb_reserve / cb_wait): the result
 // tensor must agree with the CB's element type, the tile-count attribute,
 // and `num_tiles` must not exceed the CB's total tile capacity. The bound

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -504,7 +504,7 @@ class TTLGenericCompiler(TTCompilerBase):
                     self.visit(callback_body)
 
                 self.symbol_tables.pop()
-                ttl.yield_()
+                ttl.yield_([])
 
         return None  # Statement, no return value
 
@@ -1418,7 +1418,7 @@ class TTLGenericCompiler(TTCompilerBase):
                 block = Block.create_at_start(scope_op.body)
                 with InsertionPoint(block):
                     self._emit_cb_with_body(node)
-                    ttl.yield_()
+                    ttl.yield_([])
                 return
 
             self._emit_cb_with_body(node)

--- a/test/ttlang/Dialect/TTL/IR/accumulation_scope.mlir
+++ b/test/ttlang/Dialect/TTL/IR/accumulation_scope.mlir
@@ -1,0 +1,47 @@
+// RUN: ttlang-opt %s --split-input-file | FileCheck %s
+
+// Summary: Verifies `ttl.accumulation_scope` parses and prints accumulation
+// policies, including multi-output policy metadata.
+
+// CHECK-LABEL: func.func @accumulation_scope_overwrite
+func.func @accumulation_scope_overwrite() {
+  // CHECK: ttl.accumulation_scope outs(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  // CHECK-NEXT: } {combiners = [0 : i32], initial_modes = [0 : i32]}
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32], initial_modes = [0 : i32]}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @accumulation_scope_explicit_init
+func.func @accumulation_scope_explicit_init() {
+  // CHECK: ttl.accumulation_scope outs(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) inits(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  // CHECK-NEXT: } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @accumulation_scope_multi_output
+func.func @accumulation_scope_multi_output() {
+  // CHECK: ttl.accumulation_scope outs(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>) inits(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  // CHECK-NEXT: } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 0 : i32]}
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init0 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 0 : i32]}
+  return
+}

--- a/test/ttlang/Dialect/TTL/IR/accumulation_scope.mlir
+++ b/test/ttlang/Dialect/TTL/IR/accumulation_scope.mlir
@@ -1,31 +1,37 @@
 // RUN: ttlang-opt %s --split-input-file | FileCheck %s
 
 // Summary: Verifies `ttl.accumulation_scope` parses and prints accumulation
-// policies, including multi-output stateful accumulation metadata.
+// policies, including multi-output yielded state.
 
 // CHECK-LABEL: func.func @accumulation_scope_overwrite
 func.func @accumulation_scope_overwrite() {
   // CHECK: ttl.accumulation_scope outs(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-  // CHECK-NEXT: } {combiners = [0 : i32], initial_modes = [0 : i32]}
+  // CHECK-NEXT: ^bb0(%[[ACC:.*]]: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+  // CHECK-NEXT:   ttl.yield %[[ACC]] : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // CHECK-NEXT: } initial_modes([overwrite])
   %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32], initial_modes = [0 : i32]}
+  ^bb0(%acc: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([overwrite])
   return
 }
 
 // -----
 
-// CHECK-LABEL: func.func @accumulation_scope_explicit_init
-func.func @accumulation_scope_explicit_init() {
+// CHECK-LABEL: func.func @accumulation_scope_init
+func.func @accumulation_scope_init() {
   // CHECK: ttl.accumulation_scope outs(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) inits(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-  // CHECK-NEXT: } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  // CHECK-NEXT: ^bb0(%[[ACC:.*]]: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+  // CHECK-NEXT:   ttl.yield %[[ACC]] : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // CHECK-NEXT: } initial_modes([init])
   %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>)
       inits(%init : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  ^bb0(%acc: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([init])
   return
 }
 
@@ -34,15 +40,19 @@ func.func @accumulation_scope_explicit_init() {
 // CHECK-LABEL: func.func @accumulation_scope_multi_output
 func.func @accumulation_scope_multi_output() {
   // CHECK: ttl.accumulation_scope outs(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>) inits(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-  // CHECK-NEXT: } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 0 : i32]}
+  // CHECK-NEXT: ^bb0(%[[ACC0:.*]]: tensor<1x1x!ttcore.tile<32x32, bf16>>, %[[ACC1:.*]]: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+  // CHECK-NEXT:   ttl.yield %[[ACC0]], %[[ACC1]] : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // CHECK-NEXT: } initial_modes([init, overwrite])
   %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
                                             tensor<1x1x!ttcore.tile<32x32, bf16>>)
       inits(%init0 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 0 : i32]}
+  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+       %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc0, %acc1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([init, overwrite])
   return
 }
 
@@ -55,7 +65,7 @@ func.func @accumulation_scope_stateful_multi_output() {
   // CHECK-NEXT:   %[[NEXT0:.*]] = ttl.add %[[ARG0]], %[[ARG1]]
   // CHECK-NEXT:   %[[NEXT1:.*]] = ttl.add %[[ARG1]], %[[NEXT0]]
   // CHECK-NEXT:   ttl.yield %[[NEXT0]], %[[NEXT1]] : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // CHECK-NEXT: } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  // CHECK-NEXT: } initial_modes([init, init])
   %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -69,6 +79,6 @@ func.func @accumulation_scope_stateful_multi_output() {
     %next0 = ttl.add %acc0, %acc1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
     %next1 = ttl.add %acc1, %next0 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
     ttl.yield %next0, %next1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
-  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  } initial_modes([init, init])
   return
 }

--- a/test/ttlang/Dialect/TTL/IR/accumulation_scope.mlir
+++ b/test/ttlang/Dialect/TTL/IR/accumulation_scope.mlir
@@ -1,7 +1,7 @@
 // RUN: ttlang-opt %s --split-input-file | FileCheck %s
 
 // Summary: Verifies `ttl.accumulation_scope` parses and prints accumulation
-// policies, including multi-output policy metadata.
+// policies, including multi-output stateful accumulation metadata.
 
 // CHECK-LABEL: func.func @accumulation_scope_overwrite
 func.func @accumulation_scope_overwrite() {
@@ -43,5 +43,32 @@ func.func @accumulation_scope_multi_output() {
       inits(%init0 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
     ttl.yield
   } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 0 : i32]}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @accumulation_scope_stateful_multi_output
+func.func @accumulation_scope_stateful_multi_output() {
+  // CHECK: ttl.accumulation_scope outs(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>) inits(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  // CHECK-NEXT: ^bb0(%[[ARG0:.*]]: tensor<1x1x!ttcore.tile<32x32, bf16>>, %[[ARG1:.*]]: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+  // CHECK-NEXT:   %[[NEXT0:.*]] = ttl.add %[[ARG0]], %[[ARG1]]
+  // CHECK-NEXT:   %[[NEXT1:.*]] = ttl.add %[[ARG1]], %[[NEXT0]]
+  // CHECK-NEXT:   ttl.yield %[[NEXT0]], %[[NEXT1]] : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // CHECK-NEXT: } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init0, %init1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                              tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+       %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    %next0 = ttl.add %acc0, %acc1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %next1 = ttl.add %acc1, %next0 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.yield %next0, %next1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
   return
 }

--- a/test/ttlang/Dialect/TTL/IR/accumulation_scope_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/accumulation_scope_invalid.mlir
@@ -1,21 +1,7 @@
 // RUN: ttlang-opt %s --verify-diagnostics --split-input-file
 
 // Summary: Verifier-level rejection cases for malformed `ttl.accumulation_scope`
-// accumulation policy and unsupported nesting.
-
-// One combiner is required for each output tensor.
-func.func @combiner_count_mismatch() {
-  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op requires one combiner per output}}
-  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-                                    tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32], initial_modes = [0 : i32, 0 : i32]}
-  return
-}
-
-// -----
+// initial-state policy, yielded values, and unsupported nesting.
 
 // One initial mode is required for each output tensor.
 func.func @initial_mode_count_mismatch() {
@@ -23,90 +9,83 @@ func.func @initial_mode_count_mismatch() {
   %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   // expected-error @below {{'ttl.accumulation_scope' op requires one initial mode per output}}
   ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-                                    tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32, 0 : i32], initial_modes = [0 : i32]}
+                                            tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+       %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc0, %acc1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([overwrite])
   return
 }
 
 // -----
 
-// Combiner attributes must be generated enum attributes, not arbitrary attrs.
-func.func @malformed_combiner_attr() {
-  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op combiners must contain accumulation combiner enum attributes}}
-  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [99 : i32], initial_modes = [0 : i32]}
-  return
-}
-
-// -----
-
-// Initial-mode attributes must be generated enum attributes, not arbitrary attrs.
+// Initial-mode policy entries must be known symbolic names.
 func.func @malformed_initial_mode_attr() {
   %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op initial_modes must contain accumulation initial-mode enum attributes}}
   ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32], initial_modes = [99 : i32]}
+  ^bb0(%acc: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{expected accumulation initial mode `overwrite`, `accumulate_existing`, or `init`}}
+  } initial_modes([not_a_mode])
   return
 }
 
 // -----
 
-// Explicit initial-value mode requires a corresponding init operand.
-func.func @missing_explicit_init() {
+// Init mode requires a corresponding init operand.
+func.func @missing_init() {
   %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op requires one explicit init per explicit initial mode}}
+  // expected-error @below {{'ttl.accumulation_scope' op requires one init operand per init mode}}
   ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  ^bb0(%acc: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([init])
   return
 }
 
 // -----
 
-// Explicit init operands must have the same tensor type as their outputs.
-func.func @explicit_init_type_mismatch() {
+// Init operands must have the same tensor type as their outputs.
+func.func @init_type_mismatch() {
   %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init = tensor.empty() : tensor<2x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op explicit init 0 type}}
+  // expected-error @below {{'ttl.accumulation_scope' op init operand 0 type}}
   ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>)
       inits(%init : tensor<2x1x!ttcore.tile<32x32, bf16>>) {
-    ttl.yield
-  } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  ^bb0(%acc: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([init])
   return
 }
 
 // -----
 
-// Stateful bodies require one block argument per output.
-func.func @stateful_block_arg_count_mismatch() {
+// Bodies require one block argument per output.
+func.func @body_arg_count_mismatch() {
   %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op stateful body requires one block argument per output}}
+  // expected-error @below {{'ttl.accumulation_scope' op body requires one block argument per output}}
   ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
                                             tensor<1x1x!ttcore.tile<32x32, bf16>>)
       inits(%init0, %init1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
                               tensor<1x1x!ttcore.tile<32x32, bf16>>) {
   ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>):
     ttl.yield %acc0, %acc0 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
-  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  } initial_modes([init, init])
   return
 }
 
 // -----
 
-// Stateful bodies require one yielded value per output.
-func.func @stateful_yield_count_mismatch() {
+// Bodies must yield one value per output.
+func.func @yield_count_mismatch() {
   %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op stateful body must yield one value per output}}
+  // expected-error @below {{'ttl.accumulation_scope' op body must yield one value per output}}
   ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
                                             tensor<1x1x!ttcore.tile<32x32, bf16>>)
       inits(%init0, %init1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
@@ -114,38 +93,33 @@ func.func @stateful_yield_count_mismatch() {
   ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
        %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
     ttl.yield %acc0 : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  } initial_modes([init, init])
   return
 }
 
 // -----
 
-// Stateful bodies require explicit initial values for all accumulators.
-func.func @stateful_non_explicit_initial_mode() {
-  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op stateful body requires explicit initial mode for every output}}
-  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-                                            tensor<1x1x!ttcore.tile<32x32, bf16>>)
-      inits(%init0 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
-       %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
-    ttl.yield %acc0, %acc1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
-  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 0 : i32]}
+// Body block argument types must match their corresponding output types.
+func.func @body_arg_type_mismatch() {
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op body argument 0 type}}
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%acc: tensor<2x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc : tensor<2x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([overwrite])
   return
 }
 
 // -----
 
-// Stateful yielded values must match their corresponding output types.
-func.func @stateful_yield_type_mismatch() {
+// Yielded values must match their corresponding output types.
+func.func @yield_type_mismatch() {
   %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %bad = tensor.empty() : tensor<2x1x!ttcore.tile<32x32, bf16>>
-  // expected-error @below {{'ttl.accumulation_scope' op stateful yielded value 0 type}}
+  // expected-error @below {{'ttl.accumulation_scope' op yielded value 0 type}}
   ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
                                             tensor<1x1x!ttcore.tile<32x32, bf16>>)
       inits(%init0, %init1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
@@ -153,7 +127,7 @@ func.func @stateful_yield_type_mismatch() {
   ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
        %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
     ttl.yield %bad, %acc1 : tensor<2x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
-  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  } initial_modes([init, init])
   return
 }
 
@@ -165,10 +139,12 @@ func.func @nested_accumulation_scope() {
   %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   // expected-error @below {{'ttl.accumulation_scope' op nested ttl.accumulation_scope is not supported (#648); split nested accumulations into separate scopes}}
   ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%outer_acc: tensor<1x1x!ttcore.tile<32x32, bf16>>):
     ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
-      ttl.yield
-    } {combiners = [0 : i32], initial_modes = [0 : i32]}
-    ttl.yield
-  } {combiners = [0 : i32], initial_modes = [0 : i32]}
+    ^bb0(%inner_acc: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+      ttl.yield %inner_acc : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    } initial_modes([overwrite])
+    ttl.yield %outer_acc : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } initial_modes([overwrite])
   return
 }

--- a/test/ttlang/Dialect/TTL/IR/accumulation_scope_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/accumulation_scope_invalid.mlir
@@ -1,0 +1,96 @@
+// RUN: ttlang-opt %s --verify-diagnostics --split-input-file
+
+// Summary: Verifier-level rejection cases for malformed `ttl.accumulation_scope`
+// accumulation policy and unsupported nesting.
+
+// One combiner is required for each output tensor.
+func.func @combiner_count_mismatch() {
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op requires one combiner per output}}
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                    tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32], initial_modes = [0 : i32, 0 : i32]}
+  return
+}
+
+// -----
+
+// One initial mode is required for each output tensor.
+func.func @initial_mode_count_mismatch() {
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op requires one initial mode per output}}
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                    tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32, 0 : i32], initial_modes = [0 : i32]}
+  return
+}
+
+// -----
+
+// Combiner attributes must be generated enum attributes, not arbitrary attrs.
+func.func @malformed_combiner_attr() {
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op combiners must contain accumulation combiner enum attributes}}
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [99 : i32], initial_modes = [0 : i32]}
+  return
+}
+
+// -----
+
+// Initial-mode attributes must be generated enum attributes, not arbitrary attrs.
+func.func @malformed_initial_mode_attr() {
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op initial_modes must contain accumulation initial-mode enum attributes}}
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32], initial_modes = [99 : i32]}
+  return
+}
+
+// -----
+
+// Explicit initial-value mode requires a corresponding init operand.
+func.func @missing_explicit_init() {
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op requires one explicit init per explicit initial mode}}
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  return
+}
+
+// -----
+
+// Explicit init operands must have the same tensor type as their outputs.
+func.func @explicit_init_type_mismatch() {
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init = tensor.empty() : tensor<2x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op explicit init 0 type}}
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init : tensor<2x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.yield
+  } {combiners = [0 : i32], initial_modes = [2 : i32]}
+  return
+}
+
+// -----
+
+// Nested accumulation scopes are rejected until nested policy composition is
+// specified.
+func.func @nested_accumulation_scope() {
+  %out = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op nested ttl.accumulation_scope is not supported (#648); split nested accumulations into separate scopes}}
+  ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    ttl.accumulation_scope outs(%out : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+      ttl.yield
+    } {combiners = [0 : i32], initial_modes = [0 : i32]}
+    ttl.yield
+  } {combiners = [0 : i32], initial_modes = [0 : i32]}
+  return
+}

--- a/test/ttlang/Dialect/TTL/IR/accumulation_scope_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/accumulation_scope_invalid.mlir
@@ -81,6 +81,84 @@ func.func @explicit_init_type_mismatch() {
 
 // -----
 
+// Stateful bodies require one block argument per output.
+func.func @stateful_block_arg_count_mismatch() {
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op stateful body requires one block argument per output}}
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init0, %init1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                              tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc0, %acc0 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  return
+}
+
+// -----
+
+// Stateful bodies require one yielded value per output.
+func.func @stateful_yield_count_mismatch() {
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op stateful body must yield one value per output}}
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init0, %init1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                              tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+       %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc0 : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  return
+}
+
+// -----
+
+// Stateful bodies require explicit initial values for all accumulators.
+func.func @stateful_non_explicit_initial_mode() {
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op stateful body requires explicit initial mode for every output}}
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init0 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+       %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %acc0, %acc1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 0 : i32]}
+  return
+}
+
+// -----
+
+// Stateful yielded values must match their corresponding output types.
+func.func @stateful_yield_type_mismatch() {
+  %out0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %out1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %bad = tensor.empty() : tensor<2x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.accumulation_scope' op stateful yielded value 0 type}}
+  ttl.accumulation_scope outs(%out0, %out1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                                            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      inits(%init0, %init1 : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                              tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  ^bb0(%acc0: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+       %acc1: tensor<1x1x!ttcore.tile<32x32, bf16>>):
+    ttl.yield %bad, %acc1 : tensor<2x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  } {combiners = [0 : i32, 0 : i32], initial_modes = [2 : i32, 2 : i32]}
+  return
+}
+
+// -----
+
 // Nested accumulation scopes are rejected until nested policy composition is
 // specified.
 func.func @nested_accumulation_scope() {


### PR DESCRIPTION
### Problem description
Accumulation lowering needs a semantic TTL IR representation before choosing a storage strategy. The current lowering work needs to preserve the accumulation policy independently from whether later passes use DST, L1 packer accumulation, or compiler-managed dataflow buffer state. This is PR 1 of several split out from the full accumulation scope redesign in PR #651.

### What's changed
This PR adds the first split of the accumulation scope redesign:

- Adds `ttl.accumulation_scope` to record output tensors, optional explicit initial values, accumulation combiners, and initial-value modes.
- Adds `AccumulationScopeOpInterface` so later consumers can query accumulation semantics without depending on one concrete op.
- Adds accumulation combiner and initial-mode enum attributes.
- Verifies the structural contract for policy counts, explicit init operands, explicit init types, single-block bodies, `ttl.yield` termination, and unsupported nested scopes.
- Updates `AccumulatingComputeLowering.md` to describe the semantic accumulation IR and its role before storage selection.
- Adds MLIR lit coverage for parsing/printing valid scopes and rejecting malformed policies.

### Ticket
None.

### Checklist
- [x] New/Existing tests provide coverage for changes
