### PR TITLE
[ttl] DFB index reuse: module-level finalize pass (compiler half of #670)

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -485,76 +485,29 @@ ttl-coalesce-dfb-acquires))'`) verifies this.
 
 ## Index Reuse
 
-`TTLFinalizeDFBIndices` reduces the physical DFB count by assigning the same index to compiler-allocated DFBs whose lifetimes do not overlap. The algorithm runs per function. Compiler-allocated DFBs are intra-thread (both producer and consumer are in the same compute function), so their lifetimes are independent across functions.
+`TTLFinalizeDFBIndices` is a module pass that reduces the physical DFB count by overlaying logical DFBs with disjoint lifetimes onto shared indices. It runs after `InsertCBSync` and `LowerToLoops`, when threads are separate `func.func`s and `cb_pop`s exist. A logical DFB is one `cb_index`; each kernel thread that touches it binds it once.
 
-Two DFBs may share an index only if they have identical `CircularBufferType` (shape, element type, block count). Since `CircularBufferType` is an MLIR uniqued type, this is a pointer comparison. The algorithm partitions DFBs by type and runs a linear scan within each partition.
+A physical index carries shared `pages_received`/`pages_acked` counters plus per-RISC read/write pointers. None of those are reset between lifetimes, so two logical DFBs may share an index only when:
 
-### Algorithm
+- both have the same producer thread and the same consumer thread,
+- their lifetimes are disjoint in both threads' program order,
+- they have the same element type (one page size).
 
-```
-reuseDFBIndices(funcOp, compilerAllocatedBindCBOps):
-  // Assign sequential indices to function-level operations.
-  for op in funcOp.entryBlock:
-    opIndex[op] = nextIdx++
+When thread identity matches, per-thread program order plus blocking reserve/wait make disjoint lifetimes sound at runtime; sharing across different producer or consumer threads would corrupt counters/pointers and would need a barrier-plus-reset edge, which does not exist. The element-type bar is the only shape constraint: capacity is a `>=` check, the slot is sized to the member needing the most pages, and every reserve/wait carries its own block size.
 
-  // Build intervals: [bind_cb position, last cb_pop position].
-  // CBPopOps inside nested regions (loops, compute) are projected
-  // to their function-level ancestor.
-  // If no cb_pop exists, end = last operation (conservative).
-  for bindOp in compilerAllocatedBindCBOps:
-    start = opIndex[bindOp]
-    end = max(getBodyIndex(pop) for pop in cbPopUsers(bindOp))
-    if end == start:
-      end = lastOpIdx
-    intervals[bindOp.type].append({start, end, bindOp.result})
+A DFB whose producer and consumer are the same thread is single-threaded (compiler-allocated intermediates always; user DFBs whenever the pass derives it), so the pair (thread, thread) acts as one reuse class regardless of how the buffer was declared.
 
-  // Linear scan per type partition. Each partition gets a contiguous
-  // block of indices starting at baseIndex + offset.
-  offset = 0
-  for (type, typeIntervals) in intervals:
-    sort typeIntervals by start
-    maxSlot = 0
-    for interval in typeIntervals:
-      // Expire: free slots where active.end <= interval.start
-      for active in activeList:
-        if active.end <= interval.start:
-          free(slot[active])
-      slot[interval] = allocateFirstFreeSlot()
-      maxSlot = max(maxSlot, slot[interval])
+Lifetimes are computed per thread: from the first reserve/wait (bind position when no acquire exists) to the last use, following wait -> readers -> attach_cb -> consumers and pops. Nested uses project onto their top-level ancestor, so a buffer used in a loop is live across the back-edge for the whole loop. Intervals are closed; sharing an endpoint counts as overlap.
 
-    // Rewrite BindCBOp cb_index attributes for this partition.
-    for (value, s) in partitionAssignments:
-      bindOp[value].cb_index = baseIndex + offset + s
-    offset += maxSlot + 1
-```
+The reuse condition is checked against actual blocking acquires; control-flow guards (e.g. mutually exclusive per-core roles) do not refine it. `ttl-verify-dfb-spsc` always runs afterwards and rejects shared indices with multiple producer or consumer threads on overlapping launch nodes; role-guarded accesses pass when launch-node domain analysis proves them disjoint.
 
-The expiration condition `active.end <= interval.start` matches the DST register allocator's convention. Because operation indices are integers assigned to distinct operations, strict inequality and non-strict inequality produce the same result.
+### Pipe-attached DFBs never reuse
 
-### Correctness with control flow
+For a pipe destination, `block_count` is not queue depth: each sender writes its own block, addressed by sender ordinal, so `block_count` must equal the sender count. Pipe lowering lays sender slots out per `cb_index`; two destinations on one index would concatenate their slot ranges and change the addressing. Pipe transfers also move data over NOC with semaphore protocol, outside the CB counters that make program-order lifetimes sound, and a sender's stage buffer is read asynchronously after its wait. Any DFB whose user chain reaches a pipe op or a `ttl.copy` with a pipe operand therefore keeps its dedicated index and block count.
 
-The algorithm assigns sequential indices to function-level operations only. Structured operations (`scf.for`, `ttl.compute`) occupy a single index in this sequence; their contents are not individually numbered. This is sufficient because `InsertIntermediateDFBs` and `InsertCBSync` both run before `LowerToLoops`, placing `bind_cb` and `cb_pop` at function-level while the IR is flat. These operations remain at function-level after loop creation because they bracket compute regions.
+### Runtime integration
 
