### PR TITLE
[ci][build] repair CI workflow parse error and docs table formatting regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,8 @@ jobs:
         run: sphinx-build -b html docs/sphinx build/docs/sphinx/_build/html
       - name: Warn if search ingest key is missing
         if: ${{ env.DOCS_SEARCH_INGEST_API_KEY == '' }}
-        run: echo "::warning::Skipping OpenSearch indexing: DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT secret not set."
+        run: |
+          echo "::warning::Skipping OpenSearch indexing: DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT secret not set."
       - name: Index docs into OpenSearch
         if: ${{ env.DOCS_SEARCH_INGEST_API_KEY != '' }}
         continue-on-error: true

--- a/docs/sphinx/_static/tt_theme.css
+++ b/docs/sphinx/_static/tt_theme.css
@@ -415,6 +415,40 @@ li.toctree-l1.current>a {
   line-height: inherit;
 }
 
+.rst-content .wy-table-responsive {
+  overflow-x: auto;
+}
+
+.rst-content .wy-table-responsive table.docutils,
+.rst-content table.docutils {
+  table-layout: auto;
+  width: 100%;
+}
+
+.rst-content .wy-table-responsive table.docutils th,
+.rst-content .wy-table-responsive table.docutils td,
+.rst-content table.docutils th,
+.rst-content table.docutils td {
+  white-space: normal !important;
+  overflow-wrap: break-word;
+  word-break: normal;
+}
+
+.rst-content .wy-table-responsive table.docutils code,
+.rst-content .wy-table-responsive table.docutils tt,
+.rst-content table.docutils code,
+.rst-content table.docutils tt {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.rst-content section#compiler-options table.docutils th:first-child,
+.rst-content section#compiler-options table.docutils td:first-child {
+  min-width: 14rem;
+  width: 28%;
+}
+
 .document * h1,
 .document * h2,
 .document * h3,

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinxcontrib.mermaid",
+    "sphinx_reredirects",
 ]
 
 source_suffix = {
@@ -73,12 +74,20 @@ html_favicon = _theme_favicon
 html_static_path = _theme_static_paths
 templates_path = [_theme_templates]
 html_last_updated_fmt = "%b %d, %Y"
-html_css_files = ["https://docs.tenstorrent.com/_static/tt_theme.css"]
+html_css_files = [
+    "https://docs.tenstorrent.com/_static/tt_theme.css",
+    "tt_theme.css",
+]
 
 html_context = {
     "versions": None,
     "logo_link_url": os.environ.get("homepage", "https://docs.tenstorrent.com/"),
     "search_site_base_url": "https://docs.tenstorrent.com/tt-lang/",
+}
+
+redirects = {
+    "tour/operation-basics": "index.html#operation-basics",
+    "tour/dataflow-buffers": "index.html#dataflow-buffers",
 }
 
 
@@ -91,5 +100,4 @@ def autodoc_skip_member(
 
 
 def setup(app: Any) -> None:
-    app.add_css_file("tt_theme.css")
     app.connect("autodoc-skip-member", autodoc_skip_member)

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -74,10 +74,7 @@ html_favicon = _theme_favicon
 html_static_path = _theme_static_paths
 templates_path = [_theme_templates]
 html_last_updated_fmt = "%b %d, %Y"
-html_css_files = [
-    "https://docs.tenstorrent.com/_static/tt_theme.css",
-    "tt_theme.css",
-]
+html_css_files = ["https://docs.tenstorrent.com/_static/tt_theme.css"]
 
 html_context = {
     "versions": None,
@@ -100,4 +97,5 @@ def autodoc_skip_member(
 
 
 def setup(app: Any) -> None:
+    app.add_css_file("tt_theme.css")
     app.connect("autodoc-skip-member", autodoc_skip_member)

--- a/scripts/index_remote_search.py
+++ b/scripts/index_remote_search.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 """Crawl the built docs in output/ and push them to the OpenSearch-backed
 docs search service so the in-page search modal has something to query.
 
@@ -14,31 +17,89 @@ import re
 import sys
 import urllib.error
 import urllib.request
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Iterable
 
 
 # Keep batches small: the indexer Lambda fans each batch out to an OpenSearch
-# _bulk call, and API Gateway caps the request at ~29s. 200 docs in one POST
-# times out (HTTP 504) on the larger catalogs; 50 stays comfortably under it.
+# _bulk call, and API Gateway caps the request at about 29 seconds.
 MAX_BATCH_SIZE = 50
 TIMEOUT_SECONDS = 30
 
+# HTMLParser gets no end event for slash-less HTML5 void elements, so counting
+# them would unbalance the article-body depth and leak the footer text.
+_VOID_TAGS = frozenset(
+    {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+)
 
-def _strip_html_to_text(content: str) -> str:
-    # Remove script/style blocks first so they do not pollute search text.
-    content = re.sub(r"<script\b[^>]*>.*?</script>", " ", content, flags=re.IGNORECASE | re.DOTALL)
-    content = re.sub(r"<style\b[^>]*>.*?</style>", " ", content, flags=re.IGNORECASE | re.DOTALL)
-    # Strip tags.
-    content = re.sub(r"<[^>]+>", " ", content)
-    # Decode entities and normalize whitespace.
-    content = html.unescape(content)
-    content = re.sub(r"\s+", " ", content).strip()
-    return content
+
+class _TextExtractor(HTMLParser):
+    def __init__(self, *, article_body_only: bool):
+        super().__init__(convert_charrefs=True)
+        self.article_body_only = article_body_only
+        self.article_depth: int | None = None
+        self.skip_depth = 0
+        self.parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style"}:
+            self.skip_depth += 1
+
+        if self.article_body_only:
+            attr_values = dict(attrs)
+            if (
+                self.article_depth is None
+                and attr_values.get("itemprop") == "articleBody"
+            ):
+                self.article_depth = 0
+            if self.article_depth is not None and tag not in _VOID_TAGS:
+                self.article_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.skip_depth > 0 and tag in {"script", "style"}:
+            self.skip_depth -= 1
+
+        if self.article_depth is not None and tag not in _VOID_TAGS:
+            self.article_depth -= 1
+            if self.article_depth == 0:
+                self.article_depth = None
+
+    def handle_data(self, data: str) -> None:
+        if self.skip_depth > 0:
+            return
+        if self.article_body_only and self.article_depth is None:
+            return
+        self.parts.append(data)
+
+
+def _strip_html_to_text(content: str, *, article_body_only: bool = False) -> str:
+    parser = _TextExtractor(article_body_only=article_body_only)
+    parser.feed(content)
+    parser.close()
+    text = html.unescape(" ".join(parser.parts))
+    return re.sub(r"\s+", " ", text).strip()
 
 
 def _extract_title(content: str, fallback: str) -> str:
-    match = re.search(r"<title[^>]*>(.*?)</title>", content, flags=re.IGNORECASE | re.DOTALL)
+    match = re.search(
+        r"<title[^>]*>(.*?)</title>", content, flags=re.IGNORECASE | re.DOTALL
+    )
     if not match:
         return fallback
     return _strip_html_to_text(match.group(1)) or fallback
@@ -51,14 +112,16 @@ def _iter_html_files(output_root: Path) -> Iterable[Path]:
             continue
         if "/_static/" in rel or "/_sources/" in rel:
             continue
-        # Skip Sphinx's own search/genindex shell pages — they carry no content.
+        # Skip Sphinx's own search/genindex shell pages.
         name = path.name
         if name in {"search.html", "genindex.html"}:
             continue
         yield path
 
 
-def _build_documents(output_root: Path, site_base_url: str, catalog: str, version: str, id_namespace: str) -> list[dict]:
+def _build_documents(
+    output_root: Path, site_base_url: str, catalog: str, version: str, id_namespace: str
+) -> list[dict]:
     site_base_url = site_base_url.rstrip("/")
     docs: list[dict] = []
 
@@ -66,7 +129,9 @@ def _build_documents(output_root: Path, site_base_url: str, catalog: str, versio
         rel = html_file.relative_to(output_root).as_posix()
         raw = html_file.read_text(encoding="utf-8", errors="ignore")
         title = _extract_title(raw, rel)
-        body = _strip_html_to_text(raw)
+        body = _strip_html_to_text(raw, article_body_only=True) or _strip_html_to_text(
+            raw
+        )
         doc_id = f"{catalog}:{id_namespace}:{version}:{rel}"
         url = f"{site_base_url}/{rel}"
         docs.append({"id": doc_id, "title": title, "body": body, "url": url})

--- a/test/packaging/test_index_remote_search.py
+++ b/test/packaging/test_index_remote_search.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import importlib.util
+from pathlib import Path
+
+
+def _load_index_remote_search():
+    script_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "index_remote_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("index_remote_search", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_documents_indexes_article_body_only(tmp_path):
+    module = _load_index_remote_search()
+    html_path = tmp_path / "index.html"
+    html_path.write_text(
+        """
+        <html>
+          <head><title>Compiler Options</title></head>
+          <body>
+            <nav>Repeated navigation text</nav>
+            <div itemprop="articleBody">
+              <h1>Compiler Options</h1>
+              <p>Use --ttl-maximize-dst to configure DST scheduling.</p>
+            </div>
+            <footer>Repeated footer text</footer>
+          </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+
+    docs = module._build_documents(
+        tmp_path,
+        "https://docs.example.com/tt-lang/",
+        "docs-tenstorrent",
+        "latest",
+        "tt-lang",
+    )
+
+    assert docs == [
+        {
+            "id": "docs-tenstorrent:tt-lang:latest:index.html",
+            "title": "Compiler Options",
+            "body": "Compiler Options Use --ttl-maximize-dst to configure DST scheduling.",
+            "url": "https://docs.example.com/tt-lang/index.html",
+        }
+    ]
+
+
+def test_build_documents_excludes_chrome_after_void_elements(tmp_path):
+    # Void elements get no HTMLParser end event; the body must still end at
+    # </div itemprop="articleBody"> and not leak the trailing footer.
+    module = _load_index_remote_search()
+    html_path = tmp_path / "page.html"
+    html_path.write_text(
+        """
+        <html>
+          <head><title>Diagram Page</title></head>
+          <body>
+            <nav>Repeated navigation text</nav>
+            <div itemprop="articleBody">
+              <h1>Diagram Page</h1>
+              <img src="diagram.png">
+              <p>Text after the image.</p>
+            </div>
+            <footer>Repeated footer text</footer>
+          </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+
+    (doc,) = module._build_documents(
+        tmp_path,
+        "https://docs.example.com/tt-lang/",
+        "docs-tenstorrent",
+        "latest",
+        "tt-lang",
+    )
+
+    assert doc["body"] == "Diagram Page Text after the image."
+    assert "navigation" not in doc["body"]
+    assert "footer" not in doc["body"]


### PR DESCRIPTION
## Problem

PR #711 merged with an unquoted `run:` scalar in the docs CI workflow, so CI did not run. The same PR also left the deleted the sphinx documentation "tour" pages without redirects and indexed nav/footer chrome into every search document. Separately, wide table cells — a pre-existing issue on main — did not wrap and overflowed the content column.

## What's changed

- Quoted the workflow step (block scalar) so CI parses and runs again.
- Registered `sphinx-reredirects` and redirected the deleted tour pages.
- Indexed only `itemprop="articleBody"` content; excluded HTML5 void elements from the boundary tracking (the parser emits no end event for them, which otherwise leaked the footer text).
- Added CSS to soft-wrap wide table cells.

## Tests

Regression test for the void-element case; docs build and workflow parse verified.
