### PR TITLE
[ci] tt-metal light wheel fixes

### DIFF
--- a/.github/scripts/apply-wheel-patches.sh
+++ b/.github/scripts/apply-wheel-patches.sh
@@ -2,20 +2,49 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Apply every wheel patch present in .github/wheel-patches/ to the checked-out
-# tree before building a tt-lang wheel. Patches let a wheel built from an older
-# tt-lang ref pick up targeted fixes from the current line (e.g. a corrected
-# numpy pin) without rebasing the whole checkout. The set of patches is
-# discovered, not enumerated here: drop a self-contained *.sh in that directory
-# and it runs. Patches run in sorted filename order, from the repository root.
+# Apply every wheel patch in the sibling .github/wheel-patches/ directory to a
+# tt-lang checkout before building a wheel. Patches let a wheel built from an
+# older tt-lang ref pick up targeted fixes from the current line (e.g. a
+# corrected numpy pin) without rebasing the whole checkout.
+#
+# The patch runner and the patch files come from the workflow commit, not the
+# ref being rebuilt: an older ref that needs a patch predates both. So the tree
+# to patch is passed with --target-dir and is independent of where this script
+# and its patches live. With no --target-dir, the script's own repository root
+# is patched.
+#
+# Patches are discovered, not enumerated: drop a self-contained *.sh in
+# .github/wheel-patches/ and it runs. Each patch runs with the target tree as
+# its working directory, in sorted filename order.
+#
+# Usage: apply-wheel-patches.sh [--target-dir <dir>]
 
 set -euo pipefail
