### PR TITLE
[`ttl.atom`] Introducing op library: composable atoms for common operations 

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -201,6 +201,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Ops
   ADD_TO_PARENT TTLangPythonCommon
   SOURCES
     ops/__init__.py
+    ops/pipe_util.py
     ops/mcast.py
     ops/flash_mla.py
     ops/rmsnorm.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -205,6 +205,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Ops
     ops/flash_mla.py
     ops/rmsnorm.py
     ops/topk.py
+    ops/matmul.py
 )
 
 declare_mlir_python_sources(TTLangPythonCommon.Src

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -202,6 +202,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Ops
   SOURCES
     ops/__init__.py
     ops/mcast.py
+    ops/flash_mla.py
 )
 
 declare_mlir_python_sources(TTLangPythonCommon.Src

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -196,6 +196,14 @@ declare_mlir_python_sources(TTLangPythonCommon.Generated
     config.py
 )
 
+declare_mlir_python_sources(TTLangPythonCommon.Ops
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ttl"
+  ADD_TO_PARENT TTLangPythonCommon
+  SOURCES
+    ops/__init__.py
+    ops/mcast.py
+)
+
 declare_mlir_python_sources(TTLangPythonCommon.Src
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ttl"
   ADD_TO_PARENT TTLangPythonCommon

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -204,6 +204,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Ops
     ops/mcast.py
     ops/flash_mla.py
     ops/rmsnorm.py
+    ops/topk.py
 )
 
 declare_mlir_python_sources(TTLangPythonCommon.Src

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -203,6 +203,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Ops
     ops/__init__.py
     ops/mcast.py
     ops/flash_mla.py
+    ops/rmsnorm.py
 )
 
 declare_mlir_python_sources(TTLangPythonCommon.Src

--- a/python/pykernel/_src/kernel_ast.py
+++ b/python/pykernel/_src/kernel_ast.py
@@ -548,7 +548,12 @@ class TTCompilerBase(PyKernelAstBase):
 
     def visit_BinOp(self, node):
         def materialize(value):
-            if not value:
+            # A host int operand (e.g. a shape/grid-derived bound) becomes an
+            # index constant so it can combine with SSA values. Matches how
+            # captured int constants are emitted at function entry.
+            if isinstance(value, int) and not isinstance(value, bool):
+                return arith.ConstantOp(IndexType.get(self.ctx), value).result
+            if value is None:
                 raise ValueError("Binary operands not found")
             if isinstance(value, OpView):
                 value = value.result

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -97,6 +97,7 @@ _TTL_OPS: Dict[str, str] = {
     "PipeNet": "control",
     "make_dataflow_buffer_like": "control",
     "node": "control",
+    "grid_size": "control",
     "dims": "control",
     "cores": "control",
     "tile_index": "control",

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -90,6 +90,7 @@ _TTL_OPS: Dict[str, str] = {
     "log": "trisc",
     "abs": "trisc",
     "relu": "trisc",
+    "sign": "trisc",
     "sigmoid": "trisc",
     "gelu": "trisc",
     # Compile-time / scalar producers: duplicated, not anchored.

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -641,6 +641,11 @@ class TTLGenericCompiler(TTCompilerBase):
                 if not func_args and not kwargs and node.attr == "shape":
                     value = self.visit(node.value)
                     if value is not None and hasattr(value, "type"):
+                        # A DFB block's .shape is its tile-block shape; checked
+                        # before the tensor case so cb.shape works too.
+                        cb_ty = ttl.CircularBufferType.maybe_downcast(value.type)
+                        if cb_ty is not None:
+                            return tuple(cb_ty.shape)
                         tensor_ty = RankedTensorType.maybe_downcast(value.type)
                         if tensor_ty is not None:
                             return tuple(tensor_ty.shape)

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -577,6 +577,7 @@ def node(*, dims):
     return (ttl.core_x(), ttl.core_y())
 
 
+@syntax("grid_size")
 def grid_size(*, dims):
     """
     Get the size of the grid.

--- a/python/ttl/ops/__init__.py
+++ b/python/ttl/ops/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composable @ttl.atom op library: reusable kernels and topology builders.
+
+Submodules are imported explicitly, e.g. ``from ttl.ops.mcast import
+mcast_rows``. Topology builders return lists of ttl.Pipe to wrap in
+ttl.PipeNet inside an atom body; compute ops are @ttl.atom functions meant to
+be inlined into a composing atom.
+"""

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -12,6 +12,8 @@ emits an unnormalized (o, m, l) partial; the tree reduce merges the
 rescale; normalize divides by the running sum.
 """
 
+import torch
+
 import ttl
 
 
@@ -23,6 +25,10 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
     the batch. Q is read from DRAM on every core; K/V are read per-core.
     Each core writes an unnormalized ``(o, m, l)`` partial to its row
     block of ``out_o`` / ``out_m`` / ``out_l``.
+
+    K/V are typecast to bf16 before the matmuls so a lower-precision cache
+    (e.g. bfp8) feeds the bf16 compute chain; the cast is a no-op when K/V
+    are already bf16.
 
     ``scale`` is the SDPA scale; it is folded into ``qk`` per chunk.
     """
@@ -75,7 +81,7 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
 
         q_blk = q_cb.wait()
         for _ in range(N_CHUNKS):
-            k_blk = k_cb.wait()
+            k_blk = ttl.math.typecast(k_cb.wait(), torch.bfloat16)
             sv_w = sv_cb.reserve()
             sv_w.store(ttl.mul(q_blk @ ttl.transpose(k_blk),
                                ttl.block.fill(scale, shape=sv_w.shape)))
@@ -120,7 +126,7 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
                 alpha2, dims=[1], shape=o_old.shape), o_old))
 
             ex2 = ex_cb.wait()
-            v_blk = v_cb.wait()
+            v_blk = ttl.math.typecast(v_cb.wait(), torch.bfloat16)
             pv_w = pv_cb.reserve(); pv_w.store(ex2 @ v_blk)
 
             o_corr_blk = o_corr_cb.wait()

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -15,6 +15,7 @@ rescale; normalize divides by the running sum.
 import torch
 
 import ttl
+from ttl.ops.pipe_util import pipe_send, pipe_recv
 
 
 def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
@@ -198,17 +199,9 @@ def make_flash_tree_reduce(PNHt, vDHt, B=1):
     ):
         m_a = m_in.wait(); l_a = l_in.wait(); o_a = o_in.wait()
 
-        def recv_m(pipe):
-            p = m_peer.reserve(); ttl.copy(pipe, p)
-        m_net.if_dst(recv_m)
-
-        def recv_l(pipe):
-            p = l_peer.reserve(); ttl.copy(pipe, p)
-        l_net.if_dst(recv_l)
-
-        def recv_o(pipe):
-            p = o_peer.reserve(); ttl.copy(pipe, p)
-        o_net.if_dst(recv_o)
+        pipe_recv(m_net, m_peer)
+        pipe_recv(l_net, l_peer)
+        pipe_recv(o_net, o_peer)
 
         m_b = m_peer.wait(); l_b = l_peer.wait(); o_b = o_peer.wait()
 
@@ -229,17 +222,9 @@ def make_flash_tree_reduce(PNHt, vDHt, B=1):
         m_state: ttl.DFB, l_state: ttl.DFB, o_state: ttl.DFB,
         m_net: ttl.PipeNet, l_net: ttl.PipeNet, o_net: ttl.PipeNet,
     ):
-        def send_m(pipe):
-            mb = m_state.wait(); ttl.copy(mb, pipe)
-        m_net.if_src(send_m)
-
-        def send_l(pipe):
-            lb = l_state.wait(); ttl.copy(lb, pipe)
-        l_net.if_src(send_l)
-
-        def send_o(pipe):
-            ob = o_state.wait(); ttl.copy(ob, pipe)
-        o_net.if_src(send_o)
+        pipe_send(m_net, m_state)
+        pipe_send(l_net, l_state)
+        pipe_send(o_net, o_state)
 
     @ttl.atom(grid=(8, B))
     def flash_tree_reduce(in_o, in_m, in_l, out_o, out_m, out_l):
@@ -338,17 +323,9 @@ def make_flash_tree_reduce(PNHt, vDHt, B=1):
         if s2_o.is_dst():
             m_a = m_rx2.wait(); l_a = l_rx2.wait(); o_a = o_rx2.wait()
 
