### PR TITLE
[ci] Build S3 light wheels on manylinux 2.34

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 /third-party/llvm-project/build*/
 /third-party/tt-metal/build*/
 /third-party/tt-mlir/build*/
+/third-party/*/.cpmcache/
 /ird-toolchain/
 /dist*/
 /*.whl

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,14 @@
 /build*/
 /.build/
 /*.build/
+/third-party/llvm-project/build*/
+/third-party/tt-metal/build*/
+/third-party/tt-mlir/build*/
+/ird-toolchain/
 /dist*/
 /*.whl
+/docker*.log
+/.docker-image-*
 
 # Python cache
 __pycache__/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 # Build directories
-build/
-.build/
-*.build/
+/build*/
+/.build/
+/*.build/
+/dist*/
+/*.whl
 
 # Python cache
 __pycache__/

--- a/.github/containers/Dockerfile.wheel-manylinux-2-34
+++ b/.github/containers/Dockerfile.wheel-manylinux-2-34
@@ -11,9 +11,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG PYTHON_TAG=cp312
 ARG TT_METAL_TAG
 ARG TT_METAL_SHORT_SHA
+ARG TTLANG_BUILD_PARALLEL_LEVEL=""
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain
-ENV CMAKE_BUILD_PARALLEL_LEVEL=2
 
 RUN dnf install -y \
       boost-devel \
@@ -55,7 +55,12 @@ RUN dnf install -y \
 
 # AlmaLinux clang 21 crashes while compiling generated MLIR bytecode sources in
 # this image. Keep the override local to this wheel-builder image.
-ENV TTLANG_LLVM_EXTRA_CMAKE_ARGS="-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON;-DCMAKE_C_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gcc;-DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++"
+#
+# LLVM_ENABLE_ZSTD=OFF drops LLVM's libzstd dependency (unused by the
+# tt-lang -> ttkernel -> emitc pipeline). Otherwise auditwheel vendors libzstd
+# and rewrites MLIR/tt-lang shared libraries via patchelf --replace-needed; that
+# rewrite corrupts the large libraries and makes `import ttl` segfault.
+ENV TTLANG_LLVM_EXTRA_CMAKE_ARGS="-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON;-DCMAKE_C_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gcc;-DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++;-DLLVM_ENABLE_ZSTD=OFF"
 
 COPY . /workspace
 WORKDIR /workspace
@@ -80,6 +85,9 @@ RUN python_dir="/opt/python/${PYTHON_TAG}-${PYTHON_TAG}" && \
       packaging \
       patchelf \
       wheel && \
+    if [ -n "${TTLANG_BUILD_PARALLEL_LEVEL}" ]; then \
+      export CMAKE_BUILD_PARALLEL_LEVEL="${TTLANG_BUILD_PARALLEL_LEVEL}"; \
+    fi && \
     export PATH="${python_dir}/bin:${PATH}" && \
     scripts/build-and-install.sh \
       --toolchain-only \
@@ -95,3 +103,4 @@ RUN python_dir="/opt/python/${PYTHON_TAG}-${PYTHON_TAG}" && \
       wheel
 
 ENV PATH="/opt/ttlang-toolchain/venv/bin:/opt/ttlang-toolchain/bin:${PATH}"
+ENV CMAKE_BUILD_PARALLEL_LEVEL="${TTLANG_BUILD_PARALLEL_LEVEL}"

--- a/.github/containers/Dockerfile.wheel-manylinux-2-34
+++ b/.github/containers/Dockerfile.wheel-manylinux-2-34
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build a tt-lang wheel-builder image for S3 light wheels. The toolchain is
+# built inside manylinux_2_34 base (matching tt-metal's base image) to ensure
+# the same glibc version is used for both the toolchain and the wheel build. The
+
+FROM quay.io/pypa/manylinux_2_34_x86_64
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG PYTHON_TAG=cp312
+ARG TT_METAL_TAG
+ARG TT_METAL_SHORT_SHA
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain
+ENV CMAKE_BUILD_PARALLEL_LEVEL=2
+
+RUN dnf install -y \
+      boost-devel \
+      capstone-devel \
+      clang \
+      clang-tools-extra \
+      cmake \
+      curl \
+      git \
+      hwloc-devel \
+      jq \
+      libatomic \
+      libffi-devel \
+      libstdc++ \
+      libuuid-devel \
+      llvm \
+      make \
+      ninja-build \
+      numactl-devel \
+      openssl-devel \
+      patch \
+      pkgconf-pkg-config \
+      python3-devel \
+      python3-pip \
+      sudo \
+      tar \
+      tbb-devel \
+      time \
+      unzip \
+      vim-common \
+      wget \
+      which \
+      xz \
+      yaml-cpp-devel \
+      zlib-devel \
+      zstd \
+      libzstd-devel && \
+    dnf clean all
+
+# AlmaLinux clang 21 crashes while compiling generated MLIR bytecode sources in
+# this image. Keep the override local to this wheel-builder image.
+ENV TTLANG_LLVM_EXTRA_CMAKE_ARGS="-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON;-DCMAKE_C_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gcc;-DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++"
+
+COPY . /workspace
+WORKDIR /workspace
+
+RUN git config --global --add safe.directory '*'
+
+# Docker build contexts intentionally exclude .git. tt-metal's version.cmake is
+# marked export-subst, so reproduce the git-archive substitutions in the copied
+# source tree before configuring tt-metal.
+RUN test -n "${TT_METAL_TAG}" && \
+    test -n "${TT_METAL_SHORT_SHA}" && \
+    sed -i \
+      -e "s|\\\$Format:%(describe)\\\$|${TT_METAL_TAG}|g" \
+      -e "s|\\\$Format:%h\\\$|${TT_METAL_SHORT_SHA}|g" \
+      third-party/tt-metal/cmake/version.cmake
+
+RUN python_dir="/opt/python/${PYTHON_TAG}-${PYTHON_TAG}" && \
+    test -x "${python_dir}/bin/python" && \
+    "${python_dir}/bin/python" -m pip install --no-cache-dir \
+      auditwheel \
+      cmake==3.28.4 \
+      packaging \
+      patchelf \
+      wheel && \
+    export PATH="${python_dir}/bin:${PATH}" && \
+    scripts/build-and-install.sh \
+      --toolchain-only \
+      --force-rebuild \
+      --accept-ttmetal-mismatch \
+      --python "${python_dir}/bin/python" \
+      --python-venv "${TTLANG_TOOLCHAIN_DIR}/venv" \
+      --remove-build-dir && \
+    "${TTLANG_TOOLCHAIN_DIR}/venv/bin/python" -m pip install --no-cache-dir \
+      auditwheel \
+      packaging \
+      patchelf \
+      wheel
+
+ENV PATH="/opt/ttlang-toolchain/venv/bin:/opt/ttlang-toolchain/bin:${PATH}"

--- a/.github/containers/Dockerfile.wheel-manylinux-2-34
+++ b/.github/containers/Dockerfile.wheel-manylinux-2-34
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Build a tt-lang wheel-builder image for S3 light wheels. The toolchain is
-# built inside manylinux_2_34 base (matching tt-metal's base image) to ensure
-# the same glibc version is used for both the toolchain and the wheel build. The
+# built inside manylinux_2_34 base (matching tt-metal's base image) so the
+# toolchain and the wheel are compiled against the same glibc version.
 
 FROM quay.io/pypa/manylinux_2_34_x86_64
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/.github/containers/README.md
+++ b/.github/containers/README.md
@@ -184,7 +184,7 @@ docker run -it \
 - `activate-install.sh` -- environment activation for installed tt-lang (used in containers)
 - `build-docker-images.sh` -- build/push script with `--image-type` filter
 - `cleanup-toolchain.sh` -- normalizes toolchain venv (lib64 symlink fix), strips LLVM binaries, and optionally removes headers/static libs for dist
-- `get-version-tag.sh` -- emits the Docker version tag for the current checkout: `vX.Y.Z` (clean) or `vX.Y.Z-uplift-<hash>` (uplift). See `../scripts/uplift-paths.sh`.
+- `get-version-tag.sh` -- emits the Docker version tag for the current checkout: `vX.Y.Z` when container inputs match the nearest version tag, or `vX.Y.Z-<hash>` when container inputs differ. See `../scripts/uplift-paths.sh`.
 - `test-docker-smoke.sh` -- quick smoke test for container functionality
 - `CONTAINER_README.md` -- welcome message shown inside dist container
 - `IRD_README.md` -- welcome message shown inside IRD container

--- a/.github/containers/build-wheel-manylinux-images.sh
+++ b/.github/containers/build-wheel-manylinux-images.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and optionally push manylinux_2_34 wheel-builder images for S3 light
+# wheels.
+
+set -eu
+
+NO_PUSH=false
+PYTHON_TAGS=cp310,cp312
+DOCKER_TAG=""
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: build-wheel-manylinux-images.sh [--no-push] [--image-tag <tag>] [--python-tags cp310,cp312]
+EOF
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --no-push)
+            NO_PUSH=true
+            shift
+            ;;
+        --python-tags)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            PYTHON_TAGS="$2"
+            shift 2
+            ;;
+        --image-tag)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            DOCKER_TAG="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+repo=tenstorrent/tt-lang
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(git rev-parse --show-toplevel)"
+docker_tag="${DOCKER_TAG:-$("$script_dir/get-version-tag.sh")}"
+dockerfile="$script_dir/Dockerfile.wheel-manylinux-2-34"
+
+# shellcheck source=/dev/null
+. "$repo_root/third-party/tt-metal-version"
+: "${TT_METAL_TAG:?third-party/tt-metal-version: TT_METAL_TAG not set}"
+tt_metal_short_sha="$(git -C "$repo_root/third-party/tt-metal" rev-parse --short=10 HEAD)"
+
+if [ -z "$PYTHON_TAGS" ]; then
+    echo "At least one Python tag is required" >&2
+    exit 2
+fi
+
+for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
+    case "$python_tag" in
+        cp310 | cp312) ;;
+        *)
+            echo "Unsupported Python tag: $python_tag" >&2
+            exit 2
+            ;;
+    esac
+
+    image_name="tt-lang-wheel-manylinux-2-34-${python_tag}"
+    local_image="${image_name}:${docker_tag}"
+    registry_image="ghcr.io/${repo}/${image_name}:${docker_tag}"
+
+    if [ "$NO_PUSH" = true ]; then
+        echo "Building local image: $local_image"
+        ${DOCKER:-docker} build \
+            --progress=plain \
+            --build-arg "PYTHON_TAG=$python_tag" \
+            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
+            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
+            -t "$local_image" \
+            -f "$dockerfile" \
+            "$repo_root"
+    else
+        echo "Building registry image: $registry_image"
+        ${DOCKER:-docker} build \
+            --progress=plain \
+            --build-arg "PYTHON_TAG=$python_tag" \
+            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
+            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
+            -t "$registry_image" \
+            -t "$local_image" \
+            -f "$dockerfile" \
+            "$repo_root"
+    fi
+
+    if [ "$NO_PUSH" != true ]; then
+        ${DOCKER:-docker} push "$registry_image"
+        if [ "${GITHUB_REF:-}" = "refs/heads/main" ]; then
+            latest="${registry_image%:*}:latest"
+            ${DOCKER:-docker} tag "$registry_image" "$latest"
+            ${DOCKER:-docker} push "$latest"
+        fi
+    fi
+done

--- a/.github/containers/build-wheel-manylinux-images.sh
+++ b/.github/containers/build-wheel-manylinux-images.sh
@@ -10,10 +10,11 @@ set -eu
 NO_PUSH=false
 PYTHON_TAGS=cp310,cp312
 DOCKER_TAG=""
+BUILD_PARALLEL_LEVEL=""
 
 usage() {
     cat >&2 <<'EOF'
-Usage: build-wheel-manylinux-images.sh [--no-push] [--image-tag <tag>] [--python-tags cp310,cp312]
+Usage: build-wheel-manylinux-images.sh [--no-push] [--image-tag <tag>] [--python-tags cp310,cp312] [--build-parallel-level <jobs>]
 EOF
     exit 2
 }
@@ -38,6 +39,13 @@ while [ "$#" -gt 0 ]; do
             DOCKER_TAG="$2"
             shift 2
             ;;
+        --build-parallel-level)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            BUILD_PARALLEL_LEVEL="$2"
+            shift 2
+            ;;
         *)
             usage
             ;;
@@ -60,6 +68,38 @@ if [ -z "$PYTHON_TAGS" ]; then
     exit 2
 fi
 
+case "$BUILD_PARALLEL_LEVEL" in
+    "" | *[!0-9]* | 0)
+        if [ -n "$BUILD_PARALLEL_LEVEL" ]; then
+            echo "Build parallel level must be a positive integer: $BUILD_PARALLEL_LEVEL" >&2
+            exit 2
+        fi
+        ;;
+esac
+
+docker_build() {
+    if [ -n "$BUILD_PARALLEL_LEVEL" ]; then
+        ${DOCKER:-docker} build \
+            --progress=plain \
+            --build-arg "PYTHON_TAG=$python_tag" \
+            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
+            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
+            --build-arg "TTLANG_BUILD_PARALLEL_LEVEL=$BUILD_PARALLEL_LEVEL" \
+            "$@" \
+            -f "$dockerfile" \
+            "$repo_root"
+    else
+        ${DOCKER:-docker} build \
+            --progress=plain \
+            --build-arg "PYTHON_TAG=$python_tag" \
+            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
+            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
+            "$@" \
+            -f "$dockerfile" \
+            "$repo_root"
+    fi
+}
+
 for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
     case "$python_tag" in
         cp310 | cp312) ;;
@@ -75,25 +115,10 @@ for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
 
     if [ "$NO_PUSH" = true ]; then
         echo "Building local image: $local_image"
-        ${DOCKER:-docker} build \
-            --progress=plain \
-            --build-arg "PYTHON_TAG=$python_tag" \
-            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
-            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
-            -t "$local_image" \
-            -f "$dockerfile" \
-            "$repo_root"
+        docker_build -t "$local_image"
     else
         echo "Building registry image: $registry_image"
-        ${DOCKER:-docker} build \
-            --progress=plain \
-            --build-arg "PYTHON_TAG=$python_tag" \
-            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
-            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
-            -t "$registry_image" \
-            -t "$local_image" \
-            -f "$dockerfile" \
-            "$repo_root"
+        docker_build -t "$registry_image" -t "$local_image"
     fi
 
     if [ "$NO_PUSH" != true ]; then

--- a/.github/containers/get-version-tag.sh
+++ b/.github/containers/get-version-tag.sh
@@ -4,17 +4,16 @@
 #
 # Print the Docker version tag for the current branch state.
 #
-# Clean state (no uplift-relevant changes since the nearest version tag):
+# Clean state (no container image content changes since the nearest version tag):
 # the tag name itself, e.g. `vX.Y.Z`. Git tags may carry SemVer build
 # metadata after `+` (e.g. vX.Y.Z+rcN); since Docker tags allow only
 # [A-Za-z0-9_.-], `+` is translated to `-` (`vX.Y.Z-rcN`).
 #
-# Uplift state (uplift-relevant paths differ from the nearest tag): append
-# `-uplift-<8char>` where the hash is derived from
+# Modified container-input state: append `-<8char>` where the hash is derived from
 # `git ls-tree HEAD -- <paths>`. Same submodule SHAs + Dockerfile/requirements
-# content -> same hash, so independent PRs uplifting to the same toolchain
-# resolve to the same docker tag and share the rebuilt image. The path list
-# is defined in .github/scripts/uplift-paths.sh.
+# content -> same hash, so independent PRs with the same container inputs
+# resolve to the same Docker tag and share the rebuilt image. The path list is
+# defined in .github/scripts/uplift-paths.sh.
 #
 # Usage: .github/containers/get-version-tag.sh
 # Must be run from a git repository with version tags (v[0-9]*) and full
@@ -29,7 +28,7 @@ source "${SCRIPT_DIR}/../scripts/uplift-paths.sh"
 if [[ ${#UPLIFT_PATHS[@]} -eq 0 ]]; then
     echo "ERROR: UPLIFT_PATHS is empty (defined in ${SCRIPT_DIR}/../scripts/uplift-paths.sh)." >&2
     echo "  Without a path list, git diff and git ls-tree would scan the whole tree," >&2
-    echo "  producing the uplift form for every commit." >&2
+    echo "  producing the hashed form for every commit." >&2
     exit 1
 fi
 
@@ -56,5 +55,5 @@ if git diff --quiet "$NEAREST_TAG_RAW..HEAD" -- "${UPLIFT_PATHS[@]}"; then
     echo "$NEAREST_TAG"
 else
     HASH=$(git ls-tree HEAD -- "${UPLIFT_PATHS[@]}" | sha256sum | cut -c1-8)
-    echo "${NEAREST_TAG}-uplift-${HASH}"
+    echo "${NEAREST_TAG}-${HASH}"
 fi

--- a/.github/scripts/build-s3-light-core-wheel.sh
+++ b/.github/scripts/build-s3-light-core-wheel.sh
@@ -3,15 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Build one S3 tt-lang-light core wheel inside a manylinux_2_34 builder image.
-#
-# Usage:
-#   build-s3-light-core-wheel.sh --python-tag cp310|cp312 --version <version> [options]
-#
-# Options:
-#   --build-dir <dir>                    CMake build directory. Default: build-<python-tag>.
-#   --raw-dir <dir>                      Unrepaired wheel directory. Default: dist-raw-<python-tag>.
-#   --dist-dir <dir>                     Final wheel directory. Default: dist.
-#   --allow-final-internal-version       Allow final release versions for internal light wheels.
 
 set -eu
 
@@ -23,7 +14,15 @@ DIST_DIR=dist
 ALLOW_FINAL_INTERNAL_VERSION="${TTLANG_ALLOW_FINAL_INTERNAL_VERSION:-false}"
 
 usage() {
-    sed -n '2,16p' "$0" >&2
+    cat >&2 <<'EOF'
+Usage: build-s3-light-core-wheel.sh --python-tag cp310|cp312 --version <version> [options]
+
+Options:
+  --build-dir <dir>               CMake build directory. Default: build-<python-tag>.
+  --raw-dir <dir>                 Unrepaired wheel directory. Default: dist-raw-<python-tag>.
+  --dist-dir <dir>                Final wheel directory. Default: dist.
+  --allow-final-internal-version  Allow final release versions for internal light wheels.
+EOF
     exit 2
 }
 

--- a/.github/scripts/build-s3-light-core-wheel.sh
+++ b/.github/scripts/build-s3-light-core-wheel.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build one S3 tt-lang-light core wheel inside a manylinux_2_34 builder image.
+#
+# Usage:
+#   build-s3-light-core-wheel.sh --python-tag cp310|cp312 --version <version> [options]
+#
+# Options:
+#   --build-dir <dir>                    CMake build directory. Default: build-<python-tag>.
+#   --raw-dir <dir>                      Unrepaired wheel directory. Default: dist-raw-<python-tag>.
+#   --dist-dir <dir>                     Final wheel directory. Default: dist.
+#   --allow-final-internal-version       Allow final release versions for internal light wheels.
+
+set -eu
+
+PYTHON_TAG=""
+VERSION=""
+BUILD_DIR=""
+RAW_DIR=""
+DIST_DIR=dist
+ALLOW_FINAL_INTERNAL_VERSION="${TTLANG_ALLOW_FINAL_INTERNAL_VERSION:-false}"
+
+usage() {
+    sed -n '2,16p' "$0" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --python-tag)
+            if [ "$#" -lt 2 ]; then usage; fi
+            PYTHON_TAG="$2"
+            shift 2
+            ;;
+        --version)
+            if [ "$#" -lt 2 ]; then usage; fi
+            VERSION="$2"
+            shift 2
+            ;;
+        --build-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            BUILD_DIR="$2"
+            shift 2
+            ;;
+        --raw-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            RAW_DIR="$2"
+            shift 2
+            ;;
+        --dist-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            DIST_DIR="$2"
+            shift 2
+            ;;
+        --allow-final-internal-version)
+            ALLOW_FINAL_INTERNAL_VERSION=true
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+case "$PYTHON_TAG" in
+    cp310 | cp312) ;;
+    *) echo "Unsupported Python tag: $PYTHON_TAG" >&2; exit 2 ;;
+esac
+
+if [ -z "$VERSION" ]; then
+    echo "--version is required" >&2
+    exit 2
+fi
+
+BUILD_DIR="${BUILD_DIR:-build-${PYTHON_TAG}}"
+RAW_DIR="${RAW_DIR:-dist-raw-${PYTHON_TAG}}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+version_output="$(mktemp)"
+trap 'rm -f "$version_output"' EXIT
+TTNN_DEP_MODE=external \
+VERSION_OVERRIDE="$VERSION" \
+GITHUB_OUTPUT="$version_output" \
+    "$repo_root/.github/scripts/resolve-wheel-versions.sh"
+core_version="$(sed -n 's/^core_version=//p' "$version_output")"
+
+. /opt/ttlang-toolchain/venv/bin/activate
+
+rm -rf "$BUILD_DIR" "$RAW_DIR"
+mkdir -p "$DIST_DIR"
+rm -f "$DIST_DIR"/tt_lang-*-"${PYTHON_TAG}"-"${PYTHON_TAG}"-manylinux_2_34_x86_64.whl
+
+export CMAKE_BINARY_DIR="$BUILD_DIR"
+export TTLANG_TTNN_DEP_MODE=external
+export TTLANG_VERSION_OVERRIDE="$core_version"
+export TTLANG_EXTERNAL_TT_METAL_DIR="${TTLANG_EXTERNAL_TT_METAL_DIR:-/opt/ttlang-toolchain/tt-metal}"
+export TTLANG_PYTHON_VENV="${TTLANG_PYTHON_VENV:-/opt/ttlang-toolchain/venv}"
+export TTLANG_ALLOW_FINAL_INTERNAL_VERSION="$ALLOW_FINAL_INTERNAL_VERSION"
+
+"$repo_root/.github/scripts/configure-ttlang-build.sh" "$BUILD_DIR"
+python -m pip wheel . --wheel-dir="$RAW_DIR" --no-deps --no-build-isolation
+auditwheel repair \
+    --plat manylinux_2_34_x86_64 \
+    "$RAW_DIR"/tt_lang-*.whl \
+    --wheel-dir="$DIST_DIR"
+
+expected_wheel="$DIST_DIR/tt_lang-${core_version}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_34_x86_64.whl"
+if [ ! -f "$expected_wheel" ]; then
+    echo "Expected wheel was not produced: $expected_wheel" >&2
+    ls -lh "$DIST_DIR" >&2 || true
+    exit 1
+fi
+
+auditwheel show "$expected_wheel"
+python "$repo_root/.github/scripts/check-wheel-ttnn-metadata.py" \
+    --mode external \
+    --dist-dir "$DIST_DIR"

--- a/.github/scripts/build-s3-light-metapackage-wheel.sh
+++ b/.github/scripts/build-s3-light-metapackage-wheel.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the pure-Python tt-lang-light metapackage wheel.
+#
+# Usage:
+#   build-s3-light-metapackage-wheel.sh --version <version> [options]
+#
+# Options:
+#   --dist-dir <dir>                     Final wheel directory. Default: dist.
+#   --allow-final-internal-version       Allow final release versions for internal light wheels.
+
+set -eu
+
+VERSION=""
+DIST_DIR=dist
+ALLOW_FINAL_INTERNAL_VERSION="${TTLANG_ALLOW_FINAL_INTERNAL_VERSION:-false}"
+
+usage() {
+    sed -n '2,13p' "$0" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            if [ "$#" -lt 2 ]; then usage; fi
+            VERSION="$2"
+            shift 2
+            ;;
+        --dist-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            DIST_DIR="$2"
+            shift 2
+            ;;
+        --allow-final-internal-version)
+            ALLOW_FINAL_INTERNAL_VERSION=true
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "--version is required" >&2
+    exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+version_output="$(mktemp)"
+trap 'rm -f "$version_output"' EXIT
+TTNN_DEP_MODE=external \
+VERSION_OVERRIDE="$VERSION" \
+GITHUB_OUTPUT="$version_output" \
+    "$repo_root/.github/scripts/resolve-wheel-versions.sh"
+light_version="$(sed -n 's/^light_version=//p' "$version_output")"
+
+. /opt/ttlang-toolchain/venv/bin/activate
+
+mkdir -p "$DIST_DIR"
+rm -f "$DIST_DIR"/tt_lang_light-*.whl
+
+TTLANG_VERSION_OVERRIDE="$VERSION" \
+TTLANG_LIGHT_TTLANG_VERSION="$light_version" \
+TTLANG_ALLOW_FINAL_INTERNAL_VERSION="$ALLOW_FINAL_INTERNAL_VERSION" \
+    python -m pip wheel packaging/light \
+        --wheel-dir="$DIST_DIR" \
+        --no-deps \
+        --no-build-isolation
+
+expected_wheel="$DIST_DIR/tt_lang_light-${VERSION}-py3-none-any.whl"
+if [ ! -f "$expected_wheel" ]; then
+    echo "Expected metapackage wheel was not produced: $expected_wheel" >&2
+    ls -lh "$DIST_DIR" >&2 || true
+    exit 1
+fi
+
+python "$repo_root/.github/scripts/check-light-metapackage.py" \
+    --dist-dir "$DIST_DIR" \
+    --expect-ttlang-version "$light_version"

--- a/.github/scripts/build-s3-light-metapackage-wheel.sh
+++ b/.github/scripts/build-s3-light-metapackage-wheel.sh
@@ -3,13 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Build the pure-Python tt-lang-light metapackage wheel.
-#
-# Usage:
-#   build-s3-light-metapackage-wheel.sh --version <version> [options]
-#
-# Options:
-#   --dist-dir <dir>                     Final wheel directory. Default: dist.
-#   --allow-final-internal-version       Allow final release versions for internal light wheels.
 
 set -eu
 
@@ -18,7 +11,13 @@ DIST_DIR=dist
 ALLOW_FINAL_INTERNAL_VERSION="${TTLANG_ALLOW_FINAL_INTERNAL_VERSION:-false}"
 
 usage() {
-    sed -n '2,13p' "$0" >&2
+    cat >&2 <<'EOF'
+Usage: build-s3-light-metapackage-wheel.sh --version <version> [options]
+
+Options:
+  --dist-dir <dir>                Final wheel directory. Default: dist.
+  --allow-final-internal-version  Allow final release versions for internal light wheels.
+EOF
     exit 2
 }
 

--- a/.github/scripts/lib/docker-image-utils.sh
+++ b/.github/scripts/lib/docker-image-utils.sh
@@ -25,3 +25,36 @@ ttlang_image_for_tag() {
         printf '%s/%s\n' "$ttlang_image_registry" "$ttlang_local_image"
     fi
 }
+
+ttlang_wheel_builder_image() {
+    if [ "$#" -ne 2 ]; then
+        echo "Usage: ttlang_wheel_builder_image <python-tag> <docker-tag>" >&2
+        return 2
+    fi
+    ttlang_image_for_tag "tt-lang-wheel-manylinux-2-34-$1" "$2"
+}
+
+# Validate a comma-separated list of supported Python ABI tags and print them
+# one per line. Used to iterate the light-wheel builder ABIs in one place.
+ttlang_python_tags() {
+    if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+        echo "At least one Python tag is required" >&2
+        return 2
+    fi
+    ttlang_pt_count=0
+    for ttlang_pt in $(printf '%s\n' "$1" | tr ',' ' '); do
+        case "$ttlang_pt" in
+            cp310 | cp312) ;;
+            *)
+                echo "Unsupported Python tag: $ttlang_pt" >&2
+                return 2
+                ;;
+        esac
+        ttlang_pt_count=$((ttlang_pt_count + 1))
+        printf '%s\n' "$ttlang_pt"
+    done
+    if [ "$ttlang_pt_count" -eq 0 ]; then
+        echo "At least one Python tag is required" >&2
+        return 2
+    fi
+}

--- a/.github/scripts/lib/docker-image-utils.sh
+++ b/.github/scripts/lib/docker-image-utils.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sourceable Docker image helpers for workflow and local scripts.
+
+ttlang_docker() {
+    ${DOCKER:-docker} "$@"
+}
+
+ttlang_image_for_tag() {
+    if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+        echo "Usage: ttlang_image_for_tag <image-name> <tag> [registry]" >&2
+        return 2
+    fi
+
+    ttlang_image_name="$1"
+    ttlang_image_tag="$2"
+    ttlang_image_registry="${3:-ghcr.io/tenstorrent/tt-lang}"
+    ttlang_local_image="${ttlang_image_name}:${ttlang_image_tag}"
+
+    if ttlang_docker image inspect "$ttlang_local_image" >/dev/null 2>&1; then
+        printf '%s\n' "$ttlang_local_image"
+    else
+        printf '%s/%s\n' "$ttlang_image_registry" "$ttlang_local_image"
+    fi
+}

--- a/.github/scripts/prepare-s3-publish-dist.sh
+++ b/.github/scripts/prepare-s3-publish-dist.sh
@@ -1,29 +1,28 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
 # Verify variant-specific wheel artifact directories and copy their wheels into
 # a single publish directory. A spec has the form <variant>[:no-sim]=<dist_dir>.
-# Use `:no-sim` when the same workflow run publishes bundled wheels and the
-# light artifact intentionally omits the duplicate tt-lang-sim wheel.
+# Use `:no-sim` for light artifacts that intentionally omit tt-lang-sim.
 #
 # Usage: prepare-s3-publish-dist.sh <version_override> <publish_dir> <spec>...
 
-set -euo pipefail
+set -eu
 
 usage() {
     echo "Usage: $0 <version_override> <publish_dir> <variant[:no-sim]=dist_dir>..." >&2
     exit 2
 }
 
-if [[ $# -lt 3 ]]; then
+if [ "$#" -lt 3 ]; then
     usage
 fi
 
 version="$1"
 publish_dir="$2"
 shift 2
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 case "$publish_dir" in
     "" | "." | "/")
@@ -36,23 +35,27 @@ rm -rf "$publish_dir"
 mkdir -p "$publish_dir"
 
 for spec in "$@"; do
-    if [[ "$spec" != *=* ]]; then
-        usage
-    fi
+    case "$spec" in
+        *=*) ;;
+        *) usage ;;
+    esac
     variant_spec="${spec%%=*}"
     artifact_dir="${spec#*=}"
-    verify_args=()
+    no_sim=false
 
-    if [[ "$variant_spec" == *:no-sim ]]; then
-        variant="${variant_spec%:no-sim}"
-        if [[ "$variant" != light ]]; then
-            echo ":no-sim is only valid for the light variant: $spec" >&2
-            exit 2
-        fi
-        verify_args+=(--no-sim)
-    else
-        variant="$variant_spec"
-    fi
+    case "$variant_spec" in
+        *:no-sim)
+            variant="${variant_spec%:no-sim}"
+            if [ "$variant" != light ]; then
+                echo ":no-sim is only valid for the light variant: $spec" >&2
+                exit 2
+            fi
+            no_sim=true
+            ;;
+        *)
+            variant="$variant_spec"
+            ;;
+    esac
 
     case "$variant" in
         pypi | light | bundled) ;;
@@ -62,32 +65,40 @@ for spec in "$@"; do
             ;;
     esac
 
-    if [[ ! -d "$artifact_dir" ]]; then
+    if [ ! -d "$artifact_dir" ]; then
         echo "Wheel artifact directory not found: $artifact_dir" >&2
         exit 1
     fi
 
-    "$script_dir/verify-s3-wheel-versions.sh" \
-        "${verify_args[@]}" \
-        "$variant" \
-        "$version" \
-        "$artifact_dir"
-
-    shopt -s nullglob
-    wheels=("$artifact_dir"/*.whl)
-    shopt -u nullglob
-    if [[ "${#wheels[@]}" -eq 0 ]]; then
-        echo "No wheels found under $artifact_dir" >&2
-        exit 1
+    if [ "$no_sim" = true ]; then
+        "$script_dir/verify-s3-wheel-versions.sh" \
+            --no-sim \
+            "$variant" \
+            "$version" \
+            "$artifact_dir"
+    else
+        "$script_dir/verify-s3-wheel-versions.sh" \
+            "$variant" \
+            "$version" \
+            "$artifact_dir"
     fi
 
-    for wheel in "${wheels[@]}"; do
+    seen_wheel=false
+    for wheel in "$artifact_dir"/*.whl; do
+        if [ ! -e "$wheel" ]; then
+            continue
+        fi
+        seen_wheel=true
         wheel_name="$(basename "$wheel")"
         target="$publish_dir/$wheel_name"
-        if [[ -e "$target" ]]; then
+        if [ -e "$target" ]; then
             echo "Duplicate wheel filename across S3 publish artifacts: $wheel_name" >&2
             exit 1
         fi
         cp "$wheel" "$target"
     done
+    if [ "$seen_wheel" = false ]; then
+        echo "No wheels found under $artifact_dir" >&2
+        exit 1
+    fi
 done

--- a/.github/scripts/probe-docker-image.sh
+++ b/.github/scripts/probe-docker-image.sh
@@ -6,7 +6,7 @@
 #
 # Writes needs_rebuild=true|false to $GITHUB_OUTPUT.
 #
-# Refuses to rebuild a bare release tag (vX.Y.Z without -uplift- suffix)
+# Refuses to rebuild a bare release tag (vX.Y.Z without a deterministic hash suffix)
 # when the image is missing: pushing PR/main content under the release
 # tag would silently corrupt the release image in GHCR. Only
 # publish-pypi.yml on a tag push may rebuild the release tag.
@@ -24,7 +24,7 @@ if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
     exit 0
 fi
 
-if [[ ! "$TAG" =~ -uplift-[0-9a-f]{8}$ ]]; then
+if [[ ! "$TAG" =~ -(uplift-)?[0-9a-f]{8}$ ]]; then
     echo "::error::Release image $IMAGE is missing from GHCR. Refusing to rebuild from a non-release context — re-publish via publish-pypi.yml (workflow_dispatch on tag $TAG)."
     exit 1
 fi

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -20,7 +20,8 @@
 #
 # Outputs (written to $GITHUB_OUTPUT):
 #   docker_tag, dry_run, overwrite_releases, version_override, wheel_variant,
-#   wheel_variants, wheel_matrix, allow_final_internal_version
+#   wheel_variants, wheel_matrix, standard_wheel_matrix,
+#   allow_final_internal_version
 
 set -euo pipefail
 
@@ -93,18 +94,22 @@ case "$wheel_variant" in
     bundled)
         wheel_variants='["bundled"]'
         wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
+        standard_wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
         ;;
     light)
         wheel_variants='["light"]'
         wheel_matrix='{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
+        standard_wheel_matrix='{"include":[]}'
         ;;
     bundled-and-light)
         wheel_variants='["bundled","light"]'
         wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"},{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
+        standard_wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
         ;;
     pypi)
         wheel_variants='["pypi"]'
         wheel_matrix='{"include":[{"wheel_variant":"pypi","ttnn_dep_mode":"pypi"}]}'
+        standard_wheel_matrix='{"include":[{"wheel_variant":"pypi","ttnn_dep_mode":"pypi"}]}'
         ;;
     *)
         echo "Unknown S3 wheel variant: $wheel_variant" >&2
@@ -136,11 +141,13 @@ output_file="${GITHUB_OUTPUT:-/dev/stdout}"
     echo "wheel_variant=$wheel_variant"
     echo "wheel_variants=$wheel_variants"
     echo "wheel_matrix=$wheel_matrix"
+    echo "standard_wheel_matrix=$standard_wheel_matrix"
     echo "allow_final_internal_version=$allow_final_internal_version"
 } >> "$output_file"
 
 echo "Resolved wheel_variant=$wheel_variant"
 echo "Resolved wheel_variants=$wheel_variants"
+echo "Resolved standard_wheel_matrix=$standard_wheel_matrix"
 echo "Resolved version_override=$version_override"
 echo "Resolved allow_final_internal_version=$allow_final_internal_version"
 echo "Resolved dry_run=$dry_run"

--- a/.github/scripts/test-s3-light-wheels.sh
+++ b/.github/scripts/test-s3-light-wheels.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install-test S3 tt-lang-light wheels under the manylinux_2_34 builder images.
+#
+# Usage:
+#   test-s3-light-wheels.sh --version <version> [options]
+#
+# Options:
+#   --python-tags cp310,cp312  Python ABI tags to test. Default: cp310,cp312.
+#   --docker-tag <tag>         Builder image tag. Default: current Docker tag.
+#   --dist-dir <dir>           Wheel directory. Default: dist.
+
+set -eu
+
+VERSION=""
+PYTHON_TAGS=cp310,cp312
+DOCKER_TAG=""
+DIST_DIR=dist
+
+usage() {
+    sed -n '2,14p' "$0" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            if [ "$#" -lt 2 ]; then usage; fi
+            VERSION="$2"
+            shift 2
+            ;;
+        --python-tags)
+            if [ "$#" -lt 2 ]; then usage; fi
+            PYTHON_TAGS="$2"
+            shift 2
+            ;;
+        --docker-tag)
+            if [ "$#" -lt 2 ]; then usage; fi
+            DOCKER_TAG="$2"
+            shift 2
+            ;;
+        --dist-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            DIST_DIR="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "--version is required" >&2
+    exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=lib/docker-image-utils.sh
+. "$repo_root/.github/scripts/lib/docker-image-utils.sh"
+docker_tag="${DOCKER_TAG:-$("$repo_root/.github/containers/get-version-tag.sh")}"
+dist_dir="$(cd "$DIST_DIR" && pwd)"
+
+if [ -z "$PYTHON_TAGS" ]; then
+    echo "At least one Python tag is required" >&2
+    exit 2
+fi
+
+image_for_tag() {
+    python_tag="$1"
+    ttlang_image_for_tag "tt-lang-wheel-manylinux-2-34-${python_tag}" "$docker_tag"
+}
+
+for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
+    case "$python_tag" in
+        cp310 | cp312) ;;
+        *) echo "Unsupported Python tag: $python_tag" >&2; exit 2 ;;
+    esac
+
+    image="$(image_for_tag "$python_tag")"
+    echo "Install-testing tt-lang-light on $python_tag with $image"
+    ${DOCKER:-docker} run --rm \
+        -v "$repo_root:/workspace" \
+        -v "$dist_dir:/dist" \
+        -w /workspace \
+        -e "PYTHON_TAG=$python_tag" \
+        -e "TTLANG_VERSION=$VERSION" \
+        "$image" \
+        bash -euxo pipefail -c '
+          python_dir="/opt/python/${PYTHON_TAG}-${PYTHON_TAG}"
+          test -x "${python_dir}/bin/python"
+          rm -rf /tmp/test-venv-s3-light
+          "${python_dir}/bin/python" -m venv /tmp/test-venv-s3-light
+          . /tmp/test-venv-s3-light/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install \
+            --no-cache-dir \
+            --find-links=/dist \
+            --extra-index-url https://download.pytorch.org/whl/cpu \
+            "tt-lang-light==${TTLANG_VERSION}"
+          python .github/scripts/check-installed-ttnn.py --mode external
+          python .github/scripts/smoke-test-wheel.py
+        '
+done

--- a/.github/scripts/test-s3-light-wheels.sh
+++ b/.github/scripts/test-s3-light-wheels.sh
@@ -3,14 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Install-test S3 tt-lang-light wheels under the manylinux_2_34 builder images.
-#
-# Usage:
-#   test-s3-light-wheels.sh --version <version> [options]
-#
-# Options:
-#   --python-tags cp310,cp312  Python ABI tags to test. Default: cp310,cp312.
-#   --docker-tag <tag>         Builder image tag. Default: current Docker tag.
-#   --dist-dir <dir>           Wheel directory. Default: dist.
 
 set -eu
 
@@ -20,7 +12,14 @@ DOCKER_TAG=""
 DIST_DIR=dist
 
 usage() {
-    sed -n '2,14p' "$0" >&2
+    cat >&2 <<'EOF'
+Usage: test-s3-light-wheels.sh --version <version> [options]
+
+Options:
+  --python-tags cp310,cp312  Python ABI tags to test. Default: cp310,cp312.
+  --docker-tag <tag>         Builder image tag. Default: current Docker tag.
+  --dist-dir <dir>           Wheel directory. Default: dist.
+EOF
     exit 2
 }
 

--- a/.github/scripts/test-s3-light-wheels.sh
+++ b/.github/scripts/test-s3-light-wheels.sh
@@ -62,25 +62,14 @@ repo_root="$(git rev-parse --show-toplevel)"
 docker_tag="${DOCKER_TAG:-$("$repo_root/.github/containers/get-version-tag.sh")}"
 dist_dir="$(cd "$DIST_DIR" && pwd)"
 
-if [ -z "$PYTHON_TAGS" ]; then
-    echo "At least one Python tag is required" >&2
+if ! python_tags="$(ttlang_python_tags "$PYTHON_TAGS")"; then
     exit 2
 fi
 
-image_for_tag() {
-    python_tag="$1"
-    ttlang_image_for_tag "tt-lang-wheel-manylinux-2-34-${python_tag}" "$docker_tag"
-}
-
-for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
-    case "$python_tag" in
-        cp310 | cp312) ;;
-        *) echo "Unsupported Python tag: $python_tag" >&2; exit 2 ;;
-    esac
-
-    image="$(image_for_tag "$python_tag")"
+for python_tag in $python_tags; do
+    image="$(ttlang_wheel_builder_image "$python_tag" "$docker_tag")"
     echo "Install-testing tt-lang-light on $python_tag with $image"
-    ${DOCKER:-docker} run --rm \
+    ttlang_docker run --rm \
         -v "$repo_root:/workspace" \
         -v "$dist_dir:/dist" \
         -w /workspace \

--- a/.github/scripts/tests/test_detect_uplift.bats
+++ b/.github/scripts/tests/test_detect_uplift.bats
@@ -30,7 +30,7 @@ setup() {
     BASE=$(cd "$REPO" && git rev-parse HEAD)
 }
 
-# --- Per-path uplift detection: each of the 5 uplift paths separately. ---
+# --- Per-path uplift detection: each uplift path separately. ---
 
 @test "diff in third-party/tt-metal-version marks uplift=true" {
     echo "modified" >> "$REPO/third-party/tt-metal-version"
@@ -55,6 +55,13 @@ setup() {
 
 @test "diff in .github/containers/Dockerfile.base marks uplift=true" {
     echo "modified" >> "$REPO/.github/containers/Dockerfile.base"
+    commit_all "$REPO" "uplift"
+    head=$(cd "$REPO" && git rev-parse HEAD)
+    assert_equal "$(run_detect "$BASE" "$head")" "true"
+}
+
+@test "diff in .github/containers/Dockerfile.wheel-manylinux-2-34 marks uplift=true" {
+    echo "modified" >> "$REPO/.github/containers/Dockerfile.wheel-manylinux-2-34"
     commit_all "$REPO" "uplift"
     head=$(cd "$REPO" && git rev-parse HEAD)
     assert_equal "$(run_detect "$BASE" "$head")" "true"

--- a/.github/scripts/tests/test_docker_image_utils.bats
+++ b/.github/scripts/tests/test_docker_image_utils.bats
@@ -57,3 +57,57 @@ EOF
     assert_failure
     assert_output --partial "Usage: ttlang_image_for_tag"
 }
+
+@test "ttlang_wheel_builder_image prefers a local image when it exists" {
+    write_mock_docker 0
+
+    run bash -c "source '$LIB'; ttlang_wheel_builder_image cp312 some-tag"
+
+    assert_success
+    assert_output "tt-lang-wheel-manylinux-2-34-cp312:some-tag"
+}
+
+@test "ttlang_wheel_builder_image falls back to GHCR when local image is absent" {
+    write_mock_docker 1
+
+    run bash -c "source '$LIB'; ttlang_wheel_builder_image cp310 some-tag"
+
+    assert_success
+    assert_output "ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp310:some-tag"
+}
+
+@test "ttlang_wheel_builder_image validates arguments" {
+    run bash -c "source '$LIB'; ttlang_wheel_builder_image cp312"
+
+    assert_failure
+    assert_output --partial "Usage: ttlang_wheel_builder_image"
+}
+
+@test "ttlang_python_tags validates and lists every requested tag" {
+    run bash -c "source '$LIB'; ttlang_python_tags cp310,cp312"
+
+    assert_success
+    assert_output "cp310
+cp312"
+}
+
+@test "ttlang_python_tags accepts a single tag" {
+    run bash -c "source '$LIB'; ttlang_python_tags cp312"
+
+    assert_success
+    assert_output "cp312"
+}
+
+@test "ttlang_python_tags rejects an unsupported tag" {
+    run bash -c "source '$LIB'; ttlang_python_tags cp310,cp311"
+
+    assert_failure
+    assert_output --partial "Unsupported Python tag: cp311"
+}
+
+@test "ttlang_python_tags rejects empty input" {
+    run bash -c "source '$LIB'; ttlang_python_tags ''"
+
+    assert_failure
+    assert_output --partial "At least one Python tag is required"
+}

--- a/.github/scripts/tests/test_docker_image_utils.bats
+++ b/.github/scripts/tests/test_docker_image_utils.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/lib/docker-image-utils.sh.
+
+load test_helper
+
+setup() {
+    LIB="$SCRIPTS_DIR/lib/docker-image-utils.sh"
+    MOCK_DOCKER="$BATS_TEST_TMPDIR/docker"
+}
+
+write_mock_docker() {
+    local exit_code="$1"
+    cat > "$MOCK_DOCKER" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$BATS_TEST_TMPDIR/docker.calls"
+exit $exit_code
+EOF
+    chmod +x "$MOCK_DOCKER"
+    export DOCKER="$MOCK_DOCKER"
+}
+
+@test "ttlang_image_for_tag prefers a local image when it exists" {
+    write_mock_docker 0
+
+    run bash -c "source '$LIB'; ttlang_image_for_tag tt-lang-wheel-manylinux-2-34-cp312 local-tag"
+
+    assert_success
+    assert_output "tt-lang-wheel-manylinux-2-34-cp312:local-tag"
+    run cat "$BATS_TEST_TMPDIR/docker.calls"
+    assert_output "image inspect tt-lang-wheel-manylinux-2-34-cp312:local-tag"
+}
+
+@test "ttlang_image_for_tag falls back to GHCR when local image is absent" {
+    write_mock_docker 1
+
+    run bash -c "source '$LIB'; ttlang_image_for_tag tt-lang-wheel-manylinux-2-34-cp312 local-tag"
+
+    assert_success
+    assert_output "ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp312:local-tag"
+}
+
+@test "ttlang_image_for_tag accepts an explicit registry" {
+    write_mock_docker 1
+
+    run bash -c "source '$LIB'; ttlang_image_for_tag image-name image-tag registry.example.com/repo"
+
+    assert_success
+    assert_output "registry.example.com/repo/image-name:image-tag"
+}
+
+@test "ttlang_image_for_tag validates arguments" {
+    run bash -c "source '$LIB'; ttlang_image_for_tag image-only"
+
+    assert_failure
+    assert_output --partial "Usage: ttlang_image_for_tag"
+}

--- a/.github/scripts/tests/test_get_version_tag.bats
+++ b/.github/scripts/tests/test_get_version_tag.bats
@@ -44,9 +44,9 @@ fresh_tagged_repo() {
     assert_output "$BASE_TAG"
 }
 
-# --- Clean tag, one commit past, no uplift ---
+# --- Clean tag, one commit past, no container input changes ---
 
-@test "non-uplift commit past tag returns the tag (no suffix)" {
+@test "non-container commit past tag returns the tag (no suffix)" {
     REPO=$(fresh_tagged_repo)
     echo "kernel fix" >> "$REPO/python/sim/example.py"
     commit_all "$REPO" "kernel fix"
@@ -54,39 +54,39 @@ fresh_tagged_repo() {
     assert_output "$BASE_TAG"
 }
 
-# --- Per-path uplift: each uplift path separately ---
+# --- Per-path container input changes ---
 
-uplift_one_path() {
+container_input_one_path() {
     local path_to_change="$1"
     REPO=$(fresh_tagged_repo)
     echo "modified" >> "$REPO/$path_to_change"
-    commit_all "$REPO" "uplift $path_to_change"
+    commit_all "$REPO" "container input $path_to_change"
     run -0 bash -c "cd '$REPO' && .github/containers/get-version-tag.sh"
-    [[ "$output" =~ ^v99\.99\.99-uplift-[a-f0-9]{8}$ ]]
+    [[ "$output" =~ ^v99\.99\.99-[a-f0-9]{8}$ ]]
 }
 
-@test "uplift in third-party/tt-metal-version -> -uplift-<hash> form" {
-    uplift_one_path "third-party/tt-metal-version"
+@test "container input change in third-party/tt-metal-version -> -<hash> form" {
+    container_input_one_path "third-party/tt-metal-version"
 }
 
-@test "uplift in third-party/llvm-project/sentinel -> -uplift-<hash> form" {
-    uplift_one_path "third-party/llvm-project/sentinel"
+@test "container input change in third-party/llvm-project/sentinel -> -<hash> form" {
+    container_input_one_path "third-party/llvm-project/sentinel"
 }
 
-@test "uplift in third-party/tt-metal/sentinel -> -uplift-<hash> form" {
-    uplift_one_path "third-party/tt-metal/sentinel"
+@test "container input change in third-party/tt-metal/sentinel -> -<hash> form" {
+    container_input_one_path "third-party/tt-metal/sentinel"
 }
 
-@test "uplift in .github/containers/Dockerfile.base -> -uplift-<hash> form" {
-    uplift_one_path ".github/containers/Dockerfile.base"
+@test "container input change in .github/containers/Dockerfile.base -> -<hash> form" {
+    container_input_one_path ".github/containers/Dockerfile.base"
 }
 
-@test "uplift in .github/containers/Dockerfile.wheel-manylinux-2-34 -> -uplift-<hash> form" {
-    uplift_one_path ".github/containers/Dockerfile.wheel-manylinux-2-34"
+@test "container input change in .github/containers/Dockerfile.wheel-manylinux-2-34 -> -<hash> form" {
+    container_input_one_path ".github/containers/Dockerfile.wheel-manylinux-2-34"
 }
 
-@test "uplift in requirements-runtime.txt -> -uplift-<hash> form" {
-    uplift_one_path "requirements-runtime.txt"
+@test "container input change in requirements-runtime.txt -> -<hash> form" {
+    container_input_one_path "requirements-runtime.txt"
 }
 
 # --- Hash determinism: same content yields same tag ---
@@ -96,19 +96,19 @@ uplift_one_path() {
     REPO2=$(fresh_tagged_repo)
     for r in "$REPO1" "$REPO2"; do
         echo "identical-content-v2" > "$r/third-party/tt-metal-version"
-        commit_all "$r" "uplift"
+        commit_all "$r" "container input"
     done
     tag1=$(get_tag "$REPO1")
     tag2=$(get_tag "$REPO2")
     assert_equal "$tag1" "$tag2"
 }
 
-# --- Revert determinism: uplift, revert, re-apply same uplift ---
+# --- Revert determinism: modify, revert, re-apply same container input ---
 
-@test "revert + re-apply same uplift yields same hash" {
+@test "revert + re-apply same container input yields same hash" {
     REPO=$(fresh_tagged_repo)
-    echo "uplift-state" > "$REPO/third-party/tt-metal-version"
-    commit_all "$REPO" "uplift"
+    echo "container-state" > "$REPO/third-party/tt-metal-version"
+    commit_all "$REPO" "container input"
     first_tag=$(get_tag "$REPO")
     # Restore the exact content mkrepo() initialized so revert matches BASE_TAG.
     write_tt_metal_version_file "$REPO/third-party/tt-metal-version" \
@@ -117,22 +117,22 @@ uplift_one_path() {
         "$TEST_TT_METAL_TAG"
     commit_all "$REPO" "revert"
     revert_tag=$(get_tag "$REPO")
-    echo "uplift-state" > "$REPO/third-party/tt-metal-version"
-    commit_all "$REPO" "re-uplift"
+    echo "container-state" > "$REPO/third-party/tt-metal-version"
+    commit_all "$REPO" "reapply container input"
     second_tag=$(get_tag "$REPO")
     assert_equal "$revert_tag" "$BASE_TAG"
     assert_equal "$first_tag" "$second_tag"
 }
 
-# --- Different uplift content yields different hashes ---
+# --- Different container input content yields different hashes ---
 
-@test "different uplift contents yield different hashes" {
+@test "different container input contents yield different hashes" {
     REPO1=$(fresh_tagged_repo)
     REPO2=$(fresh_tagged_repo)
     echo "content-A" > "$REPO1/third-party/tt-metal-version"
     echo "content-B" > "$REPO2/third-party/tt-metal-version"
-    commit_all "$REPO1" "uplift A"
-    commit_all "$REPO2" "uplift B"
+    commit_all "$REPO1" "container input A"
+    commit_all "$REPO2" "container input B"
     tag1=$(get_tag "$REPO1")
     tag2=$(get_tag "$REPO2")
     refute [ "$tag1" = "$tag2" ]
@@ -181,8 +181,8 @@ uplift_one_path() {
 
 @test "running from a subdirectory of the repo yields the same tag" {
     REPO=$(fresh_tagged_repo)
-    echo "uplift" > "$REPO/third-party/tt-metal-version"
-    commit_all "$REPO" "uplift"
+    echo "container input" > "$REPO/third-party/tt-metal-version"
+    commit_all "$REPO" "container input"
     top_tag=$(cd "$REPO" && .github/containers/get-version-tag.sh)
     sub_tag=$(cd "$REPO/python/sim" && ../../.github/containers/get-version-tag.sh)
     assert_equal "$top_tag" "$sub_tag"
@@ -195,34 +195,34 @@ uplift_one_path() {
         skip "en_US.UTF-8 locale not installed"
     fi
     REPO=$(fresh_tagged_repo)
-    echo "uplift" > "$REPO/third-party/tt-metal-version"
-    commit_all "$REPO" "uplift"
+    echo "container input" > "$REPO/third-party/tt-metal-version"
+    commit_all "$REPO" "container input"
     c_tag=$(LC_ALL=C get_tag "$REPO")
     en_tag=$(LC_ALL=en_US.UTF-8 get_tag "$REPO")
     assert_equal "$c_tag" "$en_tag"
 }
 
-# --- Change in a non-uplift path doesn't toggle uplift form ---
+# --- Change outside container inputs does not toggle hashed form ---
 
-@test "change in non-uplift path stays on clean tag" {
+@test "change outside container inputs stays on clean tag" {
     REPO=$(fresh_tagged_repo)
     mkdir -p "$REPO/lib"
-    echo "non-uplift file" > "$REPO/lib/something.cpp"
-    commit_all "$REPO" "non-uplift change"
+    echo "non-container file" > "$REPO/lib/something.cpp"
+    commit_all "$REPO" "non-container change"
     run -0 bash -c "cd '$REPO' && .github/containers/get-version-tag.sh"
     assert_output "$BASE_TAG"
 }
 
-# --- Multiple uplift paths together produce a single uplift tag ---
+# --- Multiple container input paths together produce a single hashed tag ---
 
-@test "multiple uplift paths together produce a single uplift tag" {
+@test "multiple container input paths together produce a single hashed tag" {
     REPO=$(fresh_tagged_repo)
     echo "new-version" > "$REPO/third-party/tt-metal-version"
     echo "new-llvm" >> "$REPO/third-party/llvm-project/sentinel"
     echo "new-dep" >> "$REPO/requirements-runtime.txt"
-    commit_all "$REPO" "multi-uplift"
+    commit_all "$REPO" "multi-container-input"
     run -0 bash -c "cd '$REPO' && .github/containers/get-version-tag.sh"
-    [[ "$output" =~ ^v99\.99\.99-uplift-[a-f0-9]{8}$ ]]
+    [[ "$output" =~ ^v99\.99\.99-[a-f0-9]{8}$ ]]
 }
 
 # --- Missing UPLIFT_PATHS file fails noisily ---
@@ -243,7 +243,7 @@ uplift_one_path() {
     echo "new-version" > "$REPO/third-party/tt-metal-version"
     echo "new-llvm" >> "$REPO/third-party/llvm-project/sentinel"
     echo "new-dep" >> "$REPO/requirements-runtime.txt"
-    commit_all "$REPO" "multi-uplift"
+    commit_all "$REPO" "multi-container-input"
     tag_forward=$(get_tag "$REPO")
     cat > "$REPO/.github/scripts/uplift-paths.sh" <<'EOF'
 #!/bin/bash

--- a/.github/scripts/tests/test_get_version_tag.bats
+++ b/.github/scripts/tests/test_get_version_tag.bats
@@ -54,7 +54,7 @@ fresh_tagged_repo() {
     assert_output "$BASE_TAG"
 }
 
-# --- Per-path uplift: each of the 5 uplift paths separately ---
+# --- Per-path uplift: each uplift path separately ---
 
 uplift_one_path() {
     local path_to_change="$1"
@@ -79,6 +79,10 @@ uplift_one_path() {
 
 @test "uplift in .github/containers/Dockerfile.base -> -uplift-<hash> form" {
     uplift_one_path ".github/containers/Dockerfile.base"
+}
+
+@test "uplift in .github/containers/Dockerfile.wheel-manylinux-2-34 -> -uplift-<hash> form" {
+    uplift_one_path ".github/containers/Dockerfile.wheel-manylinux-2-34"
 }
 
 @test "uplift in requirements-runtime.txt -> -uplift-<hash> form" {
@@ -246,6 +250,7 @@ uplift_one_path() {
 UPLIFT_PATHS=(
     requirements-runtime.txt
     .github/containers/Dockerfile.base
+    .github/containers/Dockerfile.wheel-manylinux-2-34
     third-party/tt-metal
     third-party/llvm-project
     third-party/tt-metal-version

--- a/.github/scripts/tests/test_helper.bash
+++ b/.github/scripts/tests/test_helper.bash
@@ -21,6 +21,8 @@ BIN_DIR="$(dirname "$SCRIPTS_DIR")/../bin"
 # scripts/ (top-level) without hard-coding a path.
 TTLANG_REPO_ROOT="$(dirname "$(dirname "$SCRIPTS_DIR")")"
 WHEEL_PYTAG="cp312-cp312-linux_x86_64"
+LIGHT_CP310_PYTAG="cp310-cp310-manylinux_2_34_x86_64"
+LIGHT_CP312_PYTAG="cp312-cp312-manylinux_2_34_x86_64"
 TEST_TTNN_PYPI_VERSION="99.88.77"
 TEST_TT_METAL_TAG="v99.88.77"
 TEST_TT_METAL_RC1_TAG="v99.88.77-rc1"
@@ -31,6 +33,9 @@ whl()       { printf 'tt_lang-%s-%s.whl' "$1" "$WHEEL_PYTAG"; }
 whl_sim()   { printf 'tt_lang_sim-%s-py3-none-any.whl' "$1"; }
 whl_light() { printf 'tt_lang_light-%s-py3-none-any.whl' "$1"; }
 whl_build() { printf 'tt_lang-%s-%s-%s.whl' "$1" "$2" "$WHEEL_PYTAG"; }
+whl_light_core_cp310() { printf 'tt_lang-%s+light-%s.whl' "$1" "$LIGHT_CP310_PYTAG"; }
+whl_light_core_cp312() { printf 'tt_lang-%s+light-%s.whl' "$1" "$LIGHT_CP312_PYTAG"; }
+whl_light_core_tagged() { printf 'tt_lang-%s+light-%s.whl' "$1" "$2"; }
 
 make_wheel_dir() {
     local dir

--- a/.github/scripts/tests/test_prepare_s3_publish_dist.bats
+++ b/.github/scripts/tests/test_prepare_s3_publish_dist.bats
@@ -60,7 +60,10 @@ setup() {
 
 @test "combined bundled and light artifacts copy unique wheel set" {
     bundled_dir=$(make_wheel_dir "$(whl "$VER")" "$(whl_sim "$VER")")
-    light_dir=$(make_wheel_dir "$(whl "$VER+light")" "$(whl_light "$VER")")
+    light_dir=$(make_wheel_dir \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
+        "$(whl_light "$VER")")
 
     run -0 "$SCRIPT" \
         "$VER" \
@@ -71,19 +74,21 @@ setup() {
     run ls "$PUBLISH_DIR"
     assert_output --partial "$(whl "$VER")"
     assert_output --partial "$(whl_sim "$VER")"
-    assert_output --partial "$(whl "$VER+light")"
+    assert_output --partial "$(whl_light_core_cp310 "$VER")"
+    assert_output --partial "$(whl_light_core_cp312 "$VER")"
     assert_output --partial "$(whl_light "$VER")"
 }
 
 @test "light no-sim spec rejects unexpected sim wheel" {
     light_dir=$(make_wheel_dir \
-        "$(whl "$VER+light")" \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
 
     run -1 "$SCRIPT" "$VER" "$PUBLISH_DIR" "light:no-sim=$light_dir"
 
-    assert_output --partial "No expected version configured for distribution 'tt_lang_sim'"
+    assert_output --partial "Unexpected tt-lang-sim wheel"
 }
 
 @test "duplicate wheel filename across artifacts -> error" {

--- a/.github/scripts/tests/test_probe_docker_image.bats
+++ b/.github/scripts/tests/test_probe_docker_image.bats
@@ -8,7 +8,8 @@ load test_helper
 
 IRD_IMAGE_BASE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04"
 BARE_TAG="v99.99.99"
-UPLIFT_TAG="v99.99.99-uplift-abcd1234"
+HASHED_TAG="v99.99.99-abcd1234"
+LEGACY_UPLIFT_TAG="v99.99.99-uplift-abcd1234"
 RC_TAG="v99.99.99-rc1"
 DEV_TAG="v99.99.99-dev20260515"
 
@@ -55,15 +56,20 @@ setup() {
     assert_equal "$(read_needs_rebuild "$GH_OUT")" "false"
 }
 
-@test "uplift tag, image present -> needs_rebuild=false" {
-    FAKE_DOCKER_MISSING=0 run -0 "$SCRIPT" "$UPLIFT_TAG"
+@test "hashed tag, image present -> needs_rebuild=false" {
+    FAKE_DOCKER_MISSING=0 run -0 "$SCRIPT" "$HASHED_TAG"
     assert_equal "$(read_needs_rebuild "$GH_OUT")" "false"
 }
 
-# --- Image missing, uplift form -> needs_rebuild=true, exit 0 ---
+# --- Image missing, hashed form -> needs_rebuild=true, exit 0 ---
 
-@test "uplift tag, image missing -> needs_rebuild=true" {
-    FAKE_DOCKER_MISSING=1 run -0 "$SCRIPT" "$UPLIFT_TAG"
+@test "hashed tag, image missing -> needs_rebuild=true" {
+    FAKE_DOCKER_MISSING=1 run -0 "$SCRIPT" "$HASHED_TAG"
+    assert_equal "$(read_needs_rebuild "$GH_OUT")" "true"
+}
+
+@test "legacy uplift tag, image missing -> needs_rebuild=true" {
+    FAKE_DOCKER_MISSING=1 run -0 "$SCRIPT" "$LEGACY_UPLIFT_TAG"
     assert_equal "$(read_needs_rebuild "$GH_OUT")" "true"
 }
 

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -56,6 +56,7 @@ output_value() {
     assert_equal "$(output_value wheel_variant)" "light"
     assert_equal "$(output_value wheel_variants)" '["light"]'
     assert_equal "$(output_value wheel_matrix)" '{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
+    assert_equal "$(output_value standard_wheel_matrix)" '{"include":[]}'
     assert_output --partial "Using existing docker_tag=mytag"
 }
 
@@ -65,6 +66,7 @@ output_value() {
     assert_equal "$(output_value wheel_variant)" "bundled-and-light"
     assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
     assert_equal "$(output_value wheel_matrix)" '{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"},{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
+    assert_equal "$(output_value standard_wheel_matrix)" '{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
     assert_output --partial 'Resolved wheel_variants=["bundled","light"]'
 }
 
@@ -87,6 +89,7 @@ output_value() {
     DISPATCH_WHEEL_VARIANT="" EVENT_NAME=schedule run -0 "$SCRIPT"
     assert_equal "$(output_value wheel_variant)" "bundled-and-light"
     assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
+    assert_equal "$(output_value standard_wheel_matrix)" '{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
 }
 
 @test "schedule event keeps overwrite_releases=true if already set" {
@@ -189,6 +192,7 @@ EOF
     assert_output --partial "version_override=42.42.42.dev20260527"
     assert_output --partial "wheel_variant=bundled"
     assert_output --partial 'wheel_variants=["bundled"]'
+    assert_output --partial 'standard_wheel_matrix={"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
     assert_output --partial "allow_final_internal_version=false"
 }
 

--- a/.github/scripts/tests/test_verify_s3_wheel_versions.bats
+++ b/.github/scripts/tests/test_verify_s3_wheel_versions.bats
@@ -44,41 +44,110 @@ setup() {
     run -0 "$SCRIPT" bundled "$VER" "$dir"
 }
 
-@test "light variant accepts +light tt-lang plus normal light and sim wheels" {
+@test "light variant accepts cp310/cp312 +light core wheels plus metapackage and sim" {
     dir=$(make_wheel_dir \
-        "$(whl "$VER+light")" \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
     run -0 "$SCRIPT" light "$VER" "$dir"
 }
 
-@test "light variant with --no-sim accepts light wheels without sim" {
+@test "light variant with --no-sim accepts cp310/cp312 core wheels without sim" {
     dir=$(make_wheel_dir \
-        "$(whl "$VER+light")" \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
         "$(whl_light "$VER")")
     run -0 "$SCRIPT" --no-sim light "$VER" "$dir"
 }
 
+@test "light variant can verify a single requested Python tag" {
+    dir=$(make_wheel_dir \
+        "$(whl_light_core_cp312 "$VER")" \
+        "$(whl_light "$VER")")
+    run -0 "$SCRIPT" --no-sim --python-tags cp312 light "$VER" "$dir"
+}
+
+@test "light variant rejects an unrequested Python tag" {
+    dir=$(make_wheel_dir \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
+        "$(whl_light "$VER")")
+    run -1 "$SCRIPT" --no-sim --python-tags cp312 light "$VER" "$dir"
+    assert_output --partial "Unexpected cp310 manylinux_2_34 light core wheel"
+}
+
+@test "light variant rejects unsupported requested Python tag" {
+    dir=$(make_wheel_dir "$(whl_light "$VER")")
+    run -2 "$SCRIPT" --no-sim --python-tags cp311 light "$VER" "$dir"
+    assert_output --partial "Unsupported Python tag: cp311"
+}
+
 @test "light variant with --no-sim rejects a sim wheel" {
     dir=$(make_wheel_dir \
-        "$(whl "$VER+light")" \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
     run -1 "$SCRIPT" --no-sim light "$VER" "$dir"
-    assert_output --partial "No expected version configured for distribution 'tt_lang_sim'"
+    assert_output --partial "Unexpected tt-lang-sim wheel"
 }
 
 @test "light variant rejects tt-lang without +light" {
     dir=$(make_wheel_dir \
         "$(whl "$VER")" \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
         "$(whl_light "$VER")" \
         "$(whl_sim "$VER")")
     run -1 "$SCRIPT" light "$VER" "$dir"
-    assert_output --partial "does not match expected '$VER+light'"
+    assert_output --partial "Unexpected tt-lang light wheel filename"
 }
 
 @test "light variant requires the tt-lang-light wheel" {
-    dir=$(make_wheel_dir "$(whl "$VER+light")" "$(whl_sim "$VER")")
+    dir=$(make_wheel_dir \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
+        "$(whl_sim "$VER")")
     run -1 "$SCRIPT" light "$VER" "$dir"
-    assert_output --partial "No wheel found for expected distribution 'tt_lang_light'"
+    assert_output --partial "Expected exactly one tt-lang-light metapackage wheel"
+}
+
+@test "light variant requires cp310 core wheel" {
+    dir=$(make_wheel_dir \
+        "$(whl_light_core_cp312 "$VER")" \
+        "$(whl_light "$VER")" \
+        "$(whl_sim "$VER")")
+    run -1 "$SCRIPT" light "$VER" "$dir"
+    assert_output --partial "Expected exactly one cp310 manylinux_2_34 light core wheel"
+}
+
+@test "light variant requires cp312 core wheel" {
+    dir=$(make_wheel_dir \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light "$VER")" \
+        "$(whl_sim "$VER")")
+    run -1 "$SCRIPT" light "$VER" "$dir"
+    assert_output --partial "Expected exactly one cp312 manylinux_2_34 light core wheel"
+}
+
+@test "light variant rejects manylinux_2_35 core wheel" {
+    dir=$(make_wheel_dir \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_tagged "$VER" "cp312-cp312-manylinux_2_35_x86_64")" \
+        "$(whl_light "$VER")" \
+        "$(whl_sim "$VER")")
+    run -1 "$SCRIPT" light "$VER" "$dir"
+    assert_output --partial "Unexpected tt-lang light wheel filename"
+}
+
+@test "light variant rejects duplicate metapackage wheel" {
+    dir=$(make_wheel_dir \
+        "$(whl_light_core_cp310 "$VER")" \
+        "$(whl_light_core_cp312 "$VER")" \
+        "$(whl_light "$VER")" \
+        "tt_lang_light-${VER}-1-py3-none-any.whl" \
+        "$(whl_sim "$VER")")
+    run -1 "$SCRIPT" light "$VER" "$dir"
+    assert_output --partial "Unexpected wheel in light artifact"
 }

--- a/.github/scripts/uplift-paths.sh
+++ b/.github/scripts/uplift-paths.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Paths whose change between two commits indicates the dist/ird container
-# content would differ — i.e. a new image must be built. Sourced by
+# Paths whose change between two commits indicates container image content
+# would differ -- i.e. a new image must be built. Sourced by
 # detect-uplift.sh (drift signal) and get-version-tag.sh (deterministic
 # docker-tag suffix).
 #
@@ -20,5 +20,6 @@ UPLIFT_PATHS=(
     third-party/llvm-project
     third-party/tt-metal
     .github/containers/Dockerfile.base
+    .github/containers/Dockerfile.wheel-manylinux-2-34
     requirements-runtime.txt
 )

--- a/.github/scripts/verify-s3-wheel-versions.sh
+++ b/.github/scripts/verify-s3-wheel-versions.sh
@@ -1,46 +1,156 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
 # Verify the wheel versions produced by the S3 PyPI publish workflow. The light
-# variant publishes a tt-lang wheel with a +light local version plus the
-# tt-lang-light metapackage; bundled and pypi variants publish all wheels at the
-# requested internal version.
+# variant publishes cp310/cp312 tt-lang wheels with a +light local version plus
+# the tt-lang-light metapackage; bundled and pypi variants publish all wheels at
+# the requested internal version.
 #
-# Usage: verify-s3-wheel-versions.sh [--no-sim] <wheel_variant> <version_override> <dist_dir>
+# Usage: verify-s3-wheel-versions.sh [--no-sim] [--python-tags cp310,cp312] <wheel_variant> <version_override> <dist_dir>
 
-set -euo pipefail
+set -eu
 
 usage() {
-    echo "Usage: $0 [--no-sim] <wheel_variant> <version_override> <dist_dir>" >&2
+    echo "Usage: $0 [--no-sim] [--python-tags cp310,cp312] <wheel_variant> <version_override> <dist_dir>" >&2
     exit 2
 }
 
 include_sim=1
-if [[ "${1:-}" == "--no-sim" ]]; then
-    include_sim=0
-    shift
-fi
+python_tags=cp310,cp312
 
-if [[ $# -ne 3 ]]; then
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --no-sim)
+            include_sim=0
+            shift
+            ;;
+        --python-tags)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            python_tags="$2"
+            shift 2
+            ;;
+        --*)
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ "$#" -ne 3 ]; then
     usage
 fi
 
 variant="$1"
 version="$2"
 dist_dir="$3"
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+verify_light_wheels() {
+    verify_light_version="$1"
+    verify_light_dist_dir="$2"
+    verify_light_include_sim="$3"
+    verify_light_python_tags="$4"
+    verify_light_failed=0
+    verify_light_seen_cp310=0
+    verify_light_seen_cp312=0
+    verify_light_metapackage_count=0
+    verify_light_sim_count=0
+    verify_light_expected_cp310=0
+    verify_light_expected_cp312=0
+    verify_light_seen_any=0
+
+    if [ -z "$verify_light_python_tags" ]; then
+        echo "At least one Python tag is required" >&2
+        return 2
+    fi
+
+    for verify_light_python_tag in $(printf '%s\n' "$verify_light_python_tags" | tr ',' ' '); do
+        case "$verify_light_python_tag" in
+            cp310) verify_light_expected_cp310=1 ;;
+            cp312) verify_light_expected_cp312=1 ;;
+            *)
+                echo "Unsupported Python tag: $verify_light_python_tag" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    for verify_light_wheel in "$verify_light_dist_dir"/*.whl; do
+        if [ ! -e "$verify_light_wheel" ]; then
+            continue
+        fi
+        verify_light_seen_any=1
+        verify_light_wheel_name="$(basename "$verify_light_wheel")"
+        case "$verify_light_wheel_name" in
+            "tt_lang-${verify_light_version}+light-cp310-cp310-manylinux_2_34_x86_64.whl")
+                verify_light_seen_cp310=$((verify_light_seen_cp310 + 1))
+                ;;
+            "tt_lang-${verify_light_version}+light-cp312-cp312-manylinux_2_34_x86_64.whl")
+                verify_light_seen_cp312=$((verify_light_seen_cp312 + 1))
+                ;;
+            "tt_lang_light-${verify_light_version}-py3-none-any.whl")
+                verify_light_metapackage_count=$((verify_light_metapackage_count + 1))
+                ;;
+            "tt_lang_sim-${verify_light_version}-py3-none-any.whl")
+                if [ "$verify_light_include_sim" -eq 1 ]; then
+                    verify_light_sim_count=$((verify_light_sim_count + 1))
+                else
+                    echo "Unexpected tt-lang-sim wheel in no-sim light artifact: $verify_light_wheel_name" >&2
+                    verify_light_failed=1
+                fi
+                ;;
+            tt_lang-*)
+                echo "Unexpected tt-lang light wheel filename: $verify_light_wheel_name" >&2
+                verify_light_failed=1
+                ;;
+            *)
+                echo "Unexpected wheel in light artifact: $verify_light_wheel_name" >&2
+                verify_light_failed=1
+                ;;
+        esac
+    done
+
+    if [ "$verify_light_seen_any" -eq 0 ]; then
+        echo "No wheels found in $verify_light_dist_dir" >&2
+        return 1
+    fi
+
+    if [ "$verify_light_expected_cp310" -eq 1 ] && [ "$verify_light_seen_cp310" -ne 1 ]; then
+        echo "Expected exactly one cp310 manylinux_2_34 light core wheel, found $verify_light_seen_cp310" >&2
+        verify_light_failed=1
+    fi
+    if [ "$verify_light_expected_cp310" -eq 0 ] && [ "$verify_light_seen_cp310" -ne 0 ]; then
+        echo "Unexpected cp310 manylinux_2_34 light core wheel, found $verify_light_seen_cp310" >&2
+        verify_light_failed=1
+    fi
+    if [ "$verify_light_expected_cp312" -eq 1 ] && [ "$verify_light_seen_cp312" -ne 1 ]; then
+        echo "Expected exactly one cp312 manylinux_2_34 light core wheel, found $verify_light_seen_cp312" >&2
+        verify_light_failed=1
+    fi
+    if [ "$verify_light_expected_cp312" -eq 0 ] && [ "$verify_light_seen_cp312" -ne 0 ]; then
+        echo "Unexpected cp312 manylinux_2_34 light core wheel, found $verify_light_seen_cp312" >&2
+        verify_light_failed=1
+    fi
+    if [ "$verify_light_metapackage_count" -ne 1 ]; then
+        echo "Expected exactly one tt-lang-light metapackage wheel, found $verify_light_metapackage_count" >&2
+        verify_light_failed=1
+    fi
+    if [ "$verify_light_include_sim" -eq 1 ] && [ "$verify_light_sim_count" -ne 1 ]; then
+        echo "Expected exactly one tt-lang-sim wheel, found $verify_light_sim_count" >&2
+        verify_light_failed=1
+    fi
+
+    return "$verify_light_failed"
+}
 
 case "$variant" in
     light)
-        verify_args=(
-            --expect "tt_lang=$version+light"
-            --expect "tt_lang_light=$version"
-        )
-        if [[ "$include_sim" -eq 1 ]]; then
-            verify_args+=(--expect "tt_lang_sim=$version")
-        fi
-        "$script_dir/verify-wheel-version.sh" "${verify_args[@]}" "$dist_dir"
+        verify_light_wheels "$version" "$dist_dir" "$include_sim" "$python_tags"
         ;;
     bundled | pypi)
         "$script_dir/verify-wheel-version.sh" "$version" "$dist_dir"

--- a/.github/scripts/wheel-or-container-paths.sh
+++ b/.github/scripts/wheel-or-container-paths.sh
@@ -9,8 +9,15 @@
 WHEEL_OR_CONTAINER_PATHS=(
     .github/containers/Dockerfile
     .github/containers/Dockerfile.base
+    .github/containers/Dockerfile.wheel-manylinux-2-34
+    .github/containers/build-wheel-manylinux-images.sh
+    .github/scripts/build-s3-light-core-wheel.sh
+    .github/scripts/build-s3-light-metapackage-wheel.sh
+    .github/scripts/lib/docker-image-utils.sh
     .github/scripts/run-tutorials.sh
     .github/scripts/smoke-test-wheel.py
+    .github/scripts/test-s3-light-wheels.sh
+    scripts/build-s3-light-wheels-local.sh
     bin
     CMakeLists.txt
     examples

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -144,7 +144,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_STEP_LOG_MAX_SIZE: -1
-        run: .github/containers/build-wheel-manylinux-images.sh --python-tags "${{ matrix.python_tag }}"
+        run: .github/containers/build-wheel-manylinux-images.sh --python-tags "${{ matrix.python_tag }}" --build-parallel-level 2
 
       - name: Show disk usage on failure
         if: failure()

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -33,7 +33,7 @@ on:
         description: "Base Docker image name with tag"
         value: ${{ jobs.build-image-base.outputs.docker-image-base }}
       docker-tag:
-        description: "Docker image tag (used as ird container tag)"
+        description: "Docker tag used for the built IRD image"
         value: ${{ jobs.build-images.outputs.docker-tag }}
 
 permissions:
@@ -140,11 +140,27 @@ jobs:
       - name: Fix git safe directory for submodules
         run: git config --global --add safe.directory '*'
 
+      - name: Resolve Docker tag
+        id: docker-tag
+        run: |
+          docker_tag=$(.github/containers/get-version-tag.sh)
+          registry_image="ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${docker_tag}"
+          echo "docker-tag=${docker_tag}" >> "$GITHUB_OUTPUT"
+          echo "registry-image=${registry_image}" >> "$GITHUB_OUTPUT"
+          echo "Docker tag: ${docker_tag}"
+          echo "Registry image: ${registry_image}"
+          {
+            echo "### manylinux wheel-builder image"
+            echo ""
+            echo "- Docker tag: \`${docker_tag}\`"
+            echo "- Image: \`${registry_image}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Build and push manylinux wheel-builder image
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_STEP_LOG_MAX_SIZE: -1
-        run: .github/containers/build-wheel-manylinux-images.sh --python-tags "${{ matrix.python_tag }}" --build-parallel-level 2
+        run: .github/containers/build-wheel-manylinux-images.sh --python-tags "${{ matrix.python_tag }}" --image-tag "${{ steps.docker-tag.outputs.docker-tag }}" --build-parallel-level 2
 
       - name: Show disk usage on failure
         if: failure()
@@ -210,7 +226,7 @@ jobs:
           # When push: true, build-image-base just pushed at this tag.
           # When push: false, we pull the existing base image at the same
           # tag (released images already exist at clean tags; dryrun only
-          # runs on non-uplift PRs so the tag is a release tag).
+          # runs when the resolved tag already points at an existing image).
           BASE_IMAGE="ghcr.io/${{ github.repository }}/tt-lang-base-ubuntu-24-04:${{ steps.docker-tag.outputs.docker-tag }}"
           docker pull "$BASE_IMAGE"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -11,10 +11,18 @@ on:
         description: "Push built images to GHCR. Leave false to build and smoke-test locally only."
         type: boolean
         default: false
+      build_manylinux_wheel_images:
+        description: "Build and push manylinux_2_34 wheel-builder images for S3 light wheels."
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       push:
         description: "Push built images to GHCR. Default false so accidental invocations don't upload. Only on-push (main) and publish-pypi (release tag) should set this true."
+        type: boolean
+        default: false
+      build_manylinux_wheel_images:
+        description: "Build and push manylinux_2_34 wheel-builder images for S3 light wheels."
         type: boolean
         default: false
     outputs:
@@ -94,6 +102,55 @@ jobs:
           DOCKER_IMAGE_BASE=$(cat .docker-image-base)
           echo "docker-image-base=$DOCKER_IMAGE_BASE" >> $GITHUB_OUTPUT
           echo "Base image built successfully: $DOCKER_IMAGE_BASE"
+
+  # Builds manylinux_2_34 wheel-builder images for S3 light wheels. Keep this
+  # separate from the dist/ird image job so the two Python ABI images do not
+  # extend the existing Docker build serially.
+  build-manylinux-wheel-images:
+    if: ${{ inputs.push && inputs.build_manylinux_wheel_images }}
+    runs-on: mlir-large-runner-lang
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        python_tag: [cp310, cp312]
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Free up runner space
+        run: .github/scripts/cleanup-ci-space.sh
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Fix git safe directory for submodules
+        run: git config --global --add safe.directory '*'
+
+      - name: Build and push manylinux wheel-builder image
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_STEP_LOG_MAX_SIZE: -1
+        run: .github/containers/build-wheel-manylinux-images.sh --python-tags "${{ matrix.python_tag }}"
+
+      - name: Show disk usage on failure
+        if: failure()
+        run: |
+          df -h
+          docker system df || true
 
   # Builds LLVM + tt-metal on the host (via docker run with base image),
   # then packages dist and ird Docker images.
@@ -335,13 +392,6 @@ jobs:
           LATEST="${REGISTRY%:*}:latest"
           docker tag "$LOCAL" "$LATEST"
           docker push "$LATEST"
-
-      - name: Build and push manylinux wheel-builder images
-        if: ${{ inputs.push }}
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_STEP_LOG_MAX_SIZE: -1
-        run: .github/containers/build-wheel-manylinux-images.sh
 
       - name: Clean up Docker after build
         if: always()

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -336,6 +336,13 @@ jobs:
           docker tag "$LOCAL" "$LATEST"
           docker push "$LATEST"
 
+      - name: Build and push manylinux wheel-builder images
+        if: ${{ inputs.push }}
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_STEP_LOG_MAX_SIZE: -1
+        run: .github/containers/build-wheel-manylinux-images.sh
+
       - name: Clean up Docker after build
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     secrets: inherit
     with:
       push: true
+      build_manylinux_wheel_images: true
 
   changes:
     name: Detect wheel/container-affecting changes

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -98,6 +98,7 @@ jobs:
     secrets: inherit
     with:
       push: true
+      build_manylinux_wheel_images: ${{ contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light') }}
 
   build-standard-wheels:
     needs: [preflight, build-docker]
@@ -117,7 +118,7 @@ jobs:
       external_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/tt-metal' || '' }}
       external_python_venv: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/venv' || '' }}
       bundled_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'bundled' && '/opt/ttlang-toolchain/tt-metal' || '' }}
-      build_sim_wheel: ${{ !(needs.preflight.outputs.wheel_variant == 'bundled-and-light' && matrix.wheel_variant == 'light') }}
+      build_sim_wheel: true
       allow_final_internal_version: ${{ needs.preflight.outputs.allow_final_internal_version == 'true' }}
       artifact_name: tt-lang-wheels-${{ matrix.wheel_variant }}
 

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       docker_tag:
-        description: "Docker image tag for the ird container. Leave empty to build and push one first."
+        description: "Docker image tag for required builder containers. Leave empty to build and push them first."
         type: string
         default: ""
         required: false
@@ -66,6 +66,7 @@ jobs:
       wheel_variant: ${{ steps.resolve.outputs.wheel_variant }}
       wheel_variants: ${{ steps.resolve.outputs.wheel_variants }}
       wheel_matrix: ${{ steps.resolve.outputs.wheel_matrix }}
+      standard_wheel_matrix: ${{ steps.resolve.outputs.standard_wheel_matrix }}
       allow_final_internal_version: ${{ steps.resolve.outputs.allow_final_internal_version }}
 
     steps:
@@ -98,13 +99,13 @@ jobs:
     with:
       push: true
 
-  build-wheels:
+  build-standard-wheels:
     needs: [preflight, build-docker]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') }}
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (contains(fromJSON(needs.preflight.outputs.wheel_variants), 'bundled') || contains(fromJSON(needs.preflight.outputs.wheel_variants), 'pypi')) }}
     name: "Build ${{ matrix.wheel_variant }} wheels"
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.preflight.outputs.wheel_matrix) }}
+      matrix: ${{ fromJSON(needs.preflight.outputs.standard_wheel_matrix) }}
     permissions:
       contents: read
       packages: read
@@ -120,10 +121,105 @@ jobs:
       allow_final_internal_version: ${{ needs.preflight.outputs.allow_final_internal_version == 'true' }}
       artifact_name: tt-lang-wheels-${{ matrix.wheel_variant }}
 
+  build-light-wheels:
+    needs: [preflight, build-docker]
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light') }}
+    name: "Build light wheel (${{ matrix.python_tag }})"
+    runs-on: mlir-large-runner-lang
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        python_tag: [cp310, cp312]
+    container:
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}
+
+    defaults:
+      run:
+        shell: bash
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Fix git safe directory
+        run: git config --global --add safe.directory '*'
+
+      - name: Build light core wheel
+        env:
+          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ needs.preflight.outputs.allow_final_internal_version }}
+        run: .github/scripts/build-s3-light-core-wheel.sh --python-tag "${{ matrix.python_tag }}" --version "${{ needs.preflight.outputs.version_override }}" --dist-dir dist
+
+      - name: Build tt-lang-light metapackage
+        if: ${{ matrix.python_tag == 'cp312' }}
+        env:
+          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ needs.preflight.outputs.allow_final_internal_version }}
+        run: .github/scripts/build-s3-light-metapackage-wheel.sh --version "${{ needs.preflight.outputs.version_override }}" --dist-dir dist
+
+      - name: Upload per-ABI wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: tt-lang-s3-light-${{ matrix.python_tag }}
+          path: dist/*.whl
+          retention-days: 14
+
+  collect-light-wheels:
+    name: "Verify S3 light wheel set"
+    needs: [preflight, build-docker, build-light-wheels]
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && needs.build-light-wheels.result == 'success' && contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: bash
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+
+      - name: Download per-ABI wheels
+        uses: actions/download-artifact@v8
+        with:
+          pattern: tt-lang-s3-light-*
+          path: dist
+          merge-multiple: true
+
+      - name: Verify wheel filenames and versions
+        run: .github/scripts/verify-s3-wheel-versions.sh --no-sim light "${{ needs.preflight.outputs.version_override }}" dist
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Install-test light wheels
+        run: .github/scripts/test-s3-light-wheels.sh --version "${{ needs.preflight.outputs.version_override }}" --docker-tag "${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}" --dist-dir dist
+
+      - name: Upload combined wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: tt-lang-wheels-light
+          path: dist/*.whl
+          retention-days: 14
+
   publish:
     name: "Publish wheels to S3 PyPI"
-    needs: [preflight, build-wheels]
-    if: ${{ always() && needs.preflight.result == 'success' && needs.build-wheels.result == 'success' }}
+    needs: [preflight, build-standard-wheels, collect-light-wheels]
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-standard-wheels.result == 'success' || needs.build-standard-wheels.result == 'skipped') && (needs.collect-light-wheels.result == 'success' || needs.collect-light-wheels.result == 'skipped') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -168,11 +264,7 @@ jobs:
             prepare_args+=(bundled=wheel-artifacts/bundled)
           fi
           if [ -d wheel-artifacts/light ]; then
-            if [ -d wheel-artifacts/bundled ]; then
-              prepare_args+=(light:no-sim=wheel-artifacts/light)
-            else
-              prepare_args+=(light=wheel-artifacts/light)
-            fi
+            prepare_args+=(light:no-sim=wheel-artifacts/light)
           fi
           if [ -d wheel-artifacts/pypi ]; then
             prepare_args+=(pypi=wheel-artifacts/pypi)

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 core.*
 .local
 **/build*