-If a later pass restructures a `CBPopOp` into a nested region, it is projected to its enclosing operation at function-level via `Block::findAncestorOpInBlock`. This overestimates liveness -- the interval extends to the structured op rather than to the specific point where the pop occurs -- but never produces incorrect reuse.
-
-Two DFBs consumed simultaneously by the same operation (e.g., both operands of a matmul) necessarily have overlapping intervals because both `bind_cb` must precede the consumer and both `cb_pop` must follow it. The linear scan assigns them different slots.
-
-### Module attribute and runtime integration
-
-After rewriting indices, the pass calls `getNextAvailableDFBIndex`, which returns `max(cb_index) + 1` across all `BindCBOp`s in the module. This is the index space usage, not a count of distinct DFBs (sparse indices inflate it). The pass verifies this does not exceed `kMaxCircularBuffers` (32).
-
-The pass then sets `ttl.base_cta_index` on every function. Compile-time arguments (CTAs) to each kernel are laid out as `[CB indices..., other args...]`. `base_cta_index` is the starting index of the non-CB arguments -- equivalently, one past the last CB index. CB indices occupy `[0, base_cta_index)`.
-
-Finally, the pass builds the `ttl.compiler_allocated_dfbs` module attribute with one entry per unique physical index, deduplicated from the potentially many `BindCBOp`s that now share an index. The Python runtime reads this attribute to allocate L1 buffers at dispatch time.
-
-## Limitations and Future Work
-
-The linear scan operates on a flat sequence of function-level operations. It cannot distinguish between branches of an `scf.if`, so DFBs used in mutually exclusive branches are treated as overlapping. The current pipeline does not produce conditional control flow around DFB lifecycle operations. The DSL evaluates Python `if` during tracing, so only the taken branch appears in the generated IR; runtime-conditional control flow (`scf.if` with conditions dependent on tensor values) is not supported by the frontend at this time.
-
-Index reuse is restricted to compiler-allocated DFBs. User-declared DFBs retain their original indices because the same CB index is referenced by multiple threads (reader, compute, writer) to implement cross-thread data flow. Reusing a user index in one function would invalidate references in the others.
-
-Liveness is computed at function-level granularity. If a `CBPopOp` is inside a structured op (loop, compute region), it is projected to its enclosing operation at function-level. The infrastructure for this exists (`Block::findAncestorOpInBlock`) but is not currently exercised: all compiler-allocated DFB lifecycle ops remain at function-level because `InsertIntermediateDFBs` and `InsertCBSync` run before loop creation, and Python control flow unrolls at trace time.
-
-The type compatibility constraint prevents reuse across DFBs with different shapes or element types, even when L1 footprints happen to match. A size-based rather than type-based compatibility check could recover some reuse opportunities.
+After rewriting indices, the pass recomputes `getNextAvailableDFBIndex` (max index + 1), checks `kMaxCircularBuffers` (32), and updates `ttl.base_cta_index` on every function. Two module attributes carry the result to the Python runtime: `ttl.compiler_allocated_dfbs` (one entry per physical index, sized to the largest member) and `ttl.dfb_index_map` (old -> new entries for moved user DFBs, applied to the CB config list before descriptors are built).
 
 ## Scalar Element Access to DFBs
 

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -149,6 +149,10 @@ constexpr llvm::StringLiteral
 constexpr llvm::StringLiteral
     kCompilerAllocatedAttrName("ttl.compiler_allocated");
 
+/// Module attribute mapping user DFB indices renumbered by index reuse
+/// (array of {old_index, new_index} dictionaries).
+constexpr llvm::StringLiteral kDFBIndexMapAttrName("ttl.dfb_index_map");
+
 /// Function attribute recording the base compile-time argument index.
 /// CTA layout is [CBs, TAs], so this equals the number of CBs.
 constexpr llvm::StringLiteral kBaseCTAIndexAttrName("ttl.base_cta_index");

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -6,11 +6,26 @@
 // TTL Finalize DFB Indices
 //===----------------------------------------------------------------------===//
 //
-// Module-level pass that runs after all DFB-creating passes. Reuses
-// compiler-allocated DFB indices when lifetimes do not overlap, then
-// computes the true DFB count, updates ttl.base_cta_index on every
-// function, and collects compiler-allocated DFBs into the
-// ttl.compiler_allocated_dfbs module attribute for the Python runtime.
+// Module-level pass that runs after all DFB-creating passes. Reuses DFB
+// indices when lifetimes do not overlap, then computes the true DFB count,
+// updates ttl.base_cta_index on every function, and publishes the final
+// index assignment for the Python runtime (ttl.dfb_index_map for
+// user-declared DFBs, ttl.compiler_allocated_dfbs for compiler-allocated
+// ones).
+//
+// A logical DFB is one cb_index, bound by one bind_cb per kernel thread that
+// touches it. The same physical CB index has shared pages_received /
+// pages_acked counters and per-RISC read/write pointers, so two logical DFBs
+// may share an index only when:
+//   - both have the same producer thread and the same consumer thread,
+//   - their per-thread lifetimes are disjoint in both threads' program order,
+//   - they have the same element type (uniform page size). Capacity is a
+//     >= check, not equality: the slot is sized to the member needing the
+//     most pages, and every reserve/wait carries its own block size.
+// With matching thread identity, per-thread program order plus reserve/wait
+// blocking make disjoint program-order lifetimes sound at runtime; sharing
+// across different producer or consumer threads is never sound without a
+// counter/pointer reset and is therefore not attempted.
 //
 //===----------------------------------------------------------------------===//
 
@@ -19,7 +34,6 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
-#include "ttlang/Dialect/TTL/Transforms/LiveIntervalUtils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -27,9 +41,6 @@
 
 #include "llvm/ADT/MapVector.h"
 #include "llvm/Support/Debug.h"
-
-#include <algorithm>
-#include <functional>
 
 #define DEBUG_TYPE "ttl-finalize-dfb-indices"
 
