### PR TITLE
[nfc] Uplift llvm, tt-metal, tt-mlir

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ Steps to reproduce the behavior:
 ```
 
 ## Environment
-- **OS:** [e.g., Ubuntu 22.04, macOS 14.0]
+- **OS:** [e.g., Ubuntu 24.04, macOS 14.0]
 - **Python version:** [e.g., 3.11.5]
 - **tt-lang version/commit:** [e.g., commit SHA or release version]
 - **tt-mlir version/commit:** [e.g., commit SHA]

--- a/.github/containers/Dockerfile.base
+++ b/.github/containers/Dockerfile.base
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# tt-lang base image: Ubuntu 22.04 with Python 3.12, Clang 18, and system
+# tt-lang base image: Ubuntu 24.04 with Python 3.12, Clang 18, and system
 # libraries required by tt-lang and tt-metal.
 #
 # Aligned with tt-mlir's Dockerfile.base to maintain compatibility.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,8 +32,10 @@ set -e
 apt-get update -qq
 apt-get install -y -qq software-properties-common
 add-apt-repository ppa:git-core/ppa -y
-echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu jammy main" > /etc/apt/sources.list.d/toolchain-test.list
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 1E9377A2BA9EF27F 2C277A0A352154E5
+# add-apt-repository imports the PPA signing key into a dedicated keyring;
+# apt-key was removed in Ubuntu 24.04, so the manual echo+apt-key form no
+# longer works.
+add-apt-repository ppa:ubuntu-toolchain-r/test -y
 apt-get update -qq
 apt-get install -y -qq \
     build-essential \
@@ -63,10 +65,9 @@ apt-get install -y -qq \
     gnupg \
     libstdc++6
 
-# Install Python 3.12 (matches tt-mlir)
-add-apt-repository ppa:deadsnakes/ppa -y
-apt-get update -qq
-apt-get install -y -qq python3.12 python3.12-dev python3.12-venv
+# Install Python 3.12 from Ubuntu 24.04's native packages. python3-pip
+# provides pip for the system python3.12; ensurepip is disabled on Ubuntu.
+apt-get install -y -qq python3.12 python3.12-dev python3.12-venv python3-pip
 
 # Install tt-metal runtime dependencies (firmware, SFPI, etc.) at the
 # canonical release tag (passed via --build-arg TT_METAL_TAG).
@@ -90,10 +91,10 @@ RUN wget --tries=5 --timeout=120 --waitretry=10 https://apt.llvm.org/llvm.sh && 
 # so the sibling file must be present alongside it.
 COPY requirements.txt requirements-runtime.txt /tmp/
 
-# Bootstrap pip for Python 3.12 via ensurepip (not the system python3-pip which
-# conflicts with 3.12's removal of distutils), then install dependencies.
-RUN python3.12 -m ensurepip --upgrade && \
-    python3.12 -m pip install --upgrade pip --no-cache-dir && \
+# Install Python dependencies with the apt-provided pip (python3-pip above).
+# Ubuntu 24.04 marks system Python as externally managed, and Debian-owned pip
+# cannot be upgraded in place. Use system pip with the explicit install opt-in.
+RUN export PIP_BREAK_SYSTEM_PACKAGES=1 && \
     python3.12 -m pip install cmake==3.28.4 --no-cache-dir && \
     python3.12 -m pip install --index-url https://download.pytorch.org/whl/cpu \
         torch --no-cache-dir && \

--- a/.github/containers/README.md
+++ b/.github/containers/README.md
@@ -4,19 +4,19 @@ This directory contains Dockerfiles for building tt-lang container images.
 
 ## Images
 
-### `tt-lang-base-ubuntu-22-04`
-Standalone base image built from `ubuntu:22.04` with Python 3.12, Clang 18,
+### `tt-lang-base-ubuntu-24-04`
+Standalone base image built from `ubuntu:24.04` with Python 3.12, Clang 18,
 system libraries, and tt-lang Python dependencies (pydantic, torch, numpy,
 pytest). Small and fast to build; serves as the filesystem base for `dist`
 and `ird`.
 
-### `tt-lang-dist-ubuntu-22-04`
+### `tt-lang-dist-ubuntu-24-04`
 Distribution image for end users with pre-built tt-lang, ready to `import ttl`.
 
 **Contents:** LLVM + tt-metal toolchain + installed tt-lang + examples + SSH +
 text editors
 
-### `tt-lang-ird-ubuntu-22-04`
+### `tt-lang-ird-ubuntu-24-04`
 Interactive Research & Development image. Contains the toolchain but *not*
 tt-lang -- developers clone and build tt-lang themselves.
 
@@ -96,21 +96,21 @@ missing the toolchain.
 
 After building, use the image with `docker-test.sh`:
 ```bash
-DOCKER_IMAGE=tt-lang-ird-ubuntu-22-04:<version-tag> scripts/docker-test.sh mlir
+DOCKER_IMAGE=tt-lang-ird-ubuntu-24-04:<version-tag> scripts/docker-test.sh mlir
 ```
 
 Or run interactively:
 ```bash
-sudo docker run -it --rm --device=/dev/tenstorrent/0:/dev/tenstorrent/0 -v /dev/hugepages:/dev/hugepages -v /dev/hugepages-1G:/dev/hugepages-1G tt-lang-ird-ubuntu-22-04:<version-tag> bash
+sudo docker run -it --rm --device=/dev/tenstorrent/0:/dev/tenstorrent/0 -v /dev/hugepages:/dev/hugepages -v /dev/hugepages-1G:/dev/hugepages-1G tt-lang-ird-ubuntu-24-04:<version-tag> bash
 ```
 
 ## Image Architecture
 
 ```
-ubuntu:22.04
+ubuntu:24.04
      |
      v
-tt-lang-base-ubuntu-22-04
+tt-lang-base-ubuntu-24-04
   (Python 3.12, clang, system libs, Python deps)
      |
      +---------------------+
@@ -134,7 +134,7 @@ configure-deps                build-image-base
         |                            |
         +----------------------------+
                      |
-               build-images (ubuntu-22.04)
+               build-images (large runner, ubuntu 24.04)
                  1. Restore toolchain cache
                  2. Configure + build tt-lang
                  3. docker build --target dist (with --build-context)
@@ -177,7 +177,7 @@ docker run -it \
 
 ## Files
 