+!.github/scripts/build-s3-light-core-wheel.sh
+!.github/scripts/build-s3-light-metapackage-wheel.sh
+!scripts/build-s3-light-wheels-local.sh
+_plans/
 third_party/tt-metal
 third_party/ttnn-python
 .DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 core.*
 .local
-**/build*
-!.github/scripts/build-s3-light-core-wheel.sh
-!.github/scripts/build-s3-light-metapackage-wheel.sh
-!scripts/build-s3-light-wheels-local.sh
+/build/
+/build-*/
+/test/**/build/
 _plans/
 third_party/tt-metal
 third_party/ttnn-python

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ TT-Lang bridges this gap through progressive disclosure: simple kernels require 
 
 We provide two tt-lang packages: the [tt-lang](https://pypi.org/project/tt-lang/) package includes the tt-lang compiler, Tenstorrent hardware support and depends on the `ttnn`, `pytorch` and several smaller python packages, while [tt-lang-sim](https://pypi.org/project/tt-lang-sim/) includes only the functional simulator (no compiler or hardware support) and does not depend on `ttnn`.
 
-First, create an isolated Python environment (venv, conda, etc.) with Python 3.11 or later (python3.12 recommended). For example:
+First, create an isolated Python environment (venv, conda, etc.) with Python 3.10 or later (python3.12 recommended). For example:
 
 ```bash
 python3 -m venv --prompt ttlang ttlang-venv

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 pl<br>
 
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
-![Python Version](https://img.shields.io/badge/python-3.11+-blue.svg)
+![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.12-blue.svg)
 ![Build Status](https://github.com/tenstorrent/tt-lang/actions/workflows/ci.yml/badge.svg)
 
 A Python-based Domain-Specific Language (DSL) for authoring high-performance custom kernels on Tenstorrent hardware. This project is under active development — see the [functionality matrix](docs/sphinx/specs/TTLangSpecification.md#appendix-d-functionality-matrix) for current simulator and compiler support.
@@ -44,7 +44,9 @@ TT-Lang bridges this gap through progressive disclosure: simple kernels require 
 
 We provide two tt-lang packages: the [tt-lang](https://pypi.org/project/tt-lang/) package includes the tt-lang compiler, Tenstorrent hardware support and depends on the `ttnn`, `pytorch` and several smaller python packages, while [tt-lang-sim](https://pypi.org/project/tt-lang-sim/) includes only the functional simulator (no compiler or hardware support) and does not depend on `ttnn`.
 
-First, create an isolated Python environment (venv, conda, etc.) with Python 3.10 or later (python3.12 recommended). For example:
+First, create an isolated Python environment (venv, conda, etc.) with Python
+matching the selected wheel. Public PyPI hardware wheels currently use Python
+3.12; S3 light wheels are built for Python 3.10 and Python 3.12. For example:
 
 ```bash
 python3 -m venv --prompt ttlang ttlang-venv

--- a/cmake/modules/BuildLLVM.cmake
+++ b/cmake/modules/BuildLLVM.cmake
@@ -201,6 +201,12 @@ else()
     set(_LLVM_CCACHE_BUILD OFF)
   endif()
 
+  set(_TTLANG_LLVM_EXTRA_CMAKE_ARGS)
+  if(DEFINED ENV{TTLANG_LLVM_EXTRA_CMAKE_ARGS} AND
+     NOT "$ENV{TTLANG_LLVM_EXTRA_CMAKE_ARGS}" STREQUAL "")
+    set(_TTLANG_LLVM_EXTRA_CMAKE_ARGS "$ENV{TTLANG_LLVM_EXTRA_CMAKE_ARGS}")
+  endif()
+
   ttlang_get_submodule_sha("${LLVM_SUBMODULE_DIR}" _LLVM_SUBMODULE_SHA)
   string(SUBSTRING "${_LLVM_SUBMODULE_SHA}" 0 7 _LLVM_SHORT_SHA)
 
@@ -210,6 +216,9 @@ else()
   message(STATUS "  Build dir:     ${LLVM_BUILD_DIR}")
   message(STATUS "  Install dir:   ${LLVM_INSTALL_DIR}")
   message(STATUS "  ccache:        ${_LLVM_CCACHE_BUILD}")
+  if(_TTLANG_LLVM_EXTRA_CMAKE_ARGS)
+    message(STATUS "  Extra args:    ${_TTLANG_LLVM_EXTRA_CMAKE_ARGS}")
+  endif()
 
   # Install LLVM-specific Python build dependencies (nanobind, PyYAML, etc.
   # for MLIR Python bindings) and lit for test execution.
@@ -263,6 +272,10 @@ else()
       -DMLIR_ENABLE_BINDINGS_PYTHON=ON
       -DPython3_EXECUTABLE=${Python3_EXECUTABLE}
     )
