### PR TITLE
Fix typecast, broadcast and dprint tests

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1119,8 +1119,8 @@ def TTL_TileBinaryBcastOp : TTL_TileOp<"tile_binary_bcast", [TTL_CBInputTileOpTr
     is a single row/col/scalar tile broadcast along `bcast_type` and `op` is
     selected by `eltwise_binary_type` (add/sub/mul). Both inputs are read from
     CBs and the result is written to DST (the FPU broadcast path). The output
-    operand carries the output CB for init-time configuration only. Maps to
-    ttkernel.binary_bcast_init + ttkernel.binary_bcast.
+    operand carries the output CB for init-time configuration only. Lowers to
+    ttkernel.unary_bcast followed by ttkernel.binary_dest_reuse_tiles.
 
     This is the fused form of a ttl.tile_bcast feeding a ttl.tile_{add,sub,mul}:
     it keeps the broadcast on the FPU instead of materializing it into DST for an

--- a/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
@@ -137,16 +137,13 @@ static llvm::DenseMap<mlir::TypeID, InitOpInfo> buildComputeToInitMap() {
                                       bcastOp.getBcastTypeAttr());
       }};
 
-  map[mlir::TypeID::get<ttk::BinaryBcastTileOp>()] = {[](OpBuilder &b,
-                                                         Location l,
-                                                         Operation *computeOp) {
-    auto bcastOp = cast<ttk::BinaryBcastTileOp>(computeOp);
-    Value outputCB = resolveOutputCB(computeOp, kBcastOutputCBIndexAttrName);
-    assert(outputCB && "output CB required for binary_bcast_init");
-    ttk::BinaryBcastInitOp::create(b, l, bcastOp.getIn0Cb(), bcastOp.getIn1Cb(),
-                                   outputCB, bcastOp.getEltwiseBinaryTypeAttr(),
-                                   bcastOp.getBcastTypeAttr());
-  }};
+  map[mlir::TypeID::get<ttk::BinaryDestReuseTilesOp>()] = {
+      [](OpBuilder &b, Location l, Operation *computeOp) {
+        auto binaryOp = cast<ttk::BinaryDestReuseTilesOp>(computeOp);
+        ttk::BinaryDestReuseTilesInitOp::create(
+            b, l, binaryOp.getInCb(), binaryOp.getEltwiseBinaryTypeAttr(),
+            binaryOp.getReuseTypeAttr());
+      }};
 
   map[mlir::TypeID::get<ttk::ReduceTileOp>()] = {[](OpBuilder &b, Location l,
                                                     Operation *computeOp) {
@@ -226,12 +223,13 @@ static InitKey computeInitKey(Operation *op) {
         typeId, {bcast.getInCb()}, static_cast<int64_t>(bcast.getBcastType())};
   }
 
-  // Distinct eltwise op / broadcast dim combinations configure the FPU
+  // Distinct eltwise op / reuse direction combinations configure the FPU
   // differently and must not share an init.
-  if (auto bbcast = dyn_cast<ttk::BinaryBcastTileOp>(op)) {
-    int64_t disc = (static_cast<int64_t>(bbcast.getEltwiseBinaryType()) << 8) |
-                   static_cast<int64_t>(bbcast.getBcastType());
-    return {typeId, {bbcast.getIn0Cb(), bbcast.getIn1Cb()}, disc};
+  if (auto binaryReuse = dyn_cast<ttk::BinaryDestReuseTilesOp>(op)) {
+    int64_t disc =
+        (static_cast<int64_t>(binaryReuse.getEltwiseBinaryType()) << 8) |
+        static_cast<int64_t>(binaryReuse.getReuseType());
+    return {typeId, {binaryReuse.getInCb()}, disc};
   }
 
   // Different full_fp32 modes select a different LLK kernel branch and must

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -757,8 +757,9 @@ struct TTLTileReduceToTTKernel : OpConversionPattern<TileReduceOp> {
 // Binary Broadcast Tile Lowering
 //===----------------------------------------------------------------------===//
 
-/// Lower ttl.tile_binary_bcast to ttkernel.binary_bcast. lhs and rhs are read
-/// from CBs (FPU path); rhs is the single tile broadcast along bcast_type.
+/// Lower ttl.tile_binary_bcast to ttkernel.unary_bcast followed by
+/// ttkernel.binary_dest_reuse_tiles. The broadcast source is written to DST,
+/// then lhs is read from its CB and combined with the broadcast value in DST.
 struct TTLTileBinaryBcastToTTKernel : OpConversionPattern<TileBinaryBcastOp> {
   using OpConversionPattern<TileBinaryBcastOp>::OpConversionPattern;
 
@@ -784,17 +785,22 @@ struct TTLTileBinaryBcastToTTKernel : OpConversionPattern<TileBinaryBcastOp> {
           op, "cannot compute rhs CB tile index from tensor.extract");
     }
 
-    auto binaryBcastOp = ttk::BinaryBcastTileOp::create(
-        rewriter, op.getLoc(), setup->inCB, *rhsCB, setup->inCBIdx, *rhsIdx,
-        setup->dstIdx, op.getEltwiseBinaryTypeAttr(),
+    auto bcastOp = ttk::UnaryBcastTileOp::create(
+        rewriter, op.getLoc(), *rhsCB, *rhsIdx, setup->dstIdx,
         ttk::BcastTypeAttr::get(op.getContext(),
                                 convertBcastType(op.getBcastType())));
 
     // Propagate output CB index for per-op init insertion.
     if (auto cbIdxAttr =
             op->getAttrOfType<IntegerAttr>(kBcastOutputCBIndexAttrName)) {
-      binaryBcastOp->setAttr(kBcastOutputCBIndexAttrName, cbIdxAttr);
+      bcastOp->setAttr(kBcastOutputCBIndexAttrName, cbIdxAttr);
     }
+
+    ttk::BinaryDestReuseTilesOp::create(
+        rewriter, op.getLoc(), setup->inCB, setup->inCBIdx, setup->dstIdx,
+        op.getEltwiseBinaryTypeAttr(),
+        ttk::BinaryDestReuseTypeAttr::get(
+            op.getContext(), ttk::BinaryDestReuseType::DestToSrcB));
 
     rewriter.replaceOp(op, adaptor.getLhs());
     return success();

--- a/test/python/dprint/runtime.py
+++ b/test/python/dprint/runtime.py
@@ -133,16 +133,18 @@ def dprint_f32_kernel(inp_f32, out_f32):
 # Use CHECK-DAG where ordering is non-deterministic.
 # =============================================================================
 
-# Scalar prints and thread conditioning run outside the fused compute
-# body and may appear in any order relative to each other and DM output.
-# CHECK-DAG: bf16 compute start
-# CHECK-DAG: answer: 42
-# CHECK-DAG: pi: 3.14
-# CHECK-DAG: cb_id
-# CHECK-DAG: bf16 dm hello
-# CHECK-DAG: core:
-# CHECK-DAG: math thread
-# CHECK-DAG: unpack thread
+# Scalar prints and thread conditioning run outside the fused compute body and
+# may appear in any order relative to each other and DM output. Match runtime
+# thread prefixes so generated C++ DPRINT statements do not satisfy the checks.
+# CHECK-DAG: TR1: bf16 compute start
+# CHECK-DAG: TR1: answer: 42
+# CHECK-DAG: TR1: pi: 3.14
+# CHECK-DAG: {{TR[0-2]: cb_id}}
+# CHECK-DAG: NC: bf16 dm hello
+# CHECK-DAG: NC: core:
+# CHECK-DAG: TR2: pack thread
+# CHECK-DAG: TR1: math thread
+# CHECK-DAG: TR0: unpack thread
 
 # DST and tile dprints are inside the fused compute body (pack thread).
 # They appear after the scalar/thread output since the fused compute
@@ -155,11 +157,9 @@ def dprint_f32_kernel(inp_f32, out_f32):
 # XXX: === after add ===
 # XXX: DST[0] (ttl.tile_add)
 # XXX: DST[1] (ttl.tile_exp)
-# CHECK: pack thread
-
 # Tensor pages print in dm_write (bf16 page from L1 CB)
 # The page output starts with page number followed by BF16 values.
-# CHECK: 0:
+# CHECK-DAG: BR: 0:
 
 # =============================================================================
 # FileCheck patterns -- f32 kernel (runs after bf16 kernel)

--- a/test/ttlang/Conversion/TTLToCompute/typecast.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/typecast.mlir
@@ -176,9 +176,8 @@ func.func @fuse_bcast_add_then_typecast(
   // CHECK-SAME:   ins(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bf16>>)
   // CHECK-SAME:   outs(%{{.*}} : tensor<2x2x!ttcore.tile<32x32, f32>>)
   // CHECK:      ^bb0(%[[A:.*]]: !ttcore.tile<32x32, bf16>, %[[B:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
-  // CHECK:        %[[BC:.*]] = ttl.tile_bcast %[[A]], %[[OUT]]{{.*}}-> !ttcore.tile<32x32, bf16>
-  // CHECK:        %[[ADD:.*]] = ttl.tile_add %[[BC]], %[[B]]{{.*}}: !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
-  // CHECK:        %[[C:.*]] = ttl.tile_typecast %[[ADD]]{{.*}}: !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, f32>
+  // CHECK:        %[[FUSED:.*]] = ttl.tile_binary_bcast %[[B]], %[[A]], %[[OUT]] <add>{{.*}}-> !ttcore.tile<32x32, bf16>
+  // CHECK:        %[[C:.*]] = ttl.tile_typecast %[[FUSED]]{{.*}}: !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, f32>
   // CHECK:        ttl.tile_store %[[C]], %{{.*}}
   %bc = ttl.block.broadcast %a_cb dims = [-2, -1], shape = [2, 2]
        : tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<2x2x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Conversion/TTLToTTKernel/binary_bcast_lowering.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/binary_bcast_lowering.mlir
@@ -1,22 +1,23 @@
-// Verify ttl.tile_binary_bcast lowers to ttkernel.binary_bcast (the FPU
-// broadcast-binary op that reads BOTH operands from CBs and writes DST) and
-// that ttkernel-insert-inits emits the matching, hoisted binary_bcast_init.
+// Verify ttl.tile_binary_bcast lowers to a unary broadcast into DST followed by
+// binary_dest_reuse_tiles, which combines the broadcast value in DST with the
+// lhs tile read from its CB.
 //
 // RUN: ttlang-opt %s --split-input-file \
 // RUN:   -pass-pipeline='builtin.module(convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
 // RUN:   | FileCheck %s
 
 // mul + column broadcast (the OPT8 rewrite): C[i,j] = data[i,j] * bcast_col(alpha[i,0]).
-// in0 = data (full tile, index linearized [row, col]); in1 = alpha (broadcast
-// source, index = %row). The per-op binary_bcast_init sits inside the loop
-// directly before the op, matching every other per-op init; only the common
-// init is hoisted above the loops.
+// The broadcast init uses the output CB for pack configuration. The
+// binary_dest_reuse op then uses DestToSrcB so the CB data tile is srcA and the
+// broadcast value in DST is srcB.
 //
 // CHECK-LABEL: func.func @binary_bcast_mul_col
 // CHECK: scf.for %[[ROW:.*]] = %{{.*}} to %{{.*}}
 // CHECK:   scf.for %[[COL:.*]] = %{{.*}} to %{{.*}}
-// CHECK:     ttkernel.binary_bcast_init(%{{.*}}, %{{.*}}, %{{.*}}, <mul>, <col>)
-// CHECK:     ttkernel.binary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, %[[ROW]], %{{.*}}, <mul>, <col>)
+// CHECK:     ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <col>)
+// CHECK:     ttkernel.unary_bcast(%{{.*}}, %[[ROW]], %{{.*}}, <col>)
+// CHECK:     ttkernel.binary_dest_reuse_tiles_init(%{{.*}}, <mul>, <dest_to_srcb>)
+// CHECK:     ttkernel.binary_dest_reuse_tiles(%{{.*}}, %{{.*}}, %{{.*}}, <mul>, <dest_to_srcb>)
 func.func @binary_bcast_mul_col()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %cb_data = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>


### PR DESCRIPTION
### Problem description
Test fail on the `zoecarver/mul-bcast` branch.
It makes difficult to merge something in it, when CI jobs are red.

### What's changed
Fix tests.

### Ticket
None.

### Checklist
- [ ] New/Existing tests provide coverage for changes