-            def s2_recv_m(pipe):
-                p = m_peer.reserve(); ttl.copy(pipe, p)
-            s2_m.if_dst(s2_recv_m)
-
-            def s2_recv_l(pipe):
-                p = l_peer.reserve(); ttl.copy(pipe, p)
-            s2_l.if_dst(s2_recv_l)
-
-            def s2_recv_o(pipe):
-                p = o_peer.reserve(); ttl.copy(pipe, p)
-            s2_o.if_dst(s2_recv_o)
+            pipe_recv(s2_m, m_peer)
+            pipe_recv(s2_l, l_peer)
+            pipe_recv(s2_o, o_peer)
 
             m_b = m_peer.wait(); l_b = l_peer.wait(); o_b = o_peer.wait()
 

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Flash MLA decode ops: a per-core online-softmax shard, an 8-core tree
+reduce that merges the per-core partials, and a normalize tail.
+
+Each op is a standalone @ttl.atom factory parametrized by tile shapes. A
+shard core runs flash attention over its slice of the K/V sequence and
+emits an unnormalized (o, m, l) partial; the tree reduce merges the
+``n_cols`` partials of each batch row with the flash online-softmax
+rescale; normalize divides by the running sum.
+"""
+
+import ttl
+
+
+def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
+    """Per-core flash attention over a K-dim split.
+
+    The grid is ``(n_cols, B)``: column ``col_c`` owns the K/V slice
+    starting at ``col_c * Sk_chunk_t * N_CHUNKS`` tiles, row ``row_c`` is
+    the batch. Q is read from DRAM on every core; K/V are read per-core.
+    Each core writes an unnormalized ``(o, m, l)`` partial to its row
+    block of ``out_o`` / ``out_m`` / ``out_l``.
+
+    ``scale`` is the SDPA scale; it is folded into ``qk`` per chunk.
+    """
+    St_per_core = Sk_chunk_t * N_CHUNKS
+
+    @ttl.atom(grid=(n_cols, B))
+    def flash_shard(q, k, v, out_o, out_m, out_l):
+        col_c, row_c = ttl.node(dims=2)
+
+        q_cb = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+        k_cb = ttl.make_dataflow_buffer_like(k, shape=(Sk_chunk_t, DHt), block_count=2)
+        v_cb = ttl.make_dataflow_buffer_like(k, shape=(Sk_chunk_t, vDHt), block_count=2)
+
+        sv_cb        = ttl.make_dataflow_buffer_like(q, shape=(PNHt, Sk_chunk_t), block_count=2)
+        ex_cb        = ttl.make_dataflow_buffer_like(q, shape=(PNHt, Sk_chunk_t), block_count=2)
+        chunk_max_cb = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
+        chunk_sum_cb = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
+        alpha_cb     = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
+        m_new_cb     = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
+        o_corr_cb    = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt),       block_count=2)
+        pv_cb        = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt),       block_count=2)
+
+        m_state_cb   = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),    block_count=2)
+        l_state_cb   = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),    block_count=2)
+        o_state_cb   = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt), block_count=2)
+
+        # Dedicated single-push output CBs: the compute thread waits the
+        # state CBs and stores the finals here; the datamovement thread waits
+        # these to copy to DRAM. We could copy each state CB straight to DRAM,
+        # but then the state CB would be waited on the datamovement thread too
+        # and the SPSC verifier rejects that cross-thread second consumer.
+        out_o_cb = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
+        out_m_cb = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1),    block_count=2)
+        out_l_cb = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1),    block_count=2)
+
+        qd = q_cb.reserve()
+        ttl.copy(q[0:PNHt, 0:DHt], qd)
+
+        k_base = col_c * St_per_core
+        for c in range(N_CHUNKS):
+            kc = k_base + c * Sk_chunk_t
+            k_dst = k_cb.reserve()
+            ttl.copy(k[kc:kc + Sk_chunk_t, 0:DHt], k_dst)
+            v_dst = v_cb.reserve()
+            ttl.copy(v[kc:kc + Sk_chunk_t, 0:vDHt], v_dst)
+
+        m0 = m_state_cb.reserve(); m0.store(ttl.block.fill(-1e30, shape=m0.shape))
+        l0 = l_state_cb.reserve(); l0.store(ttl.block.fill(0.0,   shape=l0.shape))
+        o0 = o_state_cb.reserve(); o0.store(ttl.block.fill(0.0,   shape=o0.shape))
+
+        q_blk = q_cb.wait()
+        for _ in range(N_CHUNKS):
+            k_blk = k_cb.wait()
+            sv_w = sv_cb.reserve()
+            sv_w.store(ttl.mul(q_blk @ ttl.transpose(k_blk),
+                               ttl.block.fill(scale, shape=sv_w.shape)))
+
+            sv = sv_cb.wait()
+            cm_w = chunk_max_cb.reserve()
+            cm_w.store(ttl.math.reduce_max(sv, dims=[1]))
+            sv_re = sv_cb.reserve(); sv_re.store(sv)
+
+            m_old = m_state_cb.wait()
+            cm = chunk_max_cb.wait()
+            mn_w = m_new_cb.reserve(); mn_w.store(ttl.math.max(m_old, cm))
+
+            mn_for_alpha = m_new_cb.wait()
+            alpha_w = alpha_cb.reserve()
+            alpha_w.store(ttl.exp(ttl.sub(m_old, mn_for_alpha)))
+            mn_re = m_new_cb.reserve(); mn_re.store(mn_for_alpha)
+
+            mn_for_state = m_new_cb.wait()
+            sv2 = sv_cb.wait()
+            ex_w = ex_cb.reserve()
+            ex_w.store(ttl.exp(ttl.sub(sv2, ttl.block.broadcast(
+                mn_for_state, dims=[1], shape=sv2.shape))))
+            m_next = m_state_cb.reserve(); m_next.store(mn_for_state)
+
+            ex = ex_cb.wait()
+            cs_w = chunk_sum_cb.reserve()
+            cs_w.store(ttl.math.reduce_sum(ex, dims=[1]))
+            ex_re = ex_cb.reserve(); ex_re.store(ex)
+
+            alpha = alpha_cb.wait()
+            l_old = l_state_cb.wait()
+            cs = chunk_sum_cb.wait()
+            l_next = l_state_cb.reserve()
+            l_next.store(ttl.add(ttl.mul(alpha, l_old), cs))
+            alpha_re = alpha_cb.reserve(); alpha_re.store(alpha)
+
+            alpha2 = alpha_cb.wait()
+            o_old = o_state_cb.wait()
+            o_corr_w = o_corr_cb.reserve()
+            o_corr_w.store(ttl.mul(ttl.block.broadcast(
+                alpha2, dims=[1], shape=o_old.shape), o_old))
+
+            ex2 = ex_cb.wait()
+            v_blk = v_cb.wait()
+            pv_w = pv_cb.reserve(); pv_w.store(ex2 @ v_blk)
+
+            o_corr_blk = o_corr_cb.wait()
+            pv_blk = pv_cb.wait()
+            o_next = o_state_cb.reserve()
+            o_next.store(ttl.add(o_corr_blk, pv_blk))
+
+        base = (row_c * n_cols + col_c) * PNHt
+        m_final = m_state_cb.wait()
+        mo = out_m_cb.reserve(); mo.store(m_final)
+        ttl.copy(out_m_cb.wait(), out_m[base:base + PNHt, 0:1])
+        l_final = l_state_cb.wait()
+        lo = out_l_cb.reserve(); lo.store(l_final)
+        ttl.copy(out_l_cb.wait(), out_l[base:base + PNHt, 0:1])
+        o_final = o_state_cb.wait()
+        oo = out_o_cb.reserve(); oo.store(o_final)
+        ttl.copy(out_o_cb.wait(), out_o[base:base + PNHt, 0:vDHt])
+
+    return flash_shard
+
+
+def make_flash_normalize(grid, PNHt, vDHt):
+    """Finalize flash output: ``o_norm = o_unnorm / l``.
+
+    ``l`` is broadcast from ``(PNHt, 1)`` to ``(PNHt, vDHt)`` and applied
+    via reciprocal + multiply.
+    """
+
+    @ttl.atom(grid=grid)
+    def flash_normalize(o_in, l_in, o_out):
+        col_c, row_c = ttl.node(dims=2)
+        base = row_c * PNHt
+
+        o_cb = ttl.make_dataflow_buffer_like(o_in, shape=(PNHt, vDHt), block_count=2)
+        l_cb = ttl.make_dataflow_buffer_like(l_in, shape=(PNHt, 1),    block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(o_out, shape=(PNHt, vDHt), block_count=2)
+
+        od = o_cb.reserve(); ttl.copy(o_in[base:base + PNHt, 0:vDHt], od)
+        ld = l_cb.reserve(); ttl.copy(l_in[base:base + PNHt, 0:1], ld)
+
+        o = o_cb.wait()
+        l = l_cb.wait()
+        l_recip_bc = ttl.block.broadcast(
+            ttl.math.recip(l), dims=[1], shape=o.shape,
+        )
+        ow = out_cb.reserve()
+        ow.store(ttl.mul(o, l_recip_bc))
+        o_blk = out_cb.wait()
+        ttl.copy(o_blk, o_out[base:base + PNHt, 0:vDHt])
+
+    return flash_normalize
+
+
+def make_flash_tree_reduce(PNHt, vDHt, B=1):
+    """8-core 3-step intra-row tree reduce, replicated across ``B`` rows.
+
+    Grid is ``(8, B)``: ``col_c`` is the partial column, ``row_c`` the
+    batch row. Each row independently merges its 8 ``(m, l, o)`` partials
+    with the flash online-softmax rescale. On ``col_c == 0`` the merged
+    unnormalized ``(o, m, l)`` is written to the row block of the outputs.
+    """
+
+    @ttl.atom()
+    def tree_step_recv(
+        m_in: ttl.DFB, l_in: ttl.DFB, o_in: ttl.DFB,
+        m_out: ttl.DFB, l_out: ttl.DFB, o_out: ttl.DFB,
+        m_peer: ttl.DFB, l_peer: ttl.DFB, o_peer: ttl.DFB,
+        m_net: ttl.PipeNet, l_net: ttl.PipeNet, o_net: ttl.PipeNet,
+    ):
+        m_a = m_in.wait(); l_a = l_in.wait(); o_a = o_in.wait()
+
+        def recv_m(pipe):
+            p = m_peer.reserve(); ttl.copy(pipe, p)
+        m_net.if_dst(recv_m)
+
+        def recv_l(pipe):
+            p = l_peer.reserve(); ttl.copy(pipe, p)
+        l_net.if_dst(recv_l)
+
+        def recv_o(pipe):
+            p = o_peer.reserve(); ttl.copy(pipe, p)
+        o_net.if_dst(recv_o)
+
+        m_b = m_peer.wait(); l_b = l_peer.wait(); o_b = o_peer.wait()
+
+        m_new = ttl.math.max(m_a, m_b)
+        aa = ttl.exp(ttl.sub(m_a, m_new))
+        ab = ttl.exp(ttl.sub(m_b, m_new))
+        l_new = ttl.add(ttl.mul(aa, l_a), ttl.mul(ab, l_b))
+        aa_bc = ttl.block.broadcast(aa, dims=[1], shape=o_a.shape)
+        ab_bc = ttl.block.broadcast(ab, dims=[1], shape=o_b.shape)
+        o_new = ttl.add(ttl.mul(aa_bc, o_a), ttl.mul(ab_bc, o_b))
+
+        mw = m_out.reserve(); mw.store(m_new)
+        lw = l_out.reserve(); lw.store(l_new)
+        ow = o_out.reserve(); ow.store(o_new)
+
+    @ttl.atom()
+    def tree_step_send(
+        m_state: ttl.DFB, l_state: ttl.DFB, o_state: ttl.DFB,
+        m_net: ttl.PipeNet, l_net: ttl.PipeNet, o_net: ttl.PipeNet,
+    ):
+        def send_m(pipe):
+            mb = m_state.wait(); ttl.copy(mb, pipe)
+        m_net.if_src(send_m)
+
+        def send_l(pipe):
+            lb = l_state.wait(); ttl.copy(lb, pipe)
+        l_net.if_src(send_l)
+
+        def send_o(pipe):
+            ob = o_state.wait(); ttl.copy(ob, pipe)
+        o_net.if_src(send_o)
+
+    @ttl.atom(grid=(8, B))
+    def flash_tree_reduce(in_o, in_m, in_l, out_o, out_m, out_l):
+        col_c, row_c = ttl.node(dims=2)
+
+        s0_m = ttl.PipeNet([ttl.Pipe(src=(2 * i + 1, b), dst=(2 * i, b)) for b in range(B) for i in range(4)])
+        s0_l = ttl.PipeNet([ttl.Pipe(src=(2 * i + 1, b), dst=(2 * i, b)) for b in range(B) for i in range(4)])
+        s0_o = ttl.PipeNet([ttl.Pipe(src=(2 * i + 1, b), dst=(2 * i, b)) for b in range(B) for i in range(4)])
+        s1_m = ttl.PipeNet([ttl.Pipe(src=(4 * i + 2, b), dst=(4 * i, b)) for b in range(B) for i in range(2)])
+        s1_l = ttl.PipeNet([ttl.Pipe(src=(4 * i + 2, b), dst=(4 * i, b)) for b in range(B) for i in range(2)])
+        s1_o = ttl.PipeNet([ttl.Pipe(src=(4 * i + 2, b), dst=(4 * i, b)) for b in range(B) for i in range(2)])
+        s2_m = ttl.PipeNet([ttl.Pipe(src=(4, b), dst=(0, b)) for b in range(B)])
+        s2_l = ttl.PipeNet([ttl.Pipe(src=(4, b), dst=(0, b)) for b in range(B)])
+        s2_o = ttl.PipeNet([ttl.Pipe(src=(4, b), dst=(0, b)) for b in range(B)])
+
+        # A single (m, l, o) DFB per stage would suffice: every wait is
+        # sequential and a core only ever plays one role. But the SPSC
+        # verifier counts a DFB's waits across all threads of the kernel, and
+        # the same stage buffer is consumed by the recv path on the compute
+        # thread and by the send path on the datamovement thread. We split
+        # each stage buffer into a recv-side (`_rx`, compute consumer) and a
+        # send-side (`_tx`, datamovement consumer) copy so each has a single
+        # consumer thread; each recv routes its result into the copy whose
+        # thread matches the next stage's consumer.
+        #
+        # TODO: these could be substantially reduced (to just 3 dfbs) if the
+        # verifier was smarter about what actually might cause a race.
+        m_rx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        l_rx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        o_rx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
+        m_tx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        l_tx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        o_tx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
+        m_rx1 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        l_rx1 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        o_rx1 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
+        m_rx2 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        l_rx2 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        o_rx2 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
+        # Send-side buffer for stages 1 and 2: both are compute-produced and
+        # datamovement-consumed, and no single core sends in both stages, so
+        # they share one DFB (keeps us under the 32 hardware DFB limit).
+        m_txc = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        l_txc = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
+        o_txc = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
+
+        # Peer DFBs receive the partner's partial and are reused across all
+        # 3 steps; block_count=3 = one slot per pipe that targets them.
+        m_peer = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=3)
+        l_peer = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=3)
+        o_peer = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=3)
+
+        # Dedicated single-push output CBs: the compute thread stores the
+        # merged result here and the datamovement thread copies it to DRAM.
+        # The merge could write to DRAM directly, but then the state CB would
+        # be waited on the datamovement thread too; the SPSC verifier rejects
+        # that cross-thread second consumer.
+        out_o_cb = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
+        out_m_cb = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1),    block_count=2)
+        out_l_cb = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1),    block_count=2)
+
+        # Load this core's partial into the rx/tx copy matching its stage-0
+        # role: receivers feed the compute thread, senders the datamovement.
+        base = (row_c * 8 + col_c) * PNHt
+        if s0_o.is_dst():
+            od = o_rx0.reserve(); ttl.copy(in_o[base:base + PNHt, 0:vDHt], od)
+            md = m_rx0.reserve(); ttl.copy(in_m[base:base + PNHt, 0:1], md)
+            ld = l_rx0.reserve(); ttl.copy(in_l[base:base + PNHt, 0:1], ld)
+        elif s0_o.is_src():
+            od = o_tx0.reserve(); ttl.copy(in_o[base:base + PNHt, 0:vDHt], od)
+            md = m_tx0.reserve(); ttl.copy(in_m[base:base + PNHt, 0:1], md)
+            ld = l_tx0.reserve(); ttl.copy(in_l[base:base + PNHt, 0:1], ld)
+
+        # Stage 0: receivers (cols 0,2,4,6) merge with their s0 peer and route
+        # the result to rx1 if they receive again next, or tx1 if they send.
+        if s1_o.is_dst():
+            tree_step_recv(m_rx0, l_rx0, o_rx0, m_rx1, l_rx1, o_rx1,
+                           m_peer, l_peer, o_peer, s0_m, s0_l, s0_o)
+        elif s1_o.is_src():
+            tree_step_recv(m_rx0, l_rx0, o_rx0, m_txc, l_txc, o_txc,
+                           m_peer, l_peer, o_peer, s0_m, s0_l, s0_o)
+        elif s0_o.is_src():
+            tree_step_send(m_tx0, l_tx0, o_tx0, s0_m, s0_l, s0_o)
+
+        # Stage 1: receivers (cols 0,4) merge with their s1 peer and route to
+        # rx2 (col 0, receives again) or tx2 (col 4, sends to col 0).
+        if s2_o.is_dst():
+            tree_step_recv(m_rx1, l_rx1, o_rx1, m_rx2, l_rx2, o_rx2,
+                           m_peer, l_peer, o_peer, s1_m, s1_l, s1_o)
+        elif s2_o.is_src():
+            tree_step_recv(m_rx1, l_rx1, o_rx1, m_txc, l_txc, o_txc,
+                           m_peer, l_peer, o_peer, s1_m, s1_l, s1_o)
+        elif s1_o.is_src():
+            tree_step_send(m_txc, l_txc, o_txc, s1_m, s1_l, s1_o)
+
+        if s2_o.is_dst():
+            m_a = m_rx2.wait(); l_a = l_rx2.wait(); o_a = o_rx2.wait()
+
+            def s2_recv_m(pipe):
+                p = m_peer.reserve(); ttl.copy(pipe, p)
+            s2_m.if_dst(s2_recv_m)
+
+            def s2_recv_l(pipe):
+                p = l_peer.reserve(); ttl.copy(pipe, p)
+            s2_l.if_dst(s2_recv_l)
+
+            def s2_recv_o(pipe):
+                p = o_peer.reserve(); ttl.copy(pipe, p)
+            s2_o.if_dst(s2_recv_o)
+
+            m_b = m_peer.wait(); l_b = l_peer.wait(); o_b = o_peer.wait()
+
+            m_fin = ttl.math.max(m_a, m_b)
+            aa = ttl.exp(ttl.sub(m_a, m_fin))
+            ab = ttl.exp(ttl.sub(m_b, m_fin))
+            l_fin = ttl.add(ttl.mul(aa, l_a), ttl.mul(ab, l_b))
+            aa_bc = ttl.block.broadcast(aa, dims=[1], shape=o_a.shape)
+            ab_bc = ttl.block.broadcast(ab, dims=[1], shape=o_b.shape)
+            o_unnorm = ttl.add(ttl.mul(aa_bc, o_a), ttl.mul(ab_bc, o_b))
+
+            obase = row_c * PNHt
+            mw = out_m_cb.reserve(); mw.store(m_fin)
+            ttl.copy(out_m_cb.wait(), out_m[obase:obase + PNHt, 0:1])
+            lw = out_l_cb.reserve(); lw.store(l_fin)
+            ttl.copy(out_l_cb.wait(), out_l[obase:obase + PNHt, 0:1])
+            ow = out_o_cb.reserve(); ow.store(o_unnorm)
+            ttl.copy(out_o_cb.wait(), out_o[obase:obase + PNHt, 0:vDHt])
+        elif s2_o.is_src():
+            tree_step_send(m_txc, l_txc, o_txc, s2_m, s2_l, s2_o)
+
+    return flash_tree_reduce

--- a/python/ttl/ops/matmul.py
+++ b/python/ttl/ops/matmul.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""K-split SUMMA matmul as a single @ttl.atom.
+
+The output is tiled into ``(bm, bn)`` blocks. The grid is ``(Np*Kp, Mp)``:
+the x axis folds ``Np`` N-partitions and ``Kp`` K-partitions, the y axis is
+``Mp`` M-partitions. A core at ``(col_c, row_c)`` has K-rank ``k_p =
+col_c // Np`` and N-rank ``n_p = col_c % Np``; it owns the ``M_BPN x N_BPN``
+output blocks of its (row_c, n_p) tile, looping over them when there are more
+blocks than cores.
+
+  - A is multicast across the ``Np`` cores of each K-band, per M row.
+  - B is multicast down the ``Mp`` rows of each column.
+  - Each core accumulates its ``K_BPN``-block K-slice; non-root K-bands ship
+    the partial to the ``k_p == 0`` root, which sums and writes out.
+
+Both broadcasts reuse the ``ttl.ops.mcast`` op inline. KP=2 (a single reduce
+step) is supported today; KP>2 (a multi-step / tree reduce) is a follow-on.
+"""
+
+from typing import Tuple
+
+import ttl
+from ttl.ops.mcast import mcast, mcast_cols
+
+TILE = 32
+
+
+def make_ksplit(
+    M: int,
+    K: int,
+    N: int,
+    block_cfg: Tuple[int, int, int],
+    part_cfg: Tuple[int, int, int],
+    *,
+    fp32_dest_acc_en: bool = True,
+):
+    """Build a K-split matmul atom. ``M``/``N`` are the padded dims; the
+    caller pads tensors so block and partition counts divide evenly."""
+    bm, bn, bk = block_cfg
+    Mp, Np, Kp = part_cfg
+
+    if Kp != 2:
+        raise ValueError(f"make_ksplit currently supports Kp == 2, got Kp={Kp}")
+    if M % TILE or N % TILE or K % TILE:
+        raise ValueError(f"M/K/N must be tile-aligned: M={M} K={K} N={N}")
+
+    Mt, Nt, Kt = M // TILE, N // TILE, K // TILE
+    if Mt % bm or Nt % bn or Kt % bk:
+        raise ValueError(
+            f"block must divide shape in tiles: Mt={Mt} Nt={Nt} Kt={Kt} "
+            f"block=(bm={bm}, bn={bn}, bk={bk})")
+
+    Mb, Nb, Kb = Mt // bm, Nt // bn, Kt // bk
+    if Mb % Mp or Nb % Np or Kb % Kp:
+        raise ValueError(
+            f"block/part mismatch: Mb={Mb} Nb={Nb} Kb={Kb} must divide "
+            f"Mp={Mp} Np={Np} Kp={Kp}")
+
+    M_BPN = Mb // Mp
+    N_BPN = Nb // Np
+    K_BPN = Kb // Kp
+    COL = Np * Kp
+
+    @ttl.atom(grid=(COL, Mp), fp32_dest_acc_en=fp32_dest_acc_en)
+    def ksplit(a, w, out):
+        a_cb = ttl.make_dataflow_buffer_like(a, shape=(bm, bk), block_count=2)
+        b_cb = ttl.make_dataflow_buffer_like(w, shape=(bk, bn), block_count=2)
+        # mcast staging buffers so the loopback src core does not double-reserve
+        # a_cb/b_cb across the send (BRISC) and receive (NCRISC) sides.
+        tmp_a_cb = ttl.make_dataflow_buffer_like(a, shape=(bm, bk), block_count=2)
+        tmp_b_cb = ttl.make_dataflow_buffer_like(w, shape=(bk, bn), block_count=2)
+        # Split the partial per consumer: compute folds the received partial in
+        # via partial_for_sum_cb; the DM thread ships the partial off via
+        # partial_for_send_cb. One producer cannot feed both compute and DM.
+        partial_for_sum_cb = ttl.make_dataflow_buffer_like(out, shape=(bm, bn), block_count=2)
+        partial_for_send_cb = ttl.make_dataflow_buffer_like(out, shape=(bm, bn), block_count=2)
+        recv_cb = ttl.make_dataflow_buffer_like(out, shape=(bm, bn), block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(out, shape=(bm, bn), block_count=2)
+
+        # A: multicast across the Np cores of each K-band, per M row.
+        a_pipes = [
+            ttl.Pipe(src=(k_p * Np, m), dst=(slice(k_p * Np, (k_p + 1) * Np), m))
+            for k_p in range(Kp)
+            for m in range(Mp)
+        ]
+        mcast_a_net = ttl.PipeNet(a_pipes)
+        # B: multicast down the Mp rows of each column.
+        mcast_b_net = ttl.PipeNet(mcast_cols(Mp, COL))
+        # Reduce: non-root K-bands ship their partial to the k_p == 0 root.
+        reduce_pipes = [
+            ttl.Pipe(src=(k_p * Np + n_p, m), dst=(n_p, m))
+            for n_p in range(Np)
+            for m in range(Mp)
+            for k_p in range(1, Kp)
+        ]
+        reduce_net = ttl.PipeNet(reduce_pipes)
+
+        col_c, row_c = ttl.node(dims=2)
+        k_p = col_c // Np
+        n_p = col_c % Np
+
+        # One pass per output block. Per block the source order is matmul ->
+        # mcast -> reduce: the mcast (DM producer of a_cb/b_cb) must precede the
+        # reduce on the DM thread, else the reduce send blocks on a partial that
+        # depends on a matmul that depends on the not-yet-run mcast.
+        for lmb in range(M_BPN):
+            mr = (row_c * M_BPN + lmb) * bm
+            for lnb in range(N_BPN):
+                nc = (n_p * N_BPN + lnb) * bn
+
+                p = partial_for_sum_cb.reserve()
+                for _ in range(K_BPN):
+                    a_blk = a_cb.wait()
+                    b_blk = b_cb.wait()
+                    p += a_blk @ b_blk
+                pf = partial_for_sum_cb.wait()
+
+                for kbl in range(K_BPN):
+                    kc = (k_p * K_BPN + kbl) * bk
+                    mcast(mcast_a_net, a[mr : mr + bm, kc : kc + bk], tmp_a_cb, a_cb)
+                    mcast(mcast_b_net, w[kc : kc + bk, nc : nc + bn], tmp_b_cb, b_cb)
+
+                if col_c < Np:
+                    def recv_partial(pipe):
+                        r_dst = recv_cb.reserve()
+                        ttl.copy(pipe, r_dst)
+                    reduce_net.if_dst(recv_partial)
+
+                    r = recv_cb.wait()
+                    o = out_cb.reserve()
+                    o.store(pf + r)
+                    out_blk = out_cb.wait()
+                    ttl.copy(out_blk, out[mr : mr + bm, nc : nc + bn])
+                else:
+                    ps = partial_for_send_cb.reserve()
+                    ps.store(pf)
+
+                    def send_partial(pipe):
+                        p_to_send = partial_for_send_cb.wait()
+                        ttl.copy(p_to_send, pipe)
+                    reduce_net.if_src(send_partial)
+
+    return ksplit

--- a/python/ttl/ops/matmul.py
+++ b/python/ttl/ops/matmul.py
@@ -16,16 +16,41 @@ blocks than cores.
   - Each core accumulates its ``K_BPN``-block K-slice; non-root K-bands ship
     the partial to the ``k_p == 0`` root, which sums and writes out.
 
-Both broadcasts reuse the ``ttl.ops.mcast`` op inline. KP=2 (a single reduce
-step) is supported today; KP>2 (a multi-step / tree reduce) is a follow-on.
+Both broadcasts reuse the ``ttl.ops.mcast`` op inline, and the reduce hand-off
+is factored into the ``reduce_send`` / ``reduce_recv`` atoms. KP=2 (a single
+reduce step) is supported today; KP>2 (a multi-step / tree reduce) is a
+follow-on.
 """
 
 from typing import Tuple
 
 import ttl
 from ttl.ops.mcast import mcast, mcast_cols
+from ttl.ops.pipe_util import pipe_send, pipe_recv
 
 TILE = 32
+
+
+@ttl.atom()
+def reduce_send(net: ttl.PipeNet, partial: ttl.DFB, stage: ttl.DFB):
+    """Each source core stages its own ``partial`` and ships it over ``net``.
+    ``stage`` decouples the compute producer from the datamovement send so the
+    partial keeps a single consumer thread."""
+    pf = partial.wait()
+    ps = stage.reserve()
+    ps.store(pf)
+    pipe_send(net, stage)
+
+
+@ttl.atom()
+def reduce_recv(net: ttl.PipeNet, partial: ttl.DFB, peer: ttl.DFB, out: ttl.DFB):
+    """Each destination (root) core receives a peer partial over ``net`` and
+    sums it with its own ``partial`` into ``out``."""
+    pipe_recv(net, peer)
+    r = peer.wait()
+    pf = partial.wait()
+    o = out.reserve()
+    o.store(pf + r)
 
 
 def make_ksplit(
@@ -116,7 +141,6 @@ def make_ksplit(
                     a_blk = a_cb.wait()
                     b_blk = b_cb.wait()
                     p += a_blk @ b_blk
-                pf = partial_for_sum_cb.wait()
 
                 for kbl in range(K_BPN):
                     kc = (k_p * K_BPN + kbl) * bk
@@ -124,23 +148,10 @@ def make_ksplit(
                     mcast(mcast_b_net, w[kc : kc + bk, nc : nc + bn], tmp_b_cb, b_cb)
 
                 if col_c < Np:
-                    def recv_partial(pipe):
-                        r_dst = recv_cb.reserve()
-                        ttl.copy(pipe, r_dst)
-                    reduce_net.if_dst(recv_partial)
-
-                    r = recv_cb.wait()
-                    o = out_cb.reserve()
-                    o.store(pf + r)
+                    reduce_recv(reduce_net, partial_for_sum_cb, recv_cb, out_cb)
                     out_blk = out_cb.wait()
                     ttl.copy(out_blk, out[mr : mr + bm, nc : nc + bn])
                 else:
-                    ps = partial_for_send_cb.reserve()
-                    ps.store(pf)
-
-                    def send_partial(pipe):
-                        p_to_send = partial_for_send_cb.wait()
-                        ttl.copy(p_to_send, pipe)
-                    reduce_net.if_src(send_partial)
+                    reduce_send(reduce_net, partial_for_sum_cb, partial_for_send_cb)
 
     return ksplit

--- a/python/ttl/ops/mcast.py
+++ b/python/ttl/ops/mcast.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multicast: broadcast a block from one source core to many destinations.
+
+`mcast` is a factory that builds an inlinable @ttl.atom wiring both sides of a
+PipeNet: the source core stages its block and sends it; every destination
+core receives into its own DFB. Call the factory with a grid, then inline the
+returned atom into a composing atom that declares the net and buffers. The
+mcast_rows / mcast_cols helpers build the PipeNet topology.
+"""
+
+from typing import List
+
+import ttl
+
+from ..pipe import Pipe
+
+
+@ttl.atom()
+def mcast(net: ttl.PipeNet, src, stage: ttl.DFB, dst: ttl.DFB):
+    """Broadcast one block over `net`. The source core copies `src` (a tensor
+    slice) into `stage` and sends it to the pipe; every destination core
+    receives into `dst`. The source is included in the destination range, so
+    it also receives its own block into `dst`.
+    """
+
+    def _send(pipe):
+        s = stage.reserve()
+        ttl.copy(src, s)
+        sr = stage.wait()
+        ttl.copy(sr, pipe)
+
+    net.if_src(_send)
+
+    def _recv(pipe):
+        d = dst.reserve()
+        ttl.copy(pipe, d)
+
+    net.if_dst(_recv)
+
+
+def mcast_rows(rows: int, cols: int) -> List[Pipe]:
+    """Row-broadcast pipes: in each of `rows` process rows, the source core in
+    column 0 fans out to all `cols` columns. One pipe per row.
+    """
+    return [Pipe(src=(0, r), dst=(slice(0, cols), r)) for r in range(rows)]
+
+
+def mcast_cols(rows: int, cols: int) -> List[Pipe]:
+    """Column-broadcast pipes: in each of `cols` process columns, the source
+    core in row 0 fans out to all `rows` rows. One pipe per column.
+    """
+    return [Pipe(src=(c, 0), dst=(c, slice(0, rows))) for c in range(cols)]

--- a/python/ttl/ops/pipe_util.py
+++ b/python/ttl/ops/pipe_util.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bare point-to-point send / receive over a PipeNet.
+
+The two halves of moving one block between cores: every source core of ``net``
+ships a staged block to its pipe; every destination core receives a peer block
+into its own buffer. These are the wire copy only -- staging, combine, and
+buffer management stay with the caller -- so the same pattern composes into a
+multicast, a K-reduce sum, or a flash tree-reduce merge.
+"""
+
+import ttl
+
+
+@ttl.atom()
+def pipe_send(net: ttl.PipeNet, src: ttl.DFB):
+    """Each source core of ``net`` ships its ``src`` block to the pipe."""
+    def send(pipe):
+        b = src.wait()
+        ttl.copy(b, pipe)
+    net.if_src(send)
+
+
+@ttl.atom()
+def pipe_recv(net: ttl.PipeNet, dst: ttl.DFB):
+    """Each destination core of ``net`` receives a peer block into ``dst``."""
+    def recv(pipe):
+        d = dst.reserve()
+        ttl.copy(pipe, d)
+    net.if_dst(recv)

--- a/python/ttl/ops/rmsnorm.py
+++ b/python/ttl/ops/rmsnorm.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""RMSNorm op: ``y = x / sqrt(mean(x^2) + eps) * weight``.
+
+The reduction is over the feature dimension and is local to a core (each
+core owns whole rows), so this is a standalone @ttl.atom with no cross-core
+collective. The row-tiles are laid out across whatever 2D core grid the atom
+is launched on: each core walks a contiguous run of ``bpc`` row blocks, so
+the op handles any number of rows independent of the core count. The feature
+dimension is streamed in width-tile chunks so an arbitrarily wide row (e.g.
+7168) fits L1: pass one accumulates the sum of squares over the chunks to
+form the per-row inverse-RMS scale, pass two re-reads each chunk and writes
+``x * inv_rms * weight``.
+"""
+
+import ttl
+
+
+def make_rmsnorm(Rt, PNt, Dt, WCt, D, eps):
+    """RMSNorm over ``Rt`` row-tiles spread across the full device grid.
+
+    Rows are grouped into blocks of ``PNt`` row-tiles (``Rt`` must divide by
+    ``PNt``); the ``Rt // PNt`` blocks are spread contiguously across the
+    device cores, ``ceil(blocks / cores)`` blocks per core, with a tail guard
+    so any block count works on any grid (idle cores when blocks < cores).
+    ``Dt`` is the row width in tiles, streamed ``WCt`` tiles at a time (``Dt``
+    must divide by ``WCt``). ``D`` is the true feature width for the mean;
+    ``weight`` is one ``(1, Dt)`` row broadcast over rows.
+    """
+    if Dt % WCt != 0:
+        raise ValueError(f"Dt ({Dt}) must be divisible by WCt ({WCt})")
+    if Rt % PNt != 0:
+        raise ValueError(f"Rt ({Rt}) must be divisible by PNt ({PNt})")
+    n_blocks = Rt // PNt
+    n_wc = Dt // WCt
+    inv_d = 1.0 / D
+
+    @ttl.atom(grid="full")
+    def rmsnorm(x, weight, out):
+        col_c, row_c = ttl.node(dims=2)
+        gx, gy = ttl.grid_size(dims=2)
+        cores = gx * gy
+        bpc = (n_blocks + cores - 1) // cores
+        cid = col_c * gy + row_c
+
+        xq_cb   = ttl.make_dataflow_buffer_like(x,      shape=(PNt, WCt), block_count=2)
+        xr_cb   = ttl.make_dataflow_buffer_like(x,      shape=(PNt, WCt), block_count=2)
+        w_cb    = ttl.make_dataflow_buffer_like(weight, shape=(1, WCt),   block_count=2)
+        out_cb  = ttl.make_dataflow_buffer_like(out,    shape=(PNt, WCt), block_count=2)
+        sq_cb   = ttl.make_dataflow_buffer_like(x,      shape=(PNt, WCt), block_count=2)
+        part_cb = ttl.make_dataflow_buffer_like(x,      shape=(PNt, 1),   block_count=2)
+        acc_cb  = ttl.make_dataflow_buffer_like(x,      shape=(PNt, 1),   block_count=2)
+        inv_cb  = ttl.make_dataflow_buffer_like(x,      shape=(PNt, 1),   block_count=2)
+
+        for blk in range(bpc):
+            b = cid * bpc + blk
+            if b < n_blocks:
+                base = b * PNt
+
+                acc0 = acc_cb.reserve()
+                acc0.store(ttl.block.fill(0.0, shape=acc0.shape))
+                for c in range(n_wc):
+                    wc = c * WCt
+                    xqd = xq_cb.reserve()
+                    ttl.copy(x[base:base + PNt, wc:wc + WCt], xqd)
+                    xq = xq_cb.wait()
+                    sqd = sq_cb.reserve()
+                    sqd.store(ttl.mul(xq, xq))
+                    part = part_cb.reserve()
+                    part.store(ttl.math.reduce_sum(sq_cb.wait(), dims=[1]))
+                    acc_old = acc_cb.wait()
+                    acc_new = acc_cb.reserve()
+                    acc_new.store(ttl.add(acc_old, part_cb.wait()))
+
+                acc_final = acc_cb.wait()
+                inv_w = inv_cb.reserve()
+                inv_w.store(ttl.recip(ttl.sqrt(ttl.add(
+                    ttl.mul(acc_final, ttl.block.fill(inv_d, shape=inv_w.shape)),
+                    ttl.block.fill(eps, shape=inv_w.shape)))))
+
+                inv = inv_cb.wait()
+                for c in range(n_wc):
+                    wc = c * WCt
+                    xrd = xr_cb.reserve()
+                    ttl.copy(x[base:base + PNt, wc:wc + WCt], xrd)
+                    wrd = w_cb.reserve()
+                    ttl.copy(weight[0:1, wc:wc + WCt], wrd)
+                    xr = xr_cb.wait()
+                    w = w_cb.wait()
+                    ow = out_cb.reserve()
+                    ow.store(ttl.mul(
+                        ttl.mul(xr, ttl.block.broadcast(inv, dims=[1], shape=xr.shape)),
+                        ttl.block.broadcast(w, dims=[0], shape=xr.shape)))
+                    ttl.copy(out_cb.wait(), out[base:base + PNt, wc:wc + WCt])
+
+    return rmsnorm

--- a/python/ttl/ops/topk.py
+++ b/python/ttl/ops/topk.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Top-K over the last dimension, e.g. MoE expert routing (top-k of N
+experts per token).
+
+Each core owns whole rows, so the per-row top-k is core-local (no cross-core
+collective) and rows are spread across the full device grid. The k results
+are produced by iterative argmax: each round takes the row max, records its
+value and column index, then masks that column out before the next round.
+
+Everything is full-tile arithmetic. The column index is recovered from an
+``index`` ramp input (column j holds value j) via a masked reduce; equality
+masks are built as ``1 - sign(abs(a - b))`` (exact since ``sign(0) == 0``).
+Indices are carried in bf16, which is exact for ramps up to 256 (so N must
+be <= 256). Each round writes its value/index straight to output tile-column
+``r`` (a runtime slice), so the outputs are K tiles wide and no sub-tile
+element writes are needed; the host reads column ``r*32`` of result ``r``.
+"""
+
+import ttl
+
+# Knock-out magnitude: subtracted from the selected column so it cannot win
+# again. Far larger than any routing logit, still well inside bf16 range.
+_KNOCKOUT = 1e30
+
+
+def make_topk(Rt, PNt, Wt, K, N):
+    """Top-K over an ``N``-wide row for ``Rt`` row-tiles on the full grid.
+
+    Rows are grouped into ``PNt``-row-tile blocks (``Rt`` divisible by
+    ``PNt``) and spread across the device cores with a tail guard, so any
+    row count works on any grid. ``N = Wt*32`` is the row width (number of
+    candidates, must be <= 256 for exact bf16 indices). ``index`` is a ramp
+    input whose column ``j`` holds value ``j`` (every row identical). The K
+    descending results are written to tile-columns ``0..K-1`` of ``out_vals``
+    / ``out_idxs`` (each K tiles wide); result ``r`` lands at element column
+    ``r*32``.
+    """
+    if Rt % PNt != 0:
+        raise ValueError(f"Rt ({Rt}) must be divisible by PNt ({PNt})")
+    if N > 256:
+        raise ValueError(f"N ({N}) must be <= 256 for exact bf16 indices")
+    n_blocks = Rt // PNt
+    Nm1 = N - 1
+
+    @ttl.atom(grid="full")
+    def topk(x, index, out_vals, out_idxs):
+        col_c, row_c = ttl.node(dims=2)
+        gx, gy = ttl.grid_size(dims=2)
+        bpc = (n_blocks + gx * gy - 1) // (gx * gy)
+        cid = col_c * gy + row_c
+
+        xin_cb     = ttl.make_dataflow_buffer_like(x,        shape=(PNt, Wt), block_count=2)
+        xs_cb      = ttl.make_dataflow_buffer_like(x,        shape=(PNt, Wt), block_count=2)
+        idx_cb     = ttl.make_dataflow_buffer_like(index,    shape=(1, Wt), block_count=2)
+        irev_cb    = ttl.make_dataflow_buffer_like(x,        shape=(1, Wt), block_count=2)
+        m_cb       = ttl.make_dataflow_buffer_like(x,        shape=(PNt, 1), block_count=2)
+        vd_cb      = ttl.make_dataflow_buffer_like(x,        shape=(PNt, Wt), block_count=2)
+        vmask_cb   = ttl.make_dataflow_buffer_like(x,        shape=(PNt, Wt), block_count=2)
+        contrib_cb = ttl.make_dataflow_buffer_like(x,        shape=(PNt, Wt), block_count=2)
+        ridx_cb    = ttl.make_dataflow_buffer_like(x,        shape=(PNt, 1), block_count=2)
+        fidx_cb    = ttl.make_dataflow_buffer_like(x,        shape=(PNt, 1), block_count=2)
+        id_cb      = ttl.make_dataflow_buffer_like(x,        shape=(PNt, Wt), block_count=2)
+        imask_cb   = ttl.make_dataflow_buffer_like(x,        shape=(PNt, Wt), block_count=2)
+        ov_cb      = ttl.make_dataflow_buffer_like(out_vals, shape=(PNt, 1), block_count=2)
+        oi_cb      = ttl.make_dataflow_buffer_like(out_idxs, shape=(PNt, 1), block_count=2)
+
+        sW = (PNt, Wt)
+        s1 = (PNt, 1)
+
+        idx0 = idx_cb.reserve()
+        ttl.copy(index[0:1, 0:Wt], idx0)
+        idx_w = idx_cb.wait()
+
+        # iota_rev: column j holds (N-1 - j), for first-index tie-breaking.
+        irev_w = irev_cb.reserve()
+        irev_w.store(ttl.sub(ttl.block.fill(Nm1, shape=(1, Wt)), idx_w))
+        irev = irev_cb.wait()
+
+        for blk in range(bpc):
+            b = cid * bpc + blk
+            if b < n_blocks:
+                base = b * PNt
+
+                # Load on the DM thread into xin, then initialize the compute
+                # working set on the compute thread so xs has a single producer.
+                xin0 = xin_cb.reserve()
+                ttl.copy(x[base:base + PNt, 0:Wt], xin0)
+                xs0 = xs_cb.reserve()
+                xs0.store(xin_cb.wait())
+
+                for r in range(K):
+                    xs = xs_cb.wait()
+
+                    m_w = m_cb.reserve()
+                    m_w.store(ttl.math.reduce_max(xs, dims=[1]))
+                    m = m_cb.wait()
+
+                    # vmask: 1 at the row max column(s). m_bc - xs >= 0 so a
+                    # plain sign (no abs) is exact: 0 at the max, 1 elsewhere.
+                    # Materialized in two steps: a single op spanning many
+                    # width tiles overflows the dst register file when nested
+                    # deeper, leaving high tiles uninitialized.
+                    vd_w = vd_cb.reserve()
+                    vd_w.store(ttl.sub(
+                        ttl.block.broadcast(m, dims=[1], shape=sW), xs))
+                    vmask_w = vmask_cb.reserve()
+                    vmask_w.store(ttl.sub(
+                        ttl.block.fill(1.0, shape=sW), ttl.sign(vd_cb.wait())))
+                    vmask = vmask_cb.wait()
+
+                    # first column index of the max = (N-1) - max(vmask*iota_rev).
+                    contrib_w = contrib_cb.reserve()
+                    contrib_w.store(ttl.mul(
+                        vmask, ttl.block.broadcast(irev, dims=[0], shape=sW)))
+                    ridx_w = ridx_cb.reserve()
+                    ridx_w.store(ttl.math.reduce_max(contrib_cb.wait(), dims=[1]))
+                    fidx_w = fidx_cb.reserve()
+                    fidx_w.store(ttl.sub(ttl.block.fill(Nm1, shape=s1), ridx_cb.wait()))
+                    fidx = fidx_cb.wait()
+
+                    ov_w = ov_cb.reserve(); ov_w.store(m)
+                    ttl.copy(ov_cb.wait(), out_vals[base:base + PNt, r:r + 1])
+                    oi_w = oi_cb.reserve(); oi_w.store(fidx)
+                    ttl.copy(oi_cb.wait(), out_idxs[base:base + PNt, r:r + 1])
+
+                    # knock out exactly the selected column (handles value
+                    # ties). Materialized in two steps for the same dst-register
+                    # reason as vmask above.
+                    id_w = id_cb.reserve()
+                    id_w.store(ttl.abs(ttl.sub(
+                        ttl.block.broadcast(idx_w, dims=[0], shape=sW),
+                        ttl.block.broadcast(fidx, dims=[1], shape=sW))))
+                    imask_w = imask_cb.reserve()
+                    imask_w.store(ttl.sub(
+                        ttl.block.fill(1.0, shape=sW), ttl.sign(id_cb.wait())))
+                    imask = imask_cb.wait()
+
+                    xs_new = xs_cb.reserve()
+                    xs_new.store(ttl.sub(xs, ttl.mul(
+                        imask, ttl.block.fill(_KNOCKOUT, shape=sW))))
+
+    return topk

--- a/test/python/atom/test_atom_summa_mcast.py
+++ b/test/python/atom/test_atom_summa_mcast.py
@@ -6,18 +6,20 @@
 # UNSUPPORTED: system-darwin
 # RUN: %python -m pytest %s -v
 
-"""SUMMA matmul as a single @ttl.atom, multicast only (no K-split).
+"""SUMMA matmul as a single @ttl.atom, composed from the ttl.ops.mcast op.
 
-Each core (col_c, row_c) owns one BM x BN output block. A is multicast
-across the NP cores of each row; B is multicast down the MP rows of each
-column. Every core accumulates the full K range locally and writes its
-block out. Isolates the multicast PipeNets from the K-split reduce.
+Each core (col_c, row_c) owns one BM x BN output block. A is multicast across
+the NP cores of each row; B is multicast down the MP rows of each column.
+Every core accumulates the full K range locally and writes its block out. The
+broadcasts are the mcast op, inlined twice (A row-broadcast, B column-
+broadcast), instead of hand-written if_src/if_dst callbacks.
 """
 
 import pytest
 import torch
 
 import ttl
+from ttl.ops.mcast import mcast, mcast_cols, mcast_rows
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
@@ -42,17 +44,14 @@ GRID_Y = MP
 def atom_summa_mcast(a, w, out):
     a_cb = ttl.make_dataflow_buffer_like(a, shape=(BM, BK), block_count=2)
     b_cb = ttl.make_dataflow_buffer_like(w, shape=(BK, BN), block_count=2)
-    # Private BRISC staging buffers so the loopback src core does not
-    # double-reserve a_cb/b_cb across BRISC (if_src) and NCRISC (if_dst).
+    # Private staging buffers so the loopback src core does not double-reserve
+    # a_cb/b_cb across the send (BRISC) and receive (NCRISC) sides.
     tmp_a_cb = ttl.make_dataflow_buffer_like(a, shape=(BM, BK), block_count=2)
     tmp_b_cb = ttl.make_dataflow_buffer_like(w, shape=(BK, BN), block_count=2)
     out_cb = ttl.make_dataflow_buffer_like(out, shape=(BM, BN), block_count=2)
 
-    a_pipes = [ttl.Pipe(src=(0, m_p), dst=(slice(0, NP), m_p)) for m_p in range(MP)]
-    mcast_a_net = ttl.PipeNet(a_pipes)
-
-    b_pipes = [ttl.Pipe(src=(n_p, 0), dst=(n_p, slice(0, MP))) for n_p in range(NP)]
-    mcast_b_net = ttl.PipeNet(b_pipes)
+    mcast_a_net = ttl.PipeNet(mcast_rows(MP, NP))
+    mcast_b_net = ttl.PipeNet(mcast_cols(MP, NP))
 
     col_c, row_c = ttl.node(dims=2)
     mr = row_c * BM
@@ -66,34 +65,8 @@ def atom_summa_mcast(a, w, out):
 
     for kb in range(K_BLOCKS):
         kc = kb * BK
-
-        def read_a(pipe):
-            tmp_w = tmp_a_cb.reserve()
-            ttl.copy(a[mr : mr + BM, kc : kc + BK], tmp_w)
-            tmp_r = tmp_a_cb.wait()
-            ttl.copy(tmp_r, pipe)
-
-        mcast_a_net.if_src(read_a)
-
-        def recv_a(pipe):
-            a_blk_dm = a_cb.reserve()
-            ttl.copy(pipe, a_blk_dm)
-
-        mcast_a_net.if_dst(recv_a)
-
-        def read_b(pipe):
-            tmp_w = tmp_b_cb.reserve()
-            ttl.copy(w[kc : kc + BK, nc : nc + BN], tmp_w)
-            tmp_r = tmp_b_cb.wait()
-            ttl.copy(tmp_r, pipe)
-
-        mcast_b_net.if_src(read_b)
-
-        def recv_b(pipe):
-            b_blk_dm = b_cb.reserve()
-            ttl.copy(pipe, b_blk_dm)
-
-        mcast_b_net.if_dst(recv_b)
+        mcast(mcast_a_net, a[mr : mr + BM, kc : kc + BK], tmp_a_cb, a_cb)
+        mcast(mcast_b_net, w[kc : kc + BK, nc : nc + BN], tmp_b_cb, b_cb)
 
     out_blk = out_cb.wait()
     ttl.copy(out_blk, out[mr : mr + BM, nc : nc + BN])

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -82,8 +82,13 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def ttnn_device():
-    """Fixture that provides a TTNN device, skipping if unavailable."""
+def ttnn_device(request):
+    """Fixture that provides a TTNN device, skipping if unavailable.
+
+    Accepts open_device kwargs via indirect parametrization, e.g.
+    ``@pytest.mark.parametrize("ttnn_device", [{"worker_l1_size": 1448000}],
+    indirect=True)`` to trim worker L1 and enlarge the kernel-config buffer
+    for large kernels."""
     global _ttnn_import_failed
     if not _ttnn_available or _ttnn_import_failed:
         pytest.skip("TTNN not available")
@@ -96,7 +101,8 @@ def ttnn_device():
         _ttnn_import_failed = True
         raise
 
-    device = ttnn.open_device(device_id=0)
+    open_kwargs = getattr(request, "param", None) or {}
+    device = ttnn.open_device(device_id=0, **open_kwargs)
     yield device
     ttnn.close_device(device)
 

--- a/test/python/ops/test_flash_mla.py
+++ b/test/python/ops/test_flash_mla.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Focused tests for ttl.ops.flash_mla.
+
+``test_flash_shard_full`` runs the shard on a single core over the whole
+K/V sequence (n_cols=1) and checks the normalized output against torch
+SDPA. This exercises the online-softmax chunk loop in isolation, without
+the cross-core tree reduce.
+
+``test_flash_chain`` runs the full shard -> tree-reduce -> normalize chain
+at toy shapes with an 8-way K split.
+
+``test_flash_mla_decode`` runs the same chain at production MLA-decode
+shapes (64 heads, kvpe_dim=576, kv_lora_rank=512, seq_len=32768) against the
+MLA golden: a single KV head broadcast over all heads, with V the leading
+``kv_lora_rank`` columns of the shared KV cache. The ops read plain DRAM
+tensors, so this matches the shapes / dtype / K-V coupling / golden but not
+the on-device L1 sharding of a multi-core sharded deployment.
+"""
+
+import math
+
+import pytest
+import torch
+
+import ttl
+from ttl.ops.flash_mla import (
+    make_flash_shard,
+    make_flash_tree_reduce,
+    make_flash_normalize,
+)
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_pcc, to_dram
+
+TILE = ttnn.TILE_SIZE
+
+PNHt = 1
+DHt = 2
+vDHt = 1
+Sk_chunk_t = 2
+N_CHUNKS = 4
+
+PN = PNHt * TILE
+D = DHt * TILE
+vD = vDHt * TILE
+S = Sk_chunk_t * N_CHUNKS * TILE
+
+
+def test_flash_shard_full(device):
+    scale = 1.0 / math.sqrt(D)
+
+    q_t = torch.randn(PN, D, dtype=torch.bfloat16) * 0.1
+    k_t = torch.randn(S, D, dtype=torch.bfloat16) * 0.1
+    v_t = torch.randn(S, vD, dtype=torch.bfloat16) * 0.1
+
+    scores = (q_t.float() @ k_t.float().T) * scale
+    attn = torch.softmax(scores, dim=-1)
+    expected = (attn @ v_t.float()).to(torch.bfloat16)
+
+    q_d = to_dram(q_t, device)
+    k_d = to_dram(k_t, device)
+    v_d = to_dram(v_t, device)
+    o_d = to_dram(torch.zeros(PN, vD, dtype=torch.bfloat16), device)
+    m_d = to_dram(torch.zeros(PN, TILE, dtype=torch.bfloat16), device)
+    l_d = to_dram(torch.zeros(PN, TILE, dtype=torch.bfloat16), device)
+
+    shard = make_flash_shard(
+        n_cols=1, B=1,
+        PNHt=PNHt, DHt=DHt, vDHt=vDHt,
+        Sk_chunk_t=Sk_chunk_t, N_CHUNKS=N_CHUNKS, scale=scale,
+    )
+    shard(q_d, k_d, v_d, o_d, m_d, l_d)
+
+    o_unnorm = ttnn.to_torch(o_d).reshape(PN, vD).float()
+    l = ttnn.to_torch(l_d).reshape(PN, TILE).float()[:, 0:1]
+    got = (o_unnorm / l).to(torch.bfloat16)
+
+    assert_pcc(expected, got, threshold=0.99)
+
+
+# Full chain: 8-way K split across cores, tree-reduce the partials, normalize.
+N_COLS = 8
+CHAIN_Sk_chunk_t = 2
+CHAIN_N_CHUNKS = 1
+CHAIN_S = N_COLS * CHAIN_Sk_chunk_t * CHAIN_N_CHUNKS * TILE
+
+
+def test_flash_chain(device):
+    scale = 1.0 / math.sqrt(D)
+
+    q_t = torch.randn(PN, D, dtype=torch.bfloat16) * 0.1
+    k_t = torch.randn(CHAIN_S, D, dtype=torch.bfloat16) * 0.1
+    v_t = torch.randn(CHAIN_S, vD, dtype=torch.bfloat16) * 0.1
+
+    scores = (q_t.float() @ k_t.float().T) * scale
+    attn = torch.softmax(scores, dim=-1)
+    expected = (attn @ v_t.float()).to(torch.bfloat16)
+
+    q_d = to_dram(q_t, device)
+    k_d = to_dram(k_t, device)
+    v_d = to_dram(v_t, device)
+    # Per-core partials: N_COLS row-blocks of (PNHt, *) tiles.
+    po_d = to_dram(torch.zeros(N_COLS * PN, vD, dtype=torch.bfloat16), device)
+    pm_d = to_dram(torch.zeros(N_COLS * PN, TILE, dtype=torch.bfloat16), device)
+    pl_d = to_dram(torch.zeros(N_COLS * PN, TILE, dtype=torch.bfloat16), device)
+    # Merged unnormalized output + normalized output.
+    o_d = to_dram(torch.zeros(PN, vD, dtype=torch.bfloat16), device)
+    m_d = to_dram(torch.zeros(PN, TILE, dtype=torch.bfloat16), device)
+    l_d = to_dram(torch.zeros(PN, TILE, dtype=torch.bfloat16), device)
+    norm_d = to_dram(torch.zeros(PN, vD, dtype=torch.bfloat16), device)
+
+    shard = make_flash_shard(
+        n_cols=N_COLS, B=1,
+        PNHt=PNHt, DHt=DHt, vDHt=vDHt,
+        Sk_chunk_t=CHAIN_Sk_chunk_t, N_CHUNKS=CHAIN_N_CHUNKS, scale=scale,
+    )
+    tree_reduce = make_flash_tree_reduce(PNHt=PNHt, vDHt=vDHt, B=1)
+    normalize = make_flash_normalize(grid=(1, 1), PNHt=PNHt, vDHt=vDHt)
+
+    shard(q_d, k_d, v_d, po_d, pm_d, pl_d)
+    tree_reduce(po_d, pm_d, pl_d, o_d, m_d, l_d)
+    normalize(o_d, l_d, norm_d)
+
+    got = ttnn.to_torch(norm_d).reshape(PN, vD).to(torch.bfloat16)
+    assert_pcc(expected, got, threshold=0.99)
+
+
+def flash_mla_golden(q, kv_cache, position_ids, head_dim_v, scale):
+    """PyTorch reference for MLA decode: one shared KV head broadcast over
+    all query heads; V is the leading ``head_dim_v`` columns of the cache."""
+    batch_size = q.shape[1]
+    num_heads = q.shape[2]
+    kvpe_dim = q.shape[3]
+
+    q = q.permute(1, 2, 0, 3)
+
+    outputs = []
+    for b in range(batch_size):
+        seq_len = position_ids[b].item() + 1
+        kv = kv_cache[b, :, :seq_len, :]
+        kv_expanded = kv.expand(num_heads, seq_len, kvpe_dim)
+        q_b = q[b]
+        attn_scores = torch.matmul(q_b, kv_expanded.transpose(-2, -1)) * scale
+        attn_probs = torch.softmax(attn_scores.float(), dim=-1).to(q.dtype)
+        v = kv_expanded[:, :, :head_dim_v]
+        out_b = torch.matmul(attn_probs, v)
+        outputs.append(out_b)
+
+    output = torch.stack(outputs, dim=0)
+    output = output.squeeze(2).unsqueeze(0)
+    return output
+
+
+# Production MLA-decode shapes (seq_len=32768, single decode token).
+NUM_HEADS = 64
+KV_LORA_RANK = 512               # head_dim_v
+QK_ROPE_HEAD_DIM = 64
+QK_NOPE_HEAD_DIM = 128
+KVPE_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM       # 576
+QK_HEAD_DIM = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM  # 192
+N_CORES = 8
+K_CHUNK = 128                    # k_chunk_size
+MAX_SEQ_LEN = 32 * 1024
+
+MLA_PNHt = NUM_HEADS // TILE              # 2  (64 query rows / 32)
+MLA_DHt = KVPE_DIM // TILE                # 18
+MLA_vDHt = KV_LORA_RANK // TILE           # 16
+# bf16 K/V at k_chunk_size=128 (4 tiles) overflows one core's L1 (~1.7MB >
+# 1.46MB); a bfp8 KV cache (half the bytes) is what makes 128 fit. Until the
+# bfp8 + typecast path lands, halve the chunk to 64 positions (2 tiles). Same
+# seq coverage, same tensor shapes; only the per-chunk buffer size changes.
+MLA_Sk_chunk_t = 2
+# Per core: (seq / n_cores) positions, split into Sk_chunk_t-tile chunks.
+MLA_N_CHUNKS = (MAX_SEQ_LEN // N_CORES) // (MLA_Sk_chunk_t * TILE)  # 64
+
+
+# Production tile counts make the compute kernel large; trim worker L1 to
+# enlarge the kernel-config buffer past the default 70656B TENSIX limit.
+@pytest.mark.parametrize("ttnn_device", [{"worker_l1_size": 1448000}], indirect=True)
+def test_flash_mla_decode(device):
+    torch.manual_seed(42)
+    scale = QK_HEAD_DIM ** -0.5
+    decode_position = MAX_SEQ_LEN - 1
+
+    torch_q = torch.randn((1, 1, NUM_HEADS, KVPE_DIM), dtype=torch.bfloat16)
+    torch_cache = torch.randn((1, 1, MAX_SEQ_LEN, KVPE_DIM), dtype=torch.bfloat16)
+    position_ids = torch.ones(1, dtype=torch.int32) * decode_position
+
+    expected = flash_mla_golden(
+        q=torch_q, kv_cache=torch_cache, position_ids=position_ids,
+        head_dim_v=KV_LORA_RANK, scale=scale,
+    )
+
+    # MLA shares one KV cache: K is the full kvpe_dim, V its leading
+    # kv_lora_rank columns. All query rows attend the same K/V.
+    q_2d = torch_q.reshape(NUM_HEADS, KVPE_DIM)
+    k_2d = torch_cache.reshape(MAX_SEQ_LEN, KVPE_DIM)
+    v_2d = k_2d[:, :KV_LORA_RANK].contiguous()
+
+    PNr = MLA_PNHt * TILE
+    q_d = to_dram(q_2d, device)
+    k_d = to_dram(k_2d, device)
+    v_d = to_dram(v_2d, device)
+    po_d = to_dram(torch.zeros(N_CORES * PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
+    pm_d = to_dram(torch.zeros(N_CORES * PNr, TILE, dtype=torch.bfloat16), device)
+    pl_d = to_dram(torch.zeros(N_CORES * PNr, TILE, dtype=torch.bfloat16), device)
+    o_d = to_dram(torch.zeros(PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
+    m_d = to_dram(torch.zeros(PNr, TILE, dtype=torch.bfloat16), device)
+    l_d = to_dram(torch.zeros(PNr, TILE, dtype=torch.bfloat16), device)
+    norm_d = to_dram(torch.zeros(PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
+
+    shard = make_flash_shard(
+        n_cols=N_CORES, B=1,
+        PNHt=MLA_PNHt, DHt=MLA_DHt, vDHt=MLA_vDHt,
+        Sk_chunk_t=MLA_Sk_chunk_t, N_CHUNKS=MLA_N_CHUNKS, scale=scale,
+    )
+    tree_reduce = make_flash_tree_reduce(PNHt=MLA_PNHt, vDHt=MLA_vDHt, B=1)
+    normalize = make_flash_normalize(grid=(1, 1), PNHt=MLA_PNHt, vDHt=MLA_vDHt)
+
+    shard(q_d, k_d, v_d, po_d, pm_d, pl_d)
+    tree_reduce(po_d, pm_d, pl_d, o_d, m_d, l_d)
+    normalize(o_d, l_d, norm_d)
+
+    got = ttnn.to_torch(norm_d).reshape(1, 1, NUM_HEADS, KV_LORA_RANK).to(torch.bfloat16)
+    assert_pcc(expected, got, threshold=0.99)

--- a/test/python/ops/test_flash_mla.py
+++ b/test/python/ops/test_flash_mla.py
@@ -17,11 +17,12 @@ the cross-core tree reduce.
 at toy shapes with an 8-way K split.
 
 ``test_flash_mla_decode`` runs the same chain at production MLA-decode
-shapes (64 heads, kvpe_dim=576, kv_lora_rank=512, seq_len=32768) against the
-MLA golden: a single KV head broadcast over all heads, with V the leading
-``kv_lora_rank`` columns of the shared KV cache. The ops read plain DRAM
-tensors, so this matches the shapes / dtype / K-V coupling / golden but not
-the on-device L1 sharding of a multi-core sharded deployment.
+shapes (64 heads, kvpe_dim=576, kv_lora_rank=512, seq_len=32768) with a
+bfp8 KV cache, against the MLA golden: a single KV head broadcast over all
+heads, with V the leading ``kv_lora_rank`` columns of the shared KV cache.
+The ops read plain DRAM tensors, so this matches the shapes / dtype / K-V
+coupling / golden but not the on-device L1 sharding of a multi-core sharded
+deployment.
 """
 
 import math
@@ -39,6 +40,16 @@ from ttl.ops.flash_mla import (
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 from ttlang_test_utils import assert_pcc, to_dram
+
+
+def to_dram_bfp8(torch_tensor, device):
+    """DRAM tensor in bfloat8_b (the KV-cache dtype). The shard typecasts
+    K/V back to bf16 for the matmuls."""
+    return ttnn.from_torch(
+        torch_tensor, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT,
+        device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
 
 TILE = ttnn.TILE_SIZE
 
@@ -66,8 +77,8 @@ def test_flash_shard_full(device):
     expected = (attn @ v_t.float()).to(torch.bfloat16)
 
     q_d = to_dram(q_t, device)
-    k_d = to_dram(k_t, device)
-    v_d = to_dram(v_t, device)
+    k_d = to_dram_bfp8(k_t, device)
+    v_d = to_dram_bfp8(v_t, device)
     o_d = to_dram(torch.zeros(PN, vD, dtype=torch.bfloat16), device)
     m_d = to_dram(torch.zeros(PN, TILE, dtype=torch.bfloat16), device)
     l_d = to_dram(torch.zeros(PN, TILE, dtype=torch.bfloat16), device)
@@ -105,8 +116,8 @@ def test_flash_chain(device):
     expected = (attn @ v_t.float()).to(torch.bfloat16)
 
     q_d = to_dram(q_t, device)
-    k_d = to_dram(k_t, device)
-    v_d = to_dram(v_t, device)
+    k_d = to_dram_bfp8(k_t, device)
+    v_d = to_dram_bfp8(v_t, device)
     # Per-core partials: N_COLS row-blocks of (PNHt, *) tiles.
     po_d = to_dram(torch.zeros(N_COLS * PN, vD, dtype=torch.bfloat16), device)
     pm_d = to_dram(torch.zeros(N_COLS * PN, TILE, dtype=torch.bfloat16), device)
@@ -167,16 +178,14 @@ QK_NOPE_HEAD_DIM = 128
 KVPE_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM       # 576
 QK_HEAD_DIM = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM  # 192
 N_CORES = 8
-K_CHUNK = 128                    # k_chunk_size
 MAX_SEQ_LEN = 32 * 1024
 
 MLA_PNHt = NUM_HEADS // TILE              # 2  (64 query rows / 32)
 MLA_DHt = KVPE_DIM // TILE                # 18
 MLA_vDHt = KV_LORA_RANK // TILE           # 16
-# bf16 K/V at k_chunk_size=128 (4 tiles) overflows one core's L1 (~1.7MB >
-# 1.46MB); a bfp8 KV cache (half the bytes) is what makes 128 fit. Until the
-# bfp8 + typecast path lands, halve the chunk to 64 positions (2 tiles). Same
-# seq coverage, same tensor shapes; only the per-chunk buffer size changes.
+# The shard typecasts each bfp8 K/V chunk to a bf16 mirror, so a 2-tile
+# compute chunk is the largest that fits one core's L1 at vDHt=16. This is
+# the compute-chunk granularity, independent of the cache layout.
 MLA_Sk_chunk_t = 2
 # Per core: (seq / n_cores) positions, split into Sk_chunk_t-tile chunks.
 MLA_N_CHUNKS = (MAX_SEQ_LEN // N_CORES) // (MLA_Sk_chunk_t * TILE)  # 64
@@ -207,8 +216,8 @@ def test_flash_mla_decode(device):
 
     PNr = MLA_PNHt * TILE
     q_d = to_dram(q_2d, device)
-    k_d = to_dram(k_2d, device)
-    v_d = to_dram(v_2d, device)
+    k_d = to_dram_bfp8(k_2d, device)
+    v_d = to_dram_bfp8(v_2d, device)
     po_d = to_dram(torch.zeros(N_CORES * PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
     pm_d = to_dram(torch.zeros(N_CORES * PNr, TILE, dtype=torch.bfloat16), device)
     pl_d = to_dram(torch.zeros(N_CORES * PNr, TILE, dtype=torch.bfloat16), device)

--- a/test/python/ops/test_matmul.py
+++ b/test/python/ops/test_matmul.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Tests for ttl.ops.matmul.make_ksplit against torch.matmul.
+
+Cases cover one block per core (the original atom shape) and several blocks
+per core (the loop), at small sizes and at benchmark-sweep shapes."""
+
+import pytest
+import torch
+
+import ttl
+from ttl.ops.matmul import make_ksplit
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_pcc, to_dram
+
+TILE = 32
+
+
+def _pad_up(n, mult):
+    return ((n + mult - 1) // mult) * mult
+
+
+def run_ksplit(device, M, K, N, block_cfg, part_cfg):
+    bm, bn, bk = block_cfg
+    Mp, Np, Kp = part_cfg
+    # The op requires block*part to divide the dims exactly; pad M/N up to the
+    # grid's full coverage (zeros add nothing to the real output, sliced below).
+    # K must divide exactly: the K-partition partials have to line up.
+    Mpad = _pad_up(M, bm * Mp * TILE)
+    Npad = _pad_up(N, bn * Np * TILE)
+
+    a_t = torch.randn(M, K, dtype=torch.bfloat16) * 0.1
+    w_t = torch.randn(K, N, dtype=torch.bfloat16) * 0.1
+    expected = torch.matmul(a_t.float(), w_t.float()).to(torch.bfloat16)
+
+    a_p = torch.nn.functional.pad(a_t, (0, 0, 0, Mpad - M))
+    w_p = torch.nn.functional.pad(w_t, (0, Npad - N))
+
+    a_d = to_dram(a_p, device)
+    w_d = to_dram(w_p, device)
+    out_d = to_dram(torch.zeros(Mpad, Npad, dtype=torch.bfloat16), device)
+
+    make_ksplit(Mpad, K, Npad, block_cfg, part_cfg)(a_d, w_d, out_d)
+
+    got = ttnn.to_torch(out_d).reshape(Mpad, Npad)[:M, :N].to(torch.bfloat16)
+    assert_pcc(expected, got, threshold=0.99)
+
+
+@pytest.mark.parametrize(
+    "M, K, N, block_cfg, part_cfg",
+    [
+        # (M, K, N, (bm,bn,bk), (Mp,Np,Kp))  -- comment: blocks per core
+        (128, 256, 128, (2, 2, 2), (2, 2, 2)),   # 1 block/core (atom baseline)
+        (256, 256, 256, (2, 2, 2), (2, 2, 2)),   # 4 blocks/core (loop)
+    ],
+)
+def test_ksplit(device, M, K, N, block_cfg, part_cfg):
+    run_ksplit(device, M, K, N, block_cfg, part_cfg)
+
+
+# The benchmark-winner plans use bm/bn/bk up to 8; their unrolled matmul blows
+# past the default kernel-config buffer, so trim worker L1 to enlarge it.
+@pytest.mark.parametrize("ttnn_device", [{"worker_l1_size": 1374544}], indirect=True)
+@pytest.mark.parametrize(
+    "M, K, N, block_cfg, part_cfg",
+    [
+        # Benchmark-sweep shapes at their empirically-best Kp=2 plans.
+        (1024, 1024, 1024, (4, 8, 8), (8, 4, 2)),  # 64c, 1 block/core
+        (2048, 2048, 2048, (8, 4, 8), (8, 6, 2)),  # 96c, 3 blocks/core (N pad)
+        (2048, 4096, 2048, (8, 4, 8), (8, 6, 2)),  # 96c, deeper K (K_BPN=8)
+        (2048, 8192, 2048, (8, 4, 8), (8, 6, 2)),  # 96c, long K (K_BPN=16)
+    ],
+)
+def test_ksplit_bench(device, M, K, N, block_cfg, part_cfg):
+    run_ksplit(device, M, K, N, block_cfg, part_cfg)

--- a/test/python/ops/test_mcast.py
+++ b/test/python/ops/test_mcast.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Focused test for ttl.ops.mcast: broadcast one tile down a column of cores.
+
+The source core (0, 0) stages an input tile and multicasts it to every row;
+each row drains its received block out. All output row-blocks must equal the
+input tile. Exercises the mcast op (if_src send + if_dst receive) and the
+INCLUDE_SRC loopback in isolation.
+"""
+
+import pytest
+import torch
+
+import ttl
+from ttl.ops.mcast import mcast, mcast_cols
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_dram
+
+TILE = ttnn.TILE_SIZE
+NROWS = 4
+BM, BK = 1, 1
+
+
+@ttl.atom(grid=(1, NROWS))
+def atom_bcast(inp, out):
+    stage = ttl.make_dataflow_buffer_like(inp, shape=(BM, BK), block_count=2)
+    recv = ttl.make_dataflow_buffer_like(inp, shape=(BM, BK), block_count=2)
+    net = ttl.PipeNet(mcast_cols(NROWS, 1))
+
+    _col, row = ttl.node(dims=2)
+
+    mcast(net, inp[0:BM, 0:BK], stage, recv)
+
+    blk = recv.wait()
+    ttl.copy(blk, out[row * BM : row * BM + BM, 0:BK])
+
+
+def test_mcast_broadcast(device):
+    inp_t = torch.randn(BM * TILE, BK * TILE, dtype=torch.bfloat16)
+    out_t = torch.zeros(NROWS * BM * TILE, BK * TILE, dtype=torch.bfloat16)
+
+    inp = to_dram(inp_t, device)
+    out = to_dram(out_t, device)
+
+    atom_bcast(inp, out)
+
+    got = ttnn.to_torch(out).reshape(NROWS * BM * TILE, BK * TILE).to(torch.bfloat16)
+    for r in range(NROWS):
+        assert_allclose(got[r * TILE : (r + 1) * TILE], inp_t, rtol=1e-2, atol=1e-2)

--- a/test/python/ops/test_rmsnorm.py
+++ b/test/python/ops/test_rmsnorm.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Tests for ttl.ops.rmsnorm against torch RMSNorm.
+
+``test_rmsnorm`` covers small shapes: fewer blocks than cores (idle cores)
+and a block count that does not divide the core count (tail guard).
+``test_rmsnorm_wide`` runs the production decoder widths (7168/1536/512, eps
+1e-6) with the feature dimension streamed in width-tile chunks and several
+row blocks per core. The op always fills the device grid, so no grid is
+passed; row count is independent of the core count."""
+
+import pytest
+import torch
+
+import ttl
+from ttl.ops.rmsnorm import make_rmsnorm
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_pcc, to_dram
+
+TILE = ttnn.TILE_SIZE
+
+EPS = 1e-6
+
+
+def rmsnorm_golden(x, weight, eps):
+    var = x.float().pow(2).mean(dim=-1, keepdim=True)
+    return (x.float() * torch.rsqrt(var + eps)).to(x.dtype) * weight
+
+
+def run_rmsnorm(device, n_rows, PNt, Dt, WCt, D):
+    Rt = n_rows // TILE
+
+    x_t = torch.randn(n_rows, D, dtype=torch.bfloat16)
+    w_t = torch.randn(1, D, dtype=torch.bfloat16) * 0.1 + 1.0
+
+    expected = rmsnorm_golden(x_t, w_t, EPS)
+
+    x_d = to_dram(x_t, device)
+    w_d = to_dram(w_t, device)
+    out_d = to_dram(torch.zeros(n_rows, D, dtype=torch.bfloat16), device)
+
+    rmsnorm = make_rmsnorm(Rt=Rt, PNt=PNt, Dt=Dt, WCt=WCt, D=D, eps=EPS)
+    rmsnorm(x_d, w_d, out_d)
+
+    got = ttnn.to_torch(out_d).reshape(n_rows, D).to(torch.bfloat16)
+    assert_pcc(expected, got, threshold=0.99)
+
+
+@pytest.mark.parametrize(
+    "n_rows, PNt, Dt, WCt, D",
+    [
+        (2 * TILE, 1, 2, 2, 64),       # fewer blocks than cores: idle cores
+        (261 * TILE, 1, 2, 2, 64),     # block count indivisible by cores: tail guard
+    ],
+)
+def test_rmsnorm(device, n_rows, PNt, Dt, WCt, D):
+    run_rmsnorm(device, n_rows, PNt, Dt, WCt, D)
+
+
+# Production decoder norm widths: hidden 7168, q-proj 1536, kv-proj 512. A
+# fixed row count (~4 blocks per core on a full Blackhole grid); the op spreads
+# it over whatever grid it lands on, so the constant needs no device query.
+N_ROWS_WIDE = 16384
+
+
+@pytest.mark.parametrize(
+    "D, Dt",
+    [(7168, 224), (1536, 48), (512, 16)],
+)
+def test_rmsnorm_wide(device, D, Dt):
+    run_rmsnorm(device, n_rows=N_ROWS_WIDE, PNt=1, Dt=Dt, WCt=8, D=D)

--- a/test/python/ops/test_topk.py
+++ b/test/python/ops/test_topk.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Tests for ttl.ops.topk against torch.topk.
+
+``test_topk`` covers a small width; ``test_topk_routing`` runs the MoE
+routing shape (top-8 of 256 experts) over many tokens spread across the
+full device grid. Values are checked directly; indices are checked by
+gathering the input at the returned indices (tolerant of value ties)."""
+
+import pytest
+import torch
+
+import ttl
+from ttl.ops.topk import make_topk
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_pcc, to_dram
+
+TILE = ttnn.TILE_SIZE
+
+
+def run_topk(device, n_tokens, N, K):
+    Wt = N // TILE
+    Rt = n_tokens // TILE
+
+    x_t = torch.randn(n_tokens, N, dtype=torch.bfloat16)
+    ramp = torch.arange(N, dtype=torch.bfloat16).unsqueeze(0).repeat(TILE, 1)
+
+    tv, ti = torch.topk(x_t.float(), K, dim=-1)
+
+    x_d = to_dram(x_t, device)
+    idx_d = to_dram(ramp, device)
+    ov_d = to_dram(torch.zeros(n_tokens, K * TILE, dtype=torch.bfloat16), device)
+    oi_d = to_dram(torch.zeros(n_tokens, K * TILE, dtype=torch.bfloat16), device)
+
+    make_topk(Rt=Rt, PNt=1, Wt=Wt, K=K, N=N)(x_d, idx_d, ov_d, oi_d)
+
+    got_v = ttnn.to_torch(ov_d).reshape(n_tokens, K * TILE)[:, 0::TILE][:, :K].float()
+    got_i = ttnn.to_torch(oi_d).reshape(n_tokens, K * TILE)[:, 0::TILE][:, :K].float()
+
+    assert_pcc(tv, got_v, threshold=0.99)
+    # Indices are correct if the input gathered at them matches the top-k
+    # values (robust to ties where a different index gives the same value).
+    gathered = torch.gather(x_t.float(), -1, got_i.long().clamp(0, N - 1))
+    assert_pcc(tv, gathered, threshold=0.99)
+
+
+def test_topk(device):
+    run_topk(device, n_tokens=TILE, N=64, K=4)
+
+
+# DeepSeek-style MoE routing: top-8 of 256 experts, many tokens over the grid.
+def test_topk_routing(device):
+    run_topk(device, n_tokens=128 * TILE, N=256, K=8)


### PR DESCRIPTION
These ops will 
* provide more comprehensive tests for real world patterns
* serve as examples for people to reference 
* eventually be high performance operations that can be dropped into models
* provide a foundation for our benchmark infrastructure 

The current ops already have some amount of composition with shared utilities for common patterns, but I'm hoping to eventually extend that (eg provide generic tree reductions) and formalize the API inference (eg to always provide dfb-level variants).