+
+    if(_TTLANG_LLVM_EXTRA_CMAKE_ARGS)
+      list(APPEND _LLVM_CMAKE_ARGS ${_TTLANG_LLVM_EXTRA_CMAKE_ARGS})
+    endif()
 
     # --- Configure ---
     message(STATUS "Configuring LLVM/MLIR...")

--- a/cmake/modules/TTLangUtils.cmake
+++ b/cmake/modules/TTLangUtils.cmake
@@ -247,29 +247,53 @@ function(ttlang_verify_ttmetal_sha SUBMODULE_DIR EXPECTED_SHA)
   endif()
 endfunction()
 
+# _ttlang_apply_patch(SOURCE_DIR PATCH SOURCE_HAS_GIT)
+# Applies one patch, skipping it when already applied.
+function(_ttlang_apply_patch SOURCE_DIR PATCH SOURCE_HAS_GIT)
+  if(SOURCE_HAS_GIT)
+    set(_reverse_check_command git -C "${SOURCE_DIR}" apply --check --reverse "${PATCH}")
+    set(_apply_command git -C "${SOURCE_DIR}" apply "${PATCH}")
+  else()
+    set(_reverse_check_command patch -d "${SOURCE_DIR}" -p1 --dry-run --reverse -i "${PATCH}")
+    set(_apply_command patch -d "${SOURCE_DIR}" -p1 --forward -i "${PATCH}")
+  endif()
+
+  execute_process(
+    COMMAND ${_reverse_check_command}
+    RESULT_VARIABLE _already_applied
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  if(_already_applied EQUAL 0)
+    return()
+  endif()
+
+  get_filename_component(_name "${PATCH}" NAME)
+  message(STATUS "Applying patch: ${_name}")
+  execute_process(
+    COMMAND ${_apply_command}
+    RESULT_VARIABLE _result
+  )
+  if(NOT _result EQUAL 0)
+    message(FATAL_ERROR "Failed to apply patch: ${_name}")
+  endif()
+endfunction()
+
 # ttlang_apply_patches(SOURCE_DIR PATCHES_GLOB)
-# Applies git patches matching PATCHES_GLOB to SOURCE_DIR.
-# Skips patches that are already applied (checked via git apply --reverse --check).
+# Applies patches matching PATCHES_GLOB to SOURCE_DIR.
 function(ttlang_apply_patches SOURCE_DIR PATCHES_GLOB)
   file(GLOB _patches "${PATCHES_GLOB}")
+
+  execute_process(
+    COMMAND git -C "${SOURCE_DIR}" rev-parse --is-inside-work-tree
+    RESULT_VARIABLE _source_has_git
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  set(_source_is_git FALSE)
+  if(_source_has_git EQUAL 0)
+    set(_source_is_git TRUE)
+  endif()
+
   foreach(_patch ${_patches})
-    # Skip if already applied.
-    execute_process(
-      COMMAND git -C "${SOURCE_DIR}" apply --check --reverse "${_patch}"
-      RESULT_VARIABLE _already_applied
-      OUTPUT_QUIET ERROR_QUIET
-    )
-    if(_already_applied EQUAL 0)
-      continue()
-    endif()
-    get_filename_component(_name "${_patch}" NAME)
-    message(STATUS "Applying patch: ${_name}")
-    execute_process(
-      COMMAND git -C "${SOURCE_DIR}" apply "${_patch}"
-      RESULT_VARIABLE _result
-    )
-    if(NOT _result EQUAL 0)
-      message(FATAL_ERROR "Failed to apply patch: ${_name}")
-    endif()
+    _ttlang_apply_patch("${SOURCE_DIR}" "${_patch}" "${_source_is_git}")
   endforeach()
 endfunction()

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -601,9 +601,11 @@ that image, verify the wheel versions, and publish the result to S3 PyPI. The
 selected variant set is `bundled-and-light` when public PyPI publishing is
 blocked, and `light` when public PyPI publishing is aligned.
 
-The scheduled workflow also defaults to `wheel_variant: bundled-and-light`,
-builds and pushes the matching IRD image, builds bundled and light wheels from
-that image, verifies the wheel versions, and publishes the result to S3 PyPI.
+The scheduled workflow defaults to `wheel_variant: bundled-and-light`. It keeps
+building the complete bundled wheel from the IRD image, and also builds and
+pushes the matching manylinux_2_34 wheel-builder images for Python 3.10 and
+Python 3.12 light wheels. The workflow verifies all wheel versions before
+publishing the combined result to S3 PyPI.
 
 For a manual bundled internal wheel with an existing IRD image, dispatch the
 workflow with:
@@ -629,12 +631,12 @@ wheel_variant: light
 version_override: <internal-version>
 ```
 
-The workflow maps this publish selection to the reusable wheel builder's
-`TTLANG_TTNN_DEP_MODE=external` build mode and sets
-`TTLANG_VERSION_OVERRIDE=<version_override>+light`. The resulting `tt-lang` wheel
-omits `Requires-Dist: ttnn`; the normal PyPI build keeps that requirement. The
-same build also emits `tt-lang-light==<version_override>`, a metapackage that
-depends on `tt-lang==<version_override>+light`.
+The workflow maps this publish selection to the manylinux_2_34 light wheel
+builder. It emits `cp310` and `cp312` `tt-lang==<version_override>+light`
+wheels. Those wheels omit `Requires-Dist: ttnn`; the normal PyPI build keeps
+that requirement. The same build also emits
+`tt-lang-light==<version_override>`, a metapackage that depends on
+`tt-lang==<version_override>+light`.
 
 To publish bundled and light wheels from the same workflow run, dispatch with:
 
@@ -645,9 +647,8 @@ version_override: <internal-version>
 
 The workflow builds the bundled and light wheel sets separately, uploads
 mode-specific artifacts, verifies each artifact with the expected version rules,
-then publishes a single combined directory. The light build skips
-`tt-lang-sim` in this mode because the bundled build already provides the same
-`tt-lang-sim==<version_override>` package/version for the S3 index.
+then publishes a single combined directory. The light build does not emit
+`tt-lang-sim`; bundled/public wheel builds keep producing the simulator wheel.
 
 #### Local internal wheel testing
 
@@ -672,32 +673,12 @@ auditwheel repair /tmp/ttlang-wheels/bundled/raw/tt_lang-*.whl \
   --wheel-dir=/tmp/ttlang-wheels/bundled/dist
 ```
 
-Light wheel:
+Light wheels:
 
 ```bash
-source /opt/ttlang-toolchain/venv/bin/activate
-TTLANG_VERSION=<internal-version>
-
-TTLANG_VERSION_OVERRIDE="$TTLANG_VERSION+light" \
-cmake -G Ninja -B build \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DTTLANG_USE_TOOLCHAIN=ON \
-  -DTTLANG_EXTERNAL_TT_METAL_DIR=/opt/ttlang-toolchain/tt-metal \
-  -DTTLANG_PYTHON_VENV=/opt/ttlang-toolchain/venv
-
-TTLANG_TTNN_DEP_MODE=external \
-TTLANG_VERSION_OVERRIDE="$TTLANG_VERSION+light" \
-TTLANG_EXTERNAL_TT_METAL_DIR=/opt/ttlang-toolchain/tt-metal \
-TTLANG_PYTHON_VENV=/opt/ttlang-toolchain/venv \
-pip wheel . --wheel-dir=/tmp/ttlang-wheels/light/raw --no-deps --no-build-isolation
-
-auditwheel repair /tmp/ttlang-wheels/light/raw/tt_lang-*.whl \
-  --wheel-dir=/tmp/ttlang-wheels/light/dist
-
-TTLANG_VERSION_OVERRIDE="$TTLANG_VERSION" \
-TTLANG_LIGHT_TTLANG_VERSION="$TTLANG_VERSION+light" \
-pip wheel packaging/light --wheel-dir=/tmp/ttlang-wheels/light/dist \
-  --no-deps --no-build-isolation
+scripts/build-s3-light-wheels-local.sh \
+  --version <internal-version> \
+  --build-images
 ```
 
 Install-test the light package from the local wheel directory. The setup command
@@ -705,9 +686,10 @@ copies tutorials into `./tutorials/` and skips sfpi installation for light
 installs because the external tt-metal tree provides sfpi:
 
 ```bash
+TTLANG_VERSION=<internal-version>
 python3.12 -m venv /tmp/ttlang-light-test
 source /tmp/ttlang-light-test/bin/activate
-pip install --find-links=/tmp/ttlang-wheels/light/dist \
+pip install --find-links=/tmp/ttlang-s3-light-wheels/dist \
   "tt-lang-light==$TTLANG_VERSION"
 tt-lang-setup
 ```

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -13,7 +13,7 @@ fully working environment.
 - CMake 3.28+
 - Ninja
 - Clang/Clang++ 17+ (or GCC 12+)
-- Python 3.11+
+- Python 3.10+ (Python 3.12 recommended)
 - Git (submodules must be initialized:
   `git submodule update --init --recursive`)
 

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -15,8 +15,8 @@ functional simulator (no compiler or hardware support) and does not depend on
 `ttnn`.
 
 First, create an isolated Python environment (venv, conda, etc.) with Python
-3.11 or later (Python 3.12 recommended). The wheel targets a specific CPython
-ABI, so the venv's Python must match — invoke `python3.12` (or `python3.11`)
+3.10 or later (Python 3.12 recommended). The wheel targets a specific CPython
+ABI, so the venv's Python must match — invoke `python3.12` (or `python3.10`)
 explicitly rather than the system default `python3`:
 
 ```bash

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -15,9 +15,11 @@ functional simulator (no compiler or hardware support) and does not depend on
 `ttnn`.
 
 First, create an isolated Python environment (venv, conda, etc.) with Python
-3.10 or later (Python 3.12 recommended). The wheel targets a specific CPython
-ABI, so the venv's Python must match — invoke `python3.12` (or `python3.10`)
-explicitly rather than the system default `python3`:
+matching the selected wheel. Public PyPI hardware wheels currently use Python
+3.12; S3 light wheels are built for Python 3.10 and Python 3.12. The wheel
+targets a specific CPython ABI, so the venv's Python must match. Invoke
+`python3.12` (or `python3.10` for a light wheel) explicitly rather than the
+system default `python3`:
 
 ```bash
 python3.12 -m venv --prompt ttlang ttlang-venv
@@ -214,7 +216,7 @@ python examples/elementwise-tutorial/step_4_multinode_grid_full.py
 ### Prerequisites
 
 - CMake 3.28+, Ninja, and Clang 17+ or GCC 12+
-- Python 3.11+
+- Python 3.10+ (Python 3.12 recommended)
 - For faster builds: a pre-built toolchain at `TTLANG_TOOLCHAIN_DIR` (default
   `/opt/ttlang-toolchain`). Without one, LLVM and tt-metal build from submodules
   on first configure.

--- a/include/ttlang-c/Dialects.h
+++ b/include/ttlang-c/Dialects.h
@@ -22,6 +22,12 @@ MLIR_CAPI_EXPORTED void ttlangRegisterAllDialects(MlirContext context);
 /// Register the TTL dialect with the given MlirDialectRegistry.
 MLIR_CAPI_EXPORTED void ttlangRegisterTTLDialect(MlirDialectRegistry registry);
 
+/// Register the minimal set of upstream MLIR dialects the tt-lang pipeline uses
+/// with the given MlirDialectRegistry. Replaces MLIR's RegisterEverything so
+/// the Python CAPI library does not statically link every upstream dialect.
+MLIR_CAPI_EXPORTED void
+ttlangRegisterUpstreamDialects(MlirDialectRegistry registry);
+
 /// Load the TTL dialect into the given MlirContext.
 MLIR_CAPI_EXPORTED MlirDialectHandle ttlangGetTTLDialectHandle(void);
 

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -16,4 +16,18 @@ add_mlir_library(TTLangCAPI
   MLIRTTLDialect
   TTLangTTLTransforms
   TTLangTTLPipelines
+
+  # Minimal upstream dialects + passes the tt-lang pipeline uses, registered in
+  # Dialects.cpp in place of MLIR's RegisterEverything.
+  MLIRArithDialect
+  MLIRMemRefDialect
+  MLIRSCFDialect
+  MLIRControlFlowDialect
+  MLIRAffineDialect
+  MLIREmitCDialect
+  MLIRIndexDialect
+  MLIRUBDialect
+  MLIRMathDialect
+  MLIRTransforms
+  MLIRAffineToStandard
 )

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -10,6 +10,19 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
+#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
 using namespace mlir::tt::ttl;
@@ -31,7 +44,24 @@ void ttlangRegisterTTLDialect(MlirDialectRegistry registry) {
   unwrap(registry)->insert<TTLDialect>();
 }
 
+void ttlangRegisterUpstreamDialects(MlirDialectRegistry registry) {
+  unwrap(registry)
+      ->insert<func::FuncDialect, arith::ArithDialect, memref::MemRefDialect,
+               scf::SCFDialect, cf::ControlFlowDialect, affine::AffineDialect,
+               emitc::EmitCDialect, index::IndexDialect, ub::UBDialect,
+               math::MathDialect>();
+}
+
 void ttlangRegisterPasses() {
   mlir::tt::ttl::registerTTLPasses();
   mlir::tt::ttl::registerTTLPipelines();
+
+  // Upstream passes the tt-lang pipeline runs. Registered explicitly (instead
+  // of via MLIR's RegisterEverything) so the Python CAPI library links only the
+  // passes the pipeline uses. Registered by factory so each pass keeps its
+  // textual name (canonicalize, cse, symbol-dce, lower-affine).
+  registerPass([] { return createCanonicalizerPass(); });
+  registerPass([] { return createCSEPass(); });
+  registerPass([] { return createSymbolDCEPass(); });
+  registerPass([] { return createLowerAffinePass(); });
 }

--- a/packaging/light/pyproject.toml
+++ b/packaging/light/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tt-lang-light"
 description = "Internal TT-Lang metapackage for an external-tt-metal tt-lang wheel"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["tt-lang", "tenstorrent", "ttnn", "metapackage"]
 license = "Apache-2.0"
 authors = [{name = "Tenstorrent AI ULC"}]
@@ -16,6 +16,7 @@ classifiers = [
   "Intended Audience :: Developers",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.12",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tt-lang"
 description = "Python Bindings and Package for TT-Lang Compiler Project"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["mlir", "tt-lang", "tt-mlir", "tenstorrent", "compiler", "dsl", "kernel"]
 license = "Apache-2.0"
 license-files = ["LICENSE*"]
@@ -31,6 +31,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: C++",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -256,9 +256,11 @@ add_mlir_python_common_capi_library(TTLangPythonCAPI
   INSTALL_DESTINATION python_packages/ttl/_mlir_libs
   OUTPUT_DIRECTORY "${TTLANG_PYTHON_PACKAGES_DIR}/ttl/_mlir_libs"
   DECLARED_SOURCES
-    # Upstream MLIR (MLIRPythonSources includes .Core and all sub-packages)
+    # Upstream MLIR sources (.Core + sub-packages). RegisterEverything is
+    # intentionally omitted; tt-lang registers only the upstream dialects and
+    # passes its pipeline uses (see lib/CAPI/Dialects.cpp) so the Python CAPI
+    # library does not statically link all of MLIR.
     MLIRPythonSources
-    MLIRPythonExtension.RegisterEverything
     # Minimal tt-mlir
     TTMLIRMinPythonSources
     TTMLIRMinPythonExtensions
@@ -281,9 +283,11 @@ add_mlir_python_modules(TTLangPythonModules
   ROOT_PREFIX "${TTLANG_PYTHON_PACKAGES_DIR}/ttl"
   INSTALL_PREFIX "python_packages/ttl"
   DECLARED_SOURCES
-    # Upstream MLIR (MLIRPythonSources includes .Core and all sub-packages)
+    # Upstream MLIR sources (.Core + sub-packages). RegisterEverything is
+    # intentionally omitted; tt-lang registers only the upstream dialects and
+    # passes its pipeline uses (see lib/CAPI/Dialects.cpp) so the Python CAPI
+    # library does not statically link all of MLIR.
     MLIRPythonSources
-    MLIRPythonExtension.RegisterEverything
     # Minimal tt-mlir
     TTMLIRMinPythonSources
     TTMLIRMinPythonExtensions

--- a/python/sim/analysis.py
+++ b/python/sim/analysis.py
@@ -548,10 +548,16 @@ def collect_reachable_analyses(
 # Public API: runtime interception
 # ---------------------------------------------------------------------------
 
-# sys.monitoring tool ID used by this module.  OPTIMIZER_ID is chosen
-# because the simulator is not a debugger, coverage tool, or profiler.
-# The tool is claimed once per interpreter session.
-_TOOL_ID: int = sys.monitoring.OPTIMIZER_ID
+
+def _monitoring_api():
+    """Return ``sys.monitoring`` or fail before copy-wait hooks are required."""
+    monitoring = getattr(sys, "monitoring", None)
+    if monitoring is None:
+        raise RuntimeError(
+            "Automatic copy-wait injection requires Python 3.12 or newer. "
+            "Add explicit tx.wait() calls or run the simulator with Python 3.12+."
+        )
+    return monitoring
 
 
 def _fire_injection(frame: types.FrameType, ip: InjectionPoint) -> None:
@@ -664,7 +670,7 @@ def install_copy_wait_hooks(
     ``get_context().active_hooks``; bare-copy line numbers (Case A) are added
     to ``get_context().auto_wait_copy_lines``.
 
-    On first call, claims ``_TOOL_ID`` from ``sys.monitoring`` and registers
+    On first call, claims a ``sys.monitoring`` tool ID and registers
     ``_line_callback`` / ``_return_callback``.  Subsequent calls only update
     the context's hooks and enable local events for new code objects.
 
@@ -681,6 +687,7 @@ def install_copy_wait_hooks(
         for code, analysis in injection_map.items()
         if analysis.injection_points
     }
+    monitoring = _monitoring_api() if active_map else None
 
     # Build lookup tables and store in the current context's active_hooks.
     from .context import get_context
@@ -695,15 +702,13 @@ def install_copy_wait_hooks(
     if not active_map:
         return
 
+    tool_id = monitoring.OPTIMIZER_ID
+
     # Claim the tool ID and register callbacks.  reset_context() frees the
     # slot between runs, so this always starts from a clean state.
-    sys.monitoring.use_tool_id(_TOOL_ID, "tt-lang-sim")
-    sys.monitoring.register_callback(
-        _TOOL_ID, sys.monitoring.events.LINE, _line_callback
-    )
-    sys.monitoring.register_callback(
-        _TOOL_ID, sys.monitoring.events.PY_RETURN, _return_callback
-    )
+    monitoring.use_tool_id(tool_id, "tt-lang-sim")
+    monitoring.register_callback(tool_id, monitoring.events.LINE, _line_callback)
+    monitoring.register_callback(tool_id, monitoring.events.PY_RETURN, _return_callback)
 
     # Build lookup tables, store them, and enable per-code-object events.
     # id(code) is used as the dict key so that lookup in the callbacks is
@@ -719,9 +724,9 @@ def install_copy_wait_hooks(
                 by_lineno.setdefault(ip.trigger_lineno, []).append(ip)  # type: ignore[arg-type]
         ctx.active_hooks[id(code)] = (by_lineno, return_ips)
 
-        ev = sys.monitoring.events.NO_EVENTS
+        ev = monitoring.events.NO_EVENTS
         if by_lineno:
-            ev |= sys.monitoring.events.LINE
+            ev |= monitoring.events.LINE
         if return_ips:
-            ev |= sys.monitoring.events.PY_RETURN
-        sys.monitoring.set_local_events(_TOOL_ID, code, ev)
+            ev |= monitoring.events.PY_RETURN
+        monitoring.set_local_events(tool_id, code, ev)

--- a/python/sim/context.py
+++ b/python/sim/context.py
@@ -10,12 +10,22 @@ eliminating the need for module-level globals.
 
 from __future__ import annotations
 
+import sys
 from typing import Optional
 
 from greenlet import getcurrent
 
 from .context_types import SimulatorContext
 from .blockstate import KernelType
+
+
+def _free_monitoring_tool_id() -> None:
+    monitoring = getattr(sys, "monitoring", None)
+    if monitoring is None:
+        return
+    tool_id = monitoring.OPTIMIZER_ID
+    if monitoring.get_tool(tool_id) is not None:
+        monitoring.free_tool_id(tool_id)
 
 
 def get_context() -> SimulatorContext:
@@ -68,10 +78,7 @@ def reset_context() -> None:
     the next simulation run can re-register its callbacks from a clean state.
     Primarily useful for test cleanup.
     """
-    import sys
-
-    if sys.monitoring.get_tool(sys.monitoring.OPTIMIZER_ID) is not None:
-        sys.monitoring.free_tool_id(sys.monitoring.OPTIMIZER_ID)
+    _free_monitoring_tool_id()
     getcurrent()._sim_context = SimulatorContext()  # type: ignore
 
 
@@ -85,8 +92,6 @@ def cleanup_run_context() -> None:
 
     Called by the ``@ttl.operation`` wrapper after each ``Program`` run.
     """
-    import sys
-
     ctx = get_context()
     ctx.scheduler = None
     ctx.current_kernel_type = None
@@ -96,8 +101,7 @@ def cleanup_run_context() -> None:
     ctx.active_hooks.clear()
     ctx.injection_points_cache.clear()
     ctx.auto_wait_copy_lines.clear()
-    if sys.monitoring.get_tool(sys.monitoring.OPTIMIZER_ID) is not None:
-        sys.monitoring.free_tool_id(sys.monitoring.OPTIMIZER_ID)
+    _free_monitoring_tool_id()
 
 
 def get_current_kernel_type() -> KernelType:

--- a/python/ttlang/TTLangModule.cpp
+++ b/python/ttlang/TTLangModule.cpp
@@ -28,10 +28,15 @@ NB_MODULE(_ttlang, m) {
       nb::arg("context"),
       "Register and load the TTL dialect into the given context");
 
-  // Register dialects into a dialect registry (for site initialization)
+  // Register dialects into a dialect registry (for site initialization).
+  // Also registers the minimal upstream MLIR dialects the pipeline uses, which
+  // previously came from MLIR's RegisterEverything.
   m.def(
       "register_dialects",
-      [](MlirDialectRegistry registry) { ttlangRegisterTTLDialect(registry); },
+      [](MlirDialectRegistry registry) {
+        ttlangRegisterTTLDialect(registry);
+        ttlangRegisterUpstreamDialects(registry);
+      },
       nb::arg("dialectRegistry"),
       "Register all tt-lang dialects into the given dialect registry");
 

--- a/scripts/build-s3-light-wheels-local.sh
+++ b/scripts/build-s3-light-wheels-local.sh
@@ -83,12 +83,11 @@ repo_root="$(git rev-parse --show-toplevel)"
 . "$repo_root/.github/scripts/lib/docker-image-utils.sh"
 image_tag="${IMAGE_TAG:-$("$repo_root/.github/containers/get-version-tag.sh")}"
 python_tags_csv="$PYTHON_TAGS"
-if [ -z "$PYTHON_TAGS" ]; then
-    echo "At least one Python tag is required" >&2
+if ! python_tags="$(ttlang_python_tags "$PYTHON_TAGS")"; then
     exit 2
 fi
 metapackage_python_tag="${PYTHON_TAGS%%,*}"
-for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
+for python_tag in $python_tags; do
     if [ "$python_tag" = "cp312" ]; then
         metapackage_python_tag=cp312
         break
@@ -107,26 +106,10 @@ if [ "$BUILD_IMAGES" = true ]; then
         --python-tags "$python_tags_csv"
 fi
 
-image_for_tag() {
-    python_tag="$1"
-    ttlang_image_for_tag "tt-lang-wheel-manylinux-2-34-${python_tag}" "$image_tag"
-}
-
-validate_python_tag() {
-    case "$1" in
-        cp310 | cp312) ;;
-        *)
-            echo "Unsupported Python tag: $1" >&2
-            exit 2
-            ;;
-    esac
-}
-
-for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
-    validate_python_tag "$python_tag"
-    image="$(image_for_tag "$python_tag")"
+for python_tag in $python_tags; do
+    image="$(ttlang_wheel_builder_image "$python_tag" "$image_tag")"
     echo "=== Building S3 light core wheel for $python_tag with $image ==="
-    ${DOCKER:-docker} run --rm \
+    ttlang_docker run --rm \
         --user "$DOCKER_USER" \
         -v "$repo_root:/workspace" \
         -v "$output_dir:/out" \
@@ -141,9 +124,9 @@ for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
             --dist-dir /out/dist
 done
 
-image="$(image_for_tag "$metapackage_python_tag")"
+image="$(ttlang_wheel_builder_image "$metapackage_python_tag" "$image_tag")"
 echo "=== Building tt-lang-light metapackage with $image ==="
-${DOCKER:-docker} run --rm \
+ttlang_docker run --rm \
     --user "$DOCKER_USER" \
     -v "$repo_root:/workspace" \
     -v "$output_dir:/out" \

--- a/scripts/build-s3-light-wheels-local.sh
+++ b/scripts/build-s3-light-wheels-local.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and test the S3 tt-lang-light wheel set locally using the same
+# manylinux_2_34 builder images as CI.
+
+set -eu
+
+VERSION=""
+PYTHON_TAGS=cp310,cp312
+IMAGE_TAG=""
+OUTPUT_DIR=/tmp/ttlang-s3-light-wheels
+BUILD_IMAGES=false
+DOCKER_USER="$(id -u):$(id -g)"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: build-s3-light-wheels-local.sh --version <pep440-version> [options]
+
+Options:
+  --python-tags cp310,cp312  Python ABI tags to build. Default: cp310,cp312.
+  --image-tag <tag>          Builder image tag. Default: current Docker tag.
+  --output-dir <dir>         Final wheel output directory. Default: /tmp/ttlang-s3-light-wheels.
+  --build-images             Build local manylinux builder images first.
+EOF
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            VERSION="$2"
+            shift 2
+            ;;
+        --python-tags)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            PYTHON_TAGS="$2"
+            shift 2
+            ;;
+        --image-tag)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            IMAGE_TAG="$2"
+            shift 2
+            ;;
+        --output-dir)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --build-images)
+            BUILD_IMAGES=true
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    usage
+fi
+
+case "$OUTPUT_DIR" in
+    "" | "." | "/")
+        echo "Unsafe output directory: $OUTPUT_DIR" >&2
+        exit 2
+        ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel)"
+# shellcheck source=.github/scripts/lib/docker-image-utils.sh
+. "$repo_root/.github/scripts/lib/docker-image-utils.sh"
+image_tag="${IMAGE_TAG:-$("$repo_root/.github/containers/get-version-tag.sh")}"
+python_tags_csv="$PYTHON_TAGS"
+if [ -z "$PYTHON_TAGS" ]; then
+    echo "At least one Python tag is required" >&2
+    exit 2
+fi
+metapackage_python_tag="${PYTHON_TAGS%%,*}"
+for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
+    if [ "$python_tag" = "cp312" ]; then
+        metapackage_python_tag=cp312
+        break
+    fi
+done
+
+mkdir -p "$OUTPUT_DIR"
+output_dir="$(cd "$OUTPUT_DIR" && pwd)"
+rm -rf "$output_dir/dist"
+mkdir -p "$output_dir/dist"
+
+if [ "$BUILD_IMAGES" = true ]; then
+    "$repo_root/.github/containers/build-wheel-manylinux-images.sh" \
+        --no-push \
+        --image-tag "$image_tag" \
+        --python-tags "$python_tags_csv"
+fi
+
+image_for_tag() {
+    python_tag="$1"
+    ttlang_image_for_tag "tt-lang-wheel-manylinux-2-34-${python_tag}" "$image_tag"
+}
+
+validate_python_tag() {
+    case "$1" in
+        cp310 | cp312) ;;
+        *)
+            echo "Unsupported Python tag: $1" >&2
+            exit 2
+            ;;
+    esac
+}
+
+for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
+    validate_python_tag "$python_tag"
+    image="$(image_for_tag "$python_tag")"
+    echo "=== Building S3 light core wheel for $python_tag with $image ==="
+    ${DOCKER:-docker} run --rm \
+        --user "$DOCKER_USER" \
+        -v "$repo_root:/workspace" \
+        -v "$output_dir:/out" \
+        -w /workspace \
+        -e HOME=/tmp \
+        -e TTLANG_EXTERNAL_TT_METAL_DIR=/opt/ttlang-toolchain/tt-metal \
+        -e TTLANG_PYTHON_VENV=/opt/ttlang-toolchain/venv \
+        "$image" \
+        .github/scripts/build-s3-light-core-wheel.sh \
+            --python-tag "$python_tag" \
+            --version "$VERSION" \
+            --dist-dir /out/dist
+done
+
+image="$(image_for_tag "$metapackage_python_tag")"
+echo "=== Building tt-lang-light metapackage with $image ==="
+${DOCKER:-docker} run --rm \
+    --user "$DOCKER_USER" \
+    -v "$repo_root:/workspace" \
+    -v "$output_dir:/out" \
+    -w /workspace \
+    -e HOME=/tmp \
+    "$image" \
+    .github/scripts/build-s3-light-metapackage-wheel.sh \
+        --version "$VERSION" \
+        --dist-dir /out/dist
+
+"$repo_root/.github/scripts/verify-s3-wheel-versions.sh" \
+    --no-sim \
+    --python-tags "$python_tags_csv" \
+    light \
+    "$VERSION" \
+    "$output_dir/dist"
+
+"$repo_root/.github/scripts/test-s3-light-wheels.sh" \
+    --version "$VERSION" \
+    --python-tags "$python_tags_csv" \
+    --docker-tag "$image_tag" \
+    --dist-dir "$output_dir/dist"
+
+echo "=== S3 light wheels ready ==="
+ls -lh "$output_dir/dist"

