### PR TITLE
[ttl.atom] DFB reuse: inliner local DFBs + dfb_index_map runtime (atom half of #670)

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -485,76 +485,29 @@ ttl-coalesce-dfb-acquires))'`) verifies this.
 
 ## Index Reuse
 
-`TTLFinalizeDFBIndices` reduces the physical DFB count by assigning the same index to compiler-allocated DFBs whose lifetimes do not overlap. The algorithm runs per function. Compiler-allocated DFBs are intra-thread (both producer and consumer are in the same compute function), so their lifetimes are independent across functions.
+`TTLFinalizeDFBIndices` is a module pass that reduces the physical DFB count by overlaying logical DFBs with disjoint lifetimes onto shared indices. It runs after `InsertCBSync` and `LowerToLoops`, when threads are separate `func.func`s and `cb_pop`s exist. A logical DFB is one `cb_index`; each kernel thread that touches it binds it once.
 
-Two DFBs may share an index only if they have identical `CircularBufferType` (shape, element type, block count). Since `CircularBufferType` is an MLIR uniqued type, this is a pointer comparison. The algorithm partitions DFBs by type and runs a linear scan within each partition.
+A physical index carries shared `pages_received`/`pages_acked` counters plus per-RISC read/write pointers. None of those are reset between lifetimes, so two logical DFBs may share an index only when:
 
-### Algorithm
+- both have the same producer thread and the same consumer thread,
+- their lifetimes are disjoint in both threads' program order,
+- they have the same element type (one page size).
 
-```
-reuseDFBIndices(funcOp, compilerAllocatedBindCBOps):
-  // Assign sequential indices to function-level operations.
-  for op in funcOp.entryBlock:
-    opIndex[op] = nextIdx++
+When thread identity matches, per-thread program order plus blocking reserve/wait make disjoint lifetimes sound at runtime; sharing across different producer or consumer threads would corrupt counters/pointers and would need a barrier-plus-reset edge, which does not exist. The element-type bar is the only shape constraint: capacity is a `>=` check, the slot is sized to the member needing the most pages, and every reserve/wait carries its own block size.
 
-  // Build intervals: [bind_cb position, last cb_pop position].
-  // CBPopOps inside nested regions (loops, compute) are projected
-  // to their function-level ancestor.
-  // If no cb_pop exists, end = last operation (conservative).
-  for bindOp in compilerAllocatedBindCBOps:
-    start = opIndex[bindOp]
-    end = max(getBodyIndex(pop) for pop in cbPopUsers(bindOp))
-    if end == start:
-      end = lastOpIdx
-    intervals[bindOp.type].append({start, end, bindOp.result})
+A DFB whose producer and consumer are the same thread is single-threaded (compiler-allocated intermediates always; user DFBs whenever the pass derives it), so the pair (thread, thread) acts as one reuse class regardless of how the buffer was declared.
 
-  // Linear scan per type partition. Each partition gets a contiguous
-  // block of indices starting at baseIndex + offset.
-  offset = 0
-  for (type, typeIntervals) in intervals:
-    sort typeIntervals by start
-    maxSlot = 0
-    for interval in typeIntervals:
-      // Expire: free slots where active.end <= interval.start
-      for active in activeList:
-        if active.end <= interval.start:
-          free(slot[active])
-      slot[interval] = allocateFirstFreeSlot()
-      maxSlot = max(maxSlot, slot[interval])
+Lifetimes are computed per thread: from the first reserve/wait (bind position when no acquire exists) to the last use, following wait -> readers -> attach_cb -> consumers and pops. Nested uses project onto their top-level ancestor, so a buffer used in a loop is live across the back-edge for the whole loop. Intervals are closed; sharing an endpoint counts as overlap.
 
-    // Rewrite BindCBOp cb_index attributes for this partition.
-    for (value, s) in partitionAssignments:
-      bindOp[value].cb_index = baseIndex + offset + s
-    offset += maxSlot + 1
-```
+The reuse condition is checked against actual blocking acquires; control-flow guards (e.g. mutually exclusive per-core roles) do not refine it. `ttl-verify-dfb-spsc` always runs afterwards and rejects shared indices with multiple producer or consumer threads on overlapping launch nodes; role-guarded accesses pass when launch-node domain analysis proves them disjoint.
 
-The expiration condition `active.end <= interval.start` matches the DST register allocator's convention. Because operation indices are integers assigned to distinct operations, strict inequality and non-strict inequality produce the same result.
+### Pipe-attached DFBs never reuse
 
-### Correctness with control flow
+For a pipe destination, `block_count` is not queue depth: each sender writes its own block, addressed by sender ordinal, so `block_count` must equal the sender count. Pipe lowering lays sender slots out per `cb_index`; two destinations on one index would concatenate their slot ranges and change the addressing. Pipe transfers also move data over NOC with semaphore protocol, outside the CB counters that make program-order lifetimes sound, and a sender's stage buffer is read asynchronously after its wait. Any DFB whose user chain reaches a pipe op or a `ttl.copy` with a pipe operand therefore keeps its dedicated index and block count.
 
-The algorithm assigns sequential indices to function-level operations only. Structured operations (`scf.for`, `ttl.compute`) occupy a single index in this sequence; their contents are not individually numbered. This is sufficient because `InsertIntermediateDFBs` and `InsertCBSync` both run before `LowerToLoops`, placing `bind_cb` and `cb_pop` at function-level while the IR is flat. These operations remain at function-level after loop creation because they bracket compute regions.
+### Runtime integration
 
-If a later pass restructures a `CBPopOp` into a nested region, it is projected to its enclosing operation at function-level via `Block::findAncestorOpInBlock`. This overestimates liveness -- the interval extends to the structured op rather than to the specific point where the pop occurs -- but never produces incorrect reuse.
-
-Two DFBs consumed simultaneously by the same operation (e.g., both operands of a matmul) necessarily have overlapping intervals because both `bind_cb` must precede the consumer and both `cb_pop` must follow it. The linear scan assigns them different slots.
-
-### Module attribute and runtime integration
-
-After rewriting indices, the pass calls `getNextAvailableDFBIndex`, which returns `max(cb_index) + 1` across all `BindCBOp`s in the module. This is the index space usage, not a count of distinct DFBs (sparse indices inflate it). The pass verifies this does not exceed `kMaxCircularBuffers` (32).
-
-The pass then sets `ttl.base_cta_index` on every function. Compile-time arguments (CTAs) to each kernel are laid out as `[CB indices..., other args...]`. `base_cta_index` is the starting index of the non-CB arguments -- equivalently, one past the last CB index. CB indices occupy `[0, base_cta_index)`.
-
-Finally, the pass builds the `ttl.compiler_allocated_dfbs` module attribute with one entry per unique physical index, deduplicated from the potentially many `BindCBOp`s that now share an index. The Python runtime reads this attribute to allocate L1 buffers at dispatch time.
-
-## Limitations and Future Work
-
-The linear scan operates on a flat sequence of function-level operations. It cannot distinguish between branches of an `scf.if`, so DFBs used in mutually exclusive branches are treated as overlapping. The current pipeline does not produce conditional control flow around DFB lifecycle operations. The DSL evaluates Python `if` during tracing, so only the taken branch appears in the generated IR; runtime-conditional control flow (`scf.if` with conditions dependent on tensor values) is not supported by the frontend at this time.
-
-Index reuse is restricted to compiler-allocated DFBs. User-declared DFBs retain their original indices because the same CB index is referenced by multiple threads (reader, compute, writer) to implement cross-thread data flow. Reusing a user index in one function would invalidate references in the others.
-
-Liveness is computed at function-level granularity. If a `CBPopOp` is inside a structured op (loop, compute region), it is projected to its enclosing operation at function-level. The infrastructure for this exists (`Block::findAncestorOpInBlock`) but is not currently exercised: all compiler-allocated DFB lifecycle ops remain at function-level because `InsertIntermediateDFBs` and `InsertCBSync` run before loop creation, and Python control flow unrolls at trace time.
-
-The type compatibility constraint prevents reuse across DFBs with different shapes or element types, even when L1 footprints happen to match. A size-based rather than type-based compatibility check could recover some reuse opportunities.
+After rewriting indices, the pass recomputes `getNextAvailableDFBIndex` (max index + 1), checks `kMaxCircularBuffers` (32), and updates `ttl.base_cta_index` on every function. Two module attributes carry the result to the Python runtime: `ttl.compiler_allocated_dfbs` (one entry per physical index, sized to the largest member) and `ttl.dfb_index_map` (old -> new entries for moved user DFBs, applied to the CB config list before descriptors are built).
 
 ## Scalar Element Access to DFBs
 

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -149,6 +149,10 @@ constexpr llvm::StringLiteral
 constexpr llvm::StringLiteral
     kCompilerAllocatedAttrName("ttl.compiler_allocated");
 
+/// Module attribute mapping user DFB indices renumbered by index reuse
+/// (array of {old_index, new_index} dictionaries).
+constexpr llvm::StringLiteral kDFBIndexMapAttrName("ttl.dfb_index_map");
+
 /// Function attribute recording the base compile-time argument index.
 /// CTA layout is [CBs, TAs], so this equals the number of CBs.
 constexpr llvm::StringLiteral kBaseCTAIndexAttrName("ttl.base_cta_index");

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -6,11 +6,26 @@
 // TTL Finalize DFB Indices
 //===----------------------------------------------------------------------===//
 //
-// Module-level pass that runs after all DFB-creating passes. Reuses
-// compiler-allocated DFB indices when lifetimes do not overlap, then
-// computes the true DFB count, updates ttl.base_cta_index on every
-// function, and collects compiler-allocated DFBs into the
-// ttl.compiler_allocated_dfbs module attribute for the Python runtime.
+// Module-level pass that runs after all DFB-creating passes. Reuses DFB
+// indices when lifetimes do not overlap, then computes the true DFB count,
+// updates ttl.base_cta_index on every function, and publishes the final
+// index assignment for the Python runtime (ttl.dfb_index_map for
+// user-declared DFBs, ttl.compiler_allocated_dfbs for compiler-allocated
+// ones).
+//
+// A logical DFB is one cb_index, bound by one bind_cb per kernel thread that
+// touches it. The same physical CB index has shared pages_received /
+// pages_acked counters and per-RISC read/write pointers, so two logical DFBs
+// may share an index only when:
+//   - both have the same producer thread and the same consumer thread,
+//   - their per-thread lifetimes are disjoint in both threads' program order,
+//   - they have the same element type (uniform page size). Capacity is a
+//     >= check, not equality: the slot is sized to the member needing the
+//     most pages, and every reserve/wait carries its own block size.
+// With matching thread identity, per-thread program order plus reserve/wait
+// blocking make disjoint program-order lifetimes sound at runtime; sharing
+// across different producer or consumer threads is never sound without a
+// counter/pointer reset and is therefore not attempted.
 //
 //===----------------------------------------------------------------------===//
 
@@ -19,7 +34,6 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
-#include "ttlang/Dialect/TTL/Transforms/LiveIntervalUtils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -27,9 +41,6 @@
 
 #include "llvm/ADT/MapVector.h"
 #include "llvm/Support/Debug.h"
-
-#include <algorithm>
-#include <functional>
 
 #define DEBUG_TYPE "ttl-finalize-dfb-indices"
 
