### PR TITLE
[nfc][ttl] Extract DFB materialization helper [acc-0]

### DIFF
--- a/include/ttlang/Dialect/TTL/Transforms/DFBMaterialization.h
+++ b/include/ttlang/Dialect/TTL/Transforms/DFBMaterialization.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBMATERIALIZATION_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBMATERIALIZATION_H
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+
+/// \file
+/// Helpers for materializing tensor SSA values through compiler-managed
+/// dataflow buffers.
+
+namespace mlir::tt::ttl {
+
+/// Allocates a fresh compiler-managed dataflow buffer and emits its
+/// `bind_cb` at function entry, where `finalize-dfb-indices` requires every
+/// compiler-allocated bind to live. The assigned DFB index is provisional;
+/// `finalize-dfb-indices` performs physical index reuse and validates the
+/// hardware DFB-index limit. The block count is set to 2, the smallest size
+/// that lets the producer and consumer use different slots concurrently;
+/// larger counts work but waste L1 since no current caller needs more than one
+/// value in flight at a time. The builder's insertion point is left at the new
+/// `bind_cb`; callers that need to emit elsewhere should wrap the call in
+/// `OpBuilder::InsertionGuard`.
+BindCBOp createCompilerAllocatedDFB(RankedTensorType tensorType, Location loc,
+                                    func::FuncOp funcOp, ModuleOp moduleOp,
+                                    OpBuilder &builder);
+
+/// Pushes `tensor` into the next slot of `dfb` via `cb_reserve` + `store`.
+StoreOp createDFBStore(Value tensor, Value dfb, OpBuilder &builder);
+
+/// Consumes one slot of `dfb` as tensor SSA via `cb_wait` + `attach_cb`.
+/// Callers use the returned attach's result wherever a tensor view of the slot
+/// is needed.
+AttachCBOp createDFBWaitAndAttach(Value dfb, RankedTensorType tensorType,
+                                  Location loc, OpBuilder &builder);
+
+/// Routes `intermediate` through a fresh compiler-allocated DFB and returns a
+/// tensor SSA value backed by it. The new `bind_cb` is placed at function entry
+/// (see `createCompilerAllocatedDFB`); the store, wait, and attach are emitted
+/// at `intermediate.getDefiningOp()`.
+Value materializeToDFB(Value intermediate, ModuleOp moduleOp,
+                       OpBuilder &builder);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBMATERIALIZATION_H

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(TTLangTTLTransforms
   ConvertTTLToTTKernel.cpp
+  DFBMaterialization.cpp
   PipeGraph.cpp
   PipeLowering.cpp
   ConvertTTLToCompute.cpp

--- a/lib/Dialect/TTL/Transforms/DFBMaterialization.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBMaterialization.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTL/Transforms/DFBMaterialization.h"
+
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
+
+namespace mlir::tt::ttl {
+
+BindCBOp createCompilerAllocatedDFB(RankedTensorType tensorType, Location loc,
+                                    func::FuncOp funcOp, ModuleOp moduleOp,
+                                    OpBuilder &builder) {
+  MLIRContext *ctx = builder.getContext();
+
+  SmallVector<int64_t> shape(tensorType.getShape());
+  Type elementType = tensorType.getElementType();
+  int64_t blockCount = 2;
+  auto dfbType = CircularBufferType::get(ctx, shape, elementType, blockCount);
+
+  int32_t dfbIndex = getNextAvailableDFBIndex(moduleOp);
+
+  // BindCBOp lives at function entry: cb_index is function-scoped and
+  // finalize-dfb-indices requires that placement. Reserve/store/wait/attach
+  // stay at the def site to preserve per-invocation accounting inside loops
+  // and conditional branches.
+  Block &body = funcOp.getBody().front();
+  Operation *insertAfter = nullptr;
+  for (Operation &op : body) {
+    if (isa<BindCBOp>(&op)) {
+      insertAfter = &op;
+    } else if (insertAfter) {
+      break;
+    }
+  }
+  if (insertAfter) {
+    builder.setInsertionPointAfter(insertAfter);
+  } else {
+    builder.setInsertionPointToStart(&body);
+  }
+
+  auto indexAttr = builder.getIndexAttr(dfbIndex);
+  auto blockCountAttr = builder.getI64IntegerAttr(blockCount);
+  auto bindDFB =
+      BindCBOp::create(builder, loc, dfbType, indexAttr, blockCountAttr);
+  bindDFB->setAttr(kCompilerAllocatedAttrName, builder.getUnitAttr());
+  return bindDFB;
+}
+
+StoreOp createDFBStore(Value tensor, Value dfb, OpBuilder &builder) {
+  auto tensorType = cast<RankedTensorType>(tensor.getType());
+  Location loc = tensor.getLoc();
+
+  auto reserve = CBReserveOp::create(builder, loc, tensorType, dfb);
+  return StoreOp::create(builder, loc, tensor, reserve.getResult(),
+                         /*accumulate=*/nullptr);
+}
+
+AttachCBOp createDFBWaitAndAttach(Value dfb, RankedTensorType tensorType,
+                                  Location loc, OpBuilder &builder) {
+  auto wait = CBWaitOp::create(builder, loc, tensorType, dfb);
+  return AttachCBOp::create(builder, loc, tensorType, wait.getResult(), dfb);
+}
+
+Value materializeToDFB(Value intermediate, ModuleOp moduleOp,
+                       OpBuilder &builder) {
+  auto tensorType = cast<RankedTensorType>(intermediate.getType());
+  Location loc = intermediate.getLoc();
+
+  Operation *defOp = intermediate.getDefiningOp();
+  assert(defOp && "intermediate must have a defining op");
+
+  auto funcOp = defOp->getParentOfType<func::FuncOp>();
+  assert(funcOp && "intermediate must be inside a func::FuncOp");
+
+  BindCBOp bindDFB =
+      createCompilerAllocatedDFB(tensorType, loc, funcOp, moduleOp, builder);
+
+  builder.setInsertionPointAfter(defOp);
+  createDFBStore(intermediate, bindDFB.getResult(), builder);
+
+  auto attach =
+      createDFBWaitAndAttach(bindDFB.getResult(), tensorType, loc, builder);
+  return attach.getResult();
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
@@ -14,11 +14,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
-#include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
+#include "ttlang/Dialect/TTL/Transforms/DFBMaterialization.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -36,74 +35,6 @@ namespace mlir::tt::ttl {
 #include "ttlang/Dialect/TTL/Passes.h.inc"
 
 namespace {
-
-/// Materialize a value to a compiler-allocated DFB. Inserts bind_cb,
-/// cb_reserve, store, cb_wait, attach_cb. Returns the CB-attached result,
-/// or failure if the maximum CB count would be exceeded.
-FailureOr<Value> materializeToDFB(Value intermediate, ModuleOp moduleOp,
-                                  OpBuilder &builder) {
-  auto tensorType = mlir::cast<RankedTensorType>(intermediate.getType());
-  Location loc = intermediate.getLoc();
-  MLIRContext *ctx = builder.getContext();
-
-  // Intra-thread push/wait requires double-buffering so the packer and
-  // unpacker can operate on different buffer halves simultaneously.
-  SmallVector<int64_t> shape(tensorType.getShape());
-  Type elementType = tensorType.getElementType();
-  int64_t blockCount = 2;
-  auto cbType = CircularBufferType::get(ctx, shape, elementType, blockCount);
-
-  int32_t dfbIndex = getNextAvailableDFBIndex(moduleOp);
-
-  Operation *defOp = intermediate.getDefiningOp();
-  assert(defOp && "intermediate must have a defining op");
-
-  // Hoist BindCBOp to the function body entry: its cb_index is function-
-  // scoped and TTLFinalizeDFBIndices requires every compiler-allocated
-  // BindCBOp to live there. Only BindCBOp hoists; reserve/store/wait/attach
-  // stay at the def site to preserve per-invocation accounting inside
-  // loops and conditional branches.
-  auto funcOp = defOp->getParentOfType<func::FuncOp>();
-  assert(funcOp && "intermediate must be inside a func::FuncOp");
-  Block &body = funcOp.getBody().front();
-
-  // Place after the last leading BindCBOp so ordering is deterministic.
-  Operation *insertAfter = nullptr;
-  for (Operation &op : body) {
-    if (isa<BindCBOp>(&op)) {
-      insertAfter = &op;
-    } else if (insertAfter) {
-      break;
-    }
-  }
-  if (insertAfter) {
-    builder.setInsertionPointAfter(insertAfter);
-  } else {
-    builder.setInsertionPointToStart(&body);
-  }
-
-  auto indexAttr = builder.getIndexAttr(dfbIndex);
-  auto blockCountAttr = builder.getI64IntegerAttr(blockCount);
-  auto bindCB =
-      BindCBOp::create(builder, loc, cbType, indexAttr, blockCountAttr);
-  bindCB->setAttr(kCompilerAllocatedAttrName, builder.getUnitAttr());
-
-  // Remaining ops bind to the intermediate's def site.
-  builder.setInsertionPointAfter(defOp);
-
-  auto reserve =
-      CBReserveOp::create(builder, loc, tensorType, bindCB.getResult());
-
-  StoreOp::create(builder, loc, intermediate, reserve.getResult(),
-                  /*accumulate=*/nullptr);
-
-  auto wait = CBWaitOp::create(builder, loc, tensorType, bindCB.getResult());
-
-  auto attachWait = AttachCBOp::create(builder, loc, tensorType,
-                                       wait.getResult(), bindCB.getResult());
-
-  return attachWait.getResult();
-}
 
 struct TTLInsertIntermediateDFBsPass
     : public impl::TTLInsertIntermediateDFBsBase<
@@ -165,18 +96,14 @@ struct TTLInsertIntermediateDFBsPass
           continue;
         }
 
-        auto replacement = materializeToDFB(operand, moduleOp, builder);
-        if (failed(replacement)) {
-          signalPassFailure();
-          return;
-        }
+        Value replacement = materializeToDFB(operand, moduleOp, builder);
 
         // Replace only this specific operand. Elementwise consumers of
         // the same value retain the original SSA value and fuse with
         // the producer in a single compute block.
-        op->setOperand(idx, *replacement);
+        op->setOperand(idx, replacement);
 
-        materialized[operand] = *replacement;
+        materialized[operand] = replacement;
       }
     }
   }


### PR DESCRIPTION
### Problem description

`TTLInsertIntermediateDFBs` contains the compiler-managed DFB materialization sequence inline. Other compiler passes need the same bind/reserve/store/wait/attach construction without duplicating placement and metadata rules.

### What's changed

Extracts the existing compiler-managed DFB materialization logic into `DFBMaterialization.{h,cpp}` and updates `TTLInsertIntermediateDFBs` to call the shared helper.

This is NFC:
- no behavior changes;
- no pipeline changes beyond CMake wiring for the extracted helper.

### Checklist

- [x] Existing tests provide coverage for changes