--- a/scripts/build-s3-light-wheels-local.sh
+++ b/scripts/build-s3-light-wheels-local.sh
@@ -96,7 +96,7 @@ done
 
 mkdir -p "$OUTPUT_DIR"
 output_dir="$(cd "$OUTPUT_DIR" && pwd)"
-rm -rf "$output_dir/dist"
+rm -rf "$output_dir/dist" "$output_dir"/dist-*
 mkdir -p "$output_dir/dist"
 
 if [ "$BUILD_IMAGES" = true ]; then
@@ -109,6 +109,10 @@ fi
 for python_tag in $python_tags; do
     image="$(ttlang_wheel_builder_image "$python_tag" "$image_tag")"
     echo "=== Building S3 light core wheel for $python_tag with $image ==="
+    # Per-ABI dist dir: build-s3-light-core-wheel.sh runs
+    # check-wheel-ttnn-metadata.py, which requires exactly one tt_lang wheel in
+    # the dir. CI isolates this per matrix leg; mirror that here, then collect.
+    mkdir -p "$output_dir/dist-$python_tag"
     ttlang_docker run --rm \
         --user "$DOCKER_USER" \
         -v "$repo_root:/workspace" \
@@ -121,7 +125,9 @@ for python_tag in $python_tags; do
         .github/scripts/build-s3-light-core-wheel.sh \
             --python-tag "$python_tag" \
             --version "$VERSION" \
