### PR TITLE
Use correct unpack mode for fp32

### DIFF
--- a/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
@@ -77,7 +77,9 @@ static bool isDstInputTileComputeOp(Operation *op) {
   if (isFPUEligibleBinaryOp(op)) {
     return false;
   }
-  return op->hasTrait<TTLDSTInputsTrait>() ||
+
+  return op->hasTrait<TTLStrategyDependentBinaryOpTrait>() ||
+         op->hasTrait<TTLDSTInputsTrait>() ||
          isa<TileBcastOp, TileTransposeOp>(op);
 }
 

--- a/test/python/test_scalar_mul.py
+++ b/test/python/test_scalar_mul.py
@@ -664,6 +664,32 @@ def test_scalar_times_reduce_fp32_dest_acc(device, reduce_fn):
     assert_allclose(actual, expected, **_tolerances(torch.float32, scaler))
 
 
+def test_fp32_scalar_mul_add_uses_fp32_unpack_for_sfpu_rhs(device):
+    """`0.5 * a + b` keeps fp32 precision when `b` is copied through DST.
+
+    The scalar multiply produces an intermediate DST value, so the following add
+    lowers through the SFPU path and copies the RHS CB operand into DST. This
+    requires `ttl.unpack_to_dest_fp32` for the fp32 RHS CB.
+    """
+    kernel = make_scalar_non_reduce_kernel("0.5 * a_blk + b_blk", 2, 2)
+
+    tensor_shape = (2 * TILE, 2 * TILE)
+    input_a_torch = (torch.rand(tensor_shape, dtype=torch.float32) - 0.5) * 4.0
+    input_b_torch = (torch.rand(tensor_shape, dtype=torch.float32) - 0.5) * 4.0
+    input_c_torch = torch.zeros(tensor_shape, dtype=torch.float32)
+    out_torch = torch.zeros(tensor_shape, dtype=torch.float32)
+
+    input_a = to_l1(input_a_torch, device)
+    input_b = to_l1(input_b_torch, device)
+    input_c = to_l1(input_c_torch, device)
+    out = to_l1(out_torch, device)
+    kernel(input_a, input_b, input_c, out)
+
+    expected = input_a_torch.float() * 0.5 + input_b_torch.float()
+    actual = ttnn.to_torch(out).float()
+    assert_allclose(actual, expected, **_tolerances(torch.float32, 0.5))
+
+
 @pytest.mark.parametrize("dtype", DTYPES, ids=DTYPE_IDS)
 def test_bf16_rounded_scalar(device, dtype):
     """Scalar computed from a torch 0-dim bf16 tensor via `.item()`. The
@@ -794,11 +820,6 @@ def test_scalar_times_non_reduce_expression(
     device, dtype, expr_name, tile_shape, scaler, expr
 ):
     """Scalar multiply over non-reduce expressions and multi-tile blocks."""
-    if expr_name == "mul_add_lhs" and dtype == torch.float32:
-        pytest.xfail(
-            "fp32 scalar unary feeding SFPU add corrupts output. Tracked in #612."
-        )
-
     tile_rows, tile_cols = tile_shape
     kernel = make_scalar_non_reduce_kernel(expr, tile_rows, tile_cols)
 

--- a/test/python/test_tensor_recurrences.py
+++ b/test/python/test_tensor_recurrences.py
@@ -579,9 +579,7 @@ def _make_aug_outside_loop_kernel():
     @ttl.operation(grid=(1, 1))
     def kernel(a_seed, delta, out):
         a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
-        delta_fpu_cb = ttl.make_dataflow_buffer_like(
-            delta, shape=(1, 1), block_count=2
-        )
+        delta_fpu_cb = ttl.make_dataflow_buffer_like(delta, shape=(1, 1), block_count=2)
         delta_sfpu_cb = ttl.make_dataflow_buffer_like(
             delta, shape=(1, 1), block_count=2
         )
@@ -589,12 +587,15 @@ def _make_aug_outside_loop_kernel():
 
         @ttl.compute()
         def compute():
-            with a_cb.wait() as a, delta_fpu_cb.wait() as d_fpu:
+            with (
+                a_cb.wait() as a,
+                delta_fpu_cb.wait() as d_fpu,
+                delta_sfpu_cb.wait() as d_sfpu,
+            ):
                 acc = a + d_fpu
                 # `+=` outside any loop: the rewrite produces a plain
                 # `acc = acc + d` with no recurrence machinery involved.
-                with delta_sfpu_cb.wait() as d_sfpu:
-                    acc += d_sfpu
+                acc += d_sfpu
                 with out_cb.reserve() as o:
                     o.store(acc)
 

--- a/test/python/test_tensor_recurrences.py
+++ b/test/python/test_tensor_recurrences.py
@@ -579,16 +579,22 @@ def _make_aug_outside_loop_kernel():
     @ttl.operation(grid=(1, 1))
     def kernel(a_seed, delta, out):
         a_cb = ttl.make_dataflow_buffer_like(a_seed, shape=(1, 1), block_count=2)
-        delta_cb = ttl.make_dataflow_buffer_like(delta, shape=(1, 1), block_count=2)
+        delta_fpu_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=2
+        )
+        delta_sfpu_cb = ttl.make_dataflow_buffer_like(
+            delta, shape=(1, 1), block_count=2
+        )
         out_cb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
 
         @ttl.compute()
         def compute():
-            with a_cb.wait() as a, delta_cb.wait() as d:
-                acc = a + d
+            with a_cb.wait() as a, delta_fpu_cb.wait() as d_fpu:
+                acc = a + d_fpu
                 # `+=` outside any loop: the rewrite produces a plain
                 # `acc = acc + d` with no recurrence machinery involved.
-                acc += d
+                with delta_sfpu_cb.wait() as d_sfpu:
+                    acc += d_sfpu
                 with out_cb.reserve() as o:
                     o.store(acc)
 
@@ -596,7 +602,9 @@ def _make_aug_outside_loop_kernel():
         def reader():
             with a_cb.reserve() as blk:
                 ttl.copy(a_seed[0:1, 0:1], blk).wait()
-            with delta_cb.reserve() as blk:
+            with delta_fpu_cb.reserve() as blk:
+                ttl.copy(delta[0:1, 0:1], blk).wait()
+            with delta_sfpu_cb.reserve() as blk:
                 ttl.copy(delta[0:1, 0:1], blk).wait()
 
         @ttl.datamovement()

--- a/test/ttlang/Conversion/TTLToTTKernel/compute_fused_chain.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/compute_fused_chain.mlir
@@ -17,12 +17,12 @@
 // FPU binary add reads from CBs (no copy_tile for add operands).
 // mul is SFPU because lhs is intermediate result in DST, needs copy_tile for rhs.
 // FPU-LABEL: func.func @fused_chain_lowering
-// FPU-SAME: (%[[AARG:.*]]: tensor<2x2x!ttcore.tile<32x32, f32>>, %[[BARG:.*]]: tensor<2x2x!ttcore.tile<32x32, f32>>)
+// FPU-SAME: (%[[AARG:.*]]: tensor<2x2x!ttcore.tile<32x32, bf16>>, %[[BARG:.*]]: tensor<2x2x!ttcore.tile<32x32, bf16>>)
 // FPU-DAG:   %[[C4:.*]] = arith.constant 4 : i32
 // FPU-DAG:   %[[C2:.*]] = arith.constant 2 : index
 // FPU-DAG:   %[[C1:.*]] = arith.constant 1 : index
 // FPU-DAG:   %[[C0:.*]] = arith.constant 0 : index
-// FPU:       %[[OUTPUT:.*]] = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+// FPU:       %[[OUTPUT:.*]] = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 // FPU:       %[[CB0:.*]] = ttkernel.get_compile_time_arg_val(0)
 // FPU:       %[[CB1:.*]] = ttkernel.get_compile_time_arg_val(1)
 // FPU:       %[[CB2:.*]] = ttkernel.get_compile_time_arg_val(2)
@@ -59,12 +59,12 @@
 // =============================================================================
 // All binary ops use copy_tile + SFPU binary.
 // SFPU-LABEL: func.func @fused_chain_lowering
-// SFPU-SAME: (%[[AARG:.*]]: tensor<2x2x!ttcore.tile<32x32, f32>>, %[[BARG:.*]]: tensor<2x2x!ttcore.tile<32x32, f32>>)
+// SFPU-SAME: (%[[AARG:.*]]: tensor<2x2x!ttcore.tile<32x32, bf16>>, %[[BARG:.*]]: tensor<2x2x!ttcore.tile<32x32, bf16>>)
 // SFPU-DAG:   %[[C4:.*]] = arith.constant 4 : i32
 // SFPU-DAG:   %[[C2:.*]] = arith.constant 2 : index
 // SFPU-DAG:   %[[C1:.*]] = arith.constant 1 : index
 // SFPU-DAG:   %[[C0:.*]] = arith.constant 0 : index
-// SFPU:       %[[OUTPUT:.*]] = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+// SFPU:       %[[OUTPUT:.*]] = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 // SFPU:       %[[CB0:.*]] = ttkernel.get_compile_time_arg_val(0)
 // SFPU:       %[[CB1:.*]] = ttkernel.get_compile_time_arg_val(1)
 // SFPU:       %[[CB2:.*]] = ttkernel.get_compile_time_arg_val(2)
@@ -101,42 +101,42 @@
 // SFPU-NOT:   ttl.copy_tile
 // SFPU-NOT:   ttkernel.add_tiles
 
-func.func @fused_chain_lowering(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                                %b: tensor<2x2x!ttcore.tile<32x32, f32>>)
-    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
-  %output = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @fused_chain_lowering(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                                %b: tensor<2x2x!ttcore.tile<32x32, bf16>>)
+    -> tensor<2x2x!ttcore.tile<32x32, bf16>> {
+  %output = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
 
   // Wait for input CBs (entire blocks) before compute.
-  %a_ready = ttl.cb_wait %cb0 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %b_ready = ttl.cb_wait %cb1 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %output_cb = ttl.attach_cb %output, %cb2 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_ready = ttl.cb_wait %cb0 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %b_ready = ttl.cb_wait %cb1 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %output_cb = ttl.attach_cb %output, %cb2 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %result_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %result_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
   %result = ttl.compute
-      ins(%a_ready, %b_ready : tensor<2x2x!ttcore.tile<32x32, f32>>,
-                               tensor<2x2x!ttcore.tile<32x32, f32>>)
-      outs(%output_cb : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      ins(%a_ready, %b_ready : tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                               tensor<2x2x!ttcore.tile<32x32, bf16>>)
+      outs(%output_cb : tensor<2x2x!ttcore.tile<32x32, bf16>>)
       {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                         affine_map<(d0, d1) -> (d0, d1)>,
                         affine_map<(d0, d1) -> (d0, d1)>],
        iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-       %b_tile: !ttcore.tile<32x32, f32>,
-       %out_tile: !ttcore.tile<32x32, f32>):
+  ^bb0(%a_tile: !ttcore.tile<32x32, bf16>,
+       %b_tile: !ttcore.tile<32x32, bf16>,
+       %out_tile: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
     %c0 = arith.constant 0 : index
-    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %mul = ttl.tile_mul %sum, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %exp = ttl.tile_exp %mul into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %exp, %result_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<2x2x!ttcore.tile<32x32, f32>>
-    ttl.cb_push %cb2 : <[2, 2], !ttcore.tile<32x32, f32>, 1>
+    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %mul = ttl.tile_mul %sum, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %exp = ttl.tile_exp %mul into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %exp, %result_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<2x2x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb2 : <[2, 2], !ttcore.tile<32x32, bf16>, 1>
     ttl.yield
-  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  } -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  func.return %result : tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %result : tensor<2x2x!ttcore.tile<32x32, bf16>>
 }

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_multi_use_patterns.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_multi_use_patterns.mlir
@@ -24,72 +24,72 @@
 
 // CHECK-LABEL: func.func @diamond_intermediate_reuse
 // CHECK:           %[[RES:.*]] = ttl.compute
-// CHECK-NEXT:      ^bb0(%[[A:.*]]: !ttcore.tile<32x32, f32>, %[[B:.*]]: !ttcore.tile<32x32, f32>, %[[C:.*]]: !ttcore.tile<32x32, f32>, %[[D:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK-NEXT:      ^bb0(%[[A:.*]]: !ttcore.tile<32x32, bf16>, %[[B:.*]]: !ttcore.tile<32x32, bf16>, %[[C:.*]]: !ttcore.tile<32x32, bf16>, %[[D:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary add: both operands are block args, no copy_tile needed
-// CHECK:           %[[SUM:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[SUM:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // Copy C before sub (SFPU operand needs copy_tile)
 // CHECK:           %{{.*}}, %[[TC:.*]] = ttl.copy_tile %[[C]][%[[I0]], %[[I1]]] into dst[%c1]
 // CHECK-NEXT:      %[[DIFF:.*]] = ttl.tile_sub %[[SUM]], %[[TC]] into dst[%c1]
 // Copy D before mul (SFPU operand needs copy_tile)
 // CHECK:           %{{.*}}, %[[TD:.*]] = ttl.copy_tile %[[D]][%[[I0]], %[[I1]]] into dst[%c2]
 // CHECK-NEXT:      %[[PROD:.*]] = ttl.tile_mul %[[SUM]], %[[TD]] into dst[%c0]
-// CHECK-NEXT:      %[[COMBO:.*]] = ttl.tile_add %[[DIFF]], %[[PROD]] into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK-NEXT:      %[[COMBO:.*]] = ttl.tile_add %[[DIFF]], %[[PROD]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // SEPARATE:        ttl.tile_add {{.*}} into dst[%c3]
 // CHECK:           ttl.tile_store %[[COMBO]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @diamond_intermediate_reuse(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                                      %b: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                                      %c: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                                      %d: tensor<2x2x!ttcore.tile<32x32, f32>>)
-    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @diamond_intermediate_reuse(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                                      %b: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                                      %c: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                                      %d: tensor<2x2x!ttcore.tile<32x32, bf16>>)
+    -> tensor<2x2x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb4 = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb4 = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
 
-  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %b_cb = ttl.attach_cb %b, %cb1 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %c_cb = ttl.attach_cb %c, %cb2 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %d_cb = ttl.attach_cb %d, %cb3 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %init_cb = ttl.attach_cb %init, %cb4 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %b_cb = ttl.attach_cb %b, %cb1 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %c_cb = ttl.attach_cb %c, %cb2 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %d_cb = ttl.attach_cb %d, %cb3 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %init_cb = ttl.attach_cb %init, %cb4 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %out_view = ttl.cb_reserve %cb4 : <[2, 2], !ttcore.tile<32x32, f32>, 2> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %out_view = ttl.cb_reserve %cb4 : <[2, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
   %result = ttl.compute
       ins(%a_cb, %b_cb, %c_cb, %d_cb :
-          tensor<2x2x!ttcore.tile<32x32, f32>>,
-          tensor<2x2x!ttcore.tile<32x32, f32>>,
-          tensor<2x2x!ttcore.tile<32x32, f32>>,
-          tensor<2x2x!ttcore.tile<32x32, f32>>)
-      outs(%init_cb : tensor<2x2x!ttcore.tile<32x32, f32>>)
+          tensor<2x2x!ttcore.tile<32x32, bf16>>,
+          tensor<2x2x!ttcore.tile<32x32, bf16>>,
+          tensor<2x2x!ttcore.tile<32x32, bf16>>,
+          tensor<2x2x!ttcore.tile<32x32, bf16>>)
+      outs(%init_cb : tensor<2x2x!ttcore.tile<32x32, bf16>>)
       {indexing_maps = [#map, #map, #map, #map, #map],
        iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-       %b_tile: !ttcore.tile<32x32, f32>,
-       %c_tile: !ttcore.tile<32x32, f32>,
-       %d_tile: !ttcore.tile<32x32, f32>,
-       %out_tile: !ttcore.tile<32x32, f32>):
+  ^bb0(%a_tile: !ttcore.tile<32x32, bf16>,
+       %b_tile: !ttcore.tile<32x32, bf16>,
+       %c_tile: !ttcore.tile<32x32, bf16>,
+       %d_tile: !ttcore.tile<32x32, bf16>,
+       %out_tile: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
 
     %c0 = arith.constant 0 : index
-    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %diff = ttl.tile_sub %sum, %c_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %prod = ttl.tile_mul %sum, %d_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %combo = ttl.tile_add %diff, %prod into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %combo, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<2x2x!ttcore.tile<32x32, f32>>
+    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %diff = ttl.tile_sub %sum, %c_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %prod = ttl.tile_mul %sum, %d_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %combo = ttl.tile_add %diff, %prod into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %combo, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<2x2x!ttcore.tile<32x32, bf16>>
 
     ttl.yield
-  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  } -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  func.return %result : tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %result : tensor<2x2x!ttcore.tile<32x32, bf16>>
 }
 
 // -----
@@ -101,11 +101,11 @@ func.func @diamond_intermediate_reuse(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 
 // CHECK-LABEL: func.func @intermediate_result_fan_out
 // CHECK:           ttl.compute
-// CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: !ttcore.tile<32x32, f32>, %[[ARG1:.*]]: !ttcore.tile<32x32, f32>, %[[ARG2:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: !ttcore.tile<32x32, bf16>, %[[ARG1:.*]]: !ttcore.tile<32x32, bf16>, %[[ARG2:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary add: both operands are block args, no copy_tile needed
-// CHECK:           %[[INTERMEDIATE:.*]] = ttl.tile_add %[[ARG0]], %[[ARG1]] into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[INTERMEDIATE:.*]] = ttl.tile_add %[[ARG0]], %[[ARG1]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // copy_dst preserves intermediate for mul (fan-out use)
 // CHECK-NEXT:      %[[COPY_DST1:.*]] = ttl.copy_dst %[[INTERMEDIATE]] into dst[%c1]
 // Copy ARG2 before mul (SFPU operand needs copy_tile)
@@ -120,44 +120,44 @@ func.func @diamond_intermediate_reuse(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK:           ttl.tile_store %[[FINAL]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 
-func.func @intermediate_result_fan_out(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>, %i1: tensor<1x1x!ttcore.tile<32x32, f32>>, %i2: tensor<1x1x!ttcore.tile<32x32, f32>>)
-    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+func.func @intermediate_result_fan_out(%i0: tensor<1x1x!ttcore.tile<32x32, bf16>>, %i1: tensor<1x1x!ttcore.tile<32x32, bf16>>, %i2: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
-  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t1 = ttl.attach_cb %i1, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t2 = ttl.attach_cb %i2, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t1 = ttl.attach_cb %i1, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t2 = ttl.attach_cb %i2, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  %out_view_0 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %out_view_0 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %res = ttl.compute
-    ins(%t0, %t1, %t2 : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>)
-    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, f32>>)
+    ins(%t0, %t1, %t2 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, bf16>>)
     {indexing_maps = [#map1, #map1, #map1, #map1],
      iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>,
-       %arg2: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+  ^bb0(%arg0: !ttcore.tile<32x32, bf16>, %arg1: !ttcore.tile<32x32, bf16>,
+       %arg2: !ttcore.tile<32x32, bf16>, %out: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
 
     // Compute an intermediate result
     %c0 = arith.constant 0 : index
-    %intermediate = ttl.tile_add %arg0, %arg1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    %intermediate = ttl.tile_add %arg0, %arg1 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 
     // Fan out: intermediate result is consumed by three different ops
     // (two binary, one unary)
-    %use1 = ttl.tile_mul %intermediate, %arg2 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %use2 = ttl.tile_exp %intermediate into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %use3 = ttl.tile_add %intermediate, %use1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %final = ttl.tile_add %use3, %use2 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %final, %out_view_0[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+    %use1 = ttl.tile_mul %intermediate, %arg2 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %use2 = ttl.tile_exp %intermediate into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %use3 = ttl.tile_add %intermediate, %use1 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %final = ttl.tile_add %use3, %use2 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %final, %out_view_0[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<1x1x!ttcore.tile<32x32, bf16>>
 
     ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  func.return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %res : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
 
 // -----
@@ -174,7 +174,7 @@ func.func @intermediate_result_fan_out(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>
 
 // CHECK-LABEL: func.func @multi_consumer_all_binary
 // CHECK:           ttl.compute
-// CHECK-NEXT:      ^bb0(%[[A:.*]]: !ttcore.tile<32x32, f32>, %[[B:.*]]: !ttcore.tile<32x32, f32>, %[[C:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK-NEXT:      ^bb0(%[[A:.*]]: !ttcore.tile<32x32, bf16>, %[[B:.*]]: !ttcore.tile<32x32, bf16>, %[[C:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary mul
@@ -189,46 +189,46 @@ func.func @intermediate_result_fan_out(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>
 // CHECK:           ttl.tile_store %[[FINAL]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 
-func.func @multi_consumer_all_binary(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                                     %b: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                                     %c: tensor<2x2x!ttcore.tile<32x32, f32>>)
-    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @multi_consumer_all_binary(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                                     %b: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                                     %c: tensor<2x2x!ttcore.tile<32x32, bf16>>)
+    -> tensor<2x2x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb3 = ttl.bind_cb {cb_index = 16, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb3 = ttl.bind_cb {cb_index = 16, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
 
-  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %b_cb = ttl.attach_cb %b, %cb1 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %c_cb = ttl.attach_cb %c, %cb2 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %init_cb = ttl.attach_cb %init, %cb3 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %b_cb = ttl.attach_cb %b, %cb1 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %c_cb = ttl.attach_cb %c, %cb2 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %init_cb = ttl.attach_cb %init, %cb3 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %out_view = ttl.cb_reserve %cb3 : <[2, 2], !ttcore.tile<32x32, f32>, 2> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %out_view = ttl.cb_reserve %cb3 : <[2, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
   %result = ttl.compute
       ins(%a_cb, %b_cb, %c_cb :
-          tensor<2x2x!ttcore.tile<32x32, f32>>,
-          tensor<2x2x!ttcore.tile<32x32, f32>>,
-          tensor<2x2x!ttcore.tile<32x32, f32>>)
-      outs(%init_cb : tensor<2x2x!ttcore.tile<32x32, f32>>)
+          tensor<2x2x!ttcore.tile<32x32, bf16>>,
+          tensor<2x2x!ttcore.tile<32x32, bf16>>,
+          tensor<2x2x!ttcore.tile<32x32, bf16>>)
+      outs(%init_cb : tensor<2x2x!ttcore.tile<32x32, bf16>>)
       {indexing_maps = [#map2, #map2, #map2, #map2],
        iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-       %b_tile: !ttcore.tile<32x32, f32>,
-       %c_tile: !ttcore.tile<32x32, f32>,
-       %out_tile: !ttcore.tile<32x32, f32>):
+  ^bb0(%a_tile: !ttcore.tile<32x32, bf16>,
+       %b_tile: !ttcore.tile<32x32, bf16>,
+       %c_tile: !ttcore.tile<32x32, bf16>,
+       %out_tile: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
     %c0 = arith.constant 0 : index
-    %mul = ttl.tile_mul %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    %mul = ttl.tile_mul %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
     // Both consumers are binary - no copy_dst needed
-    %add = ttl.tile_add %mul, %c_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %sub = ttl.tile_sub %mul, %c_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %final = ttl.tile_add %add, %sub into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %final, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<2x2x!ttcore.tile<32x32, f32>>
+    %add = ttl.tile_add %mul, %c_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %sub = ttl.tile_sub %mul, %c_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %final = ttl.tile_add %add, %sub into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %final, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<2x2x!ttcore.tile<32x32, bf16>>
     ttl.yield
-  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  } -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  func.return %result : tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %result : tensor<2x2x!ttcore.tile<32x32, bf16>>
 }

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_register_reuse.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_register_reuse.mlir
@@ -11,29 +11,29 @@
 // args). No copy_tile needed since FPU reads from CB, not DST.
 // DEBUG: Max DST usage: 1 / 4 registers
 // CHECK-LABEL: func.func @simple_add
-func.func @simple_add(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                      %b: tensor<2x2x!ttcore.tile<32x32, f32>>)
-    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @simple_add(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                      %b: tensor<2x2x!ttcore.tile<32x32, bf16>>)
+    -> tensor<2x2x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 
   // Bind circular buffers.
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 16, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 16, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>
 
   // Attach CBs to tensors.
-  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %b_cb = ttl.attach_cb %b, %cb1 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %init_cb = ttl.attach_cb %init, %cb2 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %b_cb = ttl.attach_cb %b, %cb1 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %init_cb = ttl.attach_cb %init, %cb2 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
   // FPU binary: both operands are block args, no copies needed.
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK:           ttl.compute
-// CHECK-NEXT:      ^bb0(%[[A:.*]]: !ttcore.tile<32x32, f32>, %[[B:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK-NEXT:      ^bb0(%[[A:.*]]: !ttcore.tile<32x32, bf16>, %[[B:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // CHECK-NOT:       ttl.copy_tile
-// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // CHECK:           ttl.tile_store %[[ADD]], %{{.*}}[%[[I0]], %[[I1]]] from dst[%[[C0]]]
 // CHECK-NEXT:      ttl.yield
 // SEPARATE-DAG:    %[[SC0:.*]] = arith.constant 0 : index
@@ -41,25 +41,25 @@ func.func @simple_add(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // SEPARATE:        ttl.tile_store %[[SADD]], {{.*}} from dst[%[[SC0]]]
 // SEPARATE-NEXT:   ttl.yield
 
-  %out_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, f32>, 2> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %out_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
   %result = ttl.compute
-      ins(%a_cb, %b_cb : tensor<2x2x!ttcore.tile<32x32, f32>>,
-                         tensor<2x2x!ttcore.tile<32x32, f32>>)
-      outs(%init_cb : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      ins(%a_cb, %b_cb : tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                         tensor<2x2x!ttcore.tile<32x32, bf16>>)
+      outs(%init_cb : tensor<2x2x!ttcore.tile<32x32, bf16>>)
       {indexing_maps = [#map, #map, #map],
        iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-       %b_tile: !ttcore.tile<32x32, f32>,
-       %out_tile: !ttcore.tile<32x32, f32>):
+  ^bb0(%a_tile: !ttcore.tile<32x32, bf16>,
+       %b_tile: !ttcore.tile<32x32, bf16>,
+       %out_tile: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
     %c0 = arith.constant 0 : index
-    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %sum, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<2x2x!ttcore.tile<32x32, f32>>
+    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %sum, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<2x2x!ttcore.tile<32x32, bf16>>
     ttl.yield
-  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  } -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  func.return %result : tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %result : tensor<2x2x!ttcore.tile<32x32, bf16>>
 }
 
 // -----
@@ -74,7 +74,7 @@ func.func @simple_add(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK:           ttl.compute
-// CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: !ttcore.tile<32x32, f32>, %[[ARG1:.*]]: !ttcore.tile<32x32, f32>, %[[ARG2:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: !ttcore.tile<32x32, bf16>, %[[ARG1:.*]]: !ttcore.tile<32x32, bf16>, %[[ARG2:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // First add is FPU binary (no copies for ARG0/ARG1). ARG2 copied for SFPU adds.
@@ -97,44 +97,44 @@ func.func @simple_add(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // SEPARATE:        ttl.tile_store
 // SEPARATE-NEXT:   ttl.yield
 
-func.func @chain_reuse(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>, %i1: tensor<1x1x!ttcore.tile<32x32, f32>>,
-                       %i2: tensor<1x1x!ttcore.tile<32x32, f32>>)
-    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+func.func @chain_reuse(%i0: tensor<1x1x!ttcore.tile<32x32, bf16>>, %i1: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                       %i2: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
 
   // Bind CBs
-  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
-  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t1 = ttl.attach_cb %i1, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t2 = ttl.attach_cb %i2, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t1 = ttl.attach_cb %i1, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t2 = ttl.attach_cb %i2, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  %out_view_0 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %out_view_0 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %res = ttl.compute
     ins(%t0, %t1, %t2 :
-        tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>)
-    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, f32>>)
+        tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, bf16>>)
     {indexing_maps = [#map, #map, #map, #map],
      iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>,
-       %arg2: !ttcore.tile<32x32, f32>,
-       %out: !ttcore.tile<32x32, f32>):
+  ^bb0(%arg0: !ttcore.tile<32x32, bf16>, %arg1: !ttcore.tile<32x32, bf16>,
+       %arg2: !ttcore.tile<32x32, bf16>,
+       %out: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
 
     %c0 = arith.constant 0 : index
-    %x0 = ttl.tile_add %arg0, %arg1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %x1 = ttl.tile_add %x0, %arg2 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %x2 = ttl.tile_add %x1, %arg2 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %x3 = ttl.tile_add %x2, %arg2 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %x4 = ttl.tile_add %x3, %arg2 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %x4, %out_view_0[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+    %x0 = ttl.tile_add %arg0, %arg1 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %x1 = ttl.tile_add %x0, %arg2 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %x2 = ttl.tile_add %x1, %arg2 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %x3 = ttl.tile_add %x2, %arg2 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %x4 = ttl.tile_add %x3, %arg2 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %x4, %out_view_0[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<1x1x!ttcore.tile<32x32, bf16>>
 
     ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  func.return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %res : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
 
 // -----
@@ -149,7 +149,7 @@ func.func @chain_reuse(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>, %i1: tensor<1x
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK:           ttl.compute
-// CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: !ttcore.tile<32x32, f32>, %[[ARG1:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: !ttcore.tile<32x32, bf16>, %[[ARG1:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // First add is FPU binary (no copies for ARG0/ARG1).
@@ -171,39 +171,39 @@ func.func @chain_reuse(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>, %i1: tensor<1x
 // SEPARATE:        ttl.tile_store
 // SEPARATE-NEXT:   ttl.yield
 
-func.func @block_arg_multi_use(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>, %i1: tensor<1x1x!ttcore.tile<32x32, f32>>)
-    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+func.func @block_arg_multi_use(%i0: tensor<1x1x!ttcore.tile<32x32, bf16>>, %i1: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
-  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t1 = ttl.attach_cb %i1, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t1 = ttl.attach_cb %i1, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  %out_view_1 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %out_view_1 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %res = ttl.compute
-    ins(%t0, %t1 : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>)
-    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, f32>>)
+    ins(%t0, %t1 : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, bf16>>)
     {indexing_maps = [#map, #map, #map],
      iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>,
-       %out: !ttcore.tile<32x32, f32>):
+  ^bb0(%arg0: !ttcore.tile<32x32, bf16>, %arg1: !ttcore.tile<32x32, bf16>,
+       %out: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
 
     // arg0 is used 3 times: first add is FPU (both block args),
     // subsequent adds use arg0 with DST results
     %c0 = arith.constant 0 : index
-    %x0 = ttl.tile_add %arg0, %arg1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %x1 = ttl.tile_add %arg0, %x0 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %x2 = ttl.tile_add %arg0, %x1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %x2, %out_view_1[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+    %x0 = ttl.tile_add %arg0, %arg1 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %x1 = ttl.tile_add %arg0, %x0 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %x2 = ttl.tile_add %arg0, %x1 into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %x2, %out_view_1[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<1x1x!ttcore.tile<32x32, bf16>>
 
     ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  func.return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %res : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
 
 // -----
@@ -219,7 +219,7 @@ func.func @block_arg_multi_use(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>, %i1: t
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK:           ttl.compute
-// CHECK-NEXT:      ^bb0(%[[X:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK-NEXT:      ^bb0(%[[X:.*]]: !ttcore.tile<32x32, bf16>, %[[OUT:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // CHECK:           %{{.*}}, %[[XCOPY_SIG:.*]] = ttl.copy_tile %[[X]][%[[I0]], %[[I1]]] into dst[%[[C0]]]
@@ -240,31 +240,31 @@ func.func @block_arg_multi_use(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>, %i1: t
 // SEPARATE:        ttl.tile_store
 // SEPARATE-NEXT:   ttl.yield
 
-func.func @silu_pattern(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>) -> tensor<1x1x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+func.func @silu_pattern(%i0: tensor<1x1x!ttcore.tile<32x32, bf16>>) -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
-  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %t0 = ttl.attach_cb %i0, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %t_init = ttl.attach_cb %init, %cb : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  %out_view_2 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %out_view_2 = ttl.cb_reserve %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %res = ttl.compute
-    ins(%t0 : tensor<1x1x!ttcore.tile<32x32, f32>>)
-    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, f32>>)
+    ins(%t0 : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    outs(%t_init : tensor<1x1x!ttcore.tile<32x32, bf16>>)
     {indexing_maps = [#map, #map],
      iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%x: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+  ^bb0(%x: !ttcore.tile<32x32, bf16>, %out: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
     // x is used by both sigmoid AND mul -> multi-consumer with unary
     // Phase 1 should insert copy_tile so sigmoid doesn't clobber x
     %c0 = arith.constant 0 : index
-    %sig = ttl.tile_sigmoid %x into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %prod = ttl.tile_mul %x, %sig into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %prod, %out_view_2[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+    %sig = ttl.tile_sigmoid %x into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %prod = ttl.tile_mul %x, %sig into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %prod, %out_view_2[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<1x1x!ttcore.tile<32x32, bf16>>
     ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
 
-  func.return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %res : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_seven_op_chain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_seven_op_chain.mlir
@@ -22,7 +22,7 @@
 // CHECK:           %[[CB1:.*]] = ttl.bind_cb{cb_index = 1, block_count = 1}
 // CHECK:           %[[CB2:.*]] = ttl.bind_cb{cb_index = 2, block_count = 1}
 // CHECK:           %[[RES:.*]] = ttl.compute
-// CHECK:           ^bb0(%[[A:.*]]: !ttcore.tile<32x32, f32>, %[[B:.*]]: !ttcore.tile<32x32, f32>, %[[O:.*]]: !ttcore.tile<32x32, f32>):
+// CHECK:           ^bb0(%[[A:.*]]: !ttcore.tile<32x32, bf16>, %[[B:.*]]: !ttcore.tile<32x32, bf16>, %[[O:.*]]: !ttcore.tile<32x32, bf16>):
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary add: both operands are block args, no copy_tile needed
@@ -63,45 +63,45 @@
 //
 // CHECK:             ttl.tile_store %[[SQRT]], %{{.*}}[%[[I0]], %[[I1]]] from dst[%[[C0]]]
 // CHECK-NEXT:        ttl.yield
-// CHECK-NEXT:      } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+// CHECK-NEXT:      } -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 // CHECK-NEXT:      return %[[RES]]
-func.func @seven_op_chain(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                          %b: tensor<2x2x!ttcore.tile<32x32, f32>>)
-    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
-  %output = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @seven_op_chain(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                          %b: tensor<2x2x!ttcore.tile<32x32, bf16>>)
+    -> tensor<2x2x!ttcore.tile<32x32, bf16>> {
+  %output = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
 
-  %a_ready = ttl.cb_wait %cb0 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %b_ready = ttl.cb_wait %cb1 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %output_cb = ttl.attach_cb %output, %cb2 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_ready = ttl.cb_wait %cb0 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %b_ready = ttl.cb_wait %cb1 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %output_cb = ttl.attach_cb %output, %cb2 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %result_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %result_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
   %result = ttl.compute
-      ins(%a_ready, %b_ready : tensor<2x2x!ttcore.tile<32x32, f32>>,
-                               tensor<2x2x!ttcore.tile<32x32, f32>>)
-      outs(%output_cb : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      ins(%a_ready, %b_ready : tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                               tensor<2x2x!ttcore.tile<32x32, bf16>>)
+      outs(%output_cb : tensor<2x2x!ttcore.tile<32x32, bf16>>)
       {indexing_maps = [#map, #map, #map],
        iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-       %b_tile: !ttcore.tile<32x32, f32>,
-       %out_tile: !ttcore.tile<32x32, f32>):
+  ^bb0(%a_tile: !ttcore.tile<32x32, bf16>,
+       %b_tile: !ttcore.tile<32x32, bf16>,
+       %out_tile: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
     // Seven-operation fused chain - each must appear in output with dst_idx
     %c0 = arith.constant 0 : index
-    %add = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %sub = ttl.tile_sub %add, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %mul = ttl.tile_mul %sub, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %exp = ttl.tile_exp %mul into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %log = ttl.tile_log %exp into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %neg = ttl.tile_neg %log into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %sqrt = ttl.tile_sqrt %neg into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %sqrt, %result_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<2x2x!ttcore.tile<32x32, f32>>
+    %add = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %sub = ttl.tile_sub %add, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %mul = ttl.tile_mul %sub, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %exp = ttl.tile_exp %mul into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %log = ttl.tile_log %exp into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %neg = ttl.tile_neg %log into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %sqrt = ttl.tile_sqrt %neg into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %sqrt, %result_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<2x2x!ttcore.tile<32x32, bf16>>
     ttl.yield
-  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  } -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  func.return %result : tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %result : tensor<2x2x!ttcore.tile<32x32, bf16>>
 }

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_conflict_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_conflict_invalid.mlir
@@ -175,3 +175,63 @@ func.func @f32_cb1_used_by_bcast_and_sfpu(
   } -> tensor<1x1x!ttcore.tile<32x32, f32>>
   return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
 }
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// Purpose: Non-FPU-eligible strategy-dependent binary ops lower through the
+// SFPU DST path and therefore require UnpackToDestFp32 for f32 CB inputs. This
+// conflicts when the same CB also feeds an FPU-eligible binary op.
+func.func @f32_cb1_used_by_fpu_and_strategy_dependent_sfpu_binary(
+    %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.enable_fpu_binary_ops = true} {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+
+  %a_cb = ttl.attach_cb %a, %cb0
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %b_cb_fpu = ttl.attach_cb %b, %cb1
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %b_cb_sfpu = ttl.attach_cb %b, %cb1
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %init_cb = ttl.attach_cb %init, %cb2
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+
+  %out_view = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %res = ttl.compute
+      ins(%a_cb, %b_cb_fpu, %b_cb_sfpu : tensor<1x1x!ttcore.tile<32x32, f32>>,
+                                            tensor<1x1x!ttcore.tile<32x32, f32>>,
+                                            tensor<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%init_cb : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [#map, #map, #map, #map],
+       iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
+         %b_tile_fpu: !ttcore.tile<32x32, f32>,
+         %b_tile_sfpu: !ttcore.tile<32x32, f32>,
+         %out_tile: !ttcore.tile<32x32, f32>):
+      %i = ttl.iter_index 0 : index
+      %j = ttl.iter_index 1 : index
+      // FPU path: both operands are block args with the same indexing map.
+      // expected-error @below {{f32 input from CB 1 is consumed by both FPU and SFPU strategies in the same kernel}}
+      %sum = ttl.tile_add %a_tile, %b_tile_fpu into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+      // SFPU path: lhs is an intermediate DST value, so this strategy-dependent
+      // binary op is not FPU-eligible and must copy %b_tile_sfpu through DST.
+      %mul = ttl.tile_mul %sum, %b_tile_sfpu into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+      ttl.tile_store %mul, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+      ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+
+  return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
+}

--- a/test/ttlang/Translate/TTLToCpp/compute_fused_chain_to_cpp.mlir
+++ b/test/ttlang/Translate/TTLToCpp/compute_fused_chain_to_cpp.mlir
@@ -107,41 +107,41 @@
 // SFPU-NOT:   binary_op_init_common
 // SFPU-NOT:   add_tiles
 
-func.func @fused_chain_lowering(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
-                                %b: tensor<2x2x!ttcore.tile<32x32, f32>>)
-    -> tensor<2x2x!ttcore.tile<32x32, f32>>
+func.func @fused_chain_lowering(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                                %b: tensor<2x2x!ttcore.tile<32x32, bf16>>)
+    -> tensor<2x2x!ttcore.tile<32x32, bf16>>
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %output = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+  %output = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>
 
   // Wait for input CBs (entire blocks) before compute.
-  %a_ready = ttl.cb_wait %cb0 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %b_ready = ttl.cb_wait %cb1 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  %output_cb = ttl.attach_cb %output, %cb2 : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 1>) -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_ready = ttl.cb_wait %cb0 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %b_ready = ttl.cb_wait %cb1 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
+  %output_cb = ttl.attach_cb %output, %cb2 : (tensor<2x2x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 2], !ttcore.tile<32x32, bf16>, 1>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  %result_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, f32>, 1> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %result_view = ttl.cb_reserve %cb2 : <[2, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
   %result = ttl.compute
-      ins(%a_ready, %b_ready : tensor<2x2x!ttcore.tile<32x32, f32>>,
-                               tensor<2x2x!ttcore.tile<32x32, f32>>)
-      outs(%output_cb : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      ins(%a_ready, %b_ready : tensor<2x2x!ttcore.tile<32x32, bf16>>,
+                               tensor<2x2x!ttcore.tile<32x32, bf16>>)
+      outs(%output_cb : tensor<2x2x!ttcore.tile<32x32, bf16>>)
       {indexing_maps = [#map, #map, #map],
        iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-       %b_tile: !ttcore.tile<32x32, f32>,
-       %out_tile: !ttcore.tile<32x32, f32>):
+  ^bb0(%a_tile: !ttcore.tile<32x32, bf16>,
+       %b_tile: !ttcore.tile<32x32, bf16>,
+       %out_tile: !ttcore.tile<32x32, bf16>):
     %i = ttl.iter_index 0 : index
     %j = ttl.iter_index 1 : index
     %c0 = arith.constant 0 : index
-    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %mul = ttl.tile_mul %sum, %b_tile into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    %exp = ttl.tile_exp %mul into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    ttl.tile_store %exp, %result_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<2x2x!ttcore.tile<32x32, f32>>
-    ttl.cb_push %cb2 : <[2, 2], !ttcore.tile<32x32, f32>, 1>
+    %sum = ttl.tile_add %a_tile, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %mul = ttl.tile_mul %sum, %b_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %exp = ttl.tile_exp %mul into dst[%c0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %exp, %result_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<2x2x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb2 : <[2, 2], !ttcore.tile<32x32, bf16>, 1>
     ttl.yield
-  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  } -> tensor<2x2x!ttcore.tile<32x32, bf16>>
 
-  func.return %result : tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %result : tensor<2x2x!ttcore.tile<32x32, bf16>>
 }


### PR DESCRIPTION
### Problem description
The `TTLSetComputeKernelConfig` pass in `TTLSetComputeKernelConfig.cpp` misclassifies non-FPU-eligible strategy-dependent binary ops (like `ttl.tile_add` when LHS is not a block arg). These ops lower to `add_binary_tile` (DST-based SFPU path), but since they lack `TTLDSTInputsTrait`, their f32 CB operands don't get added to sfpuCBs, so CB1 isn't marked for UnpackToDestFp32. When copy_tile_init(CB1) runs in Default mode, FP32 data is read as BF16, causing the massive errors.

### What's changed
Strategy-dependent binary ops that are NOT FPU-eligible will lower to `add_binary_tile` (DST-path), so their f32 CB inputs need UnpackToDestFp32.

### Ticket
https://github.com/tenstorrent/tt-lang/issues/612

### Checklist
- [X] New/Existing tests provide coverage for changes
