### PR TITLE
[ttl] Expose exp kernel arguments

### DIFF
--- a/docs/sphinx/specs/TTLangSpecification.externalized.md
+++ b/docs/sphinx/specs/TTLangSpecification.externalized.md
@@ -53,6 +53,7 @@
 | 0.17 | 04/28/2026 | Move `broadcast`, `transpose`, `where`, `mask`, `mask_posinf`, `fill`, `squeeze`, `unsqueeze` to `ttl.block` |
 | 0.18 | 06/16/2026 | Add `ttl.raw_element_read` and `ttl.raw_element_write` |
 | 0.19 | 06/15/2026 | Unified-body `ttl.operation` with thread assignment and composition; add multi-kernel operation with explicit kernels |
+| 0.20 | 06/23/2026 | Add `ttl.exp` hardware flags and scaled exponential canonicalization |
 
 
 ## Introduction
@@ -455,7 +456,7 @@ TT-Lang includes ability to print information to the standard output for debuggi
 | `ttl.BlockExpr.__abs__(self) -> ttl.BlockExpr`<br><br>`ttl.math.abs(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Absolute value. Example: `abs(a)`, `ttl.math.abs(a)`. |
 | `ttl.BlockExpr.__neg__(self) -> ttl.BlockExpr`<br><br>`ttl.math.neg(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Negation. Example: `-a`, `ttl.math.neg(a)`. |
 | `ttl.BlockExpr.__pow__(self, exponent: ttl.NaturalInt) -> ttl.BlockExpr`<br><br>`ttl.math.pow(expr: ttl.BlockExpr, exponent: ttl.NaturalInt) -> ttl.BlockExpr` | Power with scalar unsigned integer exponent. Example; `a ** 2`, `ttl.math.pow(a, 2)`. |
-| `ttl.math.exp(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural base exponential (`e^x`) |
+| `ttl.math.exp(expr: ttl.BlockExpr, *, approx: bool = False, scale: Optional[float] = None, skip_clamp_check: bool = False, iterations: ttl.PositiveInt = 8) -> ttl.BlockExpr` | Natural base exponential. Computes `e^x` by default. When `scale` is provided, computes `e^(scale * x)`. |
 | `ttl.math.exp2(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Base 2 exponential (`2^x`) |
 | `ttl.math.expm1(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural base exponential minus one (`ttl.math.exp(x) - 1`) |
 | `ttl.math.log(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural logarithm |
@@ -465,6 +466,14 @@ TT-Lang includes ability to print information to the standard output for debuggi
 | `ttl.math.rsqrt(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Reciprocal square root (`1 / ttl.math.sqrt(x)`) |
 | `ttl.math.recip(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Reciprocal (`1 / x`) |
 | `ttl.math.rsub(a: ttl.BlockExpr, b: ttl.NaturalInt) -> ttl.BlockExpr` | Subtract a from b where b is scalar unsigned integer (`b - a`) |
+
+The `ttl.math.exp` function exposes hardware exponential options. The `approx`
+flag enables approximate exponential evaluation. The `scale` argument applies
+a compile-time scalar multiplier before the exponential. The
+`skip_clamp_check` flag disables clamping of very negative inputs in
+approximate mode. This is faster, but inputs below approximately `-88.5` can
+produce incorrect negative outputs. The `iterations` argument controls the
+number of SFPU lane iterations and defaults to 8.
 
 ### Trigonometric unary math functions
 

--- a/docs/sphinx/specs/TTLangSpecification.md
+++ b/docs/sphinx/specs/TTLangSpecification.md
@@ -53,6 +53,7 @@
 | 0.17 | 04/28/2026 | Move `broadcast`, `transpose`, `where`, `mask`, `mask_posinf`, `fill`, `squeeze`, `unsqueeze` to `ttl.block` |
 | 0.18 | 06/16/2026 | Add `ttl.raw_element_read` and `ttl.raw_element_write` |
 | 0.19 | 06/15/2026 | Unified-body `ttl.operation` with thread assignment and composition; add multi-kernel operation with explicit kernels |
+| 0.20 | 06/23/2026 | Add `ttl.exp` hardware flags and scaled exponential canonicalization |
 
 
 ## Introduction
@@ -1458,7 +1459,7 @@ def matmul_read():
 | `ttl.BlockExpr.__abs__(self) -> ttl.BlockExpr`<br><br>`ttl.math.abs(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Absolute value. Example: `abs(a)`, `ttl.math.abs(a)`. |
 | `ttl.BlockExpr.__neg__(self) -> ttl.BlockExpr`<br><br>`ttl.math.neg(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Negation. Example: `-a`, `ttl.math.neg(a)`. |
 | `ttl.BlockExpr.__pow__(self, exponent: ttl.NaturalInt) -> ttl.BlockExpr`<br><br>`ttl.math.pow(expr: ttl.BlockExpr, exponent: ttl.NaturalInt) -> ttl.BlockExpr` | Power with scalar unsigned integer exponent. Example; `a ** 2`, `ttl.math.pow(a, 2)`. |
-| `ttl.math.exp(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural base exponential (`e^x`) |
+| `ttl.math.exp(expr: ttl.BlockExpr, *, approx: bool = False, scale: Optional[float] = None, skip_clamp_check: bool = False, iterations: ttl.PositiveInt = 8) -> ttl.BlockExpr` | Natural base exponential. Computes `e^x` by default. When `scale` is provided, computes `e^(scale * x)`. |
 | `ttl.math.exp2(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Base 2 exponential (`2^x`) |
 | `ttl.math.expm1(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural base exponential minus one (`ttl.math.exp(x) - 1`) |
 | `ttl.math.log(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural logarithm |
@@ -1468,6 +1469,14 @@ def matmul_read():
 | `ttl.math.rsqrt(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Reciprocal square root (`1 / ttl.math.sqrt(x)`) |
 | `ttl.math.recip(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Reciprocal (`1 / x`) |
 | `ttl.math.rsub(a: ttl.BlockExpr, b: ttl.NaturalInt) -> ttl.BlockExpr` | Subtract a from b where b is scalar unsigned integer (`b - a`) |
+
+The `ttl.math.exp` function exposes hardware exponential options. The `approx`
+flag enables approximate exponential evaluation. The `scale` argument applies
+a compile-time scalar multiplier before the exponential. The
+`skip_clamp_check` flag disables clamping of very negative inputs in
+approximate mode. This is faster, but inputs below approximately `-88.5` can
+produce incorrect negative outputs. The `iterations` argument controls the
+number of SFPU lane iterations and defaults to 8.
 
 ### Trigonometric unary math functions
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1101,8 +1101,6 @@ multiclass TTL_UnaryElementwisePair<string mnemonic, string kernelOp> {
   }
 }
 
-// Define all unary elementwise ops using the multiclass
-defm TTL_Exp : TTL_UnaryElementwisePair<"exp", "exp_tile">;
 defm TTL_Exp2 : TTL_UnaryElementwisePair<"exp2", "exp2_tile">;
 defm TTL_Log : TTL_UnaryElementwisePair<"log", "log_tile">;
 defm TTL_Sqrt : TTL_UnaryElementwisePair<"sqrt", "sqrt_tile">;
@@ -1131,6 +1129,52 @@ defm TTL_Softsign : TTL_UnaryElementwisePair<"softsign", "softsign_tile">;
 defm TTL_Signbit : TTL_UnaryElementwisePair<"signbit", "signbit_tile">;
 defm TTL_Frac : TTL_UnaryElementwisePair<"frac", "frac_tile">;
 defm TTL_Trunc : TTL_UnaryElementwisePair<"trunc", "trunc_tile">;
+
+//===----------------------------------------------------------------------===//
+// Exp Operations (Tensor + Tile)
+//===----------------------------------------------------------------------===//
+//
+// `exp` is broken out of the generic unary multiclass because it carries
+// hardware SFPU flags that the generic ops do not. The flags are forwarded
+// unchanged from the tensor op to the tile op and then to the TTKernel
+// exp_tile / exp_tile_init ops during lowering. All flags are optional or
+// default-valued so that `ttl.exp %x` (and tile form) keep their plain
+// spelling when no flags are set.
+//
+// Flags (mirroring tt-metal ckernel::exp_tile / exp_tile_init):
+//   approx          - enable the fast approximate exp.
+//   scale           - optional scale factor `s`; when present the op computes
+//                     exp(s * x) (sets scale_en at the TTKernel level).
+//   input_clamping  - clamp behaviour for very negative inputs (only relevant
+//                     for approximate mode); defaults to ClampToNegative.
+//   iterations      - number of SFPU lane iterations (default 8).
+
+// Shared flag arguments for both the tensor and tile exp ops.
+defvar TTL_ExpFlags = (ins
+    DefaultValuedAttr<BoolAttr, "false">:$approx,
+    OptionalAttr<F32Attr>:$scale,
+    DefaultValuedAttr<TTL_InputClampingAttr,
+        "::mlir::tt::ttl::InputClamping::ClampToNegative">:$input_clamping,
+    DefaultValuedAttr<I32Attr, "8">:$iterations);
+
+def TTL_ExpOp : TTL_ElementWiseUnary<"exp"> {
+  let description = [{
+    Elementwise exp on tensors. Lowered to ttl.compute with ttl.tile_exp.
+    Carries optional hardware exp flags (approx / scale / input_clamping /
+    iterations) that are forwarded to the tile op during lowering.
+  }];
+  let arguments = !con((ins AnyType:$input), TTL_ExpFlags);
+}
+
+def TTL_ExpTileOp : TTL_TileUnaryOp<"tile_exp"> {
+  let description = [{
+    Tile-level exp. Maps to ttkernel.exp_tile. Carries the same hardware exp
+    flags as ttl.exp; they are forwarded to the TTKernel exp_tile / exp_tile_init
+    ops during conversion.
+  }];
+  let arguments = !con((ins TTL_TileType:$input, Index:$dst_index),
+                       TTL_ExpFlags);
+}
 
 //===----------------------------------------------------------------------===//
 // Typecast Operations (Tensor + Tile)

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
@@ -69,6 +69,24 @@ def TTL_AccumulationInitialMode : I32EnumAttr<"AccumulationInitialMode",
     [TTL_AccumulationInitialMode_Overwrite,
      TTL_AccumulationInitialMode_AccumulateExisting,
      TTL_AccumulationInitialMode_Init]> {
+        let cppNamespace = "::mlir::tt::ttl";
+}
+
+//===----------------------------------------------------------------------===//
+// Exp input clamping
+//===----------------------------------------------------------------------===//
+
+// Controls whether the (approximate) exp clamps very negative inputs before
+// the SFPU evaluation. Underlying values match tt-metal's ckernel::InputClamping
+// and the TTKernel InputClamping enum so the lowering can forward by value:
+//   None (0): no clamp -- faster, but inputs below ~-88.5 produce incorrect
+//             outputs (guaranteed negative; consider packer ReLU).
+//   ClampToNegative (1): clamp very negative inputs -- safer, slightly slower.
+def TTL_InputClamping_None            : I32EnumAttrCase<"None",            0, "none">;
+def TTL_InputClamping_ClampToNegative : I32EnumAttrCase<"ClampToNegative", 1, "clamp_to_negative">;
+
+def TTL_InputClamping : I32EnumAttr<"InputClamping", "TTL exp input clamping mode",
+    [TTL_InputClamping_None, TTL_InputClamping_ClampToNegative]> {
   let cppNamespace = "::mlir::tt::ttl";
 }
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
@@ -98,6 +98,8 @@ def TTL_ReduceTypeAttr : EnumAttr<TTL_Dialect, TTL_ReduceType, "reduce_type">;
 def TTL_AccumulationInitialModeAttr
     : EnumAttr<TTL_Dialect, TTL_AccumulationInitialMode,
                "accumulation_initial_mode">;
+def TTL_InputClampingAttr
+    : EnumAttr<TTL_Dialect, TTL_InputClamping, "input_clamping">;
 
 def TTL_Pipe : TTL_Type<"Pipe", "pipe"> {
   let summary = "Pipe for core-to-core data transfer";

--- a/include/ttlang/Dialect/TTL/TTLElementwiseOps.def
+++ b/include/ttlang/Dialect/TTL/TTLElementwiseOps.def
@@ -83,7 +83,6 @@ TTL_BINARY_TILE_OP_MINMAX(Min, MinTileOp, BinaryMinTileInitOp, BinaryMinTileOp)
 
 // Unary operations: TTL tensor op -> TTL tile op -> TTKernel init/compute ops
 // These use the standard unary template: DST[dst_index] = op(DST[dst_index])
-TTL_UNARY_TILE_OP(Exp, ExpTileOp, ExpTileInitOp, ExpTileOp)
 TTL_UNARY_TILE_OP(Exp2, Exp2TileOp, Exp2TileInitOp, Exp2TileOp)
 TTL_UNARY_TILE_OP(Log, LogTileOp, LogTileInitOp, LogTileOp)
 TTL_UNARY_TILE_OP(Sqrt, SqrtTileOp, SqrtTileInitOp, SqrtTileOp)

--- a/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
@@ -162,6 +162,18 @@ static llvm::DenseMap<mlir::TypeID, InitOpInfo> buildComputeToInitMap() {
                                         typecastOp.getOutDtypeAttr());
       }};
 
+  // ExpTile: exp_tile_init configures the SFPU per exp flags. It takes approx,
+  // scale (the fp32 scale factor template), and input_clamping read off the
+  // exp_tile op. scale_en / iterations are compute-only and not part of the
+  // init. (exp is excluded from the generic unary macro above for this reason.)
+  map[mlir::TypeID::get<ttk::ExpTileOp>()] = {
+      [](OpBuilder &b, Location l, Operation *computeOp) {
+        auto expOp = cast<ttk::ExpTileOp>(computeOp);
+        ttk::ExpTileInitOp::create(b, l, expOp.getApproxAttr(),
+                                   expOp.getScaleAttr(),
+                                   expOp.getInputClampingAttr());
+      }};
+
   // Transpose: resolves output CB from annotated attribute.
   map[mlir::TypeID::get<ttk::TransposeTileOp>()] = {
       [](OpBuilder &b, Location l, Operation *computeOp) {
@@ -228,6 +240,27 @@ static InitKey computeInitKey(Operation *op) {
   if (auto typecast = dyn_cast<ttk::TypecastTileOp>(op)) {
     int64_t disc = (static_cast<int64_t>(typecast.getInDtype()) << 16) |
                    static_cast<int64_t>(typecast.getOutDtype());
+    return {typeId, {}, disc};
+  }
+
+  // For exp: distinct flag combinations configure exp_tile_init differently
+  // and must not share an init. The init depends on approx, input_clamping,
+  // and the fp32 scale template, so encode all three in the discriminator.
+  // scale_en / iterations are compute-only and do not affect the init.
+  if (auto exp = dyn_cast<ttk::ExpTileOp>(op)) {
+    uint32_t scaleBits = 0x3F800000u; // default 1.0f for exp_tile_init.
+    if (auto scaleAttr = exp.getScaleAttr()) {
+      scaleBits = static_cast<uint32_t>(scaleAttr.getInt());
+    }
+    BoolAttr approxAttr = exp.getApproxAttr();
+    bool approx = approxAttr && approxAttr.getValue();
+    int64_t inputClamping =
+        static_cast<int64_t>(ttk::InputClamping::ClampToNegative);
+    if (auto inputClampingAttr = exp.getInputClampingAttr()) {
+      inputClamping = static_cast<int64_t>(inputClampingAttr.getValue());
+    }
+    int64_t disc = (static_cast<int64_t>(scaleBits) << 8) |
+                   (static_cast<int64_t>(approx) << 1) | inputClamping;
     return {typeId, {}, disc};
   }
 

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -392,6 +392,36 @@ static FailureOr<Type> getResultTileType(Operation *source) {
   return ttcore::TileType::get(tensorType.getElementType());
 }
 
+static ExpFlagsPlan buildExpFlagsPlan(ExpOp exp,
+                                      FloatAttr scaleOverride = nullptr) {
+  FloatAttr scale = scaleOverride ? scaleOverride : exp.getScaleAttr();
+  return ExpFlagsPlan{
+      exp.getApproxAttr(),
+      scale,
+      exp.getInputClampingAttr(),
+      exp.getIterationsAttr(),
+  };
+}
+
+/// Returns true when folding `producer` into `consumer` would move its effect
+/// past an observable operation.
+static bool hasInterveningComputeSideEffect(Operation *producer,
+                                            Operation *consumer) {
+  if (producer->getBlock() != consumer->getBlock() ||
+      !producer->isBeforeInBlock(consumer)) {
+    return true;
+  }
+  for (Operation *operation = producer->getNextNode();
+       operation && operation != consumer;
+       operation = operation->getNextNode()) {
+    if (isRelocatableComputeInstrumentation(operation) ||
+        !isMemoryEffectFree(operation)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 static FailureOr<unsigned> findFusedRootInput(const ComputeOpCreationPlan &plan,
                                               Value value,
                                               FusedInputRole role) {
@@ -407,6 +437,22 @@ static LogicalResult buildFusedOperationPlans(ComputeOpCreationPlan &plan,
                                               std::string &failureReason) {
   DenseSet<Operation *> fusedOperations(plan.trace.opsInOrder.begin(),
                                         plan.trace.opsInOrder.end());
+  DenseMap<Operation *, MulUnaryConstOp> scaledExpInputs;
+  DenseSet<Operation *> deferredExpScaleMuls;
+  for (Operation *operation : plan.trace.opsInOrder) {
+    auto exp = dyn_cast<ExpOp>(operation);
+    if (!exp || exp.getScaleAttr()) {
+      continue;
+    }
+    auto multiply = exp.getInput().getDefiningOp<MulUnaryConstOp>();
+    if (multiply && multiply->hasOneUse() &&
+        fusedOperations.contains(multiply) &&
+        !hasInterveningComputeSideEffect(multiply, exp)) {
+      scaledExpInputs.try_emplace(exp, multiply);
+      deferredExpScaleMuls.insert(multiply);
+    }
+  }
+
   DenseMap<Operation *, SmallVector<MatmulOp>> foldCandidates;
   for (Operation *operation : plan.trace.opsInOrder) {
     auto matmul = dyn_cast<MatmulOp>(operation);
@@ -514,10 +560,18 @@ static LogicalResult buildFusedOperationPlans(ComputeOpCreationPlan &plan,
         return failure();
       }
       operationPlan.transposeRhs = foldedMatmul.getTransposeRhs();
+    } else if (deferredExpScaleMuls.contains(operation)) {
+      operationPlan.recipe = FusedOperationRecipe::DeferredExpScale;
     } else if (isElementwiseOp(operation) || isa<FillOp>(operation)) {
-      for (Value operand : getElementwiseOperands(operation)) {
-        if (failed(addOperand(operand, FusedInputRole::Parallel))) {
+      if (auto multiply = scaledExpInputs.lookup(operation)) {
+        if (failed(addOperand(multiply.getInput(), FusedInputRole::Parallel))) {
           return failure();
+        }
+      } else {
+        for (Value operand : getElementwiseOperands(operation)) {
+          if (failed(addOperand(operand, FusedInputRole::Parallel))) {
+            return failure();
+          }
         }
       }
       operationPlan.recipe = FusedOperationRecipe::TileOperation;
@@ -525,6 +579,13 @@ static LogicalResult buildFusedOperationPlans(ComputeOpCreationPlan &plan,
         operationPlan.constantValue = multiply.getValueAttr();
       } else if (auto fill = dyn_cast<FillOp>(operation)) {
         operationPlan.constantValue = fill.getValueAttr();
+      } else if (auto exp = dyn_cast<ExpOp>(operation)) {
+        if (auto multiply = scaledExpInputs.lookup(operation)) {
+          operationPlan.expFlags =
+              buildExpFlagsPlan(exp, multiply.getValueAttr());
+        } else {
+          operationPlan.expFlags = buildExpFlagsPlan(exp);
+        }
       }
     } else {
       failureReason = "fused operation has no tile-level recipe";
@@ -819,6 +880,12 @@ static LogicalResult buildOperationSpecificPlan(ComputeOpCreationPlan &plan,
   }
   if (isa<TypecastOp>(plan.source)) {
     plan.recipe = ComputeOpCreationRecipe::Typecast;
+    buildIdentityIterationPlan(plan);
+    return success();
+  }
+  if (auto exp = dyn_cast<ExpOp>(plan.source)) {
+    plan.recipe = ComputeOpCreationRecipe::Elementwise;
+    plan.expFlags = buildExpFlagsPlan(exp);
     buildIdentityIterationPlan(plan);
     return success();
   }

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -200,6 +200,9 @@ enum class FusedOperationRecipe {
 
   /// Emit one accumulating matmul for a previously deferred matmul and add.
   MatmulAccumulator,
+
+  /// Emit no multiply because a following exp consumes its constant as scale.
+  DeferredExpScale,
 };
 
 /// One tensor operand consumed by a fused tile-level recipe.
@@ -210,6 +213,14 @@ struct FusedOperationOperand {
   /// Compute input slot for an external root; absent for an earlier fused
   /// result produced inside the compute body.
   std::optional<unsigned> rootInputIndex;
+};
+
+/// Hardware configuration captured for an exp tile recipe.
+struct ExpFlagsPlan {
+  BoolAttr approx;
+  FloatAttr scale;
+  InputClampingAttr inputClamping;
+  IntegerAttr iterations;
 };
 
 /// Immutable tile recipe for one absorbed tensor operation.
@@ -249,6 +260,9 @@ struct FusedOperationPlan {
 
   /// Scalar used by fill and multiply-constant recipes.
   std::optional<FloatAttr> constantValue;
+
+  /// Hardware flags used by an exp recipe.
+  std::optional<ExpFlagsPlan> expFlags;
 };
 
 /// Stable identity of one source-result use during plan application.
@@ -492,6 +506,9 @@ struct ComputeOpCreationPlan {
 
   /// Scalar constant used by fill and multiply-constant recipes.
   std::optional<FloatAttr> constantValue;
+
+  /// Hardware flags used by a direct exp recipe.
+  std::optional<ExpFlagsPlan> expFlags;
 
   /// Expression absorbed by fused creation. Empty for direct creation.
   FusionTraceResult trace;

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -42,6 +42,8 @@ namespace ttk = mlir::tt::ttkernel;
 
 namespace {
 
+constexpr int64_t defaultExpIterations = 8;
+
 /// Materializes a float attribute as an i32 carrying its IEEE 754 bits. Scalar
 /// SFPU tile APIs take i32 params even for float scalars.
 static Value floatAttrToI32Bits(OpBuilder &rewriter, Location loc,
@@ -49,6 +51,14 @@ static Value floatAttrToI32Bits(OpBuilder &rewriter, Location loc,
   auto f32Val = arith::ConstantOp::create(
       rewriter, loc, rewriter.getF32FloatAttr(attr.getValueAsDouble()));
   return arith::BitcastOp::create(rewriter, loc, rewriter.getI32Type(), f32Val);
+}
+
+/// Materializes a float attribute as an i32 attribute carrying its IEEE 754
+/// bits.
+static IntegerAttr floatAttrToI32BitsAttr(OpBuilder &builder, FloatAttr attr) {
+  uint32_t bits =
+      static_cast<uint32_t>(attr.getValue().bitcastToAPInt().getZExtValue());
+  return builder.getI32IntegerAttr(bits);
 }
 
 /// Look up a CB for a copy_tile source.
@@ -286,6 +296,51 @@ struct TTLTileTypecastToTTKernel : OpConversionPattern<TileTypecastOp> {
     Value dstIdxVal = adaptor.getDstIndex();
     ttk::TypecastTileOp::create(rewriter, loc, dstIdxVal, inDtypeAttr,
                                 outDtypeAttr);
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
+/// Lower ttl.tile_exp to ttkernel.exp_tile, forwarding the hardware exp flags.
+///
+/// Cannot reuse the generic unary SFPU template because exp_tile carries
+/// flags. The matching exp_tile_init (with its own flags) is emitted later by
+/// the TTKernelInsertInits pass, which reads the flags off this exp_tile op.
+///
+/// TTKernel interface:
+///   ttkernel.exp_tile : (tile_index, approx?, input_clamping?, iterations?,
+///                        scale?)
+///   ttkernel.exp_tile_init : (approx?, scale?, input_clamping?)
+/// where InputClamping shares the underlying values of ttl::InputClamping.
+struct TTLTileExpToTTKernel : OpConversionPattern<ExpTileOp> {
+  using OpConversionPattern<ExpTileOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ExpTileOp op, ExpTileOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value dstIdxVal = adaptor.getDstIndex();
+
+    BoolAttr approxAttr;
+    if (op.getApprox()) {
+      approxAttr = rewriter.getBoolAttr(true);
+    }
+    ttk::InputClampingAttr inputClampingAttr;
+    if (op.getInputClamping() != ttl::InputClamping::ClampToNegative) {
+      inputClampingAttr = ttk::InputClampingAttr::get(
+          rewriter.getContext(),
+          static_cast<ttk::InputClamping>(op.getInputClamping()));
+    }
+    IntegerAttr iterationsAttr;
+    if (op.getIterations() != defaultExpIterations) {
+      iterationsAttr = rewriter.getI32IntegerAttr(op.getIterations());
+    }
+    IntegerAttr scaleAttr;
+    if (auto ttlScaleAttr = op.getScaleAttr()) {
+      scaleAttr = floatAttrToI32BitsAttr(rewriter, ttlScaleAttr);
+    }
+    ttk::ExpTileOp::create(rewriter, loc, dstIdxVal, approxAttr,
+                           inputClampingAttr, iterationsAttr, scaleAttr);
     rewriter.replaceOp(op, adaptor.getInput());
     return success();
   }
@@ -1054,6 +1109,7 @@ void populateTTLTileOpsToTTKernelPatterns(TypeConverter *typeConverter,
   patterns.add<TTLTileFillToTTKernel>(ctx);
   patterns.add<TTLTileMulUnaryConstToTTKernel>(ctx);
   patterns.add<TTLTileTypecastToTTKernel>(ctx);
+  patterns.add<TTLTileExpToTTKernel>(ctx);
 
   // Copy ops need the type converter.
   patterns.add<TTLTileCopyToTTKernel>(*typeConverter, ctx);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -234,6 +234,26 @@ static void eraseAbsorbedOutputOps(PatternRewriter &rewriter,
 // Tile op emission for fusion
 //===----------------------------------------------------------------------===//
 
+static Value emitExpTileOp(OpBuilder &builder, Location loc, Type tileType,
+                           Value input, const ExpFlagsPlan &flags) {
+  FloatAttr scale = flags.scale;
+  if (scale && !flags.approx.getValue()) {
+    // The current accurate BF16 LLK path passes this runtime value to
+    // immediate-only SFPMULI. Keep accurate semantics by materializing the
+    // scale as a supported tile multiply before invoking unscaled exp.
+    input = createTileOpWithPlaceholderDstIndex<TileMulUnaryConstOp>(
+        builder, loc, tileType, input, scale);
+    scale = nullptr;
+  }
+
+  Value dstIndex = createPlaceholderDstIndex(builder, loc);
+  auto tileOp =
+      ExpTileOp::create(builder, loc, tileType, input, dstIndex, flags.approx,
+                        scale, flags.inputClamping, flags.iterations);
+  addPlaceholderDstIndexAttr(tileOp.getOperation());
+  return tileOp.getResult();
+}
+
 /// Creates the generic tile operation selected by a verified fused plan.
 static Value emitTileOpFor(OpBuilder &builder, Location loc,
                            const FusedOperationPlan &operationPlan,
@@ -252,6 +272,16 @@ static Value emitTileOpFor(OpBuilder &builder, Location loc,
 #define TTL_BINARY_TILE_OP_MINMAX(TTL_OP, TILE_OP, TTK_INIT, TTK_COMPUTE)      \
   TTL_BINARY_TILE_OP(TTL_OP, TILE_OP, TTK_INIT, TTK_COMPUTE)
 #include "ttlang/Dialect/TTL/TTLElementwiseOps.def"
+
+  // ExpOp is excluded from TTLElementwiseOps.def because it carries hardware
+  // flags that must be forwarded to the tile operation.
+  if (isa<ExpOp>(sourceOp)) {
+    assert(tileOperands.size() == 1 && "exp fusion requires one tile operand");
+    assert(operationPlan.expFlags &&
+           "exp recipe must record its hardware flags");
+    return emitExpTileOp(builder, loc, tileType, tileOperands[0],
+                         *operationPlan.expFlags);
+  }
 
   if (isa<MulUnaryConstOp>(sourceOp)) {
     assert(tileOperands.size() == 1 &&
@@ -375,7 +405,8 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
       return rewriter.notifyMatchFailure(
           sinkOp, "fused operation dependency is unavailable");
     }
-    if (operationPlan.recipe == FusedOperationRecipe::DeferredMatmul) {
+    if (operationPlan.recipe == FusedOperationRecipe::DeferredMatmul ||
+        operationPlan.recipe == FusedOperationRecipe::DeferredExpScale) {
       continue;
     }
     availableValues.insert(operationPlan.source->getResult(0));
@@ -496,6 +527,9 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
     case FusedOperationRecipe::DeferredMatmul:
       assert(!instrumentationEmitter.hasAfter(op) &&
              "instrumented matmul must not be folded into its user");
+      continue;
+    case FusedOperationRecipe::DeferredExpScale:
+      instrumentationEmitter.emitAfter(op);
       continue;
     case FusedOperationRecipe::MatmulAccumulator: {
       assert(operationPlan.foldedMatmul && operationPlan.accumulator &&
@@ -756,6 +790,30 @@ struct LowerUnaryToCompute : PlannedComputeRewritePattern<TTLOp> {
                                 PatternRewriter &rewriter) const override {
     return buildUnaryCompute<TileOp>(op.getOperation(), rewriter, op.getInput(),
                                      this->kernelPlan);
+  }
+};
+
+/// Pattern for ttl.exp: TTL tensor op -> ttl.compute with ttl.tile_exp,
+/// forwarding the exp hardware flags. Dedicated (not the generic unary
+/// template) because exp carries extra attributes.
+struct LowerExpToCompute : PlannedComputeRewritePattern<ExpOp> {
+  using PlannedComputeRewritePattern<ExpOp>::PlannedComputeRewritePattern;
+
+  LogicalResult matchAndRewrite(ExpOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!getAttachedCB(op.getInput())) {
+      return tryFusion(op.getOperation(), rewriter, this->kernelPlan);
+    }
+
+    return buildComputeFromInputs(
+        op, rewriter, ComputeOpCreationRecipe::Elementwise, this->kernelPlan,
+        [](OpBuilder &builder, Location location, Type tileType, Block *body,
+           const ComputeOpCreationPlan &creation) {
+          assert(creation.expFlags &&
+                 "exp recipe must record its hardware flags");
+          return emitExpTileOp(builder, location, tileType,
+                               body->getArgument(0), *creation.expFlags);
+        });
   }
 };
 
@@ -1357,6 +1415,7 @@ static void populateTTLToComputePatternsForMode(
   patterns.add<Lower##TTL_OP>(ctx, kernelPlan);
 #include "ttlang/Dialect/TTL/TTLElementwiseOps.def"
 
+  patterns.add<LowerExpToCompute>(ctx, kernelPlan);
   patterns.add<LowerBlockBroadcastToCompute>(ctx, kernelPlan);
   patterns.add<LowerMatmulToCompute>(ctx, kernelPlan);
   patterns.add<LowerReduceToCompute>(ctx, kernelPlan);

--- a/lib/Dialect/TTL/Transforms/TTLPrintComputeOpCreationPlans.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLPrintComputeOpCreationPlans.cpp
@@ -72,6 +72,8 @@ static StringRef stringifyFusedRecipe(FusedOperationRecipe recipe) {
     return "deferred-matmul";
   case FusedOperationRecipe::MatmulAccumulator:
     return "matmul-accumulator";
+  case FusedOperationRecipe::DeferredExpScale:
+    return "deferred-exp-scale";
   }
   llvm_unreachable("unknown fused operation recipe");
 }

--- a/python/gen_elementwise.py
+++ b/python/gen_elementwise.py
@@ -17,6 +17,12 @@ import argparse
 import re
 from pathlib import Path
 
+# Ops that are hand-written in ttl.operators (because they take extra keyword
+# arguments / hardware flags) and must NOT get an auto-generated wrapper, even
+# if they appear in TTLElementwiseOps.def. `exp` carries approx / scale /
+# input_clamping / iterations flags.
+HANDWRITTEN_OPS = {"exp"}
+
 HEADER = '''\
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
@@ -102,6 +108,11 @@ def parse_def_file(def_path: Path) -> tuple[list[str], list[str]]:
             "ttk_compute",
         ):
             unary_ops.append(name)
+
+    # Drop any hand-written ops so they don't get a generic auto-generated
+    # wrapper that would shadow the hand-written one.
+    binary_ops = [op for op in binary_ops if op not in HANDWRITTEN_OPS]
+    unary_ops = [op for op in unary_ops if op not in HANDWRITTEN_OPS]
 
     return binary_ops, unary_ops
 

--- a/python/sim/math.py
+++ b/python/sim/math.py
@@ -85,7 +85,6 @@ _TORCH_UNARY_OPS: dict[str, Callable[[torch.Tensor], torch.Tensor]] = {
     # Basic unary math functions (from spec)
     "abs": torch.abs,
     "neg": torch.neg,
-    "exp": torch.exp,
     "exp2": torch.exp2,
     "expm1": torch.expm1,
     "log": torch.log,
@@ -195,6 +194,32 @@ def _apply_unary_with_params(
     result_block = Block.from_list(result_list, shape=block._shape)  # type: ignore[attr-defined]
     track_source_blocks(result_block, block)
     return result_block
+
+
+def exp(
+    block: Block,
+    *,
+    approx: bool = False,
+    scale: Optional[float] = None,
+    skip_clamp_check: bool = False,
+    iterations: int = 8,
+) -> Block:
+    """Element-wise exponential (simulator reference).
+
+    Mirrors the ``ttl.exp`` DSL signature. ``scale`` is numerically meaningful
+    (computes ``exp(scale * x)``); the remaining flags (``approx``,
+    ``skip_clamp_check``, ``iterations``) only control the hardware SFPU
+    approximation and are accepted for API parity but do not change the exact
+    reference result.
+    """
+    del approx, skip_clamp_check, iterations  # hardware-only knobs
+
+    def _op(t: torch.Tensor) -> torch.Tensor:
+        if scale is not None:
+            t = t * float(scale)
+        return torch.exp(t)
+
+    return _apply_unary_with_params(block, _op)
 
 
 # Binary operations

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -985,6 +985,66 @@ def typecast(input: TensorBlock, dtype) -> TensorBlock:
     return ttl.typecast(result_type, input)
 
 
+@syntax("exp")
+def exp(
+    input: TensorBlock,
+    *,
+    approx: bool = False,
+    scale: Optional[float] = None,
+    skip_clamp_check: bool = False,
+    iterations: int = 8,
+) -> TensorBlock:
+    """Element-wise exponential.
+
+    With default arguments this matches the plain hardware ``exp_tile`` (no
+    approximation, no scaling, clamped). Keyword flags expose the SFPU exp
+    template parameters:
+
+    Args:
+        input: Input tensor (CB-attached). Each element is a tile.
+        approx: Enable the fast approximate exp.
+        scale: Optional scale factor ``s``; when set the op computes
+            ``exp(s * x)``. ``None`` (default) disables scaling.
+        skip_clamp_check: When ``True``, disables clamping of very negative
+            inputs (``InputClamping::None``): faster, but inputs below ~-88.5
+            produce incorrect (guaranteed-negative) outputs. Only meaningful
+            with ``approx=True``. Defaults to ``False`` (``ClampToNegative``).
+        iterations: Number of SFPU lane iterations (default 8).
+
+    Returns:
+        Result tensor with the same shape and dtype as ``input``.
+    """
+    from ttl.ir import BoolAttr, IntegerType
+
+    ctx = input.type.context
+    i32 = IntegerType.get_signless(32, ctx)
+
+    # Flag literals passed inside a compute body arrive as arith.constant
+    # values, so resolve them through the constant helpers.
+    approx_b = _get_constant_bool(approx)
+    skip_clamp_b = _get_constant_bool(skip_clamp_check)
+    iterations_i = _get_constant_int(iterations)
+    scale_f = None if scale is None else _get_constant_float(scale)
+
+    # Pass None for any flag left at its default so the op keeps its plain
+    # spelling (the ODS default applies). input_clamping is an integer-backed
+    # enum attribute (built like ttl.reduce's reduce_type); None=0,
+    # ClampToNegative=1.
+    approx_attr = BoolAttr.get(True) if approx_b else None
+    iterations_attr = IntegerAttr.get(i32, iterations_i) if iterations_i != 8 else None
+    clamping_attr = IntegerAttr.get(i32, 0) if skip_clamp_b else None
+    scale_attr = None if scale_f is None else FloatAttr.get(F32Type.get(ctx), scale_f)
+
+    return ttl.exp(
+        input.type,
+        input,
+        approx=approx_attr,
+        scale=scale_attr,
+        input_clamping=clamping_attr,
+        iterations=iterations_attr,
+    )
+
+
 def _get_block_scalar_type(block):
     """Extract the scalar MLIR type from a block's tensor element type.
 
@@ -1109,6 +1169,7 @@ __all__ = [
     "matmul",
     "fill",
     "typecast",
+    "exp",
     "raw_element_read",
     "raw_element_write",
     *_generated_all,

--- a/python/ttl/ttl_math.py
+++ b/python/ttl/ttl_math.py
@@ -11,14 +11,105 @@ Re-exports elementwise operations from the generated module.
 # Re-export all generated elementwise operations
 from ._generated_elementwise import *  # noqa: F401,F403
 from ._generated_elementwise import __all__ as _generated_all
-from .operators import broadcast, reduce_sum, reduce_max, transpose, fill, typecast
+from ._src.ttl_ast import syntax
+from .operators import (
+    broadcast,
+    fill,
+    get_constant_float_value,
+    get_constant_int_value,
+    reduce_max,
+    reduce_sum,
+    transpose,
+    typecast,
+)
+from ttl.dialects import ttl
+from ttl.ir import F32Type, FloatAttr, IntegerAttr
+
+
+def _get_constant_bool(val) -> bool:
+    """Resolve a boolean flag from Python or MLIR constant values."""
+    if isinstance(val, bool):
+        return val
+    iv = get_constant_int_value(val)
+    if iv is None:
+        raise ValueError(f"Expected constant bool, got {type(val).__name__}")
+    return bool(iv)
+
+
+def _get_constant_int(val) -> int:
+    v = get_constant_int_value(val)
+    if v is None:
+        raise ValueError(f"Expected constant int, got {type(val).__name__}")
+    return v
+
+
+def _get_constant_float(val) -> float:
+    v = get_constant_float_value(val)
+    if v is None:
+        raise ValueError(f"Expected constant float, got {type(val).__name__}")
+    return v
+
+
+@syntax("exp")
+def exp(
+    input,
+    *,
+    approx: bool = False,
+    scale: float | None = None,
+    skip_clamp_check: bool = False,
+    iterations: int = 8,
+):
+    """Element-wise exponential.
+
+    With default arguments this matches the plain hardware ``exp_tile`` (no
+    approximation, no scaling, clamped). Keyword flags expose the SFPU exp
+    template parameters.
+
+    Args:
+        input: Input block expression.
+        approx: Enables approximate exponential evaluation.
+        scale: Optional compile-time input multiplier. Computes
+            ``exp(scale * input)`` when set.
+        skip_clamp_check: Disables clamping of very negative inputs in
+            approximate mode. Inputs below approximately -88.5 can produce
+            incorrect negative outputs when enabled.
+        iterations: Number of SFPU lane iterations. Defaults to 8.
+
+    Returns:
+        The element-wise exponential block expression.
+    """
+    from ttl.ir import BoolAttr, IntegerType
+
+    ctx = input.type.context
+    i32 = IntegerType.get_signless(32, ctx)
+
+    approx_b = _get_constant_bool(approx)
+    skip_clamp_b = _get_constant_bool(skip_clamp_check)
+    iterations_i = _get_constant_int(iterations)
+    scale_f = None if scale is None else _get_constant_float(scale)
+
+    approx_attr = BoolAttr.get(True) if approx_b else None
+    iterations_attr = IntegerAttr.get(i32, iterations_i) if iterations_i != 8 else None
+    clamping_attr = IntegerAttr.get(i32, 0) if skip_clamp_b else None
+    scale_attr = None if scale_f is None else FloatAttr.get(F32Type.get(ctx), scale_f)
+
+    return ttl.exp(
+        input.type,
+        input,
+        approx=approx_attr,
+        scale=scale_attr,
+        input_clamping=clamping_attr,
+        iterations=iterations_attr,
+    )
+
 
 __all__ = [
     "broadcast",
-    "reduce_sum",
-    "reduce_max",
-    "transpose",
+    "exp",
     "fill",
+    "reduce_max",
+    "reduce_sum",
+    "transpose",
     "typecast",
     *_generated_all,
 ]

--- a/test/python/test_exp_flags.py
+++ b/test/python/test_exp_flags.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""End-to-end coverage for the ttl.math.exp hardware flags.
+
+Flags must be passed as literal keyword arguments in the ``ttl.math.exp`` call
+(the TTL AST compiler cannot resolve ``**kwargs`` splats), so each variant has
+its own operation.
+"""
+
+import pytest
+import torch
+
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_l1
+
+EXP_SCALE = 2.0
+
+
+@ttl.operation(grid=(1, 1))
+def exp_default_kernel(in_t, out_t):
+    a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = a_cb.wait()
+        r = out_cb.reserve()
+        r.store(ttl.math.exp(x))
+
+    @ttl.datamovement()
+    def dm_read():
+        ttl.copy(in_t[0, 0], a_cb.reserve())
+
+    @ttl.datamovement()
+    def dm_write():
+        ttl.copy(out_cb.wait(), out_t[0, 0])
+
+
+@ttl.operation(grid=(1, 1))
+def exp_approx_kernel(in_t, out_t):
+    a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = a_cb.wait()
+        r = out_cb.reserve()
+        r.store(ttl.math.exp(x, approx=True))
+
+    @ttl.datamovement()
+    def dm_read():
+        ttl.copy(in_t[0, 0], a_cb.reserve())
+
+    @ttl.datamovement()
+    def dm_write():
+        ttl.copy(out_cb.wait(), out_t[0, 0])
+
+
+@ttl.operation(grid=(1, 1))
+def exp_approx_skip_clamp_kernel(in_t, out_t):
+    a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = a_cb.wait()
+        r = out_cb.reserve()
+        r.store(ttl.math.exp(x, approx=True, skip_clamp_check=True))
+
+    @ttl.datamovement()
+    def dm_read():
+        ttl.copy(in_t[0, 0], a_cb.reserve())
+
+    @ttl.datamovement()
+    def dm_write():
+        ttl.copy(out_cb.wait(), out_t[0, 0])
+
+
+@ttl.operation(grid=(1, 1))
+def exp_scale_literal_mul_kernel(in_t, out_t):
+    a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = a_cb.wait()
+        r = out_cb.reserve()
+        r.store(ttl.math.exp(x * 2.0))
+
+    @ttl.datamovement()
+    def dm_read():
+        ttl.copy(in_t[0, 0], a_cb.reserve())
+
+    @ttl.datamovement()
+    def dm_write():
+        ttl.copy(out_cb.wait(), out_t[0, 0])
+
+
+@ttl.operation(grid=(1, 1))
+def exp_scale_variable_mul_kernel(in_t, out_t):
+    a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = a_cb.wait()
+        r = out_cb.reserve()
+        r.store(ttl.math.exp(x * EXP_SCALE))
+
+    @ttl.datamovement()
+    def dm_read():
+        ttl.copy(in_t[0, 0], a_cb.reserve())
+
+    @ttl.datamovement()
+    def dm_write():
+        ttl.copy(out_cb.wait(), out_t[0, 0])
+
+
+@ttl.operation(grid=(1, 1))
+def exp_scale_keyword_kernel(in_t, out_t):
+    a_cb = ttl.make_dataflow_buffer_like(in_t, shape=(1, 1), block_count=2)
+    out_cb = ttl.make_dataflow_buffer_like(out_t, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        x = a_cb.wait()
+        r = out_cb.reserve()
+        r.store(ttl.math.exp(x, scale=EXP_SCALE))
+
+    @ttl.datamovement()
+    def dm_read():
+        ttl.copy(in_t[0, 0], a_cb.reserve())
+
+    @ttl.datamovement()
+    def dm_write():
+        ttl.copy(out_cb.wait(), out_t[0, 0])
+
+
+def _run(kernel, inp_t, device):
+    tile = ttnn.TILE_SIZE
+    in_t = to_l1(inp_t, device)
+    out_t = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+    kernel(in_t, out_t)
+    return ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
+
+
+def _rand_tile():
+    tile = ttnn.TILE_SIZE
+    return (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+
+
+def test_exp_default(device):
+    inp_t = _rand_tile()
+    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
+    got = _run(exp_default_kernel, inp_t, device)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_exp_approx(device):
+    inp_t = _rand_tile()
+    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
+    got = _run(exp_approx_kernel, inp_t, device)
+    # Approximate mode: relax tolerance.
+    assert_allclose(got, expected, rtol=5e-2, atol=5e-2)
+
+
+def test_exp_approx_skip_clamp(device):
+    # approx + skip_clamp_check (InputClamping::None) is a speed-over-accuracy
+    # mode: it skips the clamp the approximate SFPU exp normally relies on, so
+    # the result is not close to the exact exp (it saturates). We only verify
+    # the flags plumb through, compile, and run, producing finite positive
+    # outputs (exp is always > 0) rather than asserting close numerics.
+    inp_t = _rand_tile()
+    got = _run(exp_approx_skip_clamp_kernel, inp_t, device)
+    assert torch.isfinite(got).all()
+    assert (got > 0).all()
+
+
+def test_exp_scaled_by_literal_mul(device):
+    inp_t = _rand_tile()
+    expected = torch.exp(2.0 * inp_t.float()).to(torch.bfloat16)
+    got = _run(exp_scale_literal_mul_kernel, inp_t, device)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_exp_scaled_by_variable_mul(device):
+    inp_t = _rand_tile()
+    expected = torch.exp(EXP_SCALE * inp_t.float()).to(torch.bfloat16)
+    got = _run(exp_scale_variable_mul_kernel, inp_t, device)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_exp_scaled_by_keyword(device):
+    inp_t = _rand_tile()
+    expected = torch.exp(EXP_SCALE * inp_t.float()).to(torch.bfloat16)
+    got = _run(exp_scale_keyword_kernel, inp_t, device)
+    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)

--- a/test/sim/test_math.py
+++ b/test/sim/test_math.py
@@ -664,6 +664,29 @@ def test_exp_multitile():
     )
 
 
+def test_exp_scale_flag():
+    """Scale flag is numerically honored by the simulator: exp(scale * x)."""
+    t1 = [Tensor(torch.tensor([[0.0, 1.0]]))]
+    block1 = Block.from_list(t1, shape=(1, 1))
+
+    result = ttl.math.exp(block1, scale=2.0)
+
+    expected = torch.exp(2.0 * torch.tensor([[0.0, 1.0]]))
+    assert torch.allclose(result.to_list()[0].to_torch(), expected)
+
+
+def test_exp_approx_flags_ignored_numerically():
+    """Approximation-only flags are accepted and do not change the exact
+    reference result in the simulator."""
+    t1 = [Tensor(torch.tensor([[0.0, 1.0, -1.0]]))]
+    block1 = Block.from_list(t1, shape=(1, 1))
+
+    result = ttl.math.exp(block1, approx=True, skip_clamp_check=True, iterations=4)
+
+    expected = torch.exp(torch.tensor([[0.0, 1.0, -1.0]]))
+    assert torch.allclose(result.to_list()[0].to_torch(), expected)
+
+
 # Tests for reduce_max function
 
 

--- a/test/ttlang/Conversion/TTLToCompute/exp_flags.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/exp_flags.mlir
@@ -1,0 +1,41 @@
+// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute))' | FileCheck %s
+
+// The exp hardware flags (approx / scale / input_clamping / iterations) on the
+// tensor-level ttl.exp are forwarded unchanged to the ttl.tile_exp op created
+// inside the ttl.compute body.
+
+// CHECK-LABEL: func.func @exp_flags_forwarded
+func.func @exp_flags_forwarded(%arg0: tensor<4x4x!ttcore.tile<32x32, f32>>) -> tensor<4x4x!ttcore.tile<32x32, f32>> {
+  // CHECK: ttl.compute
+  // CHECK: %[[EXP:.*]] = ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}iterations = 4 : i32{{.*}}scale = 5.000000e-01 : f32{{.*[}]}}
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>
+  %a = ttl.attach_cb %arg0, %cb0 : (tensor<4x4x!ttcore.tile<32x32, f32>>, !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>) -> tensor<4x4x!ttcore.tile<32x32, f32>>
+  %reserve = ttl.cb_reserve %cb1 : <[4, 4], !ttcore.tile<32x32, f32>, 2> -> tensor<4x4x!ttcore.tile<32x32, f32>>
+  %0 = ttl.exp %a {approx = true, scale = 5.000000e-01 : f32,
+                   input_clamping = 0 : i32, iterations = 4 : i32}
+      : tensor<4x4x!ttcore.tile<32x32, f32>> -> tensor<4x4x!ttcore.tile<32x32, f32>>
+  ttl.store %0, %reserve : tensor<4x4x!ttcore.tile<32x32, f32>>, tensor<4x4x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<4x4x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Accurate scaled exp materializes a tile multiply before plain exp because the
+// current accurate BF16 LLK scale path requires an immediate but accepts scale
+// as a runtime argument.
+
+// CHECK-LABEL: func.func @exp_accurate_scale_materialized
+func.func @exp_accurate_scale_materialized(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>>) -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  // CHECK: ttl.compute
+  // CHECK: %[[SCALED:.*]] = ttl.tile_mul_unary_const %{{.*}}, 2.000000e+00 into dst[%{{.*}}]
+  // CHECK: ttl.tile_exp %[[SCALED]] into dst[%{{.*}}]
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %a = ttl.attach_cb %arg0, %cb0 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %scaled = ttl.mul_unary_const %a, 2.000000e+00 : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %exp = ttl.exp %scaled : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  ttl.store %exp, %reserve : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %exp : tensor<1x1x!ttcore.tile<32x32, f32>>
+}

--- a/test/ttlang/Conversion/TTLToTTKernel/exp_flags.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/exp_flags.mlir
@@ -1,0 +1,50 @@
+// RUN: ttlang-opt --convert-ttl-to-ttkernel --ttkernel-insert-inits %s | FileCheck %s
+// Summary: ttl.tile_exp hardware flags are forwarded to ttkernel.exp_tile, and
+// the matching ttkernel.exp_tile_init (carrying approx / scale / input_clamping)
+// is emitted by the init-insertion pass from the flags read off exp_tile.
+//
+// TTKernel exp ops do not define typed flag properties, so the lowering carries
+// the flags as ordinary MLIR attributes for init insertion and EmitC lowering.
+
+// A single flagged exp: one exp_tile_init then the exp_tile.
+// CHECK-LABEL: func.func @tile_exp_flags
+// CHECK: ttkernel.tile_regs_acquire
+// CHECK: ttkernel.exp_tile_init() {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}scale = 1073741824 : i32{{.*[}]}}
+// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}iterations = 4 : i32{{.*}}scale = 1073741824 : i32{{.*[}]}}
+// CHECK: ttkernel.tile_regs_release
+func.func @tile_exp_flags(%a: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
+  %c0 = arith.constant 0 : index
+  ttkernel.tile_regs_acquire() : () -> ()
+  %exp = ttl.tile_exp %a into dst[%c0] {approx = true, scale = 2.000000e+00 : f32,
+                                        input_clamping = 0 : i32,
+                                        iterations = 4 : i32}
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  ttkernel.tile_regs_release() : () -> ()
+  func.return %exp : !ttcore.tile<32x32, f32>
+}
+
+// -----
+
+// Two exps with identical flags share a single init; a third with different
+// flags forces a fresh init.
+// CHECK-LABEL: func.func @tile_exp_flag_change
+// CHECK: ttkernel.exp_tile_init
+// CHECK: ttkernel.exp_tile
+// CHECK-NOT: ttkernel.exp_tile_init
+// CHECK: ttkernel.exp_tile
+// CHECK: ttkernel.exp_tile_init
+// CHECK: ttkernel.exp_tile
+func.func @tile_exp_flag_change(%a: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  ttkernel.tile_regs_acquire() : () -> ()
+  %e0 = ttl.tile_exp %a into dst[%c0] {approx = true}
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %e1 = ttl.tile_exp %a into dst[%c1] {approx = true}
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %e2 = ttl.tile_exp %a into dst[%c2] {approx = false}
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  ttkernel.tile_regs_release() : () -> ()
+  func.return %e2 : !ttcore.tile<32x32, f32>
+}

--- a/test/ttlang/Dialect/TTL/IR/exp_flags.mlir
+++ b/test/ttlang/Dialect/TTL/IR/exp_flags.mlir
@@ -1,0 +1,55 @@
+// RUN: ttlang-opt %s --split-input-file | FileCheck %s
+
+// Verify ttl.exp and ttl.tile_exp parse and print their optional hardware
+// flags (approx / scale / input_clamping / iterations). With no flags set the
+// ops keep their plain spelling (all flags are default-valued or optional).
+
+// CHECK-LABEL: func.func @exp_no_flags
+// CHECK: ttl.exp %{{.*}} : tensor<2x2x!ttcore.tile<32x32, f32>> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @exp_no_flags(
+    %arg0: tensor<2x2x!ttcore.tile<32x32, f32>>)
+    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
+  %0 = ttl.exp %arg0
+      : tensor<2x2x!ttcore.tile<32x32, f32>> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @exp_with_flags
+// CHECK: ttl.exp %{{.*}} {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}iterations = 4 : i32{{.*}}scale = 2.000000e+00 : f32{{.*[}]}} : tensor<2x2x!ttcore.tile<32x32, f32>> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @exp_with_flags(
+    %arg0: tensor<2x2x!ttcore.tile<32x32, f32>>)
+    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
+  %0 = ttl.exp %arg0 {approx = true, scale = 2.000000e+00 : f32,
+                      input_clamping = 0 : i32,
+                      iterations = 4 : i32}
+      : tensor<2x2x!ttcore.tile<32x32, f32>> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tile_exp_no_flags
+// CHECK: ttl.tile_exp %{{.*}} into dst[%{{.*}}] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+func.func @tile_exp_no_flags(%a: !ttcore.tile<32x32, f32>)
+    -> !ttcore.tile<32x32, f32> {
+  %c0 = arith.constant 0 : index
+  %0 = ttl.tile_exp %a into dst[%c0]
+       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return %0 : !ttcore.tile<32x32, f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tile_exp_with_flags
+// CHECK: ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}iterations = 4 : i32{{.*}}scale = 2.000000e+00 : f32{{.*[}]}} : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+func.func @tile_exp_with_flags(%a: !ttcore.tile<32x32, f32>)
+    -> !ttcore.tile<32x32, f32> {
+  %c0 = arith.constant 0 : index
+  %0 = ttl.tile_exp %a into dst[%c0] {approx = true, scale = 2.000000e+00 : f32,
+                                      input_clamping = 0 : i32,
+                                      iterations = 4 : i32}
+       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return %0 : !ttcore.tile<32x32, f32>
+}

--- a/test/ttlang/Dialect/TTL/Transforms/compute_op_creation_instrumentation.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/compute_op_creation_instrumentation.mlir
@@ -213,6 +213,48 @@ func.func @intervening_operation()
 
 // -----
 
+// Folding a multiply into exp scaling must not move scaling past instrumentation
+// that observes DST. Keeping separate tile operations preserves the observation
+// point after the multiply and before exp.
+
+// CHECK-LABEL: ComputeOp creation plan @intervening_exp_scale_instrumentation
+// CHECK:       ttl.exp kind=fused recipe=fused legal=true
+// IR-LABEL:    func.func @intervening_exp_scale_instrumentation
+// IR:          ttl.compute
+// IR:            %[[SCALED:.*]] = ttl.tile_mul_unary_const
+// IR-NEXT:       ttl.dprint "after scale"
+// IR-NEXT:       ttl.tile_exp %[[SCALED]]
+func.func @intervening_exp_scale_instrumentation()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %input_wait = ttl.cb_wait %input_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %input = ttl.attach_cb %input_wait, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %scaled = ttl.mul_unary_const %input, 2.000000e+00
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  "ttl.dprint"() {fmt = "after scale", mode = "dst"} : () -> ()
+  %result = ttl.exp %scaled
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %result, %output
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
 // A direct producer owns the signposts that surround its source operation.
 // A fused consumer may recompute that source, but must not move or duplicate
 // the producer's observable events.

--- a/test/ttlang/Translate/TTLToCpp/exp_scaled_to_cpp.mlir
+++ b/test/ttlang/Translate/TTLToCpp/exp_scaled_to_cpp.mlir
@@ -1,0 +1,31 @@
+// RUN: ttlang-opt %s \
+// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' \
+// RUN:   -o %t.ttkernel.mlir
+// RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.ttkernel.mlir -o %t.emitc.mlir
+// RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
+// RUN: FileCheck %s --input-file=%t.cpp
+
+// Purpose: verify that accurate `ttl.exp(x * C)` materializes scaling before
+// plain exp to avoid the accurate BF16 LLK's immediate-only scale instruction.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: void kernel_main()
+// CHECK: binop_with_scalar_tile_init();
+// CHECK: mul_unary_tile(
+// CHECK: exp_tile_init();
+// CHECK: exp_tile(
+func.func @scaled_exp(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %output = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %input = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_cb = ttl.attach_cb %output, %cb1 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %result_view = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %scaled = ttl.mul_unary_const %input, 2.000000e+00 : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %exp = ttl.exp %scaled : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  ttl.store %exp, %result_view : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %exp : tensor<1x1x!ttcore.tile<32x32, f32>>
+}


### PR DESCRIPTION
### Problem description
Exp kernel supports useful flags, like scale, which are not available in tt-lang.

### What's changed
Use custom Exp implementation instead of UnaryElementwise.
Add user-facing `scale` attribute and SFPU-facing clamping, approximation.

### Depends on

1. https://github.com/tenstorrent/tt-mlir/pull/8796 (implementation)
2. https://github.com/tenstorrent/tt-mlir/pull/8830 (fixup)
3. https://github.com/tenstorrent/tt-mlir/pull/8883 (runtime arguments)

### Checklist
- [X] New/Existing tests provide coverage for changes
