### PR TITLE
[ttl] atom inlining + fused flash-MLA, with sound DFB index reuse

### DIFF
--- a/benchmarks/common/harness.py
+++ b/benchmarks/common/harness.py
@@ -74,7 +74,8 @@ def sweep(spec: BenchSpec, *, filter: Optional[str] = None, warmup=3, runs=5) ->
             rows.append(row)
             print(_line(spec, row), flush=True)
     finally:
-        ttnn.close_device(device)
+        if device is not None:
+            ttnn.close_device(device)
     return rows
 
 

--- a/benchmarks/common/report.py
+++ b/benchmarks/common/report.py
@@ -11,9 +11,20 @@ import torch
 
 
 def pcc(result, ref) -> float:
-    """Pearson correlation between a result tensor and its reference."""
+    """Pearson correlation between a result tensor and its reference.
+
+    Raises instead of returning nan so a kernel that never wrote its output
+    (constant tensor) or produced nan/inf is reported as such, not as a
+    silent nan ratio.
+    """
     a = result.flatten().float()
     b = ref.flatten().float()
+    if not torch.isfinite(a).all():
+        raise ValueError("pcc: result contains nan/inf")
+    if a.max() == a.min():
+        raise ValueError(
+            f"pcc: result is constant ({a.min().item()}); output likely never written"
+        )
     return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
 
 

--- a/benchmarks/e2e/flash_mla.py
+++ b/benchmarks/e2e/flash_mla.py
@@ -9,9 +9,10 @@ deepseek_v3 MLA demo. Cases:
 
   - ``ctx-*``: single-user decode (1 user, 64 heads) at a fixed 32k KV cache,
     sweeping the decode position so the attended context grows 512 -> 32k. The
-    ttl chain (shard -> tree_reduce -> normalize) processes exactly the attended
-    length, is PCC-checked against a torch MLA golden, and the ratio is taken
-    against the ttnn paged decode reading the same position via ``cur_pos``.
+    fused single-kernel ttl op (shard + tree_reduce + normalize inlined into one
+    launch) processes exactly the attended length, is PCC-checked against a torch
+    MLA golden, and the ratio is taken against the ttnn paged decode reading the
+    same position via ``cur_pos``.
     Short contexts are where ttl's fixed per-decode overhead is most exposed.
   - ``deepseek-1k``: the deepseek_v3 demo's exact problem (4 users, 128 heads,
     1k paged context). Our single-user op does not run multi-user batched
@@ -26,11 +27,7 @@ Run: ``python -m benchmarks.e2e.flash_mla [--filter ctx-8k] [--plot]``.
 import torch
 import ttnn
 
-from ttl.ops.flash_mla import (
-    make_flash_shard,
-    make_flash_tree_reduce,
-    make_flash_normalize,
-)
+from ttl.ops.flash_mla import make_flash_mla
 
 from benchmarks.common import BenchSpec, cli, pcc, time_runs
 
@@ -47,14 +44,18 @@ N_CORES = 8                              # ttl K-split (n_cols)
 PNHt = NUM_HEADS // TILE                  # 2
 DHt = KVPE_DIM // TILE                     # 18
 vDHt = KV_LORA_RANK // TILE                # 16
-Sk_chunk_t = 2
+# The fused single-kernel op inlines all three phases, so its per-chunk K/V/sv
+# buffers must fit alongside the tree-reduce and normalize scratch in one L1
+# budget; a 1-tile chunk is what fits (Sk_chunk_t=2 overflows by ~250KB).
+Sk_chunk_t = 1
 
 # Attended length must be a multiple of the ttl op's per-core chunk.
 TTL_CHUNK = N_CORES * Sk_chunk_t * TILE   # 512
 
 # Production tile counts make the compute kernel large; trim worker L1 to
-# enlarge the kernel-config buffer past the default TENSIX limit.
-WORKER_L1 = 1448000
+# enlarge the kernel-config buffer past the default TENSIX limit. The fused
+# single-kernel op inlines all three phases, so it needs the larger buffer.
+WORKER_L1 = 1430000
 
 OURS_SCALE = QK_HEAD_DIM ** -0.5                   # 192 ** -0.5
 DEEPSEEK_SCALE = (192 + 64) ** -0.5                # deepseek qk_head_dim = 256
@@ -110,12 +111,14 @@ def _golden(q, kv_cache, seq_len, head_dim_v, scale):
     return out.squeeze(1).reshape(1, 1, num_heads, head_dim_v)
 
 
-def _open_device():
-    return ttnn.open_device(device_id=0, worker_l1_size=WORKER_L1)
+# The fused ttl op and the ttnn baseline want opposite L1 splits (the fused
+# single kernel needs a large kernel-config region -> small worker L1; the 32k
+# ttnn decode needs a large CB region -> default worker L1), so they cannot
+# share one device open. run_case opens and closes a device per side instead.
 
 
 # --------------------------------------------------------------------------
-# ttl side: the shard -> tree_reduce -> normalize chain (single user)
+# ttl side: the fused single-kernel flash-MLA op (single user)
 # --------------------------------------------------------------------------
 def _run_ttl_chain(device, num_heads, seq, scale, *, warmup, runs):
     pnht = num_heads // TILE
@@ -134,31 +137,21 @@ def _run_ttl_chain(device, num_heads, seq, scale, *, warmup, runs):
     q_d = _to_dev(q_2d, device)
     k_d = _to_dev_bfp8(k_2d, device)
     v_d = _to_dev_bfp8(v_2d, device)