@@ -40,190 +51,340 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-/// Reuse compiler-allocated DFB indices within a function when their
-/// lifetimes do not overlap. Groups DFBs by CircularBufferType and runs
-/// linear scan allocation per group.
-static void reuseDFBIndices(func::FuncOp funcOp, ArrayRef<BindCBOp> dfbOps) {
-  if (dfbOps.size() <= 1) {
-    return;
+/// Closed [start, end] lifetime of a logical DFB within one kernel thread,
+/// in that thread's top-level program order.
+struct ThreadInterval {
+  int64_t start;
+  int64_t end;
+};
+
+/// One logical DFB: a cb_index with one bind_cb per kernel thread.
+struct LogicalDFB {
+  int64_t origIndex = -1;
+  SmallVector<BindCBOp, 3> binds;
+  func::FuncOp producer;
+  func::FuncOp consumer;
+  llvm::SmallDenseMap<Operation *, ThreadInterval, 4> intervals;
+  llvm::SmallDenseMap<Operation *, int64_t, 4> firstAcquire;
+  Type elemType;
+  int64_t blockCount = 0;
+  int64_t elemsPerBlock = 0;
+  bool compilerAllocated = false;
+  bool eligible = true;
+  int64_t finalIndex = -1;
+
+  int64_t totalPages() const { return blockCount * elemsPerBlock; }
+};
+
+/// Position of an op in its kernel thread's top-level program order. Nested
+/// ops project onto their body-block ancestor: a buffer touched inside a
+/// loop is acquired and released every iteration, so across the back-edge it
+/// is live for the whole loop, not one static interval within the body.
+struct ThreadOrder {
+  DenseMap<Operation *, int64_t> topLevel;
+  int64_t lastIdx = 0;
+
+  explicit ThreadOrder(func::FuncOp func) {
+    int64_t idx = 0;
+    for (Operation &op : func.getBody().front()) {
+      topLevel[&op] = idx++;
+    }
+    lastIdx = idx == 0 ? 0 : idx - 1;
   }
 
-  Block &body = funcOp.getBody().front();
-
-  // Assign sequential indices to all operations in the body block.
-  DenseMap<Operation *, int64_t> opIndex;
-  int64_t idx = 0;
-  for (Operation &op : body) {
-    opIndex[&op] = idx++;
-  }
-  int64_t lastOpIdx = idx - 1;
-
-  // Project a nested operation to its ancestor in the body block.
-  // After LowerToLoops or SubblockComputeForDST, CBPopOps may end up
-  // inside loops or compute regions.
-  auto getBodyIndex = [&](Operation *op) -> int64_t {
+  int64_t index(Operation *op, func::FuncOp func) {
+    Block &body = func.getBody().front();
     if (op->getBlock() == &body) {
-      return opIndex[op];
+      return topLevel[op];
     }
     Operation *ancestor = body.findAncestorOpInBlock(*op);
     assert(ancestor && "operation must be reachable from function body");
-    return opIndex[ancestor];
-  };
-
-  // Build intervals grouped by CircularBufferType.
-  llvm::MapVector<Type, SmallVector<ValueLiveInterval>> typeToIntervals;
-  DenseMap<Value, BindCBOp> valueToBindOp;
-
-  for (BindCBOp bindOp : dfbOps) {
-    assert(bindOp->getBlock() == &body &&
-           "compiler-allocated BindCBOp must be in function body block");
-
-    Value cbVal = bindOp.getResult();
-    // Lifetime starts at the first acquire (reserve/wait) on this CB, not
-    // at the bind_cb itself: bind_cb is just a declaration, and hoisting
-    // it to the function body entry would otherwise collapse all compiler-
-    // allocated DFB starts together and defeat reuse. If there is no
-    // acquire (synthetic IR, pop-only), fall back to the bind_cb position.
-    int64_t start = lastOpIdx;
-    int64_t end = opIndex[bindOp];
-    bool sawAcquire = false;
-
-    for (OpOperand &use : cbVal.getUses()) {
-      Operation *user = use.getOwner();
-      int64_t useIdx = getBodyIndex(user);
-      if (isa<CBReserveOp, CBWaitOp>(user)) {
-        start = std::min(start, useIdx);
-        sawAcquire = true;
-      }
-      if (isa<CBPopOp>(user)) {
-        end = std::max(end, useIdx);
-      }
-    }
-
-    if (!sawAcquire) {
-      start = opIndex[bindOp];
-    }
-
-    // No cb_pop means the DFB's L1 is never explicitly released --
-    // conservatively treat it as live for the entire function.
-    if (end <= start) {
-      end = lastOpIdx;
-    }
-
-    SmallVector<ValueLiveInterval> &intervals =
-        typeToIntervals[cbVal.getType()];
-    int64_t ordinal = static_cast<int64_t>(intervals.size());
-    intervals.push_back({start, end, cbVal, ordinal});
-    valueToBindOp[cbVal] = bindOp;
+    return topLevel[ancestor];
   }
+};
 
-  // Find the base index (smallest compiler-allocated index).
-  int32_t baseIndex = INT32_MAX;
-  for (BindCBOp bindOp : dfbOps) {
-    int32_t cbIdx = static_cast<int32_t>(bindOp.getCbIndex().getSExtValue());
-    baseIndex = std::min(baseIndex, cbIdx);
+/// Extend the per-thread interval of `dfb` to cover `op`.
+void extendInterval(LogicalDFB &dfb, Operation *op, func::FuncOp func,
+                    ThreadOrder &order) {
+  int64_t pos = order.index(op, func);
+  auto [it, inserted] =
+      dfb.intervals.try_emplace(func.getOperation(), ThreadInterval{pos, pos});
+  if (!inserted) {
+    it->second.start = std::min(it->second.start, pos);
+    it->second.end = std::max(it->second.end, pos);
   }
-
-  // Linear scan per type partition. Each partition gets a contiguous
-  // block of physical DFB indices starting at baseIndex + cumulative
-  // offset from prior partitions.
-  MLIRContext *ctx = funcOp.getContext();
-  int32_t nextSlotOffset = 0;
-
-  for (auto &entry : typeToIntervals) {
-    SmallVector<ValueLiveInterval> &intervals = entry.second;
-
-    SmallVector<SmallVector<ValueLiveInterval>> colorUsers =
-        assignGreedyIntervalColors<ValueLiveInterval>(
-            intervals, std::less<ValueLiveInterval>(),
-            [](const ValueLiveInterval &lhs, const ValueLiveInterval &rhs) {
-              return intervalsOverlap(lhs, rhs);
-            });
-
-    DenseMap<Value, int32_t> slotAssignment;
-    int32_t maxSlot = -1;
-
-    for (auto indexedColor : llvm::enumerate(colorUsers)) {
-      int32_t slotIndex = static_cast<int32_t>(indexedColor.index());
-      maxSlot = std::max(maxSlot, slotIndex);
-      for (const ValueLiveInterval &interval : indexedColor.value()) {
-        slotAssignment[interval.value] = slotIndex;
-
-        LLVM_DEBUG({
-          llvm::dbgs() << "DFB reuse: [" << interval.start << ", "
-                       << interval.end << "] -> slot " << slotIndex << "\n";
-        });
-      }
-    }
-
-    // Rewrite BindCBOp indices to the assigned physical slot.
-    for (auto &[value, slot] : slotAssignment) {
-      int32_t newIndex = baseIndex + nextSlotOffset + slot;
-      BindCBOp bindOp = valueToBindOp[value];
-      bindOp.setCbIndexAttr(IntegerAttr::get(IndexType::get(ctx), newIndex));
-    }
-
-    nextSlotOffset += maxSlot + 1;
-  }
-
-  LLVM_DEBUG({
-    llvm::dbgs() << "DFB reuse: " << dfbOps.size()
-                 << " compiler-allocated DFBs -> " << nextSlotOffset
-                 << " physical slot(s)\n";
-  });
 }
+
+/// Record producer/consumer thread identity; multiple distinct threads in
+/// either role make the DFB ineligible (sharing its index would need a
+/// counter/pointer reset, which does not exist).
+void recordRole(func::FuncOp &role, func::FuncOp func, bool &eligible) {
+  if (!role) {
+    role = func;
+  } else if (role != func) {
+    eligible = false;
+  }
+}
+
+bool disjoint(const ThreadInterval &a, const ThreadInterval &b) {
+  return a.end < b.start || b.end < a.start;
+}
+
+/// Two logical DFBs of one reuse class conflict when their lifetimes overlap
+/// in the producer thread or in the consumer thread. Intervals are closed:
+/// sharing an endpoint means both are live at that op.
+bool conflicts(const LogicalDFB &a, const LogicalDFB &b) {
+  for (auto &[func, interval] : a.intervals) {
+    auto it = b.intervals.find(func);
+    if (it != b.intervals.end() && !disjoint(interval, it->second)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
 
 struct TTLFinalizeDFBIndicesPass
     : public impl::TTLFinalizeDFBIndicesBase<TTLFinalizeDFBIndicesPass> {
   void runOnOperation() override {
     auto moduleOp = getOperation();
-    OpBuilder builder(moduleOp.getContext());
+    MLIRContext *ctx = moduleOp.getContext();
+    OpBuilder builder(ctx);
 
-    // Collect compiler-allocated BindCBOps grouped by parent function.
-    llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> funcToDFBs;
+    // Collect logical DFBs by original index across kernel threads.
+    llvm::MapVector<int64_t, LogicalDFB> dfbs;
+    llvm::SmallDenseMap<Operation *, std::unique_ptr<ThreadOrder>> orders;
+    bool sawBind = false;
+
     moduleOp->walk([&](BindCBOp bindOp) {
-      if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-        auto funcOp = bindOp->getParentOfType<func::FuncOp>();
-        funcToDFBs[funcOp].push_back(bindOp);
+      sawBind = true;
+      func::FuncOp func = getEnclosingKernelThread(bindOp);
+      int64_t idx = bindOp.getCbIndex().getSExtValue();
+      LogicalDFB &dfb = dfbs[idx];
+      dfb.origIndex = idx;
+      dfb.binds.push_back(bindOp);
+      auto cbType = mlir::cast<CircularBufferType>(bindOp.getResult().getType());
+      dfb.elemType = cbType.getElementType();
+      dfb.blockCount = cbType.getBlockCount();
+      dfb.elemsPerBlock =
+          std::max(dfb.elemsPerBlock, cbType.getElementsPerBlock());
+      dfb.compilerAllocated |= bindOp->hasAttr(kCompilerAllocatedAttrName);
+      if (!func) {
+        dfb.eligible = false;
+        return;
+      }
+
+      auto &order = orders[func.getOperation()];
+      if (!order) {
+        order = std::make_unique<ThreadOrder>(func);
+      }
+
+      // The bind anchors the interval; binds are hoisted to the function
+      // entry, so the start is refined to the first acquire below.
+      extendInterval(dfb, bindOp, func, *order);
+
+      // Pipe destinations are slot-addressed (block_count == sender count)
+      // and pipe sends read asynchronously, so pipe-attached DFBs keep
+      // dedicated indices.
+      // A DFB participates in a pipe through a ttl.copy whose other operand
+      // is a pipe, or through pipe_recv guards.
+      auto isPipeOp = [](Operation *op) {
+        if (op->getName().getStringRef().contains("pipe")) {
+          return true;
+        }
+        return llvm::any_of(op->getOperands(), [](Value operand) {
+          return mlir::isa<PipeType>(operand.getType());
+        });
+      };
+      // Pipe sends/receives reach a block through view chains (extract_slice,
+      // attach_cb, casts); walk a few hops of users.
+      auto markPipeUsers = [&](Value view) {
+        SmallVector<Value> worklist{view};
+        for (int depth = 0; depth < 3 && !worklist.empty(); ++depth) {
+          SmallVector<Value> next;
+          for (Value v : worklist) {
+            for (Operation *user : v.getUsers()) {
+              if (isPipeOp(user)) {
+                dfb.eligible = false;
+                return;
+              }
+              for (Value result : user->getResults()) {
+                next.push_back(result);
+              }
+            }
+          }
+          worklist = std::move(next);
+        }
+      };
+
+      for (Operation *user : bindOp.getResult().getUsers()) {
+        extendInterval(dfb, user, func, *order);
+        if (isPipeOp(user)) {
+          dfb.eligible = false;
+        }
+        if (auto reserveOp = dyn_cast<CBReserveOp>(user)) {
+          markPipeUsers(reserveOp.getResult());
+        }
+        if (isa<CBReserveOp, CBWaitOp>(user)) {
+          int64_t pos = order->index(user, func);
+          auto [it, inserted] =
+              dfb.firstAcquire.try_emplace(func.getOperation(), pos);
+          if (!inserted) {
+            it->second = std::min(it->second, pos);
+          }
+        }
+        if (isa<CBReserveOp, CBPushOp>(user)) {
+          recordRole(dfb.producer, func, dfb.eligible);
+        }
+        if (isa<CBWaitOp, CBPopOp>(user)) {
+          recordRole(dfb.consumer, func, dfb.eligible);
+        }
+        // A consumed block stays live until its last reader: follow
+        // wait -> readers -> attach_cb -> consumers one level deep.
+        if (auto waitOp = dyn_cast<CBWaitOp>(user)) {
+          markPipeUsers(waitOp.getResult());
+          for (Operation *reader : waitOp.getResult().getUsers()) {
+            extendInterval(dfb, reader, func, *order);
+            if (auto attachOp = dyn_cast<AttachCBOp>(reader)) {
+              markPipeUsers(attachOp.getResult());
+              for (Operation *consumer : attachOp.getResult().getUsers()) {
+                extendInterval(dfb, consumer, func, *order);
+              }
+            }
+          }
+        }
       }
     });
 
-    // Run DFB index reuse per function.
-    for (auto &[funcOp, dfbOps] : funcToDFBs) {
-      reuseDFBIndices(funcOp, dfbOps);
-    }
-
-    // Recompute DFB count after reuse may have changed indices.
-    int32_t numDFBs = getNextAvailableDFBIndex(moduleOp);
-    if (numDFBs <= 0) {
+    if (!sawBind) {
       return;
     }
 
+    // A DFB with no acquire and no release anywhere (declared but unused)
+    // keeps its index. One-sided DFBs reuse within the thread that touches
+    // them. Lifetime starts at the first acquire in each thread; without one
+    // the hoisted bind position stands, conservatively from function entry.
+    for (auto &[idx, dfb] : dfbs) {
+      if (!dfb.producer && !dfb.consumer) {
+        dfb.eligible = false;
+        continue;
+      }
+      if (!dfb.producer) {
+        dfb.producer = dfb.consumer;
+      }
+      if (!dfb.consumer) {
+        dfb.consumer = dfb.producer;
+      }
+      for (auto &[func, interval] : dfb.intervals) {
+        auto it = dfb.firstAcquire.find(func);
+        if (it != dfb.firstAcquire.end()) {
+          interval.start = it->second;
+        }
+      }
+    }
+
+    // Group eligible DFBs into reuse classes; keep deterministic order by
+    // original index. Class members may differ in block count and tiles per
+    // block: capacity is a >= constraint, the slot is sized to the member
+    // needing the most pages, and per-op tile counts come from each bind_cb's
+    // own type.
+    // User and compiler DFBs share slots freely; the runtime keeps the
+    // larger config when both describe one index.
+    using ClassKey = std::tuple<Type, Operation *, Operation *>;
+    llvm::MapVector<ClassKey, SmallVector<LogicalDFB *>> classes;
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.eligible) {
+        classes[{dfb.elemType, dfb.producer.getOperation(),
+                 dfb.consumer.getOperation()}]
+            .push_back(&dfb);
+      } else {
+        dfb.finalIndex = dfb.origIndex;
+      }
+    }
+
+    // Greedy interval coloring per class: walk by ascending producer start
+    // and place on the first slot whose members are all disjoint in both
+    // threads. A slot takes the lowest original index of its members, so
+    // indices only ever decrease and never collide with ineligible DFBs.
+    SmallVector<SmallVector<LogicalDFB *>> slots;
+    for (auto &[key, members] : classes) {
+      llvm::sort(members, [](LogicalDFB *a, LogicalDFB *b) {
+        auto pa = a->intervals.find(a->producer.getOperation())->second;
+        auto pb = b->intervals.find(b->producer.getOperation())->second;
+        return std::tie(pa.start, pa.end, a->origIndex) <
+               std::tie(pb.start, pb.end, b->origIndex);
+      });
+      size_t classBase = slots.size();
+      for (LogicalDFB *dfb : members) {
+        size_t placed = slots.size();
+        for (size_t s = classBase; s < slots.size(); ++s) {
+          if (llvm::none_of(slots[s], [&](LogicalDFB *member) {
+                return conflicts(*member, *dfb);
+              })) {
+            placed = s;
+            break;
+          }
+        }
+        if (placed == slots.size()) {
+          slots.emplace_back();
+        }
+        slots[placed].push_back(dfb);
+      }
+    }
+
+    for (auto &slot : slots) {
+      int64_t slotIndex = slot.front()->origIndex;
+      for (LogicalDFB *dfb : slot) {
+        slotIndex = std::min(slotIndex, dfb->origIndex);
+      }
+      for (LogicalDFB *dfb : slot) {
+        dfb->finalIndex = slotIndex;
+      }
+    }
+
+    // Compact to a dense index space (the runtime builds one CB descriptor
+    // per index), preserving relative order.
+    SmallVector<int64_t> usedIndices;
+    for (auto &[idx, dfb] : dfbs) {
+      usedIndices.push_back(dfb.finalIndex);
+    }
+    llvm::sort(usedIndices);
+    usedIndices.erase(llvm::unique(usedIndices), usedIndices.end());
+    DenseMap<int64_t, int64_t> rank;
+    for (auto [i, index] : llvm::enumerate(usedIndices)) {
+      rank[index] = static_cast<int64_t>(i);
+    }
+    for (auto &[idx, dfb] : dfbs) {
+      dfb.finalIndex = rank[dfb.finalIndex];
+    }
+
+    // Rewrite bind_cb indices in every kernel thread.
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.finalIndex == dfb.origIndex) {
+        continue;
+      }
+      for (BindCBOp bindOp : dfb.binds) {
+        bindOp.setCbIndexAttr(
+            IntegerAttr::get(IndexType::get(ctx), dfb.finalIndex));
+      }
+      LLVM_DEBUG(llvm::dbgs() << "DFB reuse: cb" << dfb.origIndex << " -> cb"
+                              << dfb.finalIndex << "\n");
+    }
+
+    int32_t numDFBs = getNextAvailableDFBIndex(moduleOp);
     LLVM_DEBUG(llvm::dbgs() << "Total DFB count: " << numDFBs << "\n");
 
-    // Verify the final DFB count does not exceed the hardware limit.
     if (numDFBs > kMaxCircularBuffers) {
-      // Count compiler-allocated physical slots (after reuse).
-      int32_t compilerSlots = 0;
-      for (auto &[funcOp, dfbOps] : funcToDFBs) {
-        llvm::SmallDenseSet<int32_t> uniqueIndices;
-        for (BindCBOp bindOp : dfbOps) {
-          uniqueIndices.insert(
-              static_cast<int32_t>(bindOp.getCbIndex().getSExtValue()));
-        }
-        compilerSlots += static_cast<int32_t>(uniqueIndices.size());
-      }
       moduleOp.emitError()
-          << "need " << numDFBs << " DFB indices but hardware supports "
-          << "at most " << kMaxCircularBuffers << " (" << compilerSlots
-          << " compiler-allocated after reuse); reduce the number of "
-          << "user-declared dataflow buffers or split the computation "
-          << "into multiple kernels";
+          << "need " << numDFBs << " DFB indices after reuse but hardware "
+          << "supports at most " << kMaxCircularBuffers
+          << "; reduce the number of dataflow buffers or split the "
+          << "computation into multiple kernels";
       signalPassFailure();
       return;
     }
 
-    // Update ttl.base_cta_index on every function that has it.
     moduleOp->walk([&](func::FuncOp funcOp) {
       if (funcOp->hasAttr(kBaseCTAIndexAttrName)) {
         funcOp->setAttr(kBaseCTAIndexAttrName,
@@ -231,63 +392,62 @@ struct TTLFinalizeDFBIndicesPass
       }
     });
 
-    // Re-collect compiler-allocated ops (indices may have changed).
-    SmallVector<BindCBOp> compilerAllocatedOps;
-    moduleOp->walk([&](BindCBOp bindOp) {
-      if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-        compilerAllocatedOps.push_back(bindOp);
+    // Publish remapped user DFB indices for the Python runtime.
+    SmallVector<Attribute> mapEntries;
+    for (auto &[idx, dfb] : dfbs) {
+      if (dfb.compilerAllocated || dfb.finalIndex == dfb.origIndex) {
+        continue;
       }
-    });
+      mapEntries.push_back(DictionaryAttr::get(
+          ctx, {builder.getNamedAttr(
+                    "old_index",
+                    builder.getI32IntegerAttr(static_cast<int32_t>(idx))),
+                builder.getNamedAttr("new_index",
+                                     builder.getI32IntegerAttr(
+                                         static_cast<int32_t>(dfb.finalIndex)))}));
+    }
+    if (!mapEntries.empty()) {
+      moduleOp->setAttr(kDFBIndexMapAttrName, ArrayAttr::get(ctx, mapEntries));
+    }
 
-    if (compilerAllocatedOps.empty()) {
+    // Publish compiler-allocated DFBs, one entry per physical index sized to
+    // the member needing the most pages.
+    llvm::MapVector<int64_t, LogicalDFB *> compilerByIndex;
+    for (auto &[idx, dfb] : dfbs) {
+      if (!dfb.compilerAllocated) {
+        continue;
+      }
+      auto [it, inserted] = compilerByIndex.try_emplace(dfb.finalIndex, &dfb);
+      if (!inserted && dfb.totalPages() > it->second->totalPages()) {
+        it->second = &dfb;
+      }
+    }
+    if (compilerByIndex.empty()) {
       return;
     }
 
-    // Deduplicate entries by physical index. After reuse, multiple
-    // BindCBOps may share the same index. The module attribute needs
-    // one entry per unique physical DFB.
-    llvm::DenseMap<int32_t, BindCBOp> uniqueByIndex;
-    for (BindCBOp bindOp : compilerAllocatedOps) {
-      int32_t dfbIdx = static_cast<int32_t>(bindOp.getCbIndex().getSExtValue());
-      auto [it, inserted] = uniqueByIndex.try_emplace(dfbIdx, bindOp);
-      if (!inserted) {
-        assert(it->second.getResult().getType() ==
-                   bindOp.getResult().getType() &&
-               "compiler-allocated DFBs sharing an index must have the "
-               "same CircularBufferType");
-      }
-    }
-
-    // Sort by index for deterministic output.
-    SmallVector<std::pair<int32_t, BindCBOp>> sorted(uniqueByIndex.begin(),
-                                                     uniqueByIndex.end());
+    SmallVector<std::pair<int64_t, LogicalDFB *>> sorted(
+        compilerByIndex.begin(), compilerByIndex.end());
     llvm::sort(sorted,
                [](auto &lhs, auto &rhs) { return lhs.first < rhs.first; });
 
-    MLIRContext *ctx = moduleOp.getContext();
     SmallVector<Attribute> entries;
-    for (auto &[dfbIdx, bindOp] : sorted) {
-      auto cbType =
-          mlir::cast<CircularBufferType>(bindOp.getResult().getType());
-      SmallVector<NamedAttribute> entryAttrs;
-      entryAttrs.push_back(
-          builder.getNamedAttr("dfb_index", builder.getI32IntegerAttr(dfbIdx)));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "num_tiles", builder.getI32IntegerAttr(static_cast<int32_t>(
-                           cbType.getElementsPerBlock()))));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "element_type", TypeAttr::get(cbType.getElementType())));
-      entryAttrs.push_back(builder.getNamedAttr(
-          "block_count", builder.getI32IntegerAttr(
-                             static_cast<int32_t>(cbType.getBlockCount()))));
-      entries.push_back(DictionaryAttr::get(ctx, entryAttrs));
+    for (auto &[dfbIdx, dfb] : sorted) {
+      entries.push_back(DictionaryAttr::get(
+          ctx,
+          {builder.getNamedAttr("dfb_index", builder.getI32IntegerAttr(
+                                                 static_cast<int32_t>(dfbIdx))),
+           builder.getNamedAttr("num_tiles",
+                                builder.getI32IntegerAttr(
+                                    static_cast<int32_t>(dfb->elemsPerBlock))),
+           builder.getNamedAttr("element_type", TypeAttr::get(dfb->elemType)),
+           builder.getNamedAttr("block_count",
+                                builder.getI32IntegerAttr(
+                                    static_cast<int32_t>(dfb->blockCount)))}));
     }
-
     moduleOp->setAttr(kCompilerAllocatedDFBsAttrName,
                       ArrayAttr::get(ctx, entries));
   }
 };
-
-} // namespace
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
@@ -46,11 +46,11 @@ FailureOr<Value> materializeToDFB(Value intermediate, ModuleOp moduleOp,
   Location loc = intermediate.getLoc();
   MLIRContext *ctx = builder.getContext();
 
-  // Intra-thread push/wait requires double-buffering so the packer and
-  // unpacker can operate on different buffer halves simultaneously.
+  // Single block: producer and consumer are the same compute kernel, so a
+  // second block buys no overlap and doubles the L1 footprint.
   SmallVector<int64_t> shape(tensorType.getShape());
   Type elementType = tensorType.getElementType();
-  int64_t blockCount = 2;
+  int64_t blockCount = 1;
   auto cbType = CircularBufferType::get(ctx, shape, elementType, blockCount);
 
   int32_t dfbIndex = getNextAvailableDFBIndex(moduleOp);

--- a/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
@@ -162,6 +162,21 @@ struct TTLValidateCBBudgetPass
     }
     llvm::sort(sortedIndices);
 
+    if (::getenv("TTL_CB_BUDGET_DEBUG")) {
+      for (int64_t idx : sortedIndices) {
+        BindCBOp b = bindForIndex[idx];
+        auto t = mlir::cast<CircularBufferType>(b.getResult().getType());
+        llvm::errs() << "[cb-budget] CB[" << idx << "] " << maxBytesByIndex[idx]
+                     << " bytes elemsPerBlock=" << t.getElementsPerBlock()
+                     << " blockCount=" << t.getBlockCount()
+                     << (b->hasAttr(kCompilerAllocatedAttrName) ? " (compiler)"
+                                                                : "")
+                     << "\n";
+      }
+      llvm::errs() << "[cb-budget] total=" << totalBytes
+                   << " budget=" << budgetBytes << "\n";
+    }
+
     auto emitBreakdown = [&](InFlightDiagnostic &diag) {
       for (int64_t idx : sortedIndices) {
         BindCBOp bindOp = bindForIndex[idx];

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -170,6 +170,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Main
   ADD_TO_PARENT TTLangPythonCommon
   SOURCES
     __init__.py
+    atom.py
     dataflow_buffer.py
     compiler_options.py
     constants.py
@@ -200,6 +201,8 @@ declare_mlir_python_sources(TTLangPythonCommon.Src
   ADD_TO_PARENT TTLangPythonCommon
   SOURCES
     _src/__init__.py
+    _src/atom_split.py
+    _src/atom_inline.py
     _src/auto_profile.py
     _src/perf_summary.py
     _src/perf_trace_server.py

--- a/python/pykernel/_src/kernel_ast.py
+++ b/python/pykernel/_src/kernel_ast.py
@@ -548,7 +548,12 @@ class TTCompilerBase(PyKernelAstBase):
 
     def visit_BinOp(self, node):
         def materialize(value):
-            if not value:
+            # A host int operand (e.g. a shape/grid-derived bound) becomes an
+            # index constant so it can combine with SSA values. Matches how
+            # captured int constants are emitted at function entry.
+            if isinstance(value, int) and not isinstance(value, bool):
+                return arith.ConstantOp(IndexType.get(self.ctx), value).result
+            if value is None:
                 raise ValueError("Binary operands not found")
             if isinstance(value, OpView):
                 value = value.result

--- a/python/ttl/__init__.py
+++ b/python/ttl/__init__.py
@@ -28,10 +28,13 @@ if _SIM_ONLY_INSTALL:
 else:
     from ttl.ttl import (
         operation,
+        atom,
+        DFB,
         compute,
         datamovement,
         Program,
         make_dataflow_buffer_like,
+        make_dfb,
         copy,
         node,
         grid_size,
@@ -53,6 +56,8 @@ else:
 
     __all__ = [
         "operation",
+        "atom",
+        "DFB",
         "compute",
         "datamovement",
         "Program",
@@ -64,6 +69,7 @@ else:
         "Pipe",
         "PipeNet",
         "make_dataflow_buffer_like",
+        "make_dfb",
         "copy",
         "node",
         "grid_size",

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""@ttl.atom-in-@ttl.atom AST inlining.
+
+A @ttl.atom function may invoke another @ttl.atom function as a
+statement. At decoration time the caller's AST is rewritten by
+substituting the callee's body in place of the call, binding the call
+site's args to the callee's parameters and alpha-renaming the callee's
+local variables to avoid collisions with the caller's scope.
+
+Constraints on inlined callees:
+
+  - The callee body must not declare its own DFBs or PipeNets. All
+    DataFlow buffers and PipeNets used by the callee must be passed
+    in as parameters. Operating on existing PipeNets (e.g.
+    ``.if_src``/``.if_dst``) and emitting copies is fine.
+  - The callee must be invoked as a bare statement (``Callee(...)``);
+    using the result as an expression is not supported.
+  - The callee's parameters must all be provided at the call site; no
+    defaults are applied.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import itertools
+from typing import TYPE_CHECKING, Dict, List, Set, Tuple
+
+if TYPE_CHECKING:
+    from ttl.atom import Atom
+
+
+_FORBIDDEN_CALLEE_NAMES = {"make_dataflow_buffer_like", "PipeNet"}
+
+_inline_counter = itertools.count()
+
+
+def inline_atom_calls(
+    fn_def: ast.FunctionDef,
+    fn_globals: Dict[str, object],
+    caller_name: str,
+) -> None:
+    """Rewrite ``fn_def`` in place: inline statement-level calls to
+    @ttl.atom kernels reachable through ``fn_globals``.
+
+    ``fn_def.body`` is replaced with the post-inline statement list.
+    Nested compound bodies (if / for / while / with) are inlined
+    recursively. Raises ``ValueError`` if a discovered callee's body
+    declares its own DFBs or PipeNets.
+    """
+    fn_def.body = _inline_stmts(fn_def.body, fn_globals, caller_name)
+
+
+def _inline_stmts(
+    stmts: List[ast.stmt],
+    fn_globals: Dict[str, object],
+    caller_name: str,
+) -> List[ast.stmt]:
+    out: List[ast.stmt] = []
+    for stmt in stmts:
+        _inline_inside_compound(stmt, fn_globals, caller_name)
+        match = _match_atom_call(stmt, fn_globals)
+        if match is None:
+            out.append(stmt)
+            continue
+        callee, call = match
+        out.extend(_expand_call(callee, call, caller_name))
+    return out
+
+
+def _inline_inside_compound(
+    stmt: ast.stmt,
+    fn_globals: Dict[str, object],
+    caller_name: str,
+) -> None:
+    """Recurse into compound-statement bodies so nested calls inline too."""
+    for attr in ("body", "orelse", "finalbody"):
+        body = getattr(stmt, attr, None)
+        if isinstance(body, list) and body and isinstance(body[0], ast.stmt):
+            setattr(stmt, attr, _inline_stmts(body, fn_globals, caller_name))
+    # try/except handler bodies
+    handlers = getattr(stmt, "handlers", None)
+    if isinstance(handlers, list):
+        for h in handlers:
+            if isinstance(h, ast.ExceptHandler):
+                h.body = _inline_stmts(h.body, fn_globals, caller_name)
+
+
+def _match_atom_call(
+    stmt: ast.stmt,
+    fn_globals: Dict[str, object],
+) -> Tuple["Atom", ast.Call] | None:
+    """Return (callee_atom, call_node) if ``stmt`` is a statement-level
+    call to a @ttl.atom kernel resolvable through ``fn_globals``."""
+    from ttl.atom import Atom
+
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return None
+    call = stmt.value
+    if not isinstance(call.func, ast.Name):
+        return None
+    obj = fn_globals.get(call.func.id)
+    if not isinstance(obj, Atom):
+        return None
+    return obj, call
+
+
+def _expand_call(
+    callee: "Atom",
+    call: ast.Call,
+    caller_name: str,
+) -> List[ast.stmt]:
+    spec = callee._spec
+    _validate_callee_for_inline(spec, caller_name)
+
+    bindings = _bind_args_to_params(spec, call, caller_name)
+    locals_in_callee = _collect_local_names(spec.fn_ast) - set(bindings)
+    suffix = f"__{spec.name}_inl{next(_inline_counter)}"
+    rename_map = {n: n + suffix for n in locals_in_callee}
+
+    transformer = _SubstituteTransformer(
+        bindings=bindings,
+        rename_map=rename_map,
+        callee_name=spec.name,
+        caller_name=caller_name,
+    )
+    inlined: List[ast.stmt] = []
+    for stmt in spec.fn_ast.body:
+        new_stmt = transformer.visit(copy.deepcopy(stmt))
+        ast.fix_missing_locations(new_stmt)
+        inlined.append(new_stmt)
+    return inlined
+
+
+def _validate_callee_for_inline(spec, caller_name: str) -> None:
+    """Forbid DFB / PipeNet declarations in a callee that's being inlined."""
+    for node in ast.walk(spec.fn_ast):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        attr = None
+        if isinstance(func, ast.Attribute):
+            attr = func.attr
+        elif isinstance(func, ast.Name):
+            attr = func.id
+        if attr in _FORBIDDEN_CALLEE_NAMES:
+            raise ValueError(
+                f"@ttl.atom: cannot inline {spec.name!r} into "
+                f"{caller_name!r}: callee body invokes {attr!r}. "
+                "Inlined callees must take all DFBs / PipeNets as "
+                "parameters; declare them in the caller and pass them in."
+            )
+
+
+def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, ast.expr]:
+    if any(isinstance(a, ast.Starred) for a in call.args):
+        raise ValueError(
+            f"@ttl.atom: inlining {spec.name!r} into {caller_name!r}: "
+            "*-unpacking is not supported at the call site."
+        )
+    if any(k.arg is None for k in call.keywords):
+        raise ValueError(
+            f"@ttl.atom: inlining {spec.name!r} into {caller_name!r}: "
+            "**-unpacking is not supported at the call site."
+        )
+
+    positional_params = [p for p in spec.params if not p.is_keyword_only]
+    if len(call.args) > len(positional_params):
+        raise ValueError(
+            f"@ttl.atom: inlining {spec.name!r} into {caller_name!r}: "
+            f"got {len(call.args)} positional args, expected at most "
+            f"{len(positional_params)} (params: "
+            f"{[p.name for p in positional_params]})"
+        )
+
+    bindings: Dict[str, ast.expr] = {}
+    for p, arg in zip(positional_params, call.args):
+        bindings[p.name] = arg
+
+    kwargs = {k.arg: k.value for k in call.keywords}
+    known_names = {p.name for p in spec.params}
+    unknown = set(kwargs) - known_names
+    if unknown:
+        raise ValueError(
+            f"@ttl.atom: inlining {spec.name!r} into {caller_name!r}: "
+            f"unknown keyword args {sorted(unknown)} "
+            f"(params: {sorted(known_names)})"
+        )
+
+    for p in spec.params:
+        if p.name in bindings:
+            if p.name in kwargs:
+                raise ValueError(
+                    f"@ttl.atom: inlining {spec.name!r} into "
+                    f"{caller_name!r}: param {p.name!r} passed both "
+                    "positionally and by keyword."
+                )
+            continue
+        if p.name in kwargs:
+            bindings[p.name] = kwargs[p.name]
+            continue
+        raise ValueError(
+            f"@ttl.atom: inlining {spec.name!r} into {caller_name!r}: "
+            f"missing argument for param {p.name!r}."
+        )
+
+    return bindings
+
+
+def _collect_local_names(fn_def: ast.FunctionDef) -> Set[str]:
+    """Names that the callee assigns to anywhere in its body.
+
+    Used to alpha-rename locals so they don't collide with caller-scope
+    names after substitution. Nested ``FunctionDef`` / ``Lambda`` scopes
+    are skipped: their locals shadow the outer scope already.
+    """
+    names: Set[str] = set()
+
+    class _LocalCollector(ast.NodeVisitor):
+        def visit_FunctionDef(self, node):
+            return
+
+        def visit_AsyncFunctionDef(self, node):
+            return
+
+        def visit_Lambda(self, node):
+            return
+
+        def visit_Assign(self, node):
+            for tgt in node.targets:
+                _walk_target(tgt, names)
+            self.generic_visit(node)
+
+        def visit_AugAssign(self, node):
+            _walk_target(node.target, names)
+            self.generic_visit(node)
+
+        def visit_AnnAssign(self, node):
+            _walk_target(node.target, names)
+            self.generic_visit(node)
+
+        def visit_For(self, node):
+            _walk_target(node.target, names)
+            self.generic_visit(node)
+
+        def visit_AsyncFor(self, node):
+            _walk_target(node.target, names)
+            self.generic_visit(node)
+
+        def visit_With(self, node):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    _walk_target(item.optional_vars, names)
+            self.generic_visit(node)
+
+        def visit_comprehension(self, node):
+            _walk_target(node.target, names)
+            self.generic_visit(node)
+
+    for stmt in fn_def.body:
+        _LocalCollector().visit(stmt)
+    return names
+
+
+def _walk_target(target: ast.expr, names: Set[str]) -> None:
+    if isinstance(target, ast.Name):
+        names.add(target.id)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            _walk_target(elt, names)
+    elif isinstance(target, ast.Starred):
+        _walk_target(target.value, names)
+
+
+class _SubstituteTransformer(ast.NodeTransformer):
+    """Replace param Names with caller's arg expressions; rename locals."""
+
+    def __init__(
+        self,
+        bindings: Dict[str, ast.expr],
+        rename_map: Dict[str, str],
+        callee_name: str,
+        caller_name: str,
+    ):
+        self.bindings = bindings
+        self.rename_map = rename_map
+        self.callee_name = callee_name
+        self.caller_name = caller_name
+
+    def visit_Name(self, node: ast.Name) -> ast.expr:
+        if node.id in self.bindings:
+            if isinstance(node.ctx, (ast.Store, ast.Del)):
+                raise ValueError(
+                    f"@ttl.atom: inlining {self.callee_name!r} into "
+                    f"{self.caller_name!r}: cannot assign to or delete "
+                    f"parameter {node.id!r} inside the callee body."
+                )
+            return ast.copy_location(copy.deepcopy(self.bindings[node.id]), node)
+        if node.id in self.rename_map:
+            new = ast.Name(id=self.rename_map[node.id], ctx=node.ctx)
+            return ast.copy_location(new, node)
+        return node

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from ttl.atom import Atom
 
 
-_FORBIDDEN_CALLEE_NAMES = {"make_dataflow_buffer_like", "PipeNet"}
+_FORBIDDEN_CALLEE_NAMES = {"make_dataflow_buffer_like", "make_dfb", "PipeNet"}
 
 _inline_counter = itertools.count()
 

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -12,10 +12,13 @@ local variables to avoid collisions with the caller's scope.
 
 Constraints on inlined callees:
 
-  - The callee body must not declare its own DFBs or PipeNets. All
-    DataFlow buffers and PipeNets used by the callee must be passed
-    in as parameters. Operating on existing PipeNets (e.g.
-    ``.if_src``/``.if_dst``) and emitting copies is fine.
+  - A callee may declare its own DFBs / PipeNets, but only when it is
+    inlined at the caller body's top level: the decls are hoisted to the
+    top level (where ``_lift_setup`` evaluates them), so a callee that
+    declares buffers cannot be inlined inside a for / if / while / with.
+    The buffer decls must themselves be top-level statements of the
+    callee for the same reason. Operating on existing PipeNets (e.g.
+    ``.if_src``/``.if_dst``) and emitting copies is always fine.
   - The callee must be invoked as a bare statement (``Callee(...)``);
     using the result as an expression is not supported.
   - The callee's parameters must all be provided at the call site; no
@@ -42,32 +45,43 @@ def inline_atom_calls(
     fn_def: ast.FunctionDef,
     fn_globals: Dict[str, object],
     caller_name: str,
-) -> None:
+) -> Dict[str, int]:
     """Rewrite ``fn_def`` in place: inline statement-level calls to
     @ttl.atom kernels reachable through ``fn_globals``.
 
     ``fn_def.body`` is replaced with the post-inline statement list.
     Nested compound bodies (if / for / while / with) are inlined
-    recursively. Raises ``ValueError`` if a discovered callee's body
-    declares its own DFBs or PipeNets.
+    recursively. Returns a map from each (alpha-renamed) inlined DFB name to
+    the id of the inline site it came from, so the caller can overlay the
+    scratch of distinct sibling sites onto shared CB indices. Raises
+    ``ValueError`` if a callee that declares its own buffers is inlined
+    anywhere but the body top level.
     """
-    fn_def.body = _inline_stmts(fn_def.body, fn_globals, caller_name)
+    inlined_dfb_tags: Dict[str, int] = {}
+    fn_def.body = _inline_stmts(
+        fn_def.body, fn_globals, caller_name, inlined_dfb_tags, top_level=True
+    )
+    return inlined_dfb_tags
 
 
 def _inline_stmts(
     stmts: List[ast.stmt],
     fn_globals: Dict[str, object],
     caller_name: str,
+    inlined_dfb_tags: Dict[str, int],
+    top_level: bool,
 ) -> List[ast.stmt]:
     out: List[ast.stmt] = []
     for stmt in stmts:
-        _inline_inside_compound(stmt, fn_globals, caller_name)
+        _inline_inside_compound(stmt, fn_globals, caller_name, inlined_dfb_tags)
         match = _match_atom_call(stmt, fn_globals)
         if match is None:
             out.append(stmt)
             continue
         callee, call = match
-        out.extend(_expand_call(callee, call, caller_name))
+        out.extend(
+            _expand_call(callee, call, caller_name, top_level, inlined_dfb_tags)
+        )
     return out
 
 
@@ -75,18 +89,31 @@ def _inline_inside_compound(
     stmt: ast.stmt,
     fn_globals: Dict[str, object],
     caller_name: str,
+    inlined_dfb_tags: Dict[str, int],
 ) -> None:
-    """Recurse into compound-statement bodies so nested calls inline too."""
+    """Recurse into compound-statement bodies so nested calls inline too.
+
+    Calls discovered here are not at the body top level, so a callee that
+    declares its own buffers cannot be inlined into them.
+    """
     for attr in ("body", "orelse", "finalbody"):
         body = getattr(stmt, attr, None)
         if isinstance(body, list) and body and isinstance(body[0], ast.stmt):
-            setattr(stmt, attr, _inline_stmts(body, fn_globals, caller_name))
+            setattr(
+                stmt,
+                attr,
+                _inline_stmts(
+                    body, fn_globals, caller_name, inlined_dfb_tags, top_level=False
+                ),
+            )
     # try/except handler bodies
     handlers = getattr(stmt, "handlers", None)
     if isinstance(handlers, list):
         for h in handlers:
             if isinstance(h, ast.ExceptHandler):
-                h.body = _inline_stmts(h.body, fn_globals, caller_name)
+                h.body = _inline_stmts(
+                    h.body, fn_globals, caller_name, inlined_dfb_tags, top_level=False
+                )
 
 
 def _match_atom_call(
@@ -112,14 +139,27 @@ def _expand_call(
     callee: "Atom",
     call: ast.Call,
     caller_name: str,
+    top_level: bool,
+    inlined_dfb_tags: Dict[str, int],
 ) -> List[ast.stmt]:
     spec = callee._spec
-    _validate_callee_for_inline(spec, caller_name)
+    dfb_decl_names = _check_callee_buffers(spec, caller_name, top_level)
 
     bindings = _bind_args_to_params(spec, call, caller_name)
+    # Fold the callee's constant closure freevars (e.g. factory tile-count
+    # params) into the body: after substitution they live in the caller, whose
+    # scope does not carry the callee's closure.
+    for name, value in _closure_consts(spec.fn).items():
+        bindings.setdefault(name, ast.Constant(value=value))
     locals_in_callee = _collect_local_names(spec.fn_ast) - set(bindings)
-    suffix = f"__{spec.name}_inl{next(_inline_counter)}"
+    site = next(_inline_counter)
+    suffix = f"__{spec.name}_inl{site}"
     rename_map = {n: n + suffix for n in locals_in_callee}
+
+    # The callee's local DFBs are hoisted into the caller; tag their renamed
+    # names with this inline site so sibling sites can overlay CB indices.
+    for n in dfb_decl_names:
+        inlined_dfb_tags[rename_map.get(n, n)] = site
 
     transformer = _SubstituteTransformer(
         bindings=bindings,
@@ -135,24 +175,80 @@ def _expand_call(
     return inlined
 
 
-def _validate_callee_for_inline(spec, caller_name: str) -> None:
-    """Forbid DFB / PipeNet declarations in a callee that's being inlined."""
-    for node in ast.walk(spec.fn_ast):
-        if not isinstance(node, ast.Call):
+def _check_callee_buffers(spec, caller_name: str, top_level: bool) -> Set[str]:
+    """Validate a callee's buffer declarations and return its top-level
+    DFB-decl names.
+
+    A callee may declare its own DFBs / Pipes / PipeNets only as top-level
+    statements (so they can be hoisted) and only when inlined at the caller
+    body top level (so the hoist target is the caller's top level too).
+    Returns the names of the callee's top-level ``make_dfb`` /
+    ``make_dataflow_buffer_like`` assigns (the scratch buffers eligible for
+    reuse); Pipes / PipeNets are hoisted but not reused.
+    """
+    from ttl.atom import (
+        _DFB_FACTORY_NAMES,
+        _SETUP_FACTORY_NAMES,
+        _call_name,
+        _setup_assign_target,
+    )
+
+    # Whitelist every factory call inside a top-level setup-assign's value:
+    # the whole RHS is evaluated when the assign is hoisted, so pipes nested in
+    # a ``PipeNet([Pipe(...)])`` argument are fine. Factory calls anywhere else
+    # (a compound block, a non-decl expression) cannot be hoisted.
+    dfb_names: Set[str] = set()
+    top_level_decl_calls: Set[int] = set()
+    for stmt in spec.fn_ast.body:
+        if _setup_assign_target(stmt) is None:
             continue
-        func = node.func
-        attr = None
-        if isinstance(func, ast.Attribute):
-            attr = func.attr
-        elif isinstance(func, ast.Name):
-            attr = func.id
-        if attr in _FORBIDDEN_CALLEE_NAMES:
+        for sub in ast.walk(stmt.value):
+            if isinstance(sub, ast.Call) and _call_name(sub) in _SETUP_FACTORY_NAMES:
+                top_level_decl_calls.add(id(sub))
+        if _call_name(stmt.value) in _DFB_FACTORY_NAMES:
+            dfb_names.add(stmt.targets[0].id)
+
+    declares = False
+    for node in ast.walk(spec.fn_ast):
+        if not (isinstance(node, ast.Call) and _call_name(node) in _SETUP_FACTORY_NAMES):
+            continue
+        declares = True
+        if id(node) not in top_level_decl_calls:
             raise ValueError(
-                f"@ttl.atom: cannot inline {spec.name!r} into "
-                f"{caller_name!r}: callee body invokes {attr!r}. "
-                "Inlined callees must take all DFBs / PipeNets as "
-                "parameters; declare them in the caller and pass them in."
+                f"@ttl.atom: cannot inline {spec.name!r} into {caller_name!r}: "
+                "buffer declarations must be top-level statements of the callee "
+                "so they can be hoisted; found one nested in its body."
             )
+
+    if declares and not top_level:
+        raise ValueError(
+            f"@ttl.atom: cannot inline {spec.name!r} into {caller_name!r}: it "
+            "declares its own DFBs / PipeNets, so it must be called at the atom "
+            "body top level, not inside a for / if / while / with."
+        )
+
+    return dfb_names
+
+
+def _closure_consts(fn) -> Dict[str, object]:
+    """Constant closure freevars of ``fn`` (e.g. a factory's tile-count params).
+
+    These are folded into the body as literals when it is inlined, since the
+    caller's scope does not carry the callee's closure cells. Only simple
+    constants are folded; other freevars (atoms, modules) resolve through the
+    caller's globals or are themselves inlined.
+    """
+    closure = getattr(fn, "__closure__", None) or ()
+    freevars = getattr(getattr(fn, "__code__", None), "co_freevars", ())
+    consts: Dict[str, object] = {}
+    for name, cell in zip(freevars, closure):
+        try:
+            value = cell.cell_contents
+        except ValueError:
+            continue
+        if value is None or isinstance(value, (int, float, str, bool)):
+            consts[name] = value
+    return consts
 
 
 def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, ast.expr]:

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -129,6 +129,69 @@ _BLOCK_METHODS: Dict[str, str] = {
 _DFB_PRODUCING_METHODS: Set[str] = {"wait", "reserve"}
 
 
+# ----- shared call -> thread classification ---------------------------------
+
+
+def _materialize_thread(op: Optional[str], dm_thread: str) -> Optional[str]:
+    """Resolve a registry value to a concrete thread tag.
+
+    ``"dm"`` becomes the scope's DM thread (ncrisc by default, brisc inside an
+    if_src callback). Anything that is not a concrete thread (``"control"`` and
+    compile-time producers) returns None, since it does not pin a thread.
+    """
+    if op == "dm":
+        return dm_thread
+    if op in THREADS:
+        return op
+    return None
+
+
+def _classify_ttl_call(func: ast.expr, dm_thread: str) -> Optional[str]:
+    """Thread a registry-driven call pins to, or None when the call is not a
+    registry anchor (control op, bare-name call, block / DFB method, or a
+    chained call).
+
+    Handles ``ttl.<op>(...)``, ``ttl.<ns>.<name>(...)`` and
+    ``<recv>.if_src/if_dst(...)``, raising on an unknown ``ttl.<...>`` form so a
+    new op must be registered rather than silently mis-split. This is the
+    single source of the call->thread decision; both anchor tagging and
+    block-use collection route through it.
+    """
+    # ttl.<name>(...) or <recv>.if_src/if_dst(...)
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        recv = func.value.id
+        name = func.attr
+        if recv == "ttl":
+            op = _TTL_OPS.get(name)
+            if op is None:
+                raise _split_error(
+                    func,
+                    f"unknown ttl.{name}(...) call; register it in "
+                    f"atom_split._TTL_OPS with its thread "
+                    f"('trisc', 'dm', or 'control')",
+                )
+            return _materialize_thread(op, dm_thread)
+        if name in _PIPENET_METHODS:
+            return _PIPENET_METHODS[name]
+        return None
+
+    # ttl.<ns>.<name>(...)
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
+        outer = func.value
+        if isinstance(outer.value, ast.Name) and outer.value.id == "ttl":
+            ns = outer.attr
+            ns_thread = _TTL_NAMESPACES.get(ns)
+            if ns_thread is None:
+                raise _split_error(
+                    func,
+                    f"unknown ttl.{ns}.{func.attr}(...) call; register "
+                    f"namespace 'ttl.{ns}' in atom_split._TTL_NAMESPACES",
+                )
+            return _materialize_thread(ns_thread, dm_thread)
+
+    return None
+
+
 # ----- public API -----------------------------------------------------------
 
 
@@ -395,77 +458,30 @@ class _AnchorTagger:
         return None
 
     def _classify_call(self, call: ast.Call) -> Optional[str]:
-        """Return the thread of a Call ("trisc"/"ncrisc"/"brisc"/"control"),
-        or None if it isn't an anchor at all (e.g. ``range(...)``,
-        ``int(...)``, ``.wait()`` on a call result).
+        """Return the thread of a Call ("trisc"/"ncrisc"/"brisc"), or None if
+        it isn't an anchor at all (e.g. ``range(...)``, ``int(...)``,
+        ``.wait()`` on a call result). Raises on a ``ttl.<unknown>(...)`` form.
 
-        Raises if the call is a ``ttl.<unknown>(...)`` form.
+        Delegates the registry decision (ttl ops, namespaces, pipe dispatch)
+        to ``_classify_ttl_call``; resolves ``<block>.store/pop/push`` here,
+        since deferred block methods need this scope's inferred block threads.
         """
-        func = call.func
+        thread = _classify_ttl_call(call.func, self._dm_thread)
+        if thread is not None:
+            return thread
 
-        # ttl.<name>(...) or <recv>.<method>(...)
+        # <block>.<method>(...) where <block> is a producer in this scope.
+        func = call.func
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-            recv = func.value.id
-            name = func.attr
-            if recv == "ttl":
-                op = _TTL_OPS.get(name)
-                if op is None:
-                    raise _split_error(
-                        call,
-                        f"unknown ttl.{name}(...) call; register it in "
-                        f"atom_split._TTL_OPS with its thread "
-                        f"('trisc', 'dm', or 'control')",
-                    )
-                return self._materialize_thread(op)
-            # <pipenet>.if_src/if_dst(...): method name alone is the discriminator.
-            if name in _PIPENET_METHODS:
-                return _PIPENET_METHODS[name]
-            # <block>.<method>(...)
-            if recv in self._producers:
-                method = _BLOCK_METHODS.get(name)
+            if func.value.id in self._producers:
+                method = _BLOCK_METHODS.get(func.attr)
                 if method == "trisc":
                     return "trisc"
                 if method == "deferred":
-                    bt = self.block_threads.get(recv)
+                    bt = self.block_threads.get(func.value.id)
                     if bt and len(bt) == 1:
                         return next(iter(bt))
-                    return None
-                return None
-            # <dfb>.wait()/.reserve() as an inner call: its producer-stmt
-            # handles the tagging at the enclosing Assign/With.
-            return None
-
-        # ttl.<ns>.<name>(...)
-        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
-            outer = func.value
-            if isinstance(outer.value, ast.Name) and outer.value.id == "ttl":
-                ns = outer.attr
-                ns_thread = _TTL_NAMESPACES.get(ns)
-                if ns_thread is None:
-                    raise _split_error(
-                        call,
-                        f"unknown ttl.{ns}.{func.attr}(...) call; register "
-                        f"namespace 'ttl.{ns}' in atom_split._TTL_NAMESPACES",
-                    )
-                return self._materialize_thread(ns_thread)
-            return None
-
-        # Bare Name call (range/int/len/...), chained call (.wait() on a Call),
-        # or other shapes: not an anchor.
         return None
-
-    def _materialize_thread(self, op: str) -> Optional[str]:
-        """Resolve a registry value to a concrete thread tag.
-
-        ``"dm"`` becomes the scope's current DM thread (ncrisc by default,
-        brisc inside an if_src callback). ``"control"`` returns None since
-        compile-time ops don't pin a thread.
-        """
-        if op == "dm":
-            return self._dm_thread
-        if op == "control":
-            return None
-        return op
 
     # --- post-check: forbid duplicate DM-side reserves ---
 
@@ -719,42 +735,19 @@ def _collect_block_users(
             if root in visible:
                 users[root].add(thread)
 
-    def classify(func, recv, name, visible, dm):
-        if recv == "ttl":
-            op = _TTL_OPS.get(name)
-            if op == "dm":
-                return dm
-            if op in THREADS:
-                return op
-            return None
-        if name in _PIPENET_METHODS:
-            return _PIPENET_METHODS[name]
-        if recv in visible and name == "store":
-            users[recv].add("trisc")
-            return "trisc"
-        return None
-
     def visit(node, visible, dm):
         if isinstance(node, ast.Call):
             func = node.func
-            thread: Optional[str] = None
+            thread = _classify_ttl_call(func, dm)
             sub_dm = dm
             if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
                 recv = func.value.id
                 method = func.attr
-                thread = classify(func, recv, method, visible, dm)
+                if thread is None and recv in visible and method == "store":
+                    users[recv].add("trisc")
+                    thread = "trisc"
                 if method in _PIPENET_METHODS:
                     sub_dm = _PIPENET_METHODS[method]
-            elif isinstance(func, ast.Attribute) and isinstance(
-                func.value, ast.Attribute
-            ):
-                outer = func.value
-                if isinstance(outer.value, ast.Name) and outer.value.id == "ttl":
-                    ns_thread = _TTL_NAMESPACES.get(outer.attr)
-                    if ns_thread == "dm":
-                        thread = dm
-                    elif ns_thread in THREADS:
-                        thread = ns_thread
             if thread is not None:
                 record_call_args(node, thread, visible)
             for arg in node.args:

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -761,6 +761,11 @@ def _collect_block_users(
                 visit(arg, visible, sub_dm)
             for kw in node.keywords:
                 visit(kw.value, visible, sub_dm)
+            # Recurse into the callee so a chained call such as
+            # `ttl.copy(blk, pipe).wait()` still records `blk`'s use in the
+            # inner call (the inner call is func.value, not an arg/keyword).
+            if isinstance(func, ast.Attribute):
+                visit(func.value, visible, sub_dm)
             return
         if isinstance(node, ast.BinOp):
             for side in (node.left, node.right):

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -1,0 +1,800 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Duplicate-and-prune splitter for @ttl.atom kernels.
+
+Walks the function body of a unified @ttl.atom kernel and produces
+three stripped function ASTs: one each for the TRISC (compute), NCRISC
+(default DM, receivers + non-pipe DM), and BRISC (pipe senders) threads.
+
+Algorithm:
+
+    trisc_body, ncrisc_body, brisc_body = three deepcopies of body
+
+    Pass A (anchor tagging):
+        Walk every Call/MatMult node and look it up in the op
+        registry. Anchor stmts get an ``_ttl_threads`` attribute
+        set to the frozenset of threads they belong on. Stmts that
+        produce a block via ``cb.wait()`` / ``cb.reserve()`` are
+        *deferred anchors*: their thread is the union of threads
+        observed on the produced block's downstream anchor uses.
+
+        DM ops are registered with the sentinel ``"dm"``; the tagger
+        materializes that to a concrete thread (``"ncrisc"`` outside
+        an if_src callback, ``"brisc"`` inside one). Pipe dispatch
+        methods bind directly: ``if_src`` -> brisc, ``if_dst`` -> ncrisc.
+
+    Pass B (per-side prune):
+        For each side, walk the duplicated body. If a stmt has
+        ``_ttl_threads`` and this side isn't in it, drop the stmt.
+        Non-anchor stmts (control flow, scalar arithmetic, ttl.node,
+        make_dataflow_buffer_like, ...) stay on every side; MLIR DCE
+        removes dead code per-thread later.
+
+    Post-check:
+        A DFB producer (``blk = cb.wait()`` / ``cb.reserve()``) whose
+        downstream uses span both ncrisc and brisc would be reserved
+        twice on the same CB. Raise immediately and ask the author to
+        inline the reserve inside the if_src / if_dst callback so each
+        reserve sits on a single RISC.
+
+Unknown ``ttl.<name>(...)`` calls are a hard error. To add an op,
+register it in ``_TTL_OPS`` with its thread.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+
+
+# ----- threads --------------------------------------------------------------
+
+
+THREADS: Tuple[str, ...] = ("trisc", "ncrisc", "brisc")
+DM_THREADS: Tuple[str, ...] = ("ncrisc", "brisc")
+
+
+# ----- op registry ----------------------------------------------------------
+
+
+# ttl.<name>(...) -> "trisc" | "dm" | "control".
+#
+# ``"dm"`` is a sentinel: at tagging time it is materialized to either
+# "ncrisc" or "brisc" depending on whether the call sits inside an
+# ``if_src`` callback (-> brisc) or anywhere else (-> ncrisc).
+_TTL_OPS: Dict[str, str] = {
+    # Data movement
+    "copy": "dm",
+    "element_read": "dm",
+    "element_write": "dm",
+    # Compute
+    "fill": "trisc",
+    "matmul": "trisc",
+    "reduce_sum": "trisc",
+    "reduce_max": "trisc",
+    "broadcast": "trisc",
+    "transpose": "trisc",
+    "exp": "trisc",
+    "mul": "trisc",
+    "add": "trisc",
+    "sub": "trisc",
+    "div": "trisc",
+    "recip": "trisc",
+    "neg": "trisc",
+    "sqrt": "trisc",
+    "tanh": "trisc",
+    "log": "trisc",
+    "abs": "trisc",
+    "relu": "trisc",
+    "sigmoid": "trisc",
+    "gelu": "trisc",
+    # Compile-time / scalar producers: duplicated, not anchored.
+    "Pipe": "control",
+    "PipeNet": "control",
+    "make_dataflow_buffer_like": "control",
+    "node": "control",
+    "dims": "control",
+    "cores": "control",
+    "tile_index": "control",
+    "signpost": "control",
+}
+
+# ttl.<ns>.<name>(...) -> thread, applies to every name in the namespace.
+_TTL_NAMESPACES: Dict[str, str] = {
+    "math": "trisc",
+    "block": "trisc",
+}
+
+# <pipenet>.<method>(...) -> thread. The receiver is any Name (PipeNet
+# object). ``if_src`` dispatches the sender side on BRISC; ``if_dst``
+# the receiver side on NCRISC (sender = BRISC, receiver = NCRISC).
+_PIPENET_METHODS: Dict[str, str] = {
+    "if_src": "brisc",
+    "if_dst": "ncrisc",
+}
+
+# <block>.<method>(...) where <block> is a known block. "trisc" pins
+# the call; "deferred" pins it to the block's inferred thread.
+_BLOCK_METHODS: Dict[str, str] = {
+    "store": "trisc",
+    "pop": "deferred",
+    "push": "deferred",
+}
+
+# Methods on a DFB name that produce a block.
+_DFB_PRODUCING_METHODS: Set[str] = {"wait", "reserve"}
+
+
+# ----- public API -----------------------------------------------------------
+
+
+@dataclass
+class SplitResult:
+    trisc_body: List[ast.stmt]
+    ncrisc_body: List[ast.stmt]
+    brisc_body: List[ast.stmt]
+    trisc_param_uses: Set[str] = field(default_factory=set)
+    ncrisc_param_uses: Set[str] = field(default_factory=set)
+    brisc_param_uses: Set[str] = field(default_factory=set)
+
+    def body_for(self, thread: str) -> List[ast.stmt]:
+        return getattr(self, f"{thread}_body")
+
+    def param_uses_for(self, thread: str) -> Set[str]:
+        return getattr(self, f"{thread}_param_uses")
+
+
+def split_function_body(
+    fn_def: ast.FunctionDef,
+    dfb_param_names: Set[str],
+    all_param_names: Optional[Set[str]] = None,
+    local_dfb_names: Optional[Set[str]] = None,
+) -> SplitResult:
+    """Split a @ttl.atom function body into trisc / ncrisc / brisc bodies.
+
+    Args:
+        fn_def: AST FunctionDef of the user's @ttl.atom function.
+        dfb_param_names: parameter names annotated as ttl.DFB / ttl.DFB.Output.
+        all_param_names: full atom parameter name set, used to track which
+            parameters each thread references. Defaults to dfb_param_names.
+        local_dfb_names: names of DFBs declared inside the body via
+            ``ttl.make_dataflow_buffer_like(...)``. Treated as DFB receivers
+            for wait/reserve recognition.
+    """
+    all_names = (
+        set(all_param_names) if all_param_names is not None else set(dfb_param_names)
+    )
+    dfb_names = set(dfb_param_names) | (local_dfb_names or set())
+
+    # Pass A: tag anchor stmts in-place on the original body.
+    _AnchorTagger(dfb_names=dfb_names).tag(fn_def.body)
+
+    # Pass B: deep-copy the body once per side; prune anchors that
+    # don't apply on this side. Tag attributes survive deep-copy.
+    bodies = {
+        thread: _prune_body([copy.deepcopy(s) for s in fn_def.body], thread)
+        for thread in THREADS
+    }
+
+    return SplitResult(
+        trisc_body=bodies["trisc"],
+        ncrisc_body=bodies["ncrisc"],
+        brisc_body=bodies["brisc"],
+        trisc_param_uses=_params_referenced(bodies["trisc"], all_names),
+        ncrisc_param_uses=_params_referenced(bodies["ncrisc"], all_names),
+        brisc_param_uses=_params_referenced(bodies["brisc"], all_names),
+    )
+
+
+# ----- Pass A: anchor tagging ----------------------------------------------
+
+
+class _AnchorTagger:
+    """Walks the body and annotates anchor stmts with ``_ttl_threads``.
+
+    Anchors fall into three categories:
+
+    1. Direct anchors: any stmt whose AST subtree contains a registered
+       ``ttl.<op>(...)`` call, a ``<pipenet>.if_src/if_dst(...)`` call,
+       a block-method call (``blk.store(...)``), or a ``@`` MatMult.
+       Thread = union of anchor threads found.
+
+    2. Deferred producer anchors: ``name = cb.wait()/.reserve()`` (or
+       ``with cb.<m>() as name:``). The producer stmt's thread is the
+       block's inferred thread (from the produced block's downstream
+       uses).
+
+    3. Block-method anchors with deferred thread: ``blk.pop()`` /
+       ``blk.push()`` resolve to the block's inferred thread.
+
+    ``dm_thread`` is the concrete thread used for DM-classified ops in
+    the current scope: ``"ncrisc"`` by default and ``"brisc"`` for the
+    body of an ``if_src`` callback. The outer scope's Phase 1 detects
+    which top-level FunctionDef names are passed as ``if_src(<name>)``;
+    those FunctionDefs get an inner tagger with ``dm_thread="brisc"``.
+    """
+
+    def __init__(self, dfb_names: Set[str], dm_thread: str = "ncrisc"):
+        self.dfb_names = dfb_names
+        self._dm_thread = dm_thread
+        # block_name -> frozenset of threads the block is used on.
+        self.block_threads: Dict[str, FrozenSet[str]] = {}
+        # block_name -> list of producer stmts (Assign / With) in this scope.
+        self._producers: Dict[str, List[ast.stmt]] = {}
+        # FunctionDef names in this scope used as the callback argument
+        # to a ``<recv>.if_src(<Name>)`` call. Their inner bodies are
+        # tagged with dm_thread="brisc".
+        self._brisc_callbacks: Set[str] = set()
+
+    # --- entry ---
+
+    def tag(self, body: List[ast.stmt]) -> None:
+        self._discover_producers(body)
+        self._discover_brisc_callbacks(body)
+        block_users = _collect_block_users(
+            body,
+            set(self._producers.keys()),
+            self.dfb_names,
+            dm_thread=self._dm_thread,
+            brisc_callbacks=self._brisc_callbacks,
+        )
+        for name, threads in block_users.items():
+            if threads:
+                self.block_threads[name] = frozenset(threads)
+        for stmt in body:
+            self._annotate(stmt)
+        self._check_duplicate_producers()
+
+    # --- phase 1a: producer discovery (this scope only) ---
+
+    def _discover_producers(self, stmts: List[ast.stmt]) -> None:
+        for stmt in stmts:
+            self._discover_in_stmt(stmt)
+
+    def _discover_in_stmt(self, stmt: ast.stmt) -> None:
+        prod = _bare_wait_assign_target(stmt, self.dfb_names)
+        if prod is not None:
+            block_name, _ = prod
+            self._producers.setdefault(block_name, []).append(stmt)
+
+        # `with cb.wait() as name:` form: register as producer; the
+        # with stmt itself is the producer-anchor we'll tag.
+        if isinstance(stmt, ast.With):
+            for item in stmt.items:
+                name = _with_item_block_name(item, self.dfb_names)
+                if name:
+                    self._producers.setdefault(name, []).append(stmt)
+
+        if isinstance(stmt, (ast.For, ast.While, ast.If)):
+            self._discover_producers(stmt.body)
+            self._discover_producers(stmt.orelse)
+        elif isinstance(stmt, ast.With):
+            self._discover_producers(stmt.body)
+        # Do NOT descend into FunctionDef / AsyncFunctionDef: they are
+        # their own scope and get their own tagger in Phase 3.
+
+    # --- phase 1b: if_src callback discovery (this scope only) ---
+
+    def _discover_brisc_callbacks(self, stmts: List[ast.stmt]) -> None:
+        for node in _walk_skip_nested_fns_iter(stmts):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            if func.attr != "if_src":
+                continue
+            if node.args and isinstance(node.args[0], ast.Name):
+                self._brisc_callbacks.add(node.args[0].id)
+
+    # --- phase 2: annotate every stmt with anchor threads ---
+
+    def _annotate(self, stmt: ast.stmt) -> None:
+        if isinstance(stmt, (ast.For, ast.While, ast.If)):
+            for child in list(stmt.body) + list(stmt.orelse):
+                self._annotate(child)
+            return
+        if isinstance(stmt, ast.With):
+            threads = self._with_threads(stmt)
+            if threads is not None:
+                if not threads:
+                    names = [
+                        _with_item_block_name(item, self.dfb_names)
+                        for item in stmt.items
+                    ]
+                    names = [n for n in names if n]
+                    raise _split_error(
+                        stmt,
+                        f"result of `with <dfb>.wait()/.reserve() as ...` "
+                        f"({', '.join(names)}) has no uses; the splitter "
+                        f"cannot pick a thread for the wait/reserve. "
+                        f"Add a use inside the with-body or remove it.",
+                    )
+                _tag(stmt, threads)
+            for child in stmt.body:
+                self._annotate(child)
+            return
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            inner_dm = (
+                "brisc" if stmt.name in self._brisc_callbacks else self._dm_thread
+            )
+            inner = _AnchorTagger(dfb_names=self.dfb_names, dm_thread=inner_dm)
+            inner.tag(stmt.body)
+            return
+
+        # Producer Assign: thread = block's inferred thread.
+        prod = _bare_wait_assign_target(stmt, self.dfb_names)
+        if prod is not None:
+            block_name, dfb_name = prod
+            threads = self._block_thread_set(block_name)
+            if not threads:
+                raise _split_error(
+                    stmt,
+                    f"result of {dfb_name}.wait()/.reserve() bound to "
+                    f"'{block_name}' has no uses; the splitter cannot pick "
+                    f"a thread for the wait/reserve. Add a use of "
+                    f"'{block_name}' (e.g. a no-op store into another CB) "
+                    f"or remove the producer.",
+                )
+            _tag(stmt, threads)
+            return
+
+        threads = self._stmt_anchor_threads(stmt)
+        if threads is not None:
+            _tag(stmt, threads)
+
+    def _with_threads(self, stmt: ast.With) -> Optional[Set[str]]:
+        """Thread set for a ``with cb.<wait|reserve>() as blk:`` form,
+        unioned across all DFB-sync withitems. ``None`` if the With has
+        no DFB-sync items (it's then a plain control-flow With).
+        """
+        merged: Set[str] = set()
+        any_dfb = False
+        for item in stmt.items:
+            name = _with_item_block_name(item, self.dfb_names)
+            if name is None:
+                continue
+            any_dfb = True
+            merged |= self._block_thread_set(name)
+        return merged if any_dfb else None
+
+    def _block_thread_set(self, block_name: str) -> Set[str]:
+        return set(self.block_threads.get(block_name, frozenset()))
+
+    def _stmt_anchor_threads(self, stmt: ast.stmt) -> Optional[Set[str]]:
+        """Union of anchor threads found in the stmt's subtree. ``None``
+        if the stmt has no thread-pinning anchor (control / scalar /
+        registered compile-time op); those stay duplicated on all sides.
+
+        Lambdas inside the stmt are deliberately skipped: their body's
+        DM ops are dispatched by the enclosing ``<recv>.if_src/if_dst``
+        call, whose own classification already pins the stmt to the
+        right thread. Including the lambda body would double-count an
+        ``if_src(lambda: ttl.copy(...))`` as both brisc (from if_src)
+        and ncrisc (from ttl.copy), forcing duplication.
+
+        AugAssign on a known block is still a compute anchor even when
+        the RHS has no Call / MatMult (e.g. ``blk += scalar``).
+        """
+        threads: Set[str] = set()
+        for node in _iter_skip_nested_fns(stmt):
+            if isinstance(node, ast.Call):
+                t = self._classify_call(node)
+                if t in THREADS:
+                    threads.add(t)
+            elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.MatMult):
+                threads.add("trisc")
+        if threads:
+            return threads
+        if isinstance(stmt, ast.AugAssign) and isinstance(stmt.target, ast.Name):
+            return self._block_thread_set(stmt.target.id) or None
+        return None
+
+    def _classify_call(self, call: ast.Call) -> Optional[str]:
+        """Return the thread of a Call ("trisc"/"ncrisc"/"brisc"/"control"),
+        or None if it isn't an anchor at all (e.g. ``range(...)``,
+        ``int(...)``, ``.wait()`` on a call result).
+
+        Raises if the call is a ``ttl.<unknown>(...)`` form.
+        """
+        func = call.func
+
+        # ttl.<name>(...) or <recv>.<method>(...)
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+            recv = func.value.id
+            name = func.attr
+            if recv == "ttl":
+                op = _TTL_OPS.get(name)
+                if op is None:
+                    raise _split_error(
+                        call,
+                        f"unknown ttl.{name}(...) call; register it in "
+                        f"atom_split._TTL_OPS with its thread "
+                        f"('trisc', 'dm', or 'control')",
+                    )
+                return self._materialize_thread(op)
+            # <pipenet>.if_src/if_dst(...): method name alone is the discriminator.
+            if name in _PIPENET_METHODS:
+                return _PIPENET_METHODS[name]
+            # <block>.<method>(...)
+            if recv in self._producers:
+                method = _BLOCK_METHODS.get(name)
+                if method == "trisc":
+                    return "trisc"
+                if method == "deferred":
+                    bt = self.block_threads.get(recv)
+                    if bt and len(bt) == 1:
+                        return next(iter(bt))
+                    return None
+                return None
+            # <dfb>.wait()/.reserve() as an inner call: its producer-stmt
+            # handles the tagging at the enclosing Assign/With.
+            return None
+
+        # ttl.<ns>.<name>(...)
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
+            outer = func.value
+            if isinstance(outer.value, ast.Name) and outer.value.id == "ttl":
+                ns = outer.attr
+                ns_thread = _TTL_NAMESPACES.get(ns)
+                if ns_thread is None:
+                    raise _split_error(
+                        call,
+                        f"unknown ttl.{ns}.{func.attr}(...) call; register "
+                        f"namespace 'ttl.{ns}' in atom_split._TTL_NAMESPACES",
+                    )
+                return self._materialize_thread(ns_thread)
+            return None
+
+        # Bare Name call (range/int/len/...), chained call (.wait() on a Call),
+        # or other shapes: not an anchor.
+        return None
+
+    def _materialize_thread(self, op: str) -> Optional[str]:
+        """Resolve a registry value to a concrete thread tag.
+
+        ``"dm"`` becomes the scope's current DM thread (ncrisc by default,
+        brisc inside an if_src callback). ``"control"`` returns None since
+        compile-time ops don't pin a thread.
+        """
+        if op == "dm":
+            return self._dm_thread
+        if op == "control":
+            return None
+        return op
+
+    # --- post-check: forbid duplicate DM-side reserves ---
+
+    def _check_duplicate_producers(self) -> None:
+        for name, stmts in self._producers.items():
+            threads = self.block_threads.get(name, frozenset())
+            if "ncrisc" in threads and "brisc" in threads:
+                raise _split_error(
+                    stmts[0],
+                    f"DFB '{name}' is used on both NCRISC (e.g. an if_dst "
+                    f"callback or non-pipe DM op) and BRISC (an if_src "
+                    f"callback). Splitting the producer onto both RISCs "
+                    f"would issue two cb_reserve_back / cb_wait_front calls "
+                    f"against the same CB and corrupt its pointer. Inline "
+                    f"the .reserve()/.wait() inside each callback so each "
+                    f"reserve sits on a single RISC.",
+                )
+
+
+# ----- Pass B: prune --------------------------------------------------------
+
+
+def _prune_body(body: List[ast.stmt], side: str) -> List[ast.stmt]:
+    """Walk a deep-copied body and drop anchor stmts not for ``side``.
+    Empty control-flow bodies are filled with ``pass`` (AST well-formedness).
+    """
+    result: List[ast.stmt] = []
+    for stmt in body:
+        kept = _prune_stmt(stmt, side)
+        if kept is not None:
+            result.append(kept)
+    return result if result else [ast.Pass()]
+
+
+def _prune_stmt(stmt: ast.stmt, side: str) -> Optional[ast.stmt]:
+    threads = getattr(stmt, "_ttl_threads", None)
+    if threads is not None and side not in threads:
+        return None
+    if isinstance(stmt, ast.For):
+        stmt.body = _prune_body(stmt.body, side)
+        stmt.orelse = _prune_orelse(stmt.orelse, side)
+    elif isinstance(stmt, ast.While):
+        stmt.body = _prune_body(stmt.body, side)
+        stmt.orelse = _prune_orelse(stmt.orelse, side)
+    elif isinstance(stmt, ast.If):
+        stmt.body = _prune_body(stmt.body, side)
+        stmt.orelse = _prune_orelse(stmt.orelse, side)
+    elif isinstance(stmt, ast.With):
+        stmt.body = _prune_body(stmt.body, side)
+    elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        stmt.body = _prune_body(stmt.body, side)
+    return stmt
+
+
+def _prune_orelse(body: List[ast.stmt], side: str) -> List[ast.stmt]:
+    """Prune an orelse body without inserting a placeholder ``pass``.
+
+    Python treats an empty orelse as 'no else clause'.
+    """
+    result: List[ast.stmt] = []
+    for stmt in body:
+        kept = _prune_stmt(stmt, side)
+        if kept is not None:
+            result.append(kept)
+    return result
+
+
+# ----- helpers --------------------------------------------------------------
+
+
+def _tag(stmt: ast.stmt, threads: Set[str]) -> None:
+    """Annotate a stmt with its anchor thread set. ``frozenset()`` means
+    'drop on every side'.
+    """
+    stmt._ttl_threads = frozenset(threads)
+
+
+def _bare_wait_assign_target(
+    stmt: ast.stmt, dfb_names: Set[str]
+) -> Optional[Tuple[str, str]]:
+    """If ``stmt`` is ``name = <dfb>.wait()`` or ``name = <dfb>.reserve()``,
+    return ``(block_name, dfb_name)``. Otherwise None.
+    """
+    if not isinstance(stmt, ast.Assign):
+        return None
+    if len(stmt.targets) != 1 or not isinstance(stmt.targets[0], ast.Name):
+        return None
+    if not isinstance(stmt.value, ast.Call):
+        return None
+    func = stmt.value.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if func.attr not in _DFB_PRODUCING_METHODS:
+        return None
+    if not isinstance(func.value, ast.Name):
+        return None
+    if func.value.id not in dfb_names:
+        return None
+    return stmt.targets[0].id, func.value.id
+
+
+def _with_item_block_name(item: ast.withitem, dfb_names: Set[str]) -> Optional[str]:
+    """If ``item`` is ``<dfb>.wait()/reserve() as name``, return ``name``."""
+    ctx = item.context_expr
+    if not isinstance(ctx, ast.Call):
+        return None
+    func = ctx.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if func.attr not in _DFB_PRODUCING_METHODS:
+        return None
+    if not isinstance(func.value, ast.Name):
+        return None
+    if func.value.id not in dfb_names:
+        return None
+    if not isinstance(item.optional_vars, ast.Name):
+        return None
+    return item.optional_vars.id
+
+
+def _params_referenced(stmts: List[ast.stmt], param_names: Set[str]) -> Set[str]:
+    used: Set[str] = set()
+    for stmt in stmts:
+        for sub in ast.walk(stmt):
+            if isinstance(sub, ast.Name) and sub.id in param_names:
+                used.add(sub.id)
+    return used
+
+
+def _expr_root_name(node) -> Optional[str]:
+    """Leftmost Name id of an expression, or None."""
+    while True:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            node = node.value
+            continue
+        if isinstance(node, ast.Subscript):
+            node = node.value
+            continue
+        if isinstance(node, ast.Call):
+            node = node.func
+            continue
+        return None
+
+
+def _split_error(node, msg: str) -> ValueError:
+    line = getattr(node, "lineno", "?")
+    return ValueError(f"@ttl.atom split: {msg} (line {line})")
+
+
+# ----- block use collection (shadow-aware) ---------------------------------
+
+
+def _iter_skip_nested_fns(root):
+    """Yield every AST node in ``root`` without crossing into nested
+    FunctionDef / AsyncFunctionDef / Lambda scopes.
+    """
+    stack = [root]
+    while stack:
+        n = stack.pop()
+        yield n
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(n))
+
+
+def _walk_skip_nested_fns_iter(stmts: List[ast.stmt]):
+    """Same as ``_iter_skip_nested_fns`` but over a stmt list."""
+    for stmt in stmts:
+        yield from _iter_skip_nested_fns(stmt)
+
+
+def _local_bindings(fn_node) -> Set[str]:
+    """Names locally bound inside a FunctionDef/AsyncFunctionDef/Lambda."""
+    locals_: Set[str] = set()
+    args = fn_node.args
+    for arg_list in (args.args, args.posonlyargs, args.kwonlyargs):
+        for a in arg_list:
+            locals_.add(a.arg)
+    if args.vararg:
+        locals_.add(args.vararg.arg)
+    if args.kwarg:
+        locals_.add(args.kwarg.arg)
+
+    if isinstance(fn_node, ast.Lambda):
+        return locals_
+
+    for stmt in fn_node.body:
+        for sub in _iter_skip_nested_fns(stmt):
+            if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                locals_.add(sub.name)
+            elif isinstance(sub, ast.Assign):
+                for t in sub.targets:
+                    for n in ast.walk(t):
+                        if isinstance(n, ast.Name):
+                            locals_.add(n.id)
+            elif isinstance(sub, (ast.AugAssign, ast.AnnAssign)):
+                if isinstance(sub.target, ast.Name):
+                    locals_.add(sub.target.id)
+            elif isinstance(sub, ast.For):
+                if isinstance(sub.target, ast.Name):
+                    locals_.add(sub.target.id)
+                elif isinstance(sub.target, ast.Tuple):
+                    for elt in sub.target.elts:
+                        if isinstance(elt, ast.Name):
+                            locals_.add(elt.id)
+            elif isinstance(sub, ast.With):
+                for item in sub.items:
+                    if isinstance(item.optional_vars, ast.Name):
+                        locals_.add(item.optional_vars.id)
+    return locals_
+
+
+def _collect_block_users(
+    stmts: List[ast.stmt],
+    block_names: Set[str],
+    dfb_names: Set[str],
+    dm_thread: str = "ncrisc",
+    brisc_callbacks: Optional[Set[str]] = None,
+) -> Dict[str, Set[str]]:
+    """For each block name, the set of threads ("trisc"/"ncrisc"/"brisc")
+    on which it has an anchor-relevant use. Walks nested functions and
+    lambdas with shadow awareness: a re-bound name inside a callback
+    hides the outer name.
+
+    ``dm_thread`` is the concrete thread for DM-classified ops in the
+    current scope (default "ncrisc"). When the walker descends into a
+    callback recognized as an if_src dispatch target (a FunctionDef whose
+    name is in ``brisc_callbacks``, or the lambda/named-arg of an
+    ``<recv>.if_src(...)`` call), it switches to "brisc". Descent into
+    ``<recv>.if_dst(...)`` arguments forces "ncrisc".
+
+    An anchor-relevant use:
+      - argument to a ttl.* / pipenet method call -> that call's thread
+      - receiver of ``.store(...)`` -> trisc
+      - receiver of ``.pop()``/``.push()`` -> does not pin (sync helper)
+      - operand of MatMult ``@`` or any other BinOp -> trisc
+      - target of an AugAssign -> trisc
+    """
+    brisc_callbacks = brisc_callbacks or set()
+    users: Dict[str, Set[str]] = {n: set() for n in block_names}
+
+    def record_call_args(node: ast.Call, thread: str, visible: Set[str]) -> None:
+        for arg in node.args:
+            root = _expr_root_name(arg)
+            if root in visible:
+                users[root].add(thread)
+        for kw in node.keywords:
+            root = _expr_root_name(kw.value)
+            if root in visible:
+                users[root].add(thread)
+
+    def classify(func, recv, name, visible, dm):
+        if recv == "ttl":
+            op = _TTL_OPS.get(name)
+            if op == "dm":
+                return dm
+            if op in THREADS:
+                return op
+            return None
+        if name in _PIPENET_METHODS:
+            return _PIPENET_METHODS[name]
+        if recv in visible and name == "store":
+            users[recv].add("trisc")
+            return "trisc"
+        return None
+
+    def visit(node, visible, dm):
+        if isinstance(node, ast.Call):
+            func = node.func
+            thread: Optional[str] = None
+            sub_dm = dm
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                recv = func.value.id
+                method = func.attr
+                thread = classify(func, recv, method, visible, dm)
+                if method in _PIPENET_METHODS:
+                    sub_dm = _PIPENET_METHODS[method]
+            elif isinstance(func, ast.Attribute) and isinstance(
+                func.value, ast.Attribute
+            ):
+                outer = func.value
+                if isinstance(outer.value, ast.Name) and outer.value.id == "ttl":
+                    ns_thread = _TTL_NAMESPACES.get(outer.attr)
+                    if ns_thread == "dm":
+                        thread = dm
+                    elif ns_thread in THREADS:
+                        thread = ns_thread
+            if thread is not None:
+                record_call_args(node, thread, visible)
+            for arg in node.args:
+                visit(arg, visible, sub_dm)
+            for kw in node.keywords:
+                visit(kw.value, visible, sub_dm)
+            return
+        if isinstance(node, ast.BinOp):
+            for side in (node.left, node.right):
+                root = _expr_root_name(side)
+                if root in visible:
+                    users[root].add("trisc")
+        elif isinstance(node, ast.AugAssign):
+            target = _expr_root_name(node.target)
+            if target in visible:
+                users[target].add("trisc")
+            rhs = _expr_root_name(node.value)
+            if rhs in visible:
+                users[rhs].add("trisc")
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Subscript):
+                    root = _expr_root_name(tgt.value)
+                    if root in visible:
+                        users[root].add("trisc")
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            inner = visible - _local_bindings(node)
+            sub_dm = "brisc" if node.name in brisc_callbacks else dm
+            for child in node.body:
+                visit(child, inner, sub_dm)
+            return
+        if isinstance(node, ast.Lambda):
+            inner = visible - _local_bindings(node)
+            visit(node.body, inner, dm)
+            return
+
+        for child in ast.iter_child_nodes(node):
+            visit(child, visible, dm)
+
+    for stmt in stmts:
+        visit(stmt, block_names, dm_thread)
+    return users

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -97,6 +97,7 @@ _TTL_OPS: Dict[str, str] = {
     "PipeNet": "control",
     "make_dataflow_buffer_like": "control",
     "node": "control",
+    "grid_size": "control",
     "dims": "control",
     "cores": "control",
     "tile_index": "control",

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -90,6 +90,7 @@ _TTL_OPS: Dict[str, str] = {
     "log": "trisc",
     "abs": "trisc",
     "relu": "trisc",
+    "sign": "trisc",
     "sigmoid": "trisc",
     "gelu": "trisc",
     # Compile-time / scalar producers: duplicated, not anchored.

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -641,6 +641,11 @@ class TTLGenericCompiler(TTCompilerBase):
                 if not func_args and not kwargs and node.attr == "shape":
                     value = self.visit(node.value)
                     if value is not None and hasattr(value, "type"):
+                        # A DFB block's .shape is its tile-block shape; checked
+                        # before the tensor case so cb.shape works too.
+                        cb_ty = ttl.CircularBufferType.maybe_downcast(value.type)
+                        if cb_ty is not None:
+                            return tuple(cb_ty.shape)
                         tensor_ty = RankedTensorType.maybe_downcast(value.type)
                         if tensor_ty is not None:
                             return tuple(tensor_ty.shape)

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -285,9 +285,25 @@ def _synthesize_thread_module(fn_name: str, body: List[ast.stmt]) -> ast.Module:
     return ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
 
 
+def _dfb_l1_elems(dfb: DataflowBuffer) -> int:
+    """Total tiles a DFB occupies in L1 (per-block elements x block_count)."""
+    n = dfb.block_count
+    for s in dfb.shape:
+        n *= s
+    return n
+
+
 def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
-    """DataflowBuffer list indexed by CB index, matching _collect_cb_configs."""
-    by_index = {dfb._cb_index: dfb for dfb in lifted.values()}
+    """DataflowBuffer list indexed by CB index, matching _collect_cb_configs.
+
+    Indices are declaration-dense here; the finalize pass overlays scratch
+    DFBs onto shared indices in MLIR and the runtime applies its index map.
+    """
+    by_index: Dict[int, DataflowBuffer] = {}
+    for dfb in lifted.values():
+        cur = by_index.get(dfb._cb_index)
+        if cur is None or _dfb_l1_elems(dfb) > _dfb_l1_elems(cur):
+            by_index[dfb._cb_index] = dfb
     if not by_index:
         return []
     return [by_index.get(i) for i in range(max(by_index) + 1)]

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -53,11 +53,15 @@ from .dataflow_buffer import (
     make_dfb,
 )
 from .dtype_utils import is_ttnn_tensor
+from .pipe import PipeNet
 
 
-# Names whose top-level ``x = <name>(...)`` assigns are lifted out of the
-# body and evaluated to DataflowBuffer capture objects before the split.
+# Names whose top-level ``x = <name>(...)`` assigns are lifted out of the body
+# and evaluated to capture objects (DataflowBuffer / Pipe / PipeNet) before the
+# split, the same way @ttl.operation constructs them in its setup body.
 _DFB_FACTORY_NAMES = {"make_dfb", "make_dataflow_buffer_like"}
+_PIPE_FACTORY_NAMES = {"Pipe", "PipeNet"}
+_SETUP_FACTORY_NAMES = _DFB_FACTORY_NAMES | _PIPE_FACTORY_NAMES
 
 
 class DFB:
@@ -176,45 +180,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     )
 
 
-def _lift_dfb_assigns(
-    fn_def: ast.FunctionDef,
-    eval_scope: Dict[str, Any],
-) -> Tuple[ast.FunctionDef, Dict[str, DataflowBuffer]]:
-    """Evaluate and strip top-level ``name = make_dfb(...)`` /
-    ``make_dataflow_buffer_like(...)`` assigns.
-
-    Returns a function with those statements removed and a mapping from
-    DFB variable name to the evaluated DataflowBuffer. The evaluation
-    order is source order, which fixes the CB-index order (matching the
-    @ttl.operation setup-body order).
-    """
-    lifted: Dict[str, DataflowBuffer] = {}
-    kept: List[ast.stmt] = []
-    ns = dict(eval_scope)
-    ns.setdefault("make_dfb", make_dfb)
-    ns.setdefault("make_dataflow_buffer_like", make_dataflow_buffer_like)
-
-    for stmt in fn_def.body:
-        target = _dfb_assign_target(stmt)
-        if target is None:
-            kept.append(stmt)
-            continue
-        value = eval(ast.unparse(stmt.value), ns)  # noqa: S307
-        if not isinstance(value, DataflowBuffer):
-            kept.append(stmt)
-            continue
-        lifted[target] = value
-        ns[target] = value
-
-    _reject_unsupported_pipes(fn_def)
-
-    new_fn = copy.copy(fn_def)
-    new_fn.body = kept
-    return new_fn, lifted
-
-
-def _dfb_assign_target(stmt: ast.stmt) -> Optional[str]:
-    """If ``stmt`` is ``name = <dfb-factory>(...)``, return ``name``."""
+def _setup_assign_target(stmt: ast.stmt) -> Optional[str]:
+    """If ``stmt`` is ``name = <dfb/pipe-factory>(...)``, return ``name``."""
     if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
         return None
     if not isinstance(stmt.targets[0], ast.Name):
@@ -222,26 +189,59 @@ def _dfb_assign_target(stmt: ast.stmt) -> Optional[str]:
     if not isinstance(stmt.value, ast.Call):
         return None
     func = stmt.value.func
-    fname = func.attr if isinstance(func, ast.Attribute) else (
-        func.id if isinstance(func, ast.Name) else None
+    fname = (
+        func.attr
+        if isinstance(func, ast.Attribute)
+        else (func.id if isinstance(func, ast.Name) else None)
     )
-    if fname not in _DFB_FACTORY_NAMES:
+    if fname not in _SETUP_FACTORY_NAMES:
         return None
     return stmt.targets[0].id
 
 
-def _reject_unsupported_pipes(fn_def: ast.FunctionDef) -> None:
-    for node in ast.walk(fn_def):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            if node.func.attr in ("PipeNet", "Pipe"):
-                raise NotImplementedError(
-                    "@ttl.atom: PipeNet/Pipe support is not yet implemented"
-                )
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-            if node.func.id in ("PipeNet", "Pipe"):
-                raise NotImplementedError(
-                    "@ttl.atom: PipeNet/Pipe support is not yet implemented"
-                )
+def _lift_setup(
+    fn_def: ast.FunctionDef,
+    scope: Dict[str, Any],
+) -> Tuple[ast.FunctionDef, Dict[str, DataflowBuffer], Dict[str, PipeNet]]:
+    """Strip and evaluate the top-level DFB / Pipe / PipeNet construction
+    assigns.
+
+    Returns the kernel body with those statements removed, plus the
+    DataflowBuffer and PipeNet objects keyed by name. Each construction
+    expression is evaluated in source order in a controlled namespace, with
+    results threaded back in so a later ``PipeNet([p0])`` sees an earlier
+    ``p0`` and CB indices are assigned in source order. This runs just the
+    setup statements that @ttl.operation runs as part of executing its whole
+    body; the per-thread compiler consumes the results as captures, not as
+    in-body calls.
+    """
+    import ttl as _ttl
+
+    ns = dict(scope)
+    ns.setdefault("make_dfb", make_dfb)
+    ns.setdefault("make_dataflow_buffer_like", make_dataflow_buffer_like)
+    ns.setdefault("ttl", _ttl)
+
+    dfbs: Dict[str, DataflowBuffer] = {}
+    nets: Dict[str, PipeNet] = {}
+    kept: List[ast.stmt] = []
+    for stmt in fn_def.body:
+        name = _setup_assign_target(stmt)
+        if name is None:
+            kept.append(stmt)
+            continue
+        value = eval(ast.unparse(stmt.value), ns)  # noqa: S307
+        ns[name] = value
+        if isinstance(value, DataflowBuffer):
+            dfbs[name] = value
+        elif isinstance(value, PipeNet):
+            nets[name] = value
+        # A bare Pipe stays in ns for a later PipeNet reference but is not a
+        # capture; only DataflowBuffers and PipeNets are bound on threads.
+
+    new_fn = copy.copy(fn_def)
+    new_fn.body = kept
+    return new_fn, dfbs, nets
 
 
 def _has_real_work(body: List[ast.stmt]) -> bool:
@@ -309,10 +309,10 @@ def _compile_atom(
     target_arch: Optional[str],
     compiler_options: CompilerOptions,
 ):
-    from ._pipenets import OperationPipeNets
     from .operators import _set_current_grid
     from .ttl_api import (
         Program,
+        _build_pipenet_graph,
         _detect_memory_space_from_tensor,
         _lower_program_to_kernel,
         _require_device,
@@ -349,24 +349,30 @@ def _compile_atom(
     _reset_cb_counter()
     _set_current_grid(grid)
 
-    stripped_fn, lifted = _lift_dfb_assigns(spec.fn_ast, eval_scope)
+    stripped_fn, dfbs, nets = _lift_setup(spec.fn_ast, eval_scope)
+
+    # Assign each PipeNet a distinct operation-local id (and validate), the
+    # same graph @ttl.operation builds; it also yields the runner's pipe
+    # semaphore count.
+    pipe_graph = _build_pipenet_graph(nets.values())
 
     split = split_function_body(
         fn_def=stripped_fn,
         dfb_param_names=set(spec.dfb_param_names),
         all_param_names={p.name for p in spec.params},
-        local_dfb_names=set(lifted),
+        local_dfb_names=set(dfbs),
     )
 
     # Captures shared by every thread: ttnn tensors and scalars (bound
-    # values) plus the lifted DFBs. Tensor/DFB captures are included on all
-    # threads to keep the tensor-accessor and CB layout stable; unused ones
-    # are removed by MLIR DCE.
+    # values), the lifted DFBs, and the lifted PipeNets. Tensor/DFB captures
+    # are included on all threads to keep the tensor-accessor and CB layout
+    # stable; unused ones are removed by MLIR DCE.
     captures: Dict[str, Any] = {}
     for pname, val in bound.arguments.items():
         if is_ttnn_tensor(val) or isinstance(val, (int, float)):
             captures[pname] = val
-    captures.update(lifted)
+    captures.update(dfbs)
+    captures.update(nets)
 
     threads = []
     for kernel_type, thread in (
@@ -401,8 +407,8 @@ def _compile_atom(
         args=args,
         launch_grid=grid,
         num_outs=num_outs,
-        cb_configs=_cb_configs_from_lifted(lifted),
-        pipenets=OperationPipeNets(),
+        cb_configs=_cb_configs_from_lifted(dfbs),
+        pipenets=pipe_graph,
         target_arch=target_arch,
         fp32_dest_acc_en=fp32_dest_acc_en,
         dst_full_sync_en=dst_full_sync_en,

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -215,9 +215,7 @@ def _setup_assign_target(stmt: ast.stmt) -> Optional[str]:
         return None
     if not isinstance(stmt.targets[0], ast.Name):
         return None
-    if _call_name(stmt.value) in _SETUP_FACTORY_NAMES or _is_pipe_list_expr(
-        stmt.value
-    ):
+    if _call_name(stmt.value) in _SETUP_FACTORY_NAMES or _is_pipe_list_expr(stmt.value):
         return stmt.targets[0].id
     return None
 

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -374,21 +374,24 @@ def _compile_atom(
     captures.update(dfbs)
     captures.update(nets)
 
+    # TTNN interop requires exactly 3 kernels (1 compute + 2 data movement);
+    # emit all three even when a thread has no work, filling it with a pass
+    # body, the same shape @ttl.operation produces.
     threads = []
+    any_real_work = False
     for kernel_type, thread in (
         ("compute", "trisc"),
         ("datamovement", "ncrisc"),
         ("datamovement", "brisc"),
     ):
         body = split.body_for(thread)
-        if not _has_real_work(body):
-            continue
+        any_real_work = any_real_work or _has_real_work(body)
         fn_name = f"{spec.name}__{thread}"
         threads.append(
             _make_thread_callable(spec, kernel_type, fn_name, body, captures)
         )
 
-    if not threads:
+    if not any_real_work:
         raise ValueError(
             f"@ttl.atom '{spec.name}': body contained no compute or data "
             f"movement work after classification"

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -180,23 +180,46 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     )
 
 
+def _call_name(node: ast.expr) -> Optional[str]:
+    """The callee name of a Call node (``ttl.Pipe`` -> ``Pipe``), else None."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _is_pipe_list_expr(node: ast.expr) -> bool:
+    """A list/tuple/comprehension whose elements are all ``ttl.Pipe(...)``.
+
+    Lets a PipeNet be built from a separately-named pipe list
+    (``ps = [ttl.Pipe(...) for ...]; net = ttl.PipeNet(ps)``), the natural
+    way to express multicast/reduce fan-out.
+    """
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return bool(node.elts) and all(_call_name(e) == "Pipe" for e in node.elts)
+    if isinstance(node, (ast.ListComp, ast.GeneratorExp)):
+        return _call_name(node.elt) == "Pipe"
+    return False
+
+
 def _setup_assign_target(stmt: ast.stmt) -> Optional[str]:
-    """If ``stmt`` is ``name = <dfb/pipe-factory>(...)``, return ``name``."""
+    """If ``stmt`` is a DFB/Pipe/PipeNet construction assign, return its name.
+
+    Recognizes ``name = <dfb/pipe-factory>(...)`` and ``name = [<pipes>]``
+    (a pipe list feeding a later PipeNet)."""
     if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
         return None
     if not isinstance(stmt.targets[0], ast.Name):
         return None
-    if not isinstance(stmt.value, ast.Call):
-        return None
-    func = stmt.value.func
-    fname = (
-        func.attr
-        if isinstance(func, ast.Attribute)
-        else (func.id if isinstance(func, ast.Name) else None)
-    )
-    if fname not in _SETUP_FACTORY_NAMES:
-        return None
-    return stmt.targets[0].id
+    if _call_name(stmt.value) in _SETUP_FACTORY_NAMES or _is_pipe_list_expr(
+        stmt.value
+    ):
+        return stmt.targets[0].id
+    return None
 
 
 def _lift_setup(
@@ -362,6 +385,14 @@ def _compile_atom(
         all_param_names={p.name for p in spec.params},
         local_dfb_names=set(dfbs),
     )
+
+    if os.environ.get("TTLANG_ATOM_DUMP_SPLIT"):
+        for _thread in ("trisc", "ncrisc", "brisc"):
+            _dbg = _synthesize_thread_module(
+                f"{spec.name}__{_thread}", split.body_for(_thread)
+            )
+            print(f"\n===== @ttl.atom split: {_thread} =====")
+            print(ast.unparse(_dbg))
 
     # Captures shared by every thread: ttnn tensors and scalars (bound
     # values), the lifted DFBs, and the lifted PipeNets. Tensor/DFB captures

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -1,0 +1,516 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""@ttl.atom: unified-body kernels with automatic thread splitting.
+
+Unlike @ttl.operation, which requires the author to write one
+@ttl.compute and two @ttl.datamovement thread functions explicitly, a
+@ttl.atom is a single function body. At decoration time, statement-level
+calls to other @ttl.atom functions are inlined; at compile time the
+unified body is split into compute (TRISC) and data-movement
+(NCRISC / BRISC) threads, which then flow through the same MLIR pipeline
+as @ttl.operation.
+
+An atom may take ttnn tensors (resolved at the call site, exactly like
+@ttl.operation), compile-time scalars, and -- for atoms intended to be
+inlined into another atom -- ttl.DFB parameters. DataFlow buffers used
+within a top-level atom are declared in the body via ttl.make_dfb /
+ttl.make_dataflow_buffer_like; a DFB-parameter atom has no way to be
+supplied a buffer except by being inlined, so it is never a JIT entry
+point.
+
+DFB declarations sit inline with the compute/copy work in a unified
+body, so after the split they land inside each thread body. The existing
+per-thread compiler is capture-based (thread functions take no
+parameters; DFBs arrive as closure captures), so before splitting we
+lift the top-level ``name = make_dfb(...)`` assigns out of the body,
+evaluate them to DataflowBuffer objects, and pass them as captures --
+the same shape the @ttl.operation flow produces by running its setup
+body. After that the per-thread compile, CB sizing, pass pipeline, and
+runner are identical to @ttl.operation.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import functools
+import inspect
+import os
+import random
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from ._src.atom_inline import inline_atom_calls
+from ._src.atom_split import split_function_body
+from ._src.tensor_registry import register_tensor_name
+from .compiler_options import CompilerOptions
+from .dataflow_buffer import (
+    DataflowBuffer,
+    _reset_cb_counter,
+    make_dataflow_buffer_like,
+    make_dfb,
+)
+from .dtype_utils import is_ttnn_tensor
+
+
+# Names whose top-level ``x = <name>(...)`` assigns are lifted out of the
+# body and evaluated to DataflowBuffer capture objects before the split.
+_DFB_FACTORY_NAMES = {"make_dfb", "make_dataflow_buffer_like"}
+
+
+class DFB:
+    """Marker annotation for a DataFlow buffer parameter.
+
+    Only meaningful on an atom that is inlined into another atom: the
+    caller declares the buffer (ttl.make_dfb / make_dataflow_buffer_like)
+    and passes it in, and the inliner substitutes it at the call site.
+    """
+
+
+@dataclass
+class _ParamInfo:
+    name: str
+    kind: str  # "dfb" | "pipenet" | "value"
+    is_keyword_only: bool
+
+
+@dataclass
+class _AtomSpec:
+    name: str
+    fn: Callable
+    source: str
+    source_file: str
+    line_offset: int
+    fn_ast: ast.FunctionDef  # post-inline
+    params: List[_ParamInfo]
+    dfb_param_names: List[str]
+
+
+def _function_scope(fn: Callable) -> Dict[str, Any]:
+    """Globals plus resolved closure cells for a function, used as the
+    scope for inlining lookups and for evaluating lifted DFB assigns."""
+    scope = dict(getattr(fn, "__globals__", {}) or {})
+    closure = getattr(fn, "__closure__", None)
+    freevars = getattr(fn.__code__, "co_freevars", ())
+    if closure:
+        for name, cell in zip(freevars, closure):
+            try:
+                scope[name] = cell.cell_contents
+            except ValueError:
+                continue
+    return scope
+
+
+def _classify_params(fn: Callable) -> List[_ParamInfo]:
+    from .pipe import PipeNet
+
+    info: List[_ParamInfo] = []
+    for pname, p in inspect.signature(fn).parameters.items():
+        if p.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            raise ValueError(
+                f"@ttl.atom: *args / **kwargs are not allowed (param {pname!r})"
+            )
+        ann = p.annotation
+        if ann is DFB:
+            kind = "dfb"
+        elif ann is PipeNet:
+            kind = "pipenet"
+        else:
+            kind = "value"
+        info.append(
+            _ParamInfo(
+                name=pname,
+                kind=kind,
+                is_keyword_only=(p.kind == inspect.Parameter.KEYWORD_ONLY),
+            )
+        )
+    return info
+
+
+def _build_atom_spec(fn: Callable) -> _AtomSpec:
+    from ttl.pykernel._src.utils import _cleanup_source_code
+
+    name = fn.__name__
+    try:
+        source_file = inspect.getfile(fn)
+    except (TypeError, OSError):
+        source_file = "<unknown>"
+
+    raw_lines, start_lineno = inspect.getsourcelines(fn)
+    num_decorator_lines = 0
+    for line in raw_lines:
+        stripped = line.strip()
+        if stripped.startswith("@"):
+            num_decorator_lines += 1
+        elif stripped.startswith("def ") or stripped.startswith("async def "):
+            break
+    line_offset = start_lineno + num_decorator_lines - 1
+
+    module = ast.parse(_cleanup_source_code(fn))
+    if len(module.body) != 1 or not isinstance(module.body[0], ast.FunctionDef):
+        raise ValueError(
+            f"@ttl.atom: expected a single function definition for {name!r}"
+        )
+    fn_def: ast.FunctionDef = module.body[0]
+
+    # Inline statement-level calls to other @ttl.atom functions, then keep
+    # the post-inline AST + source.
+    inline_atom_calls(fn_def, _function_scope(fn), caller_name=name)
+    source = ast.unparse(fn_def)
+
+    params = _classify_params(fn)
+    return _AtomSpec(
+        name=name,
+        fn=fn,
+        source=source,
+        source_file=source_file,
+        line_offset=line_offset,
+        fn_ast=fn_def,
+        params=params,
+        dfb_param_names=[p.name for p in params if p.kind == "dfb"],
+    )
+
+
+def _lift_dfb_assigns(
+    fn_def: ast.FunctionDef,
+    eval_scope: Dict[str, Any],
+) -> Tuple[ast.FunctionDef, Dict[str, DataflowBuffer]]:
+    """Evaluate and strip top-level ``name = make_dfb(...)`` /
+    ``make_dataflow_buffer_like(...)`` assigns.
+
+    Returns a function with those statements removed and a mapping from
+    DFB variable name to the evaluated DataflowBuffer. The evaluation
+    order is source order, which fixes the CB-index order (matching the
+    @ttl.operation setup-body order).
+    """
+    lifted: Dict[str, DataflowBuffer] = {}
+    kept: List[ast.stmt] = []
+    ns = dict(eval_scope)
+    ns.setdefault("make_dfb", make_dfb)
+    ns.setdefault("make_dataflow_buffer_like", make_dataflow_buffer_like)
+
+    for stmt in fn_def.body:
+        target = _dfb_assign_target(stmt)
+        if target is None:
+            kept.append(stmt)
+            continue
+        value = eval(ast.unparse(stmt.value), ns)  # noqa: S307
+        if not isinstance(value, DataflowBuffer):
+            kept.append(stmt)
+            continue
+        lifted[target] = value
+        ns[target] = value
+
+    _reject_unsupported_pipes(fn_def)
+
+    new_fn = copy.copy(fn_def)
+    new_fn.body = kept
+    return new_fn, lifted
+
+
+def _dfb_assign_target(stmt: ast.stmt) -> Optional[str]:
+    """If ``stmt`` is ``name = <dfb-factory>(...)``, return ``name``."""
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    if not isinstance(stmt.targets[0], ast.Name):
+        return None
+    if not isinstance(stmt.value, ast.Call):
+        return None
+    func = stmt.value.func
+    fname = func.attr if isinstance(func, ast.Attribute) else (
+        func.id if isinstance(func, ast.Name) else None
+    )
+    if fname not in _DFB_FACTORY_NAMES:
+        return None
+    return stmt.targets[0].id
+
+
+def _reject_unsupported_pipes(fn_def: ast.FunctionDef) -> None:
+    for node in ast.walk(fn_def):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in ("PipeNet", "Pipe"):
+                raise NotImplementedError(
+                    "@ttl.atom: PipeNet/Pipe support is not yet implemented"
+                )
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in ("PipeNet", "Pipe"):
+                raise NotImplementedError(
+                    "@ttl.atom: PipeNet/Pipe support is not yet implemented"
+                )
+
+
+def _has_real_work(body: List[ast.stmt]) -> bool:
+    """A pruned body is empty if it holds only the ``pass`` placeholder."""
+    return any(not isinstance(s, ast.Pass) for s in body)
+
+
+def _synthesize_thread_module(fn_name: str, body: List[ast.stmt]) -> ast.Module:
+    """A module holding one no-arg thread function for TTLGenericCompiler."""
+    fn = ast.FunctionDef(
+        name=fn_name,
+        args=ast.arguments(
+            posonlyargs=[], args=[], kwonlyargs=[], kw_defaults=[], defaults=[]
+        ),
+        body=copy.deepcopy(body) or [ast.Pass()],
+        decorator_list=[],
+        returns=None,
+        type_comment=None,
+    )
+    return ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
+
+
+def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
+    """DataflowBuffer list indexed by CB index, matching _collect_cb_configs."""
+    by_index = {dfb._cb_index: dfb for dfb in lifted.values()}
+    if not by_index:
+        return []
+    return [by_index.get(i) for i in range(max(by_index) + 1)]
+
+
+def _make_thread_callable(spec, kernel_type, fn_name, body, captures):
+    from .ttl_api import _run_thread_compiler
+
+    def _compile_thread(*args, **kwargs):
+        kwargs = dict(kwargs)
+        kwargs["_source_file"] = spec.source_file
+        kwargs["_source_lines"] = spec.source.splitlines()
+        kwargs["_line_offset"] = spec.line_offset
+        return _run_thread_compiler(
+            fn_name,
+            kernel_type,
+            captures,
+            _function_scope(spec.fn),
+            (),
+            kwargs,
+            _synthesize_thread_module(fn_name, body),
+            kwargs["_source_lines"],
+            spec.source_file,
+        )
+
+    return _compile_thread
+
+
+def _compile_atom(
+    spec: _AtomSpec,
+    args: tuple,
+    kwargs: dict,
+    grid,
+    num_outs: int,
+    memory_space: str,
+    tiled: bool,
+    program_hash: int,
+    fp32_dest_acc_en: Optional[bool],
+    dst_full_sync_en: Optional[bool],
+    target_arch: Optional[str],
+    compiler_options: CompilerOptions,
+):
+    from ._pipenets import OperationPipeNets
+    from .operators import _set_current_grid
+    from .ttl_api import (
+        Program,
+        _detect_memory_space_from_tensor,
+        _lower_program_to_kernel,
+        _require_device,
+        get_min_remaining_l1_for_device,
+    )
+
+    # Bind call-site values to parameter names.
+    bound = inspect.signature(spec.fn).bind(*args, **kwargs)
+    eval_scope = dict(_function_scope(spec.fn))
+    eval_scope.update(bound.arguments)
+
+    # Register ttnn tensors so the per-thread compiler can resolve global
+    # tensor indices for its tensor accessors.
+    for idx, (pname, val) in enumerate(bound.arguments.items()):
+        if is_ttnn_tensor(val):
+            register_tensor_name(val, pname, index=idx)
+
+    # Detect L1 vs DRAM addressing from the first tensor (matching
+    # @ttl.operation), since the tensor accessor type depends on it.
+    first_tensor = next(
+        (v for v in bound.arguments.values() if is_ttnn_tensor(v)), None
+    )
+    if first_tensor is not None:
+        memory_space = _detect_memory_space_from_tensor(first_tensor, memory_space)
+
+    has_ttnn_tensors = any(is_ttnn_tensor(v) for v in bound.arguments.values())
+    l1_budget_override = compiler_options.l1_budget
+    if l1_budget_override == 0 and has_ttnn_tensors:
+        try:
+            l1_budget_override = get_min_remaining_l1_for_device(_require_device(args))
+        except ValueError:
+            pass
+
+    _reset_cb_counter()
+    _set_current_grid(grid)
+
+    stripped_fn, lifted = _lift_dfb_assigns(spec.fn_ast, eval_scope)
+
+    split = split_function_body(
+        fn_def=stripped_fn,
+        dfb_param_names=set(spec.dfb_param_names),
+        all_param_names={p.name for p in spec.params},
+        local_dfb_names=set(lifted),
+    )
+
+    # Captures shared by every thread: ttnn tensors and scalars (bound
+    # values) plus the lifted DFBs. Tensor/DFB captures are included on all
+    # threads to keep the tensor-accessor and CB layout stable; unused ones
+    # are removed by MLIR DCE.
+    captures: Dict[str, Any] = {}
+    for pname, val in bound.arguments.items():
+        if is_ttnn_tensor(val) or isinstance(val, (int, float)):
+            captures[pname] = val
+    captures.update(lifted)
+
+    threads = []
+    for kernel_type, thread in (
+        ("compute", "trisc"),
+        ("datamovement", "ncrisc"),
+        ("datamovement", "brisc"),
+    ):
+        body = split.body_for(thread)
+        if not _has_real_work(body):
+            continue
+        fn_name = f"{spec.name}__{thread}"
+        threads.append(
+            _make_thread_callable(spec, kernel_type, fn_name, body, captures)
+        )
+
+    if not threads:
+        raise ValueError(
+            f"@ttl.atom '{spec.name}': body contained no compute or data "
+            f"movement work after classification"
+        )
+
+    injected_program_kwargs = {
+        "grid": grid,
+        "memory_space": memory_space,
+        "tiled": tiled,
+        "debug_locations": True,
+    }
+    program = Program(*threads, args=args, kwargs=injected_program_kwargs)
+
+    return _lower_program_to_kernel(
+        program=program,
+        args=args,
+        launch_grid=grid,
+        num_outs=num_outs,
+        cb_configs=_cb_configs_from_lifted(lifted),
+        pipenets=OperationPipeNets(),
+        target_arch=target_arch,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        dst_full_sync_en=dst_full_sync_en,
+        compiler_options=compiler_options,
+        program_hash=program_hash,
+        l1_budget_override=l1_budget_override,
+        kernel_source_file=spec.source_file,
+        kernel_line_offset=spec.line_offset,
+    )
+
+
+class Atom:
+    """A @ttl.atom kernel: inline-able as a callee, JIT-compiled at top level."""
+
+    def __init__(self, spec: _AtomSpec, decorator_opts: dict):
+        self._spec = spec
+        self._opts = decorator_opts
+        self._kernel_id = random.getrandbits(64)
+        self._cache: Dict[tuple, Any] = {}
+        functools.update_wrapper(self, spec.fn)
+
+    @property
+    def name(self) -> str:
+        return self._spec.name
+
+    def __call__(self, *args, **kwargs):
+        from .ttl_api import (
+            _device_target_arch,
+            _make_cache_key,
+            _resolve_grid,
+            _should_execute,
+        )
+
+        opts = self._opts
+        resolved_grid = _resolve_grid(opts["grid"], args, kwargs)
+
+        opts_str = kwargs.pop("options", opts["options"])
+        env_opts = os.environ.get("TTLANG_COMPILER_OPTIONS")
+        if env_opts:
+            opts_str = f"{opts_str or ''} {env_opts}".strip() or None
+        compiler_options = CompilerOptions.from_string(opts_str).merge(
+            CompilerOptions.from_argv()
+        )
+        target_arch = _device_target_arch(args)
+
+        cache_key = _make_cache_key(
+            args,
+            fp32_dest_acc_en=opts["fp32_dest_acc_en"],
+            dst_full_sync_en=opts["dst_full_sync_en"],
+            target_arch=target_arch,
+            compiler_options=compiler_options,
+        )
+
+        compiled_kernel = self._cache.get(cache_key)
+        if compiled_kernel is None:
+            compiled_kernel = _compile_atom(
+                self._spec,
+                args,
+                kwargs,
+                resolved_grid,
+                opts["num_outs"],
+                opts["memory_space"],
+                opts["tiled"],
+                hash((self._kernel_id, cache_key)),
+                fp32_dest_acc_en=opts["fp32_dest_acc_en"],
+                dst_full_sync_en=opts["dst_full_sync_en"],
+                target_arch=target_arch,
+                compiler_options=compiler_options,
+            )
+            if compiled_kernel is not None:
+                self._cache[cache_key] = compiled_kernel
+
+        if compiled_kernel is not None and _should_execute():
+            return compiled_kernel(*args)
+        return None
+
+
+def atom(
+    grid: Optional[Union[tuple, Callable]] = None,
+    num_outs: int = 1,
+    memory_space: str = "L1",
+    tiled: bool = True,
+    fp32_dest_acc_en: Optional[bool] = None,
+    dst_full_sync_en: Optional[bool] = None,
+    options: Optional[str] = None,
+) -> Callable:
+    """Decorator for a unified-body, auto-split @ttl.atom kernel.
+
+    Accepts the same compile parameters as @ttl.operation (grid, the fp32
+    / dst-sync overrides, compiler options). A grid is required for a
+    top-level atom; an atom used only as an inlined callee needs none.
+    """
+    if num_outs != 1:
+        raise ValueError(f"num_outs must be 1, got {num_outs}")
+
+    def _decorator(f):
+        spec = _build_atom_spec(f)
+        return Atom(
+            spec,
+            {
+                "grid": grid,
+                "num_outs": num_outs,
+                "memory_space": memory_space,
+                "tiled": tiled,
+                "fp32_dest_acc_en": fp32_dest_acc_en,
+                "dst_full_sync_en": dst_full_sync_en,
+                "options": options,
+            },
+        )
+
+    return _decorator

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -66,6 +66,14 @@ class DataflowBuffer:
             raise ValueError(f"DFB shape must have at least 2 dimensions, got {shape}")
         if block_count < 1 or block_count > 32:
             raise ValueError(f"block_count must be in range [1, 32], got {block_count}")
+        # A buffer's dtype has one source: a backing tensor or an explicit
+        # dtype. Supplying both is only valid when they resolve to the same type.
+        if dtype is not None and getattr(tensor, "dtype", None) is not None:
+            if _resolve_dfb_dtype(dtype) != _resolve_dfb_dtype(tensor.dtype):
+                raise ValueError(
+                    f"DataflowBuffer dtype {dtype!r} conflicts with backing "
+                    f"tensor dtype {tensor.dtype!r}; pass only one"
+                )
 
         self.tensor = tensor
         self.shape = shape

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -60,6 +60,7 @@ class DataflowBuffer:
         tensor: Any,
         shape: Tuple[int, ...],
         block_count: int,
+        dtype: Any = None,
     ):
         if len(shape) < 2:
             raise ValueError(f"DFB shape must have at least 2 dimensions, got {shape}")
@@ -69,13 +70,19 @@ class DataflowBuffer:
         self.tensor = tensor
         self.shape = shape
         self.block_count = block_count
+        self._dtype = dtype
         self._cb_index = _next_cb_index()
 
     @property
     def dtype(self):
+        if self._dtype is not None:
+            return self._dtype
         if hasattr(self.tensor, "dtype"):
             return self.tensor.dtype
-        raise ValueError("tensor has no dtype attribute")
+        raise ValueError(
+            "DataflowBuffer has no dtype: build it with a tensor "
+            "(make_dataflow_buffer_like) or an explicit dtype (make_dfb)"
+        )
 
     def wait(ast_self: "DataflowBuffer") -> "TensorBlock":
         """
@@ -154,3 +161,45 @@ def make_dataflow_buffer_like(
         DataflowBuffer for use in thread function closures
     """
     return DataflowBuffer(tensor, shape, block_count)
+
+
+def _resolve_dfb_dtype(dtype: Any):
+    """Resolve a ``make_dfb`` dtype argument to a ttnn.DataType.
+
+    Accepts a data-format name string ("bf16", "float32", ...), a ttnn
+    dtype (returned as-is), or a torch dtype.
+    """
+    from .dtype_utils import format_name_to_ttnn_dtype, torch_dtype_to_ttnn_datatype
+
+    if isinstance(dtype, str):
+        return format_name_to_ttnn_dtype(dtype)
+    if hasattr(dtype, "name"):  # already a ttnn.DataType enum
+        return dtype
+    return torch_dtype_to_ttnn_datatype(dtype)
+
+
+def make_dfb(
+    dtype: Any,
+    shape: Tuple[int, ...],
+    block_count: int = 2,
+) -> DataflowBuffer:
+    """
+    Create a dataflow buffer from an explicit dtype, with no backing tensor.
+
+    Unlike make_dataflow_buffer_like, no dummy tensor is needed.
+
+    Args:
+        dtype: Element data type. Accepts a data-format name string
+            ("bf16", "float32", ...), a ttnn dtype, or a torch dtype.
+        shape: Tile counts per dimension for wait/reserve operations
+        block_count: Capacity multiplier (default 2 for double-buffering)
+
+    Returns:
+        DataflowBuffer for use in thread function closures
+    """
+    return DataflowBuffer(
+        tensor=None,
+        shape=shape,
+        block_count=block_count,
+        dtype=_resolve_dfb_dtype(dtype),
+    )

--- a/python/ttl/dtype_utils.py
+++ b/python/ttl/dtype_utils.py
@@ -175,17 +175,17 @@ def format_name_to_ttnn_dtype(name: str):
         raise RuntimeError("ttnn is not available")
 
     match name:
-        case "bfloat16":
+        case "bfloat16" | "bf16":
             return ttnn.DataType.BFLOAT16
-        case "float16":
+        case "float16" | "f16":
             return ttnn.DataType.BFLOAT16  # hardware implements f16 as bf16
-        case "float32":
+        case "float32" | "f32":
             return ttnn.DataType.FLOAT32
-        case "int32":
+        case "int32" | "i32":
             return ttnn.DataType.INT32
-        case "uint32":
+        case "uint32" | "u32":
             return ttnn.DataType.UINT32
-        case "uint16":
+        case "uint16" | "u16":
             return ttnn.DataType.UINT16
         case _:
             raise ValueError(

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -43,6 +43,14 @@ from .dtype_utils import (
 )
 
 
+def _cb_data_format(cb):
+    """ttnn data format for a DataflowBuffer, from its (torch or ttnn) dtype."""
+    dtype = cb.dtype
+    if hasattr(dtype, "name"):  # already a ttnn.DataType enum
+        return dtype
+    return torch_dtype_to_ttnn_datatype(dtype)
+
+
 def get_min_remaining_l1_for_device(device):
     """Return the minimum remaining L1 CB budget (bytes) across all cores.
 
@@ -398,11 +406,7 @@ def build_cb_descriptors(
                 )
             )
         else:
-            ref_tensor = cb.tensor
-            if hasattr(ref_tensor, "dtype") and hasattr(ref_tensor.dtype, "name"):
-                data_format = ref_tensor.dtype
-            else:
-                data_format = torch_dtype_to_ttnn_datatype(ref_tensor.dtype)
+            data_format = _cb_data_format(cb)
 
             page_size = tile_bytes_from_dtype(data_format)
             num_tiles = cb.shape[0] * cb.shape[1] * cb.block_count
@@ -663,11 +667,7 @@ def emit_runner_source(
         if cb is None:
             lines.append(f"    None,  # CB {i}")
             continue
-        ref_tensor = cb.tensor
-        if hasattr(ref_tensor, "dtype") and hasattr(ref_tensor.dtype, "name"):
-            data_format = ref_tensor.dtype
-        else:
-            data_format = torch_dtype_to_ttnn_datatype(ref_tensor.dtype)
+        data_format = _cb_data_format(cb)
         page_size = tile_bytes_from_dtype(data_format)
         dtype_str = _dtype_to_ttnn_str(data_format)
         num_tiles = cb.shape[0] * cb.shape[1] * cb.block_count

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -578,6 +578,7 @@ def node(*, dims):
     return (ttl.core_x(), ttl.core_y())
 
 
+@syntax("grid_size")
 def grid_size(*, dims):
     """
     Get the size of the grid.

--- a/python/ttl/ttl.py
+++ b/python/ttl/ttl.py
@@ -21,7 +21,8 @@ Math operations:
 """
 
 from .ttl_api import pykernel_gen as operation, compute, datamovement, Program
-from .dataflow_buffer import make_dataflow_buffer_like
+from .atom import atom, DFB
+from .dataflow_buffer import make_dataflow_buffer_like, make_dfb
 from .operators import copy, node, grid_size
 
 # Math operations namespace
@@ -29,10 +30,13 @@ from . import ttl_math as math
 
 __all__ = [
     "operation",
+    "atom",
+    "DFB",
     "compute",
     "datamovement",
     "Program",
     "make_dataflow_buffer_like",
+    "make_dfb",
     "copy",
     "node",
     "grid_size",

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -951,9 +951,6 @@ def _build_operation_pipenets(f: Callable, threads):
     captured PipeNet referenced from multiple threads contributes one
     entry.
     """
-    from ._pipenets import OperationPipeNets
-    from .pipe import _pipe_to_pipe_use
-
     seen: Dict[int, PipeNet] = {}
 
     def visit(func):

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -976,8 +976,19 @@ def _build_operation_pipenets(f: Callable, threads):
     for thread in threads:
         visit(getattr(thread, "__wrapped__", None))
 
+    return _build_pipenet_graph(seen.values())
+
+
+def _build_pipenet_graph(nets):
+    """Build the OperationPipeNets graph for a sequence of PipeNet objects,
+    assigning each net (and its pipes) a dense operation-local id and
+    validating the result. Shared by @ttl.operation (closure discovery)
+    and @ttl.atom (lifted PipeNet assigns)."""
+    from ._pipenets import OperationPipeNets
+    from .pipe import _pipe_to_pipe_use
+
     graph = OperationPipeNets()
-    for net in seen.values():
+    for net in nets:
         net_use = graph.add_pipe_net(_pipe_to_pipe_use(p) for p in net.pipes)
         net.pipe_net_id = net_use.id
         # Assign every Pipe in this net the operation-local id so the AST

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1146,6 +1146,39 @@ def _extract_pipe_global_semaphore_count(module) -> int:
     return int(attr)
 
 
+def _dfb_l1_tiles(cb):
+    """Total tiles a DFB occupies in L1 (per-block tiles x block_count)."""
+    tiles = cb.block_count
+    for dim in cb.shape:
+        tiles *= dim
+    return tiles
+
+
+def _apply_dfb_index_map(cb_configs, module):
+    """Apply ttl.dfb_index_map (user DFB index reuse) to the CB config list.
+
+    The finalize pass may overlay several user DFBs onto one physical index;
+    the slot is sized to the largest member, since every reserve/wait carries
+    its own block size.
+    """
+    attr = module.operation.attributes.get("ttl.dfb_index_map", None)
+    if attr is None:
+        return cb_configs
+    moved = {int(e["old_index"]): int(e["new_index"]) for e in attr}
+
+    by_index = {}
+    for old, cb in enumerate(cb_configs):
+        if cb is None:
+            continue
+        new = moved.get(old, old)
+        cur = by_index.get(new)
+        if cur is None or _dfb_l1_tiles(cb) > _dfb_l1_tiles(cur):
+            by_index[new] = cb
+    if not by_index:
+        return []
+    return [by_index.get(i) for i in range(max(by_index) + 1)]
+
+
 def _merge_dfb_configs(cb_configs, compiler_allocated_dfbs):
     """Merge compiler-allocated DFBs into the CB config list.
 
@@ -1161,11 +1194,12 @@ def _merge_dfb_configs(cb_configs, compiler_allocated_dfbs):
 
     merged = list(cb_configs) + [None] * (total - len(cb_configs))
     for dfb in compiler_allocated_dfbs:
-        if merged[dfb.dfb_index] is not None:
-            raise ValueError(
-                f"Compiler-allocated DFB index {dfb.dfb_index} collides with "
-                f"an existing DFB."
-            )
+        existing = merged[dfb.dfb_index]
+        if existing is not None:
+            # Index reuse may overlay a compiler DFB on a user slot; keep the
+            # larger config (same element type within a reuse class).
+            if _dfb_l1_tiles(existing) >= dfb.num_tiles * dfb.block_count:
+                continue
         merged[dfb.dfb_index] = dfb
     return merged
 
@@ -1763,7 +1797,8 @@ def _lower_program_to_kernel(
             first_thread = next(iter(all_source_lines.keys()))
             profile_source_lines = all_source_lines[first_thread]
 
-        # Merge compiler-allocated DFBs into the CB config list.
+        # Apply user DFB index reuse, then merge compiler-allocated DFBs.
+        cb_configs = _apply_dfb_index_map(cb_configs, module)
         compiler_allocated_dfbs = _extract_compiler_allocated_dfbs(module)
         cb_configs = _merge_dfb_configs(cb_configs, compiler_allocated_dfbs)
         pipe_sync_semaphore_count = _extract_pipe_sync_semaphore_count(module)

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1162,6 +1162,47 @@ def _merge_dfb_configs(cb_configs, compiler_allocated_dfbs):
     return merged
 
 
+def _run_thread_compiler(
+    name,
+    kernel_type,
+    captures,
+    globals_,
+    args,
+    kwargs,
+    module_ast,
+    source_lines,
+    source_file,
+    verbose=False,
+):
+    """Construct a TTLGenericCompiler for one thread, visit its AST, and
+    verify. Returns the compiler instance (the compiled thread).
+
+    Shared by @ttl.operation thread wrappers (which build module_ast from
+    the thread function source) and @ttl.atom (which feeds a synthesized
+    per-thread function AST), so the per-thread lowering entry is in one
+    place.
+    """
+    b = TTLGenericCompiler(
+        name,
+        kernel_type,
+        captures,
+        *args,
+        _globals=globals_,
+        **kwargs,
+    )
+    if verbose:
+        print(ast.dump(module_ast, indent=4) + "\n")
+    b.visit(module_ast)
+    if verbose:
+        print(b.module)
+    try:
+        b.module.operation.verify()
+    except Exception as e:
+        formatted = format_mlir_error(str(e), source_lines, source_file)
+        raise RuntimeError(formatted) from None
+    return b
+
+
 def _compile(
     kernel_type: Optional[str] = None,
     verbose: bool = False,
@@ -1200,32 +1241,18 @@ def _compile(
             kwargs["debug_locations"] = True
 
             m = ast.parse(source_code)
-            line_offset = kwargs.get("_line_offset", 0)
-
-            b = TTLGenericCompiler(
+            return _run_thread_compiler(
                 f.__name__,
                 kernel_type,
                 _collect_captures(f),
-                *args,
-                _globals=f.__globals__,
-                **kwargs,
+                f.__globals__,
+                args,
+                kwargs,
+                m,
+                source_lines,
+                source_file,
+                verbose=verbose,
             )
-
-            if verbose:
-                print(ast.dump(m, indent=4) + "\n")
-
-            b.visit(m)
-
-            if verbose:
-                print(b.module)
-
-            try:
-                b.module.operation.verify()
-            except Exception as e:
-                formatted = format_mlir_error(str(e), source_lines, source_file)
-                raise RuntimeError(formatted) from None
-
-            return b
 
         _wrapper._decorator_name = kernel_type + "_thread"
         _wrapper._source_file = source_file
@@ -1427,6 +1454,47 @@ def _compile_kernel(
         kwargs=injected_program_kwargs,
     )
 
+    return _lower_program_to_kernel(
+        program=program,
+        args=args,
+        launch_grid=launch_grid,
+        num_outs=num_outs,
+        cb_configs=cb_configs,
+        pipenets=pipenets,
+        target_arch=target_arch,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        dst_full_sync_en=dst_full_sync_en,
+        compiler_options=compiler_options,
+        program_hash=program_hash,
+        l1_budget_override=l1_budget_override,
+        kernel_source_file=kernel_source_file,
+        kernel_line_offset=kernel_line_offset,
+    )
+
+
+def _lower_program_to_kernel(
+    *,
+    program,
+    args,
+    launch_grid,
+    num_outs,
+    cb_configs,
+    pipenets,
+    target_arch,
+    fp32_dest_acc_en,
+    dst_full_sync_en,
+    compiler_options,
+    program_hash,
+    l1_budget_override,
+    kernel_source_file,
+    kernel_line_offset,
+):
+    """Lower compiled threads to a CompiledTTNNKernel.
+
+    Assembles the per-thread MLIR funcs into a module, runs the TTL pass
+    pipeline, and builds the runner. Shared by @ttl.operation and @ttl.atom
+    so the compiler pipeline lives in one place.
+    """
     # Always generate source locations for error messages
     # TTLANG_DEBUG_LOCATIONS only controls whether locations are printed in MLIR output
     print_debug_locations = os.environ.get("TTLANG_DEBUG_LOCATIONS", "0") == "1"

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -63,6 +63,25 @@ def test_callee_with_dfb_decl_rejected():
             _declares_dfb(a_cb, out_cb)
 
 
+def test_callee_with_make_dfb_decl_rejected():
+    """A callee that declares its own DFB via make_dfb cannot be inlined."""
+
+    @ttl.atom()
+    def _declares_make_dfb(inp: ttl.DFB, out: ttl.DFB):
+        scratch = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+        x = inp.wait()
+        r = out.reserve()
+        r.store(x)
+
+    with pytest.raises(ValueError, match="make_dfb"):
+
+        @ttl.atom(grid=(1, 1))
+        def _outer_bad(in_t, out_t):
+            a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+            out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+            _declares_make_dfb(a_cb, out_cb)
+
+
 def test_atom_outer_exp(device):
     tile = ttnn.TILE_SIZE
     inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# REQUIRES: ttnn, tt-device
-# RUN: %python %s
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
 
 """@ttl.atom-in-@ttl.atom inlining. A small DFB-parameter helper atom is
 inlined into a larger atom; the helper takes its DFBs as ttl.DFB
@@ -11,10 +12,14 @@ parameters (it has no way to be supplied buffers except by inlining).
 Also checks that a callee declaring its own DFB is rejected at the outer
 atom's decoration time."""
 
+import pytest
 import torch
 
-import ttnn
 import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_l1
 
 
 @ttl.atom()
@@ -39,18 +44,7 @@ def atom_outer_exp(in_t, out_t):
     ttl.copy(out_done, out_t[0:1, 0:1])
 
 
-def _to_l1(device, t):
-    dram = ttnn.from_torch(
-        t,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
-
-
-def check_callee_with_dfb_decl_rejected():
+def test_callee_with_dfb_decl_rejected():
     """A callee that declares its own DFB cannot be inlined."""
 
     @ttl.atom()
@@ -60,7 +54,7 @@ def check_callee_with_dfb_decl_rejected():
         r = out.reserve()
         r.store(x)
 
-    try:
+    with pytest.raises(ValueError, match="make_dataflow_buffer_like"):
 
         @ttl.atom(grid=(1, 1))
         def _outer_bad(in_t, out_t):
@@ -68,38 +62,16 @@ def check_callee_with_dfb_decl_rejected():
             out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
             _declares_dfb(a_cb, out_cb)
 
-    except ValueError as e:
-        assert "make_dataflow_buffer_like" in str(e), str(e)
-        print("check_callee_with_dfb_decl_rejected: OK")
-        return
-    raise AssertionError("expected ValueError for callee declaring its own DFB")
 
+def test_atom_outer_exp(device):
+    tile = ttnn.TILE_SIZE
+    inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
 
-def main():
-    from ttlang_test_utils import require_hardware
+    in_t = to_l1(inp_t, device)
+    out_t = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
 
-    # Decoration-time check: no device needed.
-    check_callee_with_dfb_decl_rejected()
+    atom_outer_exp(in_t, out_t)
 
-    require_hardware()
-    device = ttnn.open_device(device_id=0)
-    try:
-        torch.manual_seed(2026)
-        tile = ttnn.TILE_SIZE
-        inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
-        expected = torch.exp(inp_t.float()).to(torch.bfloat16)
-
-        in_t = _to_l1(device, inp_t)
-        out_t = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
-
-        atom_outer_exp(in_t, out_t)
-
-        got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
-        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
-        print("atom_outer_exp (inlined _exp_block): OK")
-    finally:
-        ttnn.close_device(device)
-
-
-if __name__ == "__main__":
-    main()
+    got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -8,9 +8,10 @@
 
 """@ttl.atom-in-@ttl.atom inlining. A small DFB-parameter helper atom is
 inlined into a larger atom; the helper takes its DFBs as ttl.DFB
-parameters (it has no way to be supplied buffers except by inlining).
-Also checks that a callee declaring its own DFB is rejected at the outer
-atom's decoration time."""
+parameters. An inlined callee may also declare its own scratch DFBs when
+inlined at the body top level: the decls are hoisted, and the scratch
+buffers of sequential sibling callees reuse one CB index. A callee that
+declares buffers but is inlined inside a for/if is rejected."""
 
 import pytest
 import torch
@@ -19,7 +20,7 @@ import ttl
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
-from ttlang_test_utils import assert_allclose, to_l1
+from ttlang_test_utils import assert_allclose, to_dram, to_l1
 
 
 @ttl.atom()
@@ -44,42 +45,158 @@ def atom_outer_exp(in_t, out_t):
     ttl.copy(out_done, out_t[0:1, 0:1])
 
 
-def test_callee_with_dfb_decl_rejected():
-    """A callee that declares its own DFB cannot be inlined."""
+@ttl.atom()
+def _exp_via_scratch(in_cb: ttl.DFB, out_t):
+    """Inlined helper that declares its own scratch DFB: compute writes
+    exp(x) into the scratch, data movement drains it to ``out_t``."""
+    scratch = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    x = in_cb.wait()
+    s = scratch.reserve()
+    s.store(ttl.exp(x))
+    done = scratch.wait()
+    ttl.copy(done, out_t[0:1, 0:1])
+
+
+@ttl.atom(grid=(1, 1))
+def atom_two_scratch(in0, in1, out0, out1):
+    """Inlines two sibling scratch-declaring helpers; their scratch DFBs run
+    sequentially, so they share one CB index."""
+    a0 = ttl.make_dataflow_buffer_like(in0, shape=(1, 1), block_count=2)
+    a1 = ttl.make_dataflow_buffer_like(in1, shape=(1, 1), block_count=2)
+
+    b0 = a0.reserve()
+    ttl.copy(in0[0:1, 0:1], b0)
+    b1 = a1.reserve()
+    ttl.copy(in1[0:1, 0:1], b1)
+
+    _exp_via_scratch(a0, out0)
+    _exp_via_scratch(a1, out1)
+
+
+@ttl.atom()
+def _scratch_dm_then_compute(in_t, out_t):
+    """Two scratch DFBs whose textual spans are disjoint but whose runtime
+    lifetimes overlap across threads: ``a`` is data-movement-produced (copied
+    from a tensor) and compute-consumed; ``b`` is compute-produced and
+    data-movement-consumed. A statement-span reuse would merge a and b (their
+    text spans don't overlap), giving one CB two producers on two threads and
+    interleaving the streams. Site-based reuse keeps them distinct."""
+    a = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    b = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+
+    ad = a.reserve()
+    ttl.copy(in_t[0:1, 0:1], ad)  # data movement: in_t -> a
+    av = a.wait()  # compute consumes a
+    bd = b.reserve()
+    bd.store(ttl.exp(av))  # compute produces b
+    bv = b.wait()
+    ttl.copy(bv, out_t[0:1, 0:1])  # data movement: b -> out_t
+
+
+@ttl.atom(grid=(1, 1))
+def atom_cross_thread_scratch(in_t, out_t):
+    _scratch_dm_then_compute(in_t, out_t)
+
+
+@ttl.atom()
+def _forward_pipe(a, send_cb: ttl.DFB, recv_cb: ttl.DFB):
+    """Inlined helper that declares its OWN PipeNet (pure hoist, no reuse):
+    core (1,0) sends a[1] over the pipe, core (0,0) receives it into recv_cb."""
+    fwd_net = ttl.PipeNet([ttl.Pipe(src=(1, 0), dst=(0, 0))])
+    s_blk = send_cb.reserve()
+    r_dst = recv_cb.reserve()
+
+    def send(pipe):
+        ttl.copy(a[1:2, 0:1], s_blk)
+        ttl.copy(s_blk, pipe)
+
+    fwd_net.if_src(send)
+
+    def recv(pipe):
+        ttl.copy(pipe, r_dst)
+
+    fwd_net.if_dst(recv)
+
+
+@ttl.atom(grid=(2, 1))
+def atom_inline_pipenet(a, out):
+    own_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    send_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    recv_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+    node_x, _ = ttl.node(dims=2)
+
+    _forward_pipe(a, send_cb, recv_cb)  # inlined; declares its own PipeNet
+
+    if node_x == 0:
+        own_blk = own_cb.reserve()
+        ttl.copy(a[0:1, 0:1], own_blk)
+        s = out_cb.reserve()
+        s.store(own_cb.wait() + recv_cb.wait())
+        ttl.copy(out_cb.wait(), out[0:1, 0:1])
+
+
+def test_dfb_callee_in_loop_rejected():
+    """A callee that declares its own DFB cannot be inlined inside a loop:
+    its decl could not be hoisted to the body top level."""
 
     @ttl.atom()
     def _declares_dfb(inp: ttl.DFB, out: ttl.DFB):
         scratch = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
         x = inp.wait()
+        s = scratch.reserve()
+        s.store(x)
+        done = scratch.wait()
         r = out.reserve()
-        r.store(x)
+        r.store(done)
 
-    with pytest.raises(ValueError, match="make_dataflow_buffer_like"):
+    with pytest.raises(ValueError, match="atom body top level"):
 
         @ttl.atom(grid=(1, 1))
         def _outer_bad(in_t, out_t):
             a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
             out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
-            _declares_dfb(a_cb, out_cb)
+            for _ in range(2):
+                _declares_dfb(a_cb, out_cb)
 
 
-def test_callee_with_make_dfb_decl_rejected():
-    """A callee that declares its own DFB via make_dfb cannot be inlined."""
+def _dfbs(n):
+    """n fresh bf16 (1,1) double-buffered DFBs with sequential CB indices."""
+    from ttl.dataflow_buffer import DataflowBuffer, _reset_cb_counter
+
+    _reset_cb_counter()
+    return [DataflowBuffer(None, (1, 1), 2, dtype="bf16") for _ in range(n)]
+
+
+def test_dfb_indices_declaration_dense():
+    """Python assigns declaration-dense CB indices and never overlays them;
+    index reuse happens in MLIR (ttl-finalize-dfb-indices) where thread
+    identity and lifetimes are known."""
+    buffers = _dfbs(4)
+    assert [b._cb_index for b in buffers] == [0, 1, 2, 3]
+
+
+def test_callee_with_make_dfb_decl_inlines():
+    """A callee may declare its own scratch DFB via make_dfb at its top
+    level; the declaration hoists to the caller body on inlining."""
 
     @ttl.atom()
     def _declares_make_dfb(inp: ttl.DFB, out: ttl.DFB):
         scratch = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
         x = inp.wait()
+        s = scratch.reserve()
+        s.store(x)
+        y = scratch.wait()
         r = out.reserve()
-        r.store(x)
+        r.store(y)
 
-    with pytest.raises(ValueError, match="make_dfb"):
+    @ttl.atom(grid=(1, 1))
+    def _outer(in_t, out_t):
+        a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+        out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+        _declares_make_dfb(a_cb, out_cb)
 
-        @ttl.atom(grid=(1, 1))
-        def _outer_bad(in_t, out_t):
-            a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
-            out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
-            _declares_make_dfb(a_cb, out_cb)
+    assert "scratch___declares_make_dfb_inl" in _outer._spec.source
 
 
 def test_atom_outer_exp(device):
@@ -91,6 +208,58 @@ def test_atom_outer_exp(device):
     out_t = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
 
     atom_outer_exp(in_t, out_t)
+
+    got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_atom_inline_pipenet(device):
+    """An inlined callee that declares its own PipeNet is hoisted and runs."""
+    tile = ttnn.TILE_SIZE
+    a_t = torch.randn(2 * tile, tile, dtype=torch.bfloat16) * 0.5
+    expected = (a_t[:tile].float() + a_t[tile:].float()).to(torch.bfloat16)
+
+    a = to_dram(a_t, device)
+    out = to_dram(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+
+    atom_inline_pipenet(a, out)
+
+    got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_atom_two_scratch(device):
+    tile = ttnn.TILE_SIZE
+
+    def rand():
+        return (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+
+    in0_t, in1_t = rand(), rand()
+    in0 = to_l1(in0_t, device)
+    in1 = to_l1(in1_t, device)
+    out0 = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+    out1 = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+
+    atom_two_scratch(in0, in1, out0, out1)
+
+    got0 = ttnn.to_torch(out0).reshape(tile, tile).to(torch.bfloat16)
+    got1 = ttnn.to_torch(out1).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got0, torch.exp(in0_t.float()).to(torch.bfloat16), rtol=2e-2, atol=2e-2)
+    assert_allclose(got1, torch.exp(in1_t.float()).to(torch.bfloat16), rtol=2e-2, atol=2e-2)
+
+
+def test_atom_cross_thread_scratch(device):
+    """The cross-thread hazard runs correctly: the two same-site scratch DFBs
+    must not share a CB index, or the DM-produced and compute-produced streams
+    would interleave."""
+    tile = ttnn.TILE_SIZE
+    inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
+
+    in_t = to_l1(inp_t, device)
+    out_t = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+
+    atom_cross_thread_scratch(in_t, out_t)
 
     got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
     assert_allclose(got, expected, rtol=2e-2, atol=2e-2)

--- a/test/python/atom/test_atom_inline.py
+++ b/test/python/atom/test_atom_inline.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: %python %s
+
+"""@ttl.atom-in-@ttl.atom inlining. A small DFB-parameter helper atom is
+inlined into a larger atom; the helper takes its DFBs as ttl.DFB
+parameters (it has no way to be supplied buffers except by inlining).
+Also checks that a callee declaring its own DFB is rejected at the outer
+atom's decoration time."""
+
+import torch
+
+import ttnn
+import ttl
+
+
+@ttl.atom()
+def _exp_block(inp: ttl.DFB, out: ttl.DFB):
+    """Per-tile exp; declares no DFBs of its own (takes them as params)."""
+    x = inp.wait()
+    r = out.reserve()
+    r.store(ttl.exp(x))
+
+
+@ttl.atom(grid=(1, 1))
+def atom_outer_exp(in_t, out_t):
+    a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+
+    a_blk = a_cb.reserve()
+    ttl.copy(in_t[0:1, 0:1], a_blk)
+
+    _exp_block(a_cb, out_cb)  # inlined at decoration time
+
+    out_done = out_cb.wait()
+    ttl.copy(out_done, out_t[0:1, 0:1])
+
+
+def _to_l1(device, t):
+    dram = ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+
+def check_callee_with_dfb_decl_rejected():
+    """A callee that declares its own DFB cannot be inlined."""
+
+    @ttl.atom()
+    def _declares_dfb(inp: ttl.DFB, out: ttl.DFB):
+        scratch = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+        x = inp.wait()
+        r = out.reserve()
+        r.store(x)
+
+    try:
+
+        @ttl.atom(grid=(1, 1))
+        def _outer_bad(in_t, out_t):
+            a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+            out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+            _declares_dfb(a_cb, out_cb)
+
+    except ValueError as e:
+        assert "make_dataflow_buffer_like" in str(e), str(e)
+        print("check_callee_with_dfb_decl_rejected: OK")
+        return
+    raise AssertionError("expected ValueError for callee declaring its own DFB")
+
+
+def main():
+    from ttlang_test_utils import require_hardware
+
+    # Decoration-time check: no device needed.
+    check_callee_with_dfb_decl_rejected()
+
+    require_hardware()
+    device = ttnn.open_device(device_id=0)
+    try:
+        torch.manual_seed(2026)
+        tile = ttnn.TILE_SIZE
+        inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+        expected = torch.exp(inp_t.float()).to(torch.bfloat16)
+
+        in_t = _to_l1(device, inp_t)
+        out_t = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
+
+        atom_outer_exp(in_t, out_t)
+
+        got = ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
+        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
+        print("atom_outer_exp (inlined _exp_block): OK")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/atom/test_atom_make_dfb.py
+++ b/test/python/atom/test_atom_make_dfb.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: %python %s
+
+"""@ttl.atom with a tensor-less DFB built via ttl.make_dfb. The output
+buffer is declared from a dtype name string rather than a borrowed
+tensor; compute writes exp(x) into it and data movement drains it."""
+
+import torch
+
+import ttnn
+import ttl
+
+
+@ttl.atom(grid=(1, 1))
+def atom_make_dfb_exp(inp, out):
+    in_cb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+
+    a_blk = in_cb.reserve()
+    ttl.copy(inp[0:1, 0:1], a_blk)
+
+    o = out_cb.reserve()
+    x = in_cb.wait()
+    o.store(ttl.exp(x))
+
+    out_done = out_cb.wait()
+    ttl.copy(out_done, out[0:1, 0:1])
+
+
+def _to_l1(device, t):
+    dram = ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+
+def main():
+    from ttlang_test_utils import require_hardware
+
+    require_hardware()
+    device = ttnn.open_device(device_id=0)
+    try:
+        torch.manual_seed(2026)
+        tile = ttnn.TILE_SIZE
+        inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+        expected = torch.exp(inp_t.float()).to(torch.bfloat16)
+
+        inp = _to_l1(device, inp_t)
+        out = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
+
+        atom_make_dfb_exp(inp, out)
+
+        got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
+        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
+        print("atom_make_dfb_exp: OK")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/atom/test_atom_make_dfb.py
+++ b/test/python/atom/test_atom_make_dfb.py
@@ -2,17 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# REQUIRES: ttnn, tt-device
-# RUN: %python %s
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
 
 """@ttl.atom with a tensor-less DFB built via ttl.make_dfb. The output
 buffer is declared from a dtype name string rather than a borrowed
 tensor; compute writes exp(x) into it and data movement drains it."""
 
+import pytest
 import torch
 
-import ttnn
 import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_l1
 
 
 @ttl.atom(grid=(1, 1))
@@ -31,39 +36,15 @@ def atom_make_dfb_exp(inp, out):
     ttl.copy(out_done, out[0:1, 0:1])
 
 
-def _to_l1(device, t):
-    dram = ttnn.from_torch(
-        t,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
+def test_atom_make_dfb_exp(device):
+    tile = ttnn.TILE_SIZE
+    inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
 
+    inp = to_l1(inp_t, device)
+    out = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
 
-def main():
-    from ttlang_test_utils import require_hardware
+    atom_make_dfb_exp(inp, out)
 
-    require_hardware()
-    device = ttnn.open_device(device_id=0)
-    try:
-        torch.manual_seed(2026)
-        tile = ttnn.TILE_SIZE
-        inp_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
-        expected = torch.exp(inp_t.float()).to(torch.bfloat16)
-
-        inp = _to_l1(device, inp_t)
-        out = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
-
-        atom_make_dfb_exp(inp, out)
-
-        got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
-        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
-        print("atom_make_dfb_exp: OK")
-    finally:
-        ttnn.close_device(device)
-
-
-if __name__ == "__main__":
-    main()
+    got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)

--- a/test/python/atom/test_atom_pipe_unicast.py
+++ b/test/python/atom/test_atom_pipe_unicast.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: %python %s
+
+"""@ttl.atom with a single unicast PipeNet across two cores. Core (1,0)
+reads a tile and sends it over the pipe; core (0,0) reads its own tile,
+receives the sent tile, adds them, and writes the result.
+
+Each pipe buffer is touched on exactly one RISC -- send_cb only in the
+if_src callback (BRISC), recv_cb only in if_dst (NCRISC) -- because the
+splitter routes the two callbacks onto different RISCs and rejects a
+single reserve driven from both."""
+
+import torch
+
+import ttnn
+import ttl
+
+
+@ttl.atom(grid=(2, 1))
+def atom_pipe_unicast(a, out):
+    own_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    send_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    recv_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    fwd_net = ttl.PipeNet([ttl.Pipe(src=(1, 0), dst=(0, 0))])
+    node_x, _ = ttl.node(dims=2)
+
+    # Reserves hoisted out of the callbacks; each lands on a single RISC.
+    s_blk = send_cb.reserve()
+    r_dst = recv_cb.reserve()
+
+    def send(pipe):
+        ttl.copy(a[1:2, 0:1], s_blk)
+        ttl.copy(s_blk, pipe)
+
+    fwd_net.if_src(send)
+
+    def recv(pipe):
+        ttl.copy(pipe, r_dst)
+
+    fwd_net.if_dst(recv)
+
+    if node_x == 0:
+        own_blk = own_cb.reserve()
+        ttl.copy(a[0:1, 0:1], own_blk)
+        s = out_cb.reserve()
+        s.store(own_cb.wait() + recv_cb.wait())
+        ttl.copy(out_cb.wait(), out[0:1, 0:1])
+
+
+def _to_dram(device, t):
+    return ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def main():
+    from ttlang_test_utils import require_hardware
+
+    require_hardware()
+    device = ttnn.open_device(device_id=0)
+    try:
+        torch.manual_seed(2026)
+        tile = ttnn.TILE_SIZE
+        # Two row-tiles: tile 0 is core (0,0)'s own, tile 1 is sent from (1,0).
+        a_t = torch.randn(2 * tile, tile, dtype=torch.bfloat16) * 0.5
+        expected = (a_t[:tile].float() + a_t[tile:].float()).to(torch.bfloat16)
+
+        a = _to_dram(device, a_t)
+        out = _to_dram(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
+
+        atom_pipe_unicast(a, out)
+
+        got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
+        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
+        print("atom_pipe_unicast: OK")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/atom/test_atom_pipe_unicast.py
+++ b/test/python/atom/test_atom_pipe_unicast.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# REQUIRES: ttnn, tt-device
-# RUN: %python %s
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
 
 """@ttl.atom with a single unicast PipeNet across two cores. Core (1,0)
 reads a tile and sends it over the pipe; core (0,0) reads its own tile,
@@ -14,10 +15,14 @@ if_src callback (BRISC), recv_cb only in if_dst (NCRISC) -- because the
 splitter routes the two callbacks onto different RISCs and rejects a
 single reserve driven from both."""
 
+import pytest
 import torch
 
-import ttnn
 import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_dram
 
 
 @ttl.atom(grid=(2, 1))
@@ -53,39 +58,16 @@ def atom_pipe_unicast(a, out):
         ttl.copy(out_cb.wait(), out[0:1, 0:1])
 
 
-def _to_dram(device, t):
-    return ttnn.from_torch(
-        t,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
+def test_atom_pipe_unicast(device):
+    tile = ttnn.TILE_SIZE
+    # Two row-tiles: tile 0 is core (0,0)'s own, tile 1 is sent from (1,0).
+    a_t = torch.randn(2 * tile, tile, dtype=torch.bfloat16) * 0.5
+    expected = (a_t[:tile].float() + a_t[tile:].float()).to(torch.bfloat16)
 
+    a = to_dram(a_t, device)
+    out = to_dram(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
 
-def main():
-    from ttlang_test_utils import require_hardware
+    atom_pipe_unicast(a, out)
 
-    require_hardware()
-    device = ttnn.open_device(device_id=0)
-    try:
-        torch.manual_seed(2026)
-        tile = ttnn.TILE_SIZE
-        # Two row-tiles: tile 0 is core (0,0)'s own, tile 1 is sent from (1,0).
-        a_t = torch.randn(2 * tile, tile, dtype=torch.bfloat16) * 0.5
-        expected = (a_t[:tile].float() + a_t[tile:].float()).to(torch.bfloat16)
-
-        a = _to_dram(device, a_t)
-        out = _to_dram(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
-
-        atom_pipe_unicast(a, out)
-
-        got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
-        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
-        print("atom_pipe_unicast: OK")
-    finally:
-        ttnn.close_device(device)
-
-
-if __name__ == "__main__":
-    main()
+    got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python -m pytest %s -v
+
+"""Off-device unit tests for the @ttl.atom thread splitter.
+
+These drive ``split_function_body`` directly on small ASTs, so they need
+neither ttnn nor a device and run anywhere ttl imports. They lock in the
+split-time error paths (unknown op, no-use producer, NCRISC/BRISC
+double-reserve) and the basic compute/data-movement routing."""
+
+import ast
+import textwrap
+
+import pytest
+
+from ttl._src.atom_split import split_function_body
+
+
+def _fn(src: str) -> ast.FunctionDef:
+    return ast.parse(textwrap.dedent(src)).body[0]
+
+
+def _thread_src(result, thread: str) -> str:
+    return "\n".join(ast.unparse(s) for s in result.body_for(thread))
+
+
+def test_unknown_ttl_op_is_rejected():
+    fn = _fn(
+        """
+        def k(a):
+            ttl.frobnicate(a)
+        """
+    )
+    with pytest.raises(ValueError, match="unknown ttl.frobnicate"):
+        split_function_body(fn, dfb_param_names=set(), all_param_names={"a"})
+
+
+def test_producer_with_no_uses_is_rejected():
+    fn = _fn(
+        """
+        def k():
+            blk = a_cb.wait()
+        """
+    )
+    with pytest.raises(ValueError, match="has no uses"):
+        split_function_body(fn, dfb_param_names=set(), local_dfb_names={"a_cb"})
+
+
+def test_producer_split_across_ncrisc_and_brisc_is_rejected():
+    """A single reserve whose block feeds both an if_src (BRISC) and an
+    if_dst (NCRISC) callback would double-reserve the CB."""
+    fn = _fn(
+        """
+        def k(net):
+            shared = a_cb.reserve()
+
+            def send(pipe):
+                ttl.copy(shared, pipe)
+
+            net.if_src(send)
+
+            def recv(pipe):
+                ttl.copy(pipe, shared)
+
+            net.if_dst(recv)
+        """
+    )
+    with pytest.raises(ValueError, match="both NCRISC"):
+        split_function_body(
+            fn,
+            dfb_param_names=set(),
+            all_param_names={"net"},
+            local_dfb_names={"a_cb"},
+        )
+
+
+def test_compute_and_dm_route_to_separate_threads():
+    """Copies land on NCRISC, the compute op on TRISC, and the unused
+    BRISC thread is empty."""
+    fn = _fn(
+        """
+        def k(a, out):
+            a_blk = a_cb.reserve()
+            ttl.copy(a, a_blk)
+            s = out_cb.reserve()
+            x = a_cb.wait()
+            s.store(ttl.exp(x))
+            done = out_cb.wait()
+            ttl.copy(done, out)
+        """
+    )
+    result = split_function_body(
+        fn,
+        dfb_param_names=set(),
+        all_param_names={"a", "out"},
+        local_dfb_names={"a_cb", "out_cb"},
+    )
+
+    trisc = _thread_src(result, "trisc")
+    ncrisc = _thread_src(result, "ncrisc")
+    brisc = _thread_src(result, "brisc")
+
+    assert "ttl.exp" in trisc
+    assert "ttl.copy" not in trisc
+    assert "ttl.copy" in ncrisc
+    assert "ttl.exp" not in ncrisc
+    assert brisc.strip() == "pass"

--- a/test/python/atom/test_atom_summa_ksplit.py
+++ b/test/python/atom/test_atom_summa_ksplit.py
@@ -48,7 +48,7 @@ GRID_X = NUM_COLS * KP  # 4
 GRID_Y = NUM_ROWS  # 2
 
 
-@ttl.atom(grid=(GRID_X, GRID_Y))
+@ttl.atom(grid=(GRID_X, GRID_Y), fp32_dest_acc_en=True)
 def atom_summa_ksplit(a, w, out):
     a_cb = ttl.make_dataflow_buffer_like(a, shape=(BLOCK_M, BLOCK_K), block_count=2)
     b_cb = ttl.make_dataflow_buffer_like(w, shape=(BLOCK_K, BLOCK_N), block_count=2)
@@ -117,11 +117,16 @@ def atom_summa_ksplit(a, w, out):
         a_blk = a_cb.wait()
         b_blk = b_cb.wait()
         p += a_blk @ b_blk
+    # Finalize the partial before reading it: storing the still-reserved
+    # accumulator copies it before the matmul result is packed to L1, which
+    # ships garbage to the gather. Wait pins down the packed block.
+    pf = partial_for_sum_cb.wait()
 
-    # Mirror the accumulated partial into the DM-side CB so the send predicate
-    # has its own producer/consumer pair. Only k_p > 0 cores consume it.
+    # Mirror the finalized partial into the DM-side CB so the gather send has
+    # its own producer/consumer pair (one DFB cannot feed both compute and the
+    # send). Only k_p > 0 cores consume it.
     p_send_local = partial_for_send_cb.reserve()
-    p_send_local.store(p)
+    p_send_local.store(pf)
 
     for kb_local in range(K_BLOCKS_PER_KP):
         kb = k_offset + kb_local
@@ -155,29 +160,28 @@ def atom_summa_ksplit(a, w, out):
 
         mcast_b_net.if_dst(recv_b)
 
-    r_dst = recv_cb.reserve()
-
     if node_x < NUM_COLS:
 
+        # Reserve the receive block inside the callback: the pipe posts the
+        # block's address from here, so the reserve must be co-located with the
+        # post. Hoisting it out deadlocks.
         def recv_partial(pipe):
+            r_dst = recv_cb.reserve()
             ttl.copy(pipe, r_dst)
 
         reduce_net.if_dst(recv_partial)
 
-        # KP == 2: the root sums its local partial and the single received
-        # partial straight into the output CB. Each DFB is consumed exactly
-        # once; reusing one DFB across two reserve/wait cycles in a single
-        # atom deadlocks.
-        local = partial_for_sum_cb.wait()
+        # KP == 2: one received partial. Sum it with the finalized local
+        # partial into the output CB.
         r = recv_cb.wait()
         o = out_cb.reserve()
-        o.store(local + r)
+        o.store(pf + r)
         out_blk_done = out_cb.wait()
         ttl.copy(out_blk_done, out[mr : mr + BLOCK_M, nc : nc + BLOCK_N])
     else:
-        p_to_send = partial_for_send_cb.wait()
 
         def send_partial(pipe):
+            p_to_send = partial_for_send_cb.wait()
             ttl.copy(p_to_send, pipe)
 
         reduce_net.if_src(send_partial)

--- a/test/python/atom/test_atom_summa_ksplit.py
+++ b/test/python/atom/test_atom_summa_ksplit.py
@@ -63,7 +63,9 @@ def atom_summa_ksplit(a, w, out):
     partial_for_send_cb = ttl.make_dataflow_buffer_like(
         out, shape=(BLOCK_M, BLOCK_N), block_count=2
     )
-    recv_cb = ttl.make_dataflow_buffer_like(out, shape=(BLOCK_M, BLOCK_N), block_count=2)
+    recv_cb = ttl.make_dataflow_buffer_like(
+        out, shape=(BLOCK_M, BLOCK_N), block_count=2
+    )
     # Dedicated output CB: the reduce keeps consuming partial_for_sum_cb on
     # the compute thread, then stores the final tile here for the write thread
     # to drain. CBs are single-consumer, so the accumulator and the tensor

--- a/test/python/atom/test_atom_summa_ksplit.py
+++ b/test/python/atom/test_atom_summa_ksplit.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""SUMMA matmul with K-split reduction as a single @ttl.atom.
+
+Each output tile block is computed by KP cores that split the K range,
+then a reduce PipeNet gathers the non-root partials onto the root band
+(k_p == 0). KP is folded into the x axis so the grid is NUM_COLS*KP cols
+x NUM_ROWS rows.
+
+  - A is multicast across the NUM_COLS cores of each KP band, per M row.
+  - B is multicast down the NUM_ROWS rows of each (KP band, N col).
+  - Each core accumulates its K-slice partial, then non-root bands ship
+    their partial to the k_p == 0 root, which sums and writes out.
+"""
+
+import pytest
+import torch
+
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_pcc, to_dram
+
+TILE = ttnn.TILE_SIZE
+BLOCK_M = 2
+BLOCK_N = 2
+BLOCK_K = 2
+BLOCK_SIZE = BLOCK_M * TILE  # 64
+
+NUM_COLS = 2  # N blocks
+NUM_ROWS = 2  # M blocks
+KP = 2  # K-split factor
+
+M = NUM_ROWS * BLOCK_SIZE  # 128
+N = NUM_COLS * BLOCK_SIZE  # 128
+K_BLOCKS = 4
+K = K_BLOCKS * BLOCK_SIZE  # 256
+K_BLOCKS_PER_KP = K_BLOCKS // KP  # 2
+
+GRID_X = NUM_COLS * KP  # 4
+GRID_Y = NUM_ROWS  # 2
+
+
+@ttl.atom(grid=(GRID_X, GRID_Y))
+def atom_summa_ksplit(a, w, out):
+    a_cb = ttl.make_dataflow_buffer_like(a, shape=(BLOCK_M, BLOCK_K), block_count=2)
+    b_cb = ttl.make_dataflow_buffer_like(w, shape=(BLOCK_K, BLOCK_N), block_count=2)
+    # Split the partial buffer per consumer: compute uses partial_for_sum_cb
+    # to fold in the received contribution on k_p == 0 cores, the DM thread
+    # uses partial_for_send_cb to ship the partial off k_p > 0 cores. A single
+    # producer feeding both compute and DM consumers is invalid, so the matmul
+    # stores the same accumulated tile into both CBs.
+    partial_for_sum_cb = ttl.make_dataflow_buffer_like(
+        out, shape=(BLOCK_M, BLOCK_N), block_count=2
+    )
+    partial_for_send_cb = ttl.make_dataflow_buffer_like(
+        out, shape=(BLOCK_M, BLOCK_N), block_count=2
+    )
+    recv_cb = ttl.make_dataflow_buffer_like(out, shape=(BLOCK_M, BLOCK_N), block_count=2)
+    # Dedicated output CB: the reduce keeps consuming partial_for_sum_cb on
+    # the compute thread, then stores the final tile here for the write thread
+    # to drain. CBs are single-consumer, so the accumulator and the tensor
+    # write cannot share one DFB.
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=(BLOCK_M, BLOCK_N), block_count=2)
+    # Private BRISC staging buffers so the loopback src core does not
+    # double-reserve a_cb/b_cb across BRISC (if_src) and NCRISC (if_dst).
+    tmp_a_cb = ttl.make_dataflow_buffer_like(a, shape=(BLOCK_M, BLOCK_K), block_count=2)
+    tmp_b_cb = ttl.make_dataflow_buffer_like(w, shape=(BLOCK_K, BLOCK_N), block_count=2)
+
+    # A is multicast across the NUM_COLS cores of each KP band, per M row.
+    a_pipes = [
+        ttl.Pipe(
+            src=(k_p * NUM_COLS, m),
+            dst=(slice(k_p * NUM_COLS, (k_p + 1) * NUM_COLS), m),
+        )
+        for k_p in range(KP)
+        for m in range(NUM_ROWS)
+    ]
+    mcast_a_net = ttl.PipeNet(a_pipes)
+
+    # B is multicast down the NUM_ROWS rows of each (KP band, N col).
+    b_pipes = [
+        ttl.Pipe(
+            src=(n + k_p * NUM_COLS, 0),
+            dst=(n + k_p * NUM_COLS, slice(0, NUM_ROWS)),
+        )
+        for k_p in range(KP)
+        for n in range(NUM_COLS)
+    ]
+    mcast_b_net = ttl.PipeNet(b_pipes)
+
+    # K-split reduce: non-root k_p bands send their partial to the k_p == 0 root.
+    reduce_pipes = [
+        ttl.Pipe(src=(n + k_p * NUM_COLS, m), dst=(n, m))
+        for n in range(NUM_COLS)
+        for m in range(NUM_ROWS)
+        for k_p in range(1, KP)
+    ]
+    reduce_net = ttl.PipeNet(reduce_pipes)
+
+    node_x, node_m = ttl.node(dims=2)
+    k_p = node_x // NUM_COLS
+    node_n = node_x % NUM_COLS
+    mr = node_m * BLOCK_M
+    nc = node_n * BLOCK_N
+    k_offset = k_p * K_BLOCKS_PER_KP
+
+    p = partial_for_sum_cb.reserve()
+    for _ in range(K_BLOCKS_PER_KP):
+        a_blk = a_cb.wait()
+        b_blk = b_cb.wait()
+        p += a_blk @ b_blk
+
+    # Mirror the accumulated partial into the DM-side CB so the send predicate
+    # has its own producer/consumer pair. Only k_p > 0 cores consume it.
+    p_send_local = partial_for_send_cb.reserve()
+    p_send_local.store(p)
+
+    for kb_local in range(K_BLOCKS_PER_KP):
+        kb = k_offset + kb_local
+        kr = kb * BLOCK_K
+
+        def read_a(pipe):
+            tmp_w = tmp_a_cb.reserve()
+            ttl.copy(a[mr : mr + BLOCK_M, kr : kr + BLOCK_K], tmp_w)
+            tmp_r = tmp_a_cb.wait()
+            ttl.copy(tmp_r, pipe)
+
+        mcast_a_net.if_src(read_a)
+
+        def recv_a(pipe):
+            a_blk_dm = a_cb.reserve()
+            ttl.copy(pipe, a_blk_dm)
+
+        mcast_a_net.if_dst(recv_a)
+
+        def read_b(pipe):
+            tmp_w = tmp_b_cb.reserve()
+            ttl.copy(w[kr : kr + BLOCK_K, nc : nc + BLOCK_N], tmp_w)
+            tmp_r = tmp_b_cb.wait()
+            ttl.copy(tmp_r, pipe)
+
+        mcast_b_net.if_src(read_b)
+
+        def recv_b(pipe):
+            b_blk_dm = b_cb.reserve()
+            ttl.copy(pipe, b_blk_dm)
+
+        mcast_b_net.if_dst(recv_b)
+
+    r_dst = recv_cb.reserve()
+
+    if node_x < NUM_COLS:
+
+        def recv_partial(pipe):
+            ttl.copy(pipe, r_dst)
+
+        reduce_net.if_dst(recv_partial)
+
+        # KP == 2: the root sums its local partial and the single received
+        # partial straight into the output CB. Each DFB is consumed exactly
+        # once; reusing one DFB across two reserve/wait cycles in a single
+        # atom deadlocks.
+        local = partial_for_sum_cb.wait()
+        r = recv_cb.wait()
+        o = out_cb.reserve()
+        o.store(local + r)
+        out_blk_done = out_cb.wait()
+        ttl.copy(out_blk_done, out[mr : mr + BLOCK_M, nc : nc + BLOCK_N])
+    else:
+        p_to_send = partial_for_send_cb.wait()
+
+        def send_partial(pipe):
+            ttl.copy(p_to_send, pipe)
+
+        reduce_net.if_src(send_partial)
+
+
+def test_atom_summa_ksplit(device):
+    a_torch = torch.randn(M, K, dtype=torch.bfloat16) * 0.1
+    w_torch = torch.randn(K, N, dtype=torch.bfloat16) * 0.1
+    expected = torch.matmul(a_torch.float(), w_torch.float()).to(torch.bfloat16)
+
+    a_dram = to_dram(a_torch, device)
+    w_dram = to_dram(w_torch, device)
+    out_dram = to_dram(torch.zeros(M, N, dtype=torch.bfloat16), device)
+
+    atom_summa_ksplit(a_dram, w_dram, out_dram)
+
+    got = ttnn.to_torch(out_dram).reshape(M, N).to(torch.bfloat16)
+    assert_pcc(expected, got, threshold=0.99)

--- a/test/python/atom/test_atom_summa_mcast.py
+++ b/test/python/atom/test_atom_summa_mcast.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""SUMMA matmul as a single @ttl.atom, multicast only (no K-split).
+
+Each core (col_c, row_c) owns one BM x BN output block. A is multicast
+across the NP cores of each row; B is multicast down the MP rows of each
+column. Every core accumulates the full K range locally and writes its
+block out. Isolates the multicast PipeNets from the K-split reduce.
+"""
+
+import pytest
+import torch
+
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_pcc, to_dram
+
+TILE = ttnn.TILE_SIZE
+BM, BN, BK = 2, 2, 2
+
+NP = 2  # N blocks / grid cols
+MP = 2  # M blocks / grid rows
+
+M = MP * BM * TILE  # 128
+N = NP * BN * TILE  # 128
+K_BLOCKS = 2
+K = K_BLOCKS * BK * TILE  # 128
+
+GRID_X = NP
+GRID_Y = MP
+
+
+@ttl.atom(grid=(GRID_X, GRID_Y))
+def atom_summa_mcast(a, w, out):
+    a_cb = ttl.make_dataflow_buffer_like(a, shape=(BM, BK), block_count=2)
+    b_cb = ttl.make_dataflow_buffer_like(w, shape=(BK, BN), block_count=2)
+    # Private BRISC staging buffers so the loopback src core does not
+    # double-reserve a_cb/b_cb across BRISC (if_src) and NCRISC (if_dst).
+    tmp_a_cb = ttl.make_dataflow_buffer_like(a, shape=(BM, BK), block_count=2)
+    tmp_b_cb = ttl.make_dataflow_buffer_like(w, shape=(BK, BN), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=(BM, BN), block_count=2)
+
+    a_pipes = [ttl.Pipe(src=(0, m_p), dst=(slice(0, NP), m_p)) for m_p in range(MP)]
+    mcast_a_net = ttl.PipeNet(a_pipes)
+
+    b_pipes = [ttl.Pipe(src=(n_p, 0), dst=(n_p, slice(0, MP))) for n_p in range(NP)]
+    mcast_b_net = ttl.PipeNet(b_pipes)
+
+    col_c, row_c = ttl.node(dims=2)
+    mr = row_c * BM
+    nc = col_c * BN
+
+    p = out_cb.reserve()
+    for _ in range(K_BLOCKS):
+        a_blk = a_cb.wait()
+        b_blk = b_cb.wait()
+        p += a_blk @ b_blk
+
+    for kb in range(K_BLOCKS):
+        kc = kb * BK
+
+        def read_a(pipe):
+            tmp_w = tmp_a_cb.reserve()
+            ttl.copy(a[mr : mr + BM, kc : kc + BK], tmp_w)
+            tmp_r = tmp_a_cb.wait()
+            ttl.copy(tmp_r, pipe)
+
+        mcast_a_net.if_src(read_a)
+
+        def recv_a(pipe):
+            a_blk_dm = a_cb.reserve()
+            ttl.copy(pipe, a_blk_dm)
+
+        mcast_a_net.if_dst(recv_a)
+
+        def read_b(pipe):
+            tmp_w = tmp_b_cb.reserve()
+            ttl.copy(w[kc : kc + BK, nc : nc + BN], tmp_w)
+            tmp_r = tmp_b_cb.wait()
+            ttl.copy(tmp_r, pipe)
+
+        mcast_b_net.if_src(read_b)
+
+        def recv_b(pipe):
+            b_blk_dm = b_cb.reserve()
+            ttl.copy(pipe, b_blk_dm)
+
+        mcast_b_net.if_dst(recv_b)
+
+    out_blk = out_cb.wait()
+    ttl.copy(out_blk, out[mr : mr + BM, nc : nc + BN])
+
+
+def test_atom_summa_mcast(device):
+    a_torch = torch.randn(M, K, dtype=torch.bfloat16) * 0.1
+    w_torch = torch.randn(K, N, dtype=torch.bfloat16) * 0.1
+    expected = torch.matmul(a_torch.float(), w_torch.float()).to(torch.bfloat16)
+
+    a_dram = to_dram(a_torch, device)
+    w_dram = to_dram(w_torch, device)
+    out_dram = to_dram(torch.zeros(M, N, dtype=torch.bfloat16), device)
+
+    atom_summa_mcast(a_dram, w_dram, out_dram)
+
+    got = ttnn.to_torch(out_dram).reshape(M, N).to(torch.bfloat16)
+    assert_pcc(expected, got, threshold=0.99)

--- a/test/python/atom/test_atom_tensor_add.py
+++ b/test/python/atom/test_atom_tensor_add.py
@@ -2,17 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# REQUIRES: ttnn, tt-device
-# RUN: %python %s
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
 
 """@ttl.atom tensor add: a single unified body (no explicit thread
 functions) that reads two ttnn tensors through DFBs, adds them, and
 writes the result. Exercises the thread splitter end to end."""
 
+import pytest
 import torch
 
-import ttnn
 import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_l1
 
 
 @ttl.atom(grid=(1, 1))
@@ -35,41 +40,17 @@ def atom_tensor_add(a, b, out):
     ttl.copy(out_done, out[0:1, 0:1])
 
 
-def _to_l1(device, t):
-    dram = ttnn.from_torch(
-        t,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
+def test_atom_tensor_add(device):
+    tile = ttnn.TILE_SIZE
+    a_t = torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5
+    b_t = torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5
+    expected = (a_t.float() + b_t.float()).to(torch.bfloat16)
 
+    a = to_l1(a_t, device)
+    b = to_l1(b_t, device)
+    out = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
 
-def main():
-    from ttlang_test_utils import require_hardware
+    atom_tensor_add(a, b, out)
 
-    require_hardware()
-    device = ttnn.open_device(device_id=0)
-    try:
-        torch.manual_seed(2026)
-        tile = ttnn.TILE_SIZE
-        a_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5)
-        b_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5)
-        expected = (a_t.float() + b_t.float()).to(torch.bfloat16)
-
-        a = _to_l1(device, a_t)
-        b = _to_l1(device, b_t)
-        out = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
-
-        atom_tensor_add(a, b, out)
-
-        got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
-        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
-        print("atom_tensor_add: OK")
-    finally:
-        ttnn.close_device(device)
-
-
-if __name__ == "__main__":
-    main()
+    got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)

--- a/test/python/atom/test_atom_tensor_add.py
+++ b/test/python/atom/test_atom_tensor_add.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: %python %s
+
+"""@ttl.atom tensor add: a single unified body (no explicit thread
+functions) that reads two ttnn tensors through DFBs, adds them, and
+writes the result. Exercises the thread splitter end to end."""
+
+import torch
+
+import ttnn
+import ttl
+
+
+@ttl.atom(grid=(1, 1))
+def atom_tensor_add(a, b, out):
+    a_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    b_cb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    a_blk = a_cb.reserve()
+    ttl.copy(a[0:1, 0:1], a_blk)
+    b_blk = b_cb.reserve()
+    ttl.copy(b[0:1, 0:1], b_blk)
+
+    s = out_cb.reserve()
+    a_in = a_cb.wait()
+    b_in = b_cb.wait()
+    s.store(a_in + b_in)
+
+    out_done = out_cb.wait()
+    ttl.copy(out_done, out[0:1, 0:1])
+
+
+def _to_l1(device, t):
+    dram = ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+
+def main():
+    from ttlang_test_utils import require_hardware
+
+    require_hardware()
+    device = ttnn.open_device(device_id=0)
+    try:
+        torch.manual_seed(2026)
+        tile = ttnn.TILE_SIZE
+        a_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5)
+        b_t = (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5)
+        expected = (a_t.float() + b_t.float()).to(torch.bfloat16)
+
+        a = _to_l1(device, a_t)
+        b = _to_l1(device, b_t)
+        out = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
+
+        atom_tensor_add(a, b, out)
+
+        got = ttnn.to_torch(out).reshape(tile, tile).to(torch.bfloat16)
+        torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
+        print("atom_tensor_add: OK")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/atom/test_atom_tensor_copy.py
+++ b/test/python/atom/test_atom_tensor_copy.py
@@ -2,17 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# REQUIRES: ttnn, tt-device
-# RUN: %python %s
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
 
 """@ttl.atom tensor copy: the minimal unified body -- read one tile from
 a ttnn tensor into a DFB and write it back out. The compute thread is
-empty, so the splitter must emit only the two data-movement threads."""
+empty, so the splitter emits an empty compute kernel alongside the two
+data-movement threads."""
 
+import pytest
 import torch
 
-import ttnn
 import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_l1
 
 
 @ttl.atom(grid=(1, 1))
@@ -24,38 +30,14 @@ def atom_tensor_copy(src, dst):
     ttl.copy(blk_out, dst[0:1, 0:1])
 
 
-def _to_l1(device, t):
-    dram = ttnn.from_torch(
-        t,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
+def test_atom_tensor_copy(device):
+    tile = ttnn.TILE_SIZE
+    src_t = torch.randn(tile, tile, dtype=torch.bfloat16)
 
+    src = to_l1(src_t, device)
+    dst = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
 
-def main():
-    from ttlang_test_utils import require_hardware
+    atom_tensor_copy(src, dst)
 
-    require_hardware()
-    device = ttnn.open_device(device_id=0)
-    try:
-        torch.manual_seed(2026)
-        tile = ttnn.TILE_SIZE
-        src_t = torch.randn(tile, tile, dtype=torch.bfloat16)
-
-        src = _to_l1(device, src_t)
-        dst = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
-
-        atom_tensor_copy(src, dst)
-
-        got = ttnn.to_torch(dst).reshape(tile, tile).to(torch.bfloat16)
-        torch.testing.assert_close(got, src_t, rtol=1e-3, atol=1e-3)
-        print("atom_tensor_copy: OK")
-    finally:
-        ttnn.close_device(device)
-
-
-if __name__ == "__main__":
-    main()
+    got = ttnn.to_torch(dst).reshape(tile, tile).to(torch.bfloat16)
+    assert_allclose(got, src_t, rtol=1e-3, atol=1e-3)

--- a/test/python/atom/test_atom_tensor_copy.py
+++ b/test/python/atom/test_atom_tensor_copy.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: %python %s
+
+"""@ttl.atom tensor copy: the minimal unified body -- read one tile from
+a ttnn tensor into a DFB and write it back out. The compute thread is
+empty, so the splitter must emit only the two data-movement threads."""
+
+import torch
+
+import ttnn
+import ttl
+
+
+@ttl.atom(grid=(1, 1))
+def atom_tensor_copy(src, dst):
+    cb = ttl.make_dataflow_buffer_like(src, shape=(1, 1), block_count=2)
+    blk_in = cb.reserve()
+    ttl.copy(src[0:1, 0:1], blk_in)
+    blk_out = cb.wait()
+    ttl.copy(blk_out, dst[0:1, 0:1])
+
+
+def _to_l1(device, t):
+    dram = ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return ttnn.to_memory_config(dram, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+
+def main():
+    from ttlang_test_utils import require_hardware
+
+    require_hardware()
+    device = ttnn.open_device(device_id=0)
+    try:
+        torch.manual_seed(2026)
+        tile = ttnn.TILE_SIZE
+        src_t = torch.randn(tile, tile, dtype=torch.bfloat16)
+
+        src = _to_l1(device, src_t)
+        dst = _to_l1(device, torch.zeros(tile, tile, dtype=torch.bfloat16))
+
+        atom_tensor_copy(src, dst)
+
+        got = ttnn.to_torch(dst).reshape(tile, tile).to(torch.bfloat16)
+        torch.testing.assert_close(got, src_t, rtol=1e-3, atol=1e-3)
+        print("atom_tensor_copy: OK")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
@@ -8,11 +8,14 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=NOPOP
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=THREE
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SINGLE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=USER
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=XTHREAD
 
 // -----
 
-// User DFBs at indices 0, 1, 2 and a compiler-allocated DFB at index 3.
-// The pass should update base_cta_index to 4 and emit ttl.compiler_allocated_dfbs.
+// User DFBs at indices 0, 1, 2 (unused: keep their indices) and a
+// compiler-allocated DFB at index 3. The pass should update base_cta_index
+// to 4 and emit ttl.compiler_allocated_dfbs.
 
 // CHECK: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
 
@@ -70,7 +73,7 @@ func.func @compute_only()
 // Non-overlapping compiler-allocated DFBs: DFB #3 is released (cb_pop)
 // before DFB #4 is allocated (bind_cb). Both should be assigned index 3.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
+// DEBUG: DFB reuse: cb4 -> cb3
 // DEBUG: Total DFB count: 4
 
 // REUSE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -98,7 +101,6 @@ func.func @non_overlapping_reuse()
 // Overlapping compiler-allocated DFBs: DFB #4 is allocated while DFB #3
 // is still live. They must keep separate indices.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
 // OVERLAP: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -131,7 +133,8 @@ func.func @overlapping_no_reuse()
 // DFB-D [bind, pop]: nested within C, dies before C
 // Result: A and C share slot 0 (index 3), B and D share slot 1 (index 4).
 
-// DEBUG: DFB reuse: 4 compiler-allocated DFBs -> 2 physical slot(s)
+// DEBUG: DFB reuse: cb5 -> cb3
+// DEBUG: DFB reuse: cb6 -> cb4
 // DEBUG: Total DFB count: 5
 
 // FOUR: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -173,43 +176,33 @@ func.func @four_dfbs_nested_reuse()
 
 // -----
 
-// Mixed CircularBufferTypes: DFBs #3 and #5 are [1,1] bf16, DFB #4 is
-// [2,4] bf16. Type partitioning prevents #3 and #4 from sharing a slot
-// even though their lifetimes do not overlap. #3 and #5 share within
-// the [1,1] partition. The [2,4] partition gets the next contiguous index.
-//
-// [1,1] partition: #3 non-overlapping with #5 -> 1 slot (index 3)
-// [2,4] partition: #4 alone -> 1 slot (index 4)
-// Total: 2 physical compiler-allocated slots.
+// Mixed shapes, one element type: capacity is a >= constraint, so the [1,1]
+// and [2,4] buffers share one slot sized to the largest member (8 tiles per
+// block); every reserve/wait carries its own block size.
 
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 2 physical slot(s)
-// DEBUG: Total DFB count: 5
+// DEBUG: DFB reuse: cb4 -> cb3
+// DEBUG: DFB reuse: cb5 -> cb3
+// DEBUG: Total DFB count: 4
 
-// MIXED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32}]}
+// MIXED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32}]}
 
-// MIXED-LABEL: func.func @mixed_types_no_cross_reuse
-// MIXED-SAME: ttl.base_cta_index = 5 : i32
-// [1,1] partition slot
+// MIXED-LABEL: func.func @mixed_shapes_share_slot
+// MIXED-SAME: ttl.base_cta_index = 4 : i32
 // MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
-// [2,4] partition slot
-// MIXED: ttl.bind_cb{cb_index = 4, {{.*}}} {ttl.compiler_allocated} : <[2, 4],
-// [1,1] partition slot reused
+// MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[2, 4],
 // MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
-// MIXED-NOT: cb_index = 5
+// MIXED-NOT: cb_index = 4
 // MIXED: return
-func.func @mixed_types_no_cross_reuse()
+func.func @mixed_shapes_share_slot()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // [1,1] DFB
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // [2,4] DFB -- different type, cannot reuse index 3
   %alloc4 = ttl.bind_cb {cb_index = 4, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc4 : <[2, 4], !ttcore.tile<32x32, bf16>, 2>
-  // [1,1] DFB -- same type as #3, reuses its slot
   %alloc5 = ttl.bind_cb {cb_index = 5, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc5 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
@@ -217,10 +210,9 @@ func.func @mixed_types_no_cross_reuse()
 
 // -----
 
-// No cb_pop on either compiler-allocated DFB. Conservative fallback
-// treats both as live for the entire function. No reuse possible.
+// No cb_pop on either compiler-allocated DFB. No acquires or releases at
+// all: both keep their indices.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
 // NOPOP: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -247,7 +239,8 @@ func.func @no_cb_pop_conservative()
 // Three sequential non-overlapping DFBs. All should map to a single
 // physical slot (multi-round slot recycling).
 
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 1 physical slot(s)
+// DEBUG: DFB reuse: cb4 -> cb3
+// DEBUG: DFB reuse: cb5 -> cb3
 // DEBUG: Total DFB count: 4
 
 // THREE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
@@ -274,8 +267,7 @@ func.func @three_sequential_one_slot()
 
 // -----
 
-// Single compiler-allocated DFB. The reuse algorithm early-returns
-// (size <= 1). Index and module attribute should be unchanged.
+// Single compiler-allocated DFB. Index and module attribute unchanged.
 
 // SINGLE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
 
@@ -292,5 +284,91 @@ func.func @single_dfb_no_reuse()
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.cb_pop %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// User DFBs with the same producer thread (reader) and consumer thread
+// (compute) and disjoint lifetimes share one index. The pass emits
+// ttl.dfb_index_map for the runtime.
+
+// DEBUG: DFB reuse: cb1 -> cb0
+// DEBUG: Total DFB count: 1
+
+// USER: module attributes {ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]}
+
+// USER-LABEL: func.func @user_reader
+// USER-SAME: ttl.base_cta_index = 1 : i32
+// USER-COUNT-2: ttl.bind_cb{cb_index = 0,
+// USER-NOT: cb_index = 1
+// USER-LABEL: func.func @user_compute
+// USER-COUNT-2: ttl.bind_cb{cb_index = 0,
+// USER-NOT: cb_index = 1
+// USER: return
+func.func @user_reader()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r1 = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @user_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w1 = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// User DFBs with different producer threads never share an index, even with
+// disjoint lifetimes: the physical CB counters and per-RISC pointers do not
+// survive a producer change.
+
+// XTHREAD-LABEL: func.func @xt_reader
+// XTHREAD: ttl.bind_cb{cb_index = 0,
+// XTHREAD-LABEL: func.func @xt_writer
+// XTHREAD: ttl.bind_cb{cb_index = 1,
+// XTHREAD-LABEL: func.func @xt_compute
+// XTHREAD: ttl.bind_cb{cb_index = 0,
+// XTHREAD: ttl.bind_cb{cb_index = 1,
+func.func @xt_reader()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r0 = ttl.cb_reserve %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @xt_writer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %r1 = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @xt_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
+                ttl.crta_indices = []} {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w0 = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %w1 = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
@@ -9,7 +9,7 @@
 // Elementwise result feeds into reduce: pass should insert a compiler-allocated DFB.
 
 // CHECK-LABEL: func.func @elementwise_into_reduce
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: ttl.add
 // CHECK: ttl.cb_reserve
 // CHECK: ttl.store
@@ -124,24 +124,28 @@ func.func @shared_materialization()
 // compiler-allocated DFB. The first DFB is consumed and released (cb_pop)
 // before the second is created, so finalize should reuse the same index.
 
-// DBG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
-// DBG: Total DFB count: 5
+// DBG: DFB reuse: cb3 -> cb0
+// DBG: DFB reuse: cb4 -> cb3
+// DBG: DFB reuse: cb5 -> cb3
+// DBG: Total DFB count: 4
 
 // After insert: two compiler-allocated DFBs at indices 4, 5, both at
 // function body entry.
 // CHECK-LABEL: func.func @sequential_intermediates_reuse
-// CHECK: ttl.bind_cb{cb_index = 4, block_count = 2} {ttl.compiler_allocated}
-// CHECK: ttl.bind_cb{cb_index = 5, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 4, block_count = 1} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 5, block_count = 1} {ttl.compiler_allocated}
 // CHECK: ttl.add
 // CHECK: ttl.reduce
 // CHECK: ttl.mul
 // CHECK: ttl.reduce
 
-// After finalize with reuse: both DFBs get index 4 (one physical slot).
-// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// After finalize: the two intermediates share one slot, user cb3
+// (reserve-only; cb0 fully released first) merges onto cb0, and the index
+// space compacts to users 0..2 + intermediates at 3.
+// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 1 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}], ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 3 : i32}]}
 // FINALIZE-LABEL: func.func @sequential_intermediates_reuse
-// FINALIZE-SAME: ttl.base_cta_index = 5 : i32
-// FINALIZE-NOT: cb_index = 5
+// FINALIZE-SAME: ttl.base_cta_index = 4 : i32
+// FINALIZE-NOT: cb_index = 4
 // FINALIZE: return
 func.func @sequential_intermediates_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
@@ -5,19 +5,46 @@
 
 // -----
 
-// All 32 CB indices (0-31) are occupied by user DFBs. The add result
-// feeds reduce, which requires a compiler-allocated DFB at index 32.
-// After reuse (only one intermediate, nothing to reuse), the total DFB
-// count is 33, exceeding the hardware maximum of 32.
+// All 32 CB indices (0-31) are occupied by distinct user DFBs. The add
+// result feeds reduce, which requires a compiler-allocated DFB at index 32.
+// Nothing can merge, so the compacted count is 33, exceeding the hardware
+// maximum of 32.
 
-// expected-error @below {{need 33 DFB indices but hardware supports at most 32 (1 compiler-allocated after reuse)}}
+// expected-error @below {{need 33 DFB indices after reuse but hardware supports at most 32}}
 module {
 func.func @exceeds_max_cb_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // Use index 31 to occupy the last slot.
+  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb4 = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb5 = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb6 = ttl.bind_cb {cb_index = 6, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb7 = ttl.bind_cb {cb_index = 7, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb8 = ttl.bind_cb {cb_index = 8, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb9 = ttl.bind_cb {cb_index = 9, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb10 = ttl.bind_cb {cb_index = 10, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb11 = ttl.bind_cb {cb_index = 11, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb12 = ttl.bind_cb {cb_index = 12, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb13 = ttl.bind_cb {cb_index = 13, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb14 = ttl.bind_cb {cb_index = 14, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb15 = ttl.bind_cb {cb_index = 15, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb16 = ttl.bind_cb {cb_index = 16, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb17 = ttl.bind_cb {cb_index = 17, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb18 = ttl.bind_cb {cb_index = 18, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb19 = ttl.bind_cb {cb_index = 19, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb20 = ttl.bind_cb {cb_index = 20, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb21 = ttl.bind_cb {cb_index = 21, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb22 = ttl.bind_cb {cb_index = 22, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb23 = ttl.bind_cb {cb_index = 23, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb24 = ttl.bind_cb {cb_index = 24, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb25 = ttl.bind_cb {cb_index = 25, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb26 = ttl.bind_cb {cb_index = 26, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb27 = ttl.bind_cb {cb_index = 27, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb28 = ttl.bind_cb {cb_index = 28, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb29 = ttl.bind_cb {cb_index = 29, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb30 = ttl.bind_cb {cb_index = 30, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %cb31 = ttl.bind_cb {cb_index = 31, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
@@ -12,7 +12,7 @@
 // entry, the rest of the materialization bundle stays inside the loop.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_for
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   ttl.add
 // CHECK:   ttl.cb_reserve
@@ -58,7 +58,7 @@ func.func @intermediate_in_scf_for()
 // function body entry, not inside the if region.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.if
 // CHECK-NOT: ttl.compiler_allocated
 // CHECK:   ttl.add
@@ -101,7 +101,7 @@ func.func @intermediate_in_scf_if(%cond: i1)
 // Before the fix, this crashed in TTLFinalizeDFBIndices.
 
 // CHECK-LABEL: func.func @intermediate_in_nested_for_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   scf.if
 // CHECK-NOT: ttl.compiler_allocated


### PR DESCRIPTION
File-level squash of the atom-dependent half of the dfb-reuse work.

- atom_inline.py: inlined-atom local DFB/PipeNet declarations + closure-constant
  folding for inlined callees.
- atom.py: inline-site DFB handling (superseded Python scratch reuse removed in
  favor of the module-level finalize pass).
- ttl_api.py: _apply_dfb_index_map consumes the ttl.dfb_index_map module attr
  from the finalize pass; _merge_dfb_configs tolerates reuse overlay; wired into
  _lower_program_to_kernel (atom-introduced shared lowering path).
- test/python/atom/test_atom_inline.py.

Built on top of #657 and #688 *please review second commit only*