### PR TITLE
[ttl] Add loop carried tensor state [acc-2]

### DIFF
--- a/docs/development/AccumulatingComputeLowering.md
+++ b/docs/development/AccumulatingComputeLowering.md
@@ -118,6 +118,27 @@ declare accumulation outputs and policies. The initial implementation is
 `ttl.accumulation_scope`; later PRs extend the same contract to structured
 reductions where the reduction body already represents accumulation.
 
+## Loop-Carried Tensor State
+
+A Python `for` loop that reassigns a tensor variable read on a later
+iteration (`acc = acc + x`, `state = ttl.math.relu(state)`) compiles to an
+`scf.for` with a ranked-tensor `iter_arg`. `ttl-materialize-loop-state`
+eliminates those tensor iter_args before compute lowering by creating
+compiler-managed DFB state:
+
+```
+store init -> state DFB
+for ...:
+    wait/attach state DFB
+    compute next state
+    reserve/store next state -> state DFB
+wait/attach final state DFB
+```
+
+The pass preserves non-tensor loop iter_args. It also preserves zero-trip
+loop semantics because the initial value is stored before the rewritten loop
+and the final value is read after the loop.
+
 ## DstSectionOp
 
 `ttl.dst_section` demarcates a DST register acquisition scope. All

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -13,6 +13,7 @@ The hardware supports at most 32 DFBs per node (indices 0--31). User and compile
 The DFB-related passes in `ttl-to-ttkernel-pipeline` execute in this order:
 
 ```
+ttl-materialize-loop-state     (FuncOp)   Remove ranked-tensor scf.for iter_args
 ttl-insert-intermediate-dfbs   (FuncOp)   Create compiler-allocated DFBs
 ttl-insert-cb-sync             (FuncOp)   Insert cb_push / cb_pop
   ... compute lowering, DST assignment, loop lowering ...
@@ -157,6 +158,8 @@ users must duplicate explicitly via `make_dataflow_buffer_like`. Tracked in
 ## Intermediate DFB Insertion
 
 `TTLInsertIntermediateDFBs` walks all operations implementing `DFBInputOpInterface` (reduce, bcast, matmul, transpose). For each operand that the interface marks as requiring a CB-attached value, the pass checks whether the operand traces to an existing CB via `getAttachedCB`. If not, the pass materializes the value through a fresh DFB: `bind_cb`, `cb_reserve`, `store`, `cb_wait`, `attach_cb`. The new DFB receives the `ttl.compiler_allocated` marker attribute.
+
+`TTLMaterializeLoopState` uses the same compiler-DFB materialization helper (`include/ttlang/Dialect/TTL/Transforms/DFBMaterialization.h`) to remove ranked-tensor `scf.for` iter_args before compute lowering.
 
 When multiple `DFBInputOpInterface` operations consume the same non-CB-attached value, the materialization is shared -- only one DFB is created and the second consumer's operand is rewritten to the existing attached value.
 

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -117,6 +117,47 @@ def TTLInsertCopyWait
   let dependentDialects = [];
 }
 
+def TTLMaterializeLoopState
+    : Pass<"ttl-materialize-loop-state", "::mlir::func::FuncOp"> {
+  let summary = "Materialize loop-carried tensor state";
+  let description = [{
+    Rewrites ranked tensor `scf.for` iter args into explicit TTL dataflow
+    buffer state. The pass removes tensor results from the loop while
+    preserving non-tensor iter args.
+
+    Tensor recurrences use compiler-allocated dataflow buffer state:
+    ```mlir
+    %state = scf.for %iv = %lb to %ub step %step
+        iter_args(%arg = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+      %next = ttl.relu %arg : ...
+      scf.yield %next : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    ```
+
+    becomes:
+    ```mlir
+    %state_cb = ttl.bind_cb ... {ttl.compiler_allocated}
+    %init_reserve = ttl.cb_reserve %state_cb : ...
+    ttl.store %init, %init_reserve : ...
+    scf.for %iv = %lb to %ub step %step {
+      %current_wait = ttl.cb_wait %state_cb : ...
+      %current = ttl.attach_cb %current_wait, %state_cb : ...
+      %next = ttl.relu %current : ...
+      %next_reserve = ttl.cb_reserve %state_cb : ...
+      ttl.store %next, %next_reserve : ...
+      scf.yield
+    }
+    %final_wait = ttl.cb_wait %state_cb : ...
+    %final = ttl.attach_cb %final_wait, %state_cb : ...
+    ```
+  }];
+
+  let dependentDialects = [
+    "::mlir::scf::SCFDialect",
+    "::mlir::tt::ttl::TTLDialect"
+  ];
+}
+
 def TTLConvertTTLToTTKernel
     : Pass<"convert-ttl-to-ttkernel", "::mlir::ModuleOp"> {
   let summary = "Lower TTL DMA ops to TTKernel using global barriers (temporary)";

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -18,6 +18,7 @@ namespace mlir::tt::ttl {
 
 void createTTLToTTKernelPipeline(OpPassManager &pm,
                                  const TTLToTTKernelPipelineOptions &options) {
+  pm.addNestedPass<func::FuncOp>(createTTLMaterializeLoopState());
   {
     TTLInsertIntermediateDFBsOptions dfbOpts;
     dfbOpts.enable = options.compilerDFBs;

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   TTLInsertCBSync.cpp
   TTLInsertCopyWait.cpp
   TTLInsertIntermediateDFBs.cpp
+  TTLMaterializeLoopState.cpp
   TTLVerifyDFBSPSC.cpp
   TTLVerifyPipeNetGuards.cpp
   TTLErasePipeNetScopes.cpp

--- a/lib/Dialect/TTL/Transforms/TTLMaterializeLoopState.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLMaterializeLoopState.cpp
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//===----------------------------------------------------------------------===//
+// TTL Materialize Loop State
+//===----------------------------------------------------------------------===//
+//
+// Eliminates tensor-valued scf.for iter_args before compute lowering. Tensor
+// state lowers through compiler-allocated DFB slots.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/Passes.h"
+#include "ttlang/Dialect/TTL/Transforms/DFBMaterialization.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#define DEBUG_TYPE "ttl-materialize-loop-state"
+
+namespace mlir::tt::ttl {
+
+#define GEN_PASS_DEF_TTLMATERIALIZELOOPSTATE
+#include "ttlang/Dialect/TTL/Passes.h.inc"
+
+namespace {
+
+struct TensorLoopState {
+  unsigned resultIndex;
+  RankedTensorType tensorType;
+  Value initialValue;
+  BlockArgument iterArg;
+  Value yieldedValue;
+  BindCBOp stateDFB;
+};
+
+/// Collects tensor loop-carried values that require explicit DFB state. This
+/// transform does not infer or select accumulation strategies.
+static SmallVector<TensorLoopState> collectTensorLoopStates(scf::ForOp loop) {
+  auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+
+  SmallVector<TensorLoopState> states;
+  for (unsigned resultIndex = 0; resultIndex < loop.getNumResults();
+       ++resultIndex) {
+    if (!isa<RankedTensorType>(loop.getInitArgs()[resultIndex].getType())) {
+      continue;
+    }
+
+    states.push_back(TensorLoopState{
+        resultIndex,
+        cast<RankedTensorType>(loop.getInitArgs()[resultIndex].getType()),
+        loop.getInitArgs()[resultIndex], loop.getRegionIterArgs()[resultIndex],
+        yield.getOperand(resultIndex), BindCBOp()});
+  }
+  return states;
+}
+
+/// Tests whether an old loop result is one of the tensor states removed from
+/// the reconstructed scf.for signature.
+static bool isTensorStateIndex(ArrayRef<TensorLoopState> states,
+                               unsigned resultIndex) {
+  return llvm::any_of(states, [&](const TensorLoopState &state) {
+    return state.resultIndex == resultIndex;
+  });
+}
+
+/// Seeds each compiler-allocated state DFB before the rewritten loop. The
+/// pre-loop store preserves zero-trip scf.for semantics without keeping tensor
+/// values in the loop signature.
+static void createInitialStores(ArrayRef<TensorLoopState> states,
+                                scf::ForOp loop, RewriterBase &rewriter) {
+  for (TensorLoopState state : states) {
+    rewriter.setInsertionPoint(loop);
+    createDFBStore(state.initialValue, state.stateDFB.getResult(), rewriter);
+  }
+}
+
+/// Rebuilds the loop with only non-tensor iter_args so tensor state is carried
+/// by explicit dataflow buffer operations instead of scf.for results.
+static scf::ForOp createLoopWithoutTensorState(scf::ForOp loop,
+                                               ArrayRef<TensorLoopState> states,
+                                               RewriterBase &rewriter) {
+  SmallVector<Value> newInitArgs;
+  for (unsigned resultIndex = 0; resultIndex < loop.getNumResults();
+       ++resultIndex) {
+    if (isTensorStateIndex(states, resultIndex)) {
+      continue;
+    }
+    newInitArgs.push_back(loop.getInitArgs()[resultIndex]);
+  }
+
+  rewriter.setInsertionPoint(loop);
+  auto newLoop =
+      scf::ForOp::create(rewriter, loop.getLoc(), loop.getLowerBound(),
+                         loop.getUpperBound(), loop.getStep(), newInitArgs);
+  for (NamedAttribute attr : loop->getAttrs()) {
+    newLoop->setAttr(attr.getName(), attr.getValue());
+  }
+
+  Block *newBody = newLoop.getBody();
+  if (!newBody->empty() && isa<scf::YieldOp>(newBody->back())) {
+    rewriter.eraseOp(&newBody->back());
+  }
+
+  return newLoop;
+}
+
+/// Maps old loop-carried SSA values into the rebuilt loop and materializes
+/// tensor iter_args from their DFB state slots at loop entry.
+static void mapLoopCarriedValues(scf::ForOp loop, scf::ForOp newLoop,
+                                 ArrayRef<TensorLoopState> states,
+                                 IRMapping &mapper, RewriterBase &rewriter) {
+  mapper.map(loop.getInductionVar(), newLoop.getInductionVar());
+
+  unsigned newRegionArgIndex = 0;
+  for (unsigned resultIndex = 0; resultIndex < loop.getNumResults();
+       ++resultIndex) {
+    if (isTensorStateIndex(states, resultIndex)) {
+      continue;
+    }
+    mapper.map(loop.getRegionIterArgs()[resultIndex],
+               newLoop.getRegionIterArgs()[newRegionArgIndex]);
+    ++newRegionArgIndex;
+  }
+
+  rewriter.setInsertionPointToStart(newLoop.getBody());
+  for (TensorLoopState state : states) {
+    auto attach = createDFBWaitAndAttach(
+        state.stateDFB.getResult(), state.tensorType, loop.getLoc(), rewriter);
+    mapper.map(state.iterArg, attach.getResult());
+  }
+}
+
+/// Stores each yielded tensor value at the earliest cloned location where the
+/// value is available. This keeps producer-consumer ordering local to the loop
+/// body while replacing tensor iter_args with explicit DFB state.
+static void cloneBodyAndMaterializeNextState(scf::ForOp loop,
+                                             scf::ForOp newLoop,
+                                             ArrayRef<TensorLoopState> states,
+                                             IRMapping &mapper,
+                                             RewriterBase &rewriter) {
+  DenseSet<unsigned> storedStateIndices;
+
+  auto storeNextState = [&](TensorLoopState state) {
+    Value nextState = mapper.lookupOrDefault(state.yieldedValue);
+    createDFBStore(nextState, state.stateDFB.getResult(), rewriter);
+    storedStateIndices.insert(state.resultIndex);
+  };
+
+  for (TensorLoopState state : states) {
+    Operation *definingOp = state.yieldedValue.getDefiningOp();
+    if (!definingOp || definingOp->getBlock() != loop.getBody()) {
+      storeNextState(state);
+    }
+  }
+
+  for (Operation &bodyOp : *loop.getBody()) {
+    if (isa<scf::YieldOp>(bodyOp)) {
+      continue;
+    }
+
+    rewriter.clone(bodyOp, mapper);
+
+    for (TensorLoopState state : states) {
+      if (storedStateIndices.contains(state.resultIndex)) {
+        continue;
+      }
+      Operation *definingOp = state.yieldedValue.getDefiningOp();
+      if (definingOp == &bodyOp) {
+        storeNextState(state);
+      }
+    }
+  }
+
+  for (TensorLoopState state : states) {
+    if (!storedStateIndices.contains(state.resultIndex)) {
+      storeNextState(state);
+    }
+  }
+
+  auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+  SmallVector<Value> newYieldOperands;
+  for (unsigned resultIndex = 0; resultIndex < yield.getNumOperands();
+       ++resultIndex) {
+    if (isTensorStateIndex(states, resultIndex)) {
+      continue;
+    }
+    newYieldOperands.push_back(
+        mapper.lookupOrDefault(yield.getOperand(resultIndex)));
+  }
+  scf::YieldOp::create(rewriter, yield.getLoc(), newYieldOperands);
+}
+
+/// Reconnects users of the old loop results after tensor state has been
+/// materialized through compiler-allocated DFB state.
+static void replaceLoopResults(scf::ForOp loop, scf::ForOp newLoop,
+                               ArrayRef<TensorLoopState> states,
+                               RewriterBase &rewriter) {
+  DenseMap<unsigned, Value> tensorReplacements;
+  rewriter.setInsertionPointAfter(newLoop);
+  for (TensorLoopState state : states) {
+    auto attach = createDFBWaitAndAttach(
+        state.stateDFB.getResult(), state.tensorType, loop.getLoc(), rewriter);
+    tensorReplacements[state.resultIndex] = attach.getResult();
+  }
+
+  unsigned newResultIndex = 0;
+  for (unsigned resultIndex = 0; resultIndex < loop.getNumResults();
+       ++resultIndex) {
+    if (auto replacement = tensorReplacements.lookup(resultIndex)) {
+      rewriter.replaceAllUsesWith(loop.getResult(resultIndex), replacement);
+      continue;
+    }
+    if (isTensorStateIndex(states, resultIndex)) {
+      continue;
+    }
+    rewriter.replaceAllUsesWith(loop.getResult(resultIndex),
+                                newLoop.getResult(newResultIndex));
+    ++newResultIndex;
+  }
+}
+
+/// Applies tensor state materialization to one loop. A loop without tensor
+/// iter_args is not a match and is left untouched by the pass driver.
+static LogicalResult materializeLoopState(scf::ForOp loop,
+                                          RewriterBase &rewriter) {
+  SmallVector<TensorLoopState> states = collectTensorLoopStates(loop);
+  if (states.empty()) {
+    return failure();
+  }
+
+  auto funcOp = loop->getParentOfType<func::FuncOp>();
+  assert(funcOp && "pass runs on func.func");
+  auto moduleOp = funcOp->getParentOfType<ModuleOp>();
+  assert(moduleOp && "func.func must be nested in a module");
+
+  for (TensorLoopState &state : states) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    state.stateDFB = createCompilerAllocatedDFB(state.tensorType, loop.getLoc(),
+                                                funcOp, moduleOp, rewriter);
+  }
+
+  createInitialStores(states, loop, rewriter);
+  scf::ForOp newLoop = createLoopWithoutTensorState(loop, states, rewriter);
+
+  IRMapping mapper;
+  mapLoopCarriedValues(loop, newLoop, states, mapper, rewriter);
+  cloneBodyAndMaterializeNextState(loop, newLoop, states, mapper, rewriter);
+  replaceLoopResults(loop, newLoop, states, rewriter);
+
+  rewriter.eraseOp(loop);
+  return success();
+}
+
+struct TTLMaterializeLoopStatePass
+    : public impl::TTLMaterializeLoopStateBase<TTLMaterializeLoopStatePass> {
+  void runOnOperation() override {
+    SmallVector<scf::ForOp> loops;
+    getOperation().walk<WalkOrder::PostOrder>(
+        [&](scf::ForOp loop) { loops.push_back(loop); });
+
+    // This transform moves and erases sibling ops around the matched loop, so
+    // it is driven explicitly instead of relying on a greedy pattern worklist.
+    // Postorder collection ensures nested loops are handled before a parent can
+    // clone or erase its body, and RewriterBase reports every mutation.
+    IRRewriter rewriter(&getContext());
+    for (scf::ForOp loop : loops) {
+      (void)materializeLoopState(loop, rewriter);
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::ttl

--- a/python/pykernel/_src/kernel_ast.py
+++ b/python/pykernel/_src/kernel_ast.py
@@ -16,6 +16,202 @@ from .kernel_types import ClassRegistry
 from .utils import _cast, _get_type_str
 
 
+def _extract_target_names(target):
+    """Names bound by a single assignment target, supporting nested tuples
+    and starred unpacking. Subscript/Attribute targets bind storage, not
+    variables, and are skipped."""
+    if isinstance(target, ast.Name):
+        yield target.id
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            yield from _extract_target_names(elt)
+    elif isinstance(target, ast.Starred):
+        yield from _extract_target_names(target.value)
+
+
+class _ScopedCollector(ast.NodeVisitor):
+    """Base for collectors that walk a statement body without descending
+    into nested function or lambda definitions."""
+
+    def visit_FunctionDef(self, node):
+        return
+
+    def visit_AsyncFunctionDef(self, node):
+        return
+
+    def visit_Lambda(self, node):
+        return
+
+    def visit_For(self, node):
+        for stmt in node.body:
+            self.visit(stmt)
+
+    def visit_With(self, node):
+        for stmt in node.body:
+            self.visit(stmt)
+
+    def visit_If(self, node):
+        for stmt in node.body:
+            self.visit(stmt)
+        for stmt in node.orelse:
+            self.visit(stmt)
+
+
+class _ReadVariableCollector(_ScopedCollector):
+    def __init__(self):
+        self.names = set()
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, ast.Load):
+            self.names.add(node.id)
+
+
+def _collect_read_variable_names(node):
+    collector = _ReadVariableCollector()
+    collector.visit(node)
+    return collector.names
+
+
+class _LoopCarriedVarCollector(_ScopedCollector):
+    """Names assigned in a loop body to an expression that reads them
+    (`acc = acc + x`, `a, b = a + 1, b * 2`, `acc += x`), i.e. the
+    targets of a loop-carried recurrence. Order of first appearance is
+    preserved. AugAssign targets are tracked separately because
+    `out_blk += x` on a DFB-attached block target lowers via __iadd__
+    to an in-place accumulating store and is NOT an scf.for iter_arg
+    candidate, whereas `acc = acc + x` (Assign) always produces a new
+    SSA value that must be carried."""
+
+    def __init__(self):
+        self.names = []
+        self._seen = set()
+        # Names whose only recurrence form is AugAssign. If the same
+        # name also appears in a plain Assign (`acc = acc + d`), it is
+        # removed from this set; the Assign produces a new SSA value
+        # that must be carried regardless of the AugAssign's lowering.
+        self.augassign_only_names = set()
+
+    def _add(self, name, *, from_augassign):
+        if name not in self._seen:
+            self.names.append(name)
+            self._seen.add(name)
+            if from_augassign:
+                self.augassign_only_names.add(name)
+            return
+        if not from_augassign:
+            self.augassign_only_names.discard(name)
+
+    def _add_if_loop_carried(self, target, value):
+        read_variable_names = _collect_read_variable_names(value)
+        for name in _extract_target_names(target):
+            if name in read_variable_names:
+                self._add(name, from_augassign=False)
+
+    def visit_Assign(self, node):
+        if len(node.targets) != 1:
+            return
+        self._add_if_loop_carried(node.targets[0], node.value)
+
+    def visit_AnnAssign(self, node):
+        if node.value is not None:
+            self._add_if_loop_carried(node.target, node.value)
+
+    def visit_AugAssign(self, node):
+        # `target op= value` reads `target` implicitly. For block targets
+        # __iadd__ lowers them in place, so AugAssign-only entries
+        # are filtered out by `_get_loop_carried_var_names`.
+        for name in _extract_target_names(node.target):
+            self._add(name, from_augassign=True)
+
+
+class _AssignedVariableCollector(_ScopedCollector):
+    """Names assigned anywhere inside the visited body. Order of first
+    appearance is preserved."""
+
+    def __init__(self):
+        self.names = []
+        self._seen = set()
+        self.augassign_only_names = set()
+
+    def _add_target(self, target, from_augassign=False):
+        for name in _extract_target_names(target):
+            if name not in self._seen:
+                self.names.append(name)
+                self._seen.add(name)
+                if from_augassign:
+                    self.augassign_only_names.add(name)
+                continue
+            if not from_augassign:
+                self.augassign_only_names.discard(name)
+
+    def visit_Assign(self, node):
+        if len(node.targets) == 1:
+            self._add_target(node.targets[0])
+
+    def visit_AnnAssign(self, node):
+        self._add_target(node.target)
+
+    def visit_AugAssign(self, node):
+        self._add_target(node.target, from_augassign=True)
+
+
+def _get_single_result(value):
+    if isinstance(value, OpView):
+        if len(value.results) != 1:
+            raise ValueError(
+                f"Expected operation with exactly one result, got "
+                f"{len(value.results)} from {value.operation.name}"
+            )
+        return value.result
+    if isinstance(value, Operation):
+        if len(value.results) != 1:
+            raise ValueError(
+                f"Expected operation with exactly one result, got "
+                f"{len(value.results)} from {value.name}"
+            )
+        return value.results[0]
+    return value
+
+
+def _is_attach_cb_block(value):
+    """Block targets (`out_blk = cb.reserve()` / `cb.wait()`) wrap the
+    result of `ttl.attach_cb` and lower `+=` via __iadd__ to an L1 acc
+    store. They are not scf.for iter_arg / scf.if result candidates."""
+    inner = _get_single_result(value)
+    owner = getattr(inner, "owner", None)
+    if owner is None or not hasattr(owner, "name"):
+        return False
+    return owner.name == "ttl.attach_cb"
+
+
+def _get_value_type(value):
+    if hasattr(value, "type"):
+        return value.type
+    value = _get_single_result(value)
+    if hasattr(value, "type"):
+        return value.type
+    return None
+
+
+def _require_mlir_value_type(value, var_name, construct_name):
+    """Return the type for a value that will appear in an SCF result list."""
+    value_type = _get_value_type(value)
+    if value_type is not None:
+        return value_type
+    construct_display_name = (
+        "if statement" if construct_name == "an if statement" else "loop"
+    )
+    local_scope_name = "branch" if construct_name == "an if statement" else "loop body"
+    raise ValueError(
+        f"Variable '{var_name}' is reassigned inside {construct_name}, but it "
+        "is a plain Python value, such as a tuple, list, string, or integer; "
+        f"TT-Lang only supports reassigning TT-Lang tensor, block, and scalar "
+        f"values across {construct_name}; move the Python assignment outside "
+        f"the {construct_display_name} or use a different local variable name "
+        f"inside the {local_scope_name}"
+    )
+
+
 def _is_host_scalar_constant(val) -> bool:
     """True if `val` is a Float- or Integer-typed MLIR Value defined by
     arith.ConstantOp (i.e. a Python int/float captured by the AST). Index
@@ -187,25 +383,58 @@ class TTCompilerBase(PyKernelAstBase):
             if_cond = arith.cmpi(
                 arith.CmpIPredicate.ne, if_cond, arith.ConstantOp(cond_type, 0)
             )
-        if_exp = scf.IfOp(cond=if_cond, has_else=bool(node.orelse))
+        carried_var_names = self._get_if_carried_var_names(node)
+        carried_initial_values = [
+            _get_single_result(self._var_exists(var_name)[var_name])
+            for var_name in carried_var_names
+        ]
+        carried_types = [
+            _require_mlir_value_type(value, var_name, "an if statement")
+            for var_name, value in zip(carried_var_names, carried_initial_values)
+        ]
+
+        if_exp = scf.IfOp(
+            cond=if_cond,
+            results_=carried_types,
+            has_else=bool(node.orelse) or bool(carried_var_names),
+        )
 
         self._on_scope_exit()
         with InsertionPoint(if_exp.then_block), Location.unknown():
-            self.symbol_tables.append({})
-            for stmt in node.body:
-                self.visit(stmt)
-            self._on_scope_exit()
-            scf.YieldOp([])
-            self.symbol_tables.pop()
+            self._visit_if_region(node.body, carried_var_names, carried_initial_values)
 
-        if node.orelse:
+        if node.orelse or carried_var_names:
             with InsertionPoint(if_exp.else_block), Location.unknown():
-                self.symbol_tables.append({})
-                for stmt in node.orelse:
-                    self.visit(stmt)
-                self._on_scope_exit()
-                scf.YieldOp([])
-                self.symbol_tables.pop()
+                self._visit_if_region(
+                    node.orelse, carried_var_names, carried_initial_values
+                )
+
+        for var_name, result in zip(carried_var_names, if_exp.results):
+            self._set_var(var_name, result)
+
+    def _visit_if_region(self, stmts, carried_var_names, carried_initial_values):
+        self.symbol_tables.append({})
+        for stmt in stmts:
+            self.visit(stmt)
+        self._on_scope_exit()
+
+        yield_values = []
+        for var_name, initial_value in zip(carried_var_names, carried_initial_values):
+            final_value = self.symbol_tables[-1].get(var_name, initial_value)
+            initial_type = _require_mlir_value_type(
+                initial_value, var_name, "an if statement"
+            )
+            final_type = _require_mlir_value_type(
+                final_value, var_name, "an if statement"
+            )
+            if final_type != initial_type:
+                raise ValueError(
+                    f"Variable '{var_name}' changes type across an if statement from "
+                    f"{initial_type} to {final_type}"
+                )
+            yield_values.append(_get_single_result(final_value))
+        scf.YieldOp(yield_values)
+        self.symbol_tables.pop()
 
     def visit_For(self, node):
         assert node.iter.func.id == "range", "Only range() supported in for loops"
@@ -248,19 +477,96 @@ class TTCompilerBase(PyKernelAstBase):
             comment = self._get_source_comment_block(node)
             emitc.verbatim(comment, [])
 
+        carried_var_names = self._get_loop_carried_var_names(node)
+        carried_initial_values = [
+            _get_single_result(self._var_exists(var_name)[var_name])
+            for var_name in carried_var_names
+        ]
+
         self._on_scope_exit()
-        for_op = scf.ForOp(lower_bound, upper_bound, step)
+        for_op = scf.ForOp(lower_bound, upper_bound, step, carried_initial_values)
         with InsertionPoint(for_op.body), Location.unknown():
             self.symbol_tables.append({})
 
             # Add the iterator into the symbol table.
             self._set_var(node.target.id, for_op.induction_variable)
+            for var_name, iter_arg in zip(carried_var_names, for_op.inner_iter_args):
+                self._set_var(var_name, iter_arg)
 
             for stmt in node.body:
                 self.visit(stmt)
             self._on_scope_exit()
-            scf.YieldOp([])
+            yield_values = []
+            for var_name, initial_value in zip(
+                carried_var_names, carried_initial_values
+            ):
+                final_value = self.symbol_tables[-1].get(var_name, initial_value)
+                initial_type = _require_mlir_value_type(
+                    initial_value, var_name, "a loop"
+                )
+                final_type = _require_mlir_value_type(final_value, var_name, "a loop")
+                if final_type != initial_type:
+                    raise ValueError(
+                        f"Variable '{var_name}' changes type across a loop from "
+                        f"{initial_type} to {final_type}"
+                    )
+                yield_values.append(_get_single_result(final_value))
+            scf.YieldOp(yield_values)
             self.symbol_tables.pop()
+
+        for var_name, result in zip(carried_var_names, for_op.results):
+            self._set_var(var_name, result)
+
+    def _get_loop_carried_var_names(self, node):
+        collector = _LoopCarriedVarCollector()
+        for stmt in node.body:
+            collector.visit(stmt)
+
+        # A name is carried only if it already exists outside the loop;
+        # otherwise it is loop-local and rebinding it does not need an
+        # iter_arg. Type is not constrained: scf.for accepts any iter_arg
+        # type, so tensor and scalar recurrences are both materialized.
+        # An AugAssign-only entry on a DFB-attached block target
+        # (`out_blk = cb.reserve(); out_blk += x`) is dropped because
+        # __iadd__ lowers it to an in-place accumulating store rather than a
+        # new SSA value to carry. If the same name also appears in a
+        # plain Assign (`acc = acc + d`), it stays carried; the Assign
+        # produces a fresh value that scf.for must thread.
+        carried_var_names = []
+        for var_name in collector.names:
+            if var_name == node.target.id:
+                continue
+            if not self._var_exists(var_name):
+                continue
+            if var_name in collector.augassign_only_names:
+                value = self._var_exists(var_name)[var_name]
+                if _is_attach_cb_block(value):
+                    continue
+            carried_var_names.append(var_name)
+        return carried_var_names
+
+    def _get_if_carried_var_names(self, node):
+        collector = _AssignedVariableCollector()
+        for stmt in node.body:
+            collector.visit(stmt)
+        for stmt in node.orelse:
+            collector.visit(stmt)
+
+        # Only names that exist outside the if are carried; fresh names
+        # bound inside a branch stay branch-local.
+        # An AugAssign-only DFB-attached block target lowers in place through
+        # __iadd__; carrying it would replace the block view with an scf.if
+        # result and lose the DFB reserve operations.
+        carried_var_names = []
+        for var_name in collector.names:
+            if not self._var_exists(var_name):
+                continue
+            if var_name in collector.augassign_only_names:
+                value = self._var_exists(var_name)[var_name]
+                if _is_attach_cb_block(value):
+                    continue
+            carried_var_names.append(var_name)
+        return carried_var_names
 
     # Statements
     def visit_Name(self, node):

--- a/python/pykernel/_src/kernel_ast.py
+++ b/python/pykernel/_src/kernel_ast.py
@@ -72,26 +72,40 @@ def _collect_read_variable_names(node):
     return collector.names
 
 
-class _LoopCarriedVarCollector(_ScopedCollector):
-    """Names assigned in a loop body to an expression that reads them
-    (`acc = acc + x`, `a, b = a + 1, b * 2`, `acc += x`), i.e. the
-    targets of a loop-carried recurrence. Order of first appearance is
-    preserved. AugAssign targets are tracked separately because
-    `out_blk += x` on a DFB-attached block target lowers via __iadd__
-    to an in-place accumulating store and is NOT an scf.for iter_arg
-    candidate, whereas `acc = acc + x` (Assign) always produces a new
-    SSA value that must be carried."""
+class _AssignmentCollector(_ScopedCollector):
+    """Assignment analysis shared by `scf.if` and `scf.for` lowering.
+
+    `names` contains every variable assigned in the visited body, in first-use
+    order. `scf.if` uses this list because any branch-local reassignment of an
+    outer value must become an if result.
+
+    `loop_carried_names` contains assigned variables whose new value depends on
+    their previous value, directly (`acc = acc + x`) or through local aliases
+    (`tmp = acc; acc = tmp + x`). `scf.for` uses this narrower list because
+    loop-local assignments that do not depend on a previous outer value do not
+    need iter_args.
+
+    `augassign_only_names` preserves the DFB-attached block exception:
+    `out_blk += x` lowers through block `__iadd__` as an in-place accumulating
+    store, so an AugAssign-only DFB block target is not an SCF result. If the
+    same name also appears in a plain assignment, the assignment produces a new
+    SSA value and the name must be carried."""
 
     def __init__(self):
         self.names = []
         self._seen = set()
-        # Names whose only recurrence form is AugAssign. If the same
-        # name also appears in a plain Assign (`acc = acc + d`), it is
-        # removed from this set; the Assign produces a new SSA value
-        # that must be carried regardless of the AugAssign's lowering.
+        self.loop_carried_names = []
+        self._loop_carried_seen = set()
         self.augassign_only_names = set()
+        self._dependencies_by_name = {}
 
-    def _add(self, name, *, from_augassign):
+    def _expand_dependencies(self, read_variable_names):
+        dependencies = set()
+        for name in read_variable_names:
+            dependencies.update(self._dependencies_by_name.get(name, {name}))
+        return dependencies
+
+    def _add_assigned_name(self, name, *, from_augassign):
         if name not in self._seen:
             self.names.append(name)
             self._seen.add(name)
@@ -101,58 +115,76 @@ class _LoopCarriedVarCollector(_ScopedCollector):
         if not from_augassign:
             self.augassign_only_names.discard(name)
 
-    def _add_if_loop_carried(self, target, value):
+    def _add_loop_carried_name(self, name):
+        if name in self._loop_carried_seen:
+            return
+        self.loop_carried_names.append(name)
+        self._loop_carried_seen.add(name)
+
+    def _record_assignment(self, targets, value, *, from_augassign=False):
         read_variable_names = _collect_read_variable_names(value)
-        for name in _extract_target_names(target):
-            if name in read_variable_names:
-                self._add(name, from_augassign=False)
+        if from_augassign:
+            for target in targets:
+                read_variable_names.update(_extract_target_names(target))
+        dependencies = self._expand_dependencies(read_variable_names)
+
+        for target in targets:
+            for name in _extract_target_names(target):
+                self._add_assigned_name(name, from_augassign=from_augassign)
+                if name in dependencies:
+                    self._add_loop_carried_name(name)
+                self._dependencies_by_name[name] = set(dependencies)
 
     def visit_Assign(self, node):
-        if len(node.targets) != 1:
-            return
-        self._add_if_loop_carried(node.targets[0], node.value)
+        self._record_assignment(node.targets, node.value)
 
     def visit_AnnAssign(self, node):
-        if node.value is not None:
-            self._add_if_loop_carried(node.target, node.value)
+        if node.value is None:
+            self._record_assignment([node.target], ast.Constant(value=None))
+            return
+        self._record_assignment([node.target], node.value)
 
     def visit_AugAssign(self, node):
         # `target op= value` reads `target` implicitly. For block targets
-        # __iadd__ lowers them in place, so AugAssign-only entries
-        # are filtered out by `_get_loop_carried_var_names`.
-        for name in _extract_target_names(node.target):
-            self._add(name, from_augassign=True)
+        # __iadd__ lowers them in place, so AugAssign-only entries are
+        # filtered out before creating SCF result values.
+        self._record_assignment([node.target], node.value, from_augassign=True)
 
 
-class _AssignedVariableCollector(_ScopedCollector):
-    """Names assigned anywhere inside the visited body. Order of first
-    appearance is preserved."""
-
+class _UnsupportedLanguageConstructCollector(ast.NodeVisitor):
     def __init__(self):
-        self.names = []
-        self._seen = set()
-        self.augassign_only_names = set()
+        self.unsupported = []
 
-    def _add_target(self, target, from_augassign=False):
-        for name in _extract_target_names(target):
-            if name not in self._seen:
-                self.names.append(name)
-                self._seen.add(name)
-                if from_augassign:
-                    self.augassign_only_names.add(name)
-                continue
-            if not from_augassign:
-                self.augassign_only_names.discard(name)
+    def visit_FunctionDef(self, node):
+        return
 
-    def visit_Assign(self, node):
-        if len(node.targets) == 1:
-            self._add_target(node.targets[0])
+    def visit_AsyncFunctionDef(self, node):
+        return
 
-    def visit_AnnAssign(self, node):
-        self._add_target(node.target)
+    def visit_Lambda(self, node):
+        return
 
-    def visit_AugAssign(self, node):
-        self._add_target(node.target, from_augassign=True)
+    def _add(self, node, construct_name):
+        self.unsupported.append((node, construct_name))
+
+    def visit_While(self, node):
+        self._add(node, "while loops")
+
+    def visit_IfExp(self, node):
+        self._add(node, "conditional expressions")
+
+    def visit_NamedExpr(self, node):
+        self._add(node, "assignment expressions")
+
+    def visit_Match(self, node):
+        self._add(node, "match statements")
+
+
+def _collect_unsupported_language_constructs(nodes):
+    collector = _UnsupportedLanguageConstructCollector()
+    for node in nodes:
+        collector.visit(node)
+    return collector.unsupported
 
 
 def _get_single_result(value):
@@ -276,6 +308,7 @@ class TTCompilerBase(PyKernelAstBase):
             ast.Attribute,
             ast.Expr,
             ast.IfExp,
+            ast.NamedExpr,
             ast.Call,
             ast.UnaryOp,
             ast.UAdd,
@@ -315,6 +348,8 @@ class TTCompilerBase(PyKernelAstBase):
             ast.Assign,
             ast.AugAssign,
             ast.AnnAssign,
+            ast.While,
+            ast.Match,
             # Function-and-class-definitions
             ast.Module,
             ast.FunctionDef,
@@ -351,12 +386,23 @@ class TTCompilerBase(PyKernelAstBase):
         self.verbose = kwargs.get("_verbose", False)
         self.source_code = kwargs.get("_source_code", "")
 
+    def _reject_unsupported_language_constructs(self, nodes):
+        unsupported = _collect_unsupported_language_constructs(nodes)
+        if not unsupported:
+            return
+        _, construct_name = unsupported[0]
+        raise NotImplementedError(
+            f"{construct_name} are not supported in TT-Lang kernels"
+        )
+
     # Control Flow
     def _on_scope_exit(self):
         """Hook for subclasses to act before exiting a scoped body."""
         pass
 
     def visit_If(self, node):
+        self._reject_unsupported_language_constructs([node])
+
         # NOTE: else-if blocks are not supported in SCF dialect
         if_cond = self.visit(node.test)
         cond_type = None
@@ -437,6 +483,8 @@ class TTCompilerBase(PyKernelAstBase):
         self.symbol_tables.pop()
 
     def visit_For(self, node):
+        self._reject_unsupported_language_constructs([node])
+
         assert node.iter.func.id == "range", "Only range() supported in for loops"
 
         if len(node.iter.args) == 1:
@@ -518,7 +566,7 @@ class TTCompilerBase(PyKernelAstBase):
             self._set_var(var_name, result)
 
     def _get_loop_carried_var_names(self, node):
-        collector = _LoopCarriedVarCollector()
+        collector = _AssignmentCollector()
         for stmt in node.body:
             collector.visit(stmt)
 
@@ -533,7 +581,7 @@ class TTCompilerBase(PyKernelAstBase):
         # plain Assign (`acc = acc + d`), it stays carried; the Assign
         # produces a fresh value that scf.for must thread.
         carried_var_names = []
-        for var_name in collector.names:
+        for var_name in collector.loop_carried_names:
             if var_name == node.target.id:
                 continue
             if not self._var_exists(var_name):
@@ -546,7 +594,7 @@ class TTCompilerBase(PyKernelAstBase):
         return carried_var_names
 
     def _get_if_carried_var_names(self, node):
-        collector = _AssignedVariableCollector()
+        collector = _AssignmentCollector()
         for stmt in node.body:
             collector.visit(stmt)
         for stmt in node.orelse:
@@ -569,6 +617,24 @@ class TTCompilerBase(PyKernelAstBase):
         return carried_var_names
 
     # Statements
+    def visit_While(self, node):
+        raise NotImplementedError("while loops are not supported in TT-Lang kernels")
+
+    def visit_Match(self, node):
+        raise NotImplementedError(
+            "match statements are not supported in TT-Lang kernels"
+        )
+
+    def visit_IfExp(self, node):
+        raise NotImplementedError(
+            "conditional expressions are not supported in TT-Lang kernels"
+        )
+
+    def visit_NamedExpr(self, node):
+        raise NotImplementedError(
+            "assignment expressions are not supported in TT-Lang kernels"
+        )
+
     def visit_Name(self, node):
         var_name = node.id
 
@@ -582,10 +648,27 @@ class TTCompilerBase(PyKernelAstBase):
 
         return None
 
+    def _assign_target(self, target, value):
+        var = self.visit(target)
+
+        if isinstance(target, ast.Subscript):
+            memref.StoreOp(value, var.memref, var.indices)
+            return
+
+        if not isinstance(target, ast.Name):
+            raise NotImplementedError(
+                f"Assignment target {type(target).__name__} not supported"
+            )
+
+        if hasattr(var, "type") and isinstance(var.type, MemRefType):
+            memref.StoreOp(value, var, [arith.ConstantOp(IndexType.get(self.ctx), 0)])
+            return
+
+        self._set_var(target.id, value)
+
     def visit_Assign(self, node):
         # Loosely support slice + tuple assignment for rt_args
-        assert len(node.targets) == 1, "Only single assignments supported"
-        if isinstance(node.targets[0], ast.Tuple):
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Tuple):
             # Make sure that these are being assigned from rt_args
             if self.rt_args is None:
                 raise NotImplementedError(
@@ -614,21 +697,9 @@ class TTCompilerBase(PyKernelAstBase):
                 # Exit out of function now
                 return
 
-        var = self.visit(node.targets[0])
         value = self.visit(node.value)
-
-        # Handle Subscript Assignment here
-        if isinstance(node.targets[0], ast.Subscript):
-            # Var will contain a memref.LoadOp here, we can access the memref and write to it
-            memref.StoreOp(value, var.memref, var.indices)
-            return
-
-        var_name = node.targets[0].id
-
-        if hasattr(var, "type") and isinstance(var.type, MemRefType):
-            memref.StoreOp(value, var, [arith.ConstantOp(IndexType.get(self.ctx), 0)])
-        else:
-            self._set_var(var_name, value)
+        for target in node.targets:
+            self._assign_target(target, value)
 
     def visit_AnnAssign(self, node):
         # NOTE: TTKernel types can not be used with memrefs

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -334,21 +334,46 @@ class TTLGenericCompiler(TTCompilerBase):
                 self._raise_error(node, str(e))
 
     def visit_AugAssign(self, node):
-        """Handle += on tensor blocks via the registered __iadd__ method."""
+        """Handle augmented assignment on tensor values.
+
+        `+=` on a DFB-attached block emits an accumulating store through
+        `__iadd__`. Other tensor targets are rewritten to an ordinary
+        assignment so loop-carried SSA values can be represented by `scf.for`
+        iter_args.
+        """
         with self._loc_for_node(node):
             target = self.visit(node.target)
-            if (
-                isinstance(node.op, ast.Add)
-                and hasattr(target, "type")
-                and isinstance(target.type, RankedTensorType)
-            ):
-                rhs = self.visit(node.value)
-                mlir_type = _get_type_str(target.type)
-                iadd_fn = self._fn_map.get(f"{mlir_type}.__iadd__")
-                if iadd_fn:
-                    result = iadd_fn(target, rhs)
-                    self._set_var(node.target.id, result)
-                    return
+            if hasattr(target, "type") and isinstance(target.type, RankedTensorType):
+                from ..operators import _is_block
+
+                if isinstance(node.op, ast.Add) and _is_block(target):
+                    rhs = self.visit(node.value)
+                    mlir_type = _get_type_str(target.type)
+                    iadd_fn = self._fn_map.get(f"{mlir_type}.__iadd__")
+                    if iadd_fn:
+                        result = iadd_fn(target, rhs)
+                        self._set_var(node.target.id, result)
+                        return
+                if isinstance(node.target, ast.Name):
+                    load_target = ast.copy_location(
+                        ast.Name(id=node.target.id, ctx=ast.Load()), node.target
+                    )
+                    store_target = ast.copy_location(
+                        ast.Name(id=node.target.id, ctx=ast.Store()), node.target
+                    )
+                    synthetic = ast.copy_location(
+                        ast.Assign(
+                            targets=[store_target],
+                            value=ast.copy_location(
+                                ast.BinOp(
+                                    left=load_target, op=node.op, right=node.value
+                                ),
+                                node.value,
+                            ),
+                        ),
+                        node,
+                    )
+                    return self.visit(synthetic)
             return super().visit_AugAssign(node)
 
     def _is_pipenet_callback_call(self, node):
@@ -630,20 +655,25 @@ class TTLGenericCompiler(TTCompilerBase):
                     or self._is_ttl_block_access(node)
                 ):
                     return self._resolve_ttl_function(node, func_args, kwargs)
-                # Tensor-typed .shape: return the value's grid shape as a
-                # Python tuple of ints. Lets users write `y_blk.shape` inside
-                # @ttl.compute / @ttl.datamovement to derive shape kwargs for
-                # spec-form ops like ttl.block.broadcast(..., shape=y_blk.shape).
-                # Resolved before the chained-call and module-attribute branches
-                # so it also works on call expressions whose result is a ranked
-                # tensor. Non-tensor receivers fall through to the existing
-                # handlers and surface their normal diagnostic.
-                if not func_args and not kwargs and node.attr == "shape":
+                # Tensor-typed attributes are resolved from the SSA value type
+                # so spec-form ops can construct result types without reading a
+                # destination DFB during lowering.
+                if not func_args and not kwargs and node.attr in ("shape", "dtype"):
                     value = self.visit(node.value)
                     if value is not None and hasattr(value, "type"):
                         tensor_ty = RankedTensorType.maybe_downcast(value.type)
                         if tensor_ty is not None:
-                            return tuple(tensor_ty.shape)
+                            if node.attr == "shape":
+                                return tuple(tensor_ty.shape)
+                            tile_ty = ttcore.ir.TileType.maybe_downcast(
+                                tensor_ty.element_type
+                            )
+                            if tile_ty is not None:
+                                return ttcore.DataType(tile_ty.data_type_as_int)
+                            if tensor_ty.element_type == F32Type.get(self.ctx):
+                                return ttcore.DataType.Float32
+                            if tensor_ty.element_type == BF16Type.get(self.ctx):
+                                return ttcore.DataType.BFloat16
                 # Handle chained method calls: expr().method()
                 if isinstance(node.value, ast.Call):
                     return self._resolve_chained_method_call(node, func_args, kwargs)

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -345,11 +345,14 @@ def _is_block(value) -> bool:
     """Check if a value is a block (result of cb.reserve() or cb.wait()).
 
     A block is a tensor with an attached CB, produced by ttl.attach_cb.
+    BlockArguments (e.g. scf.for iter_args) report a `Block` as their
+    owner, not an `Operation`, so they are never blocks in this sense.
     """
     if not hasattr(value, "owner") or value.owner is None:
         return False
-    owner_name = value.owner.name
-    return owner_name == "ttl.attach_cb"
+    if not hasattr(value.owner, "name"):
+        return False
+    return value.owner.name == "ttl.attach_cb"
 
 
 def _get_reserve_from_block(block):

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1552,6 +1552,7 @@ def _compile_kernel(
 
         compiler_dfbs_flag = int(compiler_options.compiler_dfbs)
         pipeline_passes = [
+            "func.func(ttl-materialize-loop-state)",
             f"func.func(ttl-insert-intermediate-dfbs{{enable={compiler_dfbs_flag}}})",
             "func.func(ttl-insert-copy-wait)",
             "func.func(ttl-auto-sync)",

--- a/test/bindings/python/ttl_passes.py
+++ b/test/bindings/python/ttl_passes.py
@@ -18,6 +18,7 @@ def test_ttl_passes_registered():
 
     # Function-level passes.
     func_passes = [
+        "ttl-materialize-loop-state",
         "convert-ttl-to-compute",
         "ttl-assign-dst",
         "ttl-lower-to-loops",
@@ -27,6 +28,7 @@ def test_ttl_passes_registered():
     for pass_name in func_passes:
         PassManager.parse(f"builtin.module(func.func({pass_name}))", context=ctx)
         print(f"{pass_name} pass registered")
+        # CHECK: ttl-materialize-loop-state pass registered
         # CHECK: convert-ttl-to-compute pass registered
         # CHECK: ttl-assign-dst pass registered
         # CHECK: ttl-lower-to-loops pass registered

--- a/test/me2e/builder/pipeline.py
+++ b/test/me2e/builder/pipeline.py
@@ -42,6 +42,7 @@ def compile_ttl_to_ttkernel(
 
     # Build per-function passes.
     func_passes = [
+        "ttl-materialize-loop-state",
         "ttl-insert-intermediate-dfbs",
         "ttl-insert-copy-wait",
         "ttl-auto-sync",

--- a/test/python/test_auto_pop_push.py
+++ b/test/python/test_auto_pop_push.py
@@ -1153,23 +1153,9 @@ def test_producer_three_reserves_deferred_stores_in_loop(device):
     _run(device, repro, TOTAL, expected)
 
 
-# ---------------------------------------------------------------------------
-# xfail (#540). Tensor recurrence (acc = acc + ...) carrying an acquired
-# tile through scf.for iter_args. The DSL today does not lower this
-# pattern consistently; PR #540 adds the missing materialization. Once
-# #540 is merged, the auto-pop pass must follow uses through the iter_arg
-# block argument so the pop is placed after the loop, not before. Mirrors
-# lit test 30 in insert_cb_sync.mlir.
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.requires_device
-@pytest.mark.xfail(
-    strict=True,
-    reason="Tensor recurrence carrying an acquired tile through scf.for "
-    "iter_args. Lifted by #540 (materialize tensor loop state).",
-)
 def test_wait_result_through_for_iter_args(device):
+    """Auto-pop must preserve the waited tile through a tensor recurrence."""
     N = 4
 
     @ttl.operation(grid=(1, 1))

--- a/test/python/test_comprehensive_multinode.py
+++ b/test/python/test_comprehensive_multinode.py
@@ -18,6 +18,7 @@ import torch
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 from ttlang_test_utils import to_dram, to_l1
+from utils.correctness import assert_pcc
 
 import ttl
 
@@ -192,9 +193,9 @@ def test_comprehensive_multinode(device):
     result2 = ttnn.to_torch(out2)
     result3 = ttnn.to_torch(out3)
 
-    assert torch.allclose(result1.float(), exp1, rtol=0.05, atol=0.15)
-    assert torch.allclose(result2.float(), exp2, rtol=0.05, atol=0.15)
-    assert torch.allclose(result3.float(), exp3, rtol=0.05, atol=0.15)
+    assert_pcc(exp1.float(), result1.float(), threshold=0.999)
+    assert_pcc(exp2.float(), result2.float(), threshold=0.999)
+    assert_pcc(exp3.float(), result3.float(), threshold=0.999)
 
 
 if __name__ == "__main__":

--- a/test/python/test_kernel_ast_collectors.py
+++ b/test/python/test_kernel_ast_collectors.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""AST collector coverage for Python control-flow lowering.
+
+These tests validate the pre-lowering analysis used to decide which Python
+variables become SCF result values and which Python constructs are rejected.
+"""
+
+import ast
+
+import pytest
+
+from ttl.pykernel._src.kernel_ast import (
+    _AssignmentCollector,
+    _collect_unsupported_language_constructs,
+)
+
+
+def _collect_assignments(source):
+    parsed_module = ast.parse(source)
+    collector = _AssignmentCollector()
+    for statement in parsed_module.body:
+        collector.visit(statement)
+    return collector
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_assigned", "expected_loop_carried"),
+    [
+        (
+            "accumulator = accumulator + delta",
+            ["accumulator"],
+            ["accumulator"],
+        ),
+        (
+            "temporary = accumulator\naccumulator = temporary + delta",
+            ["temporary", "accumulator"],
+            ["accumulator"],
+        ),
+        (
+            "updated = accumulator + delta\naccumulator = updated",
+            ["updated", "accumulator"],
+            ["accumulator"],
+        ),
+        (
+            "accumulator = mirror = accumulator + delta",
+            ["accumulator", "mirror"],
+            ["accumulator"],
+        ),
+        (
+            "left_accumulator, right_accumulator = "
+            "left_accumulator + delta, right_accumulator + delta",
+            ["left_accumulator", "right_accumulator"],
+            ["left_accumulator", "right_accumulator"],
+        ),
+    ],
+)
+def test_assignment_collector_detects_loop_carried_recurrences(
+    source, expected_assigned, expected_loop_carried
+):
+    collector = _collect_assignments(source)
+
+    assert collector.names == expected_assigned
+    assert collector.loop_carried_names == expected_loop_carried
+
+
+def test_assignment_collector_tracks_augassign_only_names():
+    collector = _collect_assignments("accumulator += delta")
+
+    assert collector.names == ["accumulator"]
+    assert collector.loop_carried_names == ["accumulator"]
+    assert collector.augassign_only_names == {"accumulator"}
+
+
+def test_plain_assignment_clears_augassign_only_status():
+    collector = _collect_assignments(
+        "accumulator += delta\naccumulator = accumulator + delta"
+    )
+
+    assert collector.loop_carried_names == ["accumulator"]
+    assert collector.augassign_only_names == set()
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_construct"),
+    [
+        (
+            "while condition:\n    accumulator = delta",
+            "while loops",
+        ),
+        (
+            "accumulator = left_value if condition else right_value",
+            "conditional expressions",
+        ),
+        (
+            "if (condition_value := condition):\n    accumulator = condition_value",
+            "assignment expressions",
+        ),
+        (
+            "match selector:\n    case 0:\n        accumulator = zero_value",
+            "match statements",
+        ),
+    ],
+)
+def test_unsupported_language_constructs_are_detected(source, expected_construct):
+    parsed_module = ast.parse(source)
+
+    unsupported = _collect_unsupported_language_constructs(parsed_module.body)
+
+    assert unsupported
+    assert unsupported[0][1] == expected_construct

--- a/test/python/test_tensor_recurrences.py
+++ b/test/python/test_tensor_recurrences.py
@@ -1,0 +1,997 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tensor recurrences carried through control flow.
+
+Covers loop-carried recurrences (`acc = acc + x`), `+=` rewrite, tuple
+targets, multi-accumulator and multi-tile recurrences, zero-trip loops,
+and conditional rebinds. The core regression is #527 (`acc = acc +
+recv.wait()` silently dropped its loop-carried value); the rest
+exercise `ttl-materialize-loop-state`, augmented-assignment rewriting,
+and existing DFB-attached block `+=` behavior.
+"""
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+
+from ttlang_test_utils import to_dram  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+TILE = 32
+
+
+N_ITERS = 3
+
+
+def _make_loop_carried_add_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a, weights, recv, out):
+        a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+        weights_dfb = ttl.make_dataflow_buffer_like(
+            weights, shape=(1, 1), block_count=2
+        )
+        partial_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+        recv_dfb = ttl.make_dataflow_buffer_like(
+            recv, shape=(1, 1), block_count=N_ITERS
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with a_dfb.wait() as a_blk, weights_dfb.wait() as weights_blk:
+                with partial_dfb.reserve() as partial_blk:
+                    partial_blk.store(a_blk @ weights_blk)
+
+            with partial_dfb.wait() as acc:
+                for _ in range(N_ITERS):
+                    with recv_dfb.wait() as recv_blk:
+                        acc = acc + recv_blk
+
+                with out_dfb.reserve() as out_blk:
+                    out_blk.store(acc)
+
+        @ttl.datamovement()
+        def reader():
+            with a_dfb.reserve() as a_blk:
+                ttl.copy(a[0:1, 0:1], a_blk).wait()
+            with weights_dfb.reserve() as weights_blk:
+                ttl.copy(weights[0:1, 0:1], weights_blk).wait()
+            for _ in range(N_ITERS):
+                with recv_dfb.reserve() as recv_blk:
+                    ttl.copy(recv[0:1, 0:1], recv_blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_dfb.wait() as out_blk:
+                ttl.copy(out_blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+def _make_direct_loop_carried_add_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(initial, delta, out):
+        initial_dfb = ttl.make_dataflow_buffer_like(
+            initial, shape=(1, 1), block_count=2
+        )
+        delta_dfb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=N_ITERS
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with initial_dfb.wait() as acc:
+                for _ in range(N_ITERS):
+                    with delta_dfb.wait() as delta_blk:
+                        acc = acc + delta_blk
+
+                with out_dfb.reserve() as out_blk:
+                    out_blk.store(acc)
+
+        @ttl.datamovement()
+        def reader():
+            with initial_dfb.reserve() as initial_blk:
+                ttl.copy(initial[0:1, 0:1], initial_blk).wait()
+            for _ in range(N_ITERS):
+                with delta_dfb.reserve() as delta_blk:
+                    ttl.copy(delta[0:1, 0:1], delta_blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_dfb.wait() as out_blk:
+                ttl.copy(out_blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+def _make_loop_carried_relu_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(initial, bias, out):
+        initial_dfb = ttl.make_dataflow_buffer_like(
+            initial, shape=(1, 1), block_count=2
+        )
+        bias_dfb = ttl.make_dataflow_buffer_like(
+            bias, shape=(1, 1), block_count=N_ITERS
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with initial_dfb.wait() as state:
+                for _ in range(N_ITERS):
+                    with bias_dfb.wait() as bias_blk:
+                        state = ttl.math.relu(state + bias_blk)
+
+                with out_dfb.reserve() as out_blk:
+                    out_blk.store(state)
+
+        @ttl.datamovement()
+        def reader():
+            with initial_dfb.reserve() as initial_blk:
+                ttl.copy(initial[0:1, 0:1], initial_blk).wait()
+            for _ in range(N_ITERS):
+                with bias_dfb.reserve() as bias_blk:
+                    ttl.copy(bias[0:1, 0:1], bias_blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_dfb.wait() as out_blk:
+                ttl.copy(out_blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+_DTYPE_TOL = {
+    torch.bfloat16: dict(rtol=5e-2, atol=1.0),
+    torch.float32: dict(rtol=1e-3, atol=1e-3),
+}
+
+
+def _run_io_kernel(
+    kernel,
+    in_tensors,
+    out_zeros,
+    expected_list,
+    dtype,
+    device,
+):
+    """Common test runner: move inputs and outputs to device, invoke the
+    kernel, then assert each output tensor matches its expected value."""
+    in_devs = [to_dram(t, device) for t in in_tensors]
+    out_devs = [to_dram(t, device) for t in out_zeros]
+    kernel(*in_devs, *out_devs)
+    ttnn.synchronize_device(device)
+    for out_dev, expected in zip(out_devs, expected_list):
+        result = ttnn.to_torch(out_dev).float()
+        assert_allclose(result, expected.float(), **_DTYPE_TOL[dtype])
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_self_rebound_add_result_is_carried_out_of_loop(device, dtype):
+    kernel = _make_loop_carried_add_kernel()
+
+    a = torch.ones((TILE, TILE), dtype=dtype)
+    weights = torch.ones((TILE, TILE), dtype=dtype)
+    recv = torch.full((TILE, TILE), 2.0, dtype=dtype)
+    out = torch.zeros((TILE, TILE), dtype=dtype)
+
+    expected = a.float() @ weights.float() + N_ITERS * recv.float()
+
+    a_dev = to_dram(a, device)
+    weights_dev = to_dram(weights, device)
+    recv_dev = to_dram(recv, device)
+    out_dev = to_dram(out, device)
+
+    kernel(a_dev, weights_dev, recv_dev, out_dev)
+    ttnn.synchronize_device(device)
+
+    result = ttnn.to_torch(out_dev).float()
+    assert_allclose(result.float(), expected.float(), **_DTYPE_TOL[dtype])
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_direct_loop_carried_add(device, dtype):
+    """Direct additive recurrences are materialized through DFB state."""
+    initial = torch.full((TILE, TILE), 4.0, dtype=dtype)
+    delta = torch.full((TILE, TILE), 2.0, dtype=dtype)
+    expected = initial.float() + N_ITERS * delta.float()
+    _run_io_kernel(
+        _make_direct_loop_carried_add_kernel(),
+        in_tensors=[initial, delta],
+        out_zeros=[torch.zeros((TILE, TILE), dtype=dtype)],
+        expected_list=[expected],
+        dtype=dtype,
+        device=device,
+    )
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_non_add_tensor_recurrence_is_carried_out_of_loop(device, dtype):
+    kernel = _make_loop_carried_relu_kernel()
+
+    initial = torch.full((TILE, TILE), -3.0, dtype=dtype)
+    bias = torch.full((TILE, TILE), 5.0, dtype=dtype)
+    out = torch.zeros((TILE, TILE), dtype=dtype)
+
+    state = initial.float()
+    for _ in range(N_ITERS):
+        state = torch.relu(state + bias.float())
+    expected = state
+
+    initial_dev = to_dram(initial, device)
+    bias_dev = to_dram(bias, device)
+    out_dev = to_dram(out, device)
+
+    kernel(initial_dev, bias_dev, out_dev)
+    ttnn.synchronize_device(device)
+
+    result = ttnn.to_torch(out_dev).float()
+    assert_allclose(result.float(), expected.float(), **_DTYPE_TOL[dtype])
+
+
+def _make_tuple_target_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, b_seed, delta, out_a, out_b):
+        a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
+        b_cb = ttl.make_dataflow_buffer_like(b_seed, shape=(1, 1), block_count=2)
+        delta_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=N_ITERS
+        )
+        out_a_cb = ttl.make_dataflow_buffer_like(out_a, shape=(1, 1), block_count=2)
+        out_b_cb = ttl.make_dataflow_buffer_like(out_b, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a, b_cb.wait() as b:
+                for _ in range(N_ITERS):
+                    with delta_cb.wait() as d:
+                        a, b = a + d, b + d
+                with out_a_cb.reserve() as oa:
+                    oa.store(a)
+                with out_b_cb.reserve() as ob:
+                    ob.store(b)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(a_seed[0:1, 0:1], blk).wait()
+            with b_cb.reserve() as blk:
+                ttl.copy(b_seed[0:1, 0:1], blk).wait()
+            for _ in range(N_ITERS):
+                with delta_cb.reserve() as blk:
+                    ttl.copy(delta[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_a_cb.wait() as blk:
+                ttl.copy(blk, out_a[0:1, 0:1]).wait()
+            with out_b_cb.wait() as blk:
+                ttl.copy(blk, out_b[0:1, 0:1]).wait()
+
+    return kernel
+
+
+def _make_three_accumulator_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, b_seed, c_seed, delta, out_a, out_b, out_c):
+        a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
+        b_cb = ttl.make_dataflow_buffer_like(b_seed, shape=(1, 1), block_count=2)
+        c_cb = ttl.make_dataflow_buffer_like(c_seed, shape=(1, 1), block_count=2)
+        delta_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=N_ITERS
+        )
+        out_a_cb = ttl.make_dataflow_buffer_like(out_a, shape=(1, 1), block_count=2)
+        out_b_cb = ttl.make_dataflow_buffer_like(out_b, shape=(1, 1), block_count=2)
+        out_c_cb = ttl.make_dataflow_buffer_like(out_c, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a, b_cb.wait() as b, c_cb.wait() as c:
+                for _ in range(N_ITERS):
+                    with delta_cb.wait() as d:
+                        a, b, c = a + d, b + d, c + d
+                with out_a_cb.reserve() as oa:
+                    oa.store(a)
+                with out_b_cb.reserve() as ob:
+                    ob.store(b)
+                with out_c_cb.reserve() as oc:
+                    oc.store(c)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(a_seed[0:1, 0:1], blk).wait()
+            with b_cb.reserve() as blk:
+                ttl.copy(b_seed[0:1, 0:1], blk).wait()
+            with c_cb.reserve() as blk:
+                ttl.copy(c_seed[0:1, 0:1], blk).wait()
+            for _ in range(N_ITERS):
+                with delta_cb.reserve() as blk:
+                    ttl.copy(delta[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_a_cb.wait() as blk:
+                ttl.copy(blk, out_a[0:1, 0:1]).wait()
+            with out_b_cb.wait() as blk:
+                ttl.copy(blk, out_b[0:1, 0:1]).wait()
+            with out_c_cb.wait() as blk:
+                ttl.copy(blk, out_c[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_three_accumulators_in_one_loop(device, dtype):
+    """Covers three DFB-backed tensor recurrences in one loop."""
+    kernel = _make_three_accumulator_kernel()
+
+    a_seed = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    b_seed = torch.full((TILE, TILE), 10.0, dtype=dtype)
+    c_seed = torch.full((TILE, TILE), 100.0, dtype=dtype)
+    delta = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    out_a = torch.zeros((TILE, TILE), dtype=dtype)
+    out_b = torch.zeros((TILE, TILE), dtype=dtype)
+    out_c = torch.zeros((TILE, TILE), dtype=dtype)
+
+    expected_a = a_seed.float() + N_ITERS * delta.float()
+    expected_b = b_seed.float() + N_ITERS * delta.float()
+    expected_c = c_seed.float() + N_ITERS * delta.float()
+
+    a_dev = to_dram(a_seed, device)
+    b_dev = to_dram(b_seed, device)
+    c_dev = to_dram(c_seed, device)
+    delta_dev = to_dram(delta, device)
+    out_a_dev = to_dram(out_a, device)
+    out_b_dev = to_dram(out_b, device)
+    out_c_dev = to_dram(out_c, device)
+
+    kernel(a_dev, b_dev, c_dev, delta_dev, out_a_dev, out_b_dev, out_c_dev)
+    ttnn.synchronize_device(device)
+
+    result_a = ttnn.to_torch(out_a_dev).float()
+    result_b = ttnn.to_torch(out_b_dev).float()
+    result_c = ttnn.to_torch(out_c_dev).float()
+    assert_allclose(result_a, expected_a.float(), **_DTYPE_TOL[dtype])
+    assert_allclose(result_b, expected_b.float(), **_DTYPE_TOL[dtype])
+    assert_allclose(result_c, expected_c.float(), **_DTYPE_TOL[dtype])
+
+
+MULTI_TILE_SHAPE = (2, 2)
+MULTI_TILE_ROWS = MULTI_TILE_SHAPE[0] * TILE
+MULTI_TILE_COLS = MULTI_TILE_SHAPE[1] * TILE
+
+
+def _make_multi_tile_block_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, delta, out):
+        a_cb = ttl.make_dataflow_buffer_like(
+            a_seed, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+        delta_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=MULTI_TILE_SHAPE, block_count=N_ITERS
+        )
+        out_cb = ttl.make_dataflow_buffer_like(
+            out, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a:
+                for _ in range(N_ITERS):
+                    with delta_cb.wait() as d:
+                        a = a + d
+                with out_cb.reserve() as o:
+                    o.store(a)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(
+                    a_seed[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]], blk
+                ).wait()
+            for _ in range(N_ITERS):
+                with delta_cb.reserve() as blk:
+                    ttl.copy(
+                        delta[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]], blk
+                    ).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_cb.wait() as blk:
+                ttl.copy(
+                    blk, out[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]]
+                ).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_multi_tile_block_recurrence(device, dtype):
+    """Verifies recurrence carries a multi-tile block (shape=(2, 2)), not just a single tile."""
+    kernel = _make_multi_tile_block_kernel()
+
+    a_seed = torch.full((MULTI_TILE_ROWS, MULTI_TILE_COLS), 1.0, dtype=dtype)
+    delta = torch.full((MULTI_TILE_ROWS, MULTI_TILE_COLS), 2.0, dtype=dtype)
+    out = torch.zeros((MULTI_TILE_ROWS, MULTI_TILE_COLS), dtype=dtype)
+
+    expected = a_seed.float() + N_ITERS * delta.float()
+
+    a_dev = to_dram(a_seed, device)
+    delta_dev = to_dram(delta, device)
+    out_dev = to_dram(out, device)
+
+    kernel(a_dev, delta_dev, out_dev)
+    ttnn.synchronize_device(device)
+
+    result = ttnn.to_torch(out_dev).float()
+    assert_allclose(result, expected.float(), **_DTYPE_TOL[dtype])
+
+
+def _make_aug_assign_non_block_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, delta, out):
+        a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
+        # Need N_ITERS + 1 delta tiles: one for the pre-loop seed, then one
+        # per loop iteration.
+        delta_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=N_ITERS + 1
+        )
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a, delta_cb.wait() as d_init:
+                # `acc` is the result of ttl.add, not an attach -> not a
+                # block. `acc += d` inside the loop must therefore rewrite
+                # to `acc = acc + d` (loop-carried recurrence), not invoke
+                # __iadd__.
+                acc = a + d_init
+                for _ in range(N_ITERS):
+                    with delta_cb.wait() as d:
+                        acc += d
+                with out_cb.reserve() as o:
+                    o.store(acc)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(a_seed[0:1, 0:1], blk).wait()
+            for _ in range(N_ITERS + 1):
+                with delta_cb.reserve() as blk:
+                    ttl.copy(delta[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_cb.wait() as blk:
+                ttl.copy(blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_aug_assign_on_non_block_rewrites_to_loop_carried(device, dtype):
+    """`acc += d` on a plain tensor (not a reserve block) is rewritten by
+    the AST visitor to `acc = acc + d` so it lowers through
+    ttl-materialize-loop-state."""
+    kernel = _make_aug_assign_non_block_kernel()
+
+    a_seed = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    delta = torch.full((TILE, TILE), 2.0, dtype=dtype)
+    out = torch.zeros((TILE, TILE), dtype=dtype)
+
+    # acc starts at a + delta = 3, then N_ITERS more deltas added.
+    expected = a_seed.float() + (N_ITERS + 1) * delta.float()
+
+    a_dev = to_dram(a_seed, device)
+    delta_dev = to_dram(delta, device)
+    out_dev = to_dram(out, device)
+
+    kernel(a_dev, delta_dev, out_dev)
+    ttnn.synchronize_device(device)
+
+    result = ttnn.to_torch(out_dev).float()
+    assert_allclose(result, expected.float(), **_DTYPE_TOL[dtype])
+
+
+def _make_multi_target_aug_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, b_seed, delta, out_a, out_b):
+        a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
+        b_cb = ttl.make_dataflow_buffer_like(b_seed, shape=(1, 1), block_count=2)
+        delta_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=N_ITERS + 1
+        )
+        out_a_cb = ttl.make_dataflow_buffer_like(out_a, shape=(1, 1), block_count=2)
+        out_b_cb = ttl.make_dataflow_buffer_like(out_b, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a, b_cb.wait() as b, delta_cb.wait() as d0:
+                acc1 = a + d0
+                acc2 = b + d0
+                for _ in range(N_ITERS):
+                    with delta_cb.wait() as d:
+                        acc1 += d
+                        acc2 += d
+                with out_a_cb.reserve() as o:
+                    o.store(acc1)
+                with out_b_cb.reserve() as o:
+                    o.store(acc2)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(a_seed[0:1, 0:1], blk).wait()
+            with b_cb.reserve() as blk:
+                ttl.copy(b_seed[0:1, 0:1], blk).wait()
+            for _ in range(N_ITERS + 1):
+                with delta_cb.reserve() as blk:
+                    ttl.copy(delta[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_a_cb.wait() as blk:
+                ttl.copy(blk, out_a[0:1, 0:1]).wait()
+            with out_b_cb.wait() as blk:
+                ttl.copy(blk, out_b[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_aug_assign_multi_target_in_loop(device, dtype):
+    """Two plain-tensor accumulators each rebound with `+=` in the same
+    loop: exercises the AugAssign rewrite alongside multi-iter_arg
+    emission and multiple DFB-attached accumulating stores."""
+    a_seed = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    b_seed = torch.full((TILE, TILE), 10.0, dtype=dtype)
+    delta = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    expected_a = a_seed.float() + (N_ITERS + 1) * delta.float()
+    expected_b = b_seed.float() + (N_ITERS + 1) * delta.float()
+    _run_io_kernel(
+        _make_multi_target_aug_kernel(),
+        in_tensors=[a_seed, b_seed, delta],
+        out_zeros=[
+            torch.zeros((TILE, TILE), dtype=dtype),
+            torch.zeros((TILE, TILE), dtype=dtype),
+        ],
+        expected_list=[expected_a, expected_b],
+        dtype=dtype,
+        device=device,
+    )
+
+
+def _make_aug_outside_loop_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, delta, out):
+        a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
+        delta_cb = ttl.make_dataflow_buffer_like(delta, shape=(1, 1), block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a, delta_cb.wait() as d:
+                acc = a + d
+                # `+=` outside any loop: the rewrite produces a plain
+                # `acc = acc + d` with no recurrence machinery involved.
+                acc += d
+                with out_cb.reserve() as o:
+                    o.store(acc)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(a_seed[0:1, 0:1], blk).wait()
+            with delta_cb.reserve() as blk:
+                ttl.copy(delta[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_cb.wait() as blk:
+                ttl.copy(blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_aug_assign_outside_loop(device, dtype):
+    """`acc += d` outside any loop must lower to a single ttl.add, not
+    accidentally synthesize a scf.for."""
+    a_seed = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    delta = torch.full((TILE, TILE), 2.0, dtype=dtype)
+    expected = a_seed.float() + 2 * delta.float()
+    _run_io_kernel(
+        _make_aug_outside_loop_kernel(),
+        in_tensors=[a_seed, delta],
+        out_zeros=[torch.zeros((TILE, TILE), dtype=dtype)],
+        expected_list=[expected],
+        dtype=dtype,
+        device=device,
+    )
+
+
+def _make_sub_aug_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, delta, out):
+        a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
+        delta_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=N_ITERS + 1
+        )
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a, delta_cb.wait() as d_init:
+                acc = a - d_init
+                for _ in range(N_ITERS):
+                    with delta_cb.wait() as d:
+                        acc -= d
+                with out_cb.reserve() as o:
+                    o.store(acc)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(a_seed[0:1, 0:1], blk).wait()
+            for _ in range(N_ITERS + 1):
+                with delta_cb.reserve() as blk:
+                    ttl.copy(delta[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_cb.wait() as blk:
+                ttl.copy(blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_aug_assign_sub_op(device, dtype):
+    """`-=` on a plain tensor is rewritten the same way as `+=`; it lowers
+    through ttl.sub instead of DFB-attached in-place addition.
+    Final value: a - d_init - N_ITERS * d."""
+    a_seed = torch.full((TILE, TILE), 100.0, dtype=dtype)
+    delta = torch.full((TILE, TILE), 2.0, dtype=dtype)
+    expected = a_seed.float() - delta.float() - N_ITERS * delta.float()
+    _run_io_kernel(
+        _make_sub_aug_kernel(),
+        in_tensors=[a_seed, delta],
+        out_zeros=[torch.zeros((TILE, TILE), dtype=dtype)],
+        expected_list=[expected],
+        dtype=dtype,
+        device=device,
+    )
+
+
+def _make_block_aug_in_loop_kernel():
+    """Smallest reproducer for the iter-arg-shadows-block regression:
+    `out_blk += x` on a reserve block whose `with:` scope encloses an
+    `scf.for` loop. The collector must NOT register `out_blk` as a
+    loop-carried iter_arg; if it does, the block target is shadowed to
+    an scf.for BlockArgument and `+=` falls into the plain-tensor
+    rewrite (`ttl.add` producing an SSA value) instead of the
+    block `__iadd__` accumulating store, leaving the DFB at its initial fill."""
+
+    @ttl.operation(grid=(1, 1))
+    def kernel(x, out):
+        x_cb = ttl.make_dataflow_buffer_like(x, shape=(1, 1), block_count=N_ITERS)
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with out_cb.reserve() as out_blk:
+                out_blk.store(
+                    ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
+                )
+                for _ in range(N_ITERS):
+                    with x_cb.wait() as xj:
+                        out_blk += xj
+
+        @ttl.datamovement()
+        def reader():
+            for _ in range(N_ITERS):
+                with x_cb.reserve() as blk:
+                    ttl.copy(x[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_cb.wait() as blk:
+                ttl.copy(blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_block_aug_assign_in_loop_uses_l1_acc(device, dtype):
+    """Regression for #540 review: `out_blk += x` inside a for loop on a
+    reserve block carried over from an enclosing `with:` scope must
+    continue to lower via __iadd__ (an accumulating store), not be wrongly added
+    as an scf.for iter_arg by the new loop-carried collector."""
+    x = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    out = torch.zeros((TILE, TILE), dtype=dtype)
+    expected = N_ITERS * x.float()
+    _run_io_kernel(
+        _make_block_aug_in_loop_kernel(),
+        in_tensors=[x],
+        out_zeros=[out],
+        expected_list=[expected],
+        dtype=dtype,
+        device=device,
+    )
+
+
+def _make_three_acc_multi_tile_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(a_seed, b_seed, c_seed, delta, out_a, out_b, out_c):
+        a_cb = ttl.make_dataflow_buffer_like(
+            a_seed, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+        b_cb = ttl.make_dataflow_buffer_like(
+            b_seed, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+        c_cb = ttl.make_dataflow_buffer_like(
+            c_seed, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+        delta_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=MULTI_TILE_SHAPE, block_count=N_ITERS
+        )
+        out_a_cb = ttl.make_dataflow_buffer_like(
+            out_a, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+        out_b_cb = ttl.make_dataflow_buffer_like(
+            out_b, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+        out_c_cb = ttl.make_dataflow_buffer_like(
+            out_c, shape=MULTI_TILE_SHAPE, block_count=2
+        )
+
+        @ttl.compute()
+        def compute():
+            with a_cb.wait() as a, b_cb.wait() as b, c_cb.wait() as c:
+                for _ in range(N_ITERS):
+                    with delta_cb.wait() as d:
+                        a, b, c = a + d, b + d, c + d
+                with out_a_cb.reserve() as oa:
+                    oa.store(a)
+                with out_b_cb.reserve() as ob:
+                    ob.store(b)
+                with out_c_cb.reserve() as oc:
+                    oc.store(c)
+
+        @ttl.datamovement()
+        def reader():
+            with a_cb.reserve() as blk:
+                ttl.copy(
+                    a_seed[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]], blk
+                ).wait()
+            with b_cb.reserve() as blk:
+                ttl.copy(
+                    b_seed[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]], blk
+                ).wait()
+            with c_cb.reserve() as blk:
+                ttl.copy(
+                    c_seed[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]], blk
+                ).wait()
+            for _ in range(N_ITERS):
+                with delta_cb.reserve() as blk:
+                    ttl.copy(
+                        delta[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]], blk
+                    ).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_a_cb.wait() as blk:
+                ttl.copy(
+                    blk, out_a[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]]
+                ).wait()
+            with out_b_cb.wait() as blk:
+                ttl.copy(
+                    blk, out_b[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]]
+                ).wait()
+            with out_c_cb.wait() as blk:
+                ttl.copy(
+                    blk, out_c[0 : MULTI_TILE_SHAPE[0], 0 : MULTI_TILE_SHAPE[1]]
+                ).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_three_accumulators_multi_tile_block(device, dtype):
+    """Closes the matrix: three accumulators and multi-tile blocks together."""
+    kernel = _make_three_acc_multi_tile_kernel()
+
+    a_seed = torch.full((MULTI_TILE_ROWS, MULTI_TILE_COLS), 1.0, dtype=dtype)
+    b_seed = torch.full((MULTI_TILE_ROWS, MULTI_TILE_COLS), 10.0, dtype=dtype)
+    c_seed = torch.full((MULTI_TILE_ROWS, MULTI_TILE_COLS), 100.0, dtype=dtype)
+    delta = torch.full((MULTI_TILE_ROWS, MULTI_TILE_COLS), 1.0, dtype=dtype)
+    out_a = torch.zeros((MULTI_TILE_ROWS, MULTI_TILE_COLS), dtype=dtype)
+    out_b = torch.zeros((MULTI_TILE_ROWS, MULTI_TILE_COLS), dtype=dtype)
+    out_c = torch.zeros((MULTI_TILE_ROWS, MULTI_TILE_COLS), dtype=dtype)
+
+    expected_a = a_seed.float() + N_ITERS * delta.float()
+    expected_b = b_seed.float() + N_ITERS * delta.float()
+    expected_c = c_seed.float() + N_ITERS * delta.float()
+
+    a_dev = to_dram(a_seed, device)
+    b_dev = to_dram(b_seed, device)
+    c_dev = to_dram(c_seed, device)
+    delta_dev = to_dram(delta, device)
+    out_a_dev = to_dram(out_a, device)
+    out_b_dev = to_dram(out_b, device)
+    out_c_dev = to_dram(out_c, device)
+
+    kernel(a_dev, b_dev, c_dev, delta_dev, out_a_dev, out_b_dev, out_c_dev)
+    ttnn.synchronize_device(device)
+
+    result_a = ttnn.to_torch(out_a_dev).float()
+    result_b = ttnn.to_torch(out_b_dev).float()
+    result_c = ttnn.to_torch(out_c_dev).float()
+    assert_allclose(result_a, expected_a.float(), **_DTYPE_TOL[dtype])
+    assert_allclose(result_b, expected_b.float(), **_DTYPE_TOL[dtype])
+    assert_allclose(result_c, expected_c.float(), **_DTYPE_TOL[dtype])
+
+
+def _make_zero_trip_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(initial, out):
+        initial_cb = ttl.make_dataflow_buffer_like(initial, shape=(1, 1), block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with initial_cb.wait() as state:
+                # Loop bound = 0: body never executes; the iter_arg must
+                # propagate from the pre-loop init store to the post-loop
+                # final wait.
+                for _ in range(0):
+                    state = ttl.math.relu(state)
+                with out_cb.reserve() as o:
+                    o.store(state)
+
+        @ttl.datamovement()
+        def reader():
+            with initial_cb.reserve() as blk:
+                ttl.copy(initial[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_cb.wait() as blk:
+                ttl.copy(blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_zero_trip_loop_propagates_initial_value(device, dtype):
+    kernel = _make_zero_trip_kernel()
+
+    initial = torch.full((TILE, TILE), 7.0, dtype=dtype)
+    out = torch.zeros((TILE, TILE), dtype=dtype)
+
+    expected = initial.float()
+
+    initial_dev = to_dram(initial, device)
+    out_dev = to_dram(out, device)
+
+    kernel(initial_dev, out_dev)
+    ttnn.synchronize_device(device)
+
+    result = ttnn.to_torch(out_dev).float()
+    assert_allclose(result, expected.float(), **_DTYPE_TOL[dtype])
+
+
+N_COND_ITERS = 4
+COND_THRESHOLD = 2
+
+
+def _make_conditional_rebind_kernel():
+    @ttl.operation(grid=(1, 1))
+    def kernel(initial, bias, out):
+        initial_cb = ttl.make_dataflow_buffer_like(initial, shape=(1, 1), block_count=2)
+        bias_cb = ttl.make_dataflow_buffer_like(
+            bias, shape=(1, 1), block_count=N_COND_ITERS
+        )
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with initial_cb.wait() as x:
+                for i in range(N_COND_ITERS):
+                    with bias_cb.wait() as bias_blk:
+                        if i < COND_THRESHOLD:
+                            x = x + bias_blk
+                with out_cb.reserve() as o:
+                    o.store(x)
+
+        @ttl.datamovement()
+        def reader():
+            with initial_cb.reserve() as blk:
+                ttl.copy(initial[0:1, 0:1], blk).wait()
+            for _ in range(N_COND_ITERS):
+                with bias_cb.reserve() as blk:
+                    ttl.copy(bias[0:1, 0:1], blk).wait()
+
+        @ttl.datamovement()
+        def writer():
+            with out_cb.wait() as blk:
+                ttl.copy(blk, out[0:1, 0:1]).wait()
+
+    return kernel
+
+
+@pytest.mark.requires_device
+@pytest.mark.xfail(
+    strict=True,
+    reason="ttl-assign-dst does not descend into nested regions (#587), so "
+    "tile ops inside scf.if fail legalization in convert-ttl-to-ttkernel. "
+    "AST emission and materialize-loop-state are correct (see lit case "
+    "conditional_recurrence in materialize_loop_state.mlir).",
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_conditional_rebind_inside_loop_carries_through_scf_if(device, dtype):
+    kernel = _make_conditional_rebind_kernel()
+
+    initial = torch.full((TILE, TILE), 0.0, dtype=dtype)
+    bias = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    out = torch.zeros((TILE, TILE), dtype=dtype)
+
+    expected = initial.float() + COND_THRESHOLD * bias.float()
+
+    initial_dev = to_dram(initial, device)
+    bias_dev = to_dram(bias, device)
+    out_dev = to_dram(out, device)
+
+    kernel(initial_dev, bias_dev, out_dev)
+    ttnn.synchronize_device(device)
+
+    result = ttnn.to_torch(out_dev).float()
+    assert_allclose(result.float(), expected.float(), **_DTYPE_TOL[dtype])
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_tuple_target_loop_carried_recurrence(device, dtype):
+    kernel = _make_tuple_target_kernel()
+
+    a_seed = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    b_seed = torch.full((TILE, TILE), 10.0, dtype=dtype)
+    delta = torch.full((TILE, TILE), 1.0, dtype=dtype)
+    out_a = torch.zeros((TILE, TILE), dtype=dtype)
+    out_b = torch.zeros((TILE, TILE), dtype=dtype)
+
+    expected_a = a_seed.float() + N_ITERS * delta.float()
+    expected_b = b_seed.float() + N_ITERS * delta.float()
+
+    a_dev = to_dram(a_seed, device)
+    b_dev = to_dram(b_seed, device)
+    delta_dev = to_dram(delta, device)
+    out_a_dev = to_dram(out_a, device)
+    out_b_dev = to_dram(out_b, device)
+
+    kernel(a_dev, b_dev, delta_dev, out_a_dev, out_b_dev)
+    ttnn.synchronize_device(device)
+
+    result_a = ttnn.to_torch(out_a_dev).float()
+    result_b = ttnn.to_torch(out_b_dev).float()
+    assert_allclose(result_a, expected_a.float(), **_DTYPE_TOL[dtype])
+    assert_allclose(result_b, expected_b.float(), **_DTYPE_TOL[dtype])

--- a/test/ttlang/Dialect/TTL/Transforms/materialize_loop_state.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/materialize_loop_state.mlir
@@ -1,0 +1,365 @@
+// Verifies ttl-materialize-loop-state removes tensor-valued scf.for iter_args
+// by materializing remaining tensor state through compiler-allocated DFB slots.
+//
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-materialize-loop-state))' --split-input-file | FileCheck %s
+
+// Additive recurrence that reaches this pass uses ordinary DFB state.
+// CHECK-LABEL: func.func @carried_add
+// CHECK-SAME: (%[[INIT:[^:]+]]: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+func.func @carried_add(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%acc = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %contribution = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %sum = ttl.add %acc, %contribution : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %attached = ttl.attach_cb %reserve, %cb1 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: %[[STATE_DFB:.*]] = ttl.bind_cb{{.*}} {ttl.compiler_allocated}
+// CHECK: %[[INIT_RESERVE:.*]] = ttl.cb_reserve %[[STATE_DFB]]
+// CHECK-NEXT: ttl.store %[[INIT]], %[[INIT_RESERVE]]
+// CHECK-NEXT: scf.for
+// CHECK-NOT: iter_args
+// CHECK: %[[WAIT:.*]] = ttl.cb_wait %[[STATE_DFB]]
+// CHECK-NEXT: %[[CURRENT:.*]] = ttl.attach_cb %[[WAIT]], %[[STATE_DFB]]
+// CHECK: %[[CONTRIB:.*]] = ttl.cb_wait
+// CHECK: %[[NEXT:.*]] = ttl.add %[[CURRENT]], %[[CONTRIB]]
+// CHECK: %[[NEXT_RESERVE:.*]] = ttl.cb_reserve %[[STATE_DFB]]
+// CHECK-NEXT: ttl.store %[[NEXT]], %[[NEXT_RESERVE]]
+// CHECK-NOT: {accumulate}
+
+// -----
+
+// Attached additive recurrence with loop-local DFB contribution is materialized
+// as ordinary tensor state when accumulation scope lowering has not run.
+// CHECK-LABEL: func.func @carried_add_loop_local_contribution
+func.func @carried_add_loop_local_contribution() {
+  %cb_init = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_delta = ttl.bind_cb {cb_index = 1, block_count = 3} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+  %cb_out = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %init_wait = ttl.cb_wait %cb_init : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init = ttl.attach_cb %init_wait, %cb_init : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c3 step %c1 iter_args(%acc = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %delta_wait = ttl.cb_wait %cb_delta : <[1, 1], !ttcore.tile<32x32, bf16>, 3> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %delta = ttl.attach_cb %delta_wait, %cb_delta : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %sum = ttl.add %acc, %delta : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb_out : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: %[[STATE_DFB:.*]] = ttl.bind_cb{{.*}} {ttl.compiler_allocated}
+// CHECK: %[[INIT_WAIT:[^ ]+]] = ttl.cb_wait %[[INIT_CB:[^ ]+]] :
+// CHECK-NEXT: %[[INIT:.*]] = ttl.attach_cb %[[INIT_WAIT]], %[[INIT_CB]]
+// CHECK: %[[INIT_RESERVE:.*]] = ttl.cb_reserve %[[STATE_DFB]]
+// CHECK-NEXT: ttl.store %[[INIT]], %[[INIT_RESERVE]]
+// CHECK-NEXT: scf.for
+// CHECK-NOT: iter_args
+// CHECK: %[[CURRENT:.*]] = ttl.attach_cb {{.*}}, %[[STATE_DFB]]
+// CHECK: %[[DELTA_WAIT:[^ ]+]] = ttl.cb_wait %[[DELTA_CB:[^ ]+]] :
+// CHECK-NEXT: %[[DELTA:.*]] = ttl.attach_cb %[[DELTA_WAIT]], %[[DELTA_CB]]
+// CHECK: %[[NEXT:.*]] = ttl.add %[[CURRENT]], %[[DELTA]]
+// CHECK: ttl.store %[[NEXT]]
+// CHECK-NOT: ttl.compute
+
+// -----
+
+// Additive recurrence whose contribution is defined outside the loop body keeps
+// that contribution outside the rewritten loop.
+// CHECK-LABEL: func.func @carried_add_outer_contribution
+// CHECK-SAME: (%[[INIT:[^:]+]]: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+func.func @carried_add_outer_contribution(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %contribution_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %contribution = ttl.attach_cb %contribution_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%acc = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %sum = ttl.add %acc, %contribution : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: %[[STATE_DFB:.*]] = ttl.bind_cb{{.*}} {ttl.compiler_allocated}
+// CHECK: %[[WAIT:.*]] = ttl.cb_wait
+// CHECK-NEXT: %[[CONTRIB:.*]] = ttl.attach_cb %[[WAIT]]
+// CHECK: %[[INIT_RESERVE:.*]] = ttl.cb_reserve %[[STATE_DFB]]
+// CHECK-NEXT: ttl.store %[[INIT]], %[[INIT_RESERVE]]
+// CHECK-NEXT: scf.for
+// CHECK-NOT: iter_args
+// CHECK: %[[CURRENT:.*]] = ttl.attach_cb {{.*}}, %[[STATE_DFB]]
+// CHECK-NEXT: %[[NEXT:.*]] = ttl.add %[[CURRENT]], %[[CONTRIB]]
+// CHECK: ttl.store %[[NEXT]]
+// CHECK-NOT: {accumulate}
+
+// -----
+
+// Commuted additive recurrence preserves operand order after DFB materialization.
+// CHECK-LABEL: func.func @commuted_carried_add
+// CHECK-SAME: (%[[INIT:[^:]+]]: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+func.func @commuted_carried_add(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%acc = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %contribution = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %sum = ttl.add %contribution, %acc : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: %[[STATE_DFB:.*]] = ttl.bind_cb{{.*}} {ttl.compiler_allocated}
+// CHECK: %[[INIT_RESERVE:.*]] = ttl.cb_reserve %[[STATE_DFB]]
+// CHECK-NEXT: ttl.store %[[INIT]], %[[INIT_RESERVE]]
+// CHECK-NEXT: scf.for
+// CHECK-NOT: iter_args
+// CHECK: %[[CURRENT:.*]] = ttl.attach_cb {{.*}}, %[[STATE_DFB]]
+// CHECK: %[[CONTRIB:.*]] = ttl.cb_wait
+// CHECK: %[[NEXT:.*]] = ttl.add %[[CONTRIB]], %[[CURRENT]]
+// CHECK: ttl.store %[[NEXT]]
+// CHECK-NOT: {accumulate}
+
+// -----
+
+// Unary recurrence lowers through compiler-allocated DFB state.
+// CHECK-LABEL: func.func @unary_recurrence
+// CHECK-SAME: (%[[INIT:[^:]+]]: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+func.func @unary_recurrence(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%state = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %next = ttl.relu %state : tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %next : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.store %[[INIT]]
+// CHECK: scf.for
+// CHECK-NOT: iter_args
+// CHECK: %[[WAIT:.*]] = ttl.cb_wait
+// CHECK-NEXT: %[[CURRENT:.*]] = ttl.attach_cb %[[WAIT]]
+// CHECK-NEXT: %[[NEXT:.*]] = ttl.relu %[[CURRENT]]
+// CHECK-NEXT: %[[NEXT_RESERVE:.*]] = ttl.cb_reserve
+// CHECK-NEXT: ttl.store %[[NEXT]], %[[NEXT_RESERVE]]
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[FINAL_WAIT:.*]] = ttl.cb_wait
+// CHECK-NEXT: %[[FINAL:.*]] = ttl.attach_cb %[[FINAL_WAIT]]
+// CHECK: ttl.store %[[FINAL]]
+
+// -----
+
+// Binary recurrence can read the previous state and another input.
+// CHECK-LABEL: func.func @binary_recurrence
+func.func @binary_recurrence(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %input_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %input = ttl.attach_cb %input_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%state = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %next = ttl.mul %state, %input : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %next : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: ttl.compiler_allocated
+// CHECK: %[[INPUT_WAIT:.*]] = ttl.cb_wait
+// CHECK-NEXT: %[[INPUT:.*]] = ttl.attach_cb %[[INPUT_WAIT]]
+// CHECK: scf.for {{.*}} {
+// CHECK-NOT: iter_args
+// CHECK-NEXT: %[[WAIT:.*]] = ttl.cb_wait
+// CHECK-NEXT: %[[CURRENT:.*]] = ttl.attach_cb %[[WAIT]]
+// CHECK-NEXT: %[[NEXT:.*]] = ttl.mul %[[CURRENT]], %[[INPUT]]
+// CHECK-NEXT: %[[RES:.*]] = ttl.cb_reserve
+// CHECK-NEXT: ttl.store %[[NEXT]], %[[RES]]
+// CHECK-NEXT: }
+
+// -----
+
+// Add result used in the body is still materialized through DFB state.
+// CHECK-LABEL: func.func @add_with_in_body_use
+func.func @add_with_in_body_use(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%acc = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %contribution = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %sum = ttl.add %acc, %contribution : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %sink_reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.store %sum, %sink_reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: ttl.compiler_allocated
+// CHECK: ttl.add
+// CHECK-NOT: {accumulate}
+
+// -----
+
+// Mixed tensor and scalar iter args: tensor state is materialized and scalar
+// state remains loop-carried.
+// CHECK-LABEL: func.func @preserve_scalar_iter_arg
+// CHECK-SAME: %[[INIT:[^:]+]]: tensor<1x1x!ttcore.tile<32x32, bf16>>
+func.func @preserve_scalar_iter_arg(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %counter_init: i32) -> i32 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %one = arith.constant 1 : i32
+  %loop:2 = scf.for %iter = %c0 to %c1 step %c1 iter_args(%state = %init, %counter = %counter_init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>, i32) {
+    %next_state = ttl.relu %state : tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %next_counter = arith.addi %counter, %one : i32
+    scf.yield %next_state, %next_counter : tensor<1x1x!ttcore.tile<32x32, bf16>>, i32
+  }
+  func.return %loop#1 : i32
+}
+// CHECK: ttl.store %[[INIT]]
+// CHECK: %[[LOOP:.*]] = scf.for {{.*}} iter_args(%[[COUNTER:.*]] =
+// CHECK: ttl.attach_cb
+// CHECK: %[[NEXT_COUNTER:.*]] = arith.addi %[[COUNTER]]
+// CHECK: scf.yield %[[NEXT_COUNTER]]
+// CHECK: return %[[LOOP]]
+
+// -----
+
+// Multiple tensor iter args each receive independent compiler-allocated DFB
+// state.
+// CHECK-LABEL: func.func @mixed_tensor_states
+func.func @mixed_tensor_states(
+    %acc_init: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %state_init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop:2 = scf.for %iter = %c0 to %c1 step %c1 iter_args(%acc = %acc_init, %state = %state_init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %contribution = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %sum = ttl.add %acc, %contribution : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %next_state = ttl.relu %state : tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %sum, %next_state : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop#0, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: ttl.compiler_allocated
+// CHECK: ttl.compiler_allocated
+// CHECK: ttl.store %{{.*}}, %{{.*}}
+// CHECK: ttl.store %{{.*}}, %{{.*}}
+// CHECK: scf.for
+// CHECK-NOT: iter_args
+// CHECK: ttl.add
+// CHECK: ttl.store
+// CHECK: ttl.relu
+// CHECK: ttl.store
+// CHECK-NOT: {accumulate}
+
+// -----
+
+// Result with multiple users is materialized through DFB state once.
+// CHECK-LABEL: func.func @add_result_multiple_users
+func.func @add_result_multiple_users(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%acc = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %contribution = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %sum = ttl.add %acc, %contribution : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  %reserve0 = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve0 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %reserve1 = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %loop, %reserve1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return
+}
+// CHECK: ttl.compiler_allocated
+// CHECK: ttl.add
+// CHECK-NOT: {accumulate}
+
+// -----
+
+// Conditional recurrence remains in the loop and stores the scf.if result to
+// DFB state.
+// CHECK-LABEL: func.func @conditional_recurrence
+func.func @conditional_recurrence(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>, %cond: i1)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c1 step %c1 iter_args(%state = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %next = scf.if %cond -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+      %then_value = ttl.relu %state : tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      scf.yield %then_value : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    } else {
+      scf.yield %state : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    scf.yield %next : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  func.return %loop : tensor<1x1x!ttcore.tile<32x32, bf16>>
+}
+// CHECK: ttl.compiler_allocated
+// CHECK: scf.if
+// CHECK: ttl.store %{{.*}}
+// CHECK: ttl.cb_wait
+// CHECK: ttl.attach_cb
+
+// -----
+
+// Zero-trip semantics are represented by the pre-loop initial store and the
+// post-loop final wait.
+// CHECK-LABEL: func.func @zero_trip_loop
+// CHECK-SAME: (%[[INIT:[^:]+]]: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+func.func @zero_trip_loop(
+    %init: tensor<1x1x!ttcore.tile<32x32, bf16>>) -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %loop = scf.for %iter = %c0 to %c0 step %c1 iter_args(%state = %init) -> (tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %next = ttl.relu %state : tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.yield %next : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  func.return %loop : tensor<1x1x!ttcore.tile<32x32, bf16>>
+}
+// CHECK: ttl.store %[[INIT]]
+// CHECK: scf.for
+// CHECK: }
+// CHECK-NEXT: %[[FINAL_WAIT:.*]] = ttl.cb_wait
+// CHECK-NEXT: %[[FINAL:.*]] = ttl.attach_cb %[[FINAL_WAIT]]
+// CHECK-NEXT: return %[[FINAL]]


### PR DESCRIPTION
### Problem description
TT-Lang tensor variables can be reassigned across loop iterations, producing loop-carried tensor state before accumulation-specific optimizations are introduced. That state must lower correctly from Python through SCF and into TTL compute lowering without depending on `ttl.accumulation_scope` formation or a hardware accumulation strategy. This is PR 2 of several split out from the full accumulation scope redesign in PR #651.

### What's changed
This PR adds the loop-carried tensor-state foundation:

- Adds frontend support for reassigned tensor values in `for` loops by emitting `scf.for` iter_args for loop-carried SSA values.
- Adds support for reassigned values across `if` expressions so structured control flow can return updated values.
- Preserves DFB-attached block `+=` lowering through `__iadd__` instead of treating the block value as an SSA iter_arg.
- Adds compiler-allocated DFB materialization helpers shared by loop-state materialization and intermediate DFB insertion.
- Adds `ttl-materialize-loop-state` to replace ranked-tensor `scf.for` iter_args with explicit compiler-managed DFB state.
- Inserts `ttl-materialize-loop-state` into the `ttlang-opt`, E2E, and ME2E pipelines before intermediate DFB insertion.
- Updates the DFB and accumulation-lowering docs to describe general loop-carried tensor-state materialization.
- Adds MLIR lit coverage for tensor loop-state materialization, including zero-trip behavior and conditional recurrence IR.
- Adds runtime coverage for tensor recurrences, multi-accumulator loops, multi-tile loop state, augmented assignment rewriting, and DFB-attached block `+=` behavior.

### Ticket
None.

### Checklist
- [x] New/Existing tests provide coverage for changes