-    po_d = _to_dev(torch.zeros(N_CORES * PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
-    pm_d = _to_dev(torch.zeros(N_CORES * PNr, TILE, dtype=torch.bfloat16), device)
-    pl_d = _to_dev(torch.zeros(N_CORES * PNr, TILE, dtype=torch.bfloat16), device)
-    o_d = _to_dev(torch.zeros(PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
-    m_d = _to_dev(torch.zeros(PNr, TILE, dtype=torch.bfloat16), device)
-    l_d = _to_dev(torch.zeros(PNr, TILE, dtype=torch.bfloat16), device)
     norm_d = _to_dev(torch.zeros(PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
 
-    shard = make_flash_shard(
+    flash = make_flash_mla(
         n_cols=N_CORES, B=1, PNHt=pnht, DHt=DHt, vDHt=vDHt,
         Sk_chunk_t=Sk_chunk_t, N_CHUNKS=n_chunks, scale=scale,
     )
-    tree_reduce = make_flash_tree_reduce(PNHt=pnht, vDHt=vDHt, B=1)
-    normalize = make_flash_normalize(grid=(1, 1), PNHt=pnht, vDHt=vDHt)
 
-    def chain():
-        shard(q_d, k_d, v_d, po_d, pm_d, pl_d)
-        tree_reduce(po_d, pm_d, pl_d, o_d, m_d, l_d)
-        normalize(o_d, l_d, norm_d)
+    def fused():
+        flash(q_d, k_d, v_d, norm_d)
 
-    ttlang_s = time_runs(chain, lambda _r: None, device, warmup=warmup, runs=runs)
+    ttlang_s = time_runs(fused, lambda _r: None, device, warmup=warmup, runs=runs)
     got = ttnn.to_torch(norm_d).reshape(1, 1, num_heads, KV_LORA_RANK).to(torch.bfloat16)
     pcc_v = pcc(got, expected)
 
-    for t in (q_d, k_d, v_d, po_d, pm_d, pl_d, o_d, m_d, l_d, norm_d):
+    for t in (q_d, k_d, v_d, norm_d):
         ttnn.deallocate(t)
     return ttlang_s, pcc_v
 
@@ -272,24 +265,33 @@ def run_case(device, case, *, warmup, runs):
     label = case["label"]
 
     ttlang_s = pcc_v = None
-    # The ttl chain is single-user (the op reads one shared K/V; B>1 only
-    # replicates it) and compile-time fixed on its chunk count, so run it only
-    # for one user and only when the attended length is a multiple of its chunk.
+    # The fused op is single-user (it reads one shared K/V; B>1 only replicates
+    # it) and compile-time fixed on its chunk count, so run it only for one user
+    # and only when the attended length is a multiple of its chunk. It opens its
+    # own device (trimmed worker L1 for kernel-config headroom), separate from
+    # the ttnn baseline below.
     if num_users == 1:
         attended = positions[0] + 1
         if attended % TTL_CHUNK == 0:
+            ttl_dev = ttnn.open_device(device_id=0, worker_l1_size=WORKER_L1)
             try:
                 ttlang_s, pcc_v = _run_ttl_chain(
-                    device, num_heads, attended, scale, warmup=warmup, runs=runs
+                    ttl_dev, num_heads, attended, scale, warmup=warmup, runs=runs
                 )
             except Exception as e:
-                print(f"  ({label}: ttl chain failed: {e})", flush=True)
+                print(f"  ({label}: ttl fused failed: {e})", flush=True)
+            finally:
+                ttnn.close_device(ttl_dev)
         else:
             print(f"  ({label}: ttl skipped, attended {attended} not a multiple of {TTL_CHUNK})", flush=True)
 
-    ttnn_s = _reference_ms(
-        device, num_users, num_heads, cache_seq, positions, scale, warmup=warmup, runs=runs
-    )
+    ttnn_dev = ttnn.open_device(device_id=0)
+    try:
+        ttnn_s = _reference_ms(
+            ttnn_dev, num_users, num_heads, cache_seq, positions, scale, warmup=warmup, runs=runs
+        )
+    finally:
+        ttnn.close_device(ttnn_dev)
 
     ratio = round(ttlang_s / ttnn_s, 4) if (ttlang_s is not None and ttnn_s) else None
     return {
@@ -321,7 +323,7 @@ SPEC = BenchSpec(
     cases=CASES,
     run_case=run_case,
     label_of=lambda case: case["label"],
-    open_device=_open_device,
+    open_device=lambda: None,  # run_case opens a device per side (see above)
     format_row=_format_row,
     plot_title="ttlang flash-MLA decode vs ttnn paged MLA-decode  (bar = ratio)",
     plot_label_of=lambda r: f"{r['label']}\nu{r['users']} h{r['heads']}",

--- a/benchmarks/e2e/flash_mla.py
+++ b/benchmarks/e2e/flash_mla.py
@@ -44,10 +44,7 @@ N_CORES = 8                              # ttl K-split (n_cols)
 PNHt = NUM_HEADS // TILE                  # 2
 DHt = KVPE_DIM // TILE                     # 18
 vDHt = KV_LORA_RANK // TILE                # 16
-# The fused single-kernel op inlines all three phases, so its per-chunk K/V/sv
-# buffers must fit alongside the tree-reduce and normalize scratch in one L1
-# budget; a 1-tile chunk is what fits (Sk_chunk_t=2 overflows by ~250KB).
-Sk_chunk_t = 1
+Sk_chunk_t = 2
 
 # Attended length must be a multiple of the ttl op's per-core chunk.
 TTL_CHUNK = N_CORES * Sk_chunk_t * TILE   # 512

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -485,76 +485,25 @@ ttl-coalesce-dfb-acquires))'`) verifies this.
 
 ## Index Reuse
 
-`TTLFinalizeDFBIndices` reduces the physical DFB count by assigning the same index to compiler-allocated DFBs whose lifetimes do not overlap. The algorithm runs per function. Compiler-allocated DFBs are intra-thread (both producer and consumer are in the same compute function), so their lifetimes are independent across functions.
+`TTLFinalizeDFBIndices` is a module pass that reduces the physical DFB count by overlaying logical DFBs with disjoint lifetimes onto shared indices. It runs after `InsertCBSync` and `LowerToLoops`, when threads are separate `func.func`s and `cb_pop`s exist. A logical DFB is one `cb_index`; each kernel thread that touches it binds it once.
 
-Two DFBs may share an index only if they have identical `CircularBufferType` (shape, element type, block count). Since `CircularBufferType` is an MLIR uniqued type, this is a pointer comparison. The algorithm partitions DFBs by type and runs a linear scan within each partition.
+A physical index carries shared `pages_received`/`pages_acked` counters plus per-RISC read/write pointers. None of those are reset between lifetimes, so two logical DFBs may share an index only when:
 
-### Algorithm
+- both have the same producer thread and the same consumer thread,
+- their lifetimes are disjoint in both threads' program order,
+- they have the same element type (one page size).
 
-```
-reuseDFBIndices(funcOp, compilerAllocatedBindCBOps):
-  // Assign sequential indices to function-level operations.
-  for op in funcOp.entryBlock:
-    opIndex[op] = nextIdx++
+When thread identity matches, per-thread program order plus blocking reserve/wait make disjoint lifetimes sound at runtime; sharing across different producer or consumer threads would corrupt counters/pointers and would need a barrier-plus-reset edge, which does not exist. The element-type bar is the only shape constraint: capacity is a `>=` check, the slot is sized to the member needing the most pages, and every reserve/wait carries its own block size.
 
-  // Build intervals: [bind_cb position, last cb_pop position].
-  // CBPopOps inside nested regions (loops, compute) are projected
-  // to their function-level ancestor.
-  // If no cb_pop exists, end = last operation (conservative).
-  for bindOp in compilerAllocatedBindCBOps:
-    start = opIndex[bindOp]
-    end = max(getBodyIndex(pop) for pop in cbPopUsers(bindOp))
-    if end == start:
-      end = lastOpIdx
-    intervals[bindOp.type].append({start, end, bindOp.result})
+A DFB whose producer and consumer are the same thread is single-threaded (compiler-allocated intermediates always; user DFBs whenever the pass derives it), so the pair (thread, thread) acts as one reuse class regardless of how the buffer was declared.
 
-  // Linear scan per type partition. Each partition gets a contiguous
-  // block of indices starting at baseIndex + offset.
-  offset = 0
-  for (type, typeIntervals) in intervals:
-    sort typeIntervals by start
-    maxSlot = 0
-    for interval in typeIntervals:
-      // Expire: free slots where active.end <= interval.start
-      for active in activeList:
-        if active.end <= interval.start:
-          free(slot[active])
-      slot[interval] = allocateFirstFreeSlot()
-      maxSlot = max(maxSlot, slot[interval])
+Lifetimes are computed per thread: from the first reserve/wait (bind position when no acquire exists) to the last use, following wait -> readers -> attach_cb -> consumers and pops. Nested uses project onto their top-level ancestor, so a buffer used in a loop is live across the back-edge for the whole loop. Intervals are closed; sharing an endpoint counts as overlap.
 
-    // Rewrite BindCBOp cb_index attributes for this partition.
-    for (value, s) in partitionAssignments:
-      bindOp[value].cb_index = baseIndex + offset + s
-    offset += maxSlot + 1
-```
+The reuse condition is checked against actual blocking acquires; control-flow guards (e.g. mutually exclusive per-core roles) do not refine it. `ttl-verify-dfb-spsc` runs afterwards and rejects shared indices with multiple producer or consumer threads on overlapping launch nodes; `--ttl-relax-dfb-spsc` removes that backstop and leaves SPSC discipline to the kernel author.
 
-The expiration condition `active.end <= interval.start` matches the DST register allocator's convention. Because operation indices are integers assigned to distinct operations, strict inequality and non-strict inequality produce the same result.
+### Runtime integration
 
-### Correctness with control flow
-
-The algorithm assigns sequential indices to function-level operations only. Structured operations (`scf.for`, `ttl.compute`) occupy a single index in this sequence; their contents are not individually numbered. This is sufficient because `InsertIntermediateDFBs` and `InsertCBSync` both run before `LowerToLoops`, placing `bind_cb` and `cb_pop` at function-level while the IR is flat. These operations remain at function-level after loop creation because they bracket compute regions.
-
-If a later pass restructures a `CBPopOp` into a nested region, it is projected to its enclosing operation at function-level via `Block::findAncestorOpInBlock`. This overestimates liveness -- the interval extends to the structured op rather than to the specific point where the pop occurs -- but never produces incorrect reuse.
-
-Two DFBs consumed simultaneously by the same operation (e.g., both operands of a matmul) necessarily have overlapping intervals because both `bind_cb` must precede the consumer and both `cb_pop` must follow it. The linear scan assigns them different slots.
-
-### Module attribute and runtime integration
-
-After rewriting indices, the pass calls `getNextAvailableDFBIndex`, which returns `max(cb_index) + 1` across all `BindCBOp`s in the module. This is the index space usage, not a count of distinct DFBs (sparse indices inflate it). The pass verifies this does not exceed `kMaxCircularBuffers` (32).
-
-The pass then sets `ttl.base_cta_index` on every function. Compile-time arguments (CTAs) to each kernel are laid out as `[CB indices..., other args...]`. `base_cta_index` is the starting index of the non-CB arguments -- equivalently, one past the last CB index. CB indices occupy `[0, base_cta_index)`.
-
-Finally, the pass builds the `ttl.compiler_allocated_dfbs` module attribute with one entry per unique physical index, deduplicated from the potentially many `BindCBOp`s that now share an index. The Python runtime reads this attribute to allocate L1 buffers at dispatch time.
-
-## Limitations and Future Work
-
-The linear scan operates on a flat sequence of function-level operations. It cannot distinguish between branches of an `scf.if`, so DFBs used in mutually exclusive branches are treated as overlapping. The current pipeline does not produce conditional control flow around DFB lifecycle operations. The DSL evaluates Python `if` during tracing, so only the taken branch appears in the generated IR; runtime-conditional control flow (`scf.if` with conditions dependent on tensor values) is not supported by the frontend at this time.
-
-Index reuse is restricted to compiler-allocated DFBs. User-declared DFBs retain their original indices because the same CB index is referenced by multiple threads (reader, compute, writer) to implement cross-thread data flow. Reusing a user index in one function would invalidate references in the others.
-
-Liveness is computed at function-level granularity. If a `CBPopOp` is inside a structured op (loop, compute region), it is projected to its enclosing operation at function-level. The infrastructure for this exists (`Block::findAncestorOpInBlock`) but is not currently exercised: all compiler-allocated DFB lifecycle ops remain at function-level because `InsertIntermediateDFBs` and `InsertCBSync` run before loop creation, and Python control flow unrolls at trace time.
-
-The type compatibility constraint prevents reuse across DFBs with different shapes or element types, even when L1 footprints happen to match. A size-based rather than type-based compatibility check could recover some reuse opportunities.
+After rewriting indices, the pass recomputes `getNextAvailableDFBIndex` (max index + 1), checks `kMaxCircularBuffers` (32), and updates `ttl.base_cta_index` on every function. Two module attributes carry the result to the Python runtime: `ttl.compiler_allocated_dfbs` (one entry per physical index, sized to the largest member) and `ttl.dfb_index_map` (old -> new entries for moved user DFBs, applied to the CB config list before descriptors are built).
 
 ## Scalar Element Access to DFBs
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -499,7 +499,7 @@ A DFB whose producer and consumer are the same thread is single-threaded (compil
 
 Lifetimes are computed per thread: from the first reserve/wait (bind position when no acquire exists) to the last use, following wait -> readers -> attach_cb -> consumers and pops. Nested uses project onto their top-level ancestor, so a buffer used in a loop is live across the back-edge for the whole loop. Intervals are closed; sharing an endpoint counts as overlap.
 
-The reuse condition is checked against actual blocking acquires; control-flow guards (e.g. mutually exclusive per-core roles) do not refine it. `ttl-verify-dfb-spsc` runs afterwards and rejects shared indices with multiple producer or consumer threads on overlapping launch nodes; `--ttl-relax-dfb-spsc` removes that backstop and leaves SPSC discipline to the kernel author.
+The reuse condition is checked against actual blocking acquires; control-flow guards (e.g. mutually exclusive per-core roles) do not refine it. `ttl-verify-dfb-spsc` always runs afterwards and rejects shared indices with multiple producer or consumer threads on overlapping launch nodes; role-guarded accesses pass when launch-node domain analysis proves them disjoint.
 
 ### Pipe-attached DFBs never reuse
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -501,6 +501,10 @@ Lifetimes are computed per thread: from the first reserve/wait (bind position wh
 
 The reuse condition is checked against actual blocking acquires; control-flow guards (e.g. mutually exclusive per-core roles) do not refine it. `ttl-verify-dfb-spsc` runs afterwards and rejects shared indices with multiple producer or consumer threads on overlapping launch nodes; `--ttl-relax-dfb-spsc` removes that backstop and leaves SPSC discipline to the kernel author.
 
+### Pipe-attached DFBs never reuse
+
+For a pipe destination, `block_count` is not queue depth: each sender writes its own block, addressed by sender ordinal, so `block_count` must equal the sender count. Pipe lowering lays sender slots out per `cb_index`; two destinations on one index would concatenate their slot ranges and change the addressing. Pipe transfers also move data over NOC with semaphore protocol, outside the CB counters that make program-order lifetimes sound, and a sender's stage buffer is read asynchronously after its wait. Any DFB whose user chain reaches a pipe op or a `ttl.copy` with a pipe operand therefore keeps its dedicated index and block count.
+
 ### Runtime integration
 
 After rewriting indices, the pass recomputes `getNextAvailableDFBIndex` (max index + 1), checks `kMaxCircularBuffers` (32), and updates `ttl.base_cta_index` on every function. Two module attributes carry the result to the Python runtime: `ttl.compiler_allocated_dfbs` (one entry per physical index, sized to the largest member) and `ttl.dfb_index_map` (old -> new entries for moved user DFBs, applied to the CB config list before descriptors are built).

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -134,6 +134,10 @@ constexpr llvm::StringLiteral
 constexpr llvm::StringLiteral
     kCompilerAllocatedAttrName("ttl.compiler_allocated");
 
+/// Module attribute mapping user DFB indices renumbered by index reuse
+/// (array of {old_index, new_index} dictionaries).
+constexpr llvm::StringLiteral kDFBIndexMapAttrName("ttl.dfb_index_map");
+
 /// Function attribute recording the base compile-time argument index.
 /// CTA layout is [CBs, TAs], so this equals the number of CBs.
 constexpr llvm::StringLiteral kBaseCTAIndexAttrName("ttl.base_cta_index");

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -47,53 +47,71 @@ static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
 
   Block &body = funcOp.getBody().front();
 
-  // Assign sequential indices to all operations in the body block.
+  // Number every operation in pre-order so the lifetimes below reflect true
+  // program order, including ops nested in loops or compute regions (after
+  // LowerToLoops / SubblockComputeForDST). Projecting a nested op onto its
+  // body-block ancestor would collapse a whole loop body to one position and
+  // let concurrently-live intermediates falsely share a slot.
   DenseMap<Operation *, int64_t> opIndex;
   int64_t idx = 0;
-  for (Operation &op : body) {
-    opIndex[&op] = idx++;
-  }
+  funcOp.walk<WalkOrder::PreOrder>([&](Operation *op) { opIndex[op] = idx++; });
   int64_t lastOpIdx = idx - 1;
 
-  // Project a nested operation to its ancestor in the body block.
-  // After LowerToLoops or SubblockComputeForDST, CBPopOps may end up
-  // inside loops or compute regions.
   auto getBodyIndex = [&](Operation *op) -> int64_t {
-    if (op->getBlock() == &body) {
-      return opIndex[op];
-    }
-    Operation *ancestor = body.findAncestorOpInBlock(*op);
-    assert(ancestor && "operation must be reachable from function body");
-    return opIndex[ancestor];
+    auto it = opIndex.find(op);
+    assert(it != opIndex.end() && "operation must have been indexed");
+    return it->second;
   };
 
-  // Build intervals grouped by CircularBufferType.
-  llvm::MapVector<Type, SmallVector<Interval>> typeToIntervals;
+  // Build intervals grouped by reuse class. Two compiler-allocated DFBs may
+  // share a physical index when they have the same element type and block
+  // count: each per-op reserve/wait carries its own tile count (derived from
+  // the unchanged bind_cb type), and the L1 slot is sized to the largest
+  // member, so a smaller buffer reusing a larger slot only touches a prefix.
+  using ReuseClass = std::pair<Type, int64_t>;
+  llvm::MapVector<ReuseClass, SmallVector<Interval>> classToIntervals;
   DenseMap<Value, BindCBOp> valueToBindOp;
 
   for (BindCBOp bindOp : dfbOps) {
     assert(bindOp->getBlock() == &body &&
            "compiler-allocated BindCBOp must be in function body block");
 
+    auto cbType = mlir::cast<CircularBufferType>(bindOp.getResult().getType());
     Value cbVal = bindOp.getResult();
     // Lifetime starts at the first acquire (reserve/wait) on this CB, not
     // at the bind_cb itself: bind_cb is just a declaration, and hoisting
     // it to the function body entry would otherwise collapse all compiler-
     // allocated DFB starts together and defeat reuse. If there is no
     // acquire (synthetic IR, pop-only), fall back to the bind_cb position.
+    //
+    // The end is the last op that reads the buffer. cb_pop ops do not exist
+    // yet here (TTLInsertCBSync runs later), so follow the consumer chain
+    // wait -> attach_cb -> compute consumer rather than relying on pops; an
+    // intermediate is dead once its consuming op has executed.
     int64_t start = lastOpIdx;
     int64_t end = opIndex[bindOp];
     bool sawAcquire = false;
+    auto extendEnd = [&](Operation *op) { end = std::max(end, getBodyIndex(op)); };
 
     for (OpOperand &use : cbVal.getUses()) {
       Operation *user = use.getOwner();
-      int64_t useIdx = getBodyIndex(user);
       if (isa<CBReserveOp, CBWaitOp>(user)) {
-        start = std::min(start, useIdx);
+        start = std::min(start, getBodyIndex(user));
         sawAcquire = true;
+        extendEnd(user);
       }
       if (isa<CBPopOp>(user)) {
-        end = std::max(end, useIdx);
+        extendEnd(user);
+      }
+      if (auto waitOp = dyn_cast<CBWaitOp>(user)) {
+        for (Operation *reader : waitOp.getResult().getUsers()) {
+          extendEnd(reader);
+          if (auto attachOp = dyn_cast<AttachCBOp>(reader)) {
+            for (Operation *consumer : attachOp.getResult().getUsers()) {
+              extendEnd(consumer);
+            }
+          }
+        }
       }
     }
 
@@ -101,13 +119,13 @@ static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
       start = opIndex[bindOp];
     }
 
-    // No cb_pop means the DFB's L1 is never explicitly released --
-    // conservatively treat it as live for the entire function.
-    if (end <= start) {
+    // Degenerate (no consumer found): treat as live for the whole function.
+    if (end < start) {
       end = lastOpIdx;
     }
 
-    typeToIntervals[cbVal.getType()].push_back({start, end, cbVal});
+    ReuseClass key(cbType.getElementType(), cbType.getBlockCount());
+    classToIntervals[key].push_back({start, end, cbVal});
     valueToBindOp[cbVal] = bindOp;
   }
 
@@ -118,13 +136,13 @@ static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
     baseIndex = std::min(baseIndex, cbIdx);
   }
 
-  // Linear scan per type partition. Each partition gets a contiguous
-  // block of physical DFB indices starting at baseIndex + cumulative
-  // offset from prior partitions.
+  // Linear scan per reuse class. Each class gets a contiguous block of
+  // physical DFB indices starting at baseIndex + cumulative offset from
+  // prior classes.
   MLIRContext *ctx = funcOp.getContext();
   int32_t nextSlotOffset = 0;
 
-  for (auto &[type, intervals] : typeToIntervals) {
+  for (auto &[key, intervals] : classToIntervals) {
     llvm::sort(intervals, [](const Interval &lhs, const Interval &rhs) {
       return lhs.start < rhs.start;
     });
@@ -249,17 +267,21 @@ struct TTLFinalizeDFBIndicesPass
     }
 
     // Deduplicate entries by physical index. After reuse, multiple
-    // BindCBOps may share the same index. The module attribute needs
-    // one entry per unique physical DFB.
+    // BindCBOps may share the same index, possibly with different shapes.
+    // The module attribute needs one entry per unique physical DFB, sized
+    // to the largest member so every reuser's tiles fit in the slot.
     llvm::DenseMap<int32_t, BindCBOp> uniqueByIndex;
     for (BindCBOp bindOp : compilerAllocatedOps) {
       int32_t dfbIdx = static_cast<int32_t>(bindOp.getCbIndex().getSExtValue());
       auto [it, inserted] = uniqueByIndex.try_emplace(dfbIdx, bindOp);
       if (!inserted) {
-        assert(it->second.getResult().getType() ==
-                   bindOp.getResult().getType() &&
-               "compiler-allocated DFBs sharing an index must have the "
-               "same CircularBufferType");
+        auto existing =
+            mlir::cast<CircularBufferType>(it->second.getResult().getType());
+        auto current =
+            mlir::cast<CircularBufferType>(bindOp.getResult().getType());
+        if (current.getElementsPerBlock() > existing.getElementsPerBlock()) {
+          it->second = bindOp;
+        }
       }
     }
 

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -6,11 +6,26 @@
 // TTL Finalize DFB Indices
 //===----------------------------------------------------------------------===//
 //
-// Module-level pass that runs after all DFB-creating passes. Reuses
-// compiler-allocated DFB indices when lifetimes do not overlap, then
-// computes the true DFB count, updates ttl.base_cta_index on every
-// function, and collects compiler-allocated DFBs into the
-// ttl.compiler_allocated_dfbs module attribute for the Python runtime.
+// Module-level pass that runs after all DFB-creating passes. Reuses DFB
+// indices when lifetimes do not overlap, then computes the true DFB count,
+// updates ttl.base_cta_index on every function, and publishes the final
+// index assignment for the Python runtime (ttl.dfb_index_map for
+// user-declared DFBs, ttl.compiler_allocated_dfbs for compiler-allocated
+// ones).
+//
+// A logical DFB is one cb_index, bound by one bind_cb per kernel thread that
+// touches it. The same physical CB index has shared pages_received /
+// pages_acked counters and per-RISC read/write pointers, so two logical DFBs
+// may share an index only when:
+//   - both have the same producer thread and the same consumer thread,
+//   - their per-thread lifetimes are disjoint in both threads' program order,
+//   - they have the same element type (uniform page size). Capacity is a
+//     >= check, not equality: the slot is sized to the member needing the
+//     most pages, and every reserve/wait carries its own block size.
+// With matching thread identity, per-thread program order plus reserve/wait
+// blocking make disjoint program-order lifetimes sound at runtime; sharing
+// across different producer or consumer threads is never sound without a
+// counter/pointer reset and is therefore not attempted.
 //
 //===----------------------------------------------------------------------===//
 
@@ -25,7 +40,6 @@
 #include "mlir/IR/BuiltinOps.h"
 
 #include "llvm/ADT/MapVector.h"
-#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "ttl-finalize-dfb-indices"
@@ -37,229 +51,299 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-/// Reuse compiler-allocated DFB indices within a function when their
-/// lifetimes do not overlap. Groups DFBs by CircularBufferType and runs
-/// linear scan allocation per group.
-static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
-  if (dfbOps.size() <= 1) {
-    return;
+/// Closed [start, end] lifetime of a logical DFB within one kernel thread,
+/// in that thread's top-level program order.
+struct ThreadInterval {
+  int64_t start;
+  int64_t end;
+};
+
+/// One logical DFB: a cb_index with one bind_cb per kernel thread.
+struct LogicalDFB {
+  int64_t origIndex = -1;
+  SmallVector<BindCBOp, 3> binds;
+  func::FuncOp producer;
+  func::FuncOp consumer;
+  llvm::SmallDenseMap<Operation *, ThreadInterval, 4> intervals;
+  llvm::SmallDenseMap<Operation *, int64_t, 4> firstAcquire;
+  Type elemType;
+  int64_t blockCount = 0;
+  int64_t elemsPerBlock = 0;
+  bool compilerAllocated = false;
+  bool eligible = true;
+  int64_t finalIndex = -1;
+
+  int64_t totalPages() const { return blockCount * elemsPerBlock; }
+};
+
+/// Position of an op in its kernel thread's top-level program order. Nested
+/// ops project onto their body-block ancestor: a buffer touched inside a
+/// loop is acquired and released every iteration, so across the back-edge it
+/// is live for the whole loop, not one static interval within the body.
+struct ThreadOrder {
+  DenseMap<Operation *, int64_t> topLevel;
+  int64_t lastIdx = 0;
+
+  explicit ThreadOrder(func::FuncOp func) {
+    int64_t idx = 0;
+    for (Operation &op : func.getBody().front()) {
+      topLevel[&op] = idx++;
+    }
+    lastIdx = idx == 0 ? 0 : idx - 1;
   }
 
-  Block &body = funcOp.getBody().front();
-
-  // Number top-level body ops only, and project a nested op onto its
-  // body-block ancestor. This runs after LowerToLoops, so a circular buffer
-  // used inside a loop is acquired/released every iteration: across the loop
-  // back-edge it is live for the WHOLE loop, not just one static interval
-  // within the body. Projecting every in-loop use to the single loop op index
-  // collapses all buffers used in one loop to the same position so they
-  // overlap and never share a slot; only buffers in different top-level
-  // regions (e.g. distinct phases/loops) can reuse, which is sound.
-  DenseMap<Operation *, int64_t> opIndex;
-  int64_t idx = 0;
-  for (Operation &op : body) {
-    opIndex[&op] = idx++;
-  }
-  int64_t lastOpIdx = idx - 1;
-
-  auto getBodyIndex = [&](Operation *op) -> int64_t {
+  int64_t index(Operation *op, func::FuncOp func) {
+    Block &body = func.getBody().front();
     if (op->getBlock() == &body) {
-      return opIndex[op];
+      return topLevel[op];
     }
     Operation *ancestor = body.findAncestorOpInBlock(*op);
     assert(ancestor && "operation must be reachable from function body");
-    return opIndex[ancestor];
-  };
-
-  // Build intervals grouped by reuse class. Two compiler-allocated DFBs may
-  // share a physical index when they have the same element type and block
-  // count: each per-op reserve/wait carries its own tile count (derived from
-  // the unchanged bind_cb type), and the L1 slot is sized to the largest
-  // member, so a smaller buffer reusing a larger slot only touches a prefix.
-  using ReuseClass = std::pair<Type, int64_t>;
-  llvm::MapVector<ReuseClass, SmallVector<Interval>> classToIntervals;
-  DenseMap<Value, BindCBOp> valueToBindOp;
-
-  for (BindCBOp bindOp : dfbOps) {
-    assert(bindOp->getBlock() == &body &&
-           "compiler-allocated BindCBOp must be in function body block");
-
-    auto cbType = mlir::cast<CircularBufferType>(bindOp.getResult().getType());
-    Value cbVal = bindOp.getResult();
-    // Lifetime starts at the first acquire (reserve/wait) on this CB, not
-    // at the bind_cb itself: bind_cb is just a declaration, and hoisting
-    // it to the function body entry would otherwise collapse all compiler-
-    // allocated DFB starts together and defeat reuse. If there is no
-    // acquire (synthetic IR, pop-only), fall back to the bind_cb position.
-    //
-    // The end is the last op that reads the buffer. cb_pop ops do not exist
-    // yet here (TTLInsertCBSync runs later), so follow the consumer chain
-    // wait -> attach_cb -> compute consumer rather than relying on pops; an
-    // intermediate is dead once its consuming op has executed.
-    int64_t start = lastOpIdx;
-    int64_t end = opIndex[bindOp];
-    bool sawAcquire = false;
-    auto extendEnd = [&](Operation *op) { end = std::max(end, getBodyIndex(op)); };
-
-    for (OpOperand &use : cbVal.getUses()) {
-      Operation *user = use.getOwner();
-      if (isa<CBReserveOp, CBWaitOp>(user)) {
-        start = std::min(start, getBodyIndex(user));
-        sawAcquire = true;
-        extendEnd(user);
-      }
-      if (isa<CBPopOp>(user)) {
-        extendEnd(user);
-      }
-      if (auto waitOp = dyn_cast<CBWaitOp>(user)) {
-        for (Operation *reader : waitOp.getResult().getUsers()) {
-          extendEnd(reader);
-          if (auto attachOp = dyn_cast<AttachCBOp>(reader)) {
-            for (Operation *consumer : attachOp.getResult().getUsers()) {
-              extendEnd(consumer);
-            }
-          }
-        }
-      }
-    }
-
-    if (!sawAcquire) {
-      start = opIndex[bindOp];
-    }
-
-    // Degenerate (no consumer found): treat as live for the whole function.
-    if (end < start) {
-      end = lastOpIdx;
-    }
-
-    ReuseClass key(cbType.getElementType(), cbType.getBlockCount());
-    classToIntervals[key].push_back({start, end, cbVal});
-    valueToBindOp[cbVal] = bindOp;
+    return topLevel[ancestor];
   }
+};
 
-  // Find the base index (smallest compiler-allocated index).
-  int32_t baseIndex = INT32_MAX;
-  for (BindCBOp bindOp : dfbOps) {
-    int32_t cbIdx = static_cast<int32_t>(bindOp.getCbIndex().getSExtValue());
-    baseIndex = std::min(baseIndex, cbIdx);
+/// Extend the per-thread interval of `dfb` to cover `op`.
+void extendInterval(LogicalDFB &dfb, Operation *op, func::FuncOp func,
+                    ThreadOrder &order) {
+  int64_t pos = order.index(op, func);
+  auto [it, inserted] =
+      dfb.intervals.try_emplace(func.getOperation(), ThreadInterval{pos, pos});
+  if (!inserted) {
+    it->second.start = std::min(it->second.start, pos);
+    it->second.end = std::max(it->second.end, pos);
   }
-
-  // Linear scan per reuse class. Each class gets a contiguous block of
-  // physical DFB indices starting at baseIndex + cumulative offset from
-  // prior classes.
-  MLIRContext *ctx = funcOp.getContext();
-  int32_t nextSlotOffset = 0;
-
-  for (auto &[key, intervals] : classToIntervals) {
-    llvm::sort(intervals, [](const Interval &lhs, const Interval &rhs) {
-      return lhs.start < rhs.start;
-    });
-
-    SmallVector<Interval *> active;
-    llvm::SmallBitVector freeSlots(intervals.size());
-    freeSlots.set();
-    DenseMap<Value, int32_t> slotAssignment;
-    int32_t maxSlot = -1;
-
-    for (Interval &interval : intervals) {
-      // Expire intervals whose lifetime ended strictly before this one
-      // starts. Intervals are closed [start, end] (both endpoints live), so a
-      // slot frees only when act->end < interval.start; sharing an endpoint
-      // means both are live at that op and must keep distinct slots. Two
-      // buffers projected onto the same enclosing loop op share that point and
-      // so never reuse, which is what loop liveness requires.
-      SmallVector<Interval *> expired;
-      for (Interval *act : active) {
-        if (act->end < interval.start) {
-          freeSlots.set(slotAssignment[act->value]);
-          expired.push_back(act);
-        }
-      }
-      for (Interval *exp : expired) {
-        llvm::erase(active, exp);
-      }
-
-      int freeSlot = freeSlots.find_first();
-      assert(freeSlot >= 0 && "DFB slot allocation always succeeds");
-      freeSlots.reset(freeSlot);
-      slotAssignment[interval.value] = freeSlot;
-      maxSlot = std::max(maxSlot, static_cast<int32_t>(freeSlot));
-      active.push_back(&interval);
-
-      LLVM_DEBUG({
-        llvm::dbgs() << "DFB reuse: [" << interval.start << ", " << interval.end
-                     << "] -> slot " << freeSlot << "\n";
-      });
-    }
-
-    // Rewrite BindCBOp indices to the assigned physical slot.
-    for (auto &[value, slot] : slotAssignment) {
-      int32_t newIndex = baseIndex + nextSlotOffset + slot;
-      BindCBOp bindOp = valueToBindOp[value];
-      bindOp.setCbIndexAttr(IntegerAttr::get(IndexType::get(ctx), newIndex));
-    }
-
-    nextSlotOffset += maxSlot + 1;
-  }
-
-  LLVM_DEBUG({
-    llvm::dbgs() << "DFB reuse: " << dfbOps.size()
-                 << " compiler-allocated DFBs -> " << nextSlotOffset
-                 << " physical slot(s)\n";
-  });
 }
+
+/// Record producer/consumer thread identity; multiple distinct threads in
+/// either role make the DFB ineligible (sharing its index would need a
+/// counter/pointer reset, which does not exist).
+void recordRole(func::FuncOp &role, func::FuncOp func, bool &eligible) {
+  if (!role) {
+    role = func;
+  } else if (role != func) {
+    eligible = false;
+  }
+}
+
+bool disjoint(const ThreadInterval &a, const ThreadInterval &b) {
+  return a.end < b.start || b.end < a.start;
+}
+
+/// Two logical DFBs of one reuse class conflict when their lifetimes overlap
+/// in the producer thread or in the consumer thread. Intervals are closed:
+/// sharing an endpoint means both are live at that op.
+bool conflicts(const LogicalDFB &a, const LogicalDFB &b) {
+  for (auto &[func, interval] : a.intervals) {
+    auto it = b.intervals.find(func);
+    if (it != b.intervals.end() && !disjoint(interval, it->second)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
 
 struct TTLFinalizeDFBIndicesPass
     : public impl::TTLFinalizeDFBIndicesBase<TTLFinalizeDFBIndicesPass> {
   void runOnOperation() override {
     auto moduleOp = getOperation();
-    OpBuilder builder(moduleOp.getContext());
+    MLIRContext *ctx = moduleOp.getContext();
+    OpBuilder builder(ctx);
 
-    // Collect compiler-allocated BindCBOps grouped by parent function.
-    llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> funcToDFBs;
+    // Collect logical DFBs by original index across kernel threads.
+    llvm::MapVector<int64_t, LogicalDFB> dfbs;
+    llvm::SmallDenseMap<Operation *, std::unique_ptr<ThreadOrder>> orders;
+    bool sawBind = false;
+
     moduleOp->walk([&](BindCBOp bindOp) {
-      if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-        auto funcOp = bindOp->getParentOfType<func::FuncOp>();
-        funcToDFBs[funcOp].push_back(bindOp);
+      sawBind = true;
+      func::FuncOp func = getEnclosingKernelThread(bindOp);
+      int64_t idx = bindOp.getCbIndex().getSExtValue();
+      LogicalDFB &dfb = dfbs[idx];
+      dfb.origIndex = idx;
+      dfb.binds.push_back(bindOp);
+      auto cbType = mlir::cast<CircularBufferType>(bindOp.getResult().getType());
+      dfb.elemType = cbType.getElementType();
+      dfb.blockCount = cbType.getBlockCount();
+      dfb.elemsPerBlock =
+          std::max(dfb.elemsPerBlock, cbType.getElementsPerBlock());
+      dfb.compilerAllocated |= bindOp->hasAttr(kCompilerAllocatedAttrName);
+      if (!func) {
+        dfb.eligible = false;
+        return;
+      }
+
+      auto &order = orders[func.getOperation()];
+      if (!order) {
+        order = std::make_unique<ThreadOrder>(func);
+      }
+
+      // The bind anchors the interval; binds are hoisted to the function
+      // entry, so the start is refined to the first acquire below.
+      extendInterval(dfb, bindOp, func, *order);
+
+      for (Operation *user : bindOp.getResult().getUsers()) {
+        extendInterval(dfb, user, func, *order);
+        if (isa<CBReserveOp, CBWaitOp>(user)) {
+          int64_t pos = order->index(user, func);
+          auto [it, inserted] =
+              dfb.firstAcquire.try_emplace(func.getOperation(), pos);
+          if (!inserted) {
+            it->second = std::min(it->second, pos);
+          }
+        }
+        if (isa<CBReserveOp, CBPushOp>(user)) {
+          recordRole(dfb.producer, func, dfb.eligible);
+        }
+        if (isa<CBWaitOp, CBPopOp>(user)) {
+          recordRole(dfb.consumer, func, dfb.eligible);
+        }
+        // A consumed block stays live until its last reader: follow
+        // wait -> readers -> attach_cb -> consumers one level deep.
+        if (auto waitOp = dyn_cast<CBWaitOp>(user)) {
+          for (Operation *reader : waitOp.getResult().getUsers()) {
+            extendInterval(dfb, reader, func, *order);
+            if (auto attachOp = dyn_cast<AttachCBOp>(reader)) {
+              for (Operation *consumer : attachOp.getResult().getUsers()) {
+                extendInterval(dfb, consumer, func, *order);
+              }
+            }
+          }
+        }
       }
     });
 
-    // Run DFB index reuse per function.
-    for (auto &[funcOp, dfbOps] : funcToDFBs) {
-      reuseDFBIndices(funcOp, dfbOps);
-    }
-
-    // Recompute DFB count after reuse may have changed indices.
-    int32_t numDFBs = getNextAvailableDFBIndex(moduleOp);
-    if (numDFBs <= 0) {
+    if (!sawBind) {
       return;
     }
 
+    // A DFB with no acquire and no release anywhere (declared but unused)
+    // keeps its index. One-sided DFBs reuse within the thread that touches
+    // them. Lifetime starts at the first acquire in each thread; without one
+    // the hoisted bind position stands, conservatively from function entry.
+    for (auto &[idx, dfb] : dfbs) {
+      if (!dfb.producer && !dfb.consumer) {
+        dfb.eligible = false;
+        continue;
+      }
+      if (!dfb.producer) {
+        dfb.producer = dfb.consumer;
+      }
+      if (!dfb.consumer) {
+        dfb.consumer = dfb.producer;
+      }
+      for (auto &[func, interval] : dfb.intervals) {
+        auto it = dfb.firstAcquire.find(func);
+        if (it != dfb.firstAcquire.end()) {
+          interval.start = it->second;
+        }
+      }
+    }
+
+    // Group eligible DFBs into reuse classes; keep deterministic order by
+    // original index. Class members may differ in block count and tiles per
+    // block: capacity is a >= constraint, the slot is sized to the member
+    // needing the most pages, and per-op tile counts come from each bind_cb's
+    // own type.
+    // User and compiler DFBs never mix in one slot: the runtime sizes them
+    // from disjoint sources (CB configs vs ttl.compiler_allocated_dfbs).
+    using ClassKey = std::tuple<Type, Operation *, Operation *, int64_t>;
+    llvm::MapVector<ClassKey, SmallVector<LogicalDFB *>> classes;
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.eligible) {
+        classes[{dfb.elemType, dfb.producer.getOperation(),
+                 dfb.consumer.getOperation(),
+                 static_cast<int64_t>(dfb.compilerAllocated)}]
+            .push_back(&dfb);
+      } else {
+        dfb.finalIndex = dfb.origIndex;
+      }
+    }
+
+    // Greedy interval coloring per class: walk by ascending producer start
+    // and place on the first slot whose members are all disjoint in both
+    // threads. A slot takes the lowest original index of its members, so
+    // indices only ever decrease and never collide with ineligible DFBs.
+    SmallVector<SmallVector<LogicalDFB *>> slots;
+    for (auto &[key, members] : classes) {
+      llvm::sort(members, [](LogicalDFB *a, LogicalDFB *b) {
+        auto pa = a->intervals.find(a->producer.getOperation())->second;
+        auto pb = b->intervals.find(b->producer.getOperation())->second;
+        return std::tie(pa.start, pa.end, a->origIndex) <
+               std::tie(pb.start, pb.end, b->origIndex);
+      });
+      size_t classBase = slots.size();
+      for (LogicalDFB *dfb : members) {
+        size_t placed = slots.size();
+        for (size_t s = classBase; s < slots.size(); ++s) {
+          if (llvm::none_of(slots[s], [&](LogicalDFB *member) {
+                return conflicts(*member, *dfb);
+              })) {
+            placed = s;
+            break;
+          }
+        }
+        if (placed == slots.size()) {
+          slots.emplace_back();
+        }
+        slots[placed].push_back(dfb);
+      }
+    }
+
+    for (auto &slot : slots) {
+      int64_t slotIndex = slot.front()->origIndex;
+      for (LogicalDFB *dfb : slot) {
+        slotIndex = std::min(slotIndex, dfb->origIndex);
+      }
+      for (LogicalDFB *dfb : slot) {
+        dfb->finalIndex = slotIndex;
+      }
+    }
+
+    // Compact to a dense index space (the runtime builds one CB descriptor
+    // per index), preserving relative order.
+    SmallVector<int64_t> usedIndices;
+    for (auto &[idx, dfb] : dfbs) {
+      usedIndices.push_back(dfb.finalIndex);
+    }
+    llvm::sort(usedIndices);
+    usedIndices.erase(llvm::unique(usedIndices), usedIndices.end());
+    DenseMap<int64_t, int64_t> rank;
+    for (auto [i, index] : llvm::enumerate(usedIndices)) {
+      rank[index] = static_cast<int64_t>(i);
+    }
+    for (auto &[idx, dfb] : dfbs) {
+      dfb.finalIndex = rank[dfb.finalIndex];
+    }
+
+    // Rewrite bind_cb indices in every kernel thread.
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.finalIndex == dfb.origIndex) {
+        continue;
+      }
+      for (BindCBOp bindOp : dfb.binds) {
+        bindOp.setCbIndexAttr(
+            IntegerAttr::get(IndexType::get(ctx), dfb.finalIndex));
+      }
+      LLVM_DEBUG(llvm::dbgs() << "DFB reuse: cb" << dfb.origIndex << " -> cb"
+                              << dfb.finalIndex << "\n");
+    }
+
+    int32_t numDFBs = getNextAvailableDFBIndex(moduleOp);
     LLVM_DEBUG(llvm::dbgs() << "Total DFB count: " << numDFBs << "\n");
 
-    // Verify the final DFB count does not exceed the hardware limit.
     if (numDFBs > kMaxCircularBuffers) {
-      // Count compiler-allocated physical slots (after reuse).
-      int32_t compilerSlots = 0;
-      for (auto &[funcOp, dfbOps] : funcToDFBs) {
-        llvm::SmallDenseSet<int32_t> uniqueIndices;
-        for (BindCBOp bindOp : dfbOps) {
-          uniqueIndices.insert(
-              static_cast<int32_t>(bindOp.getCbIndex().getSExtValue()));
-        }
-        compilerSlots += static_cast<int32_t>(uniqueIndices.size());
-      }
       moduleOp.emitError()
-          << "need " << numDFBs << " DFB indices but hardware supports "
-          << "at most " << kMaxCircularBuffers << " (" << compilerSlots
-          << " compiler-allocated after reuse); reduce the number of "
-          << "user-declared dataflow buffers or split the computation "
-          << "into multiple kernels";
+          << "need " << numDFBs << " DFB indices after reuse but hardware "
+          << "supports at most " << kMaxCircularBuffers
+          << "; reduce the number of dataflow buffers or split the "
+          << "computation into multiple kernels";
       signalPassFailure();
       return;
     }
 
-    // Update ttl.base_cta_index on every function that has it.
     moduleOp->walk([&](func::FuncOp funcOp) {
       if (funcOp->hasAttr(kBaseCTAIndexAttrName)) {
         funcOp->setAttr(kBaseCTAIndexAttrName,
@@ -267,67 +351,62 @@ struct TTLFinalizeDFBIndicesPass
       }
     });
 
-    // Re-collect compiler-allocated ops (indices may have changed).
-    SmallVector<BindCBOp> compilerAllocatedOps;
-    moduleOp->walk([&](BindCBOp bindOp) {
-      if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-        compilerAllocatedOps.push_back(bindOp);
+    // Publish remapped user DFB indices for the Python runtime.
+    SmallVector<Attribute> mapEntries;
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.compilerAllocated || dfb.finalIndex == dfb.origIndex) {
+        continue;
       }
-    });
+      mapEntries.push_back(DictionaryAttr::get(
+          ctx, {builder.getNamedAttr(
+                    "old_index",
+                    builder.getI32IntegerAttr(static_cast<int32_t>(idx))),
+                builder.getNamedAttr("new_index",
+                                     builder.getI32IntegerAttr(
+                                         static_cast<int32_t>(dfb.finalIndex)))}));
+    }
+    if (!mapEntries.empty()) {
+      moduleOp->setAttr(kDFBIndexMapAttrName, ArrayAttr::get(ctx, mapEntries));
+    }
 
-    if (compilerAllocatedOps.empty()) {
+    // Publish compiler-allocated DFBs, one entry per physical index sized to
+    // the member needing the most pages.
+    llvm::MapVector<int64_t, LogicalDFB *> compilerByIndex;
+    for (auto &[idx, dfb] : dfbs) {
+      if (!dfb.compilerAllocated) {
+        continue;
+      }
+      auto [it, inserted] = compilerByIndex.try_emplace(dfb.finalIndex, &dfb);
+      if (!inserted && dfb.totalPages() > it->second->totalPages()) {
+        it->second = &dfb;
+      }
+    }
+    if (compilerByIndex.empty()) {
       return;
     }
 
-    // Deduplicate entries by physical index. After reuse, multiple
-    // BindCBOps may share the same index, possibly with different shapes.
-    // The module attribute needs one entry per unique physical DFB, sized
-    // to the largest member so every reuser's tiles fit in the slot.
-    llvm::DenseMap<int32_t, BindCBOp> uniqueByIndex;
-    for (BindCBOp bindOp : compilerAllocatedOps) {
-      int32_t dfbIdx = static_cast<int32_t>(bindOp.getCbIndex().getSExtValue());
-      auto [it, inserted] = uniqueByIndex.try_emplace(dfbIdx, bindOp);
-      if (!inserted) {
-        auto existing =
-            mlir::cast<CircularBufferType>(it->second.getResult().getType());
-        auto current =
-            mlir::cast<CircularBufferType>(bindOp.getResult().getType());
-        if (current.getElementsPerBlock() > existing.getElementsPerBlock()) {
-          it->second = bindOp;
-        }
-      }
-    }
-
-    // Sort by index for deterministic output.
-    SmallVector<std::pair<int32_t, BindCBOp>> sorted(uniqueByIndex.begin(),
-                                                     uniqueByIndex.end());
+    SmallVector<std::pair<int64_t, LogicalDFB *>> sorted(
+        compilerByIndex.begin(), compilerByIndex.end());
     llvm::sort(sorted,
                [](auto &lhs, auto &rhs) { return lhs.first < rhs.first; });
 
-    MLIRContext *ctx = moduleOp.getContext();
     SmallVector<Attribute> entries;
-    for (auto &[dfbIdx, bindOp] : sorted) {
-      auto cbType =
-          mlir::cast<CircularBufferType>(bindOp.getResult().getType());
-      SmallVector<NamedAttribute> entryAttrs;
-      entryAttrs.push_back(
-          builder.getNamedAttr("dfb_index", builder.getI32IntegerAttr(dfbIdx)));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "num_tiles", builder.getI32IntegerAttr(static_cast<int32_t>(
-                           cbType.getElementsPerBlock()))));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "element_type", TypeAttr::get(cbType.getElementType())));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "block_count", builder.getI32IntegerAttr(
-                             static_cast<int32_t>(cbType.getBlockCount()))));
-      entries.push_back(DictionaryAttr::get(ctx, entryAttrs));
+    for (auto &[dfbIdx, dfb] : sorted) {
+      entries.push_back(DictionaryAttr::get(
+          ctx,
+          {builder.getNamedAttr("dfb_index", builder.getI32IntegerAttr(
+                                                 static_cast<int32_t>(dfbIdx))),
+           builder.getNamedAttr("num_tiles",
+                                builder.getI32IntegerAttr(
+                                    static_cast<int32_t>(dfb->elemsPerBlock))),
+           builder.getNamedAttr("element_type", TypeAttr::get(dfb->elemType)),
+           builder.getNamedAttr("block_count",
+                                builder.getI32IntegerAttr(
+                                    static_cast<int32_t>(dfb->blockCount)))}));
     }
-
     moduleOp->setAttr(kCompilerAllocatedDFBsAttrName,
                       ArrayAttr::get(ctx, entries));
   }
 };
-
-} // namespace
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -247,15 +247,14 @@ struct TTLFinalizeDFBIndicesPass
     // block: capacity is a >= constraint, the slot is sized to the member
     // needing the most pages, and per-op tile counts come from each bind_cb's
     // own type.
-    // User and compiler DFBs never mix in one slot: the runtime sizes them
-    // from disjoint sources (CB configs vs ttl.compiler_allocated_dfbs).
-    using ClassKey = std::tuple<Type, Operation *, Operation *, int64_t>;
+    // User and compiler DFBs share slots freely; the runtime keeps the
+    // larger config when both describe one index.
+    using ClassKey = std::tuple<Type, Operation *, Operation *>;
     llvm::MapVector<ClassKey, SmallVector<LogicalDFB *>> classes;
     for (auto &[idx, dfb] : dfbs) {
       if (dfb.eligible) {
         classes[{dfb.elemType, dfb.producer.getOperation(),
-                 dfb.consumer.getOperation(),
-                 static_cast<int64_t>(dfb.compilerAllocated)}]
+                 dfb.consumer.getOperation()}]
             .push_back(&dfb);
       } else {
         dfb.finalIndex = dfb.origIndex;

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -184,8 +184,48 @@ struct TTLFinalizeDFBIndicesPass
       // entry, so the start is refined to the first acquire below.
       extendInterval(dfb, bindOp, func, *order);
 
+      // Pipe destinations are slot-addressed (block_count == sender count)
+      // and pipe sends read asynchronously, so pipe-attached DFBs keep
+      // dedicated indices.
+      // A DFB participates in a pipe through a ttl.copy whose other operand
+      // is a pipe, or through pipe_recv guards.
+      auto isPipeOp = [](Operation *op) {
+        if (op->getName().getStringRef().contains("pipe")) {
+          return true;
+        }
+        return llvm::any_of(op->getOperands(), [](Value operand) {
+          return mlir::isa<PipeType>(operand.getType());
+        });
+      };
+      // Pipe sends/receives reach a block through view chains (extract_slice,
+      // attach_cb, casts); walk a few hops of users.
+      auto markPipeUsers = [&](Value view) {
+        SmallVector<Value> worklist{view};
+        for (int depth = 0; depth < 3 && !worklist.empty(); ++depth) {
+          SmallVector<Value> next;
+          for (Value v : worklist) {
+            for (Operation *user : v.getUsers()) {
+              if (isPipeOp(user)) {
+                dfb.eligible = false;
+                return;
+              }
+              for (Value result : user->getResults()) {
+                next.push_back(result);
+              }
+            }
+          }
+          worklist = std::move(next);
+        }
+      };
+
       for (Operation *user : bindOp.getResult().getUsers()) {
         extendInterval(dfb, user, func, *order);
+        if (isPipeOp(user)) {
+          dfb.eligible = false;
+        }
+        if (auto reserveOp = dyn_cast<CBReserveOp>(user)) {
+          markPipeUsers(reserveOp.getResult());
+        }
         if (isa<CBReserveOp, CBWaitOp>(user)) {
           int64_t pos = order->index(user, func);
           auto [it, inserted] =
@@ -203,9 +243,11 @@ struct TTLFinalizeDFBIndicesPass
         // A consumed block stays live until its last reader: follow
         // wait -> readers -> attach_cb -> consumers one level deep.
         if (auto waitOp = dyn_cast<CBWaitOp>(user)) {
+          markPipeUsers(waitOp.getResult());
           for (Operation *reader : waitOp.getResult().getUsers()) {
             extendInterval(dfb, reader, func, *order);
             if (auto attachOp = dyn_cast<AttachCBOp>(reader)) {
+              markPipeUsers(attachOp.getResult());
               for (Operation *consumer : attachOp.getResult().getUsers()) {
                 extendInterval(dfb, consumer, func, *order);
               }

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -47,20 +47,28 @@ static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
 
   Block &body = funcOp.getBody().front();
 
-  // Number every operation in pre-order so the lifetimes below reflect true
-  // program order, including ops nested in loops or compute regions (after
-  // LowerToLoops / SubblockComputeForDST). Projecting a nested op onto its
-  // body-block ancestor would collapse a whole loop body to one position and
-  // let concurrently-live intermediates falsely share a slot.
+  // Number top-level body ops only, and project a nested op onto its
+  // body-block ancestor. This runs after LowerToLoops, so a circular buffer
+  // used inside a loop is acquired/released every iteration: across the loop
+  // back-edge it is live for the WHOLE loop, not just one static interval
+  // within the body. Projecting every in-loop use to the single loop op index
+  // collapses all buffers used in one loop to the same position so they
+  // overlap and never share a slot; only buffers in different top-level
+  // regions (e.g. distinct phases/loops) can reuse, which is sound.
   DenseMap<Operation *, int64_t> opIndex;
   int64_t idx = 0;
-  funcOp.walk<WalkOrder::PreOrder>([&](Operation *op) { opIndex[op] = idx++; });
+  for (Operation &op : body) {
+    opIndex[&op] = idx++;
+  }
   int64_t lastOpIdx = idx - 1;
 
   auto getBodyIndex = [&](Operation *op) -> int64_t {
-    auto it = opIndex.find(op);
-    assert(it != opIndex.end() && "operation must have been indexed");
-    return it->second;
+    if (op->getBlock() == &body) {
+      return opIndex[op];
+    }
+    Operation *ancestor = body.findAncestorOpInBlock(*op);
+    assert(ancestor && "operation must be reachable from function body");
+    return opIndex[ancestor];
   };
 
   // Build intervals grouped by reuse class. Two compiler-allocated DFBs may
@@ -154,10 +162,15 @@ static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
     int32_t maxSlot = -1;
 
     for (Interval &interval : intervals) {
-      // Expire intervals whose lifetime ended before this one starts.
+      // Expire intervals whose lifetime ended strictly before this one
+      // starts. Intervals are closed [start, end] (both endpoints live), so a
+      // slot frees only when act->end < interval.start; sharing an endpoint
+      // means both are live at that op and must keep distinct slots. Two
+      // buffers projected onto the same enclosing loop op share that point and
+      // so never reuse, which is what loop liveness requires.
       SmallVector<Interval *> expired;
       for (Interval *act : active) {
-        if (act->end <= interval.start) {
+        if (act->end < interval.start) {
           freeSlots.set(slotAssignment[act->value]);
           expired.push_back(act);
         }

--- a/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
@@ -46,11 +46,11 @@ FailureOr<Value> materializeToDFB(Value intermediate, ModuleOp moduleOp,
   Location loc = intermediate.getLoc();
   MLIRContext *ctx = builder.getContext();
 
-  // Intra-thread push/wait requires double-buffering so the packer and
-  // unpacker can operate on different buffer halves simultaneously.
+  // Single block: producer and consumer are the same compute kernel, so a
+  // second block buys no overlap and doubles the L1 footprint.
   SmallVector<int64_t> shape(tensorType.getShape());
   Type elementType = tensorType.getElementType();
-  int64_t blockCount = 2;
+  int64_t blockCount = 1;
   auto cbType = CircularBufferType::get(ctx, shape, elementType, blockCount);
 
   int32_t dfbIndex = getNextAvailableDFBIndex(moduleOp);

--- a/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
@@ -162,6 +162,21 @@ struct TTLValidateCBBudgetPass
     }
     llvm::sort(sortedIndices);
 
+    if (::getenv("TTL_CB_BUDGET_DEBUG")) {
+      for (int64_t idx : sortedIndices) {
+        BindCBOp b = bindForIndex[idx];
+        auto t = mlir::cast<CircularBufferType>(b.getResult().getType());
+        llvm::errs() << "[cb-budget] CB[" << idx << "] " << maxBytesByIndex[idx]
+                     << " bytes elemsPerBlock=" << t.getElementsPerBlock()
+                     << " blockCount=" << t.getBlockCount()
+                     << (b->hasAttr(kCompilerAllocatedAttrName) ? " (compiler)"
+                                                                : "")
+                     << "\n";
+      }
+      llvm::errs() << "[cb-budget] total=" << totalBytes
+                   << " budget=" << budgetBytes << "\n";
+    }
+
     auto emitBreakdown = [&](InFlightDiagnostic &diag) {
       for (int64_t idx : sortedIndices) {
         BindCBOp bindOp = bindForIndex[idx];

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -188,20 +188,20 @@ def _check_callee_buffers(spec, caller_name: str, top_level: bool) -> Set[str]:
         _setup_assign_target,
     )
 
+    # Whitelist every factory call inside a top-level setup-assign's value:
+    # the whole RHS is evaluated when the assign is hoisted, so pipes nested in
+    # a ``PipeNet([Pipe(...)])`` argument are fine. Factory calls anywhere else
+    # (a compound block, a non-decl expression) cannot be hoisted.
     dfb_names: Set[str] = set()
     top_level_decl_calls: Set[int] = set()
     for stmt in spec.fn_ast.body:
         if _setup_assign_target(stmt) is None:
             continue
-        value = stmt.value
-        if isinstance(value, (ast.List, ast.Tuple)):
-            top_level_decl_calls.update(id(e) for e in value.elts)
-        elif isinstance(value, (ast.ListComp, ast.GeneratorExp)):
-            top_level_decl_calls.add(id(value.elt))
-        else:
-            top_level_decl_calls.add(id(value))
-            if _call_name(value) in _DFB_FACTORY_NAMES:
-                dfb_names.add(stmt.targets[0].id)
+        for sub in ast.walk(stmt.value):
+            if isinstance(sub, ast.Call) and _call_name(sub) in _SETUP_FACTORY_NAMES:
+                top_level_decl_calls.add(id(sub))
+        if _call_name(stmt.value) in _DFB_FACTORY_NAMES:
+            dfb_names.add(stmt.targets[0].id)
 
     declares = False
     for node in ast.walk(spec.fn_ast):

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -12,10 +12,13 @@ local variables to avoid collisions with the caller's scope.
 
 Constraints on inlined callees:
 
-  - The callee body must not declare its own DFBs or PipeNets. All
-    DataFlow buffers and PipeNets used by the callee must be passed
-    in as parameters. Operating on existing PipeNets (e.g.
-    ``.if_src``/``.if_dst``) and emitting copies is fine.
+  - A callee may declare its own DFBs / PipeNets, but only when it is
+    inlined at the caller body's top level: the decls are hoisted to the
+    top level (where ``_lift_setup`` evaluates them), so a callee that
+    declares buffers cannot be inlined inside a for / if / while / with.
+    The buffer decls must themselves be top-level statements of the
+    callee for the same reason. Operating on existing PipeNets (e.g.
+    ``.if_src``/``.if_dst``) and emitting copies is always fine.
   - The callee must be invoked as a bare statement (``Callee(...)``);
     using the result as an expression is not supported.
   - The callee's parameters must all be provided at the call site; no
@@ -42,32 +45,43 @@ def inline_atom_calls(
     fn_def: ast.FunctionDef,
     fn_globals: Dict[str, object],
     caller_name: str,
-) -> None:
+) -> Dict[str, int]:
     """Rewrite ``fn_def`` in place: inline statement-level calls to
     @ttl.atom kernels reachable through ``fn_globals``.
 
     ``fn_def.body`` is replaced with the post-inline statement list.
     Nested compound bodies (if / for / while / with) are inlined
-    recursively. Raises ``ValueError`` if a discovered callee's body
-    declares its own DFBs or PipeNets.
+    recursively. Returns a map from each (alpha-renamed) inlined DFB name to
+    the id of the inline site it came from, so the caller can overlay the
+    scratch of distinct sibling sites onto shared CB indices. Raises
+    ``ValueError`` if a callee that declares its own buffers is inlined
+    anywhere but the body top level.
     """
-    fn_def.body = _inline_stmts(fn_def.body, fn_globals, caller_name)
+    inlined_dfb_tags: Dict[str, int] = {}
+    fn_def.body = _inline_stmts(
+        fn_def.body, fn_globals, caller_name, inlined_dfb_tags, top_level=True
+    )
+    return inlined_dfb_tags
 
 
 def _inline_stmts(
     stmts: List[ast.stmt],
     fn_globals: Dict[str, object],
     caller_name: str,
+    inlined_dfb_tags: Dict[str, int],
+    top_level: bool,
 ) -> List[ast.stmt]:
     out: List[ast.stmt] = []
     for stmt in stmts:
-        _inline_inside_compound(stmt, fn_globals, caller_name)
+        _inline_inside_compound(stmt, fn_globals, caller_name, inlined_dfb_tags)
         match = _match_atom_call(stmt, fn_globals)
         if match is None:
             out.append(stmt)
             continue
         callee, call = match
-        out.extend(_expand_call(callee, call, caller_name))
+        out.extend(
+            _expand_call(callee, call, caller_name, top_level, inlined_dfb_tags)
+        )
     return out
 
 
@@ -75,18 +89,31 @@ def _inline_inside_compound(
     stmt: ast.stmt,
     fn_globals: Dict[str, object],
     caller_name: str,
+    inlined_dfb_tags: Dict[str, int],
 ) -> None:
-    """Recurse into compound-statement bodies so nested calls inline too."""
+    """Recurse into compound-statement bodies so nested calls inline too.
+
+    Calls discovered here are not at the body top level, so a callee that
+    declares its own buffers cannot be inlined into them.
+    """
     for attr in ("body", "orelse", "finalbody"):
         body = getattr(stmt, attr, None)
         if isinstance(body, list) and body and isinstance(body[0], ast.stmt):
-            setattr(stmt, attr, _inline_stmts(body, fn_globals, caller_name))
+            setattr(
+                stmt,
+                attr,
+                _inline_stmts(
+                    body, fn_globals, caller_name, inlined_dfb_tags, top_level=False
+                ),
+            )
     # try/except handler bodies
     handlers = getattr(stmt, "handlers", None)
     if isinstance(handlers, list):
         for h in handlers:
             if isinstance(h, ast.ExceptHandler):
-                h.body = _inline_stmts(h.body, fn_globals, caller_name)
+                h.body = _inline_stmts(
+                    h.body, fn_globals, caller_name, inlined_dfb_tags, top_level=False
+                )
 
 
 def _match_atom_call(
@@ -112,14 +139,22 @@ def _expand_call(
     callee: "Atom",
     call: ast.Call,
     caller_name: str,
+    top_level: bool,
+    inlined_dfb_tags: Dict[str, int],
 ) -> List[ast.stmt]:
     spec = callee._spec
-    _validate_callee_for_inline(spec, caller_name)
+    dfb_decl_names = _check_callee_buffers(spec, caller_name, top_level)
 
     bindings = _bind_args_to_params(spec, call, caller_name)
     locals_in_callee = _collect_local_names(spec.fn_ast) - set(bindings)
-    suffix = f"__{spec.name}_inl{next(_inline_counter)}"
+    site = next(_inline_counter)
+    suffix = f"__{spec.name}_inl{site}"
     rename_map = {n: n + suffix for n in locals_in_callee}
+
+    # The callee's local DFBs are hoisted into the caller; tag their renamed
+    # names with this inline site so sibling sites can overlay CB indices.
+    for n in dfb_decl_names:
+        inlined_dfb_tags[rename_map.get(n, n)] = site
 
     transformer = _SubstituteTransformer(
         bindings=bindings,
@@ -135,24 +170,59 @@ def _expand_call(
     return inlined
 
 
-def _validate_callee_for_inline(spec, caller_name: str) -> None:
-    """Forbid DFB / PipeNet declarations in a callee that's being inlined."""
-    for node in ast.walk(spec.fn_ast):
-        if not isinstance(node, ast.Call):
+def _check_callee_buffers(spec, caller_name: str, top_level: bool) -> Set[str]:
+    """Validate a callee's buffer declarations and return its top-level
+    DFB-decl names.
+
+    A callee may declare its own DFBs / Pipes / PipeNets only as top-level
+    statements (so they can be hoisted) and only when inlined at the caller
+    body top level (so the hoist target is the caller's top level too).
+    Returns the names of the callee's top-level ``make_dfb`` /
+    ``make_dataflow_buffer_like`` assigns (the scratch buffers eligible for
+    reuse); Pipes / PipeNets are hoisted but not reused.
+    """
+    from ttl.atom import (
+        _DFB_FACTORY_NAMES,
+        _SETUP_FACTORY_NAMES,
+        _call_name,
+        _setup_assign_target,
+    )
+
+    dfb_names: Set[str] = set()
+    top_level_decl_calls: Set[int] = set()
+    for stmt in spec.fn_ast.body:
+        if _setup_assign_target(stmt) is None:
             continue
-        func = node.func
-        attr = None
-        if isinstance(func, ast.Attribute):
-            attr = func.attr
-        elif isinstance(func, ast.Name):
-            attr = func.id
-        if attr in _FORBIDDEN_CALLEE_NAMES:
+        value = stmt.value
+        if isinstance(value, (ast.List, ast.Tuple)):
+            top_level_decl_calls.update(id(e) for e in value.elts)
+        elif isinstance(value, (ast.ListComp, ast.GeneratorExp)):
+            top_level_decl_calls.add(id(value.elt))
+        else:
+            top_level_decl_calls.add(id(value))
+            if _call_name(value) in _DFB_FACTORY_NAMES:
+                dfb_names.add(stmt.targets[0].id)
+
+    declares = False
+    for node in ast.walk(spec.fn_ast):
+        if not (isinstance(node, ast.Call) and _call_name(node) in _SETUP_FACTORY_NAMES):
+            continue
+        declares = True
+        if id(node) not in top_level_decl_calls:
             raise ValueError(
-                f"@ttl.atom: cannot inline {spec.name!r} into "
-                f"{caller_name!r}: callee body invokes {attr!r}. "
-                "Inlined callees must take all DFBs / PipeNets as "
-                "parameters; declare them in the caller and pass them in."
+                f"@ttl.atom: cannot inline {spec.name!r} into {caller_name!r}: "
+                "buffer declarations must be top-level statements of the callee "
+                "so they can be hoisted; found one nested in its body."
             )
+
+    if declares and not top_level:
+        raise ValueError(
+            f"@ttl.atom: cannot inline {spec.name!r} into {caller_name!r}: it "
+            "declares its own DFBs / PipeNets, so it must be called at the atom "
+            "body top level, not inside a for / if / while / with."
+        )
+
+    return dfb_names
 
 
 def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, ast.expr]:

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -146,6 +146,11 @@ def _expand_call(
     dfb_decl_names = _check_callee_buffers(spec, caller_name, top_level)
 
     bindings = _bind_args_to_params(spec, call, caller_name)
+    # Fold the callee's constant closure freevars (e.g. factory tile-count
+    # params) into the body: after substitution they live in the caller, whose
+    # scope does not carry the callee's closure.
+    for name, value in _closure_consts(spec.fn).items():
+        bindings.setdefault(name, ast.Constant(value=value))
     locals_in_callee = _collect_local_names(spec.fn_ast) - set(bindings)
     site = next(_inline_counter)
     suffix = f"__{spec.name}_inl{site}"
@@ -223,6 +228,27 @@ def _check_callee_buffers(spec, caller_name: str, top_level: bool) -> Set[str]:
         )
 
     return dfb_names
+
+
+def _closure_consts(fn) -> Dict[str, object]:
+    """Constant closure freevars of ``fn`` (e.g. a factory's tile-count params).
+
+    These are folded into the body as literals when it is inlined, since the
+    caller's scope does not carry the callee's closure cells. Only simple
+    constants are folded; other freevars (atoms, modules) resolve through the
+    caller's globals or are themselves inlined.
+    """
+    closure = getattr(fn, "__closure__", None) or ()
+    freevars = getattr(getattr(fn, "__code__", None), "co_freevars", ())
+    consts: Dict[str, object] = {}
+    for name, cell in zip(freevars, closure):
+        try:
+            value = cell.cell_contents
+        except ValueError:
+            continue
+        if value is None or isinstance(value, (int, float, str, bool)):
+            consts[name] = value
+    return consts
 
 
 def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, ast.expr]:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -90,6 +90,7 @@ class _AtomSpec:
     fn_ast: ast.FunctionDef  # post-inline
     params: List[_ParamInfo]
     dfb_param_names: List[str]
+    inlined_dfb_tags: Dict[str, int]  # inlined scratch DFB name -> inline site id
 
 
 def _function_scope(fn: Callable) -> Dict[str, Any]:
@@ -164,7 +165,9 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
 
     # Inline statement-level calls to other @ttl.atom functions, then keep
     # the post-inline AST + source.
-    inline_atom_calls(fn_def, _function_scope(fn), caller_name=name)
+    inlined_dfb_tags = inline_atom_calls(
+        fn_def, _function_scope(fn), caller_name=name
+    )
     source = ast.unparse(fn_def)
 
     params = _classify_params(fn)
@@ -177,6 +180,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         fn_ast=fn_def,
         params=params,
         dfb_param_names=[p.name for p in params if p.kind == "dfb"],
+        inlined_dfb_tags=inlined_dfb_tags,
     )
 
 
@@ -293,6 +297,70 @@ def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
     return [by_index.get(i) for i in range(max(by_index) + 1)]
 
 
+def _reuse_inlined_dfb_indices(
+    dfbs: Dict[str, DataflowBuffer],
+    inlined_dfb_tags: Dict[str, int],
+) -> None:
+    """Overlay the scratch DFBs of distinct inline sites onto shared CB indices.
+
+    Each inlined callee's body is substituted as one contiguous block, so its
+    scratch DFBs are confined to that inline site. Sibling sites are sequenced
+    by the bridge DFBs that carry data between them (a site's outputs are only
+    pushed once its scratch has quiesced, and the next site waits on those
+    outputs), so identically-configured scratch from *different* sites can share
+    a CB index / L1 allocation.
+
+    This is structural, not lifetime-based: scratch within one site stays
+    distinct (it is that atom's working set, live across its own async threads),
+    and caller-declared (bridge) DFBs are left untouched. We never consult the
+    statement order of the unified body, because after the thread split the
+    compute and data-movement statements run concurrently and that order is not
+    a runtime order.
+    """
+    if not inlined_dfb_tags:
+        return
+
+    def cfg(name: str) -> tuple:
+        d = dfbs[name]
+        return (tuple(d.shape), d.block_count, d.dtype)
+
+    bridges = [n for n in dfbs if n not in inlined_dfb_tags]
+    # site id -> CB config -> scratch names declared by that site.
+    sites: Dict[int, Dict[tuple, List[str]]] = {}
+    for name in dfbs:
+        if name not in inlined_dfb_tags:
+            continue
+        sites.setdefault(inlined_dfb_tags[name], {}).setdefault(cfg(name), []).append(
+            name
+        )
+    if not sites:
+        return
+
+    # Per config, the overlaid width is the most any single site needs; lay the
+    # configs out contiguously above the bridge DFBs.
+    cfg_width: Dict[tuple, int] = {}
+    for per_cfg in sites.values():
+        for c, names in per_cfg.items():
+            cfg_width[c] = max(cfg_width.get(c, 0), len(names))
+
+    base = len(bridges)
+    cfg_base: Dict[tuple, int] = {}
+    offset = 0
+    for c, width in cfg_width.items():
+        cfg_base[c] = base + offset
+        offset += width
+
+    # Bridges keep indices [0, base) in their original order; every site
+    # overlays the same per-config block, so slot k of one site shares an
+    # index with slot k of any sibling site of the same config.
+    for new_index, name in enumerate(sorted(bridges, key=lambda n: dfbs[n]._cb_index)):
+        dfbs[name]._cb_index = new_index
+    for per_cfg in sites.values():
+        for c, names in per_cfg.items():
+            for slot, name in enumerate(names):
+                dfbs[name]._cb_index = cfg_base[c] + slot
+
+
 def _make_thread_callable(spec, kernel_type, fn_name, body, captures):
     from .ttl_api import _run_thread_compiler
 
@@ -371,6 +439,7 @@ def _compile_atom(
     _set_current_grid(grid)
 
     stripped_fn, dfbs, nets = _lift_setup(spec.fn_ast, eval_scope)
+    _reuse_inlined_dfb_indices(dfbs, spec.inlined_dfb_tags)
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -90,7 +90,6 @@ class _AtomSpec:
     fn_ast: ast.FunctionDef  # post-inline
     params: List[_ParamInfo]
     dfb_param_names: List[str]
-    inlined_dfb_tags: Dict[str, int]  # inlined scratch DFB name -> inline site id
 
 
 def _function_scope(fn: Callable) -> Dict[str, Any]:
@@ -165,9 +164,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
 
     # Inline statement-level calls to other @ttl.atom functions, then keep
     # the post-inline AST + source.
-    inlined_dfb_tags = inline_atom_calls(
-        fn_def, _function_scope(fn), caller_name=name
-    )
+    inline_atom_calls(fn_def, _function_scope(fn), caller_name=name)
     source = ast.unparse(fn_def)
 
     params = _classify_params(fn)
@@ -180,7 +177,6 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         fn_ast=fn_def,
         params=params,
         dfb_param_names=[p.name for p in params if p.kind == "dfb"],
-        inlined_dfb_tags=inlined_dfb_tags,
     )
 
 
@@ -300,8 +296,8 @@ def _dfb_l1_elems(dfb: DataflowBuffer) -> int:
 def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
     """DataflowBuffer list indexed by CB index, matching _collect_cb_configs.
 
-    When reuse overlays several DFBs of different shapes on one index, the slot
-    must be sized to the largest member, so the biggest DFB at each index wins.
+    Indices are declaration-dense here; the finalize pass overlays scratch
+    DFBs onto shared indices in MLIR and the runtime applies its index map.
     """
     by_index: Dict[int, DataflowBuffer] = {}
     for dfb in lifted.values():
@@ -311,107 +307,6 @@ def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
     if not by_index:
         return []
     return [by_index.get(i) for i in range(max(by_index) + 1)]
-
-
-def _dfb_lifetimes(
-    body: List[ast.stmt], names: set
-) -> Tuple[Dict[str, int], Dict[str, int]]:
-    """First / last top-level statement index of the unified body that touches
-    each name.
-
-    A name used anywhere inside a top-level statement's subtree (a loop or if
-    body) is attributed to that top-level statement, so a buffer used inside a
-    loop is live for the whole loop (it is reserved and popped every iteration,
-    so across the back-edge it never frees). This mirrors the body-block
-    ancestor projection the compiler DFB pass uses.
-    """
-    first: Dict[str, int] = {}
-    last: Dict[str, int] = {}
-    for i, stmt in enumerate(body):
-        for node in ast.walk(stmt):
-            if isinstance(node, ast.Name) and node.id in names:
-                first.setdefault(node.id, i)
-                last[node.id] = i
-    return first, last
-
-
-def _reuse_inlined_dfb_indices(
-    dfbs: Dict[str, DataflowBuffer],
-    inlined_dfb_tags: Dict[str, int],
-    body: List[ast.stmt],
-) -> None:
-    """Overlay inlined-scratch DFBs onto shared CB indices by liveness.
-
-    After top-level inlining the unified body is flat, so each inlined callee's
-    scratch DFBs occupy a contiguous span of it. We interval-color the scratch
-    over its source-order live range [first, last]: only buffers whose ranges
-    are disjoint share a CB index / L1 slot. Source order is a valid sequencing
-    of the body because a DFB producer's reserve/store always precedes its
-    consumer's wait, so disjoint ranges are never simultaneously live.
-
-    A slot holds one size class (same dtype and block_count); members may differ
-    in shape, in which case the slot is sized to the largest member (see
-    _cb_configs_from_lifted). Caller-declared (bridge) DFBs carry data between
-    sites and stay distinct.
-    """
-    if not inlined_dfb_tags:
-        return
-
-    scratch = [n for n in dfbs if n in inlined_dfb_tags]
-    bridges = [n for n in dfbs if n not in inlined_dfb_tags]
-    if not scratch:
-        return
-
-    first, last = _dfb_lifetimes(body, set(scratch))
-    # A scratch DFB with no body reference is live nowhere, but it still needs a
-    # slot; treat it as live across the whole body so it never shares one.
-    for name in scratch:
-        first.setdefault(name, 0)
-        last.setdefault(name, len(body))
-
-    # Bridges keep dense low indices in their original order.
-    base = len(bridges)
-    for new_index, name in enumerate(
-        sorted(bridges, key=lambda n: dfbs[n]._cb_index)
-    ):
-        dfbs[name]._cb_index = new_index
-
-    # Linear-scan interval coloring, mirroring the compiler DFB pass: walk the
-    # scratch by ascending live-range start and place each on the lowest slot of
-    # its size class whose previous occupant has expired. Expiry is strict (a
-    # shared endpoint counts as overlap) so a producer/consumer handoff at one
-    # statement keeps both buffers distinct.
-    def size_class(name: str) -> tuple:
-        d = dfbs[name]
-        return (d.dtype, d.block_count)
-
-    slots: List[Tuple[tuple, int]] = []  # (size class, last index occupying it)
-    for name in sorted(scratch, key=lambda n: (first[n], last[n])):
-        cls = size_class(name)
-        placed = next(
-            (
-                slot
-                for slot, (slot_cls, slot_last) in enumerate(slots)
-                if slot_cls == cls and slot_last < first[name]
-            ),
-            None,
-        )
-        if placed is None:
-            placed = len(slots)
-            slots.append((cls, last[name]))
-        else:
-            slots[placed] = (cls, last[name])
-        dfbs[name]._cb_index = base + placed
-
-    if os.environ.get("TTLANG_DFB_REUSE_DEBUG"):
-        groups: Dict[int, List[str]] = {}
-        for name in scratch:
-            groups.setdefault(dfbs[name]._cb_index, []).append(name)
-        for idx in sorted(groups):
-            spans = ", ".join(
-                f"{n}[{first[n]},{last[n]}]" for n in groups[idx]
-            )
-            print(f"[dfb-reuse] cb{idx}: {spans}")
 
 
 def _make_thread_callable(spec, kernel_type, fn_name, body, captures):
@@ -492,7 +387,6 @@ def _compile_atom(
     _set_current_grid(grid)
 
     stripped_fn, dfbs, nets = _lift_setup(spec.fn_ast, eval_scope)
-    _reuse_inlined_dfb_indices(dfbs, spec.inlined_dfb_tags, stripped_fn.body)
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -289,76 +289,129 @@ def _synthesize_thread_module(fn_name: str, body: List[ast.stmt]) -> ast.Module:
     return ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
 
 
+def _dfb_l1_elems(dfb: DataflowBuffer) -> int:
+    """Total tiles a DFB occupies in L1 (per-block elements x block_count)."""
+    n = dfb.block_count
+    for s in dfb.shape:
+        n *= s
+    return n
+
+
 def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
-    """DataflowBuffer list indexed by CB index, matching _collect_cb_configs."""
-    by_index = {dfb._cb_index: dfb for dfb in lifted.values()}
+    """DataflowBuffer list indexed by CB index, matching _collect_cb_configs.
+
+    When reuse overlays several DFBs of different shapes on one index, the slot
+    must be sized to the largest member, so the biggest DFB at each index wins.
+    """
+    by_index: Dict[int, DataflowBuffer] = {}
+    for dfb in lifted.values():
+        cur = by_index.get(dfb._cb_index)
+        if cur is None or _dfb_l1_elems(dfb) > _dfb_l1_elems(cur):
+            by_index[dfb._cb_index] = dfb
     if not by_index:
         return []
     return [by_index.get(i) for i in range(max(by_index) + 1)]
 
 
+def _dfb_lifetimes(
+    body: List[ast.stmt], names: set
+) -> Tuple[Dict[str, int], Dict[str, int]]:
+    """First / last top-level statement index of the unified body that touches
+    each name.
+
+    A name used anywhere inside a top-level statement's subtree (a loop or if
+    body) is attributed to that top-level statement, so a buffer used inside a
+    loop is live for the whole loop (it is reserved and popped every iteration,
+    so across the back-edge it never frees). This mirrors the body-block
+    ancestor projection the compiler DFB pass uses.
+    """
+    first: Dict[str, int] = {}
+    last: Dict[str, int] = {}
+    for i, stmt in enumerate(body):
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Name) and node.id in names:
+                first.setdefault(node.id, i)
+                last[node.id] = i
+    return first, last
+
+
 def _reuse_inlined_dfb_indices(
     dfbs: Dict[str, DataflowBuffer],
     inlined_dfb_tags: Dict[str, int],
+    body: List[ast.stmt],
 ) -> None:
-    """Overlay the scratch DFBs of distinct inline sites onto shared CB indices.
+    """Overlay inlined-scratch DFBs onto shared CB indices by liveness.
 
-    Each inlined callee's body is substituted as one contiguous block, so its
-    scratch DFBs are confined to that inline site. Sibling sites are sequenced
-    by the bridge DFBs that carry data between them (a site's outputs are only
-    pushed once its scratch has quiesced, and the next site waits on those
-    outputs), so identically-configured scratch from *different* sites can share
-    a CB index / L1 allocation.
+    After top-level inlining the unified body is flat, so each inlined callee's
+    scratch DFBs occupy a contiguous span of it. We interval-color the scratch
+    over its source-order live range [first, last]: only buffers whose ranges
+    are disjoint share a CB index / L1 slot. Source order is a valid sequencing
+    of the body because a DFB producer's reserve/store always precedes its
+    consumer's wait, so disjoint ranges are never simultaneously live.
 
-    This is structural, not lifetime-based: scratch within one site stays
-    distinct (it is that atom's working set, live across its own async threads),
-    and caller-declared (bridge) DFBs are left untouched. We never consult the
-    statement order of the unified body, because after the thread split the
-    compute and data-movement statements run concurrently and that order is not
-    a runtime order.
+    A slot holds one size class (same dtype and block_count); members may differ
+    in shape, in which case the slot is sized to the largest member (see
+    _cb_configs_from_lifted). Caller-declared (bridge) DFBs carry data between
+    sites and stay distinct.
     """
     if not inlined_dfb_tags:
         return
 
-    def cfg(name: str) -> tuple:
-        d = dfbs[name]
-        return (tuple(d.shape), d.block_count, d.dtype)
-
+    scratch = [n for n in dfbs if n in inlined_dfb_tags]
     bridges = [n for n in dfbs if n not in inlined_dfb_tags]
-    # site id -> CB config -> scratch names declared by that site.
-    sites: Dict[int, Dict[tuple, List[str]]] = {}
-    for name in dfbs:
-        if name not in inlined_dfb_tags:
-            continue
-        sites.setdefault(inlined_dfb_tags[name], {}).setdefault(cfg(name), []).append(
-            name
-        )
-    if not sites:
+    if not scratch:
         return
 
-    # Per config, the overlaid width is the most any single site needs; lay the
-    # configs out contiguously above the bridge DFBs.
-    cfg_width: Dict[tuple, int] = {}
-    for per_cfg in sites.values():
-        for c, names in per_cfg.items():
-            cfg_width[c] = max(cfg_width.get(c, 0), len(names))
+    first, last = _dfb_lifetimes(body, set(scratch))
+    # A scratch DFB with no body reference is live nowhere, but it still needs a
+    # slot; treat it as live across the whole body so it never shares one.
+    for name in scratch:
+        first.setdefault(name, 0)
+        last.setdefault(name, len(body))
 
+    # Bridges keep dense low indices in their original order.
     base = len(bridges)
-    cfg_base: Dict[tuple, int] = {}
-    offset = 0
-    for c, width in cfg_width.items():
-        cfg_base[c] = base + offset
-        offset += width
-
-    # Bridges keep indices [0, base) in their original order; every site
-    # overlays the same per-config block, so slot k of one site shares an
-    # index with slot k of any sibling site of the same config.
-    for new_index, name in enumerate(sorted(bridges, key=lambda n: dfbs[n]._cb_index)):
+    for new_index, name in enumerate(
+        sorted(bridges, key=lambda n: dfbs[n]._cb_index)
+    ):
         dfbs[name]._cb_index = new_index
-    for per_cfg in sites.values():
-        for c, names in per_cfg.items():
-            for slot, name in enumerate(names):
-                dfbs[name]._cb_index = cfg_base[c] + slot
+
+    # Linear-scan interval coloring, mirroring the compiler DFB pass: walk the
+    # scratch by ascending live-range start and place each on the lowest slot of
+    # its size class whose previous occupant has expired. Expiry is strict (a
+    # shared endpoint counts as overlap) so a producer/consumer handoff at one
+    # statement keeps both buffers distinct.
+    def size_class(name: str) -> tuple:
+        d = dfbs[name]
+        return (d.dtype, d.block_count)
+
+    slots: List[Tuple[tuple, int]] = []  # (size class, last index occupying it)
+    for name in sorted(scratch, key=lambda n: (first[n], last[n])):
+        cls = size_class(name)
+        placed = next(
+            (
+                slot
+                for slot, (slot_cls, slot_last) in enumerate(slots)
+                if slot_cls == cls and slot_last < first[name]
+            ),
+            None,
+        )
+        if placed is None:
+            placed = len(slots)
+            slots.append((cls, last[name]))
+        else:
+            slots[placed] = (cls, last[name])
+        dfbs[name]._cb_index = base + placed
+
+    if os.environ.get("TTLANG_DFB_REUSE_DEBUG"):
+        groups: Dict[int, List[str]] = {}
+        for name in scratch:
+            groups.setdefault(dfbs[name]._cb_index, []).append(name)
+        for idx in sorted(groups):
+            spans = ", ".join(
+                f"{n}[{first[n]},{last[n]}]" for n in groups[idx]
+            )
+            print(f"[dfb-reuse] cb{idx}: {spans}")
 
 
 def _make_thread_callable(spec, kernel_type, fn_name, body, captures):
@@ -439,7 +492,7 @@ def _compile_atom(
     _set_current_grid(grid)
 
     stripped_fn, dfbs, nets = _lift_setup(spec.fn_ast, eval_scope)
-    _reuse_inlined_dfb_indices(dfbs, spec.inlined_dfb_tags)
+    _reuse_inlined_dfb_indices(dfbs, spec.inlined_dfb_tags, stripped_fn.body)
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -91,16 +91,6 @@ def _make_parser() -> argparse.ArgumentParser:
         help="Insert compiler-allocated intermediate DFBs for fused computations (default: enabled).",
     )
     p.add_argument(
-        "--ttl-relax-dfb-spsc",
-        default=None,
-        dest="relax_dfb_spsc",
-        action=argparse.BooleanOptionalAction,
-        help="Skip the single-producer/single-consumer DFB verifier, allowing a "
-        "DFB to be produced/consumed across threads when guards make the accesses "
-        "mutually exclusive (default: disabled). Unsafe in general -- the kernel "
-        "author is responsible for the cross-thread correctness the verifier checks.",
-    )
-    p.add_argument(
         "--ttl-l1-budget",
         default=None,
         dest="l1_budget",
@@ -155,7 +145,6 @@ class CompilerOptions:
     matmul_full_fp32: bool = True
     strict_f32_acc: bool = False
     compiler_dfbs: bool = True
-    relax_dfb_spsc: bool = False
     l1_budget: int = dataclasses.field(default=0, compare=False, hash=False)
 
     # Fields that were explicitly provided (not defaulted). Excluded from

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -91,6 +91,16 @@ def _make_parser() -> argparse.ArgumentParser:
         help="Insert compiler-allocated intermediate DFBs for fused computations (default: enabled).",
     )
     p.add_argument(
+        "--ttl-relax-dfb-spsc",
+        default=None,
+        dest="relax_dfb_spsc",
+        action=argparse.BooleanOptionalAction,
+        help="Skip the single-producer/single-consumer DFB verifier, allowing a "
+        "DFB to be produced/consumed across threads when guards make the accesses "
+        "mutually exclusive (default: disabled). Unsafe in general -- the kernel "
+        "author is responsible for the cross-thread correctness the verifier checks.",
+    )
+    p.add_argument(
         "--ttl-l1-budget",
         default=None,
         dest="l1_budget",
@@ -145,6 +155,7 @@ class CompilerOptions:
     matmul_full_fp32: bool = True
     strict_f32_acc: bool = False
     compiler_dfbs: bool = True
+    relax_dfb_spsc: bool = False
     l1_budget: int = dataclasses.field(default=0, compare=False, hash=False)
 
     # Fields that were explicitly provided (not defaulted). Excluded from

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -38,13 +38,20 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
         k_cb = ttl.make_dataflow_buffer_like(k, shape=(Sk_chunk_t, DHt), block_count=2)
         v_cb = ttl.make_dataflow_buffer_like(k, shape=(Sk_chunk_t, vDHt), block_count=2)
 
+        # These four stay explicit because their consumers are not DFB-input
+        # ops, so the compiler cannot back them with implicit intermediates:
+        # sv feeds reduce_max then a later exp, alpha feeds the l rescale then a
+        # later o rescale (both second uses elementwise), and red_cb's reduce
+        # results feed max/add binary combines. pv backs the ex @ v result that
+        # the elementwise o update consumes. red_cb carries chunk_max then
+        # chunk_sum (disjoint lifetimes). The exp(sv - max) result is left as
+        # plain SSA: it feeds reduce_sum and the ex @ v matmul, both DFB-input
+        # ops, so the compiler materializes it into one shared intermediate DFB.
         sv_cb        = ttl.make_dfb("bf16", shape=(PNHt, Sk_chunk_t), block_count=2)
         ex_cb        = ttl.make_dfb("bf16", shape=(PNHt, Sk_chunk_t), block_count=2)
-        # Two (PNHt, 1) scratch slots cycled across the per-chunk stats: stat_a
-        # carries chunk_max, then m_new, then chunk_sum (their lifetimes are
-        # disjoint); stat_b carries alpha, which overlaps all three.
-        stat_a       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
-        stat_b       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
+        red_cb       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
+        mn_cb        = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
+        alpha_cb     = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
         pv_cb        = ttl.make_dfb("bf16", shape=(PNHt, vDHt),       block_count=2)
 
         m_state_cb   = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
@@ -71,20 +78,19 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
                                ttl.block.fill(scale, shape=sv_w.shape)))
 
             sv = sv_cb.wait()
-            cm_w = stat_a.reserve()
-            cm_w.store(ttl.math.reduce_max(sv, dims=[1]))
+            cm_w = red_cb.reserve(); cm_w.store(ttl.math.reduce_max(sv, dims=[1]))
             sv_re = sv_cb.reserve(); sv_re.store(sv)
 
             m_old = m_state_cb.wait()
-            cm = stat_a.wait()
-            mn_w = stat_a.reserve(); mn_w.store(ttl.math.max(m_old, cm))
+            cm = red_cb.wait()
+            mn_w = mn_cb.reserve(); mn_w.store(ttl.math.max(m_old, cm))
 
-            mn_for_alpha = stat_a.wait()
-            alpha_w = stat_b.reserve()
+            mn_for_alpha = mn_cb.wait()
+            alpha_w = alpha_cb.reserve()
             alpha_w.store(ttl.exp(ttl.sub(m_old, mn_for_alpha)))
-            mn_re = stat_a.reserve(); mn_re.store(mn_for_alpha)
+            mn_re = mn_cb.reserve(); mn_re.store(mn_for_alpha)
 
-            mn_for_state = stat_a.wait()
+            mn_for_state = mn_cb.wait()
             sv2 = sv_cb.wait()
             ex_w = ex_cb.reserve()
             ex_w.store(ttl.exp(ttl.sub(sv2, ttl.block.broadcast(
@@ -92,24 +98,22 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
             m_next = m_state_cb.reserve(); m_next.store(mn_for_state)
 
             ex = ex_cb.wait()
-            cs_w = stat_a.reserve()
-            cs_w.store(ttl.math.reduce_sum(ex, dims=[1]))
+            cs_w = red_cb.reserve(); cs_w.store(ttl.math.reduce_sum(ex, dims=[1]))
             ex_re = ex_cb.reserve(); ex_re.store(ex)
 
-            alpha = stat_b.wait()
+            alpha = alpha_cb.wait()
             l_old = l_state_cb.wait()
-            cs = stat_a.wait()
+            cs = red_cb.wait()
             l_next = l_state_cb.reserve()
             l_next.store(ttl.add(ttl.mul(alpha, l_old), cs))
-            alpha_re = stat_b.reserve(); alpha_re.store(alpha)
-
-            alpha2 = stat_b.wait()
-            o_old = o_state_cb.wait()
+            alpha_re = alpha_cb.reserve(); alpha_re.store(alpha)
 
             ex2 = ex_cb.wait()
             v_blk = ttl.math.typecast(v_cb.wait(), torch.bfloat16)
             pv_w = pv_cb.reserve(); pv_w.store(ex2 @ v_blk)
 
+            alpha2 = alpha_cb.wait()
+            o_old = o_state_cb.wait()
             pv_blk = pv_cb.wait()
             o_next = o_state_cb.reserve()
             o_next.store(ttl.add(ttl.mul(ttl.block.broadcast(
@@ -398,33 +402,41 @@ def make_flash_mla(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
     reduce = make_flash_tree_reduce_core(PNHt, vDHt, B)
     normalize = make_flash_normalize_core(PNHt, vDHt)
 
-    @ttl.atom(grid=(n_cols, B), options="--ttl-relax-dfb-spsc")
-    def flash_mla(q, k, v, norm_out):
-        col_c, row_c = ttl.node(dims=2)
-
+    # The fused kernel is two inline sites bridged by (so, sm, sl): the first
+    # multicasts q and computes this core's shard partial, the second tree-
+    # reduces the partials and normalizes. q_stage/q_recv live only in the first
+    # site and the merged-stat scratch only in the second, so their L1 collapses
+    # across the two sites; only the bridges stay at the fused top level.
+    @ttl.atom()
+    def q_shard(q, k, v, o_out: ttl.DFB, m_out: ttl.DFB, l_out: ttl.DFB):
         q_net = ttl.PipeNet(mcast_rows(B, n_cols))
         q_stage = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
         q_recv = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+        mcast(q_net, q[0:PNHt, 0:DHt], q_stage, q_recv)
+        shard(q_recv, k, v, o_out, m_out, l_out)
 
+    @ttl.atom()
+    def reduce_norm(o_in: ttl.DFB, m_in: ttl.DFB, l_in: ttl.DFB, norm_out):
+        col_c, row_c = ttl.node(dims=2)
+        to = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
+        tl = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+        # nout gets its own DFB: the datamovement drain below waits it on
+        # NCRISC, and aliasing it onto the unnormalized partial lets NCRISC read
+        # the wrong tile under the relaxed SPSC guard.
+        nout = ttl.make_dataflow_buffer_like(norm_out, shape=(PNHt, vDHt), block_count=2)
+        reduce(o_in, m_in, l_in, to, tl)
+        normalize(to, tl, nout)
+        if col_c == 0:
+            ttl.copy(nout.wait(), norm_out[row_c * PNHt:row_c * PNHt + PNHt, 0:vDHt])
+
+    @ttl.atom(grid=(n_cols, B), options="--ttl-relax-dfb-spsc")
+    def flash_mla(q, k, v, norm_out):
         # shard -> tree bridges (this core's own partial)
         so = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt), block_count=2)
         sm = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
         sl = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
-        # tree -> normalize bridges (merged, column 0 only)
-        to = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
-        tl = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
-        # Normalize gets its own output DFB: the datamovement drain below waits
-        # it on NCRISC, and aliasing it onto `so` (still carrying the
-        # unnormalized partial through the compute-side reduce) lets NCRISC read
-        # the wrong tile under the relaxed SPSC guard.
-        nout = ttl.make_dataflow_buffer_like(norm_out, shape=(PNHt, vDHt), block_count=2)
 
-        mcast(q_net, q[0:PNHt, 0:DHt], q_stage, q_recv)
-        shard(q_recv, k, v, so, sm, sl)
-        reduce(so, sm, sl, to, tl)
-        normalize(to, tl, nout)
-
-        if col_c == 0:
-            ttl.copy(nout.wait(), norm_out[row_c * PNHt:row_c * PNHt + PNHt, 0:vDHt])
+        q_shard(q, k, v, so, sm, sl)
+        reduce_norm(so, sm, sl, norm_out)
 
     return flash_mla

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -5,68 +5,51 @@
 """Flash MLA decode ops: a per-core online-softmax shard, an 8-core tree
 reduce that merges the per-core partials, and a normalize tail.
 
-Each op is a standalone @ttl.atom factory parametrized by tile shapes. A
-shard core runs flash attention over its slice of the K/V sequence and
-emits an unnormalized (o, m, l) partial; the tree reduce merges the
-``n_cols`` partials of each batch row with the flash online-softmax
-rescale; normalize divides by the running sum.
+Each phase is split into an inlinable **core** atom whose boundary buffers are
+``ttl.DFB`` params (pure compute, no DRAM) and a thin **wrapper** atom that
+stages DRAM <-> DFB and inlines the core. The wrappers are the standalone ops;
+``make_flash_mla`` fuses all three cores into one kernel, moving every
+inter-phase value through DFBs (q is multicast, partials and merged stats never
+touch DRAM) instead of round-tripping DRAM between separate launches.
 """
 
 import torch
 
 import ttl
+from ttl.ops.mcast import mcast, mcast_rows
 from ttl.ops.pipe_util import pipe_send, pipe_recv
 
 
-def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
-    """Per-core flash attention over a K-dim split.
+def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
+    """Per-core flash attention over a K-dim split, as an inlinable core.
 
-    The grid is ``(n_cols, B)``: column ``col_c`` owns the K/V slice
-    starting at ``col_c * Sk_chunk_t * N_CHUNKS`` tiles, row ``row_c`` is
-    the batch. Q is read from DRAM on every core; K/V are read per-core.
-    Each core writes an unnormalized ``(o, m, l)`` partial to its row
-    block of ``out_o`` / ``out_m`` / ``out_l``.
-
-    K/V are typecast to bf16 before the matmuls so a lower-precision cache
-    (e.g. bfp8) feeds the bf16 compute chain; the cast is a no-op when K/V
-    are already bf16.
-
-    ``scale`` is the SDPA scale; it is folded into ``qk`` per chunk.
+    ``q`` arrives in the ``q_in`` DFB (multicast or staged by the wrapper);
+    K/V are read per-core from DRAM and typecast to bf16 before the matmuls so
+    a bfp8 cache feeds the bf16 chain. The unnormalized ``(o, m, l)`` partial is
+    pushed to the ``o_out`` / ``m_out`` / ``l_out`` DFBs (the caller drains or
+    consumes them). ``scale`` is folded into ``qk`` per chunk.
     """
     St_per_core = Sk_chunk_t * N_CHUNKS
 
-    @ttl.atom(grid=(n_cols, B))
-    def flash_shard(q, k, v, out_o, out_m, out_l):
+    @ttl.atom()
+    def flash_shard_core(q_in: ttl.DFB, k, v, o_out: ttl.DFB, m_out: ttl.DFB, l_out: ttl.DFB):
         col_c, row_c = ttl.node(dims=2)
 
-        q_cb = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
         k_cb = ttl.make_dataflow_buffer_like(k, shape=(Sk_chunk_t, DHt), block_count=2)
         v_cb = ttl.make_dataflow_buffer_like(k, shape=(Sk_chunk_t, vDHt), block_count=2)
 
-        sv_cb        = ttl.make_dataflow_buffer_like(q, shape=(PNHt, Sk_chunk_t), block_count=2)
-        ex_cb        = ttl.make_dataflow_buffer_like(q, shape=(PNHt, Sk_chunk_t), block_count=2)
-        chunk_max_cb = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
-        chunk_sum_cb = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
-        alpha_cb     = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
-        m_new_cb     = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),          block_count=2)
-        o_corr_cb    = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt),       block_count=2)
-        pv_cb        = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt),       block_count=2)
+        sv_cb        = ttl.make_dfb("bf16", shape=(PNHt, Sk_chunk_t), block_count=2)
+        ex_cb        = ttl.make_dfb("bf16", shape=(PNHt, Sk_chunk_t), block_count=2)
+        # Two (PNHt, 1) scratch slots cycled across the per-chunk stats: stat_a
+        # carries chunk_max, then m_new, then chunk_sum (their lifetimes are
+        # disjoint); stat_b carries alpha, which overlaps all three.
+        stat_a       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
+        stat_b       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
+        pv_cb        = ttl.make_dfb("bf16", shape=(PNHt, vDHt),       block_count=2)
 
-        m_state_cb   = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),    block_count=2)
-        l_state_cb   = ttl.make_dataflow_buffer_like(q, shape=(PNHt, 1),    block_count=2)
-        o_state_cb   = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt), block_count=2)
-
-        # Dedicated single-push output CBs: the compute thread waits the
-        # state CBs and stores the finals here; the datamovement thread waits
-        # these to copy to DRAM. We could copy each state CB straight to DRAM,
-        # but then the state CB would be waited on the datamovement thread too
-        # and the SPSC verifier rejects that cross-thread second consumer.
-        out_o_cb = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
-        out_m_cb = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1),    block_count=2)
-        out_l_cb = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1),    block_count=2)
-
-        qd = q_cb.reserve()
-        ttl.copy(q[0:PNHt, 0:DHt], qd)
+        m_state_cb   = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
+        l_state_cb   = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
+        o_state_cb   = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
 
         k_base = col_c * St_per_core
         for c in range(N_CHUNKS):
@@ -80,7 +63,7 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
         l0 = l_state_cb.reserve(); l0.store(ttl.block.fill(0.0,   shape=l0.shape))
         o0 = o_state_cb.reserve(); o0.store(ttl.block.fill(0.0,   shape=o0.shape))
 
-        q_blk = q_cb.wait()
+        q_blk = q_in.wait()
         for _ in range(N_CHUNKS):
             k_blk = ttl.math.typecast(k_cb.wait(), torch.bfloat16)
             sv_w = sv_cb.reserve()
@@ -88,20 +71,20 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
                                ttl.block.fill(scale, shape=sv_w.shape)))
 
             sv = sv_cb.wait()