-            --dist-dir /out/dist
+            --dist-dir "/out/dist-$python_tag"
+    mv "$output_dir/dist-$python_tag"/*.whl "$output_dir/dist/"
+    rmdir "$output_dir/dist-$python_tag"
 done
 
 image="$(ttlang_wheel_builder_image "$metapackage_python_tag" "$image_tag")"

--- a/setup.py
+++ b/setup.py
@@ -260,6 +260,12 @@ class CMakeBuild(build_ext):
             if package_dir.exists():
                 shutil.rmtree(package_dir)
 
+    def _remove_stale_native_payloads(self, install_dir):
+        """Remove previously staged native extension files before CMake install."""
+        mlir_libs_dir = install_dir / "ttl" / "_mlir_libs"
+        if mlir_libs_dir.exists():
+            shutil.rmtree(mlir_libs_dir)
+
     def _sanitize_env_for_cmake(self):
         """Remove pip build-isolation env vars that break cmake's nested pip calls.
 
@@ -353,6 +359,8 @@ class CMakeBuild(build_ext):
         self.spawn(
             ["cmake", "--build", str(build_dir), "--target", "TTLangPythonModules"]
         )
+
+        self._remove_stale_native_payloads(install_dir)
 
         # Use --prefix to override the install location at install time.
         # This avoids reconfiguring the build just to change

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -30,6 +30,10 @@ CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 CALL_BUILD_DOCKER_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-build-docker.yml"
 )
+MANYLINUX_WHEEL_DOCKERFILE = (
+    REPO_ROOT / ".github" / "containers" / "Dockerfile.wheel-manylinux-2-34"
+)
+SETUP_PY = REPO_ROOT / "setup.py"
 
 
 def _run_script(
@@ -76,17 +80,34 @@ def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
     ci_workflow = CI_WORKFLOW.read_text()
     s3_workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
     pypi_workflow = PUBLISH_PYPI_WORKFLOW.read_text()
+    manylinux_dockerfile = MANYLINUX_WHEEL_DOCKERFILE.read_text()
 
     assert "build_manylinux_wheel_images" in build_docker_workflow
     assert "build-manylinux-wheel-images:" in build_docker_workflow
     assert "python_tag: [cp310, cp312]" in build_docker_workflow
     assert "build-wheel-manylinux-images.sh --python-tags" in build_docker_workflow
+    assert "--build-parallel-level 2" in build_docker_workflow
+    assert "ARG TTLANG_BUILD_PARALLEL_LEVEL" in manylinux_dockerfile
+    assert (
+        'ENV CMAKE_BUILD_PARALLEL_LEVEL="${TTLANG_BUILD_PARALLEL_LEVEL}"'
+        in manylinux_dockerfile
+    )
     assert "build_manylinux_wheel_images: true" in ci_workflow
     assert (
         "build_manylinux_wheel_images: ${{ contains(fromJSON("
         "needs.preflight.outputs.wheel_variants), 'light') }}"
     ) in s3_workflow
     assert "build_manylinux_wheel_images" not in pypi_workflow
+
+
+def test_setup_py_removes_stale_native_payloads_before_wheel_install() -> None:
+    setup_py = SETUP_PY.read_text()
+
+    assert 'mlir_libs_dir = install_dir / "ttl" / "_mlir_libs"' in setup_py
+    assert "shutil.rmtree(mlir_libs_dir)" in setup_py
+    assert setup_py.index("self._remove_stale_native_payloads(install_dir)") < (
+        setup_py.index('"cmake",\n                "--install"')
+    )
 
 
 def test_s3_stable_tags_publish_clean_version_wheels() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -25,6 +25,11 @@ COMPUTE_NIGHTLY_VERSION = SCRIPTS_DIR / "compute-nightly-version.py"
 CHECK_INSTALLED_TTNN = SCRIPTS_DIR / "check-installed-ttnn.py"
 CHECK_BUNDLED_PAYLOAD = SCRIPTS_DIR / "check-wheel-bundled-payload.py"
 PUBLISH_S3_PYPI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-s3-pypi.yml"
+PUBLISH_PYPI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CALL_BUILD_DOCKER_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "call-build-docker.yml"
+)
 
 
 def _run_script(
@@ -64,6 +69,24 @@ def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     assert ".github/scripts/build-s3-light-metapackage-wheel.sh" in workflow
     assert ".github/scripts/test-s3-light-wheels.sh" in workflow
     assert "standard_wheel_matrix" in workflow
+
+
+def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
+    build_docker_workflow = CALL_BUILD_DOCKER_WORKFLOW.read_text()
+    ci_workflow = CI_WORKFLOW.read_text()
+    s3_workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    pypi_workflow = PUBLISH_PYPI_WORKFLOW.read_text()
+
+    assert "build_manylinux_wheel_images" in build_docker_workflow
+    assert "build-manylinux-wheel-images:" in build_docker_workflow
+    assert "python_tag: [cp310, cp312]" in build_docker_workflow
+    assert "build-wheel-manylinux-images.sh --python-tags" in build_docker_workflow
+    assert "build_manylinux_wheel_images: true" in ci_workflow
+    assert (
+        "build_manylinux_wheel_images: ${{ contains(fromJSON("
+        "needs.preflight.outputs.wheel_variants), 'light') }}"
+    ) in s3_workflow
+    assert "build_manylinux_wheel_images" not in pypi_workflow
 
 
 def test_s3_stable_tags_publish_clean_version_wheels() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -51,13 +51,19 @@ def _write_wheel(dist_dir: Path, filename: str, metadata: str) -> Path:
     return wheel_path
 
 
-def test_s3_schedule_publishes_bundled_and_light_wheels() -> None:
+def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
 
     assert (
         "github.event_name == 'workflow_dispatch' && inputs.wheel_variant || ''"
     ) in workflow
     assert "EVENT_NAME: ${{ github.event_name }}" in workflow
+    assert "tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}" in workflow
+    assert "python_tag: [cp310, cp312]" in workflow
+    assert ".github/scripts/build-s3-light-core-wheel.sh" in workflow
+    assert ".github/scripts/build-s3-light-metapackage-wheel.sh" in workflow
+    assert ".github/scripts/test-s3-light-wheels.sh" in workflow
+    assert "standard_wheel_matrix" in workflow
 
 
 def test_s3_stable_tags_publish_clean_version_wheels() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -85,7 +85,14 @@ def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
     assert "build_manylinux_wheel_images" in build_docker_workflow
     assert "build-manylinux-wheel-images:" in build_docker_workflow
     assert "python_tag: [cp310, cp312]" in build_docker_workflow
-    assert "build-wheel-manylinux-images.sh --python-tags" in build_docker_workflow
+    assert "id: docker-tag" in build_docker_workflow
+    assert "registry-image=${registry_image}" in build_docker_workflow
+    assert r"Image: \`${registry_image}\`" in build_docker_workflow
+    assert (
+        "build-wheel-manylinux-images.sh --python-tags"
+        ' "${{ matrix.python_tag }}" --image-tag'
+    ) in build_docker_workflow
+    assert '"${{ steps.docker-tag.outputs.docker-tag }}"' in build_docker_workflow
     assert "--build-parallel-level 2" in build_docker_workflow
     assert "ARG TTLANG_BUILD_PARALLEL_LEVEL" in manylinux_dockerfile
     assert (

--- a/test/sim/test_analysis.py
+++ b/test/sim/test_analysis.py
@@ -14,6 +14,8 @@ Tests cover:
 - Runtime: complex control flow (nested loops, if-inside-for, issue #536 pattern)
 """
 
+import sys
+
 import pytest
 
 from sim import ttl, ttnn
@@ -23,6 +25,7 @@ from sim.analysis import (
     KernelAnalysis,
     analyze_kernel_function,
     collect_reachable_analyses,
+    install_copy_wait_hooks,
     validate_kernel_function,
 )
 from sim.context import get_context, reset_context
@@ -62,6 +65,41 @@ class TestAnalyzeKernelFunction:
 
         ips = analyze_kernel_function(dm).injection_points
         assert ips == ()
+
+    def test_importable_without_sys_monitoring_until_hooks_required(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Python 3.10 can import ttl.sim; copy-wait hooks require Python 3.12."""
+
+        monkeypatch.delattr(sys, "monitoring", raising=False)
+
+        def dm():
+            return None
+
+        analysis = KernelAnalysis(
+            injection_points=(InjectionPoint("tx", 1),),
+            bare_copy_linenos=frozenset(),
+        )
+
+        with pytest.raises(RuntimeError, match="Python 3.12"):
+            install_copy_wait_hooks({dm.__code__: analysis})
+
+    def test_bare_copy_analysis_does_not_require_sys_monitoring(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Bare copies are handled by copy() and do not need interpreter hooks."""
+
+        monkeypatch.delattr(sys, "monitoring", raising=False)
+
+        def dm():
+            return None
+
+        analysis = KernelAnalysis(
+            injection_points=(),
+            bare_copy_linenos=frozenset({1}),
+        )
+
+        install_copy_wait_hooks({dm.__code__: analysis})
 
     def test_explicit_pop_suppresses_injection(self):
         """When an explicit pop() is present no injection point is generated."""

--- a/test/sim/test_context.py
+++ b/test/sim/test_context.py
@@ -8,10 +8,13 @@ Verifies that simulator state is properly isolated per-greenlet
 and that child greenlets inherit parent context correctly.
 """
 
+import sys
+
 import pytest
 from greenlet import greenlet, getcurrent
 
 from sim.context import (
+    cleanup_run_context,
     get_context,
     set_context,
     reset_context,
@@ -89,6 +92,26 @@ class TestContextCreation:
         assert new_ctx.config.max_dfbs == 32
         assert new_ctx.config.scheduler_algorithm == "fair"
         assert len(new_ctx.copy_state.pipe_buffer) == 0
+
+    def test_reset_context_without_sys_monitoring(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Python 3.10 cleanup has no sys.monitoring tool slot to free."""
+        monkeypatch.delattr(sys, "monitoring", raising=False)
+
+        reset_context()
+
+        assert isinstance(get_context(), SimulatorContext)
+
+    def test_cleanup_run_context_without_sys_monitoring(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Run cleanup is import-safe on Python 3.10."""
+        monkeypatch.delattr(sys, "monitoring", raising=False)
+
+        cleanup_run_context()
+
+        assert get_context().active_hooks == {}
 
 
 class TestGreenletInheritance:


### PR DESCRIPTION
### Problem description
S3 `tt-lang-light` wheels need to be installable on glibc 2.34 systems for CPython 3.10 and CPython 3.12, with wheel tags compatible with the corresponding `ttnn` wheels. The publish flow also needs to preserve existing bundled-wheel behavior while adding a reproducible manylinux light-wheel build that can be exercised both locally and in CI. 

### What's changed
This PR adds a `manylinux_2_34` wheel-builder container flow that prebuilds the TT-Lang toolchain for each supported Python ABI, then uses those images to build `cp310` and `cp312` `tt-lang==...+light` wheels plus the `tt-lang-light` metapackage.

The S3 publish workflow now treats light-wheel publishing as additive: scheduled publishes continue producing the bundled wheel and also build the manylinux light wheels. The normal bundled/public wheel flow stays separate from the manylinux light-wheel flow, and the publish helpers verify exact wheel names and versions before upload.

The simulator remains importable on Python 3.10 by deferring `sys.monitoring` (requires >= 3.12) access until automatic copy-wait hook installation is actually required. Python 3.10 users can import `ttl.sim` and run paths that do not require those hooks; automatic copy-wait injection reports a Python 3.12+ requirement when used.

### Validation
- `cp310` and `cp312` local `tt-lang-light` wheel builds passed with the rebuilt manylinux images.
- Repaired wheels import successfully and pass `smoke-test-wheel.py`.
- Repaired wheel contents contain no vendored `libzstd`, no `_mlirRegisterEverything`, and no `tt_lang.libs` payload.
- A Python 3.10 manylinux container without `/opt/ttlang-toolchain` installed the local `tt-lang-light` wheel, used an external tt-metal install, and successfully ran `tutorials/elementwise/step_1_single_node_single_tile_block.py` on hardware.
- Example CI workflow (fails here because can only publish from `main`, but showing all non-publish steps passing): https://github.com/tenstorrent/tt-lang/actions/runs/27477670892

### Checklist
- [x] New/Existing tests provide coverage for changes
