### PR TITLE
[ttl][nfc] Extract DFB acquire-release analysis

### DIFF
--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(TTLangTTLTransforms
   ConvertTTLToTTKernel.cpp
+  DFBAcquireReleaseAnalysis.cpp
   DFBMaterialization.cpp
   PipeGraph.cpp
   PipeLowering.cpp

--- a/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.cpp
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "DFBAcquireReleaseAnalysis.h"
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+
+#include "llvm/ADT/DenseSet.h"
+
+#include <optional>
+
+//===----------------------------------------------------------------------===//
+// DFB Acquire/Release Ownership Analysis
+//===----------------------------------------------------------------------===//
+
+namespace mlir::tt::ttl {
+
+namespace {
+
+static bool isBefore(Operation *before, Operation *after) {
+  return before->isBeforeInBlock(after);
+}
+
+/// Direct DFB copies can use the same DFB value on either source or
+/// destination operands. Only the operand that corresponds to the acquire class
+/// consumes the acquired slot.
+static bool directDFBUseMatchesAcquire(DFBAcquireInterval interval,
+                                       Operation *user) {
+  auto copy = dyn_cast<CopyOp>(user);
+  if (!copy) {
+    return true;
+  }
+
+  switch (interval.kind) {
+  case DFBAcquireReleaseKind::Producer:
+    return copy.getDst() == interval.dfb;
+  case DFBAcquireReleaseKind::Consumer:
+    return copy.getSrc() == interval.dfb;
+  }
+  llvm_unreachable("unknown DFB acquire/release kind");
+}
+
+static bool isLifecycleOrAttachOp(Operation *op) {
+  return isDFBAcquireOp(op) || isDFBReleaseOp(op) || isa<AttachCBOp>(op);
+}
+
+/// Project `op` into the acquire block so nested regions can be ordered
+/// against the acquire interval. This keeps the interval computation block
+/// local while still noticing releases nested under control-flow operations.
+static bool projectToAcquireBlock(DFBAcquireInterval interval, Operation *op,
+                                  Operation *&projected,
+                                  bool ignoreBoundary = false) {
+  Block *block = interval.acquire->getBlock();
+  projected = op->getBlock() == block ? op : block->findAncestorOpInBlock(*op);
+  if (!projected) {
+    return false;
+  }
+  if (!isBefore(interval.acquire, projected)) {
+    return false;
+  }
+  if (!ignoreBoundary && interval.kindBoundary &&
+      !isBefore(projected, interval.kindBoundary)) {
+    return false;
+  }
+  return true;
+}
+
+static void updateLatestUse(Operation *candidate, Operation *&latest) {
+  if (isBefore(latest, candidate)) {
+    latest = candidate;
+  }
+}
+
+/// Find the first later acquire of the same class on `dfb`, projected into the
+/// current block. Direct DFB uses at or after that operation belong to another
+/// interval; tensor SSA uses are handled separately because they retain the
+/// exact acquired slot identity.
+static void updateBoundary(Value dfb, Operation *acquire,
+                           ArrayRef<Operation *> acquires,
+                           Operation *&boundary) {
+  Block *block = acquire->getBlock();
+  for (Operation *other : acquires) {
+    if (other == acquire) {
+      continue;
+    }
+    if (getDFBAcquireDFB(other) != dfb) {
+      continue;
+    }
+    Operation *ancestor = block->findAncestorOpInBlock(*other);
+    if (!ancestor) {
+      continue;
+    }
+    if (!isBefore(acquire, ancestor)) {
+      continue;
+    }
+    if (!boundary || isBefore(ancestor, boundary)) {
+      boundary = ancestor;
+    }
+  }
+}
+
+static Operation *findNextSameKindAcquire(Value dfb, Operation *acquire,
+                                          ArrayRef<Operation *> acquires) {
+  Operation *boundary = nullptr;
+  updateBoundary(dfb, acquire, acquires, boundary);
+  return boundary;
+}
+
+} // namespace
+
+bool isDFBAcquireOp(Operation *op) { return isa<CBReserveOp, CBWaitOp>(op); }
+
+bool isDFBReleaseOp(Operation *op) { return isa<CBPushOp, CBPopOp>(op); }
+
+Value getDFBAcquireDFB(Operation *op) {
+  if (auto reserve = dyn_cast<CBReserveOp>(op)) {
+    return reserve.getCb();
+  }
+  return cast<CBWaitOp>(op).getCb();
+}
+
+Value getDFBReleaseDFB(Operation *op) {
+  if (auto push = dyn_cast<CBPushOp>(op)) {
+    return push.getCb();
+  }
+  return cast<CBPopOp>(op).getCb();
+}
+
+static std::optional<DFBAcquireReleaseKind>
+getDFBAcquireReleaseKind(Operation *op) {
+  if (isa<CBReserveOp, CBPushOp>(op)) {
+    return DFBAcquireReleaseKind::Producer;
+  }
+  if (isa<CBWaitOp, CBPopOp>(op)) {
+    return DFBAcquireReleaseKind::Consumer;
+  }
+  return std::nullopt;
+}
+
+void collectDFBAcquireReleaseOps(func::FuncOp func,
+                                 SmallVectorImpl<Operation *> &reserves,
+                                 SmallVectorImpl<Operation *> &waits,
+                                 SmallVectorImpl<Operation *> &pushes,
+                                 SmallVectorImpl<Operation *> &pops) {
+  func.walk([&](Operation *op) {
+    if (isa<CBReserveOp>(op)) {
+      reserves.push_back(op);
+    } else if (isa<CBWaitOp>(op)) {
+      waits.push_back(op);
+    } else if (isa<CBPushOp>(op)) {
+      pushes.push_back(op);
+    } else if (isa<CBPopOp>(op)) {
+      pops.push_back(op);
+    }
+  });
+}
+
+DFBAcquireInterval makeDFBAcquireInterval(Operation *acquire,
+                                          ArrayRef<Operation *> acquires) {
+  Value dfb = getDFBAcquireDFB(acquire);
+  std::optional<DFBAcquireReleaseKind> kind = getDFBAcquireReleaseKind(acquire);
+  assert(kind && "DFB acquire interval requires acquire operation");
+  return {acquire, dfb, *kind, findNextSameKindAcquire(dfb, acquire, acquires)};
+}
+
+Operation *findLastDFBAcquireOwnedUse(DFBAcquireInterval interval) {
+  Operation *last = interval.acquire;
+  llvm::DenseSet<Operation *> visited;
+  SmallVector<Value, 8> worklist;
+
+  auto extend = [&](Operation *user, bool ignoreBoundary) {
+    Operation *projected = nullptr;
+    if (!projectToAcquireBlock(interval, user, projected, ignoreBoundary)) {
+      return false;
+    }
+    if (!visited.insert(user).second) {
+      return false;
+    }
+    updateLatestUse(projected, last);
+    for (Value result : user->getResults()) {
+      worklist.push_back(result);
+    }
+    return true;
+  };
+
+  // Walk result users transitively because the operation that truly ends an
+  // interval can consume a value derived from an earlier direct DFB operation.
+  auto drainWorklist = [&](bool ignoreBoundary) {
+    while (!worklist.empty()) {
+      Value value = worklist.pop_back_val();
+      for (OpOperand &use : value.getUses()) {
+        Operation *user = use.getOwner();
+        if (isa<CBPushOp, CBPopOp>(user)) {
+          continue;
+        }
+        extend(user, ignoreBoundary);
+      }
+    }
+  };
+
+  // Direct DFB uses are tied to the current DFB pointer position. A later
+  // same-kind acquire on the same DFB starts a new pointer interval, so direct
+  // uses after the boundary are excluded.
+  for (OpOperand &use : interval.dfb.getUses()) {
+    Operation *user = use.getOwner();
+    if (user == interval.acquire) {
+      continue;
+    }
+    if (isLifecycleOrAttachOp(user)) {
+      continue;
+    }
+    if (!directDFBUseMatchesAcquire(interval, user)) {
+      continue;
+    }
+    extend(user, /*ignoreBoundary=*/false);
+  }
+  drainWorklist(/*ignoreBoundary=*/false);
+
+  // Tensor SSA uses keep naming the slot acquired by this operation even after
+  // a later DFB acquire advances the pointer. Applying the direct-DFB boundary
+  // here made auto-sync insertion release a slot before its final tensor use.
+  assert(interval.acquire->getNumResults() == 1 &&
+         "DFB acquire ops produce exactly one tensor result");
+  worklist.push_back(interval.acquire->getResult(0));
+  drainWorklist(/*ignoreBoundary=*/true);
+
+  return last;
+}
+
+DFBReleaseSearch
+findOwnedDFBReleases(DFBAcquireInterval interval, Operation *lastOwnedUse,
+                     ArrayRef<Operation *> releases,
+                     const llvm::DenseSet<Operation *> *erased) {
+  DFBReleaseSearch result;
+  Block *block = interval.acquire->getBlock();
+
+  bool useExtendsPastBoundary =
+      lastOwnedUse && lastOwnedUse != interval.acquire &&
+      interval.kindBoundary && !isBefore(lastOwnedUse, interval.kindBoundary);
+
+  for (Operation *release : releases) {
+    // `ttl-insert-cb-sync` may erase releases while iterating. The set contains
+    // raw pointers to erased operations, so membership must be checked before
+    // reading the operation through an op wrapper.
+    if (erased && erased->contains(release)) {
+      continue;
+    }
+    if (getDFBReleaseDFB(release) != interval.dfb) {
+      continue;
+    }
+
+    if (release->getBlock() == block) {
+      Operation *projected = nullptr;
+      if (projectToAcquireBlock(interval, release, projected)) {
+        result.sameLevelReleases.push_back(release);
+        continue;
+      }
+      // Idempotency case: if the pass previously inserted a release after a
+      // use that crosses the next-acquire boundary, accept that release as
+      // owned by the original acquire.
+      if (useExtendsPastBoundary &&
+          projectToAcquireBlock(interval, release, projected,
+                                /*ignoreBoundary=*/true) &&
+          !isBefore(projected, lastOwnedUse)) {
+        result.sameLevelReleases.push_back(release);
+      }
+      continue;
+    }
+
+    Operation *projected = nullptr;
+    if (!projectToAcquireBlock(interval, release, projected)) {
+      continue;
+    }
+    result.nestedReleases.push_back(release);
+  }
+
+  return result;
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.h
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBACQUIRERELEASEANALYSIS_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBACQUIRERELEASEANALYSIS_H
+
+//===----------------------------------------------------------------------===//
+// DFB Acquire/Release Ownership Analysis
+//===----------------------------------------------------------------------===//
+//
+// This utility computes ownership between DFB acquire operations and matching
+// release operations:
+//
+//   ttl.cb_reserve -> ttl.cb_push
+//   ttl.cb_wait    -> ttl.cb_pop
+//
+// The analysis is intentionally local to a function and to one acquire class.
+// Producer intervals and consumer intervals are independent because
+// reserve/push and wait/pop advance different DFB pointers. A release is owned
+// by the acquire interval whose acquired DFB slot is live until that release.
+// Consumers use the result tensor as evidence of slot ownership, while direct
+// DFB operations use the DFB value itself.
+//
+// The same ownership rules are used by `ttl-insert-cb-sync` and by PipeNet
+// lowering proofs. Keeping the rules here avoids disagreement between the pass
+// that creates implicit releases and later analyses that attach protocol
+// meaning to those releases.
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttl {
+
+/// Classifies the DFB pointer advanced by an acquire/release pair.
+enum class DFBAcquireReleaseKind { Producer, Consumer };
+
+/// Half-open ownership interval for one DFB acquire operation.
+///
+/// `kindBoundary` is the closest later acquire of the same kind on the same
+/// DFB, projected into the acquire block. Direct DFB uses after that boundary
+/// belong to a later acquire interval. Tensor SSA uses may extend past the
+/// boundary because they continue to name the original acquired slot.
+struct DFBAcquireInterval {
+  /// The `ttl.cb_reserve` or `ttl.cb_wait` that starts the interval.
+  Operation *acquire = nullptr;
+
+  /// The DFB value acquired by `acquire`.
+  Value dfb;
+
+  /// Whether this interval owns producer-side or consumer-side releases.
+  DFBAcquireReleaseKind kind = DFBAcquireReleaseKind::Producer;
+
+  /// Closest later same-kind acquire on `dfb`, or null if none exists.
+  Operation *kindBoundary = nullptr;
+};
+
+/// Releases found inside one acquire interval.
+struct DFBReleaseSearch {
+  /// Releases in the acquire block or projected into that block.
+  SmallVector<Operation *> sameLevelReleases;
+
+  /// Releases nested under operations in the acquire interval.
+  SmallVector<Operation *> nestedReleases;
+
+  bool hasSameLevelRelease() const { return !sameLevelReleases.empty(); }
+};
+
+/// Returns true for DFB acquire ops accepted by this analysis.
+bool isDFBAcquireOp(Operation *op);
+
+/// Returns true for DFB release ops accepted by this analysis.
+bool isDFBReleaseOp(Operation *op);
+
+/// Returns the DFB operand of a `ttl.cb_reserve` or `ttl.cb_wait`.
+Value getDFBAcquireDFB(Operation *op);
+
+/// Returns the DFB operand of a `ttl.cb_push` or `ttl.cb_pop`.
+Value getDFBReleaseDFB(Operation *op);
+
+/// Collects DFB lifecycle operations from `func` in walk order.
+void collectDFBAcquireReleaseOps(func::FuncOp func,
+                                 SmallVectorImpl<Operation *> &reserves,
+                                 SmallVectorImpl<Operation *> &waits,
+                                 SmallVectorImpl<Operation *> &pushes,
+                                 SmallVectorImpl<Operation *> &pops);
+
+/// Builds the ownership interval for `acquire`.
+///
+/// `acquires` must contain acquire operations of the same
+/// `DFBAcquireReleaseKind`, for example all reserves or all waits in the
+/// enclosing function.
+DFBAcquireInterval makeDFBAcquireInterval(Operation *acquire,
+                                          ArrayRef<Operation *> acquires);
+
+/// Finds the last operation in `interval.acquire`'s block that is owned by the
+/// interval.
+///
+/// See `docs/development/DFBManagement.md` for the asymmetric classification of
+/// direct DFB uses and tensor SSA uses.
+Operation *findLastDFBAcquireOwnedUse(DFBAcquireInterval interval);
+
+/// Finds releases owned by `interval`.
+///
+/// When `lastOwnedUse` is null, only the strict range before the next same-kind
+/// acquire is searched. When non-null and it extends past that boundary, the
+/// search also accepts releases after `lastOwnedUse`; this makes repeated
+/// auto-sync insertion idempotent.
+DFBReleaseSearch
+findOwnedDFBReleases(DFBAcquireInterval interval, Operation *lastOwnedUse,
+                     ArrayRef<Operation *> releases,
+                     const llvm::DenseSet<Operation *> *erased = nullptr);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBACQUIRERELEASEANALYSIS_H

--- a/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "DFBAcquireReleaseAnalysis.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/Passes.h"
 
@@ -32,257 +33,6 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-enum class DFBSyncClass { Producer, Consumer };
-
-struct ReleaseSearch {
-  bool hasSameLevelRelease = false;
-  SmallVector<Operation *> nestedReleases;
-};
-
-struct AcquireInterval {
-  Operation *acquire;
-  Value cb;
-  DFBSyncClass syncClass;
-  Operation *syncClassBoundary;
-};
-
-static bool isBefore(Operation *a, Operation *b) {
-  return a->isBeforeInBlock(b);
-}
-
-static bool isAcquireOp(Operation *op) {
-  return isa<CBReserveOp, CBWaitOp>(op);
-}
-
-static bool isReleaseOp(Operation *op) { return isa<CBPushOp, CBPopOp>(op); }
-
-static Value getAcquireCB(Operation *op) {
-  if (auto reserve = dyn_cast<CBReserveOp>(op)) {
-    return reserve.getCb();
-  }
-  return cast<CBWaitOp>(op).getCb();
-}
-
-static Value getReleaseCB(Operation *op) {
-  if (auto push = dyn_cast<CBPushOp>(op)) {
-    return push.getCb();
-  }
-  return cast<CBPopOp>(op).getCb();
-}
-
-static DFBSyncClass getDFBSyncClass(Operation *op) {
-  if (isa<CBReserveOp>(op)) {
-    return DFBSyncClass::Producer;
-  }
-  assert(isa<CBWaitOp>(op) && "unsupported DFB acquire op");
-  return DFBSyncClass::Consumer;
-}
-
-static bool isLifecycleOrAttachOp(Operation *op) {
-  return isAcquireOp(op) || isReleaseOp(op) || isa<AttachCBOp>(op);
-}
-
-static bool directDFBUseMatchesAcquire(AcquireInterval interval,
-                                       Operation *user) {
-  auto copy = dyn_cast<CopyOp>(user);
-  if (!copy) {
-    return true;
-  }
-
-  switch (interval.syncClass) {
-  case DFBSyncClass::Producer:
-    return copy.getDst() == interval.cb;
-  case DFBSyncClass::Consumer:
-    return copy.getSrc() == interval.cb;
-  }
-  llvm_unreachable("unknown DFB sync class");
-}
-
-static bool projectToAcquireBlock(AcquireInterval interval, Operation *op,
-                                  Operation *&projected,
-                                  bool ignoreBoundary = false) {
-  Block *block = interval.acquire->getBlock();
-  projected = op->getBlock() == block ? op : block->findAncestorOpInBlock(*op);
-  if (!projected) {
-    return false;
-  }
-  if (!isBefore(interval.acquire, projected)) {
-    return false;
-  }
-  if (!ignoreBoundary && interval.syncClassBoundary &&
-      !isBefore(projected, interval.syncClassBoundary)) {
-    return false;
-  }
-  return true;
-}
-
-static void updateLatestUse(Operation *candidate, Operation *&latest) {
-  if (isBefore(latest, candidate)) {
-    latest = candidate;
-  }
-}
-
-/// Find releases owned by this acquire interval. When `lastOwnedUse` is
-/// non-null and falls past the next-acquire boundary, also accept releases
-/// in that extended range so the pass is idempotent on re-run.
-static ReleaseSearch findOwnedReleases(AcquireInterval interval,
-                                       Operation *lastOwnedUse,
-                                       ArrayRef<Operation *> allReleases,
-                                       const DenseSet<Operation *> &erased) {
-  ReleaseSearch result;
-  Block *block = interval.acquire->getBlock();
-
-  bool useExtendsPastBoundary =
-      lastOwnedUse && lastOwnedUse != interval.acquire &&
-      interval.syncClassBoundary &&
-      !isBefore(lastOwnedUse, interval.syncClassBoundary);
-
-  for (Operation *release : allReleases) {
-    if (erased.contains(release)) {
-      continue;
-    }
-    if (getReleaseCB(release) != interval.cb) {
-      continue;
-    }
-
-    if (release->getBlock() == block) {
-      Operation *projected = nullptr;
-      if (projectToAcquireBlock(interval, release, projected)) {
-        result.hasSameLevelRelease = true;
-        continue;
-      }
-      // Re-check past the boundary: a release at or after the acquire's
-      // last owned use is one this pass would have inserted on a prior run.
-      if (useExtendsPastBoundary &&
-          projectToAcquireBlock(interval, release, projected,
-                                /*ignoreBoundary=*/true) &&
-          !isBefore(projected, lastOwnedUse)) {
-        result.hasSameLevelRelease = true;
-      }
-      continue;
-    }
-
-    Operation *projected = nullptr;
-    if (!projectToAcquireBlock(interval, release, projected)) {
-      continue;
-    }
-    result.nestedReleases.push_back(release);
-  }
-
-  return result;
-}
-
-static void updateBoundary(Value cb, Operation *acquire,
-                           ArrayRef<Operation *> acquires,
-                           Operation *&boundary) {
-  Block *block = acquire->getBlock();
-  for (Operation *other : acquires) {
-    if (other == acquire) {
-      continue;
-    }
-    if (getAcquireCB(other) != cb) {
-      continue;
-    }
-    Operation *ancestor = block->findAncestorOpInBlock(*other);
-    if (!ancestor) {
-      continue;
-    }
-    if (!isBefore(acquire, ancestor)) {
-      continue;
-    }
-    if (!boundary || isBefore(ancestor, boundary)) {
-      boundary = ancestor;
-    }
-  }
-}
-
-/// Return the closest later acquire on `cb` in the same DFB sync class,
-/// projected into `acquire`'s block.
-static Operation *findNextSyncClassAcquire(Value cb, Operation *acquire,
-                                           ArrayRef<Operation *> acquires) {
-  Operation *boundary = nullptr;
-  updateBoundary(cb, acquire, acquires, boundary);
-  return boundary;
-}
-
-/// Return the last op in `acquire`'s block that consumes the acquired
-/// slot. See `docs/development/DFBManagement.md` for the asymmetric
-/// classification of direct-DFB vs. tensor-SSA uses that this walk
-/// implements.
-static Operation *findLastOwnedUse(AcquireInterval interval) {
-  Operation *last = interval.acquire;
-  DenseSet<Operation *> visited;
-  SmallVector<Value, 8> worklist;
-
-  auto extend = [&](Operation *user, bool ignoreBoundary) {
-    Operation *projected = nullptr;
-    if (!projectToAcquireBlock(interval, user, projected, ignoreBoundary)) {
-      return false;
-    }
-    if (!visited.insert(user).second) {
-      return false;
-    }
-    updateLatestUse(projected, last);
-    for (Value result : user->getResults()) {
-      worklist.push_back(result);
-    }
-    return true;
-  };
-
-  auto drainWorklist = [&](bool ignoreBoundary) {
-    while (!worklist.empty()) {
-      Value value = worklist.pop_back_val();
-      for (OpOperand &use : value.getUses()) {
-        Operation *user = use.getOwner();
-        if (isa<CBPushOp, CBPopOp>(user)) {
-          continue;
-        }
-        extend(user, ignoreBoundary);
-      }
-    }
-  };
-
-  // Direct-DFB uses. The walk recurses through each user's SSA results
-  // because the *true* end of the use can be a downstream op (e.g.
-  // ttl.copy returns a transfer_handle whose ttl.wait marks the actual
-  // end of the transfer). The next-acquire boundary applies: two
-  // direct-DFB uses straddling that boundary belong to different
-  // intervals.
-  for (OpOperand &use : interval.cb.getUses()) {
-    Operation *user = use.getOwner();
-    if (user == interval.acquire) {
-      continue;
-    }
-    if (isLifecycleOrAttachOp(user)) {
-      continue;
-    }
-    if (!directDFBUseMatchesAcquire(interval, user)) {
-      continue;
-    }
-    extend(user, /*ignoreBoundary=*/false);
-  }
-  drainWorklist(/*ignoreBoundary=*/false);
-
-  // Tensor-SSA uses. The next-acquire boundary does NOT apply: a tile
-  // produced by `cb_wait t1` may legitimately be consumed after
-  // `cb_wait t2`, since the consumer reads through the SSA value, not
-  // the slot's identity. Applying the boundary here was the root cause
-  // of the issue #536 follow-up miscompile.
-  assert(interval.acquire->getNumResults() == 1 &&
-         "DFB acquire ops produce exactly one tensor result");
-  worklist.push_back(interval.acquire->getResult(0));
-  drainWorklist(/*ignoreBoundary=*/true);
-
-  return last;
-}
-
-static AcquireInterval makeAcquireInterval(Operation *acquire,
-                                           ArrayRef<Operation *> acquires) {
-  Value cb = getAcquireCB(acquire);
-  return {acquire, cb, getDFBSyncClass(acquire),
-          findNextSyncClassAcquire(cb, acquire, acquires)};
-}
-
 template <typename CreateReleaseFn>
 static void insertMissingReleases(ArrayRef<Operation *> acquires,
                                   ArrayRef<Operation *> releases,
@@ -290,20 +40,20 @@ static void insertMissingReleases(ArrayRef<Operation *> acquires,
                                   OpBuilder &builder,
                                   CreateReleaseFn createRelease) {
   for (Operation *acquire : acquires) {
-    AcquireInterval interval = makeAcquireInterval(acquire, acquires);
+    DFBAcquireInterval interval = makeDFBAcquireInterval(acquire, acquires);
     // Cheap check first: any release inside the strict next-acquire range?
-    ReleaseSearch releaseSearch =
-        findOwnedReleases(interval, /*lastOwnedUse=*/nullptr, releases, erased);
-    if (releaseSearch.hasSameLevelRelease) {
+    DFBReleaseSearch releaseSearch = findOwnedDFBReleases(
+        interval, /*lastOwnedUse=*/nullptr, releases, &erased);
+    if (releaseSearch.hasSameLevelRelease()) {
       continue;
     }
 
     // Compute the last owned use; it both bounds the idempotency recheck
     // and pinpoints the insertion point.
-    Operation *last = findLastOwnedUse(interval);
+    Operation *last = findLastDFBAcquireOwnedUse(interval);
     if (last != interval.acquire) {
-      releaseSearch = findOwnedReleases(interval, last, releases, erased);
-      if (releaseSearch.hasSameLevelRelease) {
+      releaseSearch = findOwnedDFBReleases(interval, last, releases, &erased);
+      if (releaseSearch.hasSameLevelRelease()) {
         continue;
       }
     }
@@ -314,7 +64,7 @@ static void insertMissingReleases(ArrayRef<Operation *> acquires,
     }
 
     builder.setInsertionPointAfter(last);
-    createRelease(builder, acquire->getLoc(), interval.cb);
+    createRelease(builder, acquire->getLoc(), interval.dfb);
   }
 }
 
@@ -328,23 +78,13 @@ struct TTLInsertCBSyncPass
     SmallVector<Operation *> pushes;
     SmallVector<Operation *> pops;
 
-    func.walk([&](Operation *op) {
-      if (isa<CBReserveOp>(op)) {
-        reserves.push_back(op);
-      } else if (isa<CBWaitOp>(op)) {
-        waits.push_back(op);
-      } else if (isa<CBPushOp>(op)) {
-        pushes.push_back(op);
-      } else if (isa<CBPopOp>(op)) {
-        pops.push_back(op);
-      }
-    });
+    collectDFBAcquireReleaseOps(func, reserves, waits, pushes, pops);
 
     OpBuilder builder(func.getContext());
 
     // Track erased ops so later iterations skip them before any accessor
-    // call. The set holds raw pointers to freed ops; `findOwnedReleases` must
-    // check `erased.contains(...)` before touching any op wrapper method.
+    // call. The set holds raw pointers to freed ops; release ownership search
+    // must check the set before touching any op wrapper method.
     DenseSet<Operation *> erased;
 
     insertMissingReleases(reserves, pushes, erased, builder,


### PR DESCRIPTION
### Problem description

`ttl-insert-cb-sync` computes ownership between DFB acquires and releases when it inserts missing `ttl.cb_push` and `ttl.cb_pop` operations. The computed-address PipeNet PR needs the same reserve->push and wait->pop ownership rules for pipe receiver-stream proofs, so keeping the logic embedded in `ttl-insert-cb-sync` would duplicate proof rules across passes.

### What's changed

This PR extracts the DFB acquire/release ownership logic without changing `ttl-insert-cb-sync` behavior:

- Adds `DFBAcquireReleaseAnalysis` for producer and consumer DFB ownership intervals.
- Moves acquire/release classification, owned-use discovery, and owned-release search into the shared analysis.
- Rewrites `ttl-insert-cb-sync` to call the shared analysis instead of carrying a private copy of the same interval logic.
- Registers the new analysis source in the TTL transform library.

### Tests

Existing coverage for the behavior-preserving refactor:

- MLIR lit `test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir`: verifies missing `ttl.cb_push` / `ttl.cb_pop` insertion after the last transitive DFB use; preservation of explicit releases; idempotence when the pass runs twice; same-DFB producer/consumer interleavings; nested `scf.for` / `scf.if`; data-movement copy/wait chains; deferred consecutive waits/reserves.
- Device pytest `test/python/test_auto_pop_push.py`: exercises auto push/pop placement through Python-generated kernels, including multiple data-movement uses of one acquired block and deferred producer/consumer lifetimes.
- Device pytest `test/python/test_cb_sync_intrathread_hang.py`: covers the nested intra-thread DFB pattern where an outer reserve must be pushed before a loop body waits on the same DFB.
- Device pytest `test/python/test_cb_sync_intrathread_explicit.py`: covers the same intra-thread structure with explicit push/pop operations, verifying that the sync pass recognizes user-authored releases.
- Device pytest `test/python/test_layernorm.py`: keeps larger-kernel regression coverage for DFB sync placement in fused compute patterns.

PipeNet proof, capacity analysis, computed-address selection, and PipeNet runtime/device tests remain in #700 because that PR adds the PipeNet consumers of this shared analysis.

### Ticket

None.

### Checklist

- [x] New/Existing tests provide coverage for changes