-            cm_w = chunk_max_cb.reserve()
+            cm_w = stat_a.reserve()
             cm_w.store(ttl.math.reduce_max(sv, dims=[1]))
             sv_re = sv_cb.reserve(); sv_re.store(sv)
 
             m_old = m_state_cb.wait()
-            cm = chunk_max_cb.wait()
-            mn_w = m_new_cb.reserve(); mn_w.store(ttl.math.max(m_old, cm))
+            cm = stat_a.wait()
+            mn_w = stat_a.reserve(); mn_w.store(ttl.math.max(m_old, cm))
 
-            mn_for_alpha = m_new_cb.wait()
-            alpha_w = alpha_cb.reserve()
+            mn_for_alpha = stat_a.wait()
+            alpha_w = stat_b.reserve()
             alpha_w.store(ttl.exp(ttl.sub(m_old, mn_for_alpha)))
-            mn_re = m_new_cb.reserve(); mn_re.store(mn_for_alpha)
+            mn_re = stat_a.reserve(); mn_re.store(mn_for_alpha)
 
-            mn_for_state = m_new_cb.wait()
+            mn_for_state = stat_a.wait()
             sv2 = sv_cb.wait()
             ex_w = ex_cb.reserve()
             ex_w.store(ttl.exp(ttl.sub(sv2, ttl.block.broadcast(
@@ -109,85 +92,151 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
             m_next = m_state_cb.reserve(); m_next.store(mn_for_state)
 
             ex = ex_cb.wait()
-            cs_w = chunk_sum_cb.reserve()
+            cs_w = stat_a.reserve()
             cs_w.store(ttl.math.reduce_sum(ex, dims=[1]))
             ex_re = ex_cb.reserve(); ex_re.store(ex)
 
-            alpha = alpha_cb.wait()
+            alpha = stat_b.wait()
             l_old = l_state_cb.wait()
-            cs = chunk_sum_cb.wait()
+            cs = stat_a.wait()
             l_next = l_state_cb.reserve()
             l_next.store(ttl.add(ttl.mul(alpha, l_old), cs))
-            alpha_re = alpha_cb.reserve(); alpha_re.store(alpha)
+            alpha_re = stat_b.reserve(); alpha_re.store(alpha)
 
-            alpha2 = alpha_cb.wait()
+            alpha2 = stat_b.wait()
             o_old = o_state_cb.wait()
-            o_corr_w = o_corr_cb.reserve()
-            o_corr_w.store(ttl.mul(ttl.block.broadcast(
-                alpha2, dims=[1], shape=o_old.shape), o_old))
 
             ex2 = ex_cb.wait()
             v_blk = ttl.math.typecast(v_cb.wait(), torch.bfloat16)
             pv_w = pv_cb.reserve(); pv_w.store(ex2 @ v_blk)
 
-            o_corr_blk = o_corr_cb.wait()
             pv_blk = pv_cb.wait()
             o_next = o_state_cb.reserve()
-            o_next.store(ttl.add(o_corr_blk, pv_blk))
+            o_next.store(ttl.add(ttl.mul(ttl.block.broadcast(
+                alpha2, dims=[1], shape=o_old.shape), o_old), pv_blk))
+
+        m_final = m_state_cb.wait()
+        mo = m_out.reserve(); mo.store(m_final)
+        l_final = l_state_cb.wait()
+        lo = l_out.reserve(); lo.store(l_final)
+        o_final = o_state_cb.wait()
+        oo = o_out.reserve(); oo.store(o_final)
+
+    return flash_shard_core
+
+
+def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
+    """Standalone shard: q is multicast (col 0 reads DRAM, broadcasts to all
+    columns), the core computes the per-core partial, and the wrapper drains it
+    to ``out_o`` / ``out_m`` / ``out_l`` DRAM."""
+    core = make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale)
+
+    @ttl.atom(grid=(n_cols, B))
+    def flash_shard(q, k, v, out_o, out_m, out_l):
+        col_c, row_c = ttl.node(dims=2)
+
+        q_net = ttl.PipeNet(mcast_rows(B, n_cols))
+        q_stage = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+        q_recv = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+        o_b = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
+        m_b = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1), block_count=2)
+        l_b = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1), block_count=2)
+
+        mcast(q_net, q[0:PNHt, 0:DHt], q_stage, q_recv)
+        core(q_recv, k, v, o_b, m_b, l_b)
 
         base = (row_c * n_cols + col_c) * PNHt