@@ -40,190 +51,340 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-/// Reuse compiler-allocated DFB indices within a function when their
-/// lifetimes do not overlap. Groups DFBs by CircularBufferType and runs
-/// linear scan allocation per group.
-static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
-  if (dfbOps.size() <= 1) {
-    return;
+/// Closed [start, end] lifetime of a logical DFB within one kernel thread,
+/// in that thread's top-level program order.
+struct ThreadInterval {
+  int64_t start;
+  int64_t end;
+};
+
+/// One logical DFB: a cb_index with one bind_cb per kernel thread.
+struct LogicalDFB {
+  int64_t origIndex = -1;
+  SmallVector<BindCBOp, 3> binds;
+  func::FuncOp producer;
+  func::FuncOp consumer;
+  llvm::SmallDenseMap<Operation *, ThreadInterval, 4> intervals;
+  llvm::SmallDenseMap<Operation *, int64_t, 4> firstAcquire;
+  Type elemType;
+  int64_t blockCount = 0;
+  int64_t elemsPerBlock = 0;
+  bool compilerAllocated = false;
+  bool eligible = true;
+  int64_t finalIndex = -1;
+
+  int64_t totalPages() const { return blockCount * elemsPerBlock; }
+};
+
+/// Position of an op in its kernel thread's top-level program order. Nested
+/// ops project onto their body-block ancestor: a buffer touched inside a
+/// loop is acquired and released every iteration, so across the back-edge it
+/// is live for the whole loop, not one static interval within the body.
+struct ThreadOrder {
+  DenseMap<Operation *, int64_t> topLevel;
+  int64_t lastIdx = 0;
+
+  explicit ThreadOrder(func::FuncOp func) {
+    int64_t idx = 0;
+    for (Operation &op : func.getBody().front()) {
+      topLevel[&op] = idx++;
+    }
+    lastIdx = idx == 0 ? 0 : idx - 1;
   }
 
-  Block &body = funcOp.getBody().front();
-
-  // Assign sequential indices to all operations in the body block.
-  DenseMap<Operation *, int64_t> opIndex;
-  int64_t idx = 0;
-  for (Operation &op : body) {
-    opIndex[&op] = idx++;
-  }
-  int64_t lastOpIdx = idx - 1;
-
-  // Project a nested operation to its ancestor in the body block.
-  // After LowerToLoops or SubblockComputeForDST, CBPopOps may end up
-  // inside loops or compute regions.
-  auto getBodyIndex = [&](Operation *op) -> int64_t {
+  int64_t index(Operation *op, func::FuncOp func) {
+    Block &body = func.getBody().front();
     if (op->getBlock() == &body) {
-      return opIndex[op];
+      return topLevel[op];
     }
     Operation *ancestor = body.findAncestorOpInBlock(*op);
     assert(ancestor && "operation must be reachable from function body");
-    return opIndex[ancestor];
-  };
-
-  // Build intervals grouped by CircularBufferType.
-  llvm::MapVector<Type, SmallVector<ValueLiveInterval>> typeToIntervals;
-  DenseMap<Value, BindCBOp> valueToBindOp;
-
-  for (BindCBOp bindOp : dfbOps) {
-    assert(bindOp->getBlock() == &body &&
-           "compiler-allocated BindCBOp must be in function body block");
-
-    Value cbVal = bindOp.getResult();
-    // Lifetime starts at the first acquire (reserve/wait) on this CB, not
-    // at the bind_cb itself: bind_cb is just a declaration, and hoisting
-    // it to the function body entry would otherwise collapse all compiler-
-    // allocated DFB starts together and defeat reuse. If there is no
-    // acquire (synthetic IR, pop-only), fall back to the bind_cb position.
-    int64_t start = lastOpIdx;
-    int64_t end = opIndex[bindOp];
-    bool sawAcquire = false;
-
-    for (OpOperand &use : cbVal.getUses()) {
-      Operation *user = use.getOwner();
-      int64_t useIdx = getBodyIndex(user);
-      if (isa<CBReserveOp, CBWaitOp>(user)) {
-        start = std::min(start, useIdx);
-        sawAcquire = true;
-      }
-      if (isa<CBPopOp>(user)) {
-        end = std::max(end, useIdx);
-      }
-    }
-
-    if (!sawAcquire) {
-      start = opIndex[bindOp];
-    }
-
-    // No cb_pop means the DFB's L1 is never explicitly released --
-    // conservatively treat it as live for the entire function.
-    if (end <= start) {
-      end = lastOpIdx;
-    }
-
-    SmallVector<ValueLiveInterval> &intervals =
-        typeToIntervals[cbVal.getType()];
-    int64_t ordinal = static_cast<int64_t>(intervals.size());
-    intervals.push_back({start, end, cbVal, ordinal});
-    valueToBindOp[cbVal] = bindOp;
+    return topLevel[ancestor];
   }
+};
 
-  // Find the base index (smallest compiler-allocated index).
-  int32_t baseIndex = INT32_MAX;
-  for (BindCBOp bindOp : dfbOps) {
-    int32_t cbIdx = static_cast<int32_t>(bindOp.getCbIndex().getSExtValue());
-    baseIndex = std::min(baseIndex, cbIdx);
+/// Extend the per-thread interval of `dfb` to cover `op`.
+void extendInterval(LogicalDFB &dfb, Operation *op, func::FuncOp func,
+                    ThreadOrder &order) {
+  int64_t pos = order.index(op, func);
+  auto [it, inserted] =
+      dfb.intervals.try_emplace(func.getOperation(), ThreadInterval{pos, pos});
+  if (!inserted) {
+    it->second.start = std::min(it->second.start, pos);
+    it->second.end = std::max(it->second.end, pos);
   }
-
-  // Linear scan per type partition. Each partition gets a contiguous
-  // block of physical DFB indices starting at baseIndex + cumulative
-  // offset from prior partitions.
-  MLIRContext *ctx = funcOp.getContext();
-  int32_t nextSlotOffset = 0;
-
-  for (auto &entry : typeToIntervals) {
-    SmallVector<ValueLiveInterval> &intervals = entry.second;
-
-    SmallVector<SmallVector<ValueLiveInterval>> colorUsers =
-        assignGreedyIntervalColors<ValueLiveInterval>(
-            intervals, std::less<ValueLiveInterval>(),
-            [](const ValueLiveInterval &lhs, const ValueLiveInterval &rhs) {
-              return intervalsOverlap(lhs, rhs);
-            });
-
-    DenseMap<Value, int32_t> slotAssignment;
-    int32_t maxSlot = -1;
-
-    for (auto indexedColor : llvm::enumerate(colorUsers)) {
-      int32_t slotIndex = static_cast<int32_t>(indexedColor.index());
-      maxSlot = std::max(maxSlot, slotIndex);
-      for (const ValueLiveInterval &interval : indexedColor.value()) {
-        slotAssignment[interval.value] = slotIndex;
-
-        LLVM_DEBUG({
-          llvm::dbgs() << "DFB reuse: [" << interval.start << ", "
-                       << interval.end << "] -> slot " << slotIndex << "\n";
-        });
-      }
-    }
-
-    // Rewrite BindCBOp indices to the assigned physical slot.
-    for (auto &[value, slot] : slotAssignment) {
-      int32_t newIndex = baseIndex + nextSlotOffset + slot;
-      BindCBOp bindOp = valueToBindOp[value];
-      bindOp.setCbIndexAttr(IntegerAttr::get(IndexType::get(ctx), newIndex));
-    }
-
-    nextSlotOffset += maxSlot + 1;
-  }
-
-  LLVM_DEBUG({
-    llvm::dbgs() << "DFB reuse: " << dfbOps.size()
-                 << " compiler-allocated DFBs -> " << nextSlotOffset
-                 << " physical slot(s)\n";
-  });
 }
+
+/// Record producer/consumer thread identity; multiple distinct threads in
+/// either role make the DFB ineligible (sharing its index would need a
+/// counter/pointer reset, which does not exist).
+void recordRole(func::FuncOp &role, func::FuncOp func, bool &eligible) {
+  if (!role) {
+    role = func;
+  } else if (role != func) {
+    eligible = false;
+  }
+}
+
+bool disjoint(const ThreadInterval &a, const ThreadInterval &b) {
+  return a.end < b.start || b.end < a.start;
+}
+
+/// Two logical DFBs of one reuse class conflict when their lifetimes overlap
+/// in the producer thread or in the consumer thread. Intervals are closed:
+/// sharing an endpoint means both are live at that op.
+bool conflicts(const LogicalDFB &a, const LogicalDFB &b) {
+  for (auto &[func, interval] : a.intervals) {
+    auto it = b.intervals.find(func);
+    if (it != b.intervals.end() && !disjoint(interval, it->second)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
 
 struct TTLFinalizeDFBIndicesPass
     : public impl::TTLFinalizeDFBIndicesBase<TTLFinalizeDFBIndicesPass> {
   void runOnOperation() override {
     auto moduleOp = getOperation();
-    OpBuilder builder(moduleOp.getContext());
+    MLIRContext *ctx = moduleOp.getContext();
+    OpBuilder builder(ctx);
 
-    // Collect compiler-allocated BindCBOps grouped by parent function.
-    llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> funcToDFBs;
+    // Collect logical DFBs by original index across kernel threads.
+    llvm::MapVector<int64_t, LogicalDFB> dfbs;
+    llvm::SmallDenseMap<Operation *, std::unique_ptr<ThreadOrder>> orders;
+    bool sawBind = false;
+
     moduleOp->walk([&](BindCBOp bindOp) {
-      if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-        auto funcOp = bindOp->getParentOfType<func::FuncOp>();
-        funcToDFBs[funcOp].push_back(bindOp);
+      sawBind = true;
+      func::FuncOp func = getEnclosingKernelThread(bindOp);
+      int64_t idx = bindOp.getCbIndex().getSExtValue();
+      LogicalDFB &dfb = dfbs[idx];
+      dfb.origIndex = idx;
+      dfb.binds.push_back(bindOp);
+      auto cbType = mlir::cast<CircularBufferType>(bindOp.getResult().getType());
+      dfb.elemType = cbType.getElementType();
+      dfb.blockCount = cbType.getBlockCount();
+      dfb.elemsPerBlock =
+          std::max(dfb.elemsPerBlock, cbType.getElementsPerBlock());
+      dfb.compilerAllocated |= bindOp->hasAttr(kCompilerAllocatedAttrName);
+      if (!func) {
+        dfb.eligible = false;
+        return;
+      }
+
+      auto &order = orders[func.getOperation()];
+      if (!order) {
+        order = std::make_unique<ThreadOrder>(func);
+      }
+
+      // The bind anchors the interval; binds are hoisted to the function
+      // entry, so the start is refined to the first acquire below.
+      extendInterval(dfb, bindOp, func, *order);
+
+      // Pipe destinations are slot-addressed (block_count == sender count)
+      // and pipe sends read asynchronously, so pipe-attached DFBs keep
+      // dedicated indices.
+      // A DFB participates in a pipe through a ttl.copy whose other operand
+      // is a pipe, or through pipe_recv guards.
+      auto isPipeOp = [](Operation *op) {
+        if (op->getName().getStringRef().contains("pipe")) {
+          return true;
+        }
+        return llvm::any_of(op->getOperands(), [](Value operand) {
+          return mlir::isa<PipeType>(operand.getType());
+        });
+      };
+      // Pipe sends/receives reach a block through view chains (extract_slice,
+      // attach_cb, casts); walk a few hops of users.
+      auto markPipeUsers = [&](Value view) {
+        SmallVector<Value> worklist{view};
+        for (int depth = 0; depth < 3 && !worklist.empty(); ++depth) {
+          SmallVector<Value> next;
+          for (Value v : worklist) {
+            for (Operation *user : v.getUsers()) {
+              if (isPipeOp(user)) {
+                dfb.eligible = false;
+                return;
+              }
+              for (Value result : user->getResults()) {
+                next.push_back(result);
+              }
+            }
+          }
+          worklist = std::move(next);
+        }
+      };
+
+      for (Operation *user : bindOp.getResult().getUsers()) {
+        extendInterval(dfb, user, func, *order);
+        if (isPipeOp(user)) {
+          dfb.eligible = false;
+        }
+        if (auto reserveOp = dyn_cast<CBReserveOp>(user)) {
+          markPipeUsers(reserveOp.getResult());
+        }
+        if (isa<CBReserveOp, CBWaitOp>(user)) {
+          int64_t pos = order->index(user, func);
+          auto [it, inserted] =
+              dfb.firstAcquire.try_emplace(func.getOperation(), pos);
+          if (!inserted) {
+            it->second = std::min(it->second, pos);
+          }
+        }
+        if (isa<CBReserveOp, CBPushOp>(user)) {
+          recordRole(dfb.producer, func, dfb.eligible);
+        }
+        if (isa<CBWaitOp, CBPopOp>(user)) {
+          recordRole(dfb.consumer, func, dfb.eligible);
+        }
+        // A consumed block stays live until its last reader: follow
+        // wait -> readers -> attach_cb -> consumers one level deep.
+        if (auto waitOp = dyn_cast<CBWaitOp>(user)) {
+          markPipeUsers(waitOp.getResult());
+          for (Operation *reader : waitOp.getResult().getUsers()) {
+            extendInterval(dfb, reader, func, *order);
+            if (auto attachOp = dyn_cast<AttachCBOp>(reader)) {
+              markPipeUsers(attachOp.getResult());
+              for (Operation *consumer : attachOp.getResult().getUsers()) {
+                extendInterval(dfb, consumer, func, *order);
+              }
+            }
+          }
+        }
       }
     });
 
-    // Run DFB index reuse per function.
-    for (auto &[funcOp, dfbOps] : funcToDFBs) {
-      reuseDFBIndices(funcOp, dfbOps);
-    }
-
-    // Recompute DFB count after reuse may have changed indices.
-    int32_t numDFBs = getNextAvailableDFBIndex(moduleOp);
-    if (numDFBs <= 0) {
+    if (!sawBind) {
       return;
     }
 
+    // A DFB with no acquire and no release anywhere (declared but unused)
+    // keeps its index. One-sided DFBs reuse within the thread that touches
+    // them. Lifetime starts at the first acquire in each thread; without one
+    // the hoisted bind position stands, conservatively from function entry.
+    for (auto &[idx, dfb] : dfbs) {
+      if (!dfb.producer && !dfb.consumer) {
+        dfb.eligible = false;
+        continue;
+      }
+      if (!dfb.producer) {
+        dfb.producer = dfb.consumer;
+      }
+      if (!dfb.consumer) {
+        dfb.consumer = dfb.producer;
+      }
+      for (auto &[func, interval] : dfb.intervals) {
+        auto it = dfb.firstAcquire.find(func);
+        if (it != dfb.firstAcquire.end()) {
+          interval.start = it->second;
+        }
+      }
+    }
+
+    // Group eligible DFBs into reuse classes; keep deterministic order by
+    // original index. Class members may differ in block count and tiles per
+    // block: capacity is a >= constraint, the slot is sized to the member
+    // needing the most pages, and per-op tile counts come from each bind_cb's
+    // own type.
+    // User and compiler DFBs share slots freely; the runtime keeps the
+    // larger config when both describe one index.
+    using ClassKey = std::tuple<Type, Operation *, Operation *>;
+    llvm::MapVector<ClassKey, SmallVector<LogicalDFB *>> classes;
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.eligible) {
+        classes[{dfb.elemType, dfb.producer.getOperation(),
+                 dfb.consumer.getOperation()}]
+            .push_back(&dfb);
+      } else {
+        dfb.finalIndex = dfb.origIndex;
+      }
+    }
+
+    // Greedy interval coloring per class: walk by ascending producer start
+    // and place on the first slot whose members are all disjoint in both
+    // threads. A slot takes the lowest original index of its members, so
+    // indices only ever decrease and never collide with ineligible DFBs.
+    SmallVector<SmallVector<LogicalDFB *>> slots;
+    for (auto &[key, members] : classes) {
+      llvm::sort(members, [](LogicalDFB *a, LogicalDFB *b) {
+        auto pa = a->intervals.find(a->producer.getOperation())->second;
+        auto pb = b->intervals.find(b->producer.getOperation())->second;
+        return std::tie(pa.start, pa.end, a->origIndex) <
+               std::tie(pb.start, pb.end, b->origIndex);
+      });
+      size_t classBase = slots.size();
+      for (LogicalDFB *dfb : members) {
+        size_t placed = slots.size();
+        for (size_t s = classBase; s < slots.size(); ++s) {
+          if (llvm::none_of(slots[s], [&](LogicalDFB *member) {
+                return conflicts(*member, *dfb);
+              })) {
+            placed = s;
+            break;
+          }
+        }
+        if (placed == slots.size()) {
+          slots.emplace_back();
+        }
+        slots[placed].push_back(dfb);
+      }
+    }
+
+    for (auto &slot : slots) {
+      int64_t slotIndex = slot.front()->origIndex;
+      for (LogicalDFB *dfb : slot) {
+        slotIndex = std::min(slotIndex, dfb->origIndex);
+      }
+      for (LogicalDFB *dfb : slot) {
+        dfb->finalIndex = slotIndex;
+      }
+    }
+
+    // Compact to a dense index space (the runtime builds one CB descriptor
+    // per index), preserving relative order.
+    SmallVector<int64_t> usedIndices;
+    for (auto &[idx, dfb] : dfbs) {
+      usedIndices.push_back(dfb.finalIndex);
+    }
+    llvm::sort(usedIndices);
+    usedIndices.erase(llvm::unique(usedIndices), usedIndices.end());
+    DenseMap<int64_t, int64_t> rank;
+    for (auto [i, index] : llvm::enumerate(usedIndices)) {
+      rank[index] = static_cast<int64_t>(i);
+    }
+    for (auto &[idx, dfb] : dfbs) {
+      dfb.finalIndex = rank[dfb.finalIndex];
+    }
+
+    // Rewrite bind_cb indices in every kernel thread.
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.finalIndex == dfb.origIndex) {
+        continue;
+      }
+      for (BindCBOp bindOp : dfb.binds) {
+        bindOp.setCbIndexAttr(
+            IntegerAttr::get(IndexType::get(ctx), dfb.finalIndex));
+      }
+      LLVM_DEBUG(llvm::dbgs() << "DFB reuse: cb" << dfb.origIndex << " -> cb"
+                              << dfb.finalIndex << "\n");
+    }
+
+    int32_t numDFBs = getNextAvailableDFBIndex(moduleOp);
     LLVM_DEBUG(llvm::dbgs() << "Total DFB count: " << numDFBs << "\n");
 
-    // Verify the final DFB count does not exceed the hardware limit.
     if (numDFBs > kMaxCircularBuffers) {
-      // Count compiler-allocated physical slots (after reuse).
-      int32_t compilerSlots = 0;
-      for (auto &[funcOp, dfbOps] : funcToDFBs) {
-        llvm::SmallDenseSet<int32_t> uniqueIndices;
-        for (BindCBOp bindOp : dfbOps) {
-          uniqueIndices.insert(
-              static_cast<int32_t>(bindOp.getCbIndex().getSExtValue()));
-        }
-        compilerSlots += static_cast<int32_t>(uniqueIndices.size());
-      }
       moduleOp.emitError()
-          << "need " << numDFBs << " DFB indices but hardware supports "
-          << "at most " << kMaxCircularBuffers << " (" << compilerSlots
-          << " compiler-allocated after reuse); reduce the number of "
-          << "user-declared dataflow buffers or split the computation "
-          << "into multiple kernels";
+          << "need " << numDFBs << " DFB indices after reuse but hardware "
+          << "supports at most " << kMaxCircularBuffers
+          << "; reduce the number of dataflow buffers or split the "
+          << "computation into multiple kernels";
       signalPassFailure();
       return;
     }
 
-    // Update ttl.base_cta_index on every function that has it.
     moduleOp->walk([&](func::FuncOp funcOp) {
       if (funcOp->hasAttr(kBaseCTAIndexAttrName)) {
         funcOp->setAttr(kBaseCTAIndexAttrName,
@@ -231,63 +392,62 @@ struct TTLFinalizeDFBIndicesPass
       }
     });
 
-    // Re-collect compiler-allocated ops (indices may have changed).
-    SmallVector<BindCBOp> compilerAllocatedOps;
-    moduleOp->walk([&](BindCBOp bindOp) {
-      if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-        compilerAllocatedOps.push_back(bindOp);
+    // Publish remapped user DFB indices for the Python runtime.
+    SmallVector<Attribute> mapEntries;
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.compilerAllocated || dfb.finalIndex == dfb.origIndex) {
+        continue;
       }
-    });
+      mapEntries.push_back(DictionaryAttr::get(
+          ctx, {builder.getNamedAttr(
+                    "old_index",
+                    builder.getI32IntegerAttr(static_cast<int32_t>(idx))),
+                builder.getNamedAttr("new_index",
+                                     builder.getI32IntegerAttr(
+                                         static_cast<int32_t>(dfb.finalIndex)))}));
+    }
+    if (!mapEntries.empty()) {
+      moduleOp->setAttr(kDFBIndexMapAttrName, ArrayAttr::get(ctx, mapEntries));
+    }
 
-    if (compilerAllocatedOps.empty()) {
+    // Publish compiler-allocated DFBs, one entry per physical index sized to
+    // the member needing the most pages.
+    llvm::MapVector<int64_t, LogicalDFB *> compilerByIndex;
+    for (auto &[idx, dfb] : dfbs) {
+      if (!dfb.compilerAllocated) {
+        continue;
+      }
+      auto [it, inserted] = compilerByIndex.try_emplace(dfb.finalIndex, &dfb);
+      if (!inserted && dfb.totalPages() > it->second->totalPages()) {
+        it->second = &dfb;
+      }
+    }
+    if (compilerByIndex.empty()) {
       return;
     }
 
-    // Deduplicate entries by physical index. After reuse, multiple
-    // BindCBOps may share the same index. The module attribute needs
-    // one entry per unique physical DFB.
-    llvm::DenseMap<int32_t, BindCBOp> uniqueByIndex;
-    for (BindCBOp bindOp : compilerAllocatedOps) {
-      int32_t dfbIdx = static_cast<int32_t>(bindOp.getCbIndex().getSExtValue());
-      auto [it, inserted] = uniqueByIndex.try_emplace(dfbIdx, bindOp);
-      if (!inserted) {
-        assert(it->second.getResult().getType() ==
-                   bindOp.getResult().getType() &&
-               "compiler-allocated DFBs sharing an index must have the "
-               "same CircularBufferType");
-      }
-    }
-
-    // Sort by index for deterministic output.
-    SmallVector<std::pair<int32_t, BindCBOp>> sorted(uniqueByIndex.begin(),
-                                                     uniqueByIndex.end());
+    SmallVector<std::pair<int64_t, LogicalDFB *>> sorted(
+        compilerByIndex.begin(), compilerByIndex.end());
     llvm::sort(sorted,
                [](auto &lhs, auto &rhs) { return lhs.first < rhs.first; });
 
-    MLIRContext *ctx = moduleOp.getContext();
     SmallVector<Attribute> entries;
-    for (auto &[dfbIdx, bindOp] : sorted) {
-      auto cbType =
-          mlir::cast<CircularBufferType>(bindOp.getResult().getType());
-      SmallVector<NamedAttribute> entryAttrs;
-      entryAttrs.push_back(
-          builder.getNamedAttr("dfb_index", builder.getI32IntegerAttr(dfbIdx)));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "num_tiles", builder.getI32IntegerAttr(static_cast<int32_t>(
-                           cbType.getElementsPerBlock()))));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "element_type", TypeAttr::get(cbType.getElementType())));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "block_count", builder.getI32IntegerAttr(
-                             static_cast<int32_t>(cbType.getBlockCount()))));
-      entries.push_back(DictionaryAttr::get(ctx, entryAttrs));
+    for (auto &[dfbIdx, dfb] : sorted) {
+      entries.push_back(DictionaryAttr::get(
+          ctx,
+          {builder.getNamedAttr("dfb_index", builder.getI32IntegerAttr(
+                                                 static_cast<int32_t>(dfbIdx))),
+           builder.getNamedAttr("num_tiles",
+                                builder.getI32IntegerAttr(
+                                    static_cast<int32_t>(dfb->elemsPerBlock))),
+           builder.getNamedAttr("element_type", TypeAttr::get(dfb->elemType)),
+           builder.getNamedAttr("block_count",
+                                builder.getI32IntegerAttr(
+                                    static_cast<int32_t>(dfb->blockCount)))}));
     }
