### PR TITLE
docs: add html_theme_options, CDN CSS, search context to conf.py

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx-rtd-theme
 myst-parser
 sphinx
 sphinxcontrib-mermaid
+sphinx-reredirects

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -63,15 +63,22 @@ autosummary_generate = True
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
 html_logo = _theme_logo
 html_favicon = _theme_favicon
 html_static_path = _theme_static_paths
 templates_path = [_theme_templates]
 html_last_updated_fmt = "%b %d, %Y"
+html_css_files = ["https://docs.tenstorrent.com/_static/tt_theme.css"]
 
 html_context = {
     "versions": None,
     "logo_link_url": os.environ.get("homepage", "https://docs.tenstorrent.com/"),
+    "search_site_base_url": "https://docs.tenstorrent.com/tt-lang/",
 }
 
 


### PR DESCRIPTION
## Summary

- `docs/sphinx/conf.py`:
  - Added `html_theme_options` (collapse_navigation, titles_only, navigation_depth)
  - Added `html_css_files` pointing to `docs.tenstorrent.com/_static/tt_theme.css`
  - Added `search_site_base_url: https://docs.tenstorrent.com/tt-lang/` to `html_context`
- `docs/requirements.txt`: added `sphinx-reredirects`

## Merge order

Merge before `docs/theme-nav-search-modal` in this repo.

## Test plan

- [ ] Sphinx build completes without warnings
- [ ] Theme CSS loads from CDN