-        m_final = m_state_cb.wait()
-        mo = out_m_cb.reserve(); mo.store(m_final)
-        ttl.copy(out_m_cb.wait(), out_m[base:base + PNHt, 0:1])
-        l_final = l_state_cb.wait()
-        lo = out_l_cb.reserve(); lo.store(l_final)
-        ttl.copy(out_l_cb.wait(), out_l[base:base + PNHt, 0:1])
-        o_final = o_state_cb.wait()
-        oo = out_o_cb.reserve(); oo.store(o_final)
-        ttl.copy(out_o_cb.wait(), out_o[base:base + PNHt, 0:vDHt])
+        ttl.copy(m_b.wait(), out_m[base:base + PNHt, 0:1])
+        ttl.copy(l_b.wait(), out_l[base:base + PNHt, 0:1])
+        ttl.copy(o_b.wait(), out_o[base:base + PNHt, 0:vDHt])
 
     return flash_shard
 
 
-def make_flash_normalize(grid, PNHt, vDHt):
-    """Finalize flash output: ``o_norm = o_unnorm / l``.
+def make_flash_normalize_core(PNHt, vDHt):
+    """Finalize flash output ``o_norm = o_unnorm / l`` on column 0, as a core.
 
-    ``l`` is broadcast from ``(PNHt, 1)`` to ``(PNHt, vDHt)`` and applied
-    via reciprocal + multiply.
+    ``o_in`` / ``l_in`` carry the merged unnormalized output and running sum;
+    only column 0 holds them (the reduce roots there), so the work is guarded.
     """
+
+    @ttl.atom()
+    def flash_normalize_core(o_in: ttl.DFB, l_in: ttl.DFB, o_out: ttl.DFB):
+        col_c, row_c = ttl.node(dims=2)
+        if col_c == 0:
+            o = o_in.wait()
+            l = l_in.wait()
+            l_recip_bc = ttl.block.broadcast(
+                ttl.math.recip(l), dims=[1], shape=o.shape,
+            )
+            ow = o_out.reserve()
+            ow.store(ttl.mul(o, l_recip_bc))
+
+    return flash_normalize_core
+
+
+def make_flash_normalize(grid, PNHt, vDHt):
+    """Standalone normalize: stage ``o`` / ``l`` from DRAM, run the core, drain
+    the normalized output to DRAM."""
+    core = make_flash_normalize_core(PNHt, vDHt)
 
     @ttl.atom(grid=grid)
     def flash_normalize(o_in, l_in, o_out):
         col_c, row_c = ttl.node(dims=2)
         base = row_c * PNHt
 
-        o_cb = ttl.make_dataflow_buffer_like(o_in, shape=(PNHt, vDHt), block_count=2)
-        l_cb = ttl.make_dataflow_buffer_like(l_in, shape=(PNHt, 1),    block_count=2)
-        out_cb = ttl.make_dataflow_buffer_like(o_out, shape=(PNHt, vDHt), block_count=2)
+        o_b = ttl.make_dataflow_buffer_like(o_in, shape=(PNHt, vDHt), block_count=2)
+        l_b = ttl.make_dataflow_buffer_like(l_in, shape=(PNHt, 1), block_count=2)
+        out_b = ttl.make_dataflow_buffer_like(o_out, shape=(PNHt, vDHt), block_count=2)
 
-        od = o_cb.reserve(); ttl.copy(o_in[base:base + PNHt, 0:vDHt], od)
-        ld = l_cb.reserve(); ttl.copy(l_in[base:base + PNHt, 0:1], ld)
+        od = o_b.reserve(); ttl.copy(o_in[base:base + PNHt, 0:vDHt], od)
+        ld = l_b.reserve(); ttl.copy(l_in[base:base + PNHt, 0:1], ld)
 
-        o = o_cb.wait()
-        l = l_cb.wait()
-        l_recip_bc = ttl.block.broadcast(
-            ttl.math.recip(l), dims=[1], shape=o.shape,
-        )
-        ow = out_cb.reserve()
-        ow.store(ttl.mul(o, l_recip_bc))
-        o_blk = out_cb.wait()
-        ttl.copy(o_blk, o_out[base:base + PNHt, 0:vDHt])
+        core(o_b, l_b, out_b)
+
+        ttl.copy(out_b.wait(), o_out[base:base + PNHt, 0:vDHt])
 
     return flash_normalize
 
 
-def make_flash_tree_reduce(PNHt, vDHt, B=1):
-    """8-core 3-step intra-row tree reduce, replicated across ``B`` rows.
+"""
+                           ┌──────────────────────────────┐
+                           │  q  (read ONCE from DRAM,    │
+                           │      column 0)               │
+                           └───────────────┬──────────────┘
+                                           │   M U L T I C A S T  (1 → 8)
+          ┌──────┬──────┬──────┬──────┬────┴─┬──────┬──────┬──────┐
+          ▼      ▼      ▼      ▼      ▼      ▼      ▼      ▼      ▼
+        ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐
+        │ c0 │ │ c1 │ │ c2 │ │ c3 │ │ c4 │ │ c5 │ │ c6 │ │ c7 │   each column owns a
+        └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘   slice of the K/V
+          │      │      │      │      │      │      │      │       sequence and computes
+          │      │      │      │      │      │      │      │       a partial (m,l,o) =
+          ▼      ▼      ▼      ▼      ▼      ▼      ▼      ▼       flash(q, Kᵢ, Vᵢ)
 
-    Grid is ``(8, B)``: ``col_c`` is the partial column, ``row_c`` the
-    batch row. Each row independently merges its 8 ``(m, l, o)`` partials
-    with the flash online-softmax rescale. On ``col_c == 0`` the merged
-    unnormalized ``(o, m, l)`` is written to the row block of the outputs.
+  Then the partials collapse to column 0 with unicast pipes — odd→even, then quarter, then half:
+
+     c0     c1     c2     c3     c4     c5     c6     c7
+      │      │      │      │      │      │      │      │
+      │◄─────┘      │◄─────┘      │◄─────┘      │◄─────┘     step 0 (unicast):
+      │             │             │             │             1→0  3→2  5→4  7→6
+      │             │             │             │
+      │◄────────────┘             │◄────────────┘            step 1 (unicast):
+      │                           │                           2→0       6→4
+      │                           │
+      │◄──────────────────────────┘                          step 2 (unicast):
+      │                                                        4→0
+      ▼
+    (m,l,o) fully merged on c0  ──►  normalize (o / l)  ──►  output
+"""
+
+def make_flash_tree_reduce_core(PNHt, vDHt, B=1):
+    """8-core 3-step intra-row tree reduce as a core: each core's ``(o, m, l)``
+    partial arrives in the ``*_in`` DFBs, peers are exchanged over PipeNets, and
+    column 0 pushes the merged unnormalized ``(o, l)`` to ``o_out`` / ``l_out``.
+
+    The running max is consumed internally for the rescale but not emitted (the
+    normalized output needs only ``o`` and ``l``).
     """
 
     @ttl.atom()