-- `Dockerfile.base` -- base image from ubuntu:22.04 with Python and system deps
+- `Dockerfile.base` -- base image from ubuntu:24.04 with Python and system deps
 - `Dockerfile` -- multi-stage build (`ird` and `dist` targets, with separate build stages)
 - `scripts/build-and-install.sh` -- cmake configure/build/install with mode flags (`--toolchain-only`, `--force-rebuild`, `--test-toolchain`, etc. Used by CI and local toolchain builds. See '--help' for usage.)
 - `entrypoint.sh` -- activates tt-lang environment on container start

--- a/.github/containers/build-docker-images.sh
+++ b/.github/containers/build-docker-images.sh
@@ -94,13 +94,13 @@ echo ""
 
 # Compute image names up front (used by both build and check-only paths).
 if [ "$NO_PUSH" = false ]; then
-    BASE_IMAGE="ghcr.io/$REPO/tt-lang-base-ubuntu-22-04:$DOCKER_TAG"
-    DIST_IMAGE="ghcr.io/$REPO/tt-lang-dist-ubuntu-22-04:$DOCKER_TAG"
-    IRD_IMAGE="ghcr.io/$REPO/tt-lang-ird-ubuntu-22-04:$DOCKER_TAG"
+    BASE_IMAGE="ghcr.io/$REPO/tt-lang-base-ubuntu-24-04:$DOCKER_TAG"
+    DIST_IMAGE="ghcr.io/$REPO/tt-lang-dist-ubuntu-24-04:$DOCKER_TAG"
+    IRD_IMAGE="ghcr.io/$REPO/tt-lang-ird-ubuntu-24-04:$DOCKER_TAG"
 else
-    BASE_IMAGE="tt-lang-base-ubuntu-22-04:$DOCKER_TAG"
-    DIST_IMAGE="tt-lang-dist-ubuntu-22-04:$DOCKER_TAG"
-    IRD_IMAGE="tt-lang-ird-ubuntu-22-04:$DOCKER_TAG"
+    BASE_IMAGE="tt-lang-base-ubuntu-24-04:$DOCKER_TAG"
+    DIST_IMAGE="tt-lang-dist-ubuntu-24-04:$DOCKER_TAG"
+    IRD_IMAGE="tt-lang-ird-ubuntu-24-04:$DOCKER_TAG"
 fi
 
 # Write image names to files for workflow consumption (avoids fragile log parsing).