-
     moduleOp->setAttr(kCompilerAllocatedDFBsAttrName,
                       ArrayAttr::get(ctx, entries));
   }
 };
-
-} // namespace
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -164,7 +164,8 @@ struct TTLFinalizeDFBIndicesPass
       LogicalDFB &dfb = dfbs[idx];
       dfb.origIndex = idx;
       dfb.binds.push_back(bindOp);
-      auto cbType = mlir::cast<CircularBufferType>(bindOp.getResult().getType());
+      auto cbType =
+          mlir::cast<CircularBufferType>(bindOp.getResult().getType());
       dfb.elemType = cbType.getElementType();
       dfb.blockCount = cbType.getBlockCount();
       dfb.elemsPerBlock =
@@ -399,12 +400,12 @@ struct TTLFinalizeDFBIndicesPass
         continue;
       }
       mapEntries.push_back(DictionaryAttr::get(
-          ctx, {builder.getNamedAttr(
-                    "old_index",
-                    builder.getI32IntegerAttr(static_cast<int32_t>(idx))),
-                builder.getNamedAttr("new_index",
-                                     builder.getI32IntegerAttr(
-                                         static_cast<int32_t>(dfb.finalIndex)))}));
+          ctx,
+          {builder.getNamedAttr("old_index", builder.getI32IntegerAttr(
+                                                 static_cast<int32_t>(idx))),
+           builder.getNamedAttr("new_index",
+                                builder.getI32IntegerAttr(
+                                    static_cast<int32_t>(dfb.finalIndex)))}));
     }
     if (!mapEntries.empty()) {
       moduleOp->setAttr(kDFBIndexMapAttrName, ArrayAttr::get(ctx, mapEntries));

--- a/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
@@ -46,11 +46,11 @@ FailureOr<Value> materializeToDFB(Value intermediate, ModuleOp moduleOp,
   Location loc = intermediate.getLoc();
   MLIRContext *ctx = builder.getContext();
 
-  // Intra-thread push/wait requires double-buffering so the packer and
-  // unpacker can operate on different buffer halves simultaneously.
+  // Single block: producer and consumer are the same compute kernel, so a
+  // second block buys no overlap and doubles the L1 footprint.
   SmallVector<int64_t> shape(tensorType.getShape());
   Type elementType = tensorType.getElementType();
-  int64_t blockCount = 2;
+  int64_t blockCount = 1;
   auto cbType = CircularBufferType::get(ctx, shape, elementType, blockCount);
 
   int32_t dfbIndex = getNextAvailableDFBIndex(moduleOp);

--- a/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
@@ -162,6 +162,21 @@ struct TTLValidateCBBudgetPass
     }
     llvm::sort(sortedIndices);
 
+    if (::getenv("TTL_CB_BUDGET_DEBUG")) {
+      for (int64_t idx : sortedIndices) {
+        BindCBOp b = bindForIndex[idx];
+        auto t = mlir::cast<CircularBufferType>(b.getResult().getType());
+        llvm::errs() << "[cb-budget] CB[" << idx << "] " << maxBytesByIndex[idx]
+                     << " bytes elemsPerBlock=" << t.getElementsPerBlock()
+                     << " blockCount=" << t.getBlockCount()
+                     << (b->hasAttr(kCompilerAllocatedAttrName) ? " (compiler)"
+                                                                : "")
+                     << "\n";
+      }
+      llvm::errs() << "[cb-budget] total=" << totalBytes
+                   << " budget=" << budgetBytes << "\n";
+    }
+
     auto emitBreakdown = [&](InFlightDiagnostic &diag) {
       for (int64_t idx : sortedIndices) {
         BindCBOp bindOp = bindForIndex[idx];

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
@@ -8,11 +8,14 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=NOPOP
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=THREE
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SINGLE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=USER
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=XTHREAD
 
 // -----
 
-// User DFBs at indices 0, 1, 2 and a compiler-allocated DFB at index 3.
-// The pass should update base_cta_index to 4 and emit ttl.compiler_allocated_dfbs.
+// User DFBs at indices 0, 1, 2 (unused: keep their indices) and a
+// compiler-allocated DFB at index 3. The pass should update base_cta_index
+// to 4 and emit ttl.compiler_allocated_dfbs.
 
 // CHECK: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
 
@@ -70,7 +73,7 @@ func.func @compute_only()
 // Non-overlapping compiler-allocated DFBs: DFB #3 is released (cb_pop)
 // before DFB #4 is allocated (bind_cb). Both should be assigned index 3.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
+// DEBUG: DFB reuse: cb4 -> cb3
 // DEBUG: Total DFB count: 4
 
 // REUSE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -98,7 +101,6 @@ func.func @non_overlapping_reuse()
 // Overlapping compiler-allocated DFBs: DFB #4 is allocated while DFB #3
 // is still live. They must keep separate indices.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
 // OVERLAP: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -131,7 +133,8 @@ func.func @overlapping_no_reuse()
 // DFB-D [bind, pop]: nested within C, dies before C
 // Result: A and C share slot 0 (index 3), B and D share slot 1 (index 4).
 
-// DEBUG: DFB reuse: 4 compiler-allocated DFBs -> 2 physical slot(s)
+// DEBUG: DFB reuse: cb5 -> cb3
+// DEBUG: DFB reuse: cb6 -> cb4
 // DEBUG: Total DFB count: 5
 
 // FOUR: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -173,43 +176,33 @@ func.func @four_dfbs_nested_reuse()
 
 // -----
 
-// Mixed CircularBufferTypes: DFBs #3 and #5 are [1,1] bf16, DFB #4 is
-// [2,4] bf16. Type partitioning prevents #3 and #4 from sharing a slot
-// even though their lifetimes do not overlap. #3 and #5 share within
-// the [1,1] partition. The [2,4] partition gets the next contiguous index.
-//
-// [1,1] partition: #3 non-overlapping with #5 -> 1 slot (index 3)
-// [2,4] partition: #4 alone -> 1 slot (index 4)
-// Total: 2 physical compiler-allocated slots.
+// Mixed shapes, one element type: capacity is a >= constraint, so the [1,1]
+// and [2,4] buffers share one slot sized to the largest member (8 tiles per
+// block); every reserve/wait carries its own block size.
 
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 2 physical slot(s)
-// DEBUG: Total DFB count: 5
+// DEBUG: DFB reuse: cb4 -> cb3
+// DEBUG: DFB reuse: cb5 -> cb3
+// DEBUG: Total DFB count: 4
 
-// MIXED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32}]}
+// MIXED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32}]}
 
-// MIXED-LABEL: func.func @mixed_types_no_cross_reuse
-// MIXED-SAME: ttl.base_cta_index = 5 : i32
-// [1,1] partition slot
+// MIXED-LABEL: func.func @mixed_shapes_share_slot
+// MIXED-SAME: ttl.base_cta_index = 4 : i32
 // MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
-// [2,4] partition slot
-// MIXED: ttl.bind_cb{cb_index = 4, {{.*}}} {ttl.compiler_allocated} : <[2, 4],
-// [1,1] partition slot reused
+// MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[2, 4],
 // MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
-// MIXED-NOT: cb_index = 5
+// MIXED-NOT: cb_index = 4
 // MIXED: return
-func.func @mixed_types_no_cross_reuse()
+func.func @mixed_shapes_share_slot()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // [1,1] DFB
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // [2,4] DFB -- different type, cannot reuse index 3
   %alloc4 = ttl.bind_cb {cb_index = 4, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc4 : <[2, 4], !ttcore.tile<32x32, bf16>, 2>
-  // [1,1] DFB -- same type as #3, reuses its slot
   %alloc5 = ttl.bind_cb {cb_index = 5, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc5 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
@@ -217,10 +210,9 @@ func.func @mixed_types_no_cross_reuse()
 
 // -----
 
-// No cb_pop on either compiler-allocated DFB. Conservative fallback
-// treats both as live for the entire function. No reuse possible.
+// No cb_pop on either compiler-allocated DFB. No acquires or releases at
+// all: both keep their indices.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
 // NOPOP: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -247,7 +239,8 @@ func.func @no_cb_pop_conservative()
 // Three sequential non-overlapping DFBs. All should map to a single
 // physical slot (multi-round slot recycling).
 
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 1 physical slot(s)
+// DEBUG: DFB reuse: cb4 -> cb3
+// DEBUG: DFB reuse: cb5 -> cb3
 // DEBUG: Total DFB count: 4
 
 // THREE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -274,8 +267,7 @@ func.func @three_sequential_one_slot()
 
 // -----
 
-// Single compiler-allocated DFB. The reuse algorithm early-returns
-// (size <= 1). Index and module attribute should be unchanged.
+// Single compiler-allocated DFB. Index and module attribute unchanged.
 
 // SINGLE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
 
@@ -292,5 +284,91 @@ func.func @single_dfb_no_reuse()
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// User DFBs with the same producer thread (reader) and consumer thread
+// (compute) and disjoint lifetimes share one index. The pass emits
+// ttl.dfb_index_map for the runtime.
+
+// DEBUG: DFB reuse: cb1 -> cb0
+// DEBUG: Total DFB count: 1
+
+// USER: module attributes {ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]}
+
+// USER-LABEL: func.func @user_reader
+// USER-SAME: ttl.base_cta_index = 1 : i32
+// USER-COUNT-2: ttl.bind_cb{cb_index = 0,
+// USER-NOT: cb_index = 1
+// USER-LABEL: func.func @user_compute
+// USER-COUNT-2: ttl.bind_cb{cb_index = 0,
+// USER-NOT: cb_index = 1
+// USER: return
+func.func @user_reader()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r1 = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @user_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w1 = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// User DFBs with different producer threads never share an index, even with
+// disjoint lifetimes: the physical CB counters and per-RISC pointers do not
+// survive a producer change.
+
+// XTHREAD-LABEL: func.func @xt_reader
+// XTHREAD: ttl.bind_cb{cb_index = 0,
+// XTHREAD-LABEL: func.func @xt_writer
+// XTHREAD: ttl.bind_cb{cb_index = 1,
+// XTHREAD-LABEL: func.func @xt_compute
+// XTHREAD: ttl.bind_cb{cb_index = 0,
+// XTHREAD: ttl.bind_cb{cb_index = 1,
+func.func @xt_reader()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @xt_writer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r1 = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @xt_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w1 = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
@@ -9,7 +9,7 @@
 // Elementwise result feeds into reduce: pass should insert a compiler-allocated DFB.
 
 // CHECK-LABEL: func.func @elementwise_into_reduce
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: ttl.add
 // CHECK: ttl.cb_reserve
 // CHECK: ttl.store
@@ -124,24 +124,28 @@ func.func @shared_materialization()
 // compiler-allocated DFB. The first DFB is consumed and released (cb_pop)
 // before the second is created, so finalize should reuse the same index.
 
-// DBG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
-// DBG: Total DFB count: 5
+// DBG: DFB reuse: cb3 -> cb0
+// DBG: DFB reuse: cb4 -> cb3
+// DBG: DFB reuse: cb5 -> cb3
+// DBG: Total DFB count: 4
 
 // After insert: two compiler-allocated DFBs at indices 4, 5, both at
 // function body entry.
 // CHECK-LABEL: func.func @sequential_intermediates_reuse
-// CHECK: ttl.bind_cb{cb_index = 4, block_count = 2} {ttl.compiler_allocated}
-// CHECK: ttl.bind_cb{cb_index = 5, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 4, block_count = 1} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 5, block_count = 1} {ttl.compiler_allocated}
 // CHECK: ttl.add
 // CHECK: ttl.reduce
 // CHECK: ttl.mul
 // CHECK: ttl.reduce
 
-// After finalize with reuse: both DFBs get index 4 (one physical slot).
-// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// After finalize: the two intermediates share one slot, user cb3
+// (reserve-only; cb0 fully released first) merges onto cb0, and the index
+// space compacts to users 0..2 + intermediates at 3.
+// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 1 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}], ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 3 : i32}]}
 // FINALIZE-LABEL: func.func @sequential_intermediates_reuse
-// FINALIZE-SAME: ttl.base_cta_index = 5 : i32
-// FINALIZE-NOT: cb_index = 5
+// FINALIZE-SAME: ttl.base_cta_index = 4 : i32
+// FINALIZE-NOT: cb_index = 4
 // FINALIZE: return
 func.func @sequential_intermediates_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
@@ -5,19 +5,46 @@
 
 // -----
 
-// All 32 CB indices (0-31) are occupied by user DFBs. The add result
-// feeds reduce, which requires a compiler-allocated DFB at index 32.
-// After reuse (only one intermediate, nothing to reuse), the total DFB
-// count is 33, exceeding the hardware maximum of 32.
+// All 32 CB indices (0-31) are occupied by distinct user DFBs. The add
+// result feeds reduce, which requires a compiler-allocated DFB at index 32.
+// Nothing can merge, so the compacted count is 33, exceeding the hardware
+// maximum of 32.
 
-// expected-error @below {{need 33 DFB indices but hardware supports at most 32 (1 compiler-allocated after reuse)}}
+// expected-error @below {{need 33 DFB indices after reuse but hardware supports at most 32}}
 module {
 func.func @exceeds_max_cb_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // Use index 31 to occupy the last slot.
+  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb4 = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb5 = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb6 = ttl.bind_cb {cb_index = 6, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb7 = ttl.bind_cb {cb_index = 7, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb8 = ttl.bind_cb {cb_index = 8, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb9 = ttl.bind_cb {cb_index = 9, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb10 = ttl.bind_cb {cb_index = 10, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb11 = ttl.bind_cb {cb_index = 11, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb12 = ttl.bind_cb {cb_index = 12, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb13 = ttl.bind_cb {cb_index = 13, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb14 = ttl.bind_cb {cb_index = 14, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb15 = ttl.bind_cb {cb_index = 15, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb16 = ttl.bind_cb {cb_index = 16, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb17 = ttl.bind_cb {cb_index = 17, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb18 = ttl.bind_cb {cb_index = 18, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb19 = ttl.bind_cb {cb_index = 19, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb20 = ttl.bind_cb {cb_index = 20, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb21 = ttl.bind_cb {cb_index = 21, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb22 = ttl.bind_cb {cb_index = 22, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb23 = ttl.bind_cb {cb_index = 23, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb24 = ttl.bind_cb {cb_index = 24, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb25 = ttl.bind_cb {cb_index = 25, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb26 = ttl.bind_cb {cb_index = 26, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb27 = ttl.bind_cb {cb_index = 27, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb28 = ttl.bind_cb {cb_index = 28, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb29 = ttl.bind_cb {cb_index = 29, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb30 = ttl.bind_cb {cb_index = 30, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb31 = ttl.bind_cb {cb_index = 31, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
@@ -12,7 +12,7 @@
 // entry, the rest of the materialization bundle stays inside the loop.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_for
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   ttl.add
 // CHECK:   ttl.cb_reserve
@@ -58,7 +58,7 @@ func.func @intermediate_in_scf_for()
 // function body entry, not inside the if region.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.if
 // CHECK-NOT: ttl.compiler_allocated
 // CHECK:   ttl.add
@@ -101,7 +101,7 @@ func.func @intermediate_in_scf_if(%cond: i1)
 // Before the fix, this crashed in TTLFinalizeDFBIndices.
 
 // CHECK-LABEL: func.func @intermediate_in_nested_for_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   scf.if
 // CHECK-NOT: ttl.compiler_allocated


### PR DESCRIPTION
File-level squash of the non-atom half of the dfb-reuse work onto atom. Intended to rebase onto main independently of the ttl.atom changes.

- TTLFinalizeDFBIndices: module-level index reuse keyed on producer/consumer thread identity + element type with disjoint per-thread lifetimes; pipe-attached DFBs excluded; emits the ttl.dfb_index_map module attr (consumed by the atom-side runtime in the companion commit).
- TTLInsertIntermediateDFBs: single-block (blockCount 1) compiler intermediates.
- TTLValidateCBBudget: TTL_CB_BUDGET_DEBUG per-CB byte breakdown.
- TTL.h: kDFBIndexMapAttrName constant.
- lit tests (finalize_dfb_indices, insert_intermediate_dfbs*) + DFBManagement.md.