### PR TITLE
[ci] fix tt-metal light on-demand max-age input

### DIFF
--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -20,8 +20,8 @@ on:
       max_age_days:
         description: "Max |tt-lang date - tt-metal date| when searching for a compatible commit."
         required: false
-        type: number
-        default: 14
+        type: string
+        default: "14"
       python_tags:
         description: "Comma-separated CPython ABIs to build (subset of cp310,cp312)."
         required: false

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -25,8 +25,8 @@ on:
       max_age_days:
         description: "Max |tt-lang date - tt-metal date| when searching for a compatible commit."
         required: false
-        type: number
-        default: 14
+        type: string
+        default: "14"
       python_tags:
         description: "Comma-separated CPython ABIs to build."
         required: false
@@ -116,7 +116,7 @@ jobs:
     with:
       tt_metal_sha: ${{ needs.detect.outputs.tt_metal_sha }}
       docker_tag: ${{ inputs.docker_tag || needs.detect.outputs.docker_tag }}
-      max_age_days: ${{ inputs.max_age_days }}
+      max_age_days: ${{ format('{0}', inputs.max_age_days) }}
       python_tags: ${{ inputs.python_tags }}
       hw_type: ${{ inputs.hw_type }}
       dry_run: ${{ inputs.dry_run }}

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -36,6 +36,9 @@ CALL_BUILD_WHEEL_IMAGES_WORKFLOW = (
 CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-ttmetal-light-wheel.yml"
 )
+TTMETAL_LIGHT_ON_DEMAND_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "ttmetal-light-on-demand.yml"
+)
 MANYLINUX_WHEEL_DOCKERFILE = (
     REPO_ROOT / ".github" / "containers" / "Dockerfile.wheel-manylinux-2-34"
 )
@@ -96,6 +99,25 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "metapackage_wheel=$(ls dist/tt_lang_light-*-py3-none-any.whl)" in workflow
     assert "--find-links dist" in workflow
     assert '"$metapackage_wheel"' in workflow
+
+
+def test_ttmetal_light_max_age_crosses_reusable_workflow_as_string() -> None:
+    on_demand_workflow = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
+    reusable_workflow = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
+    on_demand_max_age = on_demand_workflow.split("      max_age_days:", 1)[1].split(
+        "      python_tags:", 1
+    )[0]
+    reusable_max_age = reusable_workflow.split("      max_age_days:", 1)[1].split(
+        "      python_tags:", 1
+    )[0]
+
+    assert "type: string" in on_demand_max_age
+    assert 'default: "14"' in on_demand_max_age
+    assert (
+        "max_age_days: ${{ format('{0}', inputs.max_age_days) }}" in on_demand_workflow
+    )
+    assert "type: string" in reusable_max_age
+    assert 'default: "14"' in reusable_max_age
 
 
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:


### PR DESCRIPTION
### Problem description

The `tt-lang-light wheel (on demand)` workflow fails after the detector job with reusable-workflow input evaluation errors:

`Unexpected value '14'`

The failure occurs while passing `max_age_days` from `ttmetal-light-on-demand.yml` into `call-ttmetal-light-wheel.yml`.

### What's changed

Treat `max_age_days` as a string at the workflow boundary and explicitly format the on-demand input before passing it to the reusable workflow. The downstream scripts already consume this value as command-line text, so this preserves runtime behavior while avoiding GitHub Actions numeric input binding failures.

Added a packaging workflow assertion covering the string input contract for the on-demand and reusable workflows.

### Checklist

- [x] New/Existing tests provide coverage for changes

Validation:

- `python3 -m pytest -q -c /dev/null test/packaging/test_workflow_helper_scripts.py`
- YAML parse for `.github/workflows/*.yml`
- `git diff --check`
