### PR TITLE
[nfc][ci] Relax the tt-metal version check

### DIFF
--- a/.github/scripts/lib/tt-metal-version-utils.sh
+++ b/.github/scripts/lib/tt-metal-version-utils.sh
@@ -34,8 +34,22 @@ load_tt_metal_version() {
     : "${TTNN_PYPI_TT_METAL_TAG:?$version_file: TTNN_PYPI_TT_METAL_TAG not set}"
 }
 
-# True when the public ttnn wheel was built from the same tt-metal tag this
-# release builds against. Requires load_tt_metal_version to have run.
+tt_metal_release_component() {
+    local tag="$1"
+    if [[ "$tag" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)($|[-+]) ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+# True when the public ttnn wheel and this release use the same tt-metal
+# release component. This treats a release candidate tag such as vX.Y.Z-rcN as
+# compatible with the final vX.Y.Z tag. Requires load_tt_metal_version to have
+# run.
 ttnn_pypi_aligned() {
-    [[ "$TTNN_PYPI_TT_METAL_TAG" == "$TT_METAL_TAG" ]]
+    local pypi_release_component tt_release_component
+    pypi_release_component="$(tt_metal_release_component "$TTNN_PYPI_TT_METAL_TAG")" || return 1
+    tt_release_component="$(tt_metal_release_component "$TT_METAL_TAG")" || return 1
+    [[ "$pypi_release_component" == "$tt_release_component" ]]
 }

--- a/.github/scripts/require-pypi-ttnn-alignment.sh
+++ b/.github/scripts/require-pypi-ttnn-alignment.sh
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Refuse public PyPI publishing when the ttnn wheel dependency was built from a
-# different tt-metal tag than the one used to build this tt-lang release.
+# different tt-metal release component than the one used to build this tt-lang
+# release.
 
 set -euo pipefail
 
@@ -15,7 +16,7 @@ load_tt_metal_version
 
 if ! ttnn_pypi_aligned; then
   cat >&2 <<EOF
-Public PyPI publish requires ttnn provenance to match TT_METAL_TAG.
+Public PyPI publish requires ttnn provenance to match the TT_METAL_TAG vX.Y.Z component.
 TTNN_PYPI=$TTNN_PYPI was built from TTNN_PYPI_TT_METAL_TAG=$TTNN_PYPI_TT_METAL_TAG,
 but this release builds against TT_METAL_TAG=$TT_METAL_TAG.
 Use the S3 bundled wheel workflow for this tt-metal selection, or publish after
@@ -24,4 +25,5 @@ EOF
   exit 1
 fi
 
-echo "ok: ttnn==$TTNN_PYPI and tt-lang both use tt-metal $TT_METAL_TAG"
+tt_release_component="$(tt_metal_release_component "$TT_METAL_TAG")"
+echo "ok: ttnn==$TTNN_PYPI and tt-lang both use tt-metal release $tt_release_component"

--- a/.github/scripts/tests/test_helper.bash
+++ b/.github/scripts/tests/test_helper.bash
@@ -25,6 +25,7 @@ TEST_TTNN_PYPI_VERSION="99.88.77"
 TEST_TT_METAL_TAG="v99.88.77"
 TEST_TT_METAL_RC1_TAG="v99.88.77-rc1"
 TEST_TT_METAL_RC2_TAG="v99.88.77-rc2"
+TEST_TT_METAL_NEXT_TAG="v99.88.78"
 
 whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$WHEEL_PYTAG"; }
 whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }

--- a/.github/scripts/tests/test_require_pypi_ttnn_alignment.bats
+++ b/.github/scripts/tests/test_require_pypi_ttnn_alignment.bats
@@ -28,22 +28,35 @@ run_alignment_check() {
     run run_alignment_check
 
     assert_success
-    assert_output --partial "ok: ttnn==$TEST_TTNN_PYPI_VERSION and tt-lang both use tt-metal $TEST_TT_METAL_RC1_TAG"
+    assert_output --partial "ok: ttnn==$TEST_TTNN_PYPI_VERSION and tt-lang both use tt-metal release $TEST_TT_METAL_TAG"
 }
 
-@test "rejects mismatched ttnn provenance and tt-metal tag" {
+@test "accepts matching release component with prerelease provenance tag" {
     write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
         "$TEST_TTNN_PYPI_VERSION" \
         "$TEST_TT_METAL_RC1_TAG" \
-        "$TEST_TT_METAL_RC2_TAG"
+        "$TEST_TT_METAL_TAG"
+    commit_all "$REPO" "aligned release component"
+
+    run run_alignment_check
+
+    assert_success
+    assert_output --partial "ok: ttnn==$TEST_TTNN_PYPI_VERSION and tt-lang both use tt-metal release $TEST_TT_METAL_TAG"
+}
+
+@test "rejects mismatched ttnn provenance and tt-metal release component" {
+    write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
+        "$TEST_TTNN_PYPI_VERSION" \
+        "$TEST_TT_METAL_RC1_TAG" \
+        "$TEST_TT_METAL_NEXT_TAG"
     commit_all "$REPO" "mismatched"
 
     run run_alignment_check
 
     assert_failure
-    assert_output --partial "Public PyPI publish requires ttnn provenance to match TT_METAL_TAG."
+    assert_output --partial "Public PyPI publish requires ttnn provenance to match the TT_METAL_TAG vX.Y.Z component."
     assert_output --partial "TTNN_PYPI=$TEST_TTNN_PYPI_VERSION was built from TTNN_PYPI_TT_METAL_TAG=$TEST_TT_METAL_RC1_TAG"
-    assert_output --partial "TT_METAL_TAG=$TEST_TT_METAL_RC2_TAG"
+    assert_output --partial "TT_METAL_TAG=$TEST_TT_METAL_NEXT_TAG"
 }
 
 @test "rejects missing ttnn provenance tag" {

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -102,7 +102,7 @@ output_value() {
 @test "stable tag push publishes bundled and light when public PyPI is blocked" {
     version_file=$(make_tt_metal_version_file \
         "$TEST_TT_METAL_RC1_TAG" \
-        "$TEST_TT_METAL_RC2_TAG")
+        "$TEST_TT_METAL_NEXT_TAG")
 
     DISPATCH_VERSION_OVERRIDE="" \
     DISPATCH_WHEEL_VARIANT="" \
@@ -121,7 +121,7 @@ output_value() {
 @test "stable tag push publishes only light when public PyPI is aligned" {
     version_file=$(make_tt_metal_version_file \
         "$TEST_TT_METAL_RC2_TAG" \
-        "$TEST_TT_METAL_RC2_TAG")
+        "$TEST_TT_METAL_TAG")
 
     DISPATCH_VERSION_OVERRIDE="" \
     DISPATCH_WHEEL_VARIANT="" \
@@ -139,7 +139,7 @@ output_value() {
 @test "stable manual bundled publish is rejected when public PyPI is aligned" {
     version_file=$(make_tt_metal_version_file \
         "$TEST_TT_METAL_RC2_TAG" \
-        "$TEST_TT_METAL_RC2_TAG")
+        "$TEST_TT_METAL_TAG")
 
     DISPATCH_VERSION_OVERRIDE="1.2.3" \
     DISPATCH_WHEEL_VARIANT=bundled \

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -255,9 +255,9 @@ TT_METAL_TAG="<tt-metal-tag>"
 
 `TTNN_PYPI_TT_METAL_TAG` records the tt-metal tag used to build the public
 `ttnn` wheel. `TT_METAL_TAG` records the tt-metal tag used to build TT-Lang.
-Public PyPI publishing requires these tags to match; internal S3 bundled
-wheels can use a newer `TT_METAL_TAG` before a matching public `ttnn` wheel is
-available.
+Public PyPI publishing requires these tags to have the same `vX.Y.Z` component;
+internal S3 bundled wheels can use a newer `TT_METAL_TAG` before a compatible
+public `ttnn` wheel is available.
 
 Background: `third-party/tt-metal-version` is the single source of truth for
 the `ttnn` dependency version, the public `ttnn` provenance tag, and the
@@ -520,7 +520,7 @@ Job-by-job:
    `GITHUB_REF` looks like `refs/tags/v[0-9]...`, then runs
    `require-pypi-ttnn-alignment.sh`, which fails when the public `ttnn` wheel
    recorded in `third-party/tt-metal-version` was built from a different
-   tt-metal tag than TT-Lang. Skipped under `dry_run: true`. Exposes
+   tt-metal `vX.Y.Z` component than TT-Lang. Skipped under `dry_run: true`. Exposes
    `tag_version` (tag with leading `v` stripped) for the wheel-version check.
 2. **`build-docker`** — calls `call-build-docker.yml` on tag push (where no
    `docker_tag` input is supplied). Skipped on `workflow_dispatch`, which
@@ -574,7 +574,8 @@ Automatic S3 publishing should use this policy:
 
 - Stable release tags (`vX.Y.Z`) publish clean-version bundled and light wheels
   to S3 only when public PyPI publishing is blocked because
-  `TTNN_PYPI_TT_METAL_TAG != TT_METAL_TAG`.
+  `TTNN_PYPI_TT_METAL_TAG` and `TT_METAL_TAG` have different `vX.Y.Z`
+  components.
 - Stable release tags publish only light wheels to S3 when public PyPI
   publishing is aligned. In that case public PyPI owns `tt-lang==X.Y.Z`, and S3
   owns `tt-lang==X.Y.Z+light` plus `tt-lang-light==X.Y.Z`.

--- a/third-party/tt-metal-version
+++ b/third-party/tt-metal-version
@@ -8,7 +8,8 @@
 #                  install_requires (ttnn == $TTNN_PYPI).
 #   TTNN_PYPI_TT_METAL_TAG
 #                - tt-metal git tag the ttnn PyPI release was built from.
-#                  publish-pypi.yml requires this to match TT_METAL_TAG.
+#                  publish-pypi.yml requires this to have the same vX.Y.Z
+#                  component as TT_METAL_TAG.
 #   TT_METAL_TAG - tt-metal git tag tt-lang builds against.
 #                  check-tt-metal-version.sh uses it to verify the
 #                  third-party/tt-metal submodule HEAD;
@@ -41,6 +42,7 @@
 
 TTNN_PYPI="0.72.0"
 TTNN_PYPI_TT_METAL_TAG="v0.72.0-rc4"
-# DANGER: public PyPI publish is blocked until TT_METAL_TAG matches
-# TTNN_PYPI_TT_METAL_TAG. See docs/sphinx/build.md#publishing-to-s3-pypi.
+# DANGER: public PyPI publish is blocked until TT_METAL_TAG and
+# TTNN_PYPI_TT_METAL_TAG share the same vX.Y.Z component. See
+# docs/sphinx/build.md#publishing-to-s3-pypi.
 TT_METAL_TAG="v0.72.0"


### PR DESCRIPTION
Relax the CI version check for the tt-metal, so v1.2.3 and v1.2.3-rc4 would match instead of being rejected.