@@ -226,8 +275,11 @@ def make_flash_tree_reduce(PNHt, vDHt, B=1):
         pipe_send(l_net, l_state)
         pipe_send(o_net, o_state)
 
-    @ttl.atom(grid=(8, B))
-    def flash_tree_reduce(in_o, in_m, in_l, out_o, out_m, out_l):
+    @ttl.atom()
+    def flash_tree_reduce_core(
+        o_in: ttl.DFB, m_in: ttl.DFB, l_in: ttl.DFB,
+        o_out: ttl.DFB, l_out: ttl.DFB,
+    ):
         col_c, row_c = ttl.node(dims=2)
 
         s0_m = ttl.PipeNet([ttl.Pipe(src=(2 * i + 1, b), dst=(2 * i, b)) for b in range(B) for i in range(4)])
@@ -240,88 +292,46 @@ def make_flash_tree_reduce(PNHt, vDHt, B=1):
         s2_l = ttl.PipeNet([ttl.Pipe(src=(4, b), dst=(0, b)) for b in range(B)])
         s2_o = ttl.PipeNet([ttl.Pipe(src=(4, b), dst=(0, b)) for b in range(B)])
 
-        # A single (m, l, o) DFB per stage would suffice: every wait is
-        # sequential and a core only ever plays one role. But the SPSC
-        # verifier counts a DFB's waits across all threads of the kernel, and
-        # the same stage buffer is consumed by the recv path on the compute
-        # thread and by the send path on the datamovement thread. We split
-        # each stage buffer into a recv-side (`_rx`, compute consumer) and a
-        # send-side (`_tx`, datamovement consumer) copy so each has a single
-        # consumer thread; each recv routes its result into the copy whose
-        # thread matches the next stage's consumer.
-        #
-        # TODO: these could be substantially reduced (to just 3 dfbs) if the
-        # verifier was smarter about what actually might cause a race.
-        m_rx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        l_rx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        o_rx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
-        m_tx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        l_tx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        o_tx0 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
-        m_rx1 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        l_rx1 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        o_rx1 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
-        m_rx2 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        l_rx2 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        o_rx2 = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
-        # Send-side buffer for stages 1 and 2: both are compute-produced and
-        # datamovement-consumed, and no single core sends in both stages, so
-        # they share one DFB (keeps us under the 32 hardware DFB limit).
-        m_txc = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        l_txc = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=2)
-        o_txc = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
+        # With the SPSC verifier relaxed (--ttl-relax-dfb-spsc), each stage's
+        # working buffer can feed either the next compute-recv or the
+        # datamovement-send -- the role guards make those mutually exclusive per
+        # core -- so we keep one (m,l,o) buffer per stage instead of the
+        # recv-side/send-side split that the verifier would otherwise require.
+        m_s0 = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
+        l_s0 = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
+        o_s0 = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
+        m_s1 = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
+        l_s1 = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
+        o_s1 = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
 