+
+target_dir=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target-dir)
+            [[ $# -ge 2 ]] || { echo "usage: apply-wheel-patches.sh [--target-dir <dir>]" >&2; exit 2; }
+            target_dir="$2"
+            shift 2
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            echo "usage: apply-wheel-patches.sh [--target-dir <dir>]" >&2
+            exit 2
+            ;;
+    esac
+done
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 patches_dir="$repo_root/.github/wheel-patches"
 
-cd "$repo_root"
+if [ -z "$target_dir" ]; then
+    target_dir="$repo_root"
+fi
+target_dir="$(cd "$target_dir" && pwd)"
 
 if [ ! -d "$patches_dir" ]; then
     echo "No wheel-patches directory at $patches_dir; nothing to apply."
@@ -31,9 +60,10 @@ if [ "${#patches[@]}" -eq 0 ]; then
     exit 0
 fi
 
+cd "$target_dir"
 for patch in "${patches[@]}"; do
-    echo "Applying wheel patch: $(basename "$patch")"
+    echo "Applying wheel patch to $target_dir: $(basename "$patch")"
     bash "$patch"
 done
 
-echo "Applied ${#patches[@]} wheel patch(es)."
+echo "Applied ${#patches[@]} wheel patch(es) to $target_dir."

--- a/.github/scripts/apply-wheel-patches.sh
+++ b/.github/scripts/apply-wheel-patches.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Apply every wheel patch present in .github/wheel-patches/ to the checked-out
+# tree before building a tt-lang wheel. Patches let a wheel built from an older
+# tt-lang ref pick up targeted fixes from the current line (e.g. a corrected
+# numpy pin) without rebasing the whole checkout. The set of patches is
+# discovered, not enumerated here: drop a self-contained *.sh in that directory
+# and it runs. Patches run in sorted filename order, from the repository root.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+patches_dir="$repo_root/.github/wheel-patches"
+
+cd "$repo_root"
+
+if [ ! -d "$patches_dir" ]; then
+    echo "No wheel-patches directory at $patches_dir; nothing to apply."
+    exit 0
+fi
+
+shopt -s nullglob
+patches=("$patches_dir"/*.sh)
+shopt -u nullglob
+
+if [ "${#patches[@]}" -eq 0 ]; then
+    echo "No wheel patches present; nothing to apply."
+    exit 0
+fi
+
+for patch in "${patches[@]}"; do
+    echo "Applying wheel patch: $(basename "$patch")"
+    bash "$patch"
+done
+
+echo "Applied ${#patches[@]} wheel patch(es)."

--- a/.github/scripts/build-ttmetal-at-sha.sh
+++ b/.github/scripts/build-ttmetal-at-sha.sh
@@ -8,6 +8,8 @@
 #   install_dir=<path>   (default mode)  -- pass to TTLANG_EXTERNAL_TT_METAL_DIR
 #   source_dir=<path>    (--no-build)    -- checked-out tt-metal source tree
 #   ttmetal_date=<iso>                   -- the SHA's committer date (%cI)
+#   sha=<sha>                            -- the normalized (trimmed) SHA built
+#   short=<sha7>                         -- the SHA's 7-char prefix
 #
 # The tt-metal build is standalone (its own cmake config, mirrored from
 # BuildTTMetal.cmake) rather than tt-lang's build-and-install.sh so that a
@@ -185,6 +187,8 @@ build_and_install() {
 ensure_source
 log_release_tag
 ttmetal_date="$(commit_date)"
+emit "sha=$sha"
+emit "short=${sha:0:7}"
 
 if [[ "$no_build" -eq 1 ]]; then
     emit "source_dir=$src_dir"

--- a/.github/scripts/build-ttmetal-at-sha.sh
+++ b/.github/scripts/build-ttmetal-at-sha.sh
@@ -64,6 +64,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+sha="$(printf '%s' "$sha" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
 if [[ -z "$sha" ]]; then
     echo "--sha is required" >&2
     usage

--- a/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
+++ b/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
@@ -2,20 +2,16 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Nightly detection for the per-tt-metal-SHA light wheel. Reads the tt-metal SHA
-# that tt-lang's pinned tt-mlir targets (TT_METAL_VERSION in tt-mlir's
-# third_party/CMakeLists.txt) and decides whether to build a wheel for it,
-# keyed on the SHA's 7-char S3 prefix.
+# Detect whether tt-lang should build a light wheel for tt-mlir's pinned
+# tt-metal SHA, keyed by the SHA's 7-character S3 prefix.
 #
 # A SHA is skipped when a wheel is already published, and also when a prior
 # search recorded no compatible tt-lang AND the tt-lang HEAD it searched is
 # unchanged (re-searching the same history would fail identically). Once tt-lang
 # HEAD advances, a recorded miss is retried because newer commits may now match.
 #
-# --assume-new skips the S3 idempotency check and reports the pinned SHA as
-# buildable. Dry-run builds never publish and run without S3 credentials (OIDC
-# authorizes only main), so reading the published prefix is neither possible nor
-# meaningful.
+# --assume-new treats the pinned SHA as buildable without reading S3. Dry runs
+# do not publish, and branch runs cannot use main-only OIDC credentials.
 #
 # Writes to $GITHUB_OUTPUT (or stdout):
 #   uplift=true|false
@@ -48,13 +44,12 @@ read_target_ttmetal_sha() {
     printf '%s\n' "$sha"
 }
 
-# Object basenames under the SHA's prefix (empty when the prefix does not exist).
-# Overridable in tests.
+# Object basenames under the SHA prefix. Overridable in tests.
 list_prefix_objects() {
     aws s3 ls "s3://$S3_BUCKET/$1/" 2>/dev/null | awk '{print $NF}'
 }
 
-# The tt-lang HEAD recorded by a prior miss marker, or empty. Overridable in tests.
+# tt-lang HEAD from a prior miss marker, or empty. Overridable in tests.
 read_recorded_head() {
     aws s3 cp "s3://$S3_BUCKET/$1/attempt.json" - 2>/dev/null \
         | sed -n -E 's/.*"ttlang_head"[[:space:]]*:[[:space:]]*"([a-f0-9]+)".*/\1/p' \

--- a/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
+++ b/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
@@ -12,12 +12,17 @@
 # unchanged (re-searching the same history would fail identically). Once tt-lang
 # HEAD advances, a recorded miss is retried because newer commits may now match.
 #
+# --assume-new skips the S3 idempotency check and reports the pinned SHA as
+# buildable. Dry-run builds never publish and run without S3 credentials (OIDC
+# authorizes only main), so reading the published prefix is neither possible nor
+# meaningful.
+#
 # Writes to $GITHUB_OUTPUT (or stdout):
 #   uplift=true|false
 #   tt_metal_sha=<full 40-char sha>   (only when uplift=true)
 #   tt_metal_sha_short=<7-char>       (only when uplift=true)
 #
-# Usage: detect-ttmlir-ttmetal-uplift.sh [--cmakelists <path>] [--ttlang-head <sha>]
+# Usage: detect-ttmlir-ttmetal-uplift.sh [--cmakelists <path>] [--ttlang-head <sha>] [--assume-new]
 
 set -euo pipefail
 
@@ -84,17 +89,20 @@ emit() {
 main() {
     local cmakelists="$repo_root/third-party/tt-mlir/third_party/CMakeLists.txt"
     local ttlang_head=""
+    local assume_new=false
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --cmakelists)
-                [[ $# -ge 2 ]] || { echo "Usage: $0 [--cmakelists <path>] [--ttlang-head <sha>]" >&2; return 2; }
+                [[ $# -ge 2 ]] || { echo "Usage: $0 [--cmakelists <path>] [--ttlang-head <sha>] [--assume-new]" >&2; return 2; }
                 cmakelists="$2"; shift 2 ;;
             --ttlang-head)
-                [[ $# -ge 2 ]] || { echo "Usage: $0 [--cmakelists <path>] [--ttlang-head <sha>]" >&2; return 2; }
+                [[ $# -ge 2 ]] || { echo "Usage: $0 [--cmakelists <path>] [--ttlang-head <sha>] [--assume-new]" >&2; return 2; }
                 ttlang_head="$2"; shift 2 ;;
+            --assume-new)
+                assume_new=true; shift ;;
             *)
                 echo "Unknown argument: $1" >&2
-                echo "Usage: $0 [--cmakelists <path>] [--ttlang-head <sha>]" >&2
+                echo "Usage: $0 [--cmakelists <path>] [--ttlang-head <sha>] [--assume-new]" >&2
                 return 2 ;;
         esac
     done
@@ -110,7 +118,12 @@ main() {
     short_sha="${target_sha:0:7}"
     echo "tt-mlir targets tt-metal $target_sha (prefix $short_sha); tt-lang HEAD $ttlang_head" >&2
 
-    class="$(classify_target "$short_sha" "$ttlang_head")"
+    if [[ "$assume_new" == true ]]; then
+        echo "Assuming $short_sha is unbuilt (--assume-new); skipping S3 idempotency check." >&2
+        class="new"
+    else
+        class="$(classify_target "$short_sha" "$ttlang_head")"
+    fi
     case "$class" in
         published)
             echo "Wheel already published under $short_sha; skipping." >&2

--- a/.github/scripts/inject-s3-index-readme.sh
+++ b/.github/scripts/inject-s3-index-readme.sh
@@ -2,10 +2,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Restore the human-facing README into an S3 PyPI root index. When publishing
-# under a new prefix, s3pypi may upload package indexes without creating the
-# prefix root index, so create a minimal package root index from the wheel dist
-# only for that missing-key case.
+# Restore the README into an S3 PyPI root index. If s3pypi omitted a prefixed
+# root index, create one from the wheel dist only for that missing-key case.
 
 set -euo pipefail
 

--- a/.github/scripts/inject-s3-index-readme.sh
+++ b/.github/scripts/inject-s3-index-readme.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Restore the human-facing README into an S3 PyPI root index. When publishing
+# under a new prefix, s3pypi may upload package indexes without creating the
+# prefix root index, so create a minimal package root index from the wheel dist
+# only for that missing-key case.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: inject-s3-index-readme.sh --key <s3-key> [options]
+
+Options:
+  --bucket <bucket>      S3 bucket. Default: tenstorrent-pypi.
+  --readme <path>        README markdown path. Default: packaging/s3-index/README.md.
+  --dist-dir <path>      Wheel dist dir used to create a missing root index. Default: dist.
+EOF
+    exit 2
+}
+
+bucket=tenstorrent-pypi
+readme=packaging/s3-index/README.md
+dist_dir=dist
+key=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bucket)
+            [[ $# -ge 2 ]] || usage
+            bucket="$2"
+            shift 2
+            ;;
+        --readme)
+            [[ $# -ge 2 ]] || usage
+            readme="$2"
+            shift 2
+            ;;
+        --dist-dir)
+            [[ $# -ge 2 ]] || usage
+            dist_dir="$2"
+            shift 2
+            ;;
+        --key)
+            [[ $# -ge 2 ]] || usage
+            key="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$key" ]]; then
+    usage
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+index_html="$tmpdir/index.html"
+aws_error="$tmpdir/aws-cp.err"
+
+if ! aws s3 cp "s3://$bucket/$key" "$index_html" 2>"$aws_error"; then
+    if grep -Eq 'HeadObject.*404|404.*HeadObject|Key ".+" does not exist' "$aws_error"; then
+        echo "S3 index s3://$bucket/$key does not exist; creating a root index from $dist_dir." >&2
+        rm -f "$index_html"
+    else
+        cat "$aws_error" >&2
+        exit 1
+    fi
+fi
+
+python3 .github/scripts/inject_s3_index_readme.py \
+    --create-from-dist "$dist_dir" \
+    "$readme" \
+    "$index_html"
+aws s3 cp "$index_html" "s3://$bucket/$key" \
+    --content-type "text/html; charset=utf-8"

--- a/.github/scripts/inject_s3_index_readme.py
+++ b/.github/scripts/inject_s3_index_readme.py
@@ -12,12 +12,15 @@ inert for pip resolution.
 The injected block is delimited by sentinel comments and replaced in place on
 re-run, so repeated injection never duplicates it.
 
-Usage: inject_s3_index_readme.py <readme.md> <index.html>
+Usage:
+  inject_s3_index_readme.py [--create-from-dist <dist_dir>] <readme.md> <index.html>
 """
 
+import argparse
 import html
 import re
 import sys
+from pathlib import Path
 
 START = "<!-- ttlang-s3-readme:start -->"
 END = "<!-- ttlang-s3-readme:end -->"
@@ -41,6 +44,29 @@ def build_block(readme_md: str) -> str:
     return f'{START}\n<section id="ttlang-s3-readme">\n{fragment}\n</section>\n{END}\n'
 
 
+def normalize_project_name(distribution_name: str) -> str:
+    return re.sub(r"[-_.]+", "-", distribution_name).lower()
+
+
+def project_names_from_wheels(dist_dir: Path) -> list[str]:
+    names = {
+        normalize_project_name(wheel.name.split("-", 1)[0])
+        for wheel in dist_dir.glob("*.whl")
+        if "-" in wheel.name
+    }
+    if not names:
+        raise ValueError(f"No wheel files found under {dist_dir}")
+    return sorted(names)
+
+
+def build_root_index(dist_dir: Path) -> str:
+    anchors = "\n".join(
+        f'<a href="{html.escape(project_name)}/">{html.escape(project_name)}</a>'
+        for project_name in project_names_from_wheels(dist_dir)
+    )
+    return f"<!DOCTYPE html>\n<html>\n<body>\n{anchors}\n</body>\n</html>\n"
+
+
 def inject(index_html: str, block: str) -> str:
     """Return index_html with block placed above the anchor links.
 
@@ -58,17 +84,38 @@ def inject(index_html: str, block: str) -> str:
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 3:
-        print(
-            "Usage: inject_s3_index_readme.py <readme.md> <index.html>", file=sys.stderr
-        )
-        return 2
-    readme_path, index_path = argv[1], argv[2]
+    parser = argparse.ArgumentParser(
+        description="Inject the tt-lang S3 README into an index.html file."
+    )
+    parser.add_argument(
+        "--create-from-dist",
+        metavar="DIST_DIR",
+        help=(
+            "Create a minimal root package index from wheel files when "
+            "index.html is absent."
+        ),
+    )
+    parser.add_argument("readme")
+    parser.add_argument("index")
+    args = parser.parse_args(argv[1:])
+
+    readme_path = Path(args.readme)
+    index_path = Path(args.index)
 
     with open(readme_path, encoding="utf-8") as handle:
         readme_md = handle.read()
-    with open(index_path, encoding="utf-8") as handle:
-        index_html = handle.read()
+    if index_path.exists():
+        with open(index_path, encoding="utf-8") as handle:
+            index_html = handle.read()
+    elif args.create_from_dist:
+        try:
+            index_html = build_root_index(Path(args.create_from_dist))
+        except ValueError as error:
+            print(error, file=sys.stderr)
+            return 1
+    else:
+        print(f"Index file does not exist: {index_path}", file=sys.stderr)
+        return 1
 
     result = inject(index_html, build_block(readme_md))
 

--- a/.github/scripts/inject_s3_index_readme.py
+++ b/.github/scripts/inject_s3_index_readme.py
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Inject the S3-index README into an s3pypi-generated root index.html.
+"""Inject the S3-index README into an s3pypi root index.html.
 
-s3pypi rewrites the root index.html on every `upload --put-root-index`, so this
-runs after each upload to restore the human-facing README above the package
-anchor links. PEP 503 clients read only the <a> links, so the injected block is
-inert for pip resolution.
-
-The injected block is delimited by sentinel comments and replaced in place on
-re-run, so repeated injection never duplicates it.
+s3pypi rewrites root indexes on upload. This restores the README above package
+anchors without changing pip resolution; repeated runs replace the existing
+sentinel-delimited block.
 
 Usage:
   inject_s3_index_readme.py [--create-from-dist <dist_dir>] <readme.md> <index.html>
@@ -29,8 +25,7 @@ END = "<!-- ttlang-s3-readme:end -->"
 def render_markdown(text: str) -> str:
     """Render Markdown to an HTML fragment, falling back to escaped text.
 
-    The fallback keeps the injection working when the `markdown` package is
-    absent rather than failing the publish.
+    The fallback keeps publishing independent of the optional `markdown` package.
     """
     try:
         import markdown
@@ -70,8 +65,8 @@ def build_root_index(dist_dir: Path) -> str:
 def inject(index_html: str, block: str) -> str:
     """Return index_html with block placed above the anchor links.
 
-    Any previously injected block is removed first (idempotent). The block is
-    inserted immediately after the opening <body> tag so it precedes every <a>.
+    Existing injected content is removed first. Inserting after <body> keeps
+    package anchors below the README.
     """
     existing = re.compile(re.escape(START) + ".*?" + re.escape(END) + r"\n?", re.DOTALL)
     index_html = existing.sub("", index_html)

--- a/.github/scripts/resolve-xla-build-inputs.sh
+++ b/.github/scripts/resolve-xla-build-inputs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Resolve the builder image tag and wheel version for an XLA light-wheel build
+# from a pinned tt-lang checkout. Both are computed from that checkout using its
+# own get-version-tag.sh and compute-nightly-version.py, so an older ref builds
+# against the builder image and version that match it rather than the current
+# workflow commit. Explicit --docker-tag / --version override the computation.
+#
+# Usage:
+#   resolve-xla-build-inputs.sh --target-dir <dir> [--docker-tag <tag>] [--version <ver>]
+#
+# Emits to $GITHUB_OUTPUT (or stdout):
+#   tag=<builder image tag>
+#   version=<wheel base version>
+
+set -euo pipefail
+
+target_dir=""
+docker_tag=""
+version=""
+
+usage() {
+    echo "usage: resolve-xla-build-inputs.sh --target-dir <dir> [--docker-tag <tag>] [--version <ver>]" >&2
+    exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target-dir) [[ $# -ge 2 ]] || usage; target_dir="$2"; shift 2 ;;
+        --docker-tag) [[ $# -ge 2 ]] || usage; docker_tag="$2"; shift 2 ;;
+        --version)    [[ $# -ge 2 ]] || usage; version="$2";    shift 2 ;;
+        *) echo "unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+trim() { printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+docker_tag="$(trim "$docker_tag")"
+version="$(trim "$version")"
+
+if [[ -z "$target_dir" || ! -d "$target_dir" ]]; then
+    echo "error: --target-dir must be an existing tt-lang checkout" >&2
+    usage
+fi
+
+# The target ref's own get-version-tag.sh reproduces the tag its builder image
+# was pushed under; the current workflow commit's tag would point at a newer,
+# mismatched image.
+if [[ -z "$docker_tag" ]]; then
+    docker_tag="$(cd "$target_dir" && .github/containers/get-version-tag.sh)"
+fi
+if [[ -z "$version" ]]; then
+    version="$(cd "$target_dir" && python3 .github/scripts/compute-nightly-version.py)"
+fi
+
+emit() { printf '%s\n' "$1" >> "${GITHUB_OUTPUT:-/dev/stdout}"; }
+emit "tag=$docker_tag"
+emit "version=$version"

--- a/.github/scripts/tests/test_apply_wheel_patches.bats
+++ b/.github/scripts/tests/test_apply_wheel_patches.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/apply-wheel-patches.sh and the wheel patches it runs.
+
+load test_helper
+
+setup() {
+    DRIVER="$SCRIPTS_DIR/apply-wheel-patches.sh"
+    NUMPY_PATCH="$(dirname "$SCRIPTS_DIR")/wheel-patches/fix-numpy-requirement.sh"
+    # A sandbox repo so the driver's repo-root resolution never touches the real
+    # checkout (it derives repo_root from its own location).
+    REPO="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$REPO/.github/scripts" "$REPO/.github/wheel-patches"
+    cp "$DRIVER" "$REPO/.github/scripts/apply-wheel-patches.sh"
+    DRIVER_IN_REPO="$REPO/.github/scripts/apply-wheel-patches.sh"
+}
+
+@test "driver is a no-op when no patches directory exists" {
+    rm -rf "$REPO/.github/wheel-patches"
+    run -0 "$DRIVER_IN_REPO"
+    assert_output --partial "nothing to apply"
+}
+
+@test "driver is a no-op when the patches directory is empty" {
+    run -0 "$DRIVER_IN_REPO"
+    assert_output --partial "nothing to apply"
+}
+
+@test "driver runs patches in sorted filename order" {
+    export MARKER="$BATS_TEST_TMPDIR/order"
+    cat > "$REPO/.github/wheel-patches/02-second.sh" <<'EOF'
+#!/usr/bin/env bash
+echo second >> "$MARKER"
+EOF
+    cat > "$REPO/.github/wheel-patches/01-first.sh" <<'EOF'
+#!/usr/bin/env bash
+echo first >> "$MARKER"
+EOF
+    run -0 "$DRIVER_IN_REPO"
+    run cat "$MARKER"
+    assert_line --index 0 "first"
+    assert_line --index 1 "second"
+}
+
+@test "numpy patch rewrites a stale pin to the canonical lines" {
+    cd "$BATS_TEST_TMPDIR"
+    printf 'torch\nnumpy==1.19.0\nfoo>=1\n' > requirements-runtime.txt
+    run -0 bash "$NUMPY_PATCH"
+    run cat requirements-runtime.txt
+    assert_output --partial "numpy>=1.20.0"
+    assert_output --partial 'numpy<2; platform_system == "Darwin" and platform_machine == "x86_64"'
+    refute_output --partial "numpy==1.19.0"
+    # Non-numpy requirements are untouched.
+    assert_output --partial "torch"
+    assert_output --partial "foo>=1"
+}
+
+@test "numpy patch adds the canonical lines when numpy is absent" {
+    cd "$BATS_TEST_TMPDIR"
+    printf 'torch\n' > requirements-runtime.txt
+    run -0 bash "$NUMPY_PATCH"
+    run cat requirements-runtime.txt
+    assert_output --partial "numpy>=1.20.0"
+    assert_output --partial "torch"
+}
+
+@test "numpy patch fails when requirements-runtime.txt is absent" {
+    cd "$BATS_TEST_TMPDIR"
+    run bash "$NUMPY_PATCH"
+    assert_failure
+    assert_output --partial "not found"
+}

--- a/.github/scripts/tests/test_apply_wheel_patches.bats
+++ b/.github/scripts/tests/test_apply_wheel_patches.bats
@@ -44,6 +44,31 @@ EOF
     assert_line --index 1 "second"
 }
 
+@test "--target-dir patches a separate tree, not the runner's own" {
+    # Patches live with the runner (REPO); the tree to patch is elsewhere and
+    # need not contain the runner or patches -- the older-ref rebuild case.
+    target="$BATS_TEST_TMPDIR/target"
+    mkdir -p "$target"
+    printf 'numpy==1.19.0\n' > "$target/requirements-runtime.txt"
+    printf 'numpy==1.19.0\n' > "$REPO/requirements-runtime.txt"
+    cp "$NUMPY_PATCH" "$REPO/.github/wheel-patches/fix-numpy-requirement.sh"
+
+    run -0 "$DRIVER_IN_REPO" --target-dir "$target"
+
+    run cat "$target/requirements-runtime.txt"
+    assert_output --partial "numpy>=1.20.0"
+    refute_output --partial "numpy==1.19.0"
+    # The runner's own tree is untouched.
+    run cat "$REPO/requirements-runtime.txt"
+    assert_output --partial "numpy==1.19.0"
+    refute_output --partial "numpy>=1.20.0"
+}
+
+@test "unknown argument -> exit 2" {
+    run "$DRIVER_IN_REPO" --bogus
+    assert_equal "$status" 2
+}
+
 @test "numpy patch rewrites a stale pin to the canonical lines" {
     cd "$BATS_TEST_TMPDIR"
     printf 'torch\nnumpy==1.19.0\nfoo>=1\n' > requirements-runtime.txt

--- a/.github/scripts/tests/test_build_ttmetal_at_sha.bats
+++ b/.github/scripts/tests/test_build_ttmetal_at_sha.bats
@@ -126,6 +126,9 @@ setup() {
     run cat "$GH_OUT"
     assert_output --partial "source_dir=$SCRATCH/src"
     assert_output --partial "ttmetal_date="
+    # The emitted sha is the trimmed value, not the padded input.
+    assert_output --partial "sha=$SHA"
+    assert_output --partial "short=${SHA:0:7}"
 
     run git -C "$SCRATCH/src" rev-parse HEAD
     assert_output "$SHA"

--- a/.github/scripts/tests/test_build_ttmetal_at_sha.bats
+++ b/.github/scripts/tests/test_build_ttmetal_at_sha.bats
@@ -120,6 +120,17 @@ setup() {
     [ ! -d "$SCRATCH/install" ]
 }
 
+@test "--sha trims workflow-dispatch whitespace" {
+    GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" --sha "   $SHA   " --scratch-dir "$SCRATCH" --no-build
+
+    run cat "$GH_OUT"
+    assert_output --partial "source_dir=$SCRATCH/src"
+    assert_output --partial "ttmetal_date="
+
+    run git -C "$SCRATCH/src" rev-parse HEAD
+    assert_output "$SHA"
+}
+
 @test "default mode builds and installs, emitting install_dir" {
     GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" --sha "$SHA" --scratch-dir "$SCRATCH"
 

--- a/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
+++ b/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
@@ -123,6 +123,27 @@ setup() {
     assert_output --partial "uplift=true"
 }
 
+@test "main --assume-new: uplift=true without reading S3" {
+    cml=$(make_cmakelists "$FULL_SHA")
+    # Any S3 read must abort the run; --assume-new must not reach these.
+    list_prefix_objects() { echo "S3 must not be read" >&2; return 1; }
+    read_recorded_head() { echo "S3 must not be read" >&2; return 1; }
+    export GITHUB_OUTPUT="$GH_OUT"
+    run -0 main --cmakelists "$cml" --ttlang-head "$HEAD_A" --assume-new
+    run cat "$GH_OUT"
+    assert_output --partial "uplift=true"
+    assert_output --partial "tt_metal_sha=$FULL_SHA"
+    assert_output --partial "tt_metal_sha_short=$SHORT_SHA"
+}
+
+@test "main --assume-new: unreadable CMakeLists still aborts" {
+    export GITHUB_OUTPUT="$GH_OUT"
+    run main --cmakelists "$BATS_TEST_TMPDIR/missing.txt" --assume-new
+    assert_failure
+    run cat "$GH_OUT"
+    refute_output --partial "uplift="
+}
+
 @test "main: unreadable CMakeLists aborts without emitting uplift" {
     list_prefix_objects() { printf ''; }
     export GITHUB_OUTPUT="$GH_OUT"

--- a/.github/scripts/tests/test_inject_s3_index_readme.bats
+++ b/.github/scripts/tests/test_inject_s3_index_readme.bats
@@ -68,3 +68,17 @@ run_inject() { python3 "$SCRIPT" "$README" "$INDEX"; }
     assert_line --index 0 "$(grep -m1 . <<<'<!-- ttlang-s3-readme:start -->')"
     assert_output --partial 'href="tt-lang/"'
 }
+
+@test "--create-from-dist builds a missing root index from wheel names" {
+    rm "$INDEX"
+    dist_dir=$(make_wheel_dir \
+        "tt_lang-1.0.0-py3-none-any.whl" \
+        "tt_lang_light-1.0.0-py3-none-any.whl" \
+        "tt_lang_sim-1.0.0-py3-none-any.whl")
+    run -0 python3 "$SCRIPT" --create-from-dist "$dist_dir" "$README" "$INDEX"
+    run cat "$INDEX"
+    assert_output --partial 'href="tt-lang/"'
+    assert_output --partial 'href="tt-lang-light/"'
+    assert_output --partial 'href="tt-lang-sim/"'
+    assert_output --partial 'id="ttlang-s3-readme"'
+}

--- a/.github/scripts/tests/test_inject_s3_index_readme_shell.bats
+++ b/.github/scripts/tests/test_inject_s3_index_readme_shell.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/inject-s3-index-readme.sh.
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/inject-s3-index-readme.sh"
+    README="$BATS_TEST_TMPDIR/README.md"
+    DIST_DIR=$(make_wheel_dir \
+        "tt_lang-1.0.0-py3-none-any.whl" \
+        "tt_lang_light-1.0.0-py3-none-any.whl")
+    AWS_LOG="$BATS_TEST_TMPDIR/aws.log"
+    S3_ROOT="$BATS_TEST_TMPDIR/s3"
+    mkdir -p "$S3_ROOT/2026-07"
+    cat > "$README" <<'EOF'
+# tt-lang internal index
+EOF
+    bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$AWS_LOG"
+if [[ "$1 $2" != "s3 cp" ]]; then
+    echo "unexpected aws command" >&2
+    exit 2
+fi
+src="$3"
+dst="$4"
+if [[ "$src" == s3://* ]]; then
+    key="${src#s3://tenstorrent-pypi/}"
+    source_path="$S3_ROOT/$key"
+    if [[ ! -f "$source_path" ]]; then
+        echo "fatal error: An error occurred (404) when calling the HeadObject operation: Key \"$key\" does not exist" >&2
+        exit 1
+    fi
+    cp "$source_path" "$dst"
+else
+    key="${dst#s3://tenstorrent-pypi/}"
+    mkdir -p "$(dirname "$S3_ROOT/$key")"
+    cp "$src" "$S3_ROOT/$key"
+fi
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+    export AWS_LOG S3_ROOT
+}
+
+@test "missing prefixed root index is created from dist and uploaded" {
+    run -0 "$SCRIPT" --key 2026-07/index.html --readme "$README" --dist-dir "$DIST_DIR"
+
+    run cat "$S3_ROOT/2026-07/index.html"
+    assert_output --partial 'href="tt-lang/"'
+    assert_output --partial 'href="tt-lang-light/"'
+    assert_output --partial 'id="ttlang-s3-readme"'
+}
+
+@test "existing root index is preserved and uploaded" {
+    cat > "$S3_ROOT/2026-07/index.html" <<'EOF'
+<!DOCTYPE html>
+<html>
+<body>
+<a href="existing-package/">existing-package</a>
+</body>
+</html>
+EOF
+
+    run -0 "$SCRIPT" --key 2026-07/index.html --readme "$README" --dist-dir "$DIST_DIR"
+
+    run cat "$S3_ROOT/2026-07/index.html"
+    assert_output --partial 'href="existing-package/"'
+    assert_output --partial 'id="ttlang-s3-readme"'
+}
+
+@test "non-404 aws download failure is propagated" {
+    cat > "$BATS_TEST_TMPDIR/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+echo "AccessDenied" >&2
+exit 1
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/aws"
+
+    run "$SCRIPT" --key 2026-07/index.html --readme "$README" --dist-dir "$DIST_DIR"
+    assert_equal "$status" 1
+    assert_output --partial "AccessDenied"
+}

--- a/.github/scripts/tests/test_resolve_xla_build_inputs.bats
+++ b/.github/scripts/tests/test_resolve_xla_build_inputs.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/resolve-xla-build-inputs.sh.
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/resolve-xla-build-inputs.sh"
+    GH_OUT="$BATS_TEST_TMPDIR/gh_out"
+    : > "$GH_OUT"
+
+    # A stand-in target checkout with stub versions of the two scripts the
+    # resolver invokes, so the orchestration is tested without a real git repo.
+    TARGET="$BATS_TEST_TMPDIR/target"
+    mkdir -p "$TARGET/.github/containers" "$TARGET/.github/scripts"
+    cat > "$TARGET/.github/containers/get-version-tag.sh" <<'EOF'
+#!/usr/bin/env bash
+echo computed-tag
+EOF
+    cat > "$TARGET/.github/scripts/compute-nightly-version.py" <<'EOF'
+print("computed-ver")
+EOF
+    chmod +x "$TARGET/.github/containers/get-version-tag.sh"
+}
+
+@test "computes tag and version from the target checkout" {
+    GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" --target-dir "$TARGET"
+    run cat "$GH_OUT"
+    assert_line "tag=computed-tag"
+    assert_line "version=computed-ver"
+}
+
+@test "explicit overrides win and skip the target scripts" {
+    # Make the target scripts fail; overrides must mean they are never run.
+    echo 'exit 3' >> "$TARGET/.github/containers/get-version-tag.sh"
+    echo 'import sys; sys.exit(3)' >> "$TARGET/.github/scripts/compute-nightly-version.py"
+    GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" \
+        --target-dir "$TARGET" --docker-tag my-tag --version 9.9.9
+    run cat "$GH_OUT"
+    assert_line "tag=my-tag"
+    assert_line "version=9.9.9"
+}
+
+@test "trims surrounding whitespace from overrides" {
+    GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" \
+        --target-dir "$TARGET" --docker-tag "  spaced-tag  " --version "  1.2.3  "
+    run cat "$GH_OUT"
+    assert_line "tag=spaced-tag"
+    assert_line "version=1.2.3"
+}
+
+@test "missing --target-dir -> exit 2" {
+    run "$SCRIPT" --docker-tag t --version v
+    assert_equal "$status" 2
+}
+
+@test "nonexistent --target-dir -> exit 2" {
+    run "$SCRIPT" --target-dir "$BATS_TEST_TMPDIR/nope"
+    assert_equal "$status" 2
+}
+
+@test "unknown argument -> exit 2" {
+    run "$SCRIPT" --target-dir "$TARGET" --bogus
+    assert_equal "$status" 2
+}

--- a/.github/wheel-patches/fix-numpy-requirement.sh
+++ b/.github/wheel-patches/fix-numpy-requirement.sh
@@ -4,9 +4,9 @@
 #
 # Force requirements-runtime.txt's numpy pin to the values on tt-lang main.
 # Older tagged refs may carry a numpy constraint that no longer resolves against
-# current torch/ttnn; rebuilding such a ref with this patch replaces just the
-# numpy requirement line(s) so the resulting wheel installs cleanly. Runs from
-# the repository root (see apply-wheel-patches.sh).
+# current torch/ttnn; rebuilding such a ref with this patch replaces the numpy
+# requirement line(s) so the resulting wheel installs cleanly. Runs from the
+# repository root (see apply-wheel-patches.sh).
 
 set -euo pipefail
 
@@ -17,38 +17,14 @@ if [ ! -f "$req" ]; then
     exit 1
 fi
 
-# numpy requirement lines as they currently appear on tt-lang main.
-tmp="$(mktemp)"
-awk '
-function is_numpy(line,   s, name) {
-    s = line
-    sub(/^[ \t]+/, "", s)
-    if (s == "" || substr(s, 1, 1) == "#") return 0
-    sub(/;.*$/, "", s)                 # drop environment marker
-    name = s
-    sub(/[<>=!~[ \t].*$/, "", name)    # keep the requirement name only
-    return (tolower(name) == "numpy")
-}
-{
-    if (is_numpy($0)) {
-        if (!inserted) {
-            print "numpy>=1.20.0"
-            print "numpy<2; platform_system == \"Darwin\" and platform_machine == \"x86_64\""
-            inserted = 1
-        }
-        next                           # drop the pre-existing numpy line
-    }
-    print
-}
-END {
-    if (!inserted) {
-        print "numpy>=1.20.0"
-        print "numpy<2; platform_system == \"Darwin\" and platform_machine == \"x86_64\""
-    }
-}
-' "$req" > "$tmp"
-
-mv "$tmp" "$req"
+# Drop existing numpy requirement lines -- "numpy" followed by a version
+# operator, a ';' marker, whitespace, or end of line (so numpydoc / numpy-foo
+# are left alone) -- then append the pins used on tt-lang main.
+sed -i -E '/^[[:space:]]*numpy([[:space:]<>=!~;]|$)/d' "$req"
+cat >> "$req" <<'EOF'
+numpy>=1.20.0
+numpy<2; platform_system == "Darwin" and platform_machine == "x86_64"
+EOF
 
 echo "Patched numpy requirement in $req:"
 grep -n '^numpy' "$req"

--- a/.github/wheel-patches/fix-numpy-requirement.sh
+++ b/.github/wheel-patches/fix-numpy-requirement.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Force requirements-runtime.txt's numpy pin to the values on tt-lang main.
+# Older tagged refs may carry a numpy constraint that no longer resolves against
+# current torch/ttnn; rebuilding such a ref with this patch replaces just the
+# numpy requirement line(s) so the resulting wheel installs cleanly. Runs from
+# the repository root (see apply-wheel-patches.sh).
+
+set -euo pipefail
+
+req="requirements-runtime.txt"
+
+if [ ! -f "$req" ]; then
+    echo "error: $req not found; run from the repository root." >&2
+    exit 1
+fi
+
+# numpy requirement lines as they currently appear on tt-lang main.
+tmp="$(mktemp)"
+awk '
+function is_numpy(line,   s, name) {
+    s = line
+    sub(/^[ \t]+/, "", s)
+    if (s == "" || substr(s, 1, 1) == "#") return 0
+    sub(/;.*$/, "", s)                 # drop environment marker
+    name = s
+    sub(/[<>=!~[ \t].*$/, "", name)    # keep the requirement name only
+    return (tolower(name) == "numpy")
+}
+{
+    if (is_numpy($0)) {
+        if (!inserted) {
+            print "numpy>=1.20.0"
+            print "numpy<2; platform_system == \"Darwin\" and platform_machine == \"x86_64\""
+            inserted = 1
+        }
+        next                           # drop the pre-existing numpy line
+    }
+    print
+}
+END {
+    if (!inserted) {
+        print "numpy>=1.20.0"
+        print "numpy<2; platform_system == \"Darwin\" and platform_machine == \"x86_64\""
+    }
+}
+' "$req" > "$tmp"
+
+mv "$tmp" "$req"
+
+echo "Patched numpy requirement in $req:"
+grep -n '^numpy' "$req"

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -13,6 +13,10 @@ on:
         default: false
   workflow_call:
     inputs:
+      ttlang_sha_override:
+        description: "tt-lang SHA/branch override (optional, defaults to current commit)"
+        type: string
+        required: false
       push:
         description: "Push built images to GHCR. Default false so accidental invocations don't upload. Only on-push (main) and publish-pypi (release tag) should set this true."
         type: boolean

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -56,6 +56,16 @@ on:
         type: string
         default: tt-lang-wheels
         required: false
+      ttlang_sha_override:
+        description: "tt-lang SHA/tag to build from. Leave empty to use the caller's ref."
+        type: string
+        default: ""
+        required: false
+      apply_patches:
+        description: "Apply wheel patches from .github/wheel-patches/ before building."
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: read
@@ -77,11 +87,16 @@ jobs:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
           fetch-depth: 0
           fetch-tags: true
 
       - name: Fix git safe directory
         run: git config --global --add safe.directory '*'
+
+      - name: Apply wheel patches
+        if: ${{ inputs.apply_patches }}
+        run: .github/scripts/apply-wheel-patches.sh
 
       - name: Validate wheel inputs and resolve versions
         id: versions

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -94,9 +94,22 @@ jobs:
       - name: Fix git safe directory
         run: git config --global --add safe.directory '*'
 
+      # The patch runner and patches come from the workflow commit, not the
+      # (possibly older) target ref being rebuilt, which may predate them.
+      - name: Check out wheel patches from the workflow commit
+        if: ${{ inputs.apply_patches }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-patch-src
+          sparse-checkout: |
+            .github/scripts/apply-wheel-patches.sh
+            .github/wheel-patches
+          sparse-checkout-cone-mode: false
+
       - name: Apply wheel patches
         if: ${{ inputs.apply_patches }}
-        run: .github/scripts/apply-wheel-patches.sh
+        run: .wheel-patch-src/.github/scripts/apply-wheel-patches.sh --target-dir "$GITHUB_WORKSPACE"
 
       - name: Validate wheel inputs and resolve versions
         id: versions

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -2,11 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Build, device-test, and publish a tt-lang-light wheel for an arbitrary
-# tt-metal SHA. Finds the newest tt-lang commit compatible with that tt-metal,
-# builds the light wheel against it (unmodified build-s3-light-core-wheel.sh
-# with TTLANG_EXTERNAL_TT_METAL_DIR), validates on device, and publishes under
-# the SHA's 7-character prefix so the wheel filename is unchanged.
+# Build, device-test, and publish a tt-lang-light wheel for a tt-metal SHA.
+# The S3 prefix is the tt-metal short SHA, so wheel filenames stay unchanged.
 
 name: tt-lang-light wheel for a tt-metal SHA
 
@@ -42,10 +39,7 @@ on:
         type: boolean
         default: true
 
-# workflow_call only: the nightly orchestrator is the single manual entry point
-# (its workflow_dispatch forces a tt_metal_sha and calls this). A second dispatch
-# block here would duplicate every input, since GitHub Actions cannot share input
-# definitions across triggers.
+# workflow_call only. The on-demand workflow owns workflow_dispatch input parsing.
 
 permissions:
   contents: read
@@ -129,8 +123,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure-tt-s3-credentials
 
-      # Marks this tt-metal SHA so the nightly detector does not re-attempt it
-      # until tt-lang HEAD advances past the history just searched.
+      # Retry this SHA only after tt-lang HEAD advances.
       - name: Record miss
         run: |
           .github/scripts/record-ttmetal-miss.sh \

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: boolean
         default: true
+      soft_fail:
+        description: "Tolerate job failures via continue-on-error so the caller's run is not failed by this build."
+        required: false
+        type: boolean
+        default: false
 
 # workflow_call only. The on-demand workflow owns workflow_dispatch input parsing.
 
@@ -52,6 +57,7 @@ permissions:
 jobs:
   find-compatible:
     name: "Find compatible tt-lang"
+    continue-on-error: ${{ inputs.soft_fail }}
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.hw_type) }}
     timeout-minutes: 300
     container:
@@ -137,6 +143,7 @@ jobs:
 
   record-miss:
     name: "Record no-compatible miss"
+    continue-on-error: ${{ inputs.soft_fail }}
     needs: find-compatible
     if: ${{ needs.find-compatible.outputs.found == 'false' && inputs.dry_run != true }}
     runs-on: ubuntu-24.04
@@ -164,6 +171,7 @@ jobs:
 
   build-wheels:
     name: "Build light wheel (${{ matrix.python_tag }})"
+    continue-on-error: ${{ inputs.soft_fail }}
     needs: find-compatible
     if: ${{ needs.find-compatible.outputs.found == 'true' }}
     runs-on: mlir-large-runner-lang
@@ -240,6 +248,7 @@ jobs:
 
   build-metapackage:
     name: "Build tt-lang-light metapackage"
+    continue-on-error: ${{ inputs.soft_fail }}
     needs: find-compatible
     if: ${{ needs.find-compatible.outputs.found == 'true' }}
     runs-on: mlir-large-runner-lang
@@ -278,6 +287,7 @@ jobs:
 
   device-validate:
     name: "Device-validate light wheel"
+    continue-on-error: ${{ inputs.soft_fail }}
     needs: [find-compatible, build-wheels, build-metapackage]
     if: ${{ needs.find-compatible.outputs.found == 'true' }}
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.hw_type) }}
@@ -376,6 +386,7 @@ jobs:
 
   publish:
     name: "Publish to S3 under per-SHA prefix"
+    continue-on-error: ${{ inputs.soft_fail }}
     needs: [find-compatible, build-wheels, build-metapackage, device-validate]
     if: ${{ needs.find-compatible.outputs.found == 'true' && inputs.dry_run != true }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -342,7 +342,11 @@ jobs:
           TTMETAL_INSTALL_DIR: ${{ steps.ttmetal.outputs.install_dir }}
         run: |
           set -euo pipefail
-          python3 -m venv --system-site-packages /tmp/ttl-venv
+          # Clean venv (no --system-site-packages): the installed light wheel and
+          # the external tt-metal must satisfy the suite on their own, so a
+          # dependency the wheel fails to declare surfaces here instead of being
+          # masked by the ird image's system packages.
+          python3 -m venv /tmp/ttl-venv
           # shellcheck disable=SC1091
           source /tmp/ttl-venv/bin/activate
           abi="cp$(python3 -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')"

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -322,6 +322,7 @@ jobs:
           # shellcheck disable=SC1091
           source /tmp/ttl-venv/bin/activate
           eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTL_EXTERNAL_TT_METAL_DIR")"
+          export PYTHONPATH="$PWD/test${PYTHONPATH:+:$PYTHONPATH}"
           python3 test/python/smoketest.py
           python3 test/python/simple_add.py
           python3 -m pytest test/python -v --tb=short \
@@ -376,11 +377,7 @@ jobs:
         run: |
           set -euo pipefail
           key="${{ needs.find-compatible.outputs.ttmetal_short }}/index.html"
-          aws s3 cp "s3://tenstorrent-pypi/$key" ./index.html
-          python3 .github/scripts/inject_s3_index_readme.py \
-            packaging/s3-index/README.md ./index.html
-          aws s3 cp ./index.html "s3://tenstorrent-pypi/$key" \
-            --content-type "text/html; charset=utf-8"
+          .github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist
 
       - name: Report install command
         run: |

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -14,6 +14,11 @@ on:
         description: "tt-metal commit SHA to build and test against."
         required: true
         type: string
+      ttlang_ref:
+        description: "tt-lang SHA or tag to build. Empty = search for the newest compatible commit."
+        required: false
+        type: string
+        default: ""
       max_age_days:
         description: "Max |tt-lang date - tt-metal date| when searching for a compatible commit."
         required: false
@@ -67,12 +72,15 @@ jobs:
       found: ${{ steps.search.outputs.found }}
       winner_sha: ${{ steps.search.outputs.winner_sha }}
       winner_version: ${{ steps.search.outputs.winner_version }}
-      ttmetal_short: ${{ steps.ttmetal.outputs.ttmetal_short }}
+      ttmetal_short: ${{ steps.ttmetal_short.outputs.ttmetal_short }}
       ttlang_head: ${{ steps.head.outputs.sha }}
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
         with:
+          # Empty ttlang_ref checks out the caller's ref (search mode); a pinned
+          # ref checks out exactly that SHA or tag to build.
+          ref: ${{ inputs.ttlang_ref }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -83,27 +91,49 @@ jobs:
         id: head
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Build tt-metal at SHA
-        id: ttmetal
+      - name: Normalize tt-metal SHA
+        id: ttmetal_short
+        env:
+          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
         run: |
           set -euo pipefail
           tt_metal_sha="$(printf '%s' "$TT_METAL_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-          .github/scripts/build-ttmetal-at-sha.sh \
-            --sha "$tt_metal_sha" \
-            --scratch-dir /tmp/ttmetal-sha
+          echo "sha=$tt_metal_sha" >> "$GITHUB_OUTPUT"
           echo "ttmetal_short=${tt_metal_sha:0:7}" >> "$GITHUB_OUTPUT"
-        env:
-          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
+
+      # A pinned tt-lang ref is built directly, so the compatibility search and
+      # the tt-metal build that powers its device gate are skipped.
+      - name: Build tt-metal at SHA
+        id: ttmetal
+        if: ${{ inputs.ttlang_ref == '' }}
+        run: |
+          set -euo pipefail
+          .github/scripts/build-ttmetal-at-sha.sh \
+            --sha "${{ steps.ttmetal_short.outputs.sha }}" \
+            --scratch-dir /tmp/ttmetal-sha
 
       - name: Find compatible tt-lang commit
         id: search
+        env:
+          TTLANG_REF: ${{ inputs.ttlang_ref }}
         run: |
           set -euo pipefail
-          .github/scripts/find-compatible-ttlang.sh \
-            --ttmetal-install-dir "${{ steps.ttmetal.outputs.install_dir }}" \
-            --ttmetal-date "${{ steps.ttmetal.outputs.ttmetal_date }}" \
-            --max-age-days "${{ inputs.max_age_days }}" \
-            --build-dir build-search
+          if [ -n "$TTLANG_REF" ]; then
+            winner_sha="$(git rev-parse HEAD)"
+            winner_version="$(python3 .github/scripts/compute-nightly-version.py)"
+            echo "Pinned tt-lang $TTLANG_REF -> $winner_sha (version $winner_version); skipping search." >&2
+            {
+              echo "found=true"
+              echo "winner_sha=$winner_sha"
+              echo "winner_version=$winner_version"
+            } >> "$GITHUB_OUTPUT"
+          else
+            .github/scripts/find-compatible-ttlang.sh \
+              --ttmetal-install-dir "${{ steps.ttmetal.outputs.install_dir }}" \
+              --ttmetal-date "${{ steps.ttmetal.outputs.ttmetal_date }}" \
+              --max-age-days "${{ inputs.max_age_days }}" \
+              --build-dir build-search
+          fi
 
   record-miss:
     name: "Record no-compatible miss"

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -138,7 +138,7 @@ jobs:
         with:
           # Empty ttlang_ref checks out the caller's ref (search mode); a pinned
           # ref checks out exactly that SHA or tag to build.
-          ref: ${{ inputs.ttlang_ref }}
+          ref: ${{ inputs.ttlang_ref || github.sha }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -87,10 +87,11 @@ jobs:
         id: ttmetal
         run: |
           set -euo pipefail
+          tt_metal_sha="$(printf '%s' "$TT_METAL_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
           .github/scripts/build-ttmetal-at-sha.sh \
-            --sha "${{ inputs.tt_metal_sha }}" \
+            --sha "$tt_metal_sha" \
             --scratch-dir /tmp/ttmetal-sha
-          echo "ttmetal_short=${TT_METAL_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "ttmetal_short=${tt_metal_sha:0:7}" >> "$GITHUB_OUTPUT"
         env:
           TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
 

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -182,9 +182,12 @@ jobs:
         id: ttmetal
         run: |
           set -euo pipefail
+          tt_metal_sha="$(printf '%s' "$TT_METAL_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
           .github/scripts/build-ttmetal-at-sha.sh \
-            --sha "${{ inputs.tt_metal_sha }}" \
+            --sha "$tt_metal_sha" \
             --scratch-dir /tmp/ttmetal-sha
+        env:
+          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
 
       - name: Build light core wheel
         if: ${{ steps.gate.outputs.build == 'true' }}
@@ -287,9 +290,12 @@ jobs:
         id: ttmetal
         run: |
           set -euo pipefail
+          tt_metal_sha="$(printf '%s' "$TT_METAL_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
           .github/scripts/build-ttmetal-at-sha.sh \
-            --sha "${{ inputs.tt_metal_sha }}" \
+            --sha "$tt_metal_sha" \
             --scratch-dir /tmp/ttmetal-sha
+        env:
+          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
 
       - name: Install light wheel and external tt-metal
         env:
@@ -306,6 +312,7 @@ jobs:
             --find-links dist \
             --extra-index-url https://download.pytorch.org/whl/cpu \
             "$metapackage_wheel"
+          tt-lang-setup
           pip install -r dev-requirements.txt
           eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTMETAL_INSTALL_DIR")"
           echo "TTL_EXTERNAL_TT_METAL_DIR=$TTMETAL_INSTALL_DIR" >> "$GITHUB_ENV"
@@ -316,12 +323,23 @@ jobs:
           # shellcheck disable=SC1091
           source /tmp/ttl-venv/bin/activate
           eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTL_EXTERNAL_TT_METAL_DIR")"
-          export PYTHONPATH="$PWD/test${PYTHONPATH:+:$PYTHONPATH}"
+          test_import_root="$(mktemp -d)"
+          mkdir -p "$test_import_root/utils"
+          cat > "$test_import_root/utils/__init__.py" <<'PY'
+          from ttl.utils import *  # noqa: F401,F403
+          PY
+          cat > "$test_import_root/utils/correctness.py" <<'PY'
+          from ttl.utils.correctness import *  # noqa: F401,F403
+          PY
+          cat > "$test_import_root/utils/block_allocation.py" <<'PY'
+          from ttl.utils.block_allocation import *  # noqa: F401,F403
+          PY
+          export PYTHONPATH="$test_import_root:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"
           python3 test/python/smoketest.py
           python3 test/python/simple_add.py
-          python3 -m pytest test/python -v --tb=short \
+          python3 -m pytest -c /dev/null --rootdir "$PWD" test/python -v --tb=short \
             --timeout=300 --timeout-method=thread
-          python3 -m pytest test/me2e -v --tb=short \
+          python3 -m pytest -c /dev/null --rootdir "$PWD" test/me2e -v --tb=short \
             --timeout=300 --timeout-method=thread
           bash .github/scripts/compile-and-run-examples.sh
           bash .github/scripts/run-tutorials.sh .

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -55,8 +55,60 @@ permissions:
   contents: read
 
 jobs:
+  build-ttmetal:
+    name: "Build tt-metal at SHA"
+    continue-on-error: ${{ inputs.soft_fail }}
+    runs-on: mlir-large-runner-lang
+    timeout-minutes: 180
+    # Built once in the oldest glibc (manylinux_2_34, forward-compatible to the
+    # ird runners) at cp312 to match the device jobs' ttnn import ABI.
+    container:
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      ttmetal_short: ${{ steps.ttmetal.outputs.short }}
+      ttmetal_date: ${{ steps.ttmetal.outputs.ttmetal_date }}
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Git safe directory
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Build tt-metal at SHA
+        id: ttmetal
+        env:
+          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
+        run: |
+          set -euo pipefail
+          .github/scripts/build-ttmetal-at-sha.sh \
+            --sha "$TT_METAL_SHA" \
+            --scratch-dir /tmp/ttmetal-sha
+
+      # tar preserves the +x bit on the bundled sfpi compiler that JIT needs;
+      # upload-artifact would strip it.
+      - name: Package tt-metal install
+        run: tar -C /tmp/ttmetal-sha -czf /tmp/ttmetal-install.tar.gz install
+
+      - name: Upload tt-metal install
+        uses: actions/upload-artifact@v7
+        with:
+          name: ttmetal-install
+          path: /tmp/ttmetal-install.tar.gz
+          retention-days: 7
+          if-no-files-found: error
+          compression-level: 0
+
   find-compatible:
     name: "Find compatible tt-lang"
+    needs: build-ttmetal
     continue-on-error: ${{ inputs.soft_fail }}
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.hw_type) }}
     timeout-minutes: 300
@@ -78,7 +130,7 @@ jobs:
       found: ${{ steps.search.outputs.found }}
       winner_sha: ${{ steps.search.outputs.winner_sha }}
       winner_version: ${{ steps.search.outputs.winner_version }}
-      ttmetal_short: ${{ steps.ttmetal_short.outputs.ttmetal_short }}
+      ttmetal_short: ${{ needs.build-ttmetal.outputs.ttmetal_short }}
       ttlang_head: ${{ steps.head.outputs.sha }}
     steps:
       - name: Checkout tt-lang
@@ -97,26 +149,18 @@ jobs:
         id: head
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Normalize tt-metal SHA
-        id: ttmetal_short
-        env:
-          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
-        run: |
-          set -euo pipefail
-          tt_metal_sha="$(printf '%s' "$TT_METAL_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-          echo "sha=$tt_metal_sha" >> "$GITHUB_OUTPUT"
-          echo "ttmetal_short=${tt_metal_sha:0:7}" >> "$GITHUB_OUTPUT"
+      - name: Download tt-metal install
+        if: ${{ inputs.ttlang_ref == '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ttmetal-install
+          path: /tmp/ttmetal-dl
 
-      # A pinned tt-lang ref is built directly, so the compatibility search and
-      # the tt-metal build that powers its device gate are skipped.
-      - name: Build tt-metal at SHA
-        id: ttmetal
+      - name: Unpack tt-metal install
         if: ${{ inputs.ttlang_ref == '' }}
         run: |
-          set -euo pipefail
-          .github/scripts/build-ttmetal-at-sha.sh \
-            --sha "${{ steps.ttmetal_short.outputs.sha }}" \
-            --scratch-dir /tmp/ttmetal-sha
+          mkdir -p /tmp/ttmetal-install
+          tar -C /tmp/ttmetal-install --strip-components=1 -xzf /tmp/ttmetal-dl/ttmetal-install.tar.gz
 
       - name: Find compatible tt-lang commit
         id: search
@@ -135,8 +179,8 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           else
             .github/scripts/find-compatible-ttlang.sh \
-              --ttmetal-install-dir "${{ steps.ttmetal.outputs.install_dir }}" \
-              --ttmetal-date "${{ steps.ttmetal.outputs.ttmetal_date }}" \
+              --ttmetal-install-dir /tmp/ttmetal-install \
+              --ttmetal-date "${{ needs.build-ttmetal.outputs.ttmetal_date }}" \
               --max-age-days "${{ inputs.max_age_days }}" \
               --build-dir build-search
           fi
@@ -172,7 +216,7 @@ jobs:
   build-wheels:
     name: "Build light wheel (${{ matrix.python_tag }})"
     continue-on-error: ${{ inputs.soft_fail }}
-    needs: find-compatible
+    needs: [build-ttmetal, find-compatible]
     if: ${{ needs.find-compatible.outputs.found == 'true' }}
     runs-on: mlir-large-runner-lang
     timeout-minutes: 180
@@ -215,22 +259,23 @@ jobs:
         if: ${{ steps.gate.outputs.build == 'true' }}
         run: git config --global --add safe.directory "$(pwd)"
 
-      - name: Build tt-metal at SHA
+      - name: Download tt-metal install
         if: ${{ steps.gate.outputs.build == 'true' }}
-        id: ttmetal
+        uses: actions/download-artifact@v8
+        with:
+          name: ttmetal-install
+          path: /tmp/ttmetal-dl
+
+      - name: Unpack tt-metal install
+        if: ${{ steps.gate.outputs.build == 'true' }}
         run: |
-          set -euo pipefail
-          tt_metal_sha="$(printf '%s' "$TT_METAL_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-          .github/scripts/build-ttmetal-at-sha.sh \
-            --sha "$tt_metal_sha" \
-            --scratch-dir /tmp/ttmetal-sha
-        env:
-          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
+          mkdir -p /tmp/ttmetal-install
+          tar -C /tmp/ttmetal-install --strip-components=1 -xzf /tmp/ttmetal-dl/ttmetal-install.tar.gz
 
       - name: Build light core wheel
         if: ${{ steps.gate.outputs.build == 'true' }}
         env:
-          TTLANG_EXTERNAL_TT_METAL_DIR: ${{ steps.ttmetal.outputs.install_dir }}
+          TTLANG_EXTERNAL_TT_METAL_DIR: /tmp/ttmetal-install
           TTLANG_GIT_COMMIT: ${{ needs.find-compatible.outputs.winner_sha }}
         run: |
           .github/scripts/build-s3-light-core-wheel.sh \
@@ -288,7 +333,7 @@ jobs:
   device-validate:
     name: "Device-validate light wheel"
     continue-on-error: ${{ inputs.soft_fail }}
-    needs: [find-compatible, build-wheels, build-metapackage]
+    needs: [build-ttmetal, find-compatible, build-wheels, build-metapackage]
     if: ${{ needs.find-compatible.outputs.found == 'true' }}
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.hw_type) }}
     timeout-minutes: 180
@@ -326,20 +371,20 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Build tt-metal at SHA
-        id: ttmetal
+      - name: Download tt-metal install
+        uses: actions/download-artifact@v8
+        with:
+          name: ttmetal-install
+          path: /tmp/ttmetal-dl
+
+      - name: Unpack tt-metal install
         run: |
-          set -euo pipefail
-          tt_metal_sha="$(printf '%s' "$TT_METAL_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-          .github/scripts/build-ttmetal-at-sha.sh \
-            --sha "$tt_metal_sha" \
-            --scratch-dir /tmp/ttmetal-sha
-        env:
-          TT_METAL_SHA: ${{ inputs.tt_metal_sha }}
+          mkdir -p /tmp/ttmetal-install
+          tar -C /tmp/ttmetal-install --strip-components=1 -xzf /tmp/ttmetal-dl/ttmetal-install.tar.gz
 
       - name: Install light wheel and external tt-metal
         env:
-          TTMETAL_INSTALL_DIR: ${{ steps.ttmetal.outputs.install_dir }}
+          TTMETAL_INSTALL_DIR: /tmp/ttmetal-install
         run: |
           set -euo pipefail
           # Clean venv (no --system-site-packages): the installed light wheel and

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -367,24 +367,13 @@ jobs:
           # shellcheck disable=SC1091
           source /tmp/ttl-venv/bin/activate
           eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTL_EXTERNAL_TT_METAL_DIR")"
-          test_import_root="$(mktemp -d)"
-          mkdir -p "$test_import_root/utils"
-          cat > "$test_import_root/utils/__init__.py" <<'PY'
-          from ttl.utils import *  # noqa: F401,F403
-          PY
-          cat > "$test_import_root/utils/correctness.py" <<'PY'
-          from ttl.utils.correctness import *  # noqa: F401,F403
-          PY
-          cat > "$test_import_root/utils/block_allocation.py" <<'PY'
-          from ttl.utils.block_allocation import *  # noqa: F401,F403
-          PY
-          export PYTHONPATH="$test_import_root:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"
           # Wheel validation is a device smoke: confirm the installed wheel
-          # imports and runs real programs on device. Exhaustive test/python and
-          # test/me2e regression and compiler lit coverage run against the source
-          # build in the normal CI, so they are not repeated against the wheel.
+          # imports and runs the tutorial programs on device. Exhaustive
+          # test/python and test/me2e regression and compiler lit coverage run
+          # against the source build in the normal CI, not repeated against the
+          # wheel. smoketest and the tutorials import only ttl and ttnn, so no
+          # test-tree import shim is needed.
           python3 test/python/smoketest.py
-          bash .github/scripts/compile-and-run-examples.sh
           bash .github/scripts/run-tutorials.sh .
 
   publish:

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -379,12 +379,11 @@ jobs:
           from ttl.utils.block_allocation import *  # noqa: F401,F403
           PY
           export PYTHONPATH="$test_import_root:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"
+          # Wheel validation is a device smoke: confirm the installed wheel
+          # imports and runs real programs on device. Exhaustive test/python and
+          # test/me2e regression and compiler lit coverage run against the source
+          # build in the normal CI, so they are not repeated against the wheel.
           python3 test/python/smoketest.py
-          python3 test/python/simple_add.py
-          python3 -m pytest -c /dev/null --rootdir "$PWD" test/python -v --tb=short \
-            --timeout=300 --timeout-method=thread
-          python3 -m pytest -c /dev/null --rootdir "$PWD" test/me2e -v --tb=short \
-            --timeout=300 --timeout-method=thread
           bash .github/scripts/compile-and-run-examples.sh
           bash .github/scripts/run-tutorials.sh .
 

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -334,11 +334,7 @@ jobs:
           if [ -n "$prefix" ]; then
             key="$prefix/index.html"
           fi
-          aws s3 cp "s3://tenstorrent-pypi/$key" ./index.html
-          python3 .github/scripts/inject_s3_index_readme.py \
-            packaging/s3-index/README.md ./index.html
-          aws s3 cp ./index.html "s3://tenstorrent-pypi/$key" \
-            --content-type "text/html; charset=utf-8"
+          .github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist
 
       - name: Report install command
         run: |

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -178,15 +178,29 @@ jobs:
       - name: Fix git safe directory
         run: git config --global --add safe.directory '*'
 
+      # The patch runner and patches come from the workflow commit, not the
+      # (possibly older) target ref being rebuilt, which may predate them.
+      - name: Check out wheel patches from the workflow commit
+        if: ${{ inputs.apply_patches }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-patch-src
+          sparse-checkout: |
+            .github/scripts/apply-wheel-patches.sh
+            .github/wheel-patches
+          sparse-checkout-cone-mode: false
+
       - name: Apply wheel patches
         if: ${{ inputs.apply_patches }}
-        run: .github/scripts/apply-wheel-patches.sh
+        run: .wheel-patch-src/.github/scripts/apply-wheel-patches.sh --target-dir "$GITHUB_WORKSPACE"
 
       - name: Build light core wheel
         env:
           TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ needs.preflight.outputs.allow_final_internal_version }}
-          TTLANG_GIT_COMMIT: ${{ inputs.ttlang_ref || github.sha }}
         run: |
+          # inputs.ttlang_ref may be a tag or branch; record the resolved commit.
+          export TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"
           # Submodules aren't checked out here; read tt-metal's commit from the gitlink.
           export TT_METAL_COMMIT="$(git rev-parse HEAD:third-party/tt-metal)"
           .github/scripts/build-s3-light-core-wheel.sh --python-tag "${{ matrix.python_tag }}" --version "${{ needs.preflight.outputs.version_override }}" --dist-dir dist

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -295,8 +295,7 @@ jobs:
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
         run: python3 -m pip install s3pypi
 
-      # Nightly dev wheels (X.Y.Z.devYYYYMMDD) publish under a <YYYY-MM>/ subdir;
-      # stable releases (X.Y.Z) publish at the flat root. Publish layout only.
+      # Nightly dev wheels publish under <YYYY-MM>/; stable releases use root.
       - name: Derive publish prefix
         id: publish_prefix
         run: |
@@ -322,8 +321,7 @@ jobs:
           fi
           .github/scripts/publish-s3-wheels.sh "${publish_args[@]}" dist
 
-      # s3pypi rewrites the index it just wrote on every upload, so restore the
-      # human-facing README onto that index after publishing.
+      # s3pypi rewrites the index on upload; restore the README afterward.
       - name: Inject S3 index README
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
         run: |
@@ -351,9 +349,7 @@ jobs:
             "${{ needs.preflight.outputs.wheel_variant }}" \
             "${{ needs.preflight.outputs.version_override }}"
 
-  # Scheduled runs additionally build a per-tt-metal-SHA light wheel. This runs
-  # here (not on its own schedule) so it reuses the ird and manylinux images
-  # this run just pushed; the manylinux images carry no fixed tag to target.
+  # Reuse this run's freshly pushed ird and manylinux images.
   ttmetal-light-detect:
     name: "Detect tt-metal uplift for light wheel"
     needs: preflight
@@ -376,8 +372,7 @@ jobs:
       - name: Git safe directory
         run: git config --global --add safe.directory "$(pwd)"
 
-      # Detection reads TT_METAL_VERSION from tt-mlir's third_party/CMakeLists.txt,
-      # so fetch only that submodule; llvm-project and tt-metal are never needed.
+      # Detection needs only tt-mlir's TT_METAL_VERSION pin.
       - name: Fetch tt-mlir for uplift detection
         run: git submodule update --init --depth 1 third-party/tt-mlir
 

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -44,6 +44,16 @@ on:
         type: boolean
         default: true
         required: true
+      ttlang_ref:
+        description: "tt-lang SHA or tag to build the wheels from. Leave empty to use the triggering commit."
+        type: string
+        default: ""
+        required: false
+      apply_patches:
+        description: "Apply wheel patches from .github/wheel-patches/ before building (e.g., correct the numpy version constraints when rebuilding an older ref)."
+        type: boolean
+        default: false
+        required: false
 
 concurrency:
   group: publish-s3-pypi-${{ github.ref }}
@@ -73,6 +83,7 @@ jobs:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ttlang_ref || github.sha }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -98,6 +109,7 @@ jobs:
     secrets: inherit
     with:
       push: true
+      ttlang_sha_override: ${{ inputs.ttlang_ref }}
 
   build-wheel-images:
     needs: preflight
@@ -107,6 +119,8 @@ jobs:
       packages: write
     uses: ./.github/workflows/call-build-wheel-images.yml
     secrets: inherit
+    with:
+      ttlang_sha_override: ${{ inputs.ttlang_ref }}
 
   build-standard-wheels:
     needs: [preflight, build-docker]
@@ -129,6 +143,8 @@ jobs:
       build_sim_wheel: true
       allow_final_internal_version: ${{ needs.preflight.outputs.allow_final_internal_version == 'true' }}
       artifact_name: tt-lang-wheels-${{ matrix.wheel_variant }}
+      ttlang_sha_override: ${{ inputs.ttlang_ref }}
+      apply_patches: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_patches }}
 
   build-light-wheels:
     needs: [preflight, build-docker, build-wheel-images]
@@ -155,16 +171,21 @@ jobs:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ttlang_ref || github.sha }}
           fetch-depth: 0
           fetch-tags: true
 
       - name: Fix git safe directory
         run: git config --global --add safe.directory '*'
 
+      - name: Apply wheel patches
+        if: ${{ inputs.apply_patches }}
+        run: .github/scripts/apply-wheel-patches.sh
+
       - name: Build light core wheel
         env:
           TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ needs.preflight.outputs.allow_final_internal_version }}
-          TTLANG_GIT_COMMIT: ${{ github.sha }}
+          TTLANG_GIT_COMMIT: ${{ inputs.ttlang_ref || github.sha }}
         run: |
           # Submodules aren't checked out here; read tt-metal's commit from the gitlink.
           export TT_METAL_COMMIT="$(git rev-parse HEAD:third-party/tt-metal)"
@@ -201,6 +222,8 @@ jobs:
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_ref || github.sha }}
 
       - name: Download per-ABI wheels
         uses: actions/download-artifact@v8
@@ -247,6 +270,8 @@ jobs:
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_ref || github.sha }}
 
       - name: Download bundled wheels
         if: ${{ contains(fromJSON(needs.preflight.outputs.wheel_variants), 'bundled') }}
@@ -349,11 +374,14 @@ jobs:
             "${{ needs.preflight.outputs.wheel_variant }}" \
             "${{ needs.preflight.outputs.version_override }}"
 
-  # Reuse this run's freshly pushed ird and manylinux images.
+  # Reuse this run's freshly pushed ird and manylinux images. Best-effort:
+  # continue-on-error here and soft_fail on the reusable build below keep a
+  # failure in this extra wheel from failing the nightly publish.
   ttmetal-light-detect:
     name: "Detect tt-metal uplift for light wheel"
     needs: preflight
     if: ${{ github.event_name == 'schedule' }}
+    continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     defaults:
@@ -397,3 +425,4 @@ jobs:
       tt_metal_sha: ${{ needs.ttmetal-light-detect.outputs.tt_metal_sha }}
       docker_tag: ${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}
       dry_run: false
+      soft_fail: true

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -372,11 +372,14 @@ jobs:
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Git safe directory
         run: git config --global --add safe.directory "$(pwd)"
+
+      # Detection reads TT_METAL_VERSION from tt-mlir's third_party/CMakeLists.txt,
+      # so fetch only that submodule; llvm-project and tt-metal are never needed.
+      - name: Fetch tt-mlir for uplift detection
+        run: git submodule update --init --depth 1 third-party/tt-mlir
 
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure-tt-s3-credentials

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -69,14 +69,18 @@ jobs:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
         with:
-          # get-version-tag.sh needs the full history and version tags; the
-          # tt-mlir submodule holds the TT_METAL_VERSION detection reads.
           fetch-depth: 0
           fetch-tags: true
-          submodules: true
 
       - name: Git safe directory
         run: git config --global --add safe.directory "$(pwd)"
+
+      # Detection reads TT_METAL_VERSION from tt-mlir's third_party/CMakeLists.txt,
+      # so fetch only that submodule, and only when auto-detecting. A forced SHA
+      # skips detection entirely; llvm-project and tt-metal are never needed here.
+      - name: Fetch tt-mlir for uplift detection
+        if: ${{ inputs.tt_metal_sha == '' }}
+        run: git submodule update --init --depth 1 third-party/tt-mlir
 
       # Resolve the builder-image tag for the current main. The on-push main
       # build already pushed the ird and manylinux images at this content tag;

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -85,20 +85,27 @@ jobs:
         id: docker_tag
         run: echo "tag=$(.github/containers/get-version-tag.sh)" >> "$GITHUB_OUTPUT"
 
-      # Detection reads the published S3 prefix to decide idempotency.
+      # Idempotency detection reads the published S3 prefix, so credentials are
+      # needed only when auto-detecting for a real publish. Dry-run builds never
+      # publish (and OIDC authorizes only main), so they skip S3 entirely and
+      # stay runnable from any branch.
       - name: Configure AWS Credentials
+        if: ${{ inputs.dry_run != true && inputs.tt_metal_sha == '' }}
         uses: ./.github/actions/configure-tt-s3-credentials
 
       - name: Detect uplift
         id: detect
         env:
           FORCED_SHA: ${{ inputs.tt_metal_sha }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           if [ -n "$FORCED_SHA" ]; then
             echo "Forced tt-metal SHA: $FORCED_SHA"
             echo "uplift=true" >> "$GITHUB_OUTPUT"
             echo "tt_metal_sha=$FORCED_SHA" >> "$GITHUB_OUTPUT"
+          elif [ "$DRY_RUN" = "true" ]; then
+            .github/scripts/detect-ttmlir-ttmetal-uplift.sh --assume-new
           else
             .github/scripts/detect-ttmlir-ttmetal-uplift.sh
           fi

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# On-demand: build a tt-lang-light wheel for a given (or detected) tt-metal SHA.
-# The scheduled path lives in publish-s3-pypi.yml, which reuses the images it
-# just built; this manual entry point resolves the builder-image tag itself.
-# Force a tt_metal_sha, or leave it empty to detect from tt-mlir's pin.
+# Build a tt-lang-light wheel for a forced or tt-mlir-pinned tt-metal SHA.
+# Scheduled publishes use publish-s3-pypi.yml; this manual workflow resolves
+# the builder image tag itself.
 
 name: tt-lang-light wheel (on demand)
 
@@ -75,24 +74,17 @@ jobs:
       - name: Git safe directory
         run: git config --global --add safe.directory "$(pwd)"
 
-      # Detection reads TT_METAL_VERSION from tt-mlir's third_party/CMakeLists.txt,
-      # so fetch only that submodule, and only when auto-detecting. A forced SHA
-      # skips detection entirely; llvm-project and tt-metal are never needed here.
+      # Detection needs only tt-mlir's TT_METAL_VERSION pin.
       - name: Fetch tt-mlir for uplift detection
         if: ${{ inputs.tt_metal_sha == '' }}
         run: git submodule update --init --depth 1 third-party/tt-mlir
 
-      # Resolve the builder-image tag for the current main. The on-push main
-      # build already pushed the ird and manylinux images at this content tag;
-      # the manylinux images carry no :latest, so a fixed tag will not resolve.
+      # Manylinux builder images have content tags, not :latest.
       - name: Resolve builder image tag
         id: docker_tag
         run: echo "tag=$(.github/containers/get-version-tag.sh)" >> "$GITHUB_OUTPUT"
 
-      # Idempotency detection reads the published S3 prefix, so credentials are
-      # needed only when auto-detecting for a real publish. Dry-run builds never
-      # publish (and OIDC authorizes only main), so they skip S3 entirely and
-      # stay runnable from any branch.
+      # S3 idempotency is needed only for auto-detected real publishes.
       - name: Configure AWS Credentials
         if: ${{ inputs.dry_run != true && inputs.tt_metal_sha == '' }}
         uses: ./.github/actions/configure-tt-s3-credentials

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: ""
       ttlang_ref:
-        description: "tt-lang SHA or tag to build (skips the compatibility search). Empty = newest compatible."
+        description: "tt-lang SHA or tag to build (skips the compatibility search); requires tt_metal_sha. Empty = newest compatible."
         required: false
         type: string
         default: ""
@@ -98,10 +98,17 @@ jobs:
         id: detect
         env:
           FORCED_SHA: ${{ inputs.tt_metal_sha }}
+          TTLANG_REF: ${{ inputs.ttlang_ref }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           forced_sha="$(printf '%s' "$FORCED_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -n "$TTLANG_REF" ] && [ -z "$forced_sha" ]; then
+            echo "error: set tt_metal_sha when ttlang_ref is provided. Auto-detection reads" >&2
+            echo "the dispatch ref's third-party/tt-mlir pin, not the pinned ref's, so it" >&2
+            echo "would build the pinned tt-lang ref against the wrong tt-metal." >&2
+            exit 1
+          fi
           if [ -n "$forced_sha" ]; then
             echo "Forced tt-metal SHA: $forced_sha"
             echo "uplift=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: ""
+      ttlang_ref:
+        description: "tt-lang SHA or tag to build (skips the compatibility search). Empty = newest compatible."
+        required: false
+        type: string
+        default: ""
       docker_tag:
         description: "Builder image tag. Leave empty to resolve it from the current main (get-version-tag.sh)."
         required: false
@@ -119,6 +124,7 @@ jobs:
     secrets: inherit
     with:
       tt_metal_sha: ${{ needs.detect.outputs.tt_metal_sha }}
+      ttlang_ref: ${{ inputs.ttlang_ref }}
       docker_tag: ${{ inputs.docker_tag || needs.detect.outputs.docker_tag }}
       max_age_days: ${{ format('{0}', inputs.max_age_days) }}
       python_tags: ${{ inputs.python_tags }}

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -96,10 +96,11 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          if [ -n "$FORCED_SHA" ]; then
-            echo "Forced tt-metal SHA: $FORCED_SHA"
+          forced_sha="$(printf '%s' "$FORCED_SHA" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -n "$forced_sha" ]; then
+            echo "Forced tt-metal SHA: $forced_sha"
             echo "uplift=true" >> "$GITHUB_OUTPUT"
-            echo "tt_metal_sha=$FORCED_SHA" >> "$GITHUB_OUTPUT"
+            echo "tt_metal_sha=$forced_sha" >> "$GITHUB_OUTPUT"
           elif [ "$DRY_RUN" = "true" ]; then
             .github/scripts/detect-ttmlir-ttmetal-uplift.sh --assume-new
           else

--- a/.github/workflows/ttmetal-light-xla-on-demand.yml
+++ b/.github/workflows/ttmetal-light-xla-on-demand.yml
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: tt-lang-light XLA wheel (on demand)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ttlang_ref:
+        description: "tt-lang SHA or tag to build (v1.1.2 or newer; older refs lack the light packaging)."
+        required: true
+        type: string
+      tt_metal_sha:
+        description: "tt-metal commit SHA to build and link against."
+        required: true
+        type: string
+      docker_tag:
+        description: "IRD builder image tag. Leave empty to resolve it from ttlang_ref."
+        required: false
+        type: string
+        default: ""
+      version_override:
+        description: "PEP 440 base version. Leave empty to compute a nightly version from ttlang_ref."
+        required: false
+        type: string
+        default: ""
+      apply_patches:
+        description: "Apply wheel patches from the workflow commit before building."
+        required: false
+        type: boolean
+        default: false
+      allow_final_internal_version:
+        description: "Allow final internal versions."
+        required: false
+        type: boolean
+        default: false
+      hw_type:
+        description: "Hardware runner type for device validation."
+        required: false
+        type: string
+        default: "n150"
+
+concurrency:
+  group: ttmetal-light-xla-on-demand
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  resolve:
+    name: "Resolve build inputs"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      docker_tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout workflow commit
+        uses: actions/checkout@v6
+
+      - name: Checkout target tt-lang
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_ref }}
+          path: target-tt-lang
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Git safe directory
+        run: git config --global --add safe.directory '*'
+
+      # Tag and version are computed from the pinned checkout so an older ref
+      # builds against its matching builder image, not the current commit's.
+      - name: Resolve build inputs
+        id: resolve
+        env:
+          DOCKER_TAG: ${{ inputs.docker_tag }}
+          VERSION_OVERRIDE: ${{ inputs.version_override }}
+        run: |
+          .github/scripts/resolve-xla-build-inputs.sh \
+            --target-dir target-tt-lang \
+            --docker-tag "$DOCKER_TAG" \
+            --version "$VERSION_OVERRIDE"
+
+  build:
+    name: "Build Ubuntu tt-lang-light wheel"
+    needs: resolve
+    runs-on: mlir-large-runner-lang
+    timeout-minutes: 180
+    container:
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${{ needs.resolve.outputs.docker_tag }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout target tt-lang
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Git safe directory
+        run: git config --global --add safe.directory '*'
+
+      - name: Check out workflow helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .workflow-src
+          sparse-checkout: |
+            .github/scripts/apply-wheel-patches.sh
+            .github/scripts/build-ttmetal-at-sha.sh
+            .github/wheel-patches
+            scripts/install-ttmetal.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Apply wheel patches
+        if: ${{ inputs.apply_patches }}
+        run: .workflow-src/.github/scripts/apply-wheel-patches.sh --target-dir "$GITHUB_WORKSPACE"
+
+      - name: Record tt-lang HEAD
+        id: ttlang
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build tt-metal at SHA
+        id: ttmetal
+        run: |
+          set -euo pipefail
+          .workflow-src/.github/scripts/build-ttmetal-at-sha.sh \
+            --sha "${{ inputs.tt_metal_sha }}" \
+            --scratch-dir /tmp/ttmetal-xla-sha
+
+      - name: Validate wheel inputs and resolve versions
+        id: versions
+        env:
+          TTNN_DEP_MODE: external
+          VERSION_OVERRIDE: ${{ needs.resolve.outputs.version }}
+        run: .github/scripts/resolve-wheel-versions.sh
+
+      - name: Configure tt-lang
+        env:
+          TTLANG_VERSION_OVERRIDE: ${{ steps.versions.outputs.core_version }}
+          TTLANG_EXTERNAL_TT_METAL_DIR: ${{ steps.ttmetal.outputs.install_dir }}
+          TTLANG_PYTHON_VENV: /opt/ttlang-toolchain/venv
+          TTLANG_GIT_COMMIT: ${{ steps.ttlang.outputs.sha }}
+          TT_METAL_COMMIT: ${{ steps.ttmetal.outputs.sha }}
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          .github/scripts/configure-ttlang-build.sh build
+
+      - name: Install wheel build tools
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          pip install auditwheel packaging patchelf
+
+      - name: Build tt-lang wheel
+        env:
+          TTLANG_TTNN_DEP_MODE: external
+          TTLANG_VERSION_OVERRIDE: ${{ steps.versions.outputs.core_version }}
+          TTLANG_EXTERNAL_TT_METAL_DIR: ${{ steps.ttmetal.outputs.install_dir }}
+          TTLANG_PYTHON_VENV: /opt/ttlang-toolchain/venv
+          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ inputs.allow_final_internal_version }}
+          TTLANG_GIT_COMMIT: ${{ steps.ttlang.outputs.sha }}
+          TT_METAL_COMMIT: ${{ steps.ttmetal.outputs.sha }}
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          pip wheel . --wheel-dir=dist-raw --no-deps --no-build-isolation
+
+      - name: Test CMake-installed launchers
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          cmake --build build
+          cmake --install build --prefix /tmp/ttlang-prefix
+          /tmp/ttlang-prefix/bin/tt-lang-sim --help
+          /tmp/ttlang-prefix/bin/tt-lang-sim-stats --help
+
+      # Standard tt-lang-light wheels (no name/version suffix). The XLA build is
+      # distinguished by location: dist/xla/<ttmetal7> mirrors the per-tt-metal-SHA
+      # index layout under an xla prefix, so a consumer points --extra-index-url at
+      # xla/<ttmetal7>/ the same way it does for the normal per-SHA wheels.
+      - name: Repair tt-lang wheel
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          mkdir -p "dist/xla/${{ steps.ttmetal.outputs.short }}"
+          auditwheel repair dist-raw/*.whl --wheel-dir="dist/xla/${{ steps.ttmetal.outputs.short }}"
+
+      - name: Check tt-lang wheel metadata
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          python .github/scripts/check-wheel-ttnn-metadata.py \
+            --mode external \
+            --dist-dir "dist/xla/${{ steps.ttmetal.outputs.short }}"
+
+      - name: Test tt-lang wheel
+        run: |
+          python3.12 -m venv /tmp/test-venv-hw
+          source /tmp/test-venv-hw/bin/activate
+          pip install \
+            --no-cache-dir \
+            --extra-index-url https://download.pytorch.org/whl/cpu \
+            dist/xla/${{ steps.ttmetal.outputs.short }}/tt_lang-*.whl
+          python .github/scripts/check-installed-ttnn.py --mode external
+          python .github/scripts/smoke-test-wheel.py
+
+      - name: Free disk space before metapackage build
+        run: |
+          rm -rf /tmp/test-venv-hw /tmp/ttlang-prefix build dist-raw
+          python3.12 -m pip cache purge || true
+          df -h
+
+      - name: Build tt-lang-light metapackage
+        env:
+          TTLANG_VERSION_OVERRIDE: ${{ needs.resolve.outputs.version }}
+          TTLANG_LIGHT_TTLANG_VERSION: ${{ steps.versions.outputs.light_version }}
+          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ inputs.allow_final_internal_version }}
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          pip wheel packaging/light --wheel-dir="dist/xla/${{ steps.ttmetal.outputs.short }}" --no-deps --no-build-isolation
+
+      - name: Check metapackage metadata
+        run: |
+          source /opt/ttlang-toolchain/venv/bin/activate
+          python .github/scripts/check-light-metapackage.py \
+            --dist-dir "dist/xla/${{ steps.ttmetal.outputs.short }}" \
+            --expect-ttlang-version "${{ steps.versions.outputs.light_version }}"
+
+      - name: Report wheel sizes
+        run: ls -lh dist/xla/${{ steps.ttmetal.outputs.short }}/*.whl
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: tt-lang-light-xla-wheels
+          path: dist/xla/${{ steps.ttmetal.outputs.short }}/*.whl
+          retention-days: 14
+
+  device-validate:
+    name: "Device-validate XLA light wheel"
+    needs: [resolve, build]
+    runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.hw_type) }}
+    timeout-minutes: 180
+    container:
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${{ needs.resolve.outputs.docker_tag }}
+      options: --device /dev/tenstorrent
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+      packages: read
+    env:
+      PYTHONDONTWRITEBYTECODE: 1
+      TTLANG_TEST_SEED: 42
+    steps:
+      - name: Checkout target tt-lang
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_ref }}
+          fetch-depth: 1
+
+      - name: Git safe directory
+        run: git config --global --add safe.directory '*'
+
+      - name: Check out workflow helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .workflow-src
+          sparse-checkout: .github/scripts/build-ttmetal-at-sha.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Download XLA wheels
+        uses: actions/download-artifact@v8
+        with:
+          name: tt-lang-light-xla-wheels
+          path: dist
+
+      - name: Build tt-metal at SHA
+        id: ttmetal
+        run: |
+          set -euo pipefail
+          .workflow-src/.github/scripts/build-ttmetal-at-sha.sh \
+            --sha "${{ inputs.tt_metal_sha }}" \
+            --scratch-dir /tmp/ttmetal-xla-sha
+
+      - name: Install light wheel and external tt-metal
+        env:
+          TTMETAL_INSTALL_DIR: ${{ steps.ttmetal.outputs.install_dir }}
+        run: |
+          set -euo pipefail
+          # Clean venv: the installed wheel and the external tt-metal (built at
+          # the requested tt_metal_sha) must satisfy the suite on their own.
+          python3 -m venv /tmp/ttl-venv
+          # shellcheck disable=SC1091
+          source /tmp/ttl-venv/bin/activate
+          metapackage_wheel=$(ls dist/tt_lang_light-*-py3-none-any.whl)
+          pip install \
+            --find-links dist \
+            --extra-index-url https://download.pytorch.org/whl/cpu \
+            "$metapackage_wheel"
+          tt-lang-setup
+          eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTMETAL_INSTALL_DIR")"
+          echo "TTL_EXTERNAL_TT_METAL_DIR=$TTMETAL_INSTALL_DIR" >> "$GITHUB_ENV"
+
+      - name: Device suite
+        run: |
+          set -eo pipefail
+          # shellcheck disable=SC1091
+          source /tmp/ttl-venv/bin/activate
+          eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTL_EXTERNAL_TT_METAL_DIR")"
+          python3 test/python/smoketest.py
+          bash .github/scripts/run-tutorials.sh .

--- a/.github/workflows/ttmetal-light-xla-on-demand.yml
+++ b/.github/workflows/ttmetal-light-xla-on-demand.yml
@@ -241,6 +241,20 @@ jobs:
           path: dist/xla/${{ steps.ttmetal.outputs.short }}/*.whl
           retention-days: 14
 
+      # tar preserves the +x bit on the bundled sfpi compiler that JIT needs;
+      # device-validate downloads this instead of rebuilding tt-metal.
+      - name: Package tt-metal install
+        run: tar -C /tmp/ttmetal-xla-sha -czf /tmp/ttmetal-install.tar.gz install
+
+      - name: Upload tt-metal install
+        uses: actions/upload-artifact@v7
+        with:
+          name: ttmetal-install
+          path: /tmp/ttmetal-install.tar.gz
+          retention-days: 7
+          if-no-files-found: error
+          compression-level: 0
+
   device-validate:
     name: "Device-validate XLA light wheel"
     needs: [resolve, build]
@@ -273,31 +287,26 @@ jobs:
       - name: Git safe directory
         run: git config --global --add safe.directory '*'
 
-      - name: Check out workflow helpers
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.sha }}
-          path: .workflow-src
-          sparse-checkout: .github/scripts/build-ttmetal-at-sha.sh
-          sparse-checkout-cone-mode: false
-
       - name: Download XLA wheels
         uses: actions/download-artifact@v8
         with:
           name: tt-lang-light-xla-wheels
           path: dist
 
-      - name: Build tt-metal at SHA
-        id: ttmetal
+      - name: Download tt-metal install
+        uses: actions/download-artifact@v8
+        with:
+          name: ttmetal-install
+          path: /tmp/ttmetal-dl
+
+      - name: Unpack tt-metal install
         run: |
-          set -euo pipefail
-          .workflow-src/.github/scripts/build-ttmetal-at-sha.sh \
-            --sha "${{ inputs.tt_metal_sha }}" \
-            --scratch-dir /tmp/ttmetal-xla-sha
+          mkdir -p /tmp/ttmetal-install
+          tar -C /tmp/ttmetal-install --strip-components=1 -xzf /tmp/ttmetal-dl/ttmetal-install.tar.gz
 
       - name: Install light wheel and external tt-metal
         env:
-          TTMETAL_INSTALL_DIR: ${{ steps.ttmetal.outputs.install_dir }}
+          TTMETAL_INSTALL_DIR: /tmp/ttmetal-install
         run: |
           set -euo pipefail
           # Clean venv: the installed wheel and the external tt-metal (built at

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -650,6 +650,37 @@ mode-specific artifacts, verifies each artifact with the expected version rules,
 then publishes a single combined directory. The light build does not emit
 `tt-lang-sim`; bundled/public wheel builds keep producing the simulator wheel.
 
+To rebuild a light wheel from a specific older tt-lang commit or tag -- for
+example to reissue a release line whose original wheel no longer runs -- dispatch
+the workflow with a pinned ref, adding wheel patches when that ref's pinned
+dependencies no longer resolve:
+
+```text
+wheel_variant: light
+version_override: <internal-version>
+ttlang_ref: <tt-lang SHA or tag>
+apply_patches: true
+```
+
+`ttlang_ref` checks out that commit or tag for every wheel-building job instead
+of the triggering commit. `apply_patches` runs the scripts in
+`.github/wheel-patches/` against the checkout before building; the first patch
+rewrites a stale `numpy` pin to the current line's constraint so an older ref
+installs cleanly. The patch runner and the patches are taken from the workflow
+commit, not the pinned ref, so a ref that predates them is still patched.
+
+#### Building a light wheel for a specific tt-metal SHA
+
+`ttmetal-light-on-demand.yml` builds and device-tests a light wheel against an
+arbitrary tt-metal commit. Dispatch it with a `tt_metal_sha`; leave `ttlang_ref`
+empty to search for the newest compatible tt-lang commit, or set it to pin the
+tt-lang commit or tag to build. A pinned `ttlang_ref` requires `tt_metal_sha`,
+because auto-detection reads the dispatch ref's tt-mlir pin rather than the
+pinned ref's. With `dry_run: true` the workflow builds and validates without
+publishing and needs no S3 credentials, so it can run from a feature branch; the
+scheduled per-tt-metal-SHA build in `publish-s3-pypi.yml` is best-effort and does
+not fail the nightly publish.
+
 #### Local internal wheel testing
 
 Use the same environment variables as the reusable workflow when validating the

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -681,6 +681,35 @@ publishing and needs no S3 credentials, so it can run from a feature branch; the
 scheduled per-tt-metal-SHA build in `publish-s3-pypi.yml` is best-effort and does
 not fail the nightly publish.
 
+`ttmetal-light-xla-on-demand.yml` builds standard `tt-lang-light` wheels for the
+XLA flow from a specific tt-lang ref and tt-metal SHA. Dispatch it with:
+
+```text
+ttlang_ref: <tt-lang SHA or tag>
+tt_metal_sha: <tt-metal SHA>
+```
+
+Leave `docker_tag` and `version_override` empty to resolve them from the pinned
+`ttlang_ref`; the resolver runs that checkout's `get-version-tag.sh` and
+`compute-nightly-version.py` so the build uses the matching IRD image and wheel
+version for the selected tt-lang ref. Set `apply_patches: true` when the pinned
+ref needs the workflow commit's wheel patches. Set `hw_type` to select a device
+validation runner type; it defaults to `n150`.
+
+The XLA workflow uses the Ubuntu IRD image directly, builds the requested
+tt-metal SHA with `.github/scripts/build-ttmetal-at-sha.sh`, and builds the
+tt-lang wheel in `TTLANG_TTNN_DEP_MODE=external` mode. The wheels keep the
+standard package names and versions: `tt-lang==<version>+light` and
+`tt-lang-light==<version>`. The XLA distinction is the index location, not a
+wheel suffix: the build places both wheels under `dist/xla/<ttmetal7>/` and
+uploads that wheel set as the `tt-lang-light-xla-wheels` artifact. It does not
+use the manylinux_2_34 light-wheel builder or publish to S3.
+
+The workflow device-validates the uploaded wheels in a separate hardware job.
+That job rebuilds tt-metal at the same `tt_metal_sha`, installs the downloaded
+`tt-lang-light` wheel with the external tt-metal environment, then runs
+`test/python/smoketest.py` and the tutorial suite.
+
 #### Local internal wheel testing
 
 Use the same environment variables as the reusable workflow when validating the

--- a/test/packaging/test_ttlang_test_utils.py
+++ b/test/packaging/test_ttlang_test_utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import glob
 import importlib.util
+import os
 import sys
 import types
 from pathlib import Path
@@ -15,13 +16,40 @@ from pathlib import Path
 from conftest import REPO_ROOT
 
 
-def _load_ttlang_test_utils_with_device_glob(monkeypatch, device_nodes: list[str]):
-    fake_ttl = types.ModuleType("ttl")
-    fake_ttl.__path__ = []
-    fake_config = types.ModuleType("ttl.config")
-    fake_config.HAS_TT_DEVICE = False
-    monkeypatch.setitem(sys.modules, "ttl", fake_ttl)
-    monkeypatch.setitem(sys.modules, "ttl.config", fake_config)
+def _load_ttlang_test_utils(
+    monkeypatch,
+    *,
+    device_nodes: list[str] | None = None,
+    flat_nodes: list[str] | None = None,
+    has_tt_device: bool = False,
+    ttl_importable: bool = True,
+):
+    """Import ttlang_test_utils under controlled device/config conditions.
+
+    device_nodes feeds the /dev/tenstorrent/* glob, flat_nodes the legacy
+    /dev/tenstorrent[0-9]* glob, has_tt_device the wheel's build-time
+    ttl.config.HAS_TT_DEVICE, and ttl_importable whether ttl imports at all.
+    """
+    device_nodes = device_nodes or []
+    flat_nodes = flat_nodes or []
+
+    # Env vars checked before the device-node probe must not leak in from the
+    # CI runner. TTLANG_COMPILE_ONLY is set by the module as an import side
+    # effect; delenv here so monkeypatch restores its absence on teardown.
+    monkeypatch.delenv("TT_METAL_SIMULATOR", raising=False)
+    monkeypatch.delenv("TTLANG_HAS_DEVICE", raising=False)
+    monkeypatch.delenv("TTLANG_COMPILE_ONLY", raising=False)
+
+    if ttl_importable:
+        fake_ttl = types.ModuleType("ttl")
+        fake_ttl.__path__ = []
+        fake_config = types.ModuleType("ttl.config")
+        fake_config.HAS_TT_DEVICE = has_tt_device
+        monkeypatch.setitem(sys.modules, "ttl", fake_ttl)
+        monkeypatch.setitem(sys.modules, "ttl.config", fake_config)
+    else:
+        # None in sys.modules makes `from ttl.config import ...` raise ImportError.
+        monkeypatch.setitem(sys.modules, "ttl", None)
 
     real_glob = glob.glob
 
@@ -29,7 +57,7 @@ def _load_ttlang_test_utils_with_device_glob(monkeypatch, device_nodes: list[str
         if pattern == "/dev/tenstorrent/*":
             return device_nodes
         if pattern == "/dev/tenstorrent[0-9]*":
-            return []
+            return flat_nodes
         return real_glob(pattern)
 
     monkeypatch.setattr(glob, "glob", fake_glob)
@@ -46,8 +74,41 @@ def _load_ttlang_test_utils_with_device_glob(monkeypatch, device_nodes: list[str
 
 
 def test_runtime_device_nodes_override_no_device_build_config(monkeypatch) -> None:
-    module = _load_ttlang_test_utils_with_device_glob(
-        monkeypatch, ["/dev/tenstorrent/0"]
+    # A directory-style node is present but the wheel's build config reports no
+    # device; the runtime node must win. This is the core fix.
+    module = _load_ttlang_test_utils(
+        monkeypatch, device_nodes=["/dev/tenstorrent/0"], has_tt_device=False
     )
-
     assert module.is_hardware_available() is True
+
+
+def test_flat_style_device_node_is_detected(monkeypatch) -> None:
+    # The legacy flat node (/dev/tenstorrentN) is detected via the second glob.
+    module = _load_ttlang_test_utils(
+        monkeypatch, flat_nodes=["/dev/tenstorrent0"], has_tt_device=False
+    )
+    assert module.is_hardware_available() is True
+
+
+def test_no_nodes_and_no_build_config_is_compile_only(monkeypatch) -> None:
+    # No node and HAS_TT_DEVICE=False means not available; guards against a
+    # regression (e.g. a bad glob) that would report a device where there is
+    # none, and confirms compile-only mode is set.
+    module = _load_ttlang_test_utils(monkeypatch, has_tt_device=False)
+    assert module.is_hardware_available() is False
+    assert os.environ.get("TTLANG_COMPILE_ONLY") == "1"
+
+
+def test_build_config_true_without_nodes_is_available(monkeypatch) -> None:
+    # No runtime node, but the CMake build config reports a device; the
+    # ttl.config fallback below the node check still applies.
+    module = _load_ttlang_test_utils(monkeypatch, has_tt_device=True)
+    assert module.is_hardware_available() is True
+
+
+def test_no_nodes_and_ttl_unimportable_is_unavailable(monkeypatch) -> None:
+    # No node and ttl.config not importable: the fallback is False. The PR
+    # changed this from globbing /dev/tenstorrent* (which matched an empty
+    # driver directory as available).
+    module = _load_ttlang_test_utils(monkeypatch, ttl_importable=False)
+    assert module.is_hardware_available() is False

--- a/test/packaging/test_ttlang_test_utils.py
+++ b/test/packaging/test_ttlang_test_utils.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared test utility behavior used by packaging workflows."""
+
+from __future__ import annotations
+
+import glob
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from conftest import REPO_ROOT
+
+
+def _load_ttlang_test_utils_with_device_glob(monkeypatch, device_nodes: list[str]):
+    fake_ttl = types.ModuleType("ttl")
+    fake_ttl.__path__ = []
+    fake_config = types.ModuleType("ttl.config")
+    fake_config.HAS_TT_DEVICE = False
+    monkeypatch.setitem(sys.modules, "ttl", fake_ttl)
+    monkeypatch.setitem(sys.modules, "ttl.config", fake_config)
+
+    real_glob = glob.glob
+
+    def fake_glob(pattern: str):
+        if pattern == "/dev/tenstorrent/*":
+            return device_nodes
+        if pattern == "/dev/tenstorrent[0-9]*":
+            return []
+        return real_glob(pattern)
+
+    monkeypatch.setattr(glob, "glob", fake_glob)
+
+    module_path = REPO_ROOT / "test" / "ttlang_test_utils.py"
+    module_name = "ttlang_test_utils_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runtime_device_nodes_override_no_device_build_config(monkeypatch) -> None:
+    module = _load_ttlang_test_utils_with_device_glob(
+        monkeypatch, ["/dev/tenstorrent/0"]
+    )
+
+    assert module.is_hardware_available() is True

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -131,17 +131,14 @@ def test_ttmetal_light_max_age_crosses_reusable_workflow_as_string() -> None:
 
 def test_ttmetal_light_on_demand_detect_skips_s3_for_dry_run() -> None:
     workflow = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
-    # S3 credentials are configured only when auto-detecting for a real publish;
-    # a dry-run or forced-SHA run needs none and stays runnable from a branch.
+    # Dry-run and forced-SHA branch runs do not need S3 credentials.
     assert "if: ${{ inputs.dry_run != true && inputs.tt_metal_sha == '' }}" in workflow
-    # Dry-run auto-detect skips the S3 idempotency check.
     assert "detect-ttmlir-ttmetal-uplift.sh --assume-new" in workflow
 
 
 def test_ttmetal_light_on_demand_detect_avoids_full_submodule_clone() -> None:
     workflow = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
-    # The detect job must not full-clone submodules (llvm-project and tt-metal
-    # cost ~8 min and are unused); it fetches only tt-mlir, only when detecting.
+    # The detect job needs tt-mlir only; llvm-project and tt-metal are unused.
     assert "submodules: true" not in workflow
     assert "git submodule update --init --depth 1 third-party/tt-mlir" in workflow
     assert "if: ${{ inputs.tt_metal_sha == '' }}" in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -42,6 +42,9 @@ CALL_BUILD_WHEELS_WORKFLOW = (
 TTMETAL_LIGHT_ON_DEMAND_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "ttmetal-light-on-demand.yml"
 )
+TTMETAL_LIGHT_XLA_ON_DEMAND_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "ttmetal-light-xla-on-demand.yml"
+)
 MANYLINUX_WHEEL_DOCKERFILE = (
     REPO_ROOT / ".github" / "containers" / "Dockerfile.wheel-manylinux-2-34"
 )
@@ -241,6 +244,43 @@ def test_nightly_light_wheel_soft_fails_without_failing_publish() -> None:
     # continue-on-error is not valid on a reusable-workflow job).
     assert "soft_fail:" in reusable
     assert reusable.count("continue-on-error: ${{ inputs.soft_fail }}") == 6
+
+
+def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
+    workflow = TTMETAL_LIGHT_XLA_ON_DEMAND_WORKFLOW.read_text()
+
+    assert "ttlang_ref:" in workflow
+    assert "tt_metal_sha:" in workflow
+    assert "required: true" in workflow
+    assert "resolve-xla-build-inputs.sh" in workflow
+    assert "Leave empty to resolve it from ttlang_ref." in workflow
+    assert (
+        "tt-lang-ird-ubuntu-24-04:${{ needs.resolve.outputs.docker_tag }}" in workflow
+    )
+    assert ".github/scripts/build-ttmetal-at-sha.sh" in workflow
+    assert "--scratch-dir /tmp/ttmetal-xla-sha" in workflow
+    assert "TTNN_DEP_MODE: external" in workflow
+    assert "TTLANG_TTNN_DEP_MODE: external" in workflow
+    assert (
+        "TTLANG_EXTERNAL_TT_METAL_DIR: ${{ steps.ttmetal.outputs.install_dir }}"
+        in workflow
+    )
+    assert "TT_METAL_COMMIT: ${{ steps.ttmetal.outputs.sha }}" in workflow
+    assert "pip wheel . --wheel-dir=dist-raw --no-deps --no-build-isolation" in workflow
+    # Standard tt-lang-light wheels: no name/version suffix mechanism at all.
+    assert "EXTERNAL_WHEEL_SUFFIX" not in workflow
+    assert "--package-suffix" not in workflow
+    assert "light.xla" not in workflow
+    # XLA is distinguished by the dist/xla/<ttmetal7> location, not the wheel name.
+    assert "dist/xla/${{ steps.ttmetal.outputs.short }}" in workflow
+    assert "tt-lang-light-xla-wheels" in workflow
+    # The wheel is device-validated against the same tt-metal SHA it was built on.
+    assert "Device-validate XLA light wheel" in workflow
+    assert "options: --device /dev/tenstorrent" in workflow
+    assert "bash .github/scripts/run-tutorials.sh ." in workflow
+    assert "tt-lang-wheel-manylinux-2-34" not in workflow
+    assert "build-s3-light-core-wheel.sh" not in workflow
+    assert "build-s3-light-metapackage-wheel.sh" not in workflow
 
 
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -103,9 +103,25 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "metapackage_wheel=$(ls dist/tt_lang_light-*-py3-none-any.whl)" in workflow
     assert "--find-links dist" in workflow
     assert '"$metapackage_wheel"' in workflow
-    assert "tt_metal_sha=\"$(printf '%s' \"$TT_METAL_SHA\"" in workflow
+    assert "tt-lang-setup" in workflow
+    assert workflow.count("tt_metal_sha=\"$(printf '%s' \"$TT_METAL_SHA\"") == 3
     assert "echo \"ttmetal_short=${tt_metal_sha:0:7}\"" in workflow
-    assert 'export PYTHONPATH="$PWD/test${PYTHONPATH:+:$PYTHONPATH}"' in workflow
+    assert 'test_import_root="$(mktemp -d)"' in workflow
+    assert "from ttl.utils.correctness import *" in workflow
+    assert (
+        'export PYTHONPATH="$test_import_root:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"'
+        in workflow
+    )
+    assert (
+        'python3 -m pytest -c /dev/null --rootdir "$PWD" test/python'
+        in workflow
+    )
+    assert (
+        'python3 -m pytest -c /dev/null --rootdir "$PWD" test/me2e'
+        in workflow
+    )
+    assert "python3 -m pytest test/python" not in workflow
+    assert "python3 -m pytest test/me2e" not in workflow
     assert (
         '.github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist'
         in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -190,8 +190,17 @@ def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
     assert "ref: ${{ inputs.ttlang_ref || github.sha }}" in workflow
     # The override threads to the build reusables under their own input name.
     assert "ttlang_sha_override: ${{ inputs.ttlang_ref }}" in workflow
-    # Patches are applied to the checked-out tree before building.
-    assert ".github/scripts/apply-wheel-patches.sh" in workflow
+    # Patches come from the workflow commit (a checkout of github.sha), not the
+    # target ref -- an older ref that needs a patch predates the patch files.
+    assert "ref: ${{ github.sha }}" in workflow
+    assert "path: .wheel-patch-src" in workflow
+    assert (
+        ".wheel-patch-src/.github/scripts/apply-wheel-patches.sh"
+        ' --target-dir "$GITHUB_WORKSPACE"'
+    ) in workflow
+    # TTLANG_GIT_COMMIT records the resolved commit, not a tag/branch name.
+    assert 'export TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"' in workflow
+    assert "TTLANG_GIT_COMMIT: ${{ inputs.ttlang_ref" not in workflow
     # apply_patches stays a valid boolean on push/schedule (no dispatch inputs).
     assert (
         "apply_patches: ${{ github.event_name == 'workflow_dispatch'"
@@ -204,7 +213,20 @@ def test_call_build_wheels_supports_pinned_ref_and_patches() -> None:
     assert "ttlang_sha_override:" in workflow
     assert "apply_patches:" in workflow
     assert "ref: ${{ inputs.ttlang_sha_override || github.sha }}" in workflow
-    assert ".github/scripts/apply-wheel-patches.sh" in workflow
+    # Patches are sourced from the workflow commit and applied to the target tree.
+    assert "path: .wheel-patch-src" in workflow
+    assert (
+        ".wheel-patch-src/.github/scripts/apply-wheel-patches.sh"
+        ' --target-dir "$GITHUB_WORKSPACE"'
+    ) in workflow
+
+
+def test_on_demand_requires_tt_metal_sha_when_ttlang_ref_pinned() -> None:
+    workflow = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
+    # Auto-detect reads the dispatch ref's tt-metal pin, so a pinned tt-lang ref
+    # without an explicit tt_metal_sha would target the wrong tt-metal -- reject it.
+    assert 'if [ -n "$TTLANG_REF" ] && [ -z "$forced_sha" ]; then' in workflow
+    assert "TTLANG_REF: ${{ inputs.ttlang_ref }}" in workflow
 
 
 def test_nightly_light_wheel_soft_fails_without_failing_publish() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -81,6 +81,10 @@ def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     assert ".github/scripts/build-s3-light-core-wheel.sh" in workflow
     assert ".github/scripts/build-s3-light-metapackage-wheel.sh" in workflow
     assert ".github/scripts/test-s3-light-wheels.sh" in workflow
+    assert (
+        '.github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist'
+        in workflow
+    )
     assert "standard_wheel_matrix" in workflow
 
 
@@ -99,6 +103,11 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "metapackage_wheel=$(ls dist/tt_lang_light-*-py3-none-any.whl)" in workflow
     assert "--find-links dist" in workflow
     assert '"$metapackage_wheel"' in workflow
+    assert 'export PYTHONPATH="$PWD/test${PYTHONPATH:+:$PYTHONPATH}"' in workflow
+    assert (
+        '.github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist'
+        in workflow
+    )
 
 
 def test_ttmetal_light_max_age_crosses_reusable_workflow_as_string() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -104,22 +104,16 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "--find-links dist" in workflow
     assert '"$metapackage_wheel"' in workflow
     assert "tt-lang-setup" in workflow
-    assert workflow.count("tt_metal_sha=\"$(printf '%s' \"$TT_METAL_SHA\"") == 3
-    assert "echo \"ttmetal_short=${tt_metal_sha:0:7}\"" in workflow
+    assert workflow.count('tt_metal_sha="$(printf \'%s\' "$TT_METAL_SHA"') == 3
+    assert 'echo "ttmetal_short=${tt_metal_sha:0:7}"' in workflow
     assert 'test_import_root="$(mktemp -d)"' in workflow
     assert "from ttl.utils.correctness import *" in workflow
     assert (
         'export PYTHONPATH="$test_import_root:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"'
         in workflow
     )
-    assert (
-        'python3 -m pytest -c /dev/null --rootdir "$PWD" test/python'
-        in workflow
-    )
-    assert (
-        'python3 -m pytest -c /dev/null --rootdir "$PWD" test/me2e'
-        in workflow
-    )
+    assert 'python3 -m pytest -c /dev/null --rootdir "$PWD" test/python' in workflow
+    assert 'python3 -m pytest -c /dev/null --rootdir "$PWD" test/me2e' in workflow
     assert "python3 -m pytest test/python" not in workflow
     assert "python3 -m pytest test/me2e" not in workflow
     assert (
@@ -152,8 +146,8 @@ def test_ttmetal_light_on_demand_detect_skips_s3_for_dry_run() -> None:
     # Dry-run and forced-SHA branch runs do not need S3 credentials.
     assert "if: ${{ inputs.dry_run != true && inputs.tt_metal_sha == '' }}" in workflow
     assert "detect-ttmlir-ttmetal-uplift.sh --assume-new" in workflow
-    assert "forced_sha=\"$(printf '%s' \"$FORCED_SHA\"" in workflow
-    assert "echo \"tt_metal_sha=$forced_sha\" >> \"$GITHUB_OUTPUT\"" in workflow
+    assert 'forced_sha="$(printf \'%s\' "$FORCED_SHA"' in workflow
+    assert 'echo "tt_metal_sha=$forced_sha" >> "$GITHUB_OUTPUT"' in workflow
 
 
 def test_ttmetal_light_on_demand_detect_avoids_full_submodule_clone() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -129,6 +129,15 @@ def test_ttmetal_light_max_age_crosses_reusable_workflow_as_string() -> None:
     assert 'default: "14"' in reusable_max_age
 
 
+def test_ttmetal_light_on_demand_detect_skips_s3_for_dry_run() -> None:
+    workflow = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
+    # S3 credentials are configured only when auto-detecting for a real publish;
+    # a dry-run or forced-SHA run needs none and stays runnable from a branch.
+    assert "if: ${{ inputs.dry_run != true && inputs.tt_metal_sha == '' }}" in workflow
+    # Dry-run auto-detect skips the S3 idempotency check.
+    assert "detect-ttmlir-ttmetal-uplift.sh --assume-new" in workflow
+
+
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
     build_docker_workflow = CALL_BUILD_DOCKER_WORKFLOW.read_text()
     wheel_images_workflow = CALL_BUILD_WHEEL_IMAGES_WORKFLOW.read_text()

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -36,6 +36,9 @@ CALL_BUILD_WHEEL_IMAGES_WORKFLOW = (
 CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-ttmetal-light-wheel.yml"
 )
+CALL_BUILD_WHEELS_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "call-build-wheels.yml"
+)
 TTMETAL_LIGHT_ON_DEMAND_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "ttmetal-light-on-demand.yml"
 )
@@ -176,6 +179,45 @@ def test_pinned_ttlang_ref_skips_search_and_tt_metal_build() -> None:
     # The pin path emits the winner without the compatibility search.
     assert "python3 .github/scripts/compute-nightly-version.py" in reusable
     assert 'winner_sha="$(git rev-parse HEAD)"' in reusable
+
+
+def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    # Dispatch inputs to rebuild from a pinned ref and optionally patch it.
+    assert "ttlang_ref:" in workflow
+    assert "apply_patches:" in workflow
+    # Direct checkouts honor the pinned ref, falling back to the trigger commit.
+    assert "ref: ${{ inputs.ttlang_ref || github.sha }}" in workflow
+    # The override threads to the build reusables under their own input name.
+    assert "ttlang_sha_override: ${{ inputs.ttlang_ref }}" in workflow
+    # Patches are applied to the checked-out tree before building.
+    assert ".github/scripts/apply-wheel-patches.sh" in workflow
+    # apply_patches stays a valid boolean on push/schedule (no dispatch inputs).
+    assert (
+        "apply_patches: ${{ github.event_name == 'workflow_dispatch'"
+        " && inputs.apply_patches }}"
+    ) in workflow
+
+
+def test_call_build_wheels_supports_pinned_ref_and_patches() -> None:
+    workflow = CALL_BUILD_WHEELS_WORKFLOW.read_text()
+    assert "ttlang_sha_override:" in workflow
+    assert "apply_patches:" in workflow
+    assert "ref: ${{ inputs.ttlang_sha_override || github.sha }}" in workflow
+    assert ".github/scripts/apply-wheel-patches.sh" in workflow
+
+
+def test_nightly_light_wheel_soft_fails_without_failing_publish() -> None:
+    publish = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    reusable = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
+    # The scheduled detect job tolerates its own failure, and the reusable
+    # build it feeds is invoked in soft-fail mode.
+    assert "continue-on-error: true" in publish
+    assert "soft_fail: true" in publish
+    # Every job in the reusable build honors soft_fail (caller-level
+    # continue-on-error is not valid on a reusable-workflow job).
+    assert "soft_fail:" in reusable
+    assert reusable.count("continue-on-error: ${{ inputs.soft_fail }}") == 6
 
 
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -115,10 +115,14 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
         'export PYTHONPATH="$test_import_root:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"'
         in workflow
     )
-    assert 'python3 -m pytest -c /dev/null --rootdir "$PWD" test/python' in workflow
-    assert 'python3 -m pytest -c /dev/null --rootdir "$PWD" test/me2e' in workflow
-    assert "python3 -m pytest test/python" not in workflow
-    assert "python3 -m pytest test/me2e" not in workflow
+    # Wheel validation is a device smoke (installed wheel imports and runs real
+    # programs on device); the exhaustive regression runs on the source build.
+    assert "test/python/smoketest.py" in workflow
+    assert ".github/scripts/compile-and-run-examples.sh" in workflow
+    assert ".github/scripts/run-tutorials.sh ." in workflow
+    assert 'pytest -c /dev/null --rootdir "$PWD" test/python' not in workflow
+    assert 'pytest -c /dev/null --rootdir "$PWD" test/me2e' not in workflow
+    assert "simple_add" not in workflow
     assert (
         '.github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist'
         in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -101,7 +101,10 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "matrix.python_tag == 'cp312'" not in workflow
     assert "name: ttmetal-light-metapackage" in workflow
     assert "path: dist/tt_lang_light-*.whl" in workflow
-    assert "needs: [find-compatible, build-wheels, build-metapackage]" in workflow
+    assert (
+        "needs: [build-ttmetal, find-compatible, build-wheels, build-metapackage]"
+        in workflow
+    )
     assert (
         "needs: [find-compatible, build-wheels, build-metapackage, device-validate]"
         in workflow
@@ -110,8 +113,20 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "--find-links dist" in workflow
     assert '"$metapackage_wheel"' in workflow
     assert "tt-lang-setup" in workflow
-    assert workflow.count('tt_metal_sha="$(printf \'%s\' "$TT_METAL_SHA"') == 3
-    assert 'echo "ttmetal_short=${tt_metal_sha:0:7}"' in workflow
+    # tt-metal is built once (build-ttmetal, in the oldest-glibc manylinux
+    # container) and the install is shared as an artifact; find-compatible,
+    # build-wheels, and device-validate download it instead of rebuilding.
+    assert "build-ttmetal:" in workflow
+    assert workflow.count(".github/scripts/build-ttmetal-at-sha.sh") == 1
+    assert "tt-lang-wheel-manylinux-2-34-cp312" in workflow
+    # One upload + three downloads of the shared install.
+    assert workflow.count("name: ttmetal-install") == 4
+    assert "TTLANG_EXTERNAL_TT_METAL_DIR: /tmp/ttmetal-install" in workflow
+    assert "TTMETAL_INSTALL_DIR: /tmp/ttmetal-install" in workflow
+    # tar transfer (not a bare artifact) so the sfpi compiler keeps its +x bit;
+    # unpacked by each of the three consumers.
+    assert "Package tt-metal install" in workflow
+    assert workflow.count("--strip-components=1") == 3
     # Wheel validation is a device smoke -- smoketest plus the tutorials, which
     # import only ttl and ttnn. The exhaustive test/python and test/me2e
     # regression runs against the source build, so it is not repeated here, and
@@ -243,7 +258,7 @@ def test_nightly_light_wheel_soft_fails_without_failing_publish() -> None:
     # Every job in the reusable build honors soft_fail (caller-level
     # continue-on-error is not valid on a reusable-workflow job).
     assert "soft_fail:" in reusable
-    assert reusable.count("continue-on-error: ${{ inputs.soft_fail }}") == 6
+    assert reusable.count("continue-on-error: ${{ inputs.soft_fail }}") == 7
 
 
 def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
@@ -278,6 +293,12 @@ def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
     assert "Device-validate XLA light wheel" in workflow
     assert "options: --device /dev/tenstorrent" in workflow
     assert "bash .github/scripts/run-tutorials.sh ." in workflow
+    # tt-metal built once (build job), shared as a tar artifact preserving the
+    # sfpi +x bit; device-validate downloads and unpacks it, not rebuilds.
+    assert "Package tt-metal install" in workflow
+    assert workflow.count("name: ttmetal-install") == 2
+    assert "TTMETAL_INSTALL_DIR: /tmp/ttmetal-install" in workflow
+    assert "--strip-components=1" in workflow
     assert "tt-lang-wheel-manylinux-2-34" not in workflow
     assert "build-s3-light-core-wheel.sh" not in workflow
     assert "build-s3-light-metapackage-wheel.sh" not in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -109,17 +109,14 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "tt-lang-setup" in workflow
     assert workflow.count('tt_metal_sha="$(printf \'%s\' "$TT_METAL_SHA"') == 3
     assert 'echo "ttmetal_short=${tt_metal_sha:0:7}"' in workflow
-    assert 'test_import_root="$(mktemp -d)"' in workflow
-    assert "from ttl.utils.correctness import *" in workflow
-    assert (
-        'export PYTHONPATH="$test_import_root:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"'
-        in workflow
-    )
-    # Wheel validation is a device smoke (installed wheel imports and runs real
-    # programs on device); the exhaustive regression runs on the source build.
+    # Wheel validation is a device smoke -- smoketest plus the tutorials, which
+    # import only ttl and ttnn. The exhaustive test/python and test/me2e
+    # regression runs against the source build, so it is not repeated here, and
+    # the test-tree import shim it needed is gone.
     assert "test/python/smoketest.py" in workflow
-    assert ".github/scripts/compile-and-run-examples.sh" in workflow
     assert ".github/scripts/run-tutorials.sh ." in workflow
+    assert "compile-and-run-examples.sh" not in workflow
+    assert "test_import_root" not in workflow
     assert 'pytest -c /dev/null --rootdir "$PWD" test/python' not in workflow
     assert 'pytest -c /dev/null --rootdir "$PWD" test/me2e' not in workflow
     assert "simple_add" not in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -138,6 +138,15 @@ def test_ttmetal_light_on_demand_detect_skips_s3_for_dry_run() -> None:
     assert "detect-ttmlir-ttmetal-uplift.sh --assume-new" in workflow
 
 
+def test_ttmetal_light_on_demand_detect_avoids_full_submodule_clone() -> None:
+    workflow = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
+    # The detect job must not full-clone submodules (llvm-project and tt-metal
+    # cost ~8 min and are unused); it fetches only tt-mlir, only when detecting.
+    assert "submodules: true" not in workflow
+    assert "git submodule update --init --depth 1 third-party/tt-mlir" in workflow
+    assert "if: ${{ inputs.tt_metal_sha == '' }}" in workflow
+
+
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
     build_docker_workflow = CALL_BUILD_DOCKER_WORKFLOW.read_text()
     wheel_images_workflow = CALL_BUILD_WHEEL_IMAGES_WORKFLOW.read_text()

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -103,6 +103,8 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "metapackage_wheel=$(ls dist/tt_lang_light-*-py3-none-any.whl)" in workflow
     assert "--find-links dist" in workflow
     assert '"$metapackage_wheel"' in workflow
+    assert "tt_metal_sha=\"$(printf '%s' \"$TT_METAL_SHA\"" in workflow
+    assert "echo \"ttmetal_short=${tt_metal_sha:0:7}\"" in workflow
     assert 'export PYTHONPATH="$PWD/test${PYTHONPATH:+:$PYTHONPATH}"' in workflow
     assert (
         '.github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist'
@@ -134,6 +136,8 @@ def test_ttmetal_light_on_demand_detect_skips_s3_for_dry_run() -> None:
     # Dry-run and forced-SHA branch runs do not need S3 credentials.
     assert "if: ${{ inputs.dry_run != true && inputs.tt_metal_sha == '' }}" in workflow
     assert "detect-ttmlir-ttmetal-uplift.sh --assume-new" in workflow
+    assert "forced_sha=\"$(printf '%s' \"$FORCED_SHA\"" in workflow
+    assert "echo \"tt_metal_sha=$forced_sha\" >> \"$GITHUB_OUTPUT\"" in workflow
 
 
 def test_ttmetal_light_on_demand_detect_avoids_full_submodule_clone() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -158,6 +158,26 @@ def test_ttmetal_light_on_demand_detect_avoids_full_submodule_clone() -> None:
     assert "if: ${{ inputs.tt_metal_sha == '' }}" in workflow
 
 
+def test_ttlang_ref_threads_from_on_demand_to_reusable_workflow() -> None:
+    on_demand = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
+    reusable = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
+    # The on-demand input is declared and passed through to the reusable build.
+    assert "ttlang_ref:" in on_demand
+    assert "ttlang_ref: ${{ inputs.ttlang_ref }}" in on_demand
+    assert "ttlang_ref:" in reusable
+
+
+def test_pinned_ttlang_ref_skips_search_and_tt_metal_build() -> None:
+    reusable = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
+    # A pinned ref is checked out directly and drives the build.
+    assert "ref: ${{ inputs.ttlang_ref }}" in reusable
+    # The tt-metal build (the search's device gate) is skipped when pinning.
+    assert "if: ${{ inputs.ttlang_ref == '' }}" in reusable
+    # The pin path emits the winner without the compatibility search.
+    assert "python3 .github/scripts/compute-nightly-version.py" in reusable
+    assert 'winner_sha="$(git rev-parse HEAD)"' in reusable
+
+
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
     build_docker_workflow = CALL_BUILD_DOCKER_WORKFLOW.read_text()
     wheel_images_workflow = CALL_BUILD_WHEEL_IMAGES_WORKFLOW.read_text()

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -191,8 +191,9 @@ def test_ttlang_ref_threads_from_on_demand_to_reusable_workflow() -> None:
 
 def test_pinned_ttlang_ref_skips_search_and_tt_metal_build() -> None:
     reusable = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
-    # A pinned ref is checked out directly and drives the build.
-    assert "ref: ${{ inputs.ttlang_ref }}" in reusable
+    # A pinned ref is checked out directly, falling back to the trigger commit
+    # in search mode, and drives the build.
+    assert "ref: ${{ inputs.ttlang_ref || github.sha }}" in reusable
     # The tt-metal build (the search's device gate) is skipped when pinning.
     assert "if: ${{ inputs.ttlang_ref == '' }}" in reusable
     # The pin path emits the winner without the compatibility search.

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -9,8 +9,7 @@ Provides unified feature detection (ttnn availability, hardware detection),
 tensor creation helpers, and comparison utilities. Used across pytest conftest
 files, lit configuration, and test scripts.
 
-Device availability is determined by checking environment variables and
-/dev/tenstorrent* files, avoiding the slow ttnn.GetNumAvailableDevices() call.
+Device availability is checked without importing ttnn.
 """
 
 import glob
@@ -24,8 +23,7 @@ from typing import Any, Sequence
 # Feature detection
 # =============================================================================
 
-# Check device availability: env vars first (for simulator), then runtime device
-# nodes, then CMake config.
+# Prefer runtime state over the wheel's build-time device flag.
 _hardware_available = False
 
 

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -93,7 +93,11 @@ def is_hardware_available() -> bool:
     Checks in order:
     1. TT_METAL_SIMULATOR environment variable (simulation mode)
     2. TTLANG_HAS_DEVICE environment variable (set by CMake)
-    3. Physical device files (/dev/tenstorrent*)
+    3. Runtime device nodes (/dev/tenstorrent/* or /dev/tenstorrent[0-9]*)
+    4. ttl.config.HAS_TT_DEVICE, the wheel's build-time value (fallback)
+
+    Step 3 precedes step 4 so an installed light wheel, built with no device
+    and therefore HAS_TT_DEVICE=False, still runs on a host that has a chip.
 
     Returns:
         True if hardware or simulator is available, False otherwise.

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -24,12 +24,20 @@ from typing import Any, Sequence
 # Feature detection
 # =============================================================================
 
-# Check device availability: env vars first (for simulator), then CMake config.
+# Check device availability: env vars first (for simulator), then runtime device
+# nodes, then CMake config.
 _hardware_available = False
+
+
+def _has_tenstorrent_device_node() -> bool:
+    return bool(glob.glob("/dev/tenstorrent/*") or glob.glob("/dev/tenstorrent[0-9]*"))
+
 
 if os.environ.get("TT_METAL_SIMULATOR"):
     _hardware_available = True
 elif os.environ.get("TTLANG_HAS_DEVICE") == "1":
+    _hardware_available = True
+elif _has_tenstorrent_device_node():
     _hardware_available = True
 else:
     try:
@@ -37,7 +45,7 @@ else:
 
         _hardware_available = HAS_TT_DEVICE
     except ImportError:
-        _hardware_available = bool(glob.glob("/dev/tenstorrent*"))
+        _hardware_available = False
 
 # Set compile-only mode if no hardware.
 if not _hardware_available:


### PR DESCRIPTION
### Problem description

The tt-lang-light on-demand validation was not a clean installed-wheel check. It could inherit packages from the ird image and source checkout state, which made it possible to pass for reasons unrelated to the wheel that users install. Light wheels are also built in a no-device manylinux container, so validation must use runtime device availability rather than a build-time device flag.

The scheduled S3 publish also failed when `s3pypi upload --put-root-index --prefix <YYYY-MM>` did not create the prefix root `index.html`.

Two operational gaps compounded this. There was no way to rebuild wheels from a specific older tt-lang commit or tag, which is needed for custom v1.1.x rebuilds, and the on-demand workflow could not be exercised from a feature branch because dry-run detection still assumed AWS/OIDC credentials authorized only from `main`.

### What's changed

Installed-wheel validation:
- The tt-lang-light device suite now installs the metapackage into a clean venv with no `--system-site-packages`, configures the external tt-metal install, and runs only user-facing wheel smoke coverage: `smoketest.py` plus the tutorial programs.
- The wheel smoke does not add repository `test/` to `PYTHONPATH`; it validates imports and execution through the installed `ttl` package and `ttnn`.
- `ttlang_test_utils` hardware detection now prefers runtime Tenstorrent device nodes over the wheel's build-time `HAS_TT_DEVICE` value, so repository tests that use the helper do not skip incorrectly when a chip is present.
- Adds `.github/scripts/inject-s3-index-readme.sh`, which restores the human-facing S3 index README and, only on a missing-key 404, synthesizes the prefix root package index from the wheel dist.

Rebuild from a pinned ref, with optional patches:
- Adds a `ttlang_ref` input to the on-demand workflow, `publish-s3-pypi`, and the build reusables so a specific tt-lang SHA or tag can be built.
- Requires `tt_metal_sha` when an on-demand `ttlang_ref` is provided, preventing a pinned tt-lang ref from silently using the dispatch ref's tt-metal pin.
- Adds `apply_patches`, `.github/scripts/apply-wheel-patches.sh`, and `.github/wheel-patches/`. The first patch rewrites the numpy requirement to the current line's values so older refs can install against current torch/ttnn constraints.
- Sources the patch runner and patch files from the workflow commit and applies them to the target checkout, so refs that predate the patch infrastructure can still be patched.
- Records `TTLANG_GIT_COMMIT` from the resolved checkout commit rather than a tag or branch name.

On-demand and nightly workflow:
- The detect job configures AWS credentials only for an auto-detected real publish. Branch dry-runs use `--assume-new` and skip the S3 idempotency read.
- Detect jobs fetch only the tt-mlir submodule, which contains the tt-metal pin, instead of cloning all submodules.
- Adds `soft_fail` for the scheduled per-tt-metal-SHA light wheel so failures in that extra wheel do not fail the nightly publish.
- Adds the missing `ttlang_sha_override` `workflow_call` input to `call-build-docker.yml`.

### Testing

- `git diff --check origin/main...HEAD`
- `python3 -m pytest -c /dev/null test/packaging/test_workflow_helper_scripts.py test/packaging/test_ttlang_test_utils.py -q`
- `BATS_LIB_PATH=/usr/local/lib/bats bats .github/scripts/tests/test_apply_wheel_patches.bats .github/scripts/tests/test_build_ttmetal_at_sha.bats .github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats .github/scripts/tests/test_inject_s3_index_readme.bats .github/scripts/tests/test_inject_s3_index_readme_shell.bats`

The S3 publish step itself still runs only from `main`, since its OIDC role is authorized there, and is validated after merge.
