### PR TITLE
Add transpose attribute to matmul

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1361,9 +1361,15 @@ def TTL_MatmulOp : TTL_Op<"matmul", [Pure,
     must match: lhs.shape[1] == rhs.shape[0]. Result shape is
     [lhs.shape[0], rhs.shape[1]].
 
+    When the optional `transpose_rhs` unit attribute is set, `rhs` is the
+    transpose of B and stored as [N, K]: result[i, j] = sum_k(lhs[i, k] *
+    rhs[j, k]). The inner (K) dimensions then match as lhs.shape[1] ==
+    rhs.shape[1], and the result shape is [lhs.shape[0], rhs.shape[0]].
+
     Lowered to ttl.compute with ttl.tile_matmul_block by convert-ttl-to-compute.
   }];
-  let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs);
+  let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs,
+                       UnitAttr:$transpose_rhs);
   let results = (outs AnyRankedTensor:$result);
   let assemblyFormat =
       "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)";
@@ -1384,11 +1390,16 @@ def TTL_TileMatmulBlockOp : TTL_TileOp<"tile_matmul_block",
     accumulator + lhs @ rhs, exploiting matmul_block's additive
     accumulation to eliminate an explicit add.
 
+    When the optional `transpose_rhs` unit attribute is set, the B operand
+    is the transpose of the multiplicand and stored as [N, K]; the attribute
+    is forwarded to matmul_block's transpose argument and selects the
+    transposed per-K addressing during TTKernel lowering.
+
     Maps to ttkernel.mm_block_init + ttkernel.experimental::matmul_block.
   }];
   let arguments = (ins TTL_TileOrTensor:$lhs, TTL_TileOrTensor:$rhs,
                        Optional<TTL_TileOrTensor>:$accumulator,
-                       Index:$dst_index);
+                       Index:$dst_index, UnitAttr:$transpose_rhs);
   let results = (outs TTL_TileOrTensor:$result);
   let assemblyFormat = [{
     $lhs `,` $rhs (`,` $accumulator^)? `into` `dst` `[` $dst_index `]` attr-dict `:`

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1543,15 +1543,20 @@ mlir::LogicalResult mlir::tt::ttl::MatmulOp::verify() {
     return emitOpError() << "result must have static shape";
   }
 
+  // When transpose_rhs is set, rhs is the transpose B stored as [N, K], so K
+  // is rhs.shape[1] and N is rhs.shape[0].
+  bool transposeRhs = getTransposeRhs();
   int64_t lhsK = lhsType.getDimSize(1);
-  int64_t rhsK = rhsType.getDimSize(0);
+  int64_t rhsK = transposeRhs ? rhsType.getDimSize(1) : rhsType.getDimSize(0);
   if (lhsK != rhsK) {
     return emitOpError() << "K dimension mismatch: lhs has " << lhsK
-                         << " columns but rhs has " << rhsK << " rows";
+                         << " columns but rhs has " << rhsK
+                         << (transposeRhs ? " columns" : " rows");
   }
 
   int64_t expectedM = lhsType.getDimSize(0);
-  int64_t expectedN = rhsType.getDimSize(1);
+  int64_t expectedN =
+      transposeRhs ? rhsType.getDimSize(0) : rhsType.getDimSize(1);
   if (resultType.getDimSize(0) != expectedM ||
       resultType.getDimSize(1) != expectedN) {
     return emitOpError() << "result shape [" << resultType.getDimSize(0) << ", "

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -862,11 +862,12 @@ struct TTLTileMatmulBlockToTTKernel : OpConversionPattern<TileMatmulBlockOp> {
       return rewriter.notifyMatchFailure(
           op, "cannot determine operand tensor shapes for block dimensions");
     }
-    // Assumes non-transposed: lhs is [M, K], rhs is [K, N].
-    // TODO(#420): support transpose.
-    int32_t rt = lhsTy.getDimSize(0); // M
-    int32_t ct = rhsTy.getDimSize(1); // N
-    int32_t kt = lhsTy.getDimSize(1); // K
+    // lhs is [M, K]. rhs is [K, N] (non-transposed) or [N, K] when
+    // transpose_rhs is set, so the output column count N comes from rhs[0].
+    bool transposeRhs = op.getTransposeRhs();
+    int32_t rt = lhsTy.getDimSize(0);                                      // M
+    int32_t ct = transposeRhs ? rhsTy.getDimSize(0) : rhsTy.getDimSize(1); // N
+    int32_t kt = lhsTy.getDimSize(1);                                      // K
 
     // Starting DFB tile index: 0 when not subblocked (DFB refilled each
     // K-step), or the slice offset when subblocked.
@@ -876,8 +877,8 @@ struct TTLTileMatmulBlockToTTKernel : OpConversionPattern<TileMatmulBlockOp> {
     Value in1TileIndex =
         utils::addSliceOffset(op.getRhs(), zero, rewriter, loc);
 
-    Value transpose =
-        arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
+    Value transpose = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32IntegerAttr(transposeRhs ? 1 : 0));
     Value ctVal = arith::ConstantOp::create(rewriter, loc,
                                             rewriter.getI32IntegerAttr(ct));
     Value rtVal = arith::ConstantOp::create(rewriter, loc,
@@ -907,17 +908,21 @@ struct TTLTileMatmulBlockToTTKernel : OpConversionPattern<TileMatmulBlockOp> {
       }
     }
 
-    // B stride per K step: for non-transposed B [K, N] the stride between
-    // K rows is the full CB N dimension. For transposed B [N, K] (future)
-    // the stride would be 1.
-    // TODO(#420): derive from transpose flag once transpose is supported.
+    // B stride per K step. For non-transposed B [K, N] the stride between
+    // K rows is the full CB N dimension (the innermost CB dim). For
+    // transposed B [N, K] the K tiles are the innermost dimension, so each
+    // K step advances by a single tile.
     int32_t bStridePerK = ct; // default when not subblocked
-    Value rhsCBVal = lookupCBByIndex(op.getRhs(), funcOp);
-    assert(rhsCBVal && "rhs CB lookup failed after prior successful lookup");
-    if (auto ttlCb = mlir::dyn_cast<CircularBufferType>(rhsCBVal.getType())) {
-      auto cbShape = ttlCb.getShape();
-      if (cbShape.size() == 2) {
-        bStridePerK = cbShape[1];
+    if (transposeRhs) {
+      bStridePerK = 1;
+    } else {
+      Value rhsCBVal = lookupCBByIndex(op.getRhs(), funcOp);
+      assert(rhsCBVal && "rhs CB lookup failed after prior successful lookup");
+      if (auto ttlCb = mlir::dyn_cast<CircularBufferType>(rhsCBVal.getType())) {
+        auto cbShape = ttlCb.getShape();
+        if (cbShape.size() == 2) {
+          bStridePerK = cbShape[1];
+        }
       }
     }
 
@@ -925,7 +930,8 @@ struct TTLTileMatmulBlockToTTKernel : OpConversionPattern<TileMatmulBlockOp> {
     // tile; the loop iterates K times. The kt_dim parameter passed to the
     // hardware is the full K dimension, used by the unpacker for address
     // stride setup. Each K step advances A's tile index by 1 (row-major
-    // [M, K]) and B's tile index by bStridePerK (row-major [K, N]).
+    // [M, K]) and B's tile index by bStridePerK (the CB N dimension for
+    // row-major [K, N], or 1 for transposed row-major [N, K]).
     {
       Value ub = arith::ConstantIndexOp::create(rewriter, loc, kt);
       Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -405,10 +405,12 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   // Without this, subblocking along M would incorrectly slice B (which is
   // indexed by [K, N], not [M, N]).
   DenseSet<Value> matmulLhsTensors, matmulRhsTensors;
+  bool matmulTransposeRhs = false;
   for (Operation *op : trace.opsInOrder) {
     if (auto matmulOp = dyn_cast<MatmulOp>(op)) {
       matmulLhsTensors.insert(matmulOp.getLhs());
       matmulRhsTensors.insert(matmulOp.getRhs());
+      matmulTransposeRhs |= matmulOp.getTransposeRhs();
     }
   }
   bool hasMatmul = !matmulLhsTensors.empty();
@@ -420,13 +422,14 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
 
   if (hasMatmul) {
     // 3D iteration space [M, N, K] with matmul indexing maps.
-    // LHS A is [M, K], RHS B is [K, N] (non-transposed).
-    // TODO(#420): derive RHS map from a transpose flag for transposed B.
+    // LHS A is [M, K]. RHS B is [K, N] (non-transposed) or [N, K] when
+    // transpose_rhs is set, so its indexing map swaps to (N, K) = (d1, d2).
     auto d0 = getAffineDimExpr(0, ctx); // M
     auto d1 = getAffineDimExpr(1, ctx); // N
     auto d2 = getAffineDimExpr(2, ctx); // K
     AffineMap lhsMap = AffineMap::get(3, 0, {d0, d2}, ctx);
-    AffineMap rhsMap = AffineMap::get(3, 0, {d2, d1}, ctx);
+    AffineMap rhsMap = matmulTransposeRhs ? AffineMap::get(3, 0, {d1, d2}, ctx)
+                                          : AffineMap::get(3, 0, {d2, d1}, ctx);
     AffineMap parallelMap = AffineMap::get(3, 0, {d0, d1}, ctx);
 
     for (size_t i = 0; i < trace.rootInputs.size(); ++i) {
@@ -682,6 +685,7 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
         auto matmulTileOp =
             createTileOpWithPlaceholderDstIndex<TileMatmulBlockOp>(
                 rewriter, loc, matmulTileType, lhsTile, rhsTile, Value());
+        matmulTileOp.setTransposeRhsAttr(matmulOp.getTransposeRhsAttr());
         tileResult = matmulTileOp;
       }
     } else {
@@ -710,6 +714,9 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
           auto foldedMatmul =
               createTileOpWithPlaceholderDstIndex<TileMatmulBlockOp>(
                   rewriter, loc, addTileType, mmLhs, mmRhs, accTile);
+          if (auto mmOp = tensorA.getDefiningOp<MatmulOp>()) {
+            foldedMatmul.setTransposeRhsAttr(mmOp.getTransposeRhsAttr());
+          }
           return foldedMatmul;
         };
         Value folded = tryFold(operands[0], operands[1]);
@@ -742,6 +749,9 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
             auto mmTileOp =
                 createTileOpWithPlaceholderDstIndex<TileMatmulBlockOp>(
                     rewriter, loc, matmulTileType, mmLhs, mmRhs, Value());
+            if (auto mmOp = operand.getDefiningOp<MatmulOp>()) {
+              mmTileOp.setTransposeRhsAttr(mmOp.getTransposeRhsAttr());
+            }
             tensorToTile[operand] = mmTileOp;
             deferredMatmul.erase(dfIt);
           }
@@ -1262,11 +1272,14 @@ struct LowerMatmulToCompute : OpRewritePattern<MatmulOp> {
     auto resultType = getTensorType(op.getResult());
     MLIRContext *ctx = rewriter.getContext();
 
+    bool transposeRhs = op.getTransposeRhs();
     auto d0 = getAffineDimExpr(0, ctx); // m
     auto d1 = getAffineDimExpr(1, ctx); // n
     auto d2 = getAffineDimExpr(2, ctx); // k
     AffineMap lhsMap = AffineMap::get(3, 0, {d0, d2}, ctx);
-    AffineMap rhsMap = AffineMap::get(3, 0, {d2, d1}, ctx);
+    // RHS B is [K, N] (non-transposed) or [N, K] when transpose_rhs is set.
+    AffineMap rhsMap = transposeRhs ? AffineMap::get(3, 0, {d1, d2}, ctx)
+                                    : AffineMap::get(3, 0, {d2, d1}, ctx);
     AffineMap outMap = AffineMap::get(3, 0, {d0, d1}, ctx);
     SmallVector<Attribute> inputMaps = {AffineMapAttr::get(lhsMap),
                                         AffineMapAttr::get(rhsMap)};
@@ -1276,10 +1289,12 @@ struct LowerMatmulToCompute : OpRewritePattern<MatmulOp> {
 
     return buildComputeFromInputs(
         op, rewriter, ValueRange{lhs, rhs}, resultType, inputMaps, outMap,
-        iterTypes, [](OpBuilder &b, Location loc, Type tileType, Block *body) {
-          return createTileOpWithPlaceholderDstIndex<TileMatmulBlockOp>(
+        iterTypes, [&](OpBuilder &b, Location loc, Type tileType, Block *body) {
+          auto tileOp = createTileOpWithPlaceholderDstIndex<TileMatmulBlockOp>(
               b, loc, tileType, body->getArgument(0), body->getArgument(1),
               Value());
+          tileOp.setTransposeRhsAttr(op.getTransposeRhsAttr());
+          return tileOp;
         });
   }
 };

--- a/lib/Dialect/TTL/Transforms/LowerMatmulCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerMatmulCompute.cpp
@@ -489,10 +489,10 @@ LogicalResult generateMatmulCompute(PatternRewriter &rewriter, Location loc,
   Value accTensor = accumulatorInfo.kind == MatmulAccumulatorKind::InputTensor
                         ? accumulatorInfo.tensorAccumulator
                         : Value();
-  Value mmResult =
-      TileMatmulBlockOp::create(secBuilder, loc, tileType, lhsTensor, rhsTensor,
-                                accTensor, dstZero)
-          .getResult();
+  auto newMmOp = TileMatmulBlockOp::create(secBuilder, loc, tileType, lhsTensor,
+                                           rhsTensor, accTensor, dstZero);
+  newMmOp.setTransposeRhsAttr(mmOp.getTransposeRhsAttr());
+  Value mmResult = newMmOp.getResult();
 
   SmallVector<PendingStore> pendingStores;
   for (TileExpansion &expansion : expansions) {

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -195,17 +195,10 @@ class TensorBlock:
         """Matrix multiplication using ttl.matmul.
 
         Computes C[M,N] = A[M,K] * B[K,N]. Both operands must be
-        CB-attached tensors of tiles.
+        CB-attached tensors of tiles. This is sugar for the non-transposed
+        ``ttl.matmul`` free function.
         """
-        lhs_type = ast_self.type
-        rhs_type = rhs.type
-        lhs_shape = list(lhs_type.shape)
-        rhs_shape = list(rhs_type.shape)
-        result_shape = [lhs_shape[0], rhs_shape[1]]
-        result_type = RankedTensorType.get(
-            result_shape, lhs_type.element_type, lhs_type.encoding
-        )
-        return ttl.matmul(result_type, ast_self, rhs)
+        return _build_matmul(ast_self, rhs, transpose_rhs=False)
 
     def store(ast_self: TensorBlock, rhs: TensorBlock) -> None:
         """Store result tensor to the output CB reserve view (overwrite).
@@ -759,6 +752,69 @@ def reduce_max(input: TensorBlock, *, dims: List[int]) -> TensorBlock:
     return _reduce_impl(input, dims, reduce_type=1)
 
 
+def _resolve_transpose_flag(val) -> bool:
+    """Resolve a transpose keyword into a Python bool.
+
+    Inside ``@ttl.compute``, ``True``/``False`` literals are lowered to i1
+    ``arith.constant`` SSA values by the AST compiler, so accept either a
+    Python bool (from the default argument) or a constant int/i1 value.
+    """
+    if isinstance(val, bool):
+        return val
+    iv = get_constant_int_value(val)
+    if iv is not None:
+        return bool(iv)
+    raise ValueError("transpose_rhs must be a compile-time boolean constant")
+
+
+def _build_matmul(lhs: TensorBlock, rhs: TensorBlock, *, transpose_rhs: bool):
+    """Build a ttl.matmul op, computing the result shape from the operands.
+
+    For the non-transposed form ``rhs`` is ``[K, N]``; for the transposed
+    form (``transpose_rhs``) ``rhs`` is ``[N, K]`` and the matmul computes
+    ``C[M, N] = A[M, K] * B[N, K]^T``.
+    """
+    transpose = _resolve_transpose_flag(transpose_rhs)
+    lhs_type = lhs.type
+    rhs_type = rhs.type
+    lhs_shape = list(lhs_type.shape)
+    rhs_shape = list(rhs_type.shape)
+    if len(lhs_shape) != 2 or len(rhs_shape) != 2:
+        raise ValueError(
+            f"matmul requires rank-2 operands, got lhs rank {len(lhs_shape)} "
+            f"and rhs rank {len(rhs_shape)}"
+        )
+
+    # K is lhs columns. For transposed rhs [N, K], K is rhs.shape[1] and N is
+    # rhs.shape[0]; otherwise rhs is [K, N], so K is rhs.shape[0] and N is
+    # rhs.shape[1].
+    rhs_k = rhs_shape[1] if transpose else rhs_shape[0]
+    if lhs_shape[1] != rhs_k:
+        raise ValueError(
+            f"matmul K dimension mismatch: lhs has {lhs_shape[1]} columns but "
+            f"rhs has {rhs_k} {'columns' if transpose else 'rows'}"
+        )
+    n = rhs_shape[0] if transpose else rhs_shape[1]
+    result_shape = [lhs_shape[0], n]
+    result_type = RankedTensorType.get(
+        result_shape, lhs_type.element_type, lhs_type.encoding
+    )
+    if transpose:
+        return ttl.matmul(result_type, lhs, rhs, transpose_rhs=True)
+    return ttl.matmul(result_type, lhs, rhs)
+
+
+@syntax("matmul")
+def matmul(lhs: TensorBlock, rhs: TensorBlock, *, transpose_rhs=False) -> TensorBlock:
+    """Matrix multiply two CB-attached tensors of tiles.
+
+    Computes ``C[M, N] = A[M, K] * B[K, N]``. When ``transpose_rhs`` is set,
+    ``rhs`` is provided as ``[N, K]`` and the matmul computes
+    ``C[M, N] = A[M, K] * B[N, K]^T`` using the hardware transpose path.
+    """
+    return _build_matmul(lhs, rhs, transpose_rhs=transpose_rhs)
+
+
 @syntax("transpose")
 def transpose(input: TensorBlock) -> TensorBlock:
     """Transpose a 2D block: (M, N) -> (N, M)."""
@@ -998,6 +1054,7 @@ __all__ = [
     "core",
     "grid_size",
     "signpost",
+    "matmul",
     "fill",
     "typecast",
     "raw_element_read",

--- a/python/ttl/ttl.py
+++ b/python/ttl/ttl.py
@@ -22,7 +22,7 @@ Math operations:
 
 from .ttl_api import pykernel_gen as operation, compute, datamovement, Program
 from .dataflow_buffer import make_dataflow_buffer_like
-from .operators import copy, node, grid_size
+from .operators import copy, node, grid_size, matmul
 
 # Math operations namespace
 from . import ttl_math as math
@@ -36,5 +36,6 @@ __all__ = [
     "copy",
     "node",
     "grid_size",
+    "matmul",
     "math",
 ]

--- a/test/python/test_matmul_simple.py
+++ b/test/python/test_matmul_simple.py
@@ -257,6 +257,105 @@ def test_matmul_n_tiling_distinct(device):
     )
 
 
+def _make_matmul_transpose_kernel(block_count=2):
+    """Matmul kernel where B is provided transposed as [N, K]."""
+
+    @ttl.operation(grid=(1, 1))
+    def kernel(a, b, out):
+        Mt = a.shape[0] // TILE
+        Kt = a.shape[1] // TILE
+        Nt = b.shape[0] // TILE  # B is [N, K]
+
+        a_dfb = ttl.make_dataflow_buffer_like(
+            a, shape=(Mt, Kt), block_count=block_count
+        )
+        b_dfb = ttl.make_dataflow_buffer_like(
+            b, shape=(Nt, Kt), block_count=block_count
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(Mt, Nt), block_count=block_count
+        )
+
+        @ttl.compute()
+        def mm_compute():
+            a_blk = a_dfb.wait()
+            b_blk = b_dfb.wait()
+            o = out_dfb.reserve()
+            result = ttl.matmul(a_blk, b_blk, transpose_rhs=True)
+            o.store(result)
+            a_blk.pop()
+            b_blk.pop()
+            o.push()
+
+        @ttl.datamovement()
+        def dm_read():
+            with a_dfb.reserve() as blk:
+                tx = ttl.copy(a[0:Mt, 0:Kt], blk)
+                tx.wait()
+            with b_dfb.reserve() as blk:
+                tx = ttl.copy(b[0:Nt, 0:Kt], blk)
+                tx.wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with out_dfb.wait() as blk:
+                tx = ttl.copy(blk, out[0:Mt, 0:Nt])
+                tx.wait()
+
+    return kernel
+
+
+matmul_transpose_kernel = _make_matmul_transpose_kernel(block_count=2)
+
+
+# Transposed RHS: B is stored as [N, K] and the matmul computes A @ B^T.
+# N (output columns) is kept at 1 tile: the hardware matmul_block reads the
+# ct output-column tiles consecutively, which only matches the [N, K] layout
+# for a single output column.
+TRANSPOSE_SHAPES = [
+    (1, 1, 1),  # Minimal: single tile.
+    (2, 1, 1),  # Tall output.
+    (1, 2, 1),  # K > 1.
+    (2, 4, 1),  # Multi-tile M with K > 1.
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dtype",
+    [(s, torch.bfloat16) for s in TRANSPOSE_SHAPES]
+    + [(s, torch.float32) for s in TRANSPOSE_SHAPES],
+    ids=[f"{m}x{k}x{n}_bf16" for (m, k, n) in TRANSPOSE_SHAPES]
+    + [f"{m}x{k}x{n}_f32" for (m, k, n) in TRANSPOSE_SHAPES],
+)
+@pytest.mark.requires_device
+def test_matmul_transpose_rhs(shape, dtype, device):
+    """A @ B^T where B is passed in its transposed [N, K] tile layout."""
+    Mt, Kt, Nt = shape
+    M, K, N = Mt * TILE, Kt * TILE, Nt * TILE
+
+    a_torch = torch.randn(M, K, dtype=dtype)
+    b_torch = torch.randn(N, K, dtype=dtype)  # B stored as [N, K]
+    out_torch = torch.zeros(M, N, dtype=dtype)
+
+    a = to_dram(a_torch, device)
+    b = to_dram(b_torch, device)
+    out = to_dram(out_torch, device)
+
+    matmul_transpose_kernel(a, b, out)
+
+    result = ttnn.to_torch(out).float()
+    golden = (a_torch @ b_torch.t()).float()
+
+    pcc = torch.corrcoef(torch.stack([result.flatten(), golden.flatten()]))[0, 1].item()
+    threshold = 0.9999 if dtype == torch.float32 else 0.999
+    assert pcc > threshold, (
+        f"PCC {pcc:.6f} < {threshold} for {Mt}x{Kt}x{Nt} transposed matmul. "
+        f"Max diff: {(result - golden).abs().max().item()}"
+    )
+    rtol, atol = (1e-2, 2e-2)
+    assert_allclose(result, golden, rtol=rtol, atol=atol)
+
+
 @pytest.mark.requires_device
 def test_matmul_l1(device):
     """Matmul with tensors in L1 memory (instead of DRAM)."""

--- a/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
@@ -90,3 +90,31 @@ func.func @matmul_1x8_8x1(
   ttl.store %mm, %reserve : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>
   func.return %mm : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
+
+// -----
+
+// Transposed RHS: [2,4] @ [3,4]^T -> [2,3]. RHS is stored as [N, K] so its
+// indexing map swaps to (d1, d2) and the transpose_rhs attr is propagated to
+// tile_matmul_block.
+// CHECK: #[[$RHS_T_MAP:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK-LABEL: func.func @matmul_transpose_rhs
+func.func @matmul_transpose_rhs(
+    %arg0: tensor<2x4x!ttcore.tile<32x32, bf16>>,
+    %arg1: tensor<3x4x!ttcore.tile<32x32, bf16>>) -> tensor<2x3x!ttcore.tile<32x32, bf16>> {
+  // CHECK: ttl.compute
+  // CHECK-SAME: ins({{.*}} : tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<3x4x!ttcore.tile<32x32, bf16>>)
+  // CHECK-SAME: outs({{.*}} : tensor<2x3x!ttcore.tile<32x32, bf16>>)
+  // CHECK-SAME: indexing_maps = [#[[$LHS_MAP]], #[[$RHS_T_MAP]], #[[$OUT_MAP]]]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+  // CHECK: ttl.tile_matmul_block
+  // CHECK-SAME: transpose_rhs
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[3, 4], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[2, 3], !ttcore.tile<32x32, bf16>, 2>
+  %a = ttl.attach_cb %arg0, %cb0 : (tensor<2x4x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x4x!ttcore.tile<32x32, bf16>>
+  %b = ttl.attach_cb %arg1, %cb1 : (tensor<3x4x!ttcore.tile<32x32, bf16>>, !ttl.cb<[3, 4], !ttcore.tile<32x32, bf16>, 2>) -> tensor<3x4x!ttcore.tile<32x32, bf16>>
+  %reserve = ttl.cb_reserve %cb2 : <[2, 3], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x3x!ttcore.tile<32x32, bf16>>
+  %mm = ttl.matmul %a, %b {transpose_rhs} : tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<3x4x!ttcore.tile<32x32, bf16>> -> tensor<2x3x!ttcore.tile<32x32, bf16>>
+  ttl.store %mm, %reserve : tensor<2x3x!ttcore.tile<32x32, bf16>>, tensor<2x3x!ttcore.tile<32x32, bf16>>
+  func.return %mm : tensor<2x3x!ttcore.tile<32x32, bf16>>
+}

--- a/test/ttlang/Conversion/TTLToTTKernel/matmul_block_lowering.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/matmul_block_lowering.mlir
@@ -259,3 +259,46 @@ func.func @matmul_k3(
   ttl.store %mm, %reserve : tensor<2x1x!ttcore.tile<32x32, bf16>>, tensor<2x1x!ttcore.tile<32x32, bf16>>
   func.return %mm : tensor<2x1x!ttcore.tile<32x32, bf16>>
 }
+
+// -----
+
+// =============================================================================
+// Test 6: Transposed RHS. [2,3] @ [2,3]^T -> [2,2]. rhs is stored as [N, K]
+// so N (ct) comes from rhs[0]=2 (not rhs[1]=3), the transpose operand is 1,
+// and the per-K in1 stride is 1 (K is the innermost CB dim), so in1_idx=k.
+// =============================================================================
+
+// CHECK-LABEL: func.func @matmul_transpose_rhs
+// CHECK-DAG: %[[C1_I32:.*]] = arith.constant 1 : i32
+// CHECK-DAG: %[[C2_I32:.*]] = arith.constant 2 : i32
+// CHECK-DAG: %[[C3_I32:.*]] = arith.constant 3 : i32
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[CB0:.*]] = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, bf16>>
+// CHECK-DAG: %[[CB1:.*]] = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, bf16>>
+// CHECK-DAG: %[[CB2:.*]] = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+// mm_block_init: transpose=1, ct=2, rt=2, kt=3.
+// CHECK:      "ttkernel.mm_block_init"(%[[CB0]], %[[CB1]], %[[CB2]], %[[C1_I32]], %[[C2_I32]], %[[C2_I32]], %[[C3_I32]])
+// CHECK:      ttkernel.tile_regs_acquire
+// CHECK-NEXT: "ttkernel.mm_block_init_short"(%[[CB0]], %[[CB1]], %[[C1_I32]], %[[C2_I32]], %[[C2_I32]], %[[C3_I32]])
+// K loop: stride 1 so in1_idx=k (CSE merges with in0_idx=k); transpose operand=1.
+// CHECK-NEXT: scf.for %[[K:.*]] = %[[C0]] to %[[C3]] step
+// CHECK:        ttkernel.matmul_block(%[[CB0]], %[[CB1]], %[[K]], %[[K]], %[[C0]],
+// CHECK-SAME:     %[[C1_I32]], %[[C2_I32]], %[[C2_I32]], %[[C3_I32]])
+// CHECK:      }
+// CHECK-NEXT: ttkernel.tile_regs_commit
+func.func @matmul_transpose_rhs(
+    %arg0: tensor<2x3x!ttcore.tile<32x32, bf16>>,
+    %arg1: tensor<2x3x!ttcore.tile<32x32, bf16>>) -> tensor<2x2x!ttcore.tile<32x32, bf16>> {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 3], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 3], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %a = ttl.attach_cb %arg0, %cb0 : (tensor<2x3x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 3], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x3x!ttcore.tile<32x32, bf16>>
+  %b = ttl.attach_cb %arg1, %cb1 : (tensor<2x3x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 3], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x3x!ttcore.tile<32x32, bf16>>
+  %reserve = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %mm = ttl.matmul %a, %b {transpose_rhs} : tensor<2x3x!ttcore.tile<32x32, bf16>>, tensor<2x3x!ttcore.tile<32x32, bf16>> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  ttl.store %mm, %reserve : tensor<2x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bf16>>
+  func.return %mm : tensor<2x2x!ttcore.tile<32x32, bf16>>
+}

--- a/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
@@ -75,3 +75,27 @@ func.func @matmul_result_element_mismatch(
   %r = ttl.matmul %a, %b : tensor<2x3x!ttcore.tile<32x32, bf16>>, tensor<3x4x!ttcore.tile<32x32, bf16>> -> tensor<2x4x!ttcore.tile<32x32, f32>>
   return %r : tensor<2x4x!ttcore.tile<32x32, f32>>
 }
+
+// -----
+
+// Test: transpose_rhs K mismatch. RHS is [N, K]=[4, 5] so its K (5) does not
+// match lhs K (3).
+func.func @matmul_transpose_k_mismatch(
+    %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
+    %b: tensor<4x5x!ttcore.tile<32x32, bf16>>) -> tensor<2x4x!ttcore.tile<32x32, bf16>> {
+  // expected-error @below {{K dimension mismatch: lhs has 3 columns but rhs has 5 columns}}
+  %r = ttl.matmul %a, %b {transpose_rhs} : tensor<2x3x!ttcore.tile<32x32, bf16>>, tensor<4x5x!ttcore.tile<32x32, bf16>> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
+  return %r : tensor<2x4x!ttcore.tile<32x32, bf16>>
+}
+
+// -----
+
+// Test: transpose_rhs wrong result shape. RHS is [N, K]=[4, 3] so the result
+// must be [M, N]=[2, 4], not [2, 3].
+func.func @matmul_transpose_bad_result(
+    %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
+    %b: tensor<4x3x!ttcore.tile<32x32, bf16>>) -> tensor<2x3x!ttcore.tile<32x32, bf16>> {
+  // expected-error @below {{result shape [2, 3] does not match expected [2, 4]}}
+  %r = ttl.matmul %a, %b {transpose_rhs} : tensor<2x3x!ttcore.tile<32x32, bf16>>, tensor<4x3x!ttcore.tile<32x32, bf16>> -> tensor<2x3x!ttcore.tile<32x32, bf16>>
+  return %r : tensor<2x3x!ttcore.tile<32x32, bf16>>
+}


### PR DESCRIPTION
### Problem description
There is a hardware support for matmul-transpose, which is not present in tt-lang.

### What's changed
Add the transpose attribute to matmul.

### Ticket
Partly addresses https://github.com/tenstorrent/tt-lang/issues/420

### Performance

#### Complex operation, blackhole

| Metric               | Transpose as loop | Transpose attribute | Delta (attr − loop)    |
| -------------------- | ----------------- | ------------------- | ---------------------- |
| Device kernel cycles | 416,996           | 380,798             | −36,198 (−8.7%)        |
| Device kernel time   | 308.9 us          | 282.1 us            | −26.8 us (−8.7%)       |
| Time per chunk       | 19.31 us/chunk    | 17.63 us/chunk      | −1.68 us/chunk (−8.7%) |
| BRISC cycles         | 2,076             | 2,075               | −1                     |
| NCRISC cycles        | 416,866           | 380,653             | −36,213                |
| TRISC_0 cycles       | 415,308           | 379,115             | −36,193                |
| TRISC_1 cycles       | 415,595           | 379,369             | −36,226                |
| TRISC_2 cycles       | 415,447           | 379,241             | −36,206                |

#### Raw matmul, wormhole

| RISC    | attr (cyc) | loop (cyc) | attr/loop |
| ------- | ---------- | ---------- | --------- |
| BRISC   | 15,987     | 17,124     | 0.934     |
| NCRISC  | 7,533      | 7,545      | 0.998     |
| TRISC_0 | 13,592     | 14,851     | 0.915     |
| TRISC_1 | 14,187     | 15,405     | 0.921     |
| TRISC_2 | 14,563     | 15,757     | 0.924     |
| Total   | 16,299     | 17,439     | 0.935     |

### Checklist
- [X] New/Existing tests provide coverage for changes