-        # Peer DFBs receive the partner's partial and are reused across all
-        # 3 steps; block_count=3 = one slot per pipe that targets them.
-        m_peer = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=3)
-        l_peer = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, 1),    block_count=3)
-        o_peer = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=3)
+        m_peer = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=3)
+        l_peer = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=3)
+        o_peer = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=3)
 
-        # Dedicated single-push output CBs: the compute thread stores the
-        # merged result here and the datamovement thread copies it to DRAM.
-        # The merge could write to DRAM directly, but then the state CB would
-        # be waited on the datamovement thread too; the SPSC verifier rejects
-        # that cross-thread second consumer.
-        out_o_cb = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
-        out_m_cb = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1),    block_count=2)
-        out_l_cb = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1),    block_count=2)
-
-        # Load this core's partial into the rx/tx copy matching its stage-0
-        # role: receivers feed the compute thread, senders the datamovement.
-        base = (row_c * 8 + col_c) * PNHt
+        # Stage 0: receivers (cols 0,2,4,6) merge their own partial (*_in) with
+        # the s0 peer into the stage-0 buffer; senders (cols 1,3,5,7) stage
+        # their partial there and ship it.
         if s0_o.is_dst():
-            od = o_rx0.reserve(); ttl.copy(in_o[base:base + PNHt, 0:vDHt], od)
-            md = m_rx0.reserve(); ttl.copy(in_m[base:base + PNHt, 0:1], md)
-            ld = l_rx0.reserve(); ttl.copy(in_l[base:base + PNHt, 0:1], ld)
+            tree_step_recv(m_in, l_in, o_in, m_s0, l_s0, o_s0,
+                           m_peer, l_peer, o_peer, s0_m, s0_l, s0_o)
         elif s0_o.is_src():
-            od = o_tx0.reserve(); ttl.copy(in_o[base:base + PNHt, 0:vDHt], od)
-            md = m_tx0.reserve(); ttl.copy(in_m[base:base + PNHt, 0:1], md)
-            ld = l_tx0.reserve(); ttl.copy(in_l[base:base + PNHt, 0:1], ld)
+            md = m_s0.reserve(); md.store(m_in.wait())
+            ld = l_s0.reserve(); ld.store(l_in.wait())
+            od = o_s0.reserve(); od.store(o_in.wait())
+            tree_step_send(m_s0, l_s0, o_s0, s0_m, s0_l, s0_o)
 
-        # Stage 0: receivers (cols 0,2,4,6) merge with their s0 peer and route
-        # the result to rx1 if they receive again next, or tx1 if they send.
+        # Stage 1: receivers (cols 0,4) merge s0 with the s1 peer into s1;
+        # senders (cols 2,6) ship their s0 result.
         if s1_o.is_dst():
-            tree_step_recv(m_rx0, l_rx0, o_rx0, m_rx1, l_rx1, o_rx1,
-                           m_peer, l_peer, o_peer, s0_m, s0_l, s0_o)
-        elif s1_o.is_src():
-            tree_step_recv(m_rx0, l_rx0, o_rx0, m_txc, l_txc, o_txc,
-                           m_peer, l_peer, o_peer, s0_m, s0_l, s0_o)
-        elif s0_o.is_src():
-            tree_step_send(m_tx0, l_tx0, o_tx0, s0_m, s0_l, s0_o)
-
-        # Stage 1: receivers (cols 0,4) merge with their s1 peer and route to
-        # rx2 (col 0, receives again) or tx2 (col 4, sends to col 0).
-        if s2_o.is_dst():
-            tree_step_recv(m_rx1, l_rx1, o_rx1, m_rx2, l_rx2, o_rx2,
-                           m_peer, l_peer, o_peer, s1_m, s1_l, s1_o)
-        elif s2_o.is_src():
-            tree_step_recv(m_rx1, l_rx1, o_rx1, m_txc, l_txc, o_txc,
+            tree_step_recv(m_s0, l_s0, o_s0, m_s1, l_s1, o_s1,
                            m_peer, l_peer, o_peer, s1_m, s1_l, s1_o)
         elif s1_o.is_src():
-            tree_step_send(m_txc, l_txc, o_txc, s1_m, s1_l, s1_o)
+            tree_step_send(m_s0, l_s0, o_s0, s1_m, s1_l, s1_o)
 
+        # Stage 2: col 0 merges s1 with the final peer and writes the output;
+        # col 4 ships its s1 result.
         if s2_o.is_dst():
-            m_a = m_rx2.wait(); l_a = l_rx2.wait(); o_a = o_rx2.wait()
+            m_a = m_s1.wait(); l_a = l_s1.wait(); o_a = o_s1.wait()
 
             pipe_recv(s2_m, m_peer)
             pipe_recv(s2_l, l_peer)
@@ -337,14 +347,80 @@ def make_flash_tree_reduce(PNHt, vDHt, B=1):
             ab_bc = ttl.block.broadcast(ab, dims=[1], shape=o_b.shape)
             o_unnorm = ttl.add(ttl.mul(aa_bc, o_a), ttl.mul(ab_bc, o_b))
 
-            obase = row_c * PNHt
-            mw = out_m_cb.reserve(); mw.store(m_fin)
-            ttl.copy(out_m_cb.wait(), out_m[obase:obase + PNHt, 0:1])
-            lw = out_l_cb.reserve(); lw.store(l_fin)
-            ttl.copy(out_l_cb.wait(), out_l[obase:obase + PNHt, 0:1])
-            ow = out_o_cb.reserve(); ow.store(o_unnorm)
-            ttl.copy(out_o_cb.wait(), out_o[obase:obase + PNHt, 0:vDHt])
+            lw = l_out.reserve(); lw.store(l_fin)
+            ow = o_out.reserve(); ow.store(o_unnorm)
         elif s2_o.is_src():
-            tree_step_send(m_txc, l_txc, o_txc, s2_m, s2_l, s2_o)
+            tree_step_send(m_s1, l_s1, o_s1, s2_m, s2_l, s2_o)
+
+    return flash_tree_reduce_core
+
+
+def make_flash_tree_reduce(PNHt, vDHt, B=1):
+    """Standalone tree reduce: stage each core's partial from DRAM, run the
+    core, drain the merged ``(o, l)`` to DRAM on column 0."""
+    core = make_flash_tree_reduce_core(PNHt, vDHt, B)
+
+    @ttl.atom(grid=(8, B), options="--ttl-relax-dfb-spsc")
+    def flash_tree_reduce(in_o, in_m, in_l, out_o, out_l):
+        col_c, row_c = ttl.node(dims=2)
+        base = (row_c * 8 + col_c) * PNHt
+
+        o_b = ttl.make_dataflow_buffer_like(in_o, shape=(PNHt, vDHt), block_count=2)
+        m_b = ttl.make_dataflow_buffer_like(in_m, shape=(PNHt, 1), block_count=2)
+        l_b = ttl.make_dataflow_buffer_like(in_l, shape=(PNHt, 1), block_count=2)
+        o_t = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
+        l_t = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1), block_count=2)
+
+        od = o_b.reserve(); ttl.copy(in_o[base:base + PNHt, 0:vDHt], od)
+        md = m_b.reserve(); ttl.copy(in_m[base:base + PNHt, 0:1], md)
+        ld = l_b.reserve(); ttl.copy(in_l[base:base + PNHt, 0:1], ld)
+
+        core(o_b, m_b, l_b, o_t, l_t)
+
+        obase = row_c * PNHt
+        if col_c == 0:
+            ttl.copy(l_t.wait(), out_l[obase:obase + PNHt, 0:1])
+            ttl.copy(o_t.wait(), out_o[obase:obase + PNHt, 0:vDHt])
 
     return flash_tree_reduce