@@ -171,11 +171,11 @@ build_image() {
     # registry image if no local build exists.
     local base_image_arg=""
     if [ "$NO_PUSH" = false ]; then
-        base_image_arg="--build-arg BASE_IMAGE=ghcr.io/$REPO/tt-lang-base-ubuntu-22-04:$DOCKER_TAG"
-    elif docker image inspect "tt-lang-base-ubuntu-22-04:$DOCKER_TAG" > /dev/null 2>&1; then
-        base_image_arg="--build-arg BASE_IMAGE=tt-lang-base-ubuntu-22-04:$DOCKER_TAG"
+        base_image_arg="--build-arg BASE_IMAGE=ghcr.io/$REPO/tt-lang-base-ubuntu-24-04:$DOCKER_TAG"
+    elif docker image inspect "tt-lang-base-ubuntu-24-04:$DOCKER_TAG" > /dev/null 2>&1; then
+        base_image_arg="--build-arg BASE_IMAGE=tt-lang-base-ubuntu-24-04:$DOCKER_TAG"
     else
-        base_image_arg="--build-arg BASE_IMAGE=ghcr.io/$REPO/tt-lang-base-ubuntu-22-04:$DOCKER_TAG"
+        base_image_arg="--build-arg BASE_IMAGE=ghcr.io/$REPO/tt-lang-base-ubuntu-24-04:$DOCKER_TAG"
     fi
 
     docker build \
@@ -211,13 +211,13 @@ DOCKERFILE=".github/containers/Dockerfile"
 
 # Build images -- filtered by --image-type if specified, otherwise build all three
 if [[ -z "$IMAGE_TYPE" || "$IMAGE_TYPE" == "base" ]]; then
-    build_image "tt-lang-base-ubuntu-22-04" .github/containers/Dockerfile.base ""
+    build_image "tt-lang-base-ubuntu-24-04" .github/containers/Dockerfile.base ""
 fi
 if [[ -z "$IMAGE_TYPE" || "$IMAGE_TYPE" == "dist" ]]; then
-    build_image "tt-lang-dist-ubuntu-22-04" "$DOCKERFILE" dist
+    build_image "tt-lang-dist-ubuntu-24-04" "$DOCKERFILE" dist
 fi
 if [[ -z "$IMAGE_TYPE" || "$IMAGE_TYPE" == "ird" ]]; then
-    build_image "tt-lang-ird-ubuntu-22-04"  "$DOCKERFILE" ird
+    build_image "tt-lang-ird-ubuntu-24-04"  "$DOCKERFILE" ird
 fi
 
 

--- a/.github/containers/test-docker-smoke.sh
+++ b/.github/containers/test-docker-smoke.sh
@@ -30,7 +30,7 @@ if [ -z "$DOCKER_TAG" ]; then
     echo "ERROR: Could not determine Docker tag from git tags and no tag argument provided."
     exit 1
 fi
-DIST_IMAGE="tt-lang-dist-ubuntu-22-04:$DOCKER_TAG"
+DIST_IMAGE="tt-lang-dist-ubuntu-24-04:$DOCKER_TAG"
 
 echo "=== tt-lang Docker Smoke Test ==="
 echo "Image: $DIST_IMAGE"

--- a/.github/scripts/probe-docker-image.sh
+++ b/.github/scripts/probe-docker-image.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 TAG="${1:?usage: probe-docker-image.sh <tag>}"
-IMAGE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:${TAG}"
+IMAGE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${TAG}"
 
 if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
     echo "needs_rebuild=false" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/tests/test_helper.bash
+++ b/.github/scripts/tests/test_helper.bash
@@ -84,7 +84,7 @@ mkrepo() {
         echo "llvm-content-v1" > third-party/llvm-project/sentinel
         echo "tt-metal-content-v1" > third-party/tt-metal/sentinel
         cat > .github/containers/Dockerfile.base <<'EOF'
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN echo "base v1"
 EOF
         echo "greenlet>=3.0.0" > requirements-runtime.txt

--- a/.github/scripts/tests/test_probe_docker_image.bats
+++ b/.github/scripts/tests/test_probe_docker_image.bats
@@ -6,7 +6,7 @@
 
 load test_helper
 
-IRD_IMAGE_BASE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04"
+IRD_IMAGE_BASE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04"
 BARE_TAG="v99.99.99"
 UPLIFT_TAG="v99.99.99-uplift-abcd1234"
 RC_TAG="v99.99.99-rc1"

--- a/.github/scripts/tests/test_wheel_or_container_changed.bats
+++ b/.github/scripts/tests/test_wheel_or_container_changed.bats
@@ -34,7 +34,7 @@ setup() {
     (
         cd "$REPO"
         mkdir -p .github/containers .github/scripts bin examples packaging python
-        echo "FROM ubuntu:22.04" > .github/containers/Dockerfile
+        echo "FROM ubuntu:24.04" > .github/containers/Dockerfile
         echo "# run-tutorials" > .github/scripts/run-tutorials.sh
         echo "# smoke-test" > .github/scripts/smoke-test-wheel.py
         echo "#!/bin/sh" > bin/tt-lang-sim

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -40,7 +40,7 @@ jobs:
   # Builds the base image (system deps, Python, Clang)
   build-image-base:
     if: ${{ inputs.push }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
 
     outputs:
@@ -154,7 +154,7 @@ jobs:
           # When push: false, we pull the existing base image at the same
           # tag (released images already exist at clean tags; dryrun only
           # runs on non-uplift PRs so the tag is a release tag).
-          BASE_IMAGE="ghcr.io/${{ github.repository }}/tt-lang-base-ubuntu-22-04:${{ steps.docker-tag.outputs.docker-tag }}"
+          BASE_IMAGE="ghcr.io/${{ github.repository }}/tt-lang-base-ubuntu-24-04:${{ steps.docker-tag.outputs.docker-tag }}"
           docker pull "$BASE_IMAGE"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV
 

--- a/.github/workflows/call-build-toolchain.yml
+++ b/.github/workflows/call-build-toolchain.yml
@@ -11,6 +11,14 @@ permissions:
   contents: read
 
 jobs:
+  # Choose the runner based on whether the toolchain cache already exists.
+  # On a cache hit, configure-deps only restores the cache, so the cheap
+  # standard runner is enough. On a cache miss it must build LLVM + tt-metal
+  # from scratch, which needs the large runner's disk and cores. A job's
+  # runs-on is fixed when the job is scheduled, so a separate lookup job has
+  # to decide the label before configure-deps starts. Both labels are
+  # Ubuntu 24.04 (glibc 2.39), matching the ubuntu:24.04 Docker base image
+  # that consumes the cached toolchain.
   select-runner:
     name: "Select runner"
     runs-on: ubuntu-latest
@@ -43,7 +51,7 @@ jobs:
         id: decide
         run: |
           if [ "${{ steps.cache-lookup.outputs.cache-hit }}" = "true" ]; then
-            echo "runner=ubuntu-22.04" >> "$GITHUB_OUTPUT"
+            echo "runner=ubuntu-24.04" >> "$GITHUB_OUTPUT"
             echo "Toolchain cache hit -> standard runner (restore only)"
           else
             echo "runner=mlir-large-runner-lang" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/call-build-toolchain.yml
+++ b/.github/workflows/call-build-toolchain.yml
@@ -11,13 +11,53 @@ permissions:
   contents: read
 
 jobs:
+  select-runner:
+    name: "Select runner"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      runner: ${{ steps.decide.outputs.runner }}
+      cache-key: ${{ steps.submodule-shas.outputs.cache-key }}
+    steps:
+      - name: Checkout tt-lang (without submodules)
+        uses: actions/checkout@v6
+
+      - name: Extract submodule SHAs for cache keys
+        id: submodule-shas
+        run: |
+          LLVM_SHA=$(git ls-tree HEAD third-party/llvm-project | awk '{print substr($3,1,7)}')
+          TTMETAL_SHA=$(git ls-tree HEAD third-party/tt-metal | awk '{print substr($3,1,7)}')
+          CACHE_KEY="Linux-toolchain_llvm-${LLVM_SHA}_ttmetal-${TTMETAL_SHA}"
+          echo "cache-key=$CACHE_KEY" >> $GITHUB_OUTPUT
+          echo "Cache key: $CACHE_KEY"
+
+      - name: Look up toolchain cache (no download)
+        id: cache-lookup
+        uses: actions/cache/restore@v5
+        with:
+          path: /opt/ttlang-toolchain
+          key: ${{ steps.submodule-shas.outputs.cache-key }}
+          lookup-only: true
+
+      - name: Decide runner
+        id: decide
+        run: |
+          if [ "${{ steps.cache-lookup.outputs.cache-hit }}" = "true" ]; then
+            echo "runner=ubuntu-22.04" >> "$GITHUB_OUTPUT"
+            echo "Toolchain cache hit -> standard runner (restore only)"
+          else
+            echo "runner=mlir-large-runner-lang" >> "$GITHUB_OUTPUT"
+            echo "Toolchain cache miss -> large runner (cold LLVM + tt-metal build)"
+          fi
+
   configure-deps:
     name: "Configure dependencies"
-    runs-on: ubuntu-22.04
+    needs: select-runner
+    runs-on: ${{ needs.select-runner.outputs.runner }}
     timeout-minutes: 360
 
     outputs:
-      cache-key: ${{ steps.submodule-shas.outputs.cache-key }}
+      cache-key: ${{ needs.select-runner.outputs.cache-key }}
 
     defaults:
       run:
@@ -30,25 +70,12 @@ jobs:
       - name: Checkout tt-lang (without submodules)
         uses: actions/checkout@v6
 
-      - name: Extract submodule SHAs for cache keys
-        id: submodule-shas
-        run: |
-          LLVM_SHA=$(git ls-tree HEAD third-party/llvm-project | awk '{print substr($3,1,7)}')
-          TTMETAL_SHA=$(git ls-tree HEAD third-party/tt-metal | awk '{print substr($3,1,7)}')
-          CACHE_KEY="Linux-toolchain_llvm-${LLVM_SHA}_ttmetal-${TTMETAL_SHA}"
-          echo "llvm-sha=$LLVM_SHA" >> $GITHUB_OUTPUT
-          echo "ttmetal-sha=$TTMETAL_SHA" >> $GITHUB_OUTPUT
-          echo "cache-key=$CACHE_KEY" >> $GITHUB_OUTPUT
-          echo "LLVM submodule SHA: $LLVM_SHA"
-          echo "tt-metal submodule SHA: $TTMETAL_SHA"
-          echo "Cache key: $CACHE_KEY"
-
       - name: Restore toolchain cache
         id: cache-toolchain
         uses: actions/cache/restore@v5
         with:
           path: /opt/ttlang-toolchain
-          key: ${{ steps.submodule-shas.outputs.cache-key }}
+          key: ${{ needs.select-runner.outputs.cache-key }}
 
       # Everything below only runs on cache miss
       - name: Checkout submodules
@@ -126,4 +153,4 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: /opt/ttlang-toolchain
-          key: ${{ steps.submodule-shas.outputs.cache-key }}
+          key: ${{ needs.select-runner.outputs.cache-key }}

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: mlir-large-runner-lang
     timeout-minutes: 120
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:${{ inputs.docker_tag }}
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${{ inputs.docker_tag }}
 
     defaults:
       run:

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -31,11 +31,11 @@ permissions:
 jobs:
     build-tt-lang:
         name: "Build and test tt-lang"
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         timeout-minutes: 60
 
         container:
-            image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:${{ inputs.docker_tag }}
+            image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${{ inputs.docker_tag }}
 
         defaults:
             run:

--- a/.github/workflows/call-test-dist-tutorials.yml
+++ b/.github/workflows/call-test-dist-tutorials.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
 
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-22-04:${{ inputs.dist_docker_tag }}
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-24-04:${{ inputs.dist_docker_tag }}
       options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
 
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:${{ inputs.docker_tag }}
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${{ inputs.docker_tag }}
       options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -56,7 +56,7 @@ permissions:
 jobs:
   preflight:
     name: "Resolve S3 publish inputs"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       docker_tag: ${{ steps.resolve.outputs.docker_tag }}
@@ -124,7 +124,7 @@ jobs:
     name: "Publish wheels to S3 PyPI"
     needs: [preflight, build-wheels]
     if: ${{ always() && needs.preflight.result == 'success' && needs.build-wheels.result == 'success' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 core.*
 .local
-**/build
+**/build*
 third_party/tt-metal
 third_party/ttnn-python
 .DS_STORE

--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ Two images are available:
 
 | Image                                                                                           | Purpose                                                            | Preinstalled tt-lang<br />(including tt-lang-sim) | Can clone/build tt-lang? |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | :----------------------------------------------: | :----------------------: |
-| ![dist](https://img.shields.io/badge/dist-tt--lang--dist--ubuntu--22--04-brightgreen)<br />"dist" | Run tt-lang programs using<br />tt-lang-sim or Tenstorrent hardware |                       Yes                       |            No            |
-| ![ird](https://img.shields.io/badge/ird-tt--lang--ird--ubuntu--22--04-blueviolet)<br />"ird"      | Develop and build tt-lang from source                              |                        No                        |           Yes           |
+| ![dist](https://img.shields.io/badge/dist-tt--lang--dist--ubuntu--24--04-brightgreen)<br />"dist" | Run tt-lang programs using<br />tt-lang-sim or Tenstorrent hardware |                       Yes                       |            No            |
+| ![ird](https://img.shields.io/badge/ird-tt--lang--ird--ubuntu--24--04-blueviolet)<br />"ird"      | Develop and build tt-lang from source                              |                        No                        |           Yes           |
 
 Both images can be used with `ird reserve` (see [container build docs](.github/containers/README.md) for details).
 
 ### 2.3 ![dist](https://img.shields.io/badge/dist-brightgreen) Pre-built tt-lang (for users)
 
-Image: ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-22-04:latest ([all versions](https://github.com/tenstorrent/tt-lang/pkgs/container/tt-lang-dist-ubuntu-22-04))
+Image: ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-24-04:latest ([all versions](https://github.com/tenstorrent/tt-lang/pkgs/container/tt-lang-dist-ubuntu-24-04))
 
 The **dist** image contains a single, fully built tt-lang installation in `/opt/ttlang-toolchain`. Use it to compile and run any tt-lang program without building any of the prerequisites.
 
@@ -107,7 +107,7 @@ docker run -d --name $USER-dist \
   -v /dev/hugepages:/dev/hugepages \
   -v /dev/hugepages-1G:/dev/hugepages-1G \
   -v $HOME:$HOME \
-  ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-22-04:latest \
+  ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-24-04:latest \
   sleep infinity
 ```
 
@@ -127,7 +127,7 @@ To learn more, take a [tour](docs/sphinx/tour/index.md), explore the [programmin
 
 ### 2.4 ![ird](https://img.shields.io/badge/ird-blueviolet) Development image (for building tt-lang)
 
-Image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:latest ([all versions](https://github.com/tenstorrent/tt-lang/pkgs/container/tt-lang-ird-ubuntu-22-04))
+Image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:latest ([all versions](https://github.com/tenstorrent/tt-lang/pkgs/container/tt-lang-ird-ubuntu-24-04))
 
 The **ird** image has the pre-built toolchain (LLVM, tt-metal, Python venv) but does not include tt-lang itself. Clone the repository and build against the toolchain. You can maintain multiple clones or branches side by side, each with its own build directory.
 
@@ -141,7 +141,7 @@ docker run -d --name $USER-ird \
   -v $HOME:$HOME \
   -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent \
   -v $HOME/.ssh/known_hosts:/root/.ssh/known_hosts:ro \
-  ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:latest \
+  ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:latest \
   sleep infinity
 ```
 

--- a/cmake/modules/BuildTTMetal.cmake
+++ b/cmake/modules/BuildTTMetal.cmake
@@ -276,13 +276,21 @@ else()
   endif()
 
   # --- Build ---
+  # Build the ttnn runtime targets, not the default `all`. tt-metal adds
+  # googletest unconditionally (its CPMAddPackage is not guarded by
+  # TT_METAL_BUILD_TESTS), so `all` compiles gtest/gmock even though tt-lang
+  # never builds or runs tt-metal's unit tests. The `ttnn` target transitively
+  # links every runtime library tt-lang consumes (ttnncpp, tt_metal, tt-umd,
+  # tt_stl, tracy, the ttnn_op_* libraries) and produces _ttnn.so/_ttnncpp.so;
+  # gtest is not in its dependency graph. Firmware is built separately via the
+  # precompile-fw target below.
   message(STATUS "Building tt-metal (this may take a while)...")
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E env
       "TT_METAL_RUNTIME_ROOT=${TT_METAL_SOURCE_DIR}"
       "TT_METAL_HOME=${TT_METAL_SOURCE_DIR}"
       "TT_METAL_CACHE=${TTMETAL_BUILD_DIR}/tt-metal-cache"
-      ${CMAKE_COMMAND} --build "${TTMETAL_BUILD_DIR}"
+      ${CMAKE_COMMAND} --build "${TTMETAL_BUILD_DIR}" --target ttnn ttnncpp
     RESULT_VARIABLE _TTMETAL_BUILD_RESULT
   )
 

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -162,7 +162,7 @@ docker run -d --name $USER-dist \
   -v /dev/hugepages:/dev/hugepages \
   -v /dev/hugepages-1G:/dev/hugepages-1G \
   -v $HOME:$HOME \
-  ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-22-04:latest \
+  ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-24-04:latest \
   sleep infinity
 
 docker exec -it $USER-dist /bin/bash
@@ -186,7 +186,7 @@ docker run -d --name $USER-ird \
   -v /dev/hugepages-1G:/dev/hugepages-1G \
   -v $HOME:$HOME \
   -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent \
-  ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:latest \
+  ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:latest \
   sleep infinity
 
 docker exec -it $USER-ird /bin/bash

--- a/lib/Dialect/TTL/Transforms/LowerDPrintToEmitC.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerDPrintToEmitC.cpp
@@ -94,38 +94,47 @@ static FailureOr<std::string> resolveScalarExpr(Value val, Operation *op) {
                        "arith constants and core coordinates are supported");
 }
 
-/// Build the DPRINT streaming statement for scalar mode.
-/// Format string uses {} as placeholder for each argv operand.
+/// Append a character to a DEVICE_PRINT format-string literal, escaping
+/// quotes/backslashes and doubling literal braces so they are not parsed as
+/// placeholders.
+static void appendFmtChar(std::string &fmt, char c) {
+  if (c == '"' || c == '\\') {
+    fmt += '\\';
+    fmt += c;
+  } else if (c == '{') {
+    fmt += "{{";
+  } else if (c == '}') {
+    fmt += "}}";
+  } else {
+    fmt += c;
+  }
+}
+
+/// Build the printf-style DPRINT statement for scalar mode. The op format
+/// string uses {} placeholders, matching the fmt-style DEVICE_PRINT syntax, so
+/// each {} is forwarded verbatim and its argv operand becomes a call argument.
 static FailureOr<std::string> buildScalarDPrintStmt(DPrintOp op) {
-  std::string stmt = "DPRINT << ";
-  StringRef fmt = op.getFmt();
+  std::string fmt;
+  std::string args;
+  StringRef rawFmt = op.getFmt();
   auto argv = op.getArgv();
   unsigned argIdx = 0;
 
   size_t pos = 0;
-  while (pos < fmt.size()) {
-    size_t placeholderPos = fmt.find("{}", pos);
+  while (pos < rawFmt.size()) {
+    size_t placeholderPos = rawFmt.find("{}", pos);
 
-    // Emit the string literal before the placeholder (or remaining string).
-    StringRef strPart = fmt.slice(
-        pos, placeholderPos == StringRef::npos ? fmt.size() : placeholderPos);
-    if (!strPart.empty()) {
-      stmt += "\"";
-      // Escape quotes and backslashes in the string literal.
-      for (char c : strPart) {
-        if (c == '"' || c == '\\') {
-          stmt += '\\';
-        }
-        stmt += c;
-      }
-      stmt += "\" << ";
+    StringRef strPart =
+        rawFmt.slice(pos, placeholderPos == StringRef::npos ? rawFmt.size()
+                                                            : placeholderPos);
+    for (char c : strPart) {
+      appendFmtChar(fmt, c);
     }
 
     if (placeholderPos == StringRef::npos) {
       break;
     }
 
-    // Emit the variable expression for this placeholder.
     if (argIdx >= argv.size()) {
       return op.emitError("format string has more {} placeholders than argv "
                           "operands");
@@ -134,23 +143,34 @@ static FailureOr<std::string> buildScalarDPrintStmt(DPrintOp op) {
     if (failed(expr)) {
       return failure();
     }
-    stmt += *expr + " << ";
+    fmt += "{}";
+    args += ", " + *expr;
     argIdx++;
     pos = placeholderPos + 2; // skip "{}"
   }
 
-  stmt += "ENDL()";
-  return stmt;
+  return "DPRINT(\"" + fmt + "\\n\"" + args + ")";
 }
 
-/// Resolve tensor element type info for page printing.
-/// Returns {dprint_formatter, c_ptr_type, elements_per_page, page_size_bytes}.
+/// Resolve tensor element type info for page printing. `cPtrType` is the L1
+/// pointer element type used to read each value; bf16 is read as raw bits and
+/// wrapped in `bf16_t` for DEVICE_PRINT, while f32 is read directly as `float`.
 struct TensorPrintInfo {
-  std::string formatter; // e.g. "BF16" or "F32"
-  std::string cPtrType;  // e.g. "uint16_t" or "uint32_t"
+  std::string cPtrType; // "uint16_t" or "float"
+  bool wrapBf16;        // true: print bf16_t(x); false: print x directly
   int64_t eltsPerPage;
   int64_t pageSizeBytes;
 };
+
+/// Wrap a value-read expression in the DEVICE_PRINT argument form for the
+/// element type (bf16_t for bf16, the raw float otherwise).
+static std::string makeTensorPrintArg(const TensorPrintInfo &info,
+                                      StringRef valueExpr) {
+  if (info.wrapBf16) {
+    return ("bf16_t(" + valueExpr + ")").str();
+  }
+  return valueExpr.str();
+}
 
 static FailureOr<TensorPrintInfo> getTensorPrintInfo(Type elementType,
                                                      Operation *op) {
@@ -164,11 +184,12 @@ static FailureOr<TensorPrintInfo> getTensorPrintInfo(Type elementType,
   Type dataType = tileType.getElementType();
 
   if (dataType.isBF16()) {
-    return TensorPrintInfo{"BF16", "uint16_t", tileH * tileW,
+    return TensorPrintInfo{"uint16_t", /*wrapBf16=*/true, tileH * tileW,
                            tileH * tileW * 2};
   }
   if (dataType.isF32()) {
-    return TensorPrintInfo{"F32", "uint32_t", tileH * tileW, tileH * tileW * 4};
+    return TensorPrintInfo{"float", /*wrapBf16=*/false, tileH * tileW,
+                           tileH * tileW * 4};
   }
   return op->emitError("unsupported data type for tensor print: only bf16 "
                        "and f32 are supported");
@@ -250,15 +271,18 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
     StringRef mode = op.getMode();
     auto thread = op.getThread();
 
-    // Thread conditioning: open DPRINT_THREAD( wrapper.
+    // Thread conditioning: open a compute block-guard. tt-metal removed the
+    // stream-style DPRINT_THREAD(...) statement wrappers; the printf-style
+    // DEVICE_PRINT_THREAD macros take a format string, not a statement block,
+    // so multi-statement prints use the MATH/PACK/UNPACK block macros instead.
     if (thread) {
       std::string macro;
       if (*thread == "math") {
-        macro = "DPRINT_MATH(";
+        macro = "MATH({";
       } else if (*thread == "pack") {
-        macro = "DPRINT_PACK(";
+        macro = "PACK({";
       } else if (*thread == "unpack") {
-        macro = "DPRINT_UNPACK(";
+        macro = "UNPACK({";
       } else {
         return op.emitError("unsupported thread type: ") << *thread;
       }
@@ -280,10 +304,11 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
       if (failed(cbIdx)) {
         return failure();
       }
-      emitVerbatim(loc,
-                   "DPRINT << ttmlir::CBPrinter(get_compile_time_arg_val(" +
-                       std::to_string(*cbIdx) + ")) << ENDL();",
-                   rewriter);
+      emitVerbatim(
+          loc,
+          "ttmlir::dprint(ttmlir::CBPrinter(get_compile_time_arg_val(" +
+              std::to_string(*cbIdx) + ")));",
+          rewriter);
 
     } else if (mode == "tile") {
       if (op.getArgv().size() != 1) {
@@ -305,15 +330,15 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
       std::string cbArg =
           "get_compile_time_arg_val(" + std::to_string(*cbIdx) + ")";
       emitVerbatim(loc, "{", rewriter);
-      emitVerbatim(loc, "DPRINT << \"======\" << ENDL();", rewriter);
+      emitVerbatim(loc, "DPRINT(\"======\\n\");", rewriter);
       emitVerbatim(loc, "for (uint16_t r = 0; r < 32; ++r) {", rewriter);
       emitVerbatim(loc,
-                   "DPRINT << (uint)r << \" : \" << TileSlice(" + cbArg +
+                   "DPRINT(\"{} : {}\\n\", (uint)r, TSLICE(" + cbArg +
                        ", 0, SliceRange{.h0=(uint8_t)r, .h1=(uint8_t)(r+1), "
-                       ".hs=1, .w0=0, .w1=32, .ws=1}, true, false) << ENDL();",
+                       ".hs=1, .w0=0, .w1=32, .ws=1}, true, false));",
                    rewriter);
       emitVerbatim(loc, "}", rewriter);
-      emitVerbatim(loc, "DPRINT << \"++++++\" << ENDL();", rewriter);
+      emitVerbatim(loc, "DPRINT(\"++++++\\n\");", rewriter);
       emitVerbatim(loc, "}", rewriter);
 
     } else if (mode == "tensor") {
@@ -352,15 +377,16 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
                      "for (uint32_t page = 0; page < " +
                          std::to_string(numPages) + "; ++page) {",
                      rewriter);
-        emitVerbatim(loc, "DPRINT << page << \": \";", rewriter);
+        emitVerbatim(loc, "DPRINT(\"{}: \", page);", rewriter);
         emitVerbatim(loc,
                      "for (uint32_t j = 0; j < " +
                          std::to_string(info->eltsPerPage) + "; ++j, ++ptr) {",
                      rewriter);
-        emitVerbatim(loc, "DPRINT << " + info->formatter + "(*ptr) << \" \";",
-                     rewriter);
+        emitVerbatim(
+            loc, "DPRINT(\"{} \", " + makeTensorPrintArg(*info, "*ptr") + ");",
+            rewriter);
         emitVerbatim(loc, "}", rewriter);
-        emitVerbatim(loc, "DPRINT << ENDL();", rewriter);
+        emitVerbatim(loc, "DPRINT(\"\\n\");", rewriter);
         emitVerbatim(loc, "}", rewriter);
         emitVerbatim(loc, "}", rewriter);
       } else {
@@ -434,15 +460,17 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
                          "* ptr = reinterpret_cast<volatile tt_l1_ptr " +
                          info->cPtrType + "*>(dprint_scratch);",
                      rewriter);
-        emitVerbatim(loc, "DPRINT << page << \": \";", rewriter);
+        emitVerbatim(loc, "DPRINT(\"{}: \", page);", rewriter);
         emitVerbatim(loc,
                      "for (uint32_t j = 0; j < " +
                          std::to_string(info->eltsPerPage) + "; ++j) {",
                      rewriter);
-        emitVerbatim(loc, "DPRINT << " + info->formatter + "(ptr[j]) << \" \";",
+        emitVerbatim(loc,
+                     "DPRINT(\"{} \", " + makeTensorPrintArg(*info, "ptr[j]") +
+                         ");",
                      rewriter);
         emitVerbatim(loc, "}", rewriter);
-        emitVerbatim(loc, "DPRINT << ENDL();", rewriter);
+        emitVerbatim(loc, "DPRINT(\"\\n\");", rewriter);
         emitVerbatim(loc, "}", rewriter);
         emitVerbatim(loc, "}", rewriter);
       }
@@ -463,15 +491,20 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
 
       emitVerbatim(loc, "{", rewriter);
       if (!label.empty()) {
-        emitVerbatim(loc,
-                     "DPRINT << \"=== " + label.str() + " ===\" << ENDL();",
-                     rewriter);
+        std::string escLabel;
+        for (char c : label) {
+          appendFmtChar(escLabel, c);
+        }
+        emitVerbatim(loc, "DPRINT(\"=== " + escLabel + " ===\\n\");", rewriter);
       }
       for (auto &info : liveSlots) {
         std::string slotStr = std::to_string(info.slot);
+        std::string escOpName;
+        for (char c : info.opName) {
+          appendFmtChar(escOpName, c);
+        }
         emitVerbatim(loc,
-                     "DPRINT << \"DST[" + slotStr + "] (" + info.opName +
-                         ")\" << ENDL();",
+                     "DPRINT(\"DST[" + slotStr + "] (" + escOpName + ")\\n\");",
                      rewriter);
         // Inline dest register read. dbg_read_dest_acc_row is available
         // from compute_kernel_api.h (no extra include needed). Reads
@@ -487,12 +520,12 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
                      "    dbg_read_dest_acc_row(" + slotStr +
                          " * 64 + f * 16, rd_data);",
                      rewriter);
-        emitVerbatim(loc, "    DPRINT << \"  f\" << f << \": \";", rewriter);
+        emitVerbatim(loc, "    DPRINT(\"  f{}: \", f);", rewriter);
         emitVerbatim(loc,
-                     "    for (int i = 0; i < 8; ++i) { DPRINT << HEX() << "
-                     "rd_data[i] << \" \"; }",
+                     "    for (int i = 0; i < 8; ++i) { DPRINT(\"{:x} \", "
+                     "rd_data[i]); }",
                      rewriter);
-        emitVerbatim(loc, "    DPRINT << ENDL();", rewriter);
+        emitVerbatim(loc, "    DPRINT(\"\\n\");", rewriter);
         emitVerbatim(loc, "  }", rewriter);
         emitVerbatim(loc, "})", rewriter);
         emitVerbatim(loc, "dbg_unhalt();", rewriter);
@@ -503,9 +536,9 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
       return op.emitError("unsupported dprint mode: ") << mode;
     }
 
-    // Thread conditioning: close wrapper.
+    // Thread conditioning: close the MATH/PACK/UNPACK block-guard.
     if (thread) {
-      emitVerbatim(loc, ");", rewriter);
+      emitVerbatim(loc, "});", rewriter);
     }
 
     rewriter.eraseOp(op);

--- a/lib/Dialect/TTL/Transforms/LowerDPrintToEmitC.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerDPrintToEmitC.cpp
@@ -275,7 +275,10 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
     // stream-style DPRINT_THREAD(...) statement wrappers; the printf-style
     // DEVICE_PRINT_THREAD macros take a format string, not a statement block,
     // so multi-statement prints use the MATH/PACK/UNPACK block macros instead.
-    if (thread) {
+    // cb mode is exempt: ttmlir::dprint(CBPrinter) already self-guards each
+    // thread internally, so an outer block-guard would nest redundantly.
+    bool wrapThread = thread && mode != "cb";
+    if (wrapThread) {
       std::string macro;
       if (*thread == "math") {
         macro = "MATH({";
@@ -309,6 +312,12 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
           "ttmlir::dprint(ttmlir::CBPrinter(get_compile_time_arg_val(" +
               std::to_string(*cbIdx) + ")));",
           rewriter);
+      // ttmlir::print_cb_details_ emits no trailing newline. The host
+      // DEVICE_PRINT server buffers each RISC's output until a newline, so a
+      // CB print with no following newline-terminated print on the same thread
+      // never flushes. Emit a newline on every thread (it is part of the
+      // format string, not a value argument) to flush the per-thread line.
+      emitVerbatim(loc, "DPRINT(\"\\n\");", rewriter);
 
     } else if (mode == "tile") {
       if (op.getArgv().size() != 1) {
@@ -537,7 +546,7 @@ struct DPrintLowering : OpConversionPattern<DPrintOp> {
     }
 
     // Thread conditioning: close the MATH/PACK/UNPACK block-guard.
-    if (thread) {
+    if (wrapThread) {
       emitVerbatim(loc, "});", rewriter);
     }
 

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -65,14 +65,6 @@ void PipeGraph::assignGatherSlotIndices() {
     }
   };
   struct ReceiverKeyInfo {
-    static ReceiverKey getEmptyKey() {
-      int64_t sentinel = llvm::DenseMapInfo<int64_t>::getEmptyKey();
-      return {sentinel, sentinel, sentinel};
-    }
-    static ReceiverKey getTombstoneKey() {
-      int64_t sentinel = llvm::DenseMapInfo<int64_t>::getTombstoneKey();
-      return {sentinel, sentinel, sentinel};
-    }
     static unsigned getHashValue(const ReceiverKey &key) {
       return llvm::hash_combine(key.recvX, key.recvY, key.dfbIndex);
     }

--- a/lib/Dialect/TTL/Transforms/PipeGraph.h
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.h
@@ -44,14 +44,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<mlir::tt::ttl::PipeKey> {
   using Key = mlir::tt::ttl::PipeKey;
-  static Key getEmptyKey() {
-    int64_t s = DenseMapInfo<int64_t>::getEmptyKey();
-    return {s, s, s, s, s, s, s};
-  }
-  static Key getTombstoneKey() {
-    int64_t s = DenseMapInfo<int64_t>::getTombstoneKey();
-    return {s, s, s, s, s, s, s};
-  }
   static unsigned getHashValue(const Key &k) {
     return hash_combine(k.srcX, k.srcY, k.dstStartX, k.dstStartY, k.dstEndX,
                         k.dstEndY, k.pipeNetId);

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -98,14 +98,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<mlir::tt::ttl::PipeSourceKey> {
   using Key = mlir::tt::ttl::PipeSourceKey;
-  static Key getEmptyKey() {
-    int64_t sentinel = DenseMapInfo<int64_t>::getEmptyKey();
-    return {sentinel, sentinel};
-  }
-  static Key getTombstoneKey() {
-    int64_t sentinel = DenseMapInfo<int64_t>::getTombstoneKey();
-    return {sentinel, sentinel};
-  }
   static unsigned getHashValue(const Key &sourceKey) {
     return hash_combine(sourceKey.srcX, sourceKey.srcY);
   }

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -37,7 +37,7 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 # Defaults
 BUILD_DIR="build-dev"
 DOCKER_TAG="${DOCKER_TAG:-latest}"
-IMAGE="${DOCKER_IMAGE:-ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:$DOCKER_TAG}"
+IMAGE="${DOCKER_IMAGE:-ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:$DOCKER_TAG}"
 CONTAINER_NAME="${USER}-test-$$"
 TARGET=""
 

--- a/scripts/test-dist-container.sh
+++ b/scripts/test-dist-container.sh
@@ -37,7 +37,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-IMAGE="ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-22-04:${TAG}"
+IMAGE="ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-24-04:${TAG}"
 CONTAINER="ttlang-dist-test-$$"
 
 echo "=== Dist Container Test ==="

--- a/scripts/test-ird-container.sh
+++ b/scripts/test-ird-container.sh
@@ -42,7 +42,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-IMAGE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-22-04:${TAG}"
+IMAGE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${TAG}"
 CONTAINER="ttlang-ird-test-$$"
 
 echo "=== IRD Container Test ==="

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -276,7 +276,7 @@ scripts (`bin/tt-lang-sim`, `bin/tt-lang-sim-stats`). CI runs it via
 inside the ird container) install bats and the helper libraries once:
 
 ```bash
-# Ubuntu 22.04 apt's bats is 1.2.1, too old for this suite. Install 1.11.0 from upstream:
+# Ubuntu apt's bats package can be too old for this suite. Install 1.11.0 from upstream:
 curl -fsSL https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.0.tar.gz | tar -xz -C /tmp
 sudo /tmp/bats-core-1.11.0/install.sh /usr/local
 sudo git clone --depth 1 https://github.com/bats-core/bats-support /usr/local/lib/bats-support

--- a/test/python/dprint/codegen.py
+++ b/test/python/dprint/codegen.py
@@ -77,55 +77,50 @@ def dprint_test_kernel(inp, out):
 # CHECK: void kernel_main()
 
 # Scalar prints in compute auto-default to math thread
-# CHECK: DPRINT_MATH(
-# CHECK: DPRINT << "compute start" << ENDL();
-# CHECK: );
-# CHECK: DPRINT_MATH(
-# CHECK: DPRINT << "magic: 42" << ENDL();
-# CHECK: );
+# CHECK: MATH({
+# CHECK: DPRINT("compute start\n");
+# CHECK: });
+# CHECK: MATH({
+# CHECK: DPRINT("magic: 42\n");
+# CHECK: });
 
-# CB print in compute auto-defaults to pack thread
-# CHECK: DPRINT_PACK(
-# CHECK: DPRINT << ttmlir::CBPrinter(get_compile_time_arg_val(
-# CHECK: );
+# CB print uses the self-thread-guarded ttmlir::dprint(CBPrinter) helper
+# CHECK: ttmlir::dprint(ttmlir::CBPrinter(get_compile_time_arg_val(
 
-# Mixed-arg: scalar label + CB object (label on math, CB on pack)
-# CHECK: DPRINT_MATH(
-# CHECK: DPRINT << "cb state:" << ENDL();
-# CHECK: );
-# CHECK: DPRINT_PACK(
-# CHECK: DPRINT << ttmlir::CBPrinter(get_compile_time_arg_val(
-# CHECK: );
+# Mixed-arg: scalar label (math) + CB object (self-guarded helper)
+# CHECK: MATH({
+# CHECK: DPRINT("cb state:\n");
+# CHECK: });
+# CHECK: ttmlir::dprint(ttmlir::CBPrinter(get_compile_time_arg_val(
 
 # Tile print in compute auto-defaults to pack thread
-# CHECK: DPRINT_PACK(
-# CHECK: TileSlice(get_compile_time_arg_val(
-# CHECK: );
+# CHECK: PACK({
+# CHECK: TSLICE(get_compile_time_arg_val(
+# CHECK: });
 
 # Mixed-arg: scalar label + tile object
-# CHECK: DPRINT_MATH(
-# CHECK: DPRINT << "tile:" << ENDL();
-# CHECK: );
-# CHECK: DPRINT_PACK(
-# CHECK: TileSlice(get_compile_time_arg_val(
-# CHECK: );
+# CHECK: MATH({
+# CHECK: DPRINT("tile:\n");
+# CHECK: });
+# CHECK: PACK({
+# CHECK: TSLICE(get_compile_time_arg_val(
+# CHECK: });
 
 # DST dump after exp auto-defaults to math thread
 # (no live slots because the dprint is outside the fused compute
 # body; the store clears all slots before it)
-# CHECK: DPRINT_MATH(
-# CHECK: DPRINT << "=== after exp ===" << ENDL();
-# CHECK: );
+# CHECK: MATH({
+# CHECK: DPRINT("=== after exp ===\n");
 
 # Thread conditioning: explicit pack-only tile print
-# CHECK: DPRINT_PACK(
-# CHECK: TileSlice(get_compile_time_arg_val(
-# CHECK: );
+# CHECK: PACK({
+# CHECK: TSLICE(get_compile_time_arg_val(
+# CHECK: });
 
 # Thread conditioning: explicit math-only scalar print
-# CHECK: DPRINT_MATH(
-# CHECK: DPRINT << "math only" << ENDL();
-# CHECK: );
+# CHECK: MATH({
+# CHECK: DPRINT("math only\n");
+# CHECK: });
 
 # =============================================================================
 # C++ Kernel Checks - Verify dprint with variables in dm_read kernel
@@ -135,15 +130,15 @@ def dprint_test_kernel(inp, out):
 # CHECK: // dm_read
 # CHECK: #include "api/debug/dprint.h"
 # CHECK: void kernel_main()
-# CHECK: DPRINT << "dm_read core: " << get_absolute_logical_x() << " " << get_absolute_logical_y() << ENDL();
+# CHECK: DPRINT("dm_read core: {} {}\n", get_absolute_logical_x(), get_absolute_logical_y());
 
 # Mixed-arg: scalar label + tensor accessor pages in datamovement
-# CHECK: DPRINT << "inp:" << ENDL();
+# CHECK: DPRINT("inp:\n");
 # CHECK: TensorAccessorArgs<
 # CHECK: noc_async_read_tile(
 
 # Tensor accessor without num_pages defaults to num_pages=1
-# CHECK: DPRINT << "A:" << ENDL();
+# CHECK: DPRINT("A:\n");
 # CHECK: TensorAccessorArgs<
 # CHECK: noc_async_read_tile(
 

--- a/third-party/tt-metal-version
+++ b/third-party/tt-metal-version
@@ -39,8 +39,8 @@
 # CMake to develop against a newer tt-metal locally (releases must
 # still align with the ttnn PyPI wheel).
 
-TTNN_PYPI="0.70.1"
-TTNN_PYPI_TT_METAL_TAG="v0.70.1-rc1"
+TTNN_PYPI="0.72.0"
+TTNN_PYPI_TT_METAL_TAG="v0.72.0-rc4"
 # DANGER: public PyPI publish is blocked until TT_METAL_TAG matches
 # TTNN_PYPI_TT_METAL_TAG. See docs/sphinx/build.md#publishing-to-s3-pypi.
-TT_METAL_TAG="v0.71.0-rc2"
+TT_METAL_TAG="v0.72.0"


### PR DESCRIPTION
Uplift submodule shas to latest stable tt-metal (v0.72.0), latest llvm, latest tt-mlir.

Changes to tt-lang only, no new patches for third-party submodules.
1. `third-party/tt-metal-version` — version bump.
2. `cmake/modules/BuildTTMetal.cmake` — build ttnn ttnncpp instead of all, so tt-metal's unconditionally-added (and broken-under-GCC15) gtest never compiles. (Filed tt-metal issue #46510 on the unconditional gtest inclusion.)
3. `lib/Dialect/TTL/Transforms/{PipeGraph.h,PipeGraph.cpp,PipeLowering.cpp}` — dropped the now-removed `getEmptyKey/getTombstoneKey` from custom `DenseMapInfo`s (LLVM HEAD rewrote DenseMap to be tombstone-free).
4. `lib/Dialect/TTL/Transforms/LowerDPrintToEmitC.cpp` — migrated `DPRINT` emission from the removed stream-style `DPRINT << … << ENDL()` to the new `std::format` style `DEVICE_PRINT/ttmlir::dprint(CBPrinter)`, including the per-thread newline flush.
5. `test/python/dprint/codegen.py` — updated CHECK lines to the new emission.
6. Update to Ubuntu 24.04 throughout (removes compatibility issues by mixing 22.04 and 24.04 runners -- the large runner is 24.04 and makes it consistent with tt-mlir).