+
+
+def make_flash_mla(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
+    """Fully fused flash MLA decode: one kernel on grid ``(n_cols, B)``.
+
+    q is multicast (column 0 reads DRAM, fans out to all columns); the shard,
+    tree reduce, and normalize cores are inlined back to back with their
+    boundary values carried through DFB bridges, so no partial or merged stat
+    round-trips DRAM. Column 0 drains the normalized output. Requires
+    ``n_cols == 8`` (the tree reduce topology).
+    """
+    shard = make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale)
+    reduce = make_flash_tree_reduce_core(PNHt, vDHt, B)
+    normalize = make_flash_normalize_core(PNHt, vDHt)
+
+    @ttl.atom(grid=(n_cols, B), options="--ttl-relax-dfb-spsc")
+    def flash_mla(q, k, v, norm_out):
+        col_c, row_c = ttl.node(dims=2)
+
+        q_net = ttl.PipeNet(mcast_rows(B, n_cols))
+        q_stage = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+        q_recv = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+
+        # shard -> tree bridges (this core's own partial)
+        so = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt), block_count=2)
+        sm = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+        sl = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+        # tree -> normalize bridges (merged, column 0 only)
+        to = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
+        tl = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+        nout = ttl.make_dataflow_buffer_like(norm_out, shape=(PNHt, vDHt), block_count=2)
+
+        mcast(q_net, q[0:PNHt, 0:DHt], q_stage, q_recv)
+        shard(q_recv, k, v, so, sm, sl)
+        reduce(so, sm, sl, to, tl)
+        normalize(to, tl, nout)
+
+        if col_c == 0:
+            ttl.copy(nout.wait(), norm_out[row_c * PNHt:row_c * PNHt + PNHt, 0:vDHt])
+
+    return flash_mla

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -413,6 +413,10 @@ def make_flash_mla(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
         # tree -> normalize bridges (merged, column 0 only)
         to = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
         tl = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+        # Normalize gets its own output DFB: the datamovement drain below waits
+        # it on NCRISC, and aliasing it onto `so` (still carrying the
+        # unnormalized partial through the compute-side reduce) lets NCRISC read
+        # the wrong tile under the relaxed SPSC guard.
         nout = ttl.make_dataflow_buffer_like(norm_out, shape=(PNHt, vDHt), block_count=2)
 
         mcast(q_net, q[0:PNHt, 0:DHt], q_stage, q_recv)

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -25,9 +25,10 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
 
     ``q`` arrives in the ``q_in`` DFB (multicast or staged by the wrapper);
     K/V are read per-core from DRAM and typecast to bf16 before the matmuls so
-    a bfp8 cache feeds the bf16 chain. The unnormalized ``(o, m, l)`` partial is
-    pushed to the ``o_out`` / ``m_out`` / ``l_out`` DFBs (the caller drains or
-    consumes them). ``scale`` is folded into ``qk`` per chunk.
+    a bfp8 cache feeds the bf16 chain. The running ``(o, m, l)`` accumulators
+    live in the ``o_out`` / ``m_out`` / ``l_out`` DFBs directly, so the final
+    chunk leaves the unnormalized partial there for the caller to drain or
+    consume. ``scale`` is folded into ``qk`` per chunk.
     """
     St_per_core = Sk_chunk_t * N_CHUNKS
 
@@ -54,10 +55,9 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
         alpha_cb     = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
         pv_cb        = ttl.make_dfb("bf16", shape=(PNHt, vDHt),       block_count=2)
 
-        m_state_cb   = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
-        l_state_cb   = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
-        o_state_cb   = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
-
+        # The running m / l / o accumulators live in the output DFBs directly:
+        # each chunk waits the prior value and reserves the next, and the final
+        # chunk leaves exactly one block pushed for the consumer to drain.
         k_base = col_c * St_per_core
         for c in range(N_CHUNKS):
             kc = k_base + c * Sk_chunk_t
@@ -66,9 +66,9 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
             v_dst = v_cb.reserve()
             ttl.copy(v[kc:kc + Sk_chunk_t, 0:vDHt], v_dst)
 
-        m0 = m_state_cb.reserve(); m0.store(ttl.block.fill(-1e30, shape=m0.shape))
-        l0 = l_state_cb.reserve(); l0.store(ttl.block.fill(0.0,   shape=l0.shape))
-        o0 = o_state_cb.reserve(); o0.store(ttl.block.fill(0.0,   shape=o0.shape))
+        m0 = m_out.reserve(); m0.store(ttl.block.fill(-1e30, shape=m0.shape))
+        l0 = l_out.reserve(); l0.store(ttl.block.fill(0.0,   shape=l0.shape))
+        o0 = o_out.reserve(); o0.store(ttl.block.fill(0.0,   shape=o0.shape))
 
         q_blk = q_in.wait()
         for _ in range(N_CHUNKS):
@@ -81,7 +81,7 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
             cm_w = red_cb.reserve(); cm_w.store(ttl.math.reduce_max(sv, dims=[1]))
             sv_re = sv_cb.reserve(); sv_re.store(sv)
 
-            m_old = m_state_cb.wait()
+            m_old = m_out.wait()
             cm = red_cb.wait()
             mn_w = mn_cb.reserve(); mn_w.store(ttl.math.max(m_old, cm))
 
@@ -95,16 +95,16 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
             ex_w = ex_cb.reserve()
             ex_w.store(ttl.exp(ttl.sub(sv2, ttl.block.broadcast(
                 mn_for_state, dims=[1], shape=sv2.shape))))
-            m_next = m_state_cb.reserve(); m_next.store(mn_for_state)
+            m_next = m_out.reserve(); m_next.store(mn_for_state)
 
             ex = ex_cb.wait()
             cs_w = red_cb.reserve(); cs_w.store(ttl.math.reduce_sum(ex, dims=[1]))
             ex_re = ex_cb.reserve(); ex_re.store(ex)
 
             alpha = alpha_cb.wait()
-            l_old = l_state_cb.wait()
+            l_old = l_out.wait()
             cs = red_cb.wait()
-            l_next = l_state_cb.reserve()
+            l_next = l_out.reserve()
             l_next.store(ttl.add(ttl.mul(alpha, l_old), cs))
             alpha_re = alpha_cb.reserve(); alpha_re.store(alpha)
 
@@ -113,18 +113,11 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
             pv_w = pv_cb.reserve(); pv_w.store(ex2 @ v_blk)
 
             alpha2 = alpha_cb.wait()
-            o_old = o_state_cb.wait()
+            o_old = o_out.wait()
             pv_blk = pv_cb.wait()
-            o_next = o_state_cb.reserve()
+            o_next = o_out.reserve()
             o_next.store(ttl.add(ttl.mul(ttl.block.broadcast(
                 alpha2, dims=[1], shape=o_old.shape), o_old), pv_blk))
-
-        m_final = m_state_cb.wait()
-        mo = m_out.reserve(); mo.store(m_final)
-        l_final = l_state_cb.wait()
-        lo = l_out.reserve(); lo.store(l_final)
-        o_final = o_state_cb.wait()
-        oo = o_out.reserve(); oo.store(o_final)
 
     return flash_shard_core
 
@@ -145,14 +138,24 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
         o_b = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
         m_b = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1), block_count=2)
         l_b = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1), block_count=2)
+        # The core accumulates the partial into o_b/m_b/l_b across chunks and
+        # consumes them on compute, so the NCRISC drain needs its own buffer:
+        # re-store the final partial on compute, then copy that to DRAM.
+        o_d = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
+        m_d = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1), block_count=2)
+        l_d = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1), block_count=2)
 
         mcast(q_net, q[0:PNHt, 0:DHt], q_stage, q_recv)
         core(q_recv, k, v, o_b, m_b, l_b)
 
+        m_dw = m_d.reserve(); m_dw.store(m_b.wait())
+        l_dw = l_d.reserve(); l_dw.store(l_b.wait())
+        o_dw = o_d.reserve(); o_dw.store(o_b.wait())
+
         base = (row_c * n_cols + col_c) * PNHt
-        ttl.copy(m_b.wait(), out_m[base:base + PNHt, 0:1])
-        ttl.copy(l_b.wait(), out_l[base:base + PNHt, 0:1])
-        ttl.copy(o_b.wait(), out_o[base:base + PNHt, 0:vDHt])
+        ttl.copy(m_d.wait(), out_m[base:base + PNHt, 0:1])
+        ttl.copy(l_d.wait(), out_l[base:base + PNHt, 0:1])
+        ttl.copy(o_d.wait(), out_o[base:base + PNHt, 0:vDHt])
 
     return flash_shard
 

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -53,7 +53,7 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
         red_cb       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
         mn_cb        = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
         alpha_cb     = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
-        pv_cb        = ttl.make_dfb("bf16", shape=(PNHt, vDHt),       block_count=2)
+        pv_cb        = ttl.make_dfb("bf16", shape=(PNHt, vDHt),       block_count=1)
 
         # The running m / l / o accumulators live in the output DFBs directly:
         # each chunk waits the prior value and reserves the next, and the final
@@ -133,8 +133,8 @@ def make_flash_shard(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0
         col_c, row_c = ttl.node(dims=2)
 
         q_net = ttl.PipeNet(mcast_rows(B, n_cols))
-        q_stage = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
-        q_recv = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+        q_stage = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=1)
+        q_recv = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=1)
         o_b = ttl.make_dataflow_buffer_like(out_o, shape=(PNHt, vDHt), block_count=2)
         m_b = ttl.make_dataflow_buffer_like(out_m, shape=(PNHt, 1), block_count=2)
         l_b = ttl.make_dataflow_buffer_like(out_l, shape=(PNHt, 1), block_count=2)
@@ -413,8 +413,8 @@ def make_flash_mla(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
     @ttl.atom()
     def q_shard(q, k, v, o_out: ttl.DFB, m_out: ttl.DFB, l_out: ttl.DFB):
         q_net = ttl.PipeNet(mcast_rows(B, n_cols))
-        q_stage = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
-        q_recv = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=2)
+        q_stage = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=1)
+        q_recv = ttl.make_dataflow_buffer_like(q, shape=(PNHt, DHt), block_count=1)
         mcast(q_net, q[0:PNHt, 0:DHt], q_stage, q_recv)
         shard(q_recv, k, v, o_out, m_out, l_out)
 
@@ -426,7 +426,7 @@ def make_flash_mla(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
         # nout gets its own DFB: the datamovement drain below waits it on
         # NCRISC, and aliasing it onto the unnormalized partial lets NCRISC read
         # the wrong tile under the relaxed SPSC guard.
-        nout = ttl.make_dataflow_buffer_like(norm_out, shape=(PNHt, vDHt), block_count=2)
+        nout = ttl.make_dataflow_buffer_like(norm_out, shape=(PNHt, vDHt), block_count=1)
         reduce(o_in, m_in, l_in, to, tl)
         normalize(to, tl, nout)
         if col_c == 0:

--- a/python/ttl/ops/flash_mla.py
+++ b/python/ttl/ops/flash_mla.py
@@ -48,9 +48,12 @@ def make_flash_shard_core(B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
         # chunk_sum (disjoint lifetimes). The exp(sv - max) result is left as
         # plain SSA: it feeds reduce_sum and the ex @ v matmul, both DFB-input
         # ops, so the compiler materializes it into one shared intermediate DFB.
+        # sv/ex/mn/alpha re-store: wait() then reserve() hold two blocks at
+        # once, so block_count=1 would deadlock the reserve. red_cb pops
+        # before each reserve, so one block suffices.
         sv_cb        = ttl.make_dfb("bf16", shape=(PNHt, Sk_chunk_t), block_count=2)
         ex_cb        = ttl.make_dfb("bf16", shape=(PNHt, Sk_chunk_t), block_count=2)
-        red_cb       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
+        red_cb       = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=1)
         mn_cb        = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
         alpha_cb     = ttl.make_dfb("bf16", shape=(PNHt, 1),          block_count=2)
         pv_cb        = ttl.make_dfb("bf16", shape=(PNHt, vDHt),       block_count=1)
@@ -299,11 +302,9 @@ def make_flash_tree_reduce_core(PNHt, vDHt, B=1):
         s2_l = ttl.PipeNet([ttl.Pipe(src=(4, b), dst=(0, b)) for b in range(B)])
         s2_o = ttl.PipeNet([ttl.Pipe(src=(4, b), dst=(0, b)) for b in range(B)])
 
-        # With the SPSC verifier relaxed (--ttl-relax-dfb-spsc), each stage's
-        # working buffer can feed either the next compute-recv or the
-        # datamovement-send -- the role guards make those mutually exclusive per
-        # core -- so we keep one (m,l,o) buffer per stage instead of the
-        # recv-side/send-side split that the verifier would otherwise require.
+        # Each stage's working buffer feeds either the next compute-recv or the
+        # datamovement-send; the per-core role guards make those mutually
+        # exclusive, which the SPSC verifier proves via launch-node domains.
         m_s0 = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
         l_s0 = ttl.make_dfb("bf16", shape=(PNHt, 1),    block_count=2)
         o_s0 = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
@@ -367,7 +368,7 @@ def make_flash_tree_reduce(PNHt, vDHt, B=1):
     core, drain the merged ``(o, l)`` to DRAM on column 0."""
     core = make_flash_tree_reduce_core(PNHt, vDHt, B)
 
-    @ttl.atom(grid=(8, B), options="--ttl-relax-dfb-spsc")
+    @ttl.atom(grid=(8, B))
     def flash_tree_reduce(in_o, in_m, in_l, out_o, out_l):
         col_c, row_c = ttl.node(dims=2)
         base = (row_c * 8 + col_c) * PNHt
@@ -424,15 +425,15 @@ def make_flash_mla(n_cols, B, PNHt, DHt, vDHt, Sk_chunk_t, N_CHUNKS, scale=1.0):
         to = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
         tl = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
         # nout gets its own DFB: the datamovement drain below waits it on
-        # NCRISC, and aliasing it onto the unnormalized partial lets NCRISC read
-        # the wrong tile under the relaxed SPSC guard.
+        # NCRISC, and aliasing it onto the unnormalized partial would let
+        # NCRISC read the wrong tile.
         nout = ttl.make_dataflow_buffer_like(norm_out, shape=(PNHt, vDHt), block_count=1)
         reduce(o_in, m_in, l_in, to, tl)
         normalize(to, tl, nout)
         if col_c == 0:
             ttl.copy(nout.wait(), norm_out[row_c * PNHt:row_c * PNHt + PNHt, 0:vDHt])
 
-    @ttl.atom(grid=(n_cols, B), options="--ttl-relax-dfb-spsc")
+    @ttl.atom(grid=(n_cols, B))
     def flash_mla(q, k, v, norm_out):
         # shard -> tree bridges (this core's own partial)
         so = ttl.make_dataflow_buffer_like(q, shape=(PNHt, vDHt), block_count=2)

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1146,6 +1146,39 @@ def _extract_pipe_global_semaphore_count(module) -> int:
     return int(attr)
 
 
+def _dfb_l1_tiles(cb):
+    """Total tiles a DFB occupies in L1 (per-block tiles x block_count)."""
+    tiles = cb.block_count
+    for dim in cb.shape:
+        tiles *= dim
+    return tiles
+
+
+def _apply_dfb_index_map(cb_configs, module):
+    """Apply ttl.dfb_index_map (user DFB index reuse) to the CB config list.
+
+    The finalize pass may overlay several user DFBs onto one physical index;
+    the slot is sized to the largest member, since every reserve/wait carries
+    its own block size.
+    """
+    attr = module.operation.attributes.get("ttl.dfb_index_map", None)
+    if attr is None:
+        return cb_configs
+    moved = {int(e["old_index"]): int(e["new_index"]) for e in attr}
+
+    by_index = {}
+    for old, cb in enumerate(cb_configs):
+        if cb is None:
+            continue
+        new = moved.get(old, old)
+        cur = by_index.get(new)
+        if cur is None or _dfb_l1_tiles(cb) > _dfb_l1_tiles(cur):
+            by_index[new] = cb
+    if not by_index:
+        return []
+    return [by_index.get(i) for i in range(max(by_index) + 1)]
+
+
 def _merge_dfb_configs(cb_configs, compiler_allocated_dfbs):
     """Merge compiler-allocated DFBs into the CB config list.
 
@@ -1763,7 +1796,8 @@ def _lower_program_to_kernel(
             first_thread = next(iter(all_source_lines.keys()))
             profile_source_lines = all_source_lines[first_thread]
 
-        # Merge compiler-allocated DFBs into the CB config list.
+        # Apply user DFB index reuse, then merge compiler-allocated DFBs.
+        cb_configs = _apply_dfb_index_map(cb_configs, module)
         compiler_allocated_dfbs = _extract_compiler_allocated_dfbs(module)
         cb_configs = _merge_dfb_configs(cb_configs, compiler_allocated_dfbs)
         pipe_sync_semaphore_count = _extract_pipe_sync_semaphore_count(module)

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1194,11 +1194,12 @@ def _merge_dfb_configs(cb_configs, compiler_allocated_dfbs):
 
     merged = list(cb_configs) + [None] * (total - len(cb_configs))
     for dfb in compiler_allocated_dfbs:
-        if merged[dfb.dfb_index] is not None:
-            raise ValueError(
-                f"Compiler-allocated DFB index {dfb.dfb_index} collides with "
-                f"an existing DFB."
-            )
+        existing = merged[dfb.dfb_index]
+        if existing is not None:
+            # Index reuse may overlay a compiler DFB on a user slot; keep the
+            # larger config (same element type within a reuse class).
+            if _dfb_l1_tiles(existing) >= dfb.num_tiles * dfb.block_count:
+                continue
         merged[dfb.dfb_index] = dfb
     return merged
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1686,8 +1686,7 @@ def _lower_program_to_kernel(
         pipeline_passes.append("ttl-finalize-dfb-indices")
         pipeline_passes.append("func.func(ttl-annotate-cb-associations)")
         pipeline_passes.append("ttl-verify-pipenet-guards")
-        if not compiler_options.relax_dfb_spsc:
-            pipeline_passes.append("ttl-verify-dfb-spsc")
+        pipeline_passes.append("ttl-verify-dfb-spsc")
         pipeline_passes.append("ttl-erase-pipenet-scopes")
         if l1_budget_override > 0:
             pipeline_passes.append(

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1652,7 +1652,8 @@ def _lower_program_to_kernel(
         pipeline_passes.append("ttl-finalize-dfb-indices")
         pipeline_passes.append("func.func(ttl-annotate-cb-associations)")
         pipeline_passes.append("ttl-verify-pipenet-guards")
-        pipeline_passes.append("ttl-verify-dfb-spsc")
+        if not compiler_options.relax_dfb_spsc:
+            pipeline_passes.append("ttl-verify-dfb-spsc")
         pipeline_passes.append("ttl-erase-pipenet-scopes")
         if l1_budget_override > 0:
             pipeline_passes.append(

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -8,9 +8,10 @@
 
 """@ttl.atom-in-@ttl.atom inlining. A small DFB-parameter helper atom is
 inlined into a larger atom; the helper takes its DFBs as ttl.DFB
-parameters (it has no way to be supplied buffers except by inlining).
-Also checks that a callee declaring its own DFB is rejected at the outer
-atom's decoration time."""
+parameters. An inlined callee may also declare its own scratch DFBs when
+inlined at the body top level: the decls are hoisted, and the scratch
+buffers of sequential sibling callees reuse one CB index. A callee that
+declares buffers but is inlined inside a for/if is rejected."""
 
 import pytest
 import torch
@@ -44,23 +45,119 @@ def atom_outer_exp(in_t, out_t):
     ttl.copy(out_done, out_t[0:1, 0:1])
 
 
-def test_callee_with_dfb_decl_rejected():
-    """A callee that declares its own DFB cannot be inlined."""
+@ttl.atom()
+def _exp_via_scratch(in_cb: ttl.DFB, out_t):
+    """Inlined helper that declares its own scratch DFB: compute writes
+    exp(x) into the scratch, data movement drains it to ``out_t``."""
+    scratch = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    x = in_cb.wait()
+    s = scratch.reserve()
+    s.store(ttl.exp(x))
+    done = scratch.wait()
+    ttl.copy(done, out_t[0:1, 0:1])
+
+
+@ttl.atom(grid=(1, 1))
+def atom_two_scratch(in0, in1, out0, out1):
+    """Inlines two sibling scratch-declaring helpers; their scratch DFBs run
+    sequentially, so they share one CB index."""
+    a0 = ttl.make_dataflow_buffer_like(in0, shape=(1, 1), block_count=2)
+    a1 = ttl.make_dataflow_buffer_like(in1, shape=(1, 1), block_count=2)
+
+    b0 = a0.reserve()
+    ttl.copy(in0[0:1, 0:1], b0)
+    b1 = a1.reserve()
+    ttl.copy(in1[0:1, 0:1], b1)
+
+    _exp_via_scratch(a0, out0)
+    _exp_via_scratch(a1, out1)
+
+
+@ttl.atom()
+def _scratch_dm_then_compute(in_t, out_t):
+    """Two scratch DFBs whose textual spans are disjoint but whose runtime
+    lifetimes overlap across threads: ``a`` is data-movement-produced (copied
+    from a tensor) and compute-consumed; ``b`` is compute-produced and
+    data-movement-consumed. A statement-span reuse would merge a and b (their
+    text spans don't overlap), giving one CB two producers on two threads and
+    interleaving the streams. Site-based reuse keeps them distinct."""
+    a = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    b = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+
+    ad = a.reserve()
+    ttl.copy(in_t[0:1, 0:1], ad)  # data movement: in_t -> a
+    av = a.wait()  # compute consumes a
+    bd = b.reserve()
+    bd.store(ttl.exp(av))  # compute produces b
+    bv = b.wait()
+    ttl.copy(bv, out_t[0:1, 0:1])  # data movement: b -> out_t
+
+
+@ttl.atom(grid=(1, 1))
+def atom_cross_thread_scratch(in_t, out_t):
+    _scratch_dm_then_compute(in_t, out_t)
+
+
+def test_dfb_callee_in_loop_rejected():
+    """A callee that declares its own DFB cannot be inlined inside a loop:
+    its decl could not be hoisted to the body top level."""
 
     @ttl.atom()
     def _declares_dfb(inp: ttl.DFB, out: ttl.DFB):
         scratch = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
         x = inp.wait()
+        s = scratch.reserve()
+        s.store(x)
+        done = scratch.wait()
         r = out.reserve()
-        r.store(x)
+        r.store(done)
 
-    with pytest.raises(ValueError, match="make_dataflow_buffer_like"):
+    with pytest.raises(ValueError, match="atom body top level"):
 
         @ttl.atom(grid=(1, 1))
         def _outer_bad(in_t, out_t):
             a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
             out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
-            _declares_dfb(a_cb, out_cb)
+            for _ in range(2):
+                _declares_dfb(a_cb, out_cb)
+
+
+def _dfbs(n):
+    """n fresh bf16 (1,1) double-buffered DFBs with sequential CB indices."""
+    from ttl.dataflow_buffer import DataflowBuffer, _reset_cb_counter
+
+    _reset_cb_counter()
+    return [DataflowBuffer(None, (1, 1), 2, dtype="bf16") for _ in range(n)]
+
+
+def test_reuse_overlays_sibling_sites():
+    """Scratch from two different inline sites overlays onto one CB index;
+    bridge DFBs keep distinct indices below the overlay."""
+    from ttl.atom import _reuse_inlined_dfb_indices
+
+    a0, a1, s0, s1 = _dfbs(4)
+    dfbs = {"a0": a0, "a1": a1, "s0": s0, "s1": s1}
+    # s0 from site 0, s1 from site 1 (distinct sibling sites).
+    _reuse_inlined_dfb_indices(dfbs, {"s0": 0, "s1": 1})
+
+    assert s0._cb_index == s1._cb_index
+    assert {a0._cb_index, a1._cb_index} == {0, 1}
+    assert len({a0._cb_index, a1._cb_index, s0._cb_index}) == 3
+
+
+def test_reuse_keeps_same_site_distinct():
+    """Two scratch DFBs from the SAME inline site stay distinct, even though
+    their textual lifetimes are disjoint. This is the case a statement-span
+    analysis would wrongly merge: across the compute/data-movement split the
+    two buffers can be live concurrently (e.g. one DM-produced, one
+    compute-produced), so sharing a CB index would interleave their streams."""
+    from ttl.atom import _reuse_inlined_dfb_indices
+
+    s0, s1 = _dfbs(2)
+    dfbs = {"s0": s0, "s1": s1}
+    _reuse_inlined_dfb_indices(dfbs, {"s0": 0, "s1": 0})
+
+    assert s0._cb_index != s1._cb_index
 
 
 def test_callee_with_make_dfb_decl_rejected():
@@ -91,6 +188,43 @@ def test_atom_outer_exp(device):
     out_t = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
 
     atom_outer_exp(in_t, out_t)
+
+    got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_atom_two_scratch(device):
+    tile = ttnn.TILE_SIZE
+
+    def rand():
+        return (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+
+    in0_t, in1_t = rand(), rand()
+    in0 = to_l1(in0_t, device)
+    in1 = to_l1(in1_t, device)
+    out0 = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+    out1 = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+
+    atom_two_scratch(in0, in1, out0, out1)
+
+    got0 = ttnn.to_torch(out0).reshape(tile, tile).to(torch.bfloat16)
+    got1 = ttnn.to_torch(out1).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got0, torch.exp(in0_t.float()).to(torch.bfloat16), rtol=2e-2, atol=2e-2)
+    assert_allclose(got1, torch.exp(in1_t.float()).to(torch.bfloat16), rtol=2e-2, atol=2e-2)
+
+
+def test_atom_cross_thread_scratch(device):
+    """The cross-thread hazard runs correctly: the two same-site scratch DFBs
+    must not share a CB index, or the DM-produced and compute-produced streams
+    would interleave."""
+    tile = ttnn.TILE_SIZE
+    inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
+
+    in_t = to_l1(inp_t, device)
+    out_t = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+
+    atom_cross_thread_scratch(in_t, out_t)
 
     got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
     assert_allclose(got, expected, rtol=2e-2, atol=2e-2)

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -168,34 +168,12 @@ def _dfbs(n):
     return [DataflowBuffer(None, (1, 1), 2, dtype="bf16") for _ in range(n)]
 
 
-def test_reuse_overlays_sibling_sites():
-    """Scratch from two different inline sites overlays onto one CB index;
-    bridge DFBs keep distinct indices below the overlay."""
-    from ttl.atom import _reuse_inlined_dfb_indices
-
-    a0, a1, s0, s1 = _dfbs(4)
-    dfbs = {"a0": a0, "a1": a1, "s0": s0, "s1": s1}
-    # s0 from site 0, s1 from site 1 (distinct sibling sites).
-    _reuse_inlined_dfb_indices(dfbs, {"s0": 0, "s1": 1})
-
-    assert s0._cb_index == s1._cb_index
-    assert {a0._cb_index, a1._cb_index} == {0, 1}
-    assert len({a0._cb_index, a1._cb_index, s0._cb_index}) == 3
-
-
-def test_reuse_keeps_same_site_distinct():
-    """Two scratch DFBs from the SAME inline site stay distinct, even though
-    their textual lifetimes are disjoint. This is the case a statement-span
-    analysis would wrongly merge: across the compute/data-movement split the
-    two buffers can be live concurrently (e.g. one DM-produced, one
-    compute-produced), so sharing a CB index would interleave their streams."""
-    from ttl.atom import _reuse_inlined_dfb_indices
-
-    s0, s1 = _dfbs(2)
-    dfbs = {"s0": s0, "s1": s1}
-    _reuse_inlined_dfb_indices(dfbs, {"s0": 0, "s1": 0})
-
-    assert s0._cb_index != s1._cb_index
+def test_dfb_indices_declaration_dense():
+    """Python assigns declaration-dense CB indices and never overlays them;
+    index reuse happens in MLIR (ttl-finalize-dfb-indices) where thread
+    identity and lifetimes are known."""
+    buffers = _dfbs(4)
+    assert [b._cb_index for b in buffers] == [0, 1, 2, 3]
 
 
 def test_callee_with_make_dfb_decl_rejected():

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -176,23 +176,27 @@ def test_dfb_indices_declaration_dense():
     assert [b._cb_index for b in buffers] == [0, 1, 2, 3]
 
 
-def test_callee_with_make_dfb_decl_rejected():
-    """A callee that declares its own DFB via make_dfb cannot be inlined."""
+def test_callee_with_make_dfb_decl_inlines():
+    """A callee may declare its own scratch DFB via make_dfb at its top
+    level; the declaration hoists to the caller body on inlining."""
 
     @ttl.atom()
     def _declares_make_dfb(inp: ttl.DFB, out: ttl.DFB):
         scratch = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
         x = inp.wait()
+        s = scratch.reserve()
+        s.store(x)
+        y = scratch.wait()
         r = out.reserve()
-        r.store(x)
+        r.store(y)
 
-    with pytest.raises(ValueError, match="make_dfb"):
+    @ttl.atom(grid=(1, 1))
+    def _outer(in_t, out_t):
+        a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+        _declares_make_dfb(a_cb, out_cb)
 
-        @ttl.atom(grid=(1, 1))
-        def _outer_bad(in_t, out_t):
-            a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
-            out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
-            _declares_make_dfb(a_cb, out_cb)
+    assert "scratch___declares_make_dfb_inl" in _outer._spec.source
 
 
 def test_atom_outer_exp(device):

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -20,7 +20,7 @@ import ttl
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
-from ttlang_test_utils import assert_allclose, to_l1
+from ttlang_test_utils import assert_allclose, to_dram, to_l1
 
 
 @ttl.atom()
@@ -96,6 +96,44 @@ def _scratch_dm_then_compute(in_t, out_t):
 @ttl.atom(grid=(1, 1))
 def atom_cross_thread_scratch(in_t, out_t):
     _scratch_dm_then_compute(in_t, out_t)
+
+
+@ttl.atom()
+def _forward_pipe(a, send_cb: ttl.DFB, recv_cb: ttl.DFB):
+    """Inlined helper that declares its OWN PipeNet (pure hoist, no reuse):
+    core (1,0) sends a[1] over the pipe, core (0,0) receives it into recv_cb."""
+    fwd_net = ttl.PipeNet([ttl.Pipe(src=(1, 0), dst=(0, 0))])
+    s_blk = send_cb.reserve()
+    r_dst = recv_cb.reserve()
+
+    def send(pipe):
+        ttl.copy(a[1:2, 0:1], s_blk)
+        ttl.copy(s_blk, pipe)
+
+    fwd_net.if_src(send)
+
+    def recv(pipe):
+        ttl.copy(pipe, r_dst)
+
+    fwd_net.if_dst(recv)
+
+
+@ttl.atom(grid=(2, 1))
+def atom_inline_pipenet(a, out):
+    own_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    send_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    recv_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+    node_x, _ = ttl.node(dims=2)
+
+    _forward_pipe(a, send_cb, recv_cb)  # inlined; declares its own PipeNet
+
+    if node_x == 0:
+        own_blk = own_cb.reserve()
+        ttl.copy(a[0:1, 0:1], own_blk)
+        s = out_cb.reserve()
+        s.store(own_cb.wait() + recv_cb.wait())
+        ttl.copy(out_cb.wait(), out[0:1, 0:1])
 
 
 def test_dfb_callee_in_loop_rejected():
@@ -190,6 +228,21 @@ def test_atom_outer_exp(device):
     atom_outer_exp(in_t, out_t)
 
     got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_atom_inline_pipenet(device):
+    """An inlined callee that declares its own PipeNet is hoisted and runs."""
+    tile = ttnn.TILE_SIZE
+    a_t = torch.randn(2 * tile, tile, dtype=torch.bfloat16) * 0.5
+    expected = (a_t[:tile].float() + a_t[tile:].float()).to(torch.bfloat16)
+
+    a = to_dram(a_t, device)
+    out = to_dram(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+
+    atom_inline_pipenet(a, out)
+
+    got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
     assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
 
 

--- a/test/python/ops/test_flash_mla.py
+++ b/test/python/ops/test_flash_mla.py
@@ -137,7 +137,7 @@ def test_flash_chain(device):
     normalize = make_flash_normalize(grid=(1, 1), PNHt=PNHt, vDHt=vDHt)
 
     shard(q_d, k_d, v_d, po_d, pm_d, pl_d)
-    tree_reduce(po_d, pm_d, pl_d, o_d, m_d, l_d)
+    tree_reduce(po_d, pm_d, pl_d, o_d, l_d)
     normalize(o_d, l_d, norm_d)
 
     got = ttnn.to_torch(norm_d).reshape(PN, vD).to(torch.bfloat16)
@@ -235,8 +235,48 @@ def test_flash_mla_decode(device):
     normalize = make_flash_normalize(grid=(1, 1), PNHt=MLA_PNHt, vDHt=MLA_vDHt)
 
     shard(q_d, k_d, v_d, po_d, pm_d, pl_d)
-    tree_reduce(po_d, pm_d, pl_d, o_d, m_d, l_d)
+    tree_reduce(po_d, pm_d, pl_d, o_d, l_d)
     normalize(o_d, l_d, norm_d)
+
+    got = ttnn.to_torch(norm_d).reshape(1, 1, NUM_HEADS, KV_LORA_RANK).to(torch.bfloat16)
+    assert_pcc(expected, got, threshold=0.99)
+
+
+@pytest.mark.parametrize("ttnn_device", [{"worker_l1_size": 1448000}], indirect=True)
+def test_flash_mla_decode_fused(device):
+    """The fully fused single-kernel MLA: q multicast, partials and merged
+    stats carried through DFB bridges (no inter-phase DRAM), one launch."""
+    from ttl.ops.flash_mla import make_flash_mla
+
+    torch.manual_seed(42)
+    scale = QK_HEAD_DIM ** -0.5
+    decode_position = MAX_SEQ_LEN - 1
+
+    torch_q = torch.randn((1, 1, NUM_HEADS, KVPE_DIM), dtype=torch.bfloat16)
+    torch_cache = torch.randn((1, 1, MAX_SEQ_LEN, KVPE_DIM), dtype=torch.bfloat16)
+    position_ids = torch.ones(1, dtype=torch.int32) * decode_position
+
+    expected = flash_mla_golden(
+        q=torch_q, kv_cache=torch_cache, position_ids=position_ids,
+        head_dim_v=KV_LORA_RANK, scale=scale,
+    )
+
+    q_2d = torch_q.reshape(NUM_HEADS, KVPE_DIM)
+    k_2d = torch_cache.reshape(MAX_SEQ_LEN, KVPE_DIM)
+    v_2d = k_2d[:, :KV_LORA_RANK].contiguous()
+
+    PNr = MLA_PNHt * TILE
+    q_d = to_dram(q_2d, device)
+    k_d = to_dram_bfp8(k_2d, device)
+    v_d = to_dram_bfp8(v_2d, device)
+    norm_d = to_dram(torch.zeros(PNr, KV_LORA_RANK, dtype=torch.bfloat16), device)
+
+    flash = make_flash_mla(
+        n_cols=N_CORES, B=1,
+        PNHt=MLA_PNHt, DHt=MLA_DHt, vDHt=MLA_vDHt,
+        Sk_chunk_t=MLA_Sk_chunk_t, N_CHUNKS=MLA_N_CHUNKS, scale=scale,
+    )
+    flash(q_d, k_d, v_d, norm_d)
 
     got = ttnn.to_torch(norm_d).reshape(1, 1, NUM_HEADS, KV_LORA_RANK).to(torch.bfloat16)
     assert_pcc(expected, got, threshold=0.99)

--- a/test/python/ops/test_flash_mla.py
+++ b/test/python/ops/test_flash_mla.py
@@ -186,7 +186,7 @@ MLA_vDHt = KV_LORA_RANK // TILE           # 16
 # The shard typecasts each bfp8 K/V chunk to a bf16 mirror, so a 2-tile
 # compute chunk is the largest that fits one core's L1 at vDHt=16. This is
 # the compute-chunk granularity, independent of the cache layout.
-MLA_Sk_chunk_t = 2
+MLA_Sk_chunk_t = 1
 # Per core: (seq / n_cores) positions, split into Sk_chunk_t-tile chunks.
 MLA_N_CHUNKS = (MAX_SEQ_LEN // N_CORES) // (MLA_Sk_chunk_t * TILE)  # 64
 
@@ -242,7 +242,7 @@ def test_flash_mla_decode(device):
     assert_pcc(expected, got, threshold=0.99)
 
 
-@pytest.mark.parametrize("ttnn_device", [{"worker_l1_size": 1448000}], indirect=True)
+@pytest.mark.parametrize("ttnn_device", [{"worker_l1_size": 1430000}], indirect=True)
 def test_flash_mla_decode_fused(device):
     """The fully fused single-kernel MLA: q multicast, partials and merged
     stats carried through DFB bridges (no inter-phase DRAM), one launch."""

--- a/test/python/ops/test_flash_mla.py
+++ b/test/python/ops/test_flash_mla.py
@@ -243,10 +243,15 @@ def test_flash_mla_decode(device):
 
 
 @pytest.mark.parametrize("ttnn_device", [{"worker_l1_size": 1430000}], indirect=True)
-def test_flash_mla_decode_fused(device):
+@pytest.mark.parametrize("sk", [1, 2])
+def test_flash_mla_decode_fused(device, sk):
     """The fully fused single-kernel MLA: q multicast, partials and merged
-    stats carried through DFB bridges (no inter-phase DRAM), one launch."""
+    stats carried through DFB bridges (no inter-phase DRAM), one launch.
+    Swept over the 1- and 2-tile compute chunk, the largest that fits one
+    fused kernel's L1."""
     from ttl.ops.flash_mla import make_flash_mla
+
+    n_chunks = (MAX_SEQ_LEN // N_CORES) // (sk * TILE)
 
     torch.manual_seed(42)
     scale = QK_HEAD_DIM ** -0.5
@@ -274,7 +279,7 @@ def test_flash_mla_decode_fused(device):
     flash = make_flash_mla(
         n_cols=N_CORES, B=1,
         PNHt=MLA_PNHt, DHt=MLA_DHt, vDHt=MLA_vDHt,
-        Sk_chunk_t=MLA_Sk_chunk_t, N_CHUNKS=MLA_N_CHUNKS, scale=scale,
+        Sk_chunk_t=sk, N_CHUNKS=n_chunks, scale=scale,
     )
     flash(q_d, k_d, v_d, norm_d)
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
@@ -8,11 +8,14 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=NOPOP
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=THREE
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SINGLE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=USER
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=XTHREAD
 
 // -----
 
-// User DFBs at indices 0, 1, 2 and a compiler-allocated DFB at index 3.
-// The pass should update base_cta_index to 4 and emit ttl.compiler_allocated_dfbs.
+// User DFBs at indices 0, 1, 2 (unused: keep their indices) and a
+// compiler-allocated DFB at index 3. The pass should update base_cta_index
+// to 4 and emit ttl.compiler_allocated_dfbs.
 
 // CHECK: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
 
@@ -70,7 +73,7 @@ func.func @compute_only()
 // Non-overlapping compiler-allocated DFBs: DFB #3 is released (cb_pop)
 // before DFB #4 is allocated (bind_cb). Both should be assigned index 3.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
+// DEBUG: DFB reuse: cb4 -> cb3
 // DEBUG: Total DFB count: 4
 
 // REUSE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -98,7 +101,6 @@ func.func @non_overlapping_reuse()
 // Overlapping compiler-allocated DFBs: DFB #4 is allocated while DFB #3
 // is still live. They must keep separate indices.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
 // OVERLAP: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -131,7 +133,8 @@ func.func @overlapping_no_reuse()
 // DFB-D [bind, pop]: nested within C, dies before C
 // Result: A and C share slot 0 (index 3), B and D share slot 1 (index 4).
 
-// DEBUG: DFB reuse: 4 compiler-allocated DFBs -> 2 physical slot(s)
+// DEBUG: DFB reuse: cb5 -> cb3
+// DEBUG: DFB reuse: cb6 -> cb4
 // DEBUG: Total DFB count: 5
 
 // FOUR: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -173,43 +176,33 @@ func.func @four_dfbs_nested_reuse()
 
 // -----
 
-// Mixed CircularBufferTypes: DFBs #3 and #5 are [1,1] bf16, DFB #4 is
-// [2,4] bf16. Type partitioning prevents #3 and #4 from sharing a slot
-// even though their lifetimes do not overlap. #3 and #5 share within
-// the [1,1] partition. The [2,4] partition gets the next contiguous index.
-//
-// [1,1] partition: #3 non-overlapping with #5 -> 1 slot (index 3)
-// [2,4] partition: #4 alone -> 1 slot (index 4)
-// Total: 2 physical compiler-allocated slots.
+// Mixed shapes, one element type: capacity is a >= constraint, so the [1,1]
+// and [2,4] buffers share one slot sized to the largest member (8 tiles per
+// block); every reserve/wait carries its own block size.
 
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 2 physical slot(s)
-// DEBUG: Total DFB count: 5
+// DEBUG: DFB reuse: cb4 -> cb3
+// DEBUG: DFB reuse: cb5 -> cb3
+// DEBUG: Total DFB count: 4
 
-// MIXED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32}]}
+// MIXED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32}]}
 
-// MIXED-LABEL: func.func @mixed_types_no_cross_reuse
-// MIXED-SAME: ttl.base_cta_index = 5 : i32
-// [1,1] partition slot
+// MIXED-LABEL: func.func @mixed_shapes_share_slot
+// MIXED-SAME: ttl.base_cta_index = 4 : i32
 // MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
-// [2,4] partition slot
-// MIXED: ttl.bind_cb{cb_index = 4, {{.*}}} {ttl.compiler_allocated} : <[2, 4],
-// [1,1] partition slot reused
+// MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[2, 4],
 // MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
-// MIXED-NOT: cb_index = 5
+// MIXED-NOT: cb_index = 4
 // MIXED: return
-func.func @mixed_types_no_cross_reuse()
+func.func @mixed_shapes_share_slot()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // [1,1] DFB
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // [2,4] DFB -- different type, cannot reuse index 3
   %alloc4 = ttl.bind_cb {cb_index = 4, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc4 : <[2, 4], !ttcore.tile<32x32, bf16>, 2>
-  // [1,1] DFB -- same type as #3, reuses its slot
   %alloc5 = ttl.bind_cb {cb_index = 5, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc5 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
@@ -217,10 +210,9 @@ func.func @mixed_types_no_cross_reuse()
 
 // -----
 
-// No cb_pop on either compiler-allocated DFB. Conservative fallback
-// treats both as live for the entire function. No reuse possible.
+// No cb_pop on either compiler-allocated DFB. No acquires or releases at
+// all: both keep their indices.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
 // NOPOP: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -247,7 +239,8 @@ func.func @no_cb_pop_conservative()
 // Three sequential non-overlapping DFBs. All should map to a single
 // physical slot (multi-round slot recycling).
 
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 1 physical slot(s)
+// DEBUG: DFB reuse: cb4 -> cb3
+// DEBUG: DFB reuse: cb5 -> cb3
 // DEBUG: Total DFB count: 4
 
 // THREE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -274,8 +267,7 @@ func.func @three_sequential_one_slot()
 
 // -----
 
-// Single compiler-allocated DFB. The reuse algorithm early-returns
-// (size <= 1). Index and module attribute should be unchanged.
+// Single compiler-allocated DFB. Index and module attribute unchanged.
 
 // SINGLE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
 
@@ -292,5 +284,91 @@ func.func @single_dfb_no_reuse()
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// User DFBs with the same producer thread (reader) and consumer thread
+// (compute) and disjoint lifetimes share one index. The pass emits
+// ttl.dfb_index_map for the runtime.
+
+// DEBUG: DFB reuse: cb1 -> cb0
+// DEBUG: Total DFB count: 1
+
+// USER: module attributes {ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]}
+
+// USER-LABEL: func.func @user_reader
+// USER-SAME: ttl.base_cta_index = 1 : i32
+// USER-COUNT-2: ttl.bind_cb{cb_index = 0,
+// USER-NOT: cb_index = 1
+// USER-LABEL: func.func @user_compute
+// USER-COUNT-2: ttl.bind_cb{cb_index = 0,
+// USER-NOT: cb_index = 1
+// USER: return
+func.func @user_reader()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r1 = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @user_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w1 = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// User DFBs with different producer threads never share an index, even with
+// disjoint lifetimes: the physical CB counters and per-RISC pointers do not
+// survive a producer change.
+
+// XTHREAD-LABEL: func.func @xt_reader
+// XTHREAD: ttl.bind_cb{cb_index = 0,
+// XTHREAD-LABEL: func.func @xt_writer
+// XTHREAD: ttl.bind_cb{cb_index = 1,
+// XTHREAD-LABEL: func.func @xt_compute
+// XTHREAD: ttl.bind_cb{cb_index = 0,
+// XTHREAD: ttl.bind_cb{cb_index = 1,
+func.func @xt_reader()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @xt_writer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r1 = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @xt_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w1 = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
@@ -9,7 +9,7 @@
 // Elementwise result feeds into reduce: pass should insert a compiler-allocated DFB.
 
 // CHECK-LABEL: func.func @elementwise_into_reduce
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: ttl.add
 // CHECK: ttl.cb_reserve
 // CHECK: ttl.store
@@ -132,8 +132,8 @@ func.func @shared_materialization()
 // After insert: two compiler-allocated DFBs at indices 4, 5, both at
 // function body entry.
 // CHECK-LABEL: func.func @sequential_intermediates_reuse
-// CHECK: ttl.bind_cb{cb_index = 4, block_count = 2} {ttl.compiler_allocated}
-// CHECK: ttl.bind_cb{cb_index = 5, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 4, block_count = 1} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 5, block_count = 1} {ttl.compiler_allocated}
 // CHECK: ttl.add
 // CHECK: ttl.reduce
 // CHECK: ttl.mul
@@ -142,7 +142,7 @@ func.func @shared_materialization()
 // After finalize: the two intermediates share one slot, user cb3
 // (reserve-only; cb0 fully released first) merges onto cb0, and the index
 // space compacts to users 0..2 + intermediates at 3.
-// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}], ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 3 : i32}]}
+// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 1 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}], ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 3 : i32}]}
 // FINALIZE-LABEL: func.func @sequential_intermediates_reuse
 // FINALIZE-SAME: ttl.base_cta_index = 4 : i32
 // FINALIZE-NOT: cb_index = 4

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
@@ -124,8 +124,10 @@ func.func @shared_materialization()
 // compiler-allocated DFB. The first DFB is consumed and released (cb_pop)
 // before the second is created, so finalize should reuse the same index.
 
-// DBG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
-// DBG: Total DFB count: 5
+// DBG: DFB reuse: cb3 -> cb0
+// DBG: DFB reuse: cb4 -> cb3
+// DBG: DFB reuse: cb5 -> cb3
+// DBG: Total DFB count: 4
 
 // After insert: two compiler-allocated DFBs at indices 4, 5, both at
 // function body entry.
@@ -137,11 +139,13 @@ func.func @shared_materialization()
 // CHECK: ttl.mul
 // CHECK: ttl.reduce
 
-// After finalize with reuse: both DFBs get index 4 (one physical slot).
-// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// After finalize: the two intermediates share one slot, user cb3
+// (reserve-only; cb0 fully released first) merges onto cb0, and the index
+// space compacts to users 0..2 + intermediates at 3.
+// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}], ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 3 : i32}]}
 // FINALIZE-LABEL: func.func @sequential_intermediates_reuse
-// FINALIZE-SAME: ttl.base_cta_index = 5 : i32
-// FINALIZE-NOT: cb_index = 5
+// FINALIZE-SAME: ttl.base_cta_index = 4 : i32
+// FINALIZE-NOT: cb_index = 4
 // FINALIZE: return
 func.func @sequential_intermediates_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
@@ -5,19 +5,46 @@
 
 // -----
 
-// All 32 CB indices (0-31) are occupied by user DFBs. The add result
-// feeds reduce, which requires a compiler-allocated DFB at index 32.
-// After reuse (only one intermediate, nothing to reuse), the total DFB
-// count is 33, exceeding the hardware maximum of 32.
+// All 32 CB indices (0-31) are occupied by distinct user DFBs. The add
+// result feeds reduce, which requires a compiler-allocated DFB at index 32.
+// Nothing can merge, so the compacted count is 33, exceeding the hardware
+// maximum of 32.
 
-// expected-error @below {{need 33 DFB indices but hardware supports at most 32 (1 compiler-allocated after reuse)}}
+// expected-error @below {{need 33 DFB indices after reuse but hardware supports at most 32}}
 module {
 func.func @exceeds_max_cb_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // Use index 31 to occupy the last slot.
+  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb4 = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb5 = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb6 = ttl.bind_cb {cb_index = 6, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb7 = ttl.bind_cb {cb_index = 7, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb8 = ttl.bind_cb {cb_index = 8, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb9 = ttl.bind_cb {cb_index = 9, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb10 = ttl.bind_cb {cb_index = 10, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb11 = ttl.bind_cb {cb_index = 11, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb12 = ttl.bind_cb {cb_index = 12, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb13 = ttl.bind_cb {cb_index = 13, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb14 = ttl.bind_cb {cb_index = 14, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb15 = ttl.bind_cb {cb_index = 15, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb16 = ttl.bind_cb {cb_index = 16, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb17 = ttl.bind_cb {cb_index = 17, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb18 = ttl.bind_cb {cb_index = 18, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb19 = ttl.bind_cb {cb_index = 19, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb20 = ttl.bind_cb {cb_index = 20, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb21 = ttl.bind_cb {cb_index = 21, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb22 = ttl.bind_cb {cb_index = 22, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb23 = ttl.bind_cb {cb_index = 23, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb24 = ttl.bind_cb {cb_index = 24, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb25 = ttl.bind_cb {cb_index = 25, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb26 = ttl.bind_cb {cb_index = 26, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb27 = ttl.bind_cb {cb_index = 27, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb28 = ttl.bind_cb {cb_index = 28, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb29 = ttl.bind_cb {cb_index = 29, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb30 = ttl.bind_cb {cb_index = 30, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb31 = ttl.bind_cb {cb_index = 31, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
@@ -12,7 +12,7 @@
 // entry, the rest of the materialization bundle stays inside the loop.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_for
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   ttl.add
 // CHECK:   ttl.cb_reserve
@@ -58,7 +58,7 @@ func.func @intermediate_in_scf_for()
 // function body entry, not inside the if region.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.if
 // CHECK-NOT: ttl.compiler_allocated
 // CHECK:   ttl.add
@@ -101,7 +101,7 @@ func.func @intermediate_in_scf_if(%cond: i1)
 // Before the fix, this crashed in TTLFinalizeDFBIndices.
 
 // CHECK-LABEL: func.func @intermediate_in_nested_for_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   scf.if
 // CHECK-NOT: ttl.compiler_allocated


### PR DESCRIPTION
* Allows `ttl.atom`s to define dfbs locally
* Provides a flash mla that is fully fused (4 atoms called in one top level caller to produce a single program with DFBs to send data between atoms)
* Improves re-use:

To fit one L1, DFB index reuse runs in ttl-finalize-dfb-indices as a module pass: two DFBs share a CB index only with the same producer thread, same consumer thread, same element type, and disjoint pop-bounded lifetimes in both threads' program order. Capacity is a >= check (slot sized to the largest member), user and compiler DFBs share slots, pipe-attached DFBs never reuse (destination blocks are sender-slot addressed). Moves reach the runtime via ttl.dfb_index_map. Compiler intermediates drop to one block (compute-local). 

Tests: atom inline/split pytests, flash sweep over both chunk sizes, lit for reuse classes/lifetimes/compaction.

Perf report: 
```
  ┌─────────┬───────────────────────┬────────────┬────────────┬─────────────┐
  │ context │ baseline (chain sk=2) │ fused sk=1 │ fused sk=2 │   verdict   │
  ├─────────┼───────────────────────┼────────────┼────────────┼─────────────┤
  │ ctx-512 │ 12×                   │ 5.85×      │ 5.34×      │ 2.2× better │
  ├─────────┼───────────────────────┼────────────┼────────────┼─────────────┤
  │ ctx-1k  │ 10×                   │ 6.07×      │ 5.15×      │ 1.9× better │
  ├─────────┼───────────────────────┼────────────┼────────────┼─────────────┤
  │ ctx-2k  │ 7×                    │ 6.97×      │ 5.72×      │ 1.2× better │
  ├─────────┼───────────────────────┼────────────┼────────────┼─────────────┤
  │ ctx-8k  │ 8×                    │ 12.87×     │ 8.35×      │ ~par        │
  ├─────────┼───────────────────────┼────────────┼────────────┼─────────────┤
  │ ctx-32k │ 13×                   │ 21.13×     │ 13.25×     │ ~par        │
  └─────────┴───────────────────────┴────────────┴────────────┴─────────────┘
```