### PR TITLE
[ci] Miscellaneous fixes for the tt-lang-light wheel publishing CI workflow

### DIFF
--- a/.github/scripts/build-s3-light-core-wheel.sh
+++ b/.github/scripts/build-s3-light-core-wheel.sh
@@ -113,7 +113,14 @@ if [ ! -f "$expected_wheel" ]; then
 fi
 
 auditwheel show "$expected_wheel"
-python "$repo_root/.github/scripts/check-wheel-ttnn-metadata.py" \
-    --mode external \
-    --dist-dir "$DIST_DIR"
+if [ -n "${TT_METAL_COMMIT:-}" ]; then
+    python "$repo_root/.github/scripts/check-wheel-ttnn-metadata.py" \
+        --mode external \
+        --dist-dir "$DIST_DIR" \
+        --expect-tt-metal-commit "$TT_METAL_COMMIT"
+else
+    python "$repo_root/.github/scripts/check-wheel-ttnn-metadata.py" \
+        --mode external \
+        --dist-dir "$DIST_DIR"
+fi
 "$repo_root/.github/scripts/assert-no-gnu-unique.sh" "$expected_wheel"

--- a/.github/scripts/build-ttmetal-at-sha.sh
+++ b/.github/scripts/build-ttmetal-at-sha.sh
@@ -8,7 +8,7 @@
 #   install_dir=<path>   (default mode)  -- pass to TTLANG_EXTERNAL_TT_METAL_DIR
 #   source_dir=<path>    (--no-build)    -- checked-out tt-metal source tree
 #   ttmetal_date=<iso>                   -- the SHA's committer date (%cI)
-#   sha=<sha>                            -- the normalized (trimmed) SHA built
+#   sha=<sha>                            -- the full checked-out SHA built
 #   short=<sha7>                         -- the SHA's 7-char prefix
 #
 # The tt-metal build is standalone (its own cmake config, mirrored from
@@ -98,7 +98,7 @@ ensure_source() {
 }
 
 commit_date() {
-    git -C "$src_dir" show -s --format=%cI "$sha"
+    git -C "$src_dir" show -s --format=%cI "$1"
 }
 
 # Log whether $sha carries a release tag. The published ttnn wheel for a tagged
@@ -186,9 +186,10 @@ build_and_install() {
 
 ensure_source
 log_release_tag
-ttmetal_date="$(commit_date)"
-emit "sha=$sha"
-emit "short=${sha:0:7}"
+checked_out_sha="$(source_sha)"
+ttmetal_date="$(commit_date "$checked_out_sha")"
+emit "sha=$checked_out_sha"
+emit "short=${checked_out_sha:0:7}"
 
 if [[ "$no_build" -eq 1 ]]; then
     emit "source_dir=$src_dir"

--- a/.github/scripts/check-light-metapackage.py
+++ b/.github/scripts/check-light-metapackage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-"""Verify the tt-lang-light metapackage pins tt-lang at the expected version.
+"""Verify the tt-lang-light metapackage metadata.
 
 Usage: check-light-metapackage.py --dist-dir <dir> --expect-ttlang-version <ver>
 """
@@ -12,6 +12,8 @@ import sys
 import zipfile
 
 from packaging.requirements import InvalidRequirement, Requirement
+
+REQUIRES_PYTHON = ">=3.10"
 
 
 def _metadata_for(pattern: str) -> str:
@@ -34,8 +36,12 @@ def main() -> int:
     parser.add_argument("--expect-ttlang-version", required=True)
     args = parser.parse_args()
 
+    metadata = _metadata_for(f"{args.dist_dir}/tt_lang_light-*.whl")
     requirements = []
-    for line in _metadata_for(f"{args.dist_dir}/tt_lang_light-*.whl").splitlines():
+    has_requires_python = False
+    for line in metadata.splitlines():
+        if line == f"Requires-Python: {REQUIRES_PYTHON}":
+            has_requires_python = True
         if not line.startswith("Requires-Dist:"):
             continue
         try:
@@ -59,7 +65,18 @@ def main() -> int:
         )
         return 1
 
-    print(f"tt-lang-light pins tt-lang=={args.expect_ttlang_version}")
+    if not has_requires_python:
+        print(
+            "tt-lang-light must declare "
+            f"Requires-Python: {REQUIRES_PYTHON}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"tt-lang-light pins tt-lang=={args.expect_ttlang_version} "
+        f"and Requires-Python: {REQUIRES_PYTHON}"
+    )
     return 0
 
 

--- a/.github/scripts/check-light-metapackage.py
+++ b/.github/scripts/check-light-metapackage.py
@@ -67,8 +67,7 @@ def main() -> int:
 
     if not has_requires_python:
         print(
-            "tt-lang-light must declare "
-            f"Requires-Python: {REQUIRES_PYTHON}",
+            "tt-lang-light must declare " f"Requires-Python: {REQUIRES_PYTHON}",
             file=sys.stderr,
         )
         return 1

--- a/.github/scripts/check-wheel-ttnn-metadata.py
+++ b/.github/scripts/check-wheel-ttnn-metadata.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-"""Verify the tt-lang wheel METADATA Requires-Dist matches the ttnn dep mode.
+"""Verify the tt-lang wheel metadata matches the requested build mode.
 
 The "pypi" mode must declare a Requires-Dist on ttnn. The "external" and
-"bundled" modes must not.
+"bundled" modes must not. When --expect-tt-metal-commit is passed, the generated
+ttl/config.py file must record the same tt-metal commit.
 
-Usage: check-wheel-ttnn-metadata.py --mode {pypi,external,bundled} --dist-dir <dir>
+Usage: check-wheel-ttnn-metadata.py --mode {pypi,external,bundled}
+    --dist-dir <dir> [--expect-tt-metal-commit <sha>]
 """
 
 import argparse
 import glob
+import re
 import sys
 import zipfile
 
 from packaging.requirements import InvalidRequirement, Requirement
 
 MODES = ("pypi", "external", "bundled")
+TT_METAL_COMMIT_RE = re.compile(r'^TT_METAL_COMMIT = "([^"]*)"$', re.MULTILINE)
 
 
 def _read_metadata(wheel_path: str) -> str:
@@ -33,6 +37,18 @@ def _read_metadata(wheel_path: str) -> str:
 def _has_bundled_ttnn_payload(wheel_path: str) -> bool:
     with zipfile.ZipFile(wheel_path) as wheel:
         return any(name.startswith("ttnn/") for name in wheel.namelist())
+
+
+def _tt_metal_commit(wheel_path: str) -> str:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        try:
+            config_py = wheel.read("ttl/config.py").decode()
+        except KeyError as error:
+            raise ValueError(f"{wheel_path} has no ttl/config.py entry") from error
+    match = TT_METAL_COMMIT_RE.search(config_py)
+    if not match:
+        raise ValueError(f"{wheel_path} ttl/config.py has no TT_METAL_COMMIT")
+    return match.group(1)
 
 
 def _requires_ttnn(metadata: str) -> bool:
@@ -52,6 +68,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", required=True, choices=MODES)
     parser.add_argument("--dist-dir", required=True)
+    parser.add_argument("--expect-tt-metal-commit")
     args = parser.parse_args()
 
     wheels = glob.glob(f"{args.dist_dir}/tt_lang-*.whl")
@@ -77,6 +94,19 @@ def main() -> int:
     if args.mode == "pypi" and not has_ttnn:
         print("default wheel metadata must require ttnn", file=sys.stderr)
         return 1
+    if args.expect_tt_metal_commit is not None:
+        try:
+            tt_metal_commit = _tt_metal_commit(wheels[0])
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 1
+        if tt_metal_commit != args.expect_tt_metal_commit:
+            print(
+                "tt-lang wheel tt-metal provenance mismatch: "
+                f"expected {args.expect_tt_metal_commit}, got {tt_metal_commit}",
+                file=sys.stderr,
+            )
+            return 1
 
     print(f"{wheels[0]}: ttnn dependency present={has_ttnn}")
     return 0

--- a/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
+++ b/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Detect whether tt-lang should build a light wheel for tt-mlir's pinned
-# tt-metal SHA, keyed by the tt-lang/<SHA7> S3 prefix.
+# tt-metal SHA, keyed by the tt-lang/<ttmetal7> S3 prefix.
 #
 # A SHA is skipped when a wheel is already published, and also when a prior
 # search recorded no compatible tt-lang AND the tt-lang HEAD it searched is
@@ -121,11 +121,11 @@ main() {
     fi
     case "$class" in
         published)
-        echo "Wheel already published under tt-lang/$short_sha; skipping." >&2
-        emit "uplift=false" ;;
-    doomed)
-        echo "Recorded miss under tt-lang/$short_sha for the current tt-lang HEAD; skipping." >&2
-        emit "uplift=false" ;;
+            echo "Wheel already published under tt-lang/$short_sha; skipping." >&2
+            emit "uplift=false" ;;
+        doomed)
+            echo "Recorded miss under tt-lang/$short_sha for the current tt-lang HEAD; skipping." >&2
+            emit "uplift=false" ;;
         retry|new)
             echo "Building for $short_sha ($class)." >&2
             emit "uplift=true"

--- a/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
+++ b/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Detect whether tt-lang should build a light wheel for tt-mlir's pinned
-# tt-metal SHA, keyed by the SHA's 7-character S3 prefix.
+# tt-metal SHA, keyed by the tt-lang/<SHA7> S3 prefix.
 #
 # A SHA is skipped when a wheel is already published, and also when a prior
 # search recorded no compatible tt-lang AND the tt-lang HEAD it searched is
@@ -44,14 +44,14 @@ read_target_ttmetal_sha() {
     printf '%s\n' "$sha"
 }
 
-# Object basenames under the SHA prefix. Overridable in tests.
+# Object basenames under the per-SHA wheel prefix. Overridable in tests.
 list_prefix_objects() {
-    aws s3 ls "s3://$S3_BUCKET/$1/" 2>/dev/null | awk '{print $NF}'
+    aws s3 ls "s3://$S3_BUCKET/tt-lang/$1/" 2>/dev/null | awk '{print $NF}'
 }
 
 # tt-lang HEAD from a prior miss marker, or empty. Overridable in tests.
 read_recorded_head() {
-    aws s3 cp "s3://$S3_BUCKET/$1/attempt.json" - 2>/dev/null \
+    aws s3 cp "s3://$S3_BUCKET/tt-lang/$1/attempt.json" - 2>/dev/null \
         | sed -n -E 's/.*"ttlang_head"[[:space:]]*:[[:space:]]*"([a-f0-9]+)".*/\1/p' \
         | head -n1
 }
@@ -111,7 +111,7 @@ main() {
         return 1
     fi
     short_sha="${target_sha:0:7}"
-    echo "tt-mlir targets tt-metal $target_sha (prefix $short_sha); tt-lang HEAD $ttlang_head" >&2
+    echo "tt-mlir targets tt-metal $target_sha (prefix tt-lang/$short_sha); tt-lang HEAD $ttlang_head" >&2
 
     if [[ "$assume_new" == true ]]; then
         echo "Assuming $short_sha is unbuilt (--assume-new); skipping S3 idempotency check." >&2
@@ -121,11 +121,11 @@ main() {
     fi
     case "$class" in
         published)
-            echo "Wheel already published under $short_sha; skipping." >&2
-            emit "uplift=false" ;;
-        doomed)
-            echo "Recorded miss under $short_sha for the current tt-lang HEAD; skipping." >&2
-            emit "uplift=false" ;;
+        echo "Wheel already published under tt-lang/$short_sha; skipping." >&2
+        emit "uplift=false" ;;
+    doomed)
+        echo "Recorded miss under tt-lang/$short_sha for the current tt-lang HEAD; skipping." >&2
+        emit "uplift=false" ;;
         retry|new)
             echo "Building for $short_sha ($class)." >&2
             emit "uplift=true"

--- a/.github/scripts/prepare-s3-publish-dist.sh
+++ b/.github/scripts/prepare-s3-publish-dist.sh
@@ -6,14 +6,33 @@
 # a single publish directory. A spec has the form <variant>[:no-sim]=<dist_dir>.
 # Use `:no-sim` for light artifacts that intentionally omit tt-lang-sim.
 #
-# Usage: prepare-s3-publish-dist.sh <version_override> <publish_dir> <spec>...
+# Usage: prepare-s3-publish-dist.sh [--light-python-tags cp310,cp312] <version_override> <publish_dir> <spec>...
 
 set -eu
 
 usage() {
-    echo "Usage: $0 <version_override> <publish_dir> <variant[:no-sim]=dist_dir>..." >&2
+    echo "Usage: $0 [--light-python-tags cp310,cp312] <version_override> <publish_dir> <variant[:no-sim]=dist_dir>..." >&2
     exit 2
 }
+
+light_python_tags=cp310,cp312
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --light-python-tags)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            light_python_tags="$2"
+            shift 2
+            ;;
+        --*)
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 if [ "$#" -lt 3 ]; then
     usage
@@ -73,11 +92,13 @@ for spec in "$@"; do
     if [ "$no_sim" = true ]; then
         "$script_dir/verify-s3-wheel-versions.sh" \
             --no-sim \
+            --python-tags "$light_python_tags" \
             "$variant" \
             "$version" \
             "$artifact_dir"
     else
         "$script_dir/verify-s3-wheel-versions.sh" \
+            --python-tags "$light_python_tags" \
             "$variant" \
             "$version" \
             "$artifact_dir"

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -10,6 +10,9 @@
 
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
 usage() {
     echo "Usage: $0 --prefix <prefix> [--readme <path>] <dist_dir>" >&2
     exit 2
@@ -17,7 +20,7 @@ usage() {
 
 bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
 prefix=""
-readme="packaging/s3-index/README.md"
+readme="$repo_root/packaging/s3-index/README.md"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --prefix)
@@ -67,8 +70,6 @@ from urllib.parse import quote
 dist_dir = Path(sys.argv[1])
 index_path = Path(sys.argv[2])
 wheels = sorted(dist_dir.glob("*.whl"))
-if not wheels:
-    raise SystemExit(f"No wheels found under {dist_dir}")
 
 anchors = ['    <a href="README.txt">README.txt</a><br>']
 for wheel in wheels:
@@ -96,7 +97,7 @@ index_path.write_text(
 )
 PY
 
-python3 .github/scripts/inject_s3_index_readme.py "$readme" "$index_html"
+python3 "$script_dir/inject_s3_index_readme.py" "$readme" "$index_html"
 cp "$readme" "$readme_txt"
 
 aws s3 cp "$readme_txt" "s3://$bucket/$prefix/README.txt" \

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Upload wheel files directly under an S3 prefix and write an index.html file
+# listing in the same directory. This layout is for per-tt-metal-SHA wheel sets
+# that are consumed with pip --find-links, not as a PEP 503 package index.
+#
+# Usage: publish-s3-direct-wheels.sh --prefix <prefix> [--readme <path>] <dist_dir>
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --prefix <prefix> [--readme <path>] <dist_dir>" >&2
+    exit 2
+}
+
+bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
+prefix=""
+readme="packaging/s3-index/README.md"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prefix)
+            [[ $# -ge 2 ]] || usage
+            prefix="${2%/}"
+            shift 2
+            ;;
+        --readme)
+            [[ $# -ge 2 ]] || usage
+            readme="$2"
+            shift 2
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ $# -ne 1 || -z "$prefix" ]]; then
+    usage
+fi
+
+dist_dir="$1"
+shopt -s nullglob
+wheels=("$dist_dir"/*.whl)
+if [[ "${#wheels[@]}" -eq 0 ]]; then
+    echo "No wheels found under $dist_dir" >&2
+    exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+index_html="$tmpdir/index.html"
+readme_txt="$tmpdir/README.txt"
+
+python3 - "$dist_dir" "$index_html" <<'PY'
+import hashlib
+import html
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+dist_dir = Path(sys.argv[1])
+index_path = Path(sys.argv[2])
+wheels = sorted(dist_dir.glob("*.whl"))
+if not wheels:
+    raise SystemExit(f"No wheels found under {dist_dir}")
+
+anchors = ['    <a href="README.txt">README.txt</a><br>']
+for wheel in wheels:
+    hasher = hashlib.sha256()
+    with wheel.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    digest = hasher.hexdigest()
+    name = wheel.name
+    href = f"{quote(name)}#sha256={digest}"
+    anchors.append(f'    <a href="{href}">{html.escape(name)}</a><br>')
+
+index_path.write_text(
+    "<!DOCTYPE html>\n"
+    "<html>\n"
+    "  <head>\n"
+    '    <meta charset="UTF-8">\n'
+    "    <title>tt-lang per-SHA wheels</title>\n"
+    "  </head>\n"
+    "  <body>\n"
+    + "\n".join(anchors)
+    + "\n  </body>\n"
+    "</html>\n",
+    encoding="utf-8",
+)
+PY
+
+python3 .github/scripts/inject_s3_index_readme.py "$readme" "$index_html"
+cp "$readme" "$readme_txt"
+
+aws s3 cp "$readme_txt" "s3://$bucket/$prefix/README.txt" \
+    --content-type "text/plain; charset=utf-8"
+
+for wheel in "${wheels[@]}"; do
+    aws s3 cp "$wheel" "s3://$bucket/$prefix/$(basename "$wheel")" \
+        --content-type "application/octet-stream"
+done
+
+aws s3 cp "$index_html" "s3://$bucket/$prefix/index.html" \
+    --content-type "text/html; charset=utf-8"

--- a/.github/scripts/publish-s3-summary.sh
+++ b/.github/scripts/publish-s3-summary.sh
@@ -5,21 +5,23 @@
 # Append a Markdown install summary to $GITHUB_STEP_SUMMARY for the S3 PyPI
 # publish workflow. With --dry-run, record that no upload occurred. With
 # --index-subdir <subdir>, point the install commands at the .../<subdir>/
-# simple index (year-month <YYYY-MM>/ for nightlies, <ttmetal7>/ for per-SHA
-# light wheels) instead of the flat root. With no $GITHUB_STEP_SUMMARY set,
+# simple index (year-month <YYYY-MM>/ for nightlies) instead of the flat root.
+# --find-links-subdir <subdir> points install commands at a direct wheel
+# directory consumed with pip --find-links. With no $GITHUB_STEP_SUMMARY set,
 # output goes to stdout for local invocations/tests.
 #
-# Usage: publish-s3-summary.sh [--dry-run] [--index-subdir <subdir>] <wheel_variant> <version_override>
+# Usage: publish-s3-summary.sh [--dry-run] [--index-subdir <subdir>] [--find-links-subdir <subdir>] <wheel_variant> <version_override>
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 [--dry-run] [--index-subdir <subdir>] <wheel_variant> <version_override>" >&2
+    echo "Usage: $0 [--dry-run] [--index-subdir <subdir>] [--find-links-subdir <subdir>] <wheel_variant> <version_override>" >&2
     exit 2
 }
 
 dry_run=0
 index_subdir=""
+find_links_subdir=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)
@@ -29,6 +31,11 @@ while [[ $# -gt 0 ]]; do
         --index-subdir)
             [[ $# -ge 2 ]] || usage
             index_subdir="$2"
+            shift 2
+            ;;
+        --find-links-subdir)
+            [[ $# -ge 2 ]] || usage
+            find_links_subdir="$2"
             shift 2
             ;;
         -*)
@@ -44,12 +51,23 @@ done
 if [[ $# -ne 2 ]]; then
     usage
 fi
+if [[ -n "$index_subdir" && -n "$find_links_subdir" ]]; then
+    echo "--index-subdir and --find-links-subdir are mutually exclusive" >&2
+    exit 2
+fi
 
 variant="$1"
 version="$2"
 index_url="https://pypi.eng.aws.tenstorrent.com/"
+index_label="Package index"
 if [[ -n "$index_subdir" ]]; then
     index_url="https://pypi.eng.aws.tenstorrent.com/${index_subdir}/"
+fi
+find_links_url=""
+if [[ -n "$find_links_subdir" ]]; then
+    find_links_url="https://pypi.eng.aws.tenstorrent.com/${find_links_subdir}/"
+    index_url="$find_links_url"
+    index_label="Wheel directory"
 fi
 pytorch_url="https://download.pytorch.org/whl/cpu"
 summary_title="### Published wheels"
@@ -85,7 +103,7 @@ No wheels were uploaded.
 EOF
     fi
     emit <<EOF
-Package index: $index_url
+$index_label: $index_url
 
 EOF
 }
@@ -101,6 +119,17 @@ $heading
 
 EOF
     fi
+    if [[ -n "$find_links_url" ]]; then
+        emit <<EOF
+\`\`\`bash
+pip install \\
+  --find-links $find_links_url \\
+  --extra-index-url $pytorch_url \\
+  $package_spec
+\`\`\`
+EOF
+        return
+    fi
     emit <<EOF
 \`\`\`bash
 pip install \\
@@ -112,6 +141,28 @@ EOF
 }
 
 emit_light_install() {
+    if [[ -n "$find_links_url" ]]; then
+        emit <<EOF
+Light install:
+
+\`\`\`bash
+pip install \\
+  --find-links $find_links_url \\
+  --extra-index-url $pytorch_url \\
+  tt-lang-light==$version
+\`\`\`
+
+Underlying light tt-lang wheel:
+
+\`\`\`bash
+pip install \\
+  --find-links $find_links_url \\
+  --extra-index-url $pytorch_url \\
+  tt-lang==$version+light
+\`\`\`
+EOF
+        return
+    fi
     emit <<EOF
 Light install:
 

--- a/.github/scripts/record-ttmetal-miss.sh
+++ b/.github/scripts/record-ttmetal-miss.sh
@@ -4,7 +4,7 @@
 #
 # Record that no compatible tt-lang was found for a tt-metal SHA, so the nightly
 # detector skips re-attempting it until tt-lang HEAD advances. Writes a small
-# attempt.json marker under the SHA's 7-char S3 prefix.
+# attempt.json marker under the tt-lang/<SHA7> S3 prefix.
 #
 # Usage:
 #   record-ttmetal-miss.sh --ttmetal-sha <sha> --ttlang-head <sha>
@@ -46,7 +46,7 @@ attempt_date="${attempt_date:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 marker="$(printf '{"ttmetal_sha":"%s","ttlang_head":"%s","max_age_days":"%s","attempt_date":"%s","result":"no_compatible"}\n' \
     "$ttmetal_sha" "$ttlang_head" "$max_age_days" "$attempt_date")"
 
-printf '%s' "$marker" | aws s3 cp - "s3://$S3_BUCKET/$short/attempt.json" \
+printf '%s' "$marker" | aws s3 cp - "s3://$S3_BUCKET/tt-lang/$short/attempt.json" \
     --content-type "application/json"
 
-echo "Recorded miss for $short (tt-lang HEAD $ttlang_head)" >&2
+echo "Recorded miss for tt-lang/$short (tt-lang HEAD $ttlang_head)" >&2

--- a/.github/scripts/record-ttmetal-miss.sh
+++ b/.github/scripts/record-ttmetal-miss.sh
@@ -4,7 +4,7 @@
 #
 # Record that no compatible tt-lang was found for a tt-metal SHA, so the nightly
 # detector skips re-attempting it until tt-lang HEAD advances. Writes a small
-# attempt.json marker under the tt-lang/<SHA7> S3 prefix.
+# attempt.json marker under the tt-lang/<ttmetal7> S3 prefix.
 #
 # Usage:
 #   record-ttmetal-miss.sh --ttmetal-sha <sha> --ttlang-head <sha>

--- a/.github/scripts/resolve-ird-docker-tag.sh
+++ b/.github/scripts/resolve-ird-docker-tag.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Resolve a tt-lang IRD Docker image tag against the tags present in GHCR.
+#
+# Exact matches always win. With --allow-version-prefix-fallback, a missing
+# bare release tag such as v1.1.2 may resolve to a single existing v1.1.2-*
+# image tag. Multiple matches are ambiguous and require an explicit docker_tag.
+
+set -euo pipefail
+
+candidate=""
+owner="${GITHUB_REPOSITORY_OWNER:-}"
+tags_file=""
+allow_version_prefix_fallback=false
+
+usage() {
+    echo "usage: resolve-ird-docker-tag.sh --candidate <tag> [--owner <org>] [--tags-file <file>] [--allow-version-prefix-fallback]" >&2
+    exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --candidate) [[ $# -ge 2 ]] || usage; candidate="$2"; shift 2 ;;
+        --owner) [[ $# -ge 2 ]] || usage; owner="$2"; shift 2 ;;
+        --tags-file) [[ $# -ge 2 ]] || usage; tags_file="$2"; shift 2 ;;
+        --allow-version-prefix-fallback) allow_version_prefix_fallback=true; shift ;;
+        *) echo "unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+trim() { printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+candidate="$(trim "$candidate")"
+owner="$(trim "$owner")"
+
+if [[ -z "$candidate" ]]; then
+    echo "error: --candidate is required" >&2
+    usage
+fi
+
+list_tags() {
+    if [[ -n "$tags_file" ]]; then
+        sed '/^[[:space:]]*$/d' "$tags_file"
+        return
+    fi
+
+    if [[ -z "$owner" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+        owner="${GITHUB_REPOSITORY%%/*}"
+    fi
+    if [[ -z "$owner" ]]; then
+        echo "error: --owner is required unless GITHUB_REPOSITORY_OWNER or GITHUB_REPOSITORY is set" >&2
+        exit 2
+    fi
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "error: gh is required to query GHCR tags" >&2
+        exit 2
+    fi
+
+    gh api --paginate \
+        "/orgs/${owner}/packages/container/tt-lang%2Ftt-lang-ird-ubuntu-24-04/versions?per_page=100" \
+        --jq '.[].metadata.container.tags[]?'
+}
+
+tags_tmp="$(mktemp)"
+trap 'rm -f "$tags_tmp"' EXIT
+if ! list_tags > "$tags_tmp"; then
+    exit 1
+fi
+mapfile -t tags < <(sort -u "$tags_tmp")
+
+for tag in "${tags[@]}"; do
+    if [[ "$tag" == "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        exit 0
+    fi
+done
+
+if [[ "$allow_version_prefix_fallback" != true ]]; then
+    echo "error: IRD builder image tag does not exist: $candidate" >&2
+    exit 1
+fi
+
+if [[ ! "$candidate" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+    echo "error: IRD builder image tag does not exist: $candidate" >&2
+    exit 1
+fi
+
+matches=()
+for tag in "${tags[@]}"; do
+    if [[ "$tag" == "$candidate"-* ]]; then
+        matches+=("$tag")
+    fi
+done
+
+case "${#matches[@]}" in
+    0)
+        echo "error: no existing IRD image tag matches $candidate or $candidate-*" >&2
+        exit 1
+        ;;
+    1)
+        echo "Exact IRD image tag $candidate is missing; using ${matches[0]}" >&2
+        printf '%s\n' "${matches[0]}"
+        ;;
+    *)
+        echo "error: multiple IRD image tags match $candidate-*; pass docker_tag explicitly:" >&2
+        printf '  %s\n' "${matches[@]}" >&2
+        exit 1
+        ;;
+esac

--- a/.github/scripts/resolve-ird-docker-tag.sh
+++ b/.github/scripts/resolve-ird-docker-tag.sh
@@ -67,7 +67,13 @@ trap 'rm -f "$tags_tmp"' EXIT
 if ! list_tags > "$tags_tmp"; then
     exit 1
 fi
-mapfile -t tags < <(sort -u "$tags_tmp")
+# Normalize before matching: strip CRLF carriage returns and surrounding
+# whitespace so a tags file with trailing spaces or CRLF still matches the
+# trimmed candidate, then drop any lines left empty.
+mapfile -t tags < <(
+    sed -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' "$tags_tmp" \
+        | sort -u
+)
 
 for tag in "${tags[@]}"; do
     if [[ "$tag" == "$candidate" ]]; then

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Resolve the inputs of the S3 PyPI publish workflow into a single set of
-# step outputs. Stable tag pushes use the tag version, scheduled runs compute
-# a nightly version, and scheduled runs force `overwrite_releases=true`.
+# step outputs. Scheduled runs compute a nightly version and force
+# `overwrite_releases=true`; workflow_dispatch runs use their explicit inputs.
 #
 # Required env:
 #   DISPATCH_DOCKER_TAG          May be empty (workflow_dispatch input).
@@ -14,7 +14,6 @@
 #   DISPATCH_WHEEL_VARIANT       pypi|light|bundled|bundled-and-light, may be
 #                                empty for non-dispatch events.
 #   EVENT_NAME                   github.event_name.
-#   GITHUB_REF                   github.ref, required for push events.
 #   GITHUB_OUTPUT                Path that receives the resolved outputs.
 #                                Falls back to stdout when unset.
 #
@@ -28,18 +27,6 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/tt-metal-version-utils.sh
 . "$script_dir/lib/tt-metal-version-utils.sh"
-
-stable_tag_version() {
-    local ref="$1"
-
-    if [[ "$ref" =~ ^refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-        printf '%s.%s.%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
-        return 0
-    fi
-
-    echo "S3 release-tag publish requires a stable tag like refs/tags/vX.Y.Z (got '$ref')." >&2
-    return 1
-}
 
 is_stable_version() {
     [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
@@ -63,23 +50,25 @@ overwrite_releases="$DISPATCH_OVERWRITE_RELEASES"
 version_override="${DISPATCH_VERSION_OVERRIDE:-}"
 wheel_variant="${DISPATCH_WHEEL_VARIANT:-}"
 
+case "$EVENT_NAME" in
+    workflow_dispatch | schedule)
+        ;;
+    push)
+        echo "S3 PyPI publishing does not run for push events; use workflow_dispatch from refs/heads/main or the scheduled main-branch run." >&2
+        exit 1
+        ;;
+    *)
+        echo "Unsupported S3 PyPI publish event: $EVENT_NAME" >&2
+        exit 1
+        ;;
+esac
+
 if [[ -z "$version_override" ]]; then
-    if [[ "$EVENT_NAME" == "push" ]]; then
-        version_override=$(stable_tag_version "${GITHUB_REF:-}")
-    else
-        version_override=$(python3 "$script_dir/compute-nightly-version.py")
-    fi
+    version_override=$(python3 "$script_dir/compute-nightly-version.py")
 fi
 
 if [[ -z "$wheel_variant" ]]; then
     case "$EVENT_NAME" in
-        push)
-            if pypi_aligned; then
-                wheel_variant=light
-            else
-                wheel_variant=bundled-and-light
-            fi
-            ;;
         schedule)
             wheel_variant=bundled-and-light
             ;;

--- a/.github/scripts/resolve-xla-build-inputs.sh
+++ b/.github/scripts/resolve-xla-build-inputs.sh
@@ -10,6 +10,8 @@
 #
 # Usage:
 #   resolve-xla-build-inputs.sh --target-dir <dir> [--docker-tag <tag>] [--version <ver>]
+#                                [--resolve-existing-docker-tag]
+#                                [--docker-tags-file <file>]
 #
 # Emits to $GITHUB_OUTPUT (or stdout):
 #   tag=<builder image tag>
@@ -20,9 +22,11 @@ set -euo pipefail
 target_dir=""
 docker_tag=""
 version=""
+resolve_existing_docker_tag=false
+docker_tags_file=""
 
 usage() {
-    echo "usage: resolve-xla-build-inputs.sh --target-dir <dir> [--docker-tag <tag>] [--version <ver>]" >&2
+    echo "usage: resolve-xla-build-inputs.sh --target-dir <dir> [--docker-tag <tag>] [--version <ver>] [--resolve-existing-docker-tag] [--docker-tags-file <file>]" >&2
     exit 2
 }
 
@@ -31,6 +35,8 @@ while [[ $# -gt 0 ]]; do
         --target-dir) [[ $# -ge 2 ]] || usage; target_dir="$2"; shift 2 ;;
         --docker-tag) [[ $# -ge 2 ]] || usage; docker_tag="$2"; shift 2 ;;
         --version)    [[ $# -ge 2 ]] || usage; version="$2";    shift 2 ;;
+        --resolve-existing-docker-tag) resolve_existing_docker_tag=true; shift ;;
+        --docker-tags-file) [[ $# -ge 2 ]] || usage; docker_tags_file="$2"; shift 2 ;;
         *) echo "unknown argument: $1" >&2; usage ;;
     esac
 done
@@ -38,6 +44,7 @@ done
 trim() { printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
 docker_tag="$(trim "$docker_tag")"
 version="$(trim "$version")"
+docker_tag_override="$docker_tag"
 
 if [[ -z "$target_dir" || ! -d "$target_dir" ]]; then
     echo "error: --target-dir must be an existing tt-lang checkout" >&2
@@ -52,6 +59,20 @@ if [[ -z "$docker_tag" ]]; then
 fi
 if [[ -z "$version" ]]; then
     version="$(cd "$target_dir" && python3 .github/scripts/compute-nightly-version.py)"
+fi
+
+if [[ "$resolve_existing_docker_tag" == true ]]; then
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    resolve_args=(--candidate "$docker_tag")
+    if [[ -n "$docker_tags_file" ]]; then
+        resolve_args+=(--tags-file "$docker_tags_file")
+    else
+        resolve_args+=(--owner "${TTLANG_IRD_DOCKER_OWNER:-${GITHUB_REPOSITORY_OWNER:-tenstorrent}}")
+    fi
+    if [[ -z "$docker_tag_override" ]]; then
+        resolve_args+=(--allow-version-prefix-fallback)
+    fi
+    docker_tag="$("$script_dir/resolve-ird-docker-tag.sh" "${resolve_args[@]}")"
 fi
 
 emit() { printf '%s\n' "$1" >> "${GITHUB_OUTPUT:-/dev/stdout}"; }

--- a/.github/scripts/tests/test_build_ttmetal_at_sha.bats
+++ b/.github/scripts/tests/test_build_ttmetal_at_sha.bats
@@ -126,9 +126,21 @@ setup() {
     run cat "$GH_OUT"
     assert_output --partial "source_dir=$SCRATCH/src"
     assert_output --partial "ttmetal_date="
-    # The emitted sha is the trimmed value, not the padded input.
+    # The emitted sha is the full checked-out commit, not the padded input.
     assert_output --partial "sha=$SHA"
     assert_output --partial "short=${SHA:0:7}"
+
+    run git -C "$SCRATCH/src" rev-parse HEAD
+    assert_output "$SHA"
+}
+
+@test "--sha accepts a short SHA but emits the full commit" {
+    short="${SHA:0:7}"
+    GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" --sha "$short" --scratch-dir "$SCRATCH" --no-build
+
+    run cat "$GH_OUT"
+    assert_output --partial "sha=$SHA"
+    assert_output --partial "short=$short"
 
     run git -C "$SCRATCH/src" rev-parse HEAD
     assert_output "$SHA"

--- a/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
+++ b/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
@@ -80,7 +80,7 @@ setup() {
     assert_output "retry"
 }
 
-@test "default S3 object listing reads the tt-lang SHA prefix" {
+@test "default S3 object listing reads the tt-lang/<ttmetal7> prefix" {
     bindir="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$bindir"
     AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
@@ -98,7 +98,7 @@ EOF
     assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/$SHORT_SHA/"
 }
 
-@test "default miss marker read uses the tt-lang SHA prefix" {
+@test "default miss marker read uses the tt-lang/<ttmetal7> prefix" {
     bindir="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$bindir"
     AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"

--- a/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
+++ b/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
@@ -80,6 +80,42 @@ setup() {
     assert_output "retry"
 }
 
+@test "default S3 object listing reads the tt-lang SHA prefix" {
+    bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
+    export AWS_ARGS
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$AWS_ARGS"
+printf '2026-07-04 00:00:00       1234 tt_lang-1.0.0+light.whl\n'
+EOF
+    chmod +x "$bindir/aws"
+    PATH="$bindir:$PATH" run -0 list_prefix_objects "$SHORT_SHA"
+    assert_output "tt_lang-1.0.0+light.whl"
+
+    run cat "$AWS_ARGS"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/$SHORT_SHA/"
+}
+
+@test "default miss marker read uses the tt-lang SHA prefix" {
+    bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
+    export AWS_ARGS
+    cat > "$bindir/aws" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "\$AWS_ARGS"
+printf '{"ttlang_head":"%s"}\n' "$HEAD_A"
+EOF
+    chmod +x "$bindir/aws"
+    PATH="$bindir:$PATH" run -0 read_recorded_head "$SHORT_SHA"
+    assert_output "$HEAD_A"
+
+    run cat "$AWS_ARGS"
+    assert_output --partial "s3 cp s3://tenstorrent-pypi/tt-lang/$SHORT_SHA/attempt.json -"
+}
+
 # --- main ---
 
 @test "main: new sha -> uplift=true with sha outputs" {

--- a/.github/scripts/tests/test_prepare_s3_publish_dist.bats
+++ b/.github/scripts/tests/test_prepare_s3_publish_dist.bats
@@ -43,6 +43,10 @@ setup() {
     assert_output --partial ":no-sim is only valid for the light variant"
 }
 
+@test "--light-python-tags without value -> usage error (exit 2)" {
+    run -2 "$SCRIPT" --light-python-tags
+}
+
 @test "missing artifact dir -> error" {
     run -1 "$SCRIPT" "$VER" "$PUBLISH_DIR" bundled="$BATS_TEST_TMPDIR/missing"
     assert_output --partial "Wheel artifact directory not found"
@@ -77,6 +81,23 @@ setup() {
     assert_output --partial "$(whl_light_core_cp310 "$VER")"
     assert_output --partial "$(whl_light_core_cp312 "$VER")"
     assert_output --partial "$(whl_light "$VER")"
+}
+
+@test "light no-sim artifact honors requested Python tag subset" {
+    light_dir=$(make_wheel_dir \
+        "$(whl_light_core_cp312 "$VER")" \
+        "$(whl_light "$VER")")
+
+    run -0 "$SCRIPT" \
+        --light-python-tags cp312 \
+        "$VER" \
+        "$PUBLISH_DIR" \
+        "light:no-sim=$light_dir"
+
+    run ls "$PUBLISH_DIR"
+    assert_output --partial "$(whl_light_core_cp312 "$VER")"
+    assert_output --partial "$(whl_light "$VER")"
+    refute_output --partial "$(whl_light_core_cp310 "$VER")"
 }
 
 @test "light no-sim spec rejects unexpected sim wheel" {

--- a/.github/scripts/tests/test_publish_s3_direct_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_direct_wheels.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/publish-s3-direct-wheels.sh.
+
+load test_helper
+
+make_aws_mock() {
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" != "s3 cp" ]]; then
+    echo "unexpected aws command" >&2
+    exit 2
+fi
+src="$3"
+dst="$4"
+if [[ "$dst" == s3://tenstorrent-pypi/tt-lang/13adda8/index.html ]]; then
+    cp "$src" "$CAPTURED_INDEX"
+fi
+if [[ "$dst" == s3://tenstorrent-pypi/tt-lang/13adda8/README.txt ]]; then
+    cp "$src" "$CAPTURED_README"
+fi
+EOF
+    chmod +x "$bindir/aws"
+    echo "$bindir"
+}
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/publish-s3-direct-wheels.sh"
+    FAKE_AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
+    CAPTURED_INDEX="$BATS_TEST_TMPDIR/index.html"
+    CAPTURED_README="$BATS_TEST_TMPDIR/README.capture.txt"
+    README="$BATS_TEST_TMPDIR/README.md"
+    : > "$FAKE_AWS_ARGS"
+    cat > "$README" <<'EOF'
+# tt-lang per-SHA wheels
+EOF
+    export FAKE_AWS_ARGS CAPTURED_INDEX CAPTURED_README
+    BINDIR=$(make_aws_mock)
+    export PATH="$BINDIR:$PATH"
+}
+
+@test "missing prefix -> usage error (exit 2)" {
+    dir=$(make_wheel_dir "tt_lang-1.0.0-py3-none-any.whl")
+    run -2 "$SCRIPT" "$dir"
+}
+
+@test "empty dist dir -> error (exit 1)" {
+    dir=$(make_wheel_dir)
+    run -1 "$SCRIPT" --prefix tt-lang/13adda8 "$dir"
+    assert_output --partial "No wheels found under $dir"
+}
+
+@test "uploads wheels and direct index under tt-lang sha prefix" {
+    dir=$(make_wheel_dir \
+        "tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl" \
+        "tt_lang_light-1.0.0-py3-none-any.whl")
+
+    run -0 "$SCRIPT" --prefix tt-lang/13adda8 --readme "$README" "$dir"
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 cp $dir/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl s3://tenstorrent-pypi/tt-lang/13adda8/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl --content-type application/octet-stream"
+    assert_output --partial "s3 cp $dir/tt_lang_light-1.0.0-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/13adda8/tt_lang_light-1.0.0-py3-none-any.whl --content-type application/octet-stream"
+    assert_output --partial "s3://tenstorrent-pypi/tt-lang/13adda8/index.html --content-type text/html; charset=utf-8"
+    assert_output --partial "s3://tenstorrent-pypi/tt-lang/13adda8/README.txt --content-type text/plain; charset=utf-8"
+
+    run cat "$CAPTURED_INDEX"
+    assert_output --partial 'id="ttlang-s3-readme"'
+    assert_output --partial "tt-lang per-SHA wheels"
+    assert_output --partial 'href="README.txt"'
+    assert_output --partial 'href="tt_lang-1.0.0%2Blight-cp312-cp312-manylinux_2_34_x86_64.whl#sha256='
+    assert_output --partial 'href="tt_lang_light-1.0.0-py3-none-any.whl#sha256='
+    refute_output --partial 'href="tt-lang-light/"'
+    readme_line=$(grep -n 'href="README.txt"' "$CAPTURED_INDEX" | head -1 | cut -d: -f1)
+    wheel_line=$(grep -n 'href="tt_lang-' "$CAPTURED_INDEX" | head -1 | cut -d: -f1)
+    [ "$readme_line" -lt "$wheel_line" ]
+
+    run cat "$CAPTURED_README"
+    assert_output --partial "tt-lang per-SHA wheels"
+}
+
+@test "bucket is overridable via TTLANG_S3_BUCKET" {
+    dir=$(make_wheel_dir "tt_lang-1.0.0-py3-none-any.whl")
+    TTLANG_S3_BUCKET=other-bucket run -0 "$SCRIPT" --prefix tt-lang/13adda8 "$dir"
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3://other-bucket/tt-lang/13adda8/tt_lang-1.0.0-py3-none-any.whl"
+}

--- a/.github/scripts/tests/test_publish_s3_summary.bats
+++ b/.github/scripts/tests/test_publish_s3_summary.bats
@@ -87,6 +87,20 @@ setup() {
     run -2 "$SCRIPT" --index-subdir
 }
 
+@test "--find-links-subdir points install commands at the direct wheel directory" {
+    run -0 "$SCRIPT" --find-links-subdir tt-lang/13adda8 light "$VER"
+    assert_output --partial "Wheel directory: https://pypi.eng.aws.tenstorrent.com/tt-lang/13adda8/"
+    assert_output --partial "--find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/13adda8/"
+    assert_output --partial "tt-lang-light==$VER"
+    assert_output --partial "tt-lang==$VER+light"
+    refute_output --partial "extra-index-url https://pypi.eng.aws.tenstorrent.com/tt-lang/13adda8/"
+}
+
+@test "--find-links-subdir and --index-subdir conflict" {
+    run -2 "$SCRIPT" --index-subdir 2026-06 --find-links-subdir tt-lang/13adda8 light "$VER"
+    assert_output --partial "mutually exclusive"
+}
+
 @test "no --index-subdir keeps the flat-root index url" {
     run -0 "$SCRIPT" light "$VER"
     assert_output --partial "extra-index-url https://pypi.eng.aws.tenstorrent.com/ "

--- a/.github/scripts/tests/test_record_ttmetal_miss.bats
+++ b/.github/scripts/tests/test_record_ttmetal_miss.bats
@@ -39,12 +39,12 @@ setup() {
     run -2 "$SCRIPT" --ttmetal-sha "$FULL_SHA"
 }
 
-@test "writes attempt.json under the SHA's 7-char prefix" {
+@test "writes attempt.json under the tt-lang SHA prefix" {
     run -0 "$SCRIPT" --ttmetal-sha "$FULL_SHA" --ttlang-head "$HEAD_SHA" \
         --max-age-days 14 --date "2026-06-30T00:00:00Z"
 
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3 cp - s3://tenstorrent-pypi/$SHORT_SHA/attempt.json"
+    assert_output --partial "s3 cp - s3://tenstorrent-pypi/tt-lang/$SHORT_SHA/attempt.json"
     assert_output --partial "--content-type application/json"
 }
 
@@ -62,5 +62,5 @@ setup() {
     TTLANG_S3_BUCKET=other-bucket run -0 "$SCRIPT" \
         --ttmetal-sha "$FULL_SHA" --ttlang-head "$HEAD_SHA"
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3://other-bucket/$SHORT_SHA/attempt.json"
+    assert_output --partial "s3://other-bucket/tt-lang/$SHORT_SHA/attempt.json"
 }

--- a/.github/scripts/tests/test_record_ttmetal_miss.bats
+++ b/.github/scripts/tests/test_record_ttmetal_miss.bats
@@ -39,7 +39,7 @@ setup() {
     run -2 "$SCRIPT" --ttmetal-sha "$FULL_SHA"
 }
 
-@test "writes attempt.json under the tt-lang SHA prefix" {
+@test "writes attempt.json under tt-lang/<ttmetal7>" {
     run -0 "$SCRIPT" --ttmetal-sha "$FULL_SHA" --ttlang-head "$HEAD_SHA" \
         --max-age-days 14 --date "2026-06-30T00:00:00Z"
 

--- a/.github/scripts/tests/test_resolve_ird_docker_tag.bats
+++ b/.github/scripts/tests/test_resolve_ird_docker_tag.bats
@@ -59,6 +59,16 @@ EOF
     assert_output --partial "v1.1.2-uplift-cafebabe"
 }
 
+@test "bare release does not match a longer patch sibling" {
+    cat > "$TAGS" <<'EOF'
+v1.1.20-uplift-aaaa
+v1.1.3
+EOF
+    run "$SCRIPT" --candidate v1.1.2 --tags-file "$TAGS" --allow-version-prefix-fallback
+    assert_equal "$status" 1
+    assert_output --partial "no existing IRD image tag matches v1.1.2 or v1.1.2-*"
+}
+
 @test "missing candidate -> exit 2" {
     run "$SCRIPT" --tags-file "$TAGS"
     assert_equal "$status" 2

--- a/.github/scripts/tests/test_resolve_ird_docker_tag.bats
+++ b/.github/scripts/tests/test_resolve_ird_docker_tag.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/resolve-ird-docker-tag.sh.
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/resolve-ird-docker-tag.sh"
+    TAGS="$BATS_TEST_TMPDIR/tags"
+    cat > "$TAGS" <<'EOF'
+v1.1.2-uplift-b4f623c2
+v1.1.3
+v1.1.4-6746fe2e
+EOF
+}
+
+@test "returns exact existing tag" {
+    run -0 "$SCRIPT" --candidate v1.1.3 --tags-file "$TAGS"
+    assert_output "v1.1.3"
+}
+
+@test "resolves missing bare release to unique version-prefixed tag" {
+    run -0 "$SCRIPT" \
+        --candidate v1.1.2 \
+        --tags-file "$TAGS" \
+        --allow-version-prefix-fallback
+    assert_line "Exact IRD image tag v1.1.2 is missing; using v1.1.2-uplift-b4f623c2"
+    assert_line "v1.1.2-uplift-b4f623c2"
+}
+
+@test "does not fallback when exact explicit tag is missing" {
+    run "$SCRIPT" --candidate v1.1.2 --tags-file "$TAGS"
+    assert_equal "$status" 1
+    assert_output --partial "IRD builder image tag does not exist: v1.1.2"
+}
+
+@test "does not fallback for missing non-release tag" {
+    run "$SCRIPT" \
+        --candidate v1.1.4-deadbeef \
+        --tags-file "$TAGS" \
+        --allow-version-prefix-fallback
+    assert_equal "$status" 1
+    assert_output --partial "IRD builder image tag does not exist: v1.1.4-deadbeef"
+}
+
+@test "ambiguous version-prefixed matches fail" {
+    cat >> "$TAGS" <<'EOF'
+v1.1.2-uplift-cafebabe
+EOF
+    run "$SCRIPT" \
+        --candidate v1.1.2 \
+        --tags-file "$TAGS" \
+        --allow-version-prefix-fallback
+    assert_equal "$status" 1
+    assert_output --partial "multiple IRD image tags match v1.1.2-*"
+    assert_output --partial "v1.1.2-uplift-b4f623c2"
+    assert_output --partial "v1.1.2-uplift-cafebabe"
+}
+
+@test "missing candidate -> exit 2" {
+    run "$SCRIPT" --tags-file "$TAGS"
+    assert_equal "$status" 2
+}
+
+@test "unknown argument -> exit 2" {
+    run "$SCRIPT" --candidate v1.1.3 --tags-file "$TAGS" --bogus
+    assert_equal "$status" 2
+}

--- a/.github/scripts/tests/test_resolve_ird_docker_tag.bats
+++ b/.github/scripts/tests/test_resolve_ird_docker_tag.bats
@@ -59,6 +59,12 @@ EOF
     assert_output --partial "v1.1.2-uplift-cafebabe"
 }
 
+@test "tolerates trailing whitespace and CRLF in the tags file" {
+    printf 'v1.1.3  \r\n  v1.1.4-6746fe2e\r\n' > "$TAGS"
+    run -0 "$SCRIPT" --candidate v1.1.3 --tags-file "$TAGS"
+    assert_output "v1.1.3"
+}
+
 @test "bare release does not match a longer patch sibling" {
     cat > "$TAGS" <<'EOF'
 v1.1.20-uplift-aaaa

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -102,41 +102,9 @@ output_value() {
     assert_equal "$(output_value overwrite_releases)" "false"
 }
 
-@test "stable tag push publishes bundled and light when public PyPI is blocked" {
-    version_file=$(make_tt_metal_version_file \
-        "$TEST_TT_METAL_RC1_TAG" \
-        "$TEST_TT_METAL_NEXT_TAG")
-
-    DISPATCH_VERSION_OVERRIDE="" \
-    DISPATCH_WHEEL_VARIANT="" \
-    EVENT_NAME=push \
-    GITHUB_REF=refs/tags/v1.2.3 \
-    TTLANG_TT_METAL_VERSION_FILE="$version_file" \
-        run -0 "$SCRIPT"
-
-    assert_equal "$(output_value version_override)" "1.2.3"
-    assert_equal "$(output_value wheel_variant)" "bundled-and-light"
-    assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
-    assert_equal "$(output_value overwrite_releases)" "false"
-    assert_equal "$(output_value allow_final_internal_version)" "true"
-}
-
-@test "stable tag push publishes only light when public PyPI is aligned" {
-    version_file=$(make_tt_metal_version_file \
-        "$TEST_TT_METAL_RC2_TAG" \
-        "$TEST_TT_METAL_TAG")
-
-    DISPATCH_VERSION_OVERRIDE="" \
-    DISPATCH_WHEEL_VARIANT="" \
-    EVENT_NAME=push \
-    GITHUB_REF=refs/tags/v1.2.3 \
-    TTLANG_TT_METAL_VERSION_FILE="$version_file" \
-        run -0 "$SCRIPT"
-
-    assert_equal "$(output_value version_override)" "1.2.3"
-    assert_equal "$(output_value wheel_variant)" "light"
-    assert_equal "$(output_value wheel_variants)" '["light"]'
-    assert_equal "$(output_value allow_final_internal_version)" "true"
+@test "push event is rejected" {
+    EVENT_NAME=push run -1 "$SCRIPT"
+    assert_output --partial "S3 PyPI publishing does not run for push events"
 }
 
 @test "stable manual bundled publish is rejected when public PyPI is aligned" {
@@ -153,14 +121,9 @@ output_value() {
     assert_output --partial "Refusing to publish bundled tt-lang==1.2.3 to S3"
 }
 
-@test "push event rejects non-stable tag when version is unset" {
-    DISPATCH_VERSION_OVERRIDE="" \
-    DISPATCH_WHEEL_VARIANT="" \
-    EVENT_NAME=push \
-    GITHUB_REF=refs/tags/v1.2.3-rc1 \
-        run -1 "$SCRIPT"
-
-    assert_output --partial "S3 release-tag publish requires a stable tag"
+@test "unsupported event is rejected" {
+    EVENT_NAME=pull_request run -1 "$SCRIPT"
+    assert_output --partial "Unsupported S3 PyPI publish event: pull_request"
 }
 
 @test "empty version_override invokes compute-nightly-version.py" {

--- a/.github/scripts/tests/test_resolve_xla_build_inputs.bats
+++ b/.github/scripts/tests/test_resolve_xla_build_inputs.bats
@@ -51,6 +51,41 @@ EOF
     assert_line "version=1.2.3"
 }
 
+@test "resolves missing bare release to unique existing IRD image tag" {
+    cat > "$BATS_TEST_TMPDIR/tags" <<'EOF'
+v1.1.2-uplift-b4f623c2
+EOF
+    cat > "$TARGET/.github/containers/get-version-tag.sh" <<'EOF'
+#!/usr/bin/env bash
+echo v1.1.2
+EOF
+    chmod +x "$TARGET/.github/containers/get-version-tag.sh"
+
+    GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" \
+        --target-dir "$TARGET" \
+        --resolve-existing-docker-tag \
+        --docker-tags-file "$BATS_TEST_TMPDIR/tags"
+    run cat "$GH_OUT"
+    assert_line "tag=v1.1.2-uplift-b4f623c2"
+    assert_line "version=computed-ver"
+}
+
+@test "explicit docker tag validates exactly when resolving existing images" {
+    cat > "$BATS_TEST_TMPDIR/tags" <<'EOF'
+my-tag
+v1.1.2-uplift-b4f623c2
+EOF
+
+    GITHUB_OUTPUT="$GH_OUT" run -0 "$SCRIPT" \
+        --target-dir "$TARGET" \
+        --docker-tag my-tag \
+        --resolve-existing-docker-tag \
+        --docker-tags-file "$BATS_TEST_TMPDIR/tags"
+    run cat "$GH_OUT"
+    assert_line "tag=my-tag"
+    assert_line "version=computed-ver"
+}
+
 @test "missing --target-dir -> exit 2" {
     run "$SCRIPT" --docker-tag t --version v
     assert_equal "$status" 2

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build, device-test, and publish a tt-lang-light wheel for a tt-metal SHA.
-# The S3 prefix is the tt-metal short SHA, so wheel filenames stay unchanged.
+# The per-SHA S3 location is tt-lang/<tt-metal-short-SHA>/, so wheel filenames
+# stay unchanged and light/normal wheels live in the same find-links directory.
 
 name: tt-lang-light wheel for a tt-metal SHA
 
@@ -422,7 +423,7 @@ jobs:
           bash .github/scripts/run-tutorials.sh .
 
   publish:
-    name: "Publish to S3 under per-SHA prefix"
+    name: "Publish to S3 under tt-lang/<SHA> prefix"
     continue-on-error: ${{ inputs.soft_fail }}
     needs: [find-compatible, build-wheels, build-metapackage, device-validate]
     if: ${{ needs.find-compatible.outputs.found == 'true' && inputs.dry_run != true }}
@@ -455,23 +456,14 @@ jobs:
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure-tt-s3-credentials
 
-      - name: Install s3pypi
-        run: python3 -m pip install s3pypi markdown
-
       - name: Publish wheels
         run: |
-          .github/scripts/publish-s3-wheels.sh --overwrite \
-            --prefix "${{ needs.find-compatible.outputs.ttmetal_short }}" dist
-
-      - name: Inject S3 index README
-        run: |
-          set -euo pipefail
-          key="${{ needs.find-compatible.outputs.ttmetal_short }}/index.html"
-          .github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist
+          .github/scripts/publish-s3-direct-wheels.sh \
+            --prefix "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}" dist
 
       - name: Report install command
         run: |
           .github/scripts/publish-s3-summary.sh \
-            --index-subdir "${{ needs.find-compatible.outputs.ttmetal_short }}" \
+            --find-links-subdir "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}" \
             light \
             "${{ needs.find-compatible.outputs.winner_version }}"

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -6,7 +6,7 @@
 # The per-SHA S3 location is tt-lang/<tt-metal-short-SHA>/, so wheel filenames
 # stay unchanged and light/normal wheels live in the same find-links directory.
 
-name: tt-lang-light wheel for a tt-metal SHA
+name: Build tt-lang-light per-tt-metal-SHA wheel (reusable)
 
 on:
   workflow_call:
@@ -72,6 +72,7 @@ jobs:
       contents: read
       packages: read
     outputs:
+      ttmetal_sha: ${{ steps.ttmetal.outputs.sha }}
       ttmetal_short: ${{ steps.ttmetal.outputs.short }}
       ttmetal_date: ${{ steps.ttmetal.outputs.ttmetal_date }}
     steps:
@@ -131,6 +132,7 @@ jobs:
       found: ${{ steps.search.outputs.found }}
       winner_sha: ${{ steps.search.outputs.winner_sha }}
       winner_version: ${{ steps.search.outputs.winner_version }}
+      ttmetal_sha: ${{ needs.build-ttmetal.outputs.ttmetal_sha }}
       ttmetal_short: ${{ needs.build-ttmetal.outputs.ttmetal_short }}
       ttlang_head: ${{ steps.head.outputs.sha }}
     steps:
@@ -167,6 +169,7 @@ jobs:
         id: search
         env:
           TTLANG_REF: ${{ inputs.ttlang_ref }}
+          TT_METAL_COMMIT: ${{ needs.build-ttmetal.outputs.ttmetal_sha }}
         run: |
           set -euo pipefail
           if [ -n "$TTLANG_REF" ]; then
@@ -278,6 +281,7 @@ jobs:
         env:
           TTLANG_EXTERNAL_TT_METAL_DIR: /tmp/ttmetal-install
           TTLANG_GIT_COMMIT: ${{ needs.find-compatible.outputs.winner_sha }}
+          TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}
         run: |
           .github/scripts/build-s3-light-core-wheel.sh \
             --python-tag "${{ matrix.python_tag }}" \
@@ -386,6 +390,7 @@ jobs:
       - name: Install light wheel and external tt-metal
         env:
           TTMETAL_INSTALL_DIR: /tmp/ttmetal-install
+          EXPECTED_TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}
         run: |
           set -euo pipefail
           # Clean venv (no --system-site-packages): the installed light wheel and
@@ -405,6 +410,17 @@ jobs:
           tt-lang-setup
           pip install -r dev-requirements.txt
           eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTMETAL_INSTALL_DIR")"
+          python3 - <<'PY'
+          import os
+          import ttl
+
+          expected = os.environ["EXPECTED_TT_METAL_COMMIT"]
+          actual = ttl.build_info()["tt_metal"]
+          if actual != expected:
+              raise SystemExit(
+                  f"tt-lang wheel tt-metal provenance mismatch: expected {expected}, got {actual}"
+              )
+          PY
           echo "TTL_EXTERNAL_TT_METAL_DIR=$TTMETAL_INSTALL_DIR" >> "$GITHUB_ENV"
 
       - name: Device suite

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -26,7 +26,7 @@ on:
         type: string
         default: "14"
       python_tags:
-        description: "Comma-separated CPython ABIs to build (subset of cp310,cp312)."
+        description: "Comma-separated CPython ABIs to build (subset of cp310,cp312; must include cp312 for device validation)."
         required: false
         type: string
         default: "cp310,cp312"
@@ -56,8 +56,45 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    name: "Validate tt-lang-light per-tt-metal-SHA inputs"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      python_tags: ${{ steps.python_tags.outputs.python_tags }}
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+
+      - name: Require main ref for S3 publishing
+        if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "S3 publishing is restricted to refs/heads/main (got ${GITHUB_REF}). Set dry_run=true for non-main validation." >&2
+          exit 1
+
+      - name: Validate Python ABI tags
+        id: python_tags
+        env:
+          PYTHON_TAGS: ${{ inputs.python_tags }}
+        run: |
+          set -euo pipefail
+          source .github/scripts/lib/docker-image-utils.sh
+          python_tags="$(ttlang_python_tags "$PYTHON_TAGS" | paste -sd, -)"
+          if [[ ",$python_tags," != *,cp312,* ]]; then
+            echo "python_tags must include cp312 because device validation runs under the cp312 IRD environment." >&2
+            exit 1
+          fi
+          echo "python_tags=$python_tags" >> "$GITHUB_OUTPUT"
+          echo "Python ABI tags: $python_tags"
+
   build-ttmetal:
     name: "Build tt-metal at SHA"
+    needs: preflight
     continue-on-error: ${{ inputs.soft_fail }}
     runs-on: mlir-large-runner-lang
     timeout-minutes: 180
@@ -193,7 +230,7 @@ jobs:
     name: "Record no-compatible miss"
     continue-on-error: ${{ inputs.soft_fail }}
     needs: find-compatible
-    if: ${{ needs.find-compatible.outputs.found == 'false' && inputs.dry_run != true }}
+    if: ${{ needs.find-compatible.outputs.found == 'false' && inputs.dry_run != true && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     defaults:
@@ -220,7 +257,7 @@ jobs:
   build-wheels:
     name: "Build light wheel (${{ matrix.python_tag }})"
     continue-on-error: ${{ inputs.soft_fail }}
-    needs: [build-ttmetal, find-compatible]
+    needs: [preflight, build-ttmetal, find-compatible]
     if: ${{ needs.find-compatible.outputs.found == 'true' }}
     runs-on: mlir-large-runner-lang
     timeout-minutes: 180
@@ -240,7 +277,7 @@ jobs:
       - name: Skip unrequested ABI
         id: gate
         env:
-          PYTHON_TAGS: ${{ inputs.python_tags }}
+          PYTHON_TAGS: ${{ needs.preflight.outputs.python_tags }}
           ABI: ${{ matrix.python_tag }}
         run: |
           python_tags="$(printf '%s' "$PYTHON_TAGS" | tr -d '[:space:]')"
@@ -441,8 +478,8 @@ jobs:
   publish:
     name: "Publish to S3 under tt-lang/<SHA> prefix"
     continue-on-error: ${{ inputs.soft_fail }}
-    needs: [find-compatible, build-wheels, build-metapackage, device-validate]
-    if: ${{ needs.find-compatible.outputs.found == 'true' && inputs.dry_run != true }}
+    needs: [preflight, find-compatible, build-wheels, build-metapackage, device-validate]
+    if: ${{ needs.find-compatible.outputs.found == 'true' && inputs.dry_run != true && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     defaults:
@@ -465,6 +502,7 @@ jobs:
       - name: Prepare publish dist
         run: |
           .github/scripts/prepare-s3-publish-dist.sh \
+            --light-python-tags "${{ needs.preflight.outputs.python_tags }}" \
             "${{ needs.find-compatible.outputs.winner_version }}" \
             dist \
             light:no-sim=wheel-artifacts/light

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -392,7 +392,7 @@ jobs:
   # continue-on-error here and soft_fail on the reusable build below keep a
   # failure in this extra wheel from failing the nightly publish.
   ttmetal-light-detect:
-    name: "Detect tt-metal uplift for light wheel"
+    name: "Detect tt-lang-light per-tt-metal-SHA build"
     needs: preflight
     if: ${{ github.event_name == 'schedule' }}
     continue-on-error: true
@@ -426,7 +426,7 @@ jobs:
         run: .github/scripts/detect-ttmlir-ttmetal-uplift.sh
 
   ttmetal-light-build:
-    name: "Build light wheel for tt-metal SHA"
+    name: "Build tt-lang-light per-tt-metal-SHA wheel"
     needs: [preflight, build-docker, build-wheel-images, ttmetal-light-detect]
     if: ${{ github.event_name == 'schedule' && needs.ttmetal-light-detect.outputs.uplift == 'true' }}
     permissions:

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -5,10 +5,6 @@
 name: Publish S3 PyPI Wheels
 
 on:
-  push:
-    tags:
-      # Publish clean-version internal bundled/light wheels for stable releases.
-      - 'v[0-9]+.[0-9]+.[0-9]+'
   schedule:
     # Nightly S3-only internal wheel publish. GitHub cron uses UTC.
     - cron: "0 8 * * *"
@@ -97,6 +93,12 @@ jobs:
           DISPATCH_WHEEL_VARIANT: ${{ github.event_name == 'workflow_dispatch' && inputs.wheel_variant || '' }}
           EVENT_NAME: ${{ github.event_name }}
         run: .github/scripts/resolve-s3-publish-inputs.sh
+
+      - name: Require main ref for publishing
+        if: ${{ github.ref != 'refs/heads/main' && (steps.resolve.outputs.dry_run != 'true' || steps.resolve.outputs.docker_tag == '') }}
+        run: |
+          echo "Publishing is restricted to refs/heads/main (got ${GITHUB_REF}). Non-main dry runs must provide docker_tag." >&2
+          exit 1
 
   build-docker:
     needs: preflight
@@ -269,7 +271,7 @@ jobs:
   publish:
     name: "Publish wheels to S3 PyPI"
     needs: [preflight, build-standard-wheels, collect-light-wheels]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-standard-wheels.result == 'success' || needs.build-standard-wheels.result == 'skipped') && (needs.collect-light-wheels.result == 'success' || needs.collect-light-wheels.result == 'skipped') }}
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-standard-wheels.result == 'success' || needs.build-standard-wheels.result == 'skipped') && (needs.collect-light-wheels.result == 'success' || needs.collect-light-wheels.result == 'skipped') && (needs.preflight.outputs.dry_run == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -32,7 +32,7 @@ on:
         type: string
         default: "14"
       python_tags:
-        description: "Comma-separated CPython ABIs to build."
+        description: "Comma-separated CPython ABIs to build; must include cp312 for device validation."
         required: false
         type: string
         default: "cp310,cp312"
@@ -78,6 +78,12 @@ jobs:
 
       - name: Git safe directory
         run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Require main ref for S3 publishing
+        if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "S3 publishing is restricted to refs/heads/main (got ${GITHUB_REF}). Set dry_run=true for non-main validation." >&2
+          exit 1
 
       # Detection needs only tt-mlir's TT_METAL_VERSION pin.
       - name: Fetch tt-mlir for uplift detection

--- a/.github/workflows/ttmetal-light-on-demand.yml
+++ b/.github/workflows/ttmetal-light-on-demand.yml
@@ -6,7 +6,7 @@
 # Scheduled publishes use publish-s3-pypi.yml; this manual workflow resolves
 # the builder image tag itself.
 
-name: tt-lang-light wheel (on demand)
+name: Build tt-lang-light per-tt-metal-SHA wheel (on demand)
 
 on:
   workflow_dispatch:
@@ -56,7 +56,7 @@ permissions:
 
 jobs:
   detect:
-    name: "Detect tt-metal uplift"
+    name: "Detect tt-lang-light per-tt-metal-SHA build"
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -120,7 +120,7 @@ jobs:
           fi
 
   build:
-    name: "Build light wheel for tt-metal SHA"
+    name: "Build tt-lang-light per-tt-metal-SHA wheel"
     needs: detect
     if: ${{ needs.detect.outputs.uplift == 'true' }}
     permissions:

--- a/.github/workflows/ttmetal-light-xla-on-demand.yml
+++ b/.github/workflows/ttmetal-light-xla-on-demand.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       docker_tag:
-        description: "IRD builder image tag. Leave empty to resolve it from ttlang_ref."
+        description: "IRD builder image tag. Leave empty to resolve the closest existing tag from ttlang_ref."
         required: false
         type: string
         default: ""
@@ -82,11 +82,14 @@ jobs:
         env:
           DOCKER_TAG: ${{ inputs.docker_tag }}
           VERSION_OVERRIDE: ${{ inputs.version_override }}
+          GH_TOKEN: ${{ github.token }}
+          TTLANG_IRD_DOCKER_OWNER: tenstorrent
         run: |
           .github/scripts/resolve-xla-build-inputs.sh \
             --target-dir target-tt-lang \
             --docker-tag "$DOCKER_TAG" \
-            --version "$VERSION_OVERRIDE"
+            --version "$VERSION_OVERRIDE" \
+            --resolve-existing-docker-tag
 
   build:
     name: "Build Ubuntu tt-lang-light wheel"

--- a/.github/workflows/ttmetal-light-xla-on-demand.yml
+++ b/.github/workflows/ttmetal-light-xla-on-demand.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: tt-lang-light XLA wheel (on demand)
+name: Build tt-lang-light XLA per-tt-metal-SHA wheel (on demand)
 
 on:
   workflow_dispatch:
@@ -51,7 +51,7 @@ permissions:
 
 jobs:
   resolve:
-    name: "Resolve build inputs"
+    name: "Resolve tt-lang-light XLA per-tt-metal-SHA inputs"
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
@@ -92,7 +92,7 @@ jobs:
             --resolve-existing-docker-tag
 
   build:
-    name: "Build Ubuntu tt-lang-light wheel"
+    name: "Build Ubuntu tt-lang-light XLA per-tt-metal-SHA wheel"
     needs: resolve
     runs-on: mlir-large-runner-lang
     timeout-minutes: 180
@@ -199,7 +199,8 @@ jobs:
           source /opt/ttlang-toolchain/venv/bin/activate
           python .github/scripts/check-wheel-ttnn-metadata.py \
             --mode external \
-            --dist-dir "dist/xla/${{ steps.ttmetal.outputs.short }}"
+            --dist-dir "dist/xla/${{ steps.ttmetal.outputs.short }}" \
+            --expect-tt-metal-commit "${{ steps.ttmetal.outputs.sha }}"
 
       - name: Test tt-lang wheel
         run: |
@@ -259,7 +260,7 @@ jobs:
           compression-level: 0
 
   device-validate:
-    name: "Device-validate XLA light wheel"
+    name: "Device-validate tt-lang-light XLA per-tt-metal-SHA wheel"
     needs: [resolve, build]
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.hw_type) }}
     timeout-minutes: 180
@@ -310,6 +311,7 @@ jobs:
       - name: Install light wheel and external tt-metal
         env:
           TTMETAL_INSTALL_DIR: /tmp/ttmetal-install
+          EXPECTED_TT_METAL_COMMIT: ${{ inputs.tt_metal_sha }}
         run: |
           set -euo pipefail
           # Clean venv: the installed wheel and the external tt-metal (built at
@@ -323,6 +325,17 @@ jobs:
             --extra-index-url https://download.pytorch.org/whl/cpu \
             "$metapackage_wheel"
           tt-lang-setup
+          python3 - <<'PY'
+          import os
+          import ttl
+
+          expected = os.environ["EXPECTED_TT_METAL_COMMIT"]
+          actual = ttl.build_info()["tt_metal"]
+          if actual != expected:
+              raise SystemExit(
+                  f"tt-lang wheel tt-metal provenance mismatch: expected {expected}, got {actual}"
+              )
+          PY
           eval "$(tt-lang-setup-external-tt-metal --tt-metal-dir "$TTMETAL_INSTALL_DIR")"
           echo "TTL_EXTERNAL_TT_METAL_DIR=$TTMETAL_INSTALL_DIR" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ttmetal-light-xla-on-demand.yml
+++ b/.github/workflows/ttmetal-light-xla-on-demand.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ttlang_ref:
-        description: "tt-lang SHA or tag to build (v1.1.2 or newer; older refs lack the light packaging)."
+        description: "tt-lang SHA or tag with light-wheel packaging and build_info() provenance support."
         required: true
         type: string
       tt_metal_sha:
@@ -101,6 +101,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    outputs:
+      ttmetal_sha: ${{ steps.ttmetal.outputs.sha }}
     steps:
       - name: Checkout target tt-lang
         uses: actions/checkout@v6
@@ -311,7 +313,7 @@ jobs:
       - name: Install light wheel and external tt-metal
         env:
           TTMETAL_INSTALL_DIR: /tmp/ttmetal-install
-          EXPECTED_TT_METAL_COMMIT: ${{ inputs.tt_metal_sha }}
+          EXPECTED_TT_METAL_COMMIT: ${{ needs.build.outputs.ttmetal_sha }}
         run: |
           set -euo pipefail
           # Clean venv: the installed wheel and the external tt-metal (built at

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -681,6 +681,10 @@ publishing and needs no S3 credentials, so it can run from a feature branch; the
 scheduled per-tt-metal-SHA build in `publish-s3-pypi.yml` is best-effort and does
 not fail the nightly publish.
 
+Successful per-SHA publishes place the wheel files (both tt-lang and tt-lang-light)directly under
+`https://pypi.eng.aws.tenstorrent.com/tt-lang/<ttmetal7>/`. Install from that
+directory with `--find-links`. The same directory contains a brief `README.txt`.
+
 `ttmetal-light-xla-on-demand.yml` builds standard `tt-lang-light` wheels for the
 XLA flow from a specific tt-lang ref and tt-metal SHA. Dispatch it with:
 

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -681,9 +681,16 @@ publishing and needs no S3 credentials, so it can run from a feature branch; the
 scheduled per-tt-metal-SHA build in `publish-s3-pypi.yml` is best-effort and does
 not fail the nightly publish.
 
-Successful per-SHA publishes place the wheel files (both tt-lang and tt-lang-light)directly under
+Successful per-SHA publishes place the wheel files (both tt-lang and
+tt-lang-light) directly under
 `https://pypi.eng.aws.tenstorrent.com/tt-lang/<ttmetal7>/`. Install from that
-directory with `--find-links`. The same directory contains a brief `README.txt`.
+directory with `--find-links`. The `tt-lang-light` wheel is a pure metapackage;
+the supported CPython ABIs and glibc floor are carried by the
+`tt_lang-<version>+light-cp310-cp310-manylinux_2_34_x86_64.whl` and
+`tt_lang-<version>+light-cp312-cp312-manylinux_2_34_x86_64.whl` files in the
+same directory. The same directory contains a brief `README.txt`.
+The `ttl.build_info()["tt_metal"]` value in each `tt-lang` wheel must equal
+`<ttmetal7>` expanded to the requested tt-metal commit.
 
 `ttmetal-light-xla-on-demand.yml` builds standard `tt-lang-light` wheels for the
 XLA flow from a specific tt-lang ref and tt-metal SHA. Dispatch it with:

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -689,12 +689,17 @@ ttlang_ref: <tt-lang SHA or tag>
 tt_metal_sha: <tt-metal SHA>
 ```
 
-Leave `docker_tag` and `version_override` empty to resolve them from the pinned
-`ttlang_ref`; the resolver runs that checkout's `get-version-tag.sh` and
-`compute-nightly-version.py` so the build uses the matching IRD image and wheel
-version for the selected tt-lang ref. Set `apply_patches: true` when the pinned
-ref needs the workflow commit's wheel patches. Set `hw_type` to select a device
-validation runner type; it defaults to `n150`.
+Leave `docker_tag` empty to resolve an existing `tt-lang-ird-ubuntu-24-04` image
+from the pinned `ttlang_ref`. The resolver first tries that checkout's
+`get-version-tag.sh` output exactly. If the exact tag is missing and the
+computed tag is a bare release tag such as `v1.1.2`, it uses a single existing
+`v1.1.2-*` image tag. Multiple matching image tags are ambiguous and require an
+explicit `docker_tag`. Leave `version_override` empty to compute the wheel
+version from the pinned `ttlang_ref`; the resolver runs that checkout's
+`compute-nightly-version.py` so the build uses the selected tt-lang ref's
+versioning rules. Set `apply_patches: true` when the pinned ref needs the
+workflow commit's wheel patches. Set `hw_type` to select a device validation
+runner type; it defaults to `n150`.
 
 The XLA workflow uses the Ubuntu IRD image directly, builds the requested
 tt-metal SHA with `.github/scripts/build-ttmetal-at-sha.sh`, and builds the
@@ -706,9 +711,10 @@ uploads that wheel set as the `tt-lang-light-xla-wheels` artifact. It does not
 use the manylinux_2_34 light-wheel builder or publish to S3.
 
 The workflow device-validates the uploaded wheels in a separate hardware job.
-That job rebuilds tt-metal at the same `tt_metal_sha`, installs the downloaded
-`tt-lang-light` wheel with the external tt-metal environment, then runs
-`test/python/smoketest.py` and the tutorial suite.
+The build job uploads the `tt_metal_sha` install as a tar artifact so executable
+bits are preserved. The device job installs the downloaded `tt-lang-light` wheel
+with that external tt-metal environment, then runs `test/python/smoketest.py`
+and the tutorial suite.
 
 #### Local internal wheel testing
 

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -560,25 +560,27 @@ ird image tag):
 #### Publishing to S3 PyPI
 
 `publish-s3-pypi.yml` publishes internal wheels to the Tenstorrent S3 PyPI
-index at `https://pypi.eng.aws.tenstorrent.com/`. It runs on stable release tag
-pushes, runs nightly on a GitHub schedule, and can also be dispatched manually.
-It uses GitHub OIDC for AWS access, then uploads with
+index at `https://pypi.eng.aws.tenstorrent.com/`. It runs nightly on a GitHub
+schedule and can also be dispatched manually. Publishing is restricted to
+workflow runs on `refs/heads/main` because the AWS OIDC role is limited to
+main-branch refs; a manual dispatch from another ref can only perform a dry run.
+The workflow uses
+GitHub OIDC for AWS access, then uploads with
 `s3pypi upload --put-root-index --bucket tenstorrent-pypi`.
+Non-main dry runs must provide an existing `docker_tag`. If `docker_tag` is
+empty, the workflow builds and pushes GHCR IRD and manylinux wheel-builder images
+before the wheel build; that image publication is also restricted to
+`refs/heads/main`.
 
 The workflow prevents publishing a bundled internal `tt-lang` wheel with the
 same package name and version as the public PyPI wheel when public PyPI
 publishing is already valid for that tt-metal tag. This avoids having two
 indexes expose `tt-lang==X.Y.Z` artifacts with different dependency metadata.
 
-Automatic S3 publishing should use this policy:
+S3 publishing uses this policy:
 
-- Stable release tags (`vX.Y.Z`) publish clean-version bundled and light wheels
-  to S3 only when public PyPI publishing is blocked because
-  `TTNN_PYPI_TT_METAL_TAG` and `TT_METAL_TAG` have different `vX.Y.Z`
-  components.
-- Stable release tags publish only light wheels to S3 when public PyPI
-  publishing is aligned. In that case public PyPI owns `tt-lang==X.Y.Z`, and S3
-  owns `tt-lang==X.Y.Z+light` plus `tt-lang-light==X.Y.Z`.
+- Tag pushes are not S3 publishing triggers. Stable internal publishes use
+  manual dispatch from `refs/heads/main` with an explicit `version_override`.
 - Manual stable-version S3 publishes that include the bundled variant are
   rejected when public PyPI publishing is aligned for the same tt-metal tag.
 - The S3 resolver passes `TTLANG_ALLOW_FINAL_INTERNAL_VERSION=true` to the wheel
@@ -595,11 +597,10 @@ Automatic S3 publishing should use this policy:
   keeps nightly versions readable, but existing local pip caches may still hold
   the older wheel for that version.
 
-Stable tag pushes derive `version_override` from the tag (`v1.1.2` -> `1.1.2`),
-build and push the matching IRD image, build the selected wheel variants from
-that image, verify the wheel versions, and publish the result to S3 PyPI. The
-selected variant set is `bundled-and-light` when public PyPI publishing is
-blocked, and `light` when public PyPI publishing is aligned.
+Manual stable-version publishes set `version_override` explicitly, build and
+push the matching IRD image when `docker_tag` is empty, build the selected wheel
+variants from that image, verify the wheel versions, and publish the result to
+S3 PyPI.
 
 The scheduled workflow defaults to `wheel_variant: bundled-and-light`. It keeps
 building the complete bundled wheel from the IRD image, and also builds and
@@ -693,7 +694,10 @@ The `ttl.build_info()["tt_metal"]` value in each `tt-lang` wheel must equal
 `<ttmetal7>` expanded to the requested tt-metal commit.
 
 `ttmetal-light-xla-on-demand.yml` builds standard `tt-lang-light` wheels for the
-XLA flow from a specific tt-lang ref and tt-metal SHA. Dispatch it with:
+XLA flow from a specific tt-lang ref and tt-metal SHA. The selected tt-lang ref
+must include the light-wheel packaging and `ttl.build_info()` provenance support,
+because the workflow verifies that the built wheel records the requested
+tt-metal commit. Dispatch it with:
 
 ```text
 ttlang_ref: <tt-lang SHA or tag>

--- a/packaging/light/setup.py
+++ b/packaging/light/setup.py
@@ -69,6 +69,7 @@ require_non_final_internal_version("tt-lang-light", VERSION)
 setup(
     name="tt-lang-light",
     version=VERSION,
+    python_requires=">=3.10",
     install_requires=[_ttlang_requirement(VERSION)],
     packages=[],
     cmdclass={"sdist": NoSdist},

--- a/packaging/s3-index/README.md
+++ b/packaging/s3-index/README.md
@@ -22,8 +22,14 @@ Light wheels built and device-tested against a specific tt-metal commit are
 published as direct wheel directories under `tt-lang/<ttmetal7>/`, where
 `<ttmetal7>` is that commit's 7-character prefix. The directory contains both the
 `tt-lang` `+light` wheel and the `tt-lang-light` metapackage, plus this README as
-`README.txt`. Use these when the environment already provides `ttnn` from an
-external tt-metal at that commit:
+`README.txt`. The `tt-lang-light` wheel is a pure metapackage; the supported
+CPython ABIs and glibc floor are carried by the
+`tt_lang-<version>+light-cp310-cp310-manylinux_2_34_x86_64.whl` and
+`tt_lang-<version>+light-cp312-cp312-manylinux_2_34_x86_64.whl` files in the
+same directory. The `ttl.build_info()["tt_metal"]` value in each `tt-lang`
+wheel must equal `<ttmetal7>` expanded to the requested tt-metal commit. Use
+these when the environment already provides `ttnn` from an external tt-metal at
+that commit:
 
 ```bash
 pip install \

--- a/packaging/s3-index/README.md
+++ b/packaging/s3-index/README.md
@@ -18,13 +18,16 @@ pip install \
   "tt-lang==<version>"
 ```
 
-Light wheels built and device-tested against a specific tt-metal commit are grouped
-by that commit's 7-character prefix. Use these when the environment already provides
-`ttnn` from an external tt-metal at that commit:
+Light wheels built and device-tested against a specific tt-metal commit are
+published as direct wheel directories under `tt-lang/<ttmetal7>/`, where
+`<ttmetal7>` is that commit's 7-character prefix. The directory contains both the
+`tt-lang` `+light` wheel and the `tt-lang-light` metapackage, plus this README as
+`README.txt`. Use these when the environment already provides `ttnn` from an
+external tt-metal at that commit:
 
 ```bash
 pip install \
-  --extra-index-url https://pypi.eng.aws.tenstorrent.com/<ttmetal7>/ \
+  --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/<ttmetal7>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   "tt-lang-light==<version>"
 ```

--- a/test/packaging/test_light_setup.py
+++ b/test/packaging/test_light_setup.py
@@ -25,6 +25,21 @@ def test_light_metadata_pins_ttlang_version(
     assert "tt-lang==0.71.0.dev20260525+light" in requires_text()
 
 
+def test_light_metadata_declares_python_requirement(
+    run_egg_info: Callable[..., object],
+    tmp_path: Path,
+) -> None:
+    result = run_egg_info(
+        {"TTLANG_VERSION_OVERRIDE": "0.71.0.dev20260525"},
+        cwd=LIGHT_ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    metadata_files = list((tmp_path / "egg-info").glob("*.egg-info/PKG-INFO"))
+    assert len(metadata_files) == 1
+    assert "Requires-Python: >=3.10" in metadata_files[0].read_text()
+
+
 def test_light_metadata_accepts_explicit_ttlang_version(
     run_egg_info: Callable[..., object],
     requires_text: Callable[[], str],

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -264,12 +264,22 @@ def test_nightly_light_wheel_soft_fails_without_failing_publish() -> None:
 
 def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
     workflow = TTMETAL_LIGHT_XLA_ON_DEMAND_WORKFLOW.read_text()
+    docker_tag_input = workflow.split("      docker_tag:", 1)[1].split(
+        "      version_override:", 1
+    )[0]
 
     assert "ttlang_ref:" in workflow
     assert "tt_metal_sha:" in workflow
+    assert "Leave empty to resolve the closest existing tag from ttlang_ref" in (
+        docker_tag_input
+    )
     assert "required: true" in workflow
     assert "resolve-xla-build-inputs.sh" in workflow
-    assert "Leave empty to resolve it from ttlang_ref." in workflow
+    assert "required: false" in docker_tag_input
+    assert 'default: ""' in docker_tag_input
+    assert "--resolve-existing-docker-tag" in workflow
+    assert "GH_TOKEN: ${{ github.token }}" in workflow
+    assert "TTLANG_IRD_DOCKER_OWNER: tenstorrent" in workflow
     assert (
         "tt-lang-ird-ubuntu-24-04:${{ needs.resolve.outputs.docker_tag }}" in workflow
     )

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -104,6 +104,12 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     workflow = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
 
     assert "name: Build tt-lang-light per-tt-metal-SHA wheel (reusable)" in workflow
+    assert "preflight:" in workflow
+    assert 'name: "Validate tt-lang-light per-tt-metal-SHA inputs"' in workflow
+    assert "S3 publishing is restricted to refs/heads/main" in workflow
+    assert "python_tags must include cp312" in workflow
+    assert "python_tags: ${{ steps.python_tags.outputs.python_tags }}" in workflow
+    assert "needs: preflight" in workflow
     assert "build-metapackage:" in workflow
     assert "matrix.python_tag == 'cp312'" not in workflow
     assert "name: ttmetal-light-metapackage" in workflow
@@ -113,7 +119,15 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
         in workflow
     )
     assert (
-        "needs: [find-compatible, build-wheels, build-metapackage, device-validate]"
+        "needs: [preflight, find-compatible, build-wheels, build-metapackage, device-validate]"
+        in workflow
+    )
+    assert (
+        "needs.find-compatible.outputs.found == 'false' && inputs.dry_run != true && github.ref == 'refs/heads/main'"
+        in workflow
+    )
+    assert (
+        "needs.find-compatible.outputs.found == 'true' && inputs.dry_run != true && github.ref == 'refs/heads/main'"
         in workflow
     )
     assert "metapackage_wheel=$(ls dist/tt_lang_light-*-py3-none-any.whl)" in workflow
@@ -133,7 +147,9 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert "ttmetal_sha: ${{ steps.ttmetal.outputs.sha }}" in workflow
     assert "ttmetal_sha: ${{ needs.build-ttmetal.outputs.ttmetal_sha }}" in workflow
     assert "TT_METAL_COMMIT: ${{ needs.build-ttmetal.outputs.ttmetal_sha }}" in workflow
-    assert "TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}" in workflow
+    assert (
+        "TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}" in workflow
+    )
     assert (
         "EXPECTED_TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}"
         in workflow
@@ -155,6 +171,9 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert 'pytest -c /dev/null --rootdir "$PWD" test/me2e' not in workflow
     assert "simple_add" not in workflow
     assert ".github/scripts/publish-s3-direct-wheels.sh" in workflow
+    assert (
+        '--light-python-tags "${{ needs.preflight.outputs.python_tags }}"' in workflow
+    )
     assert '--prefix "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}"' in (
         workflow
     )
@@ -176,19 +195,10 @@ def test_ttmetal_light_workflow_names_are_specific() -> None:
     assert 'name: "Build tt-lang-light per-tt-metal-SHA wheel"' in on_demand
     assert "name: Build tt-lang-light per-tt-metal-SHA wheel (reusable)" in reusable
 
-    assert (
-        "name: Build tt-lang-light XLA per-tt-metal-SHA wheel (on demand)" in xla
-    )
-    assert (
-        'name: "Resolve tt-lang-light XLA per-tt-metal-SHA inputs"' in xla
-    )
-    assert (
-        'name: "Build Ubuntu tt-lang-light XLA per-tt-metal-SHA wheel"' in xla
-    )
-    assert (
-        'name: "Device-validate tt-lang-light XLA per-tt-metal-SHA wheel"'
-        in xla
-    )
+    assert "name: Build tt-lang-light XLA per-tt-metal-SHA wheel (on demand)" in xla
+    assert 'name: "Resolve tt-lang-light XLA per-tt-metal-SHA inputs"' in xla
+    assert 'name: "Build Ubuntu tt-lang-light XLA per-tt-metal-SHA wheel"' in xla
+    assert 'name: "Device-validate tt-lang-light XLA per-tt-metal-SHA wheel"' in xla
 
     assert 'name: "Detect tt-lang-light per-tt-metal-SHA build"' in publish
     assert 'name: "Build tt-lang-light per-tt-metal-SHA wheel"' in publish
@@ -217,6 +227,11 @@ def test_ttmetal_light_on_demand_detect_skips_s3_for_dry_run() -> None:
     workflow = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
     # Dry-run and forced-SHA branch runs do not need S3 credentials.
     assert "if: ${{ inputs.dry_run != true && inputs.tt_metal_sha == '' }}" in workflow
+    assert (
+        "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}"
+        in workflow
+    )
+    assert "S3 publishing is restricted to refs/heads/main" in workflow
     assert "detect-ttmlir-ttmetal-uplift.sh --assume-new" in workflow
     assert 'forced_sha="$(printf \'%s\' "$FORCED_SHA"' in workflow
     assert 'echo "tt_metal_sha=$forced_sha" >> "$GITHUB_OUTPUT"' in workflow
@@ -319,6 +334,7 @@ def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
     )[0]
 
     assert "ttlang_ref:" in workflow
+    assert "light-wheel packaging and build_info() provenance support" in workflow
     assert "tt_metal_sha:" in workflow
     assert "Leave empty to resolve the closest existing tag from ttlang_ref" in (
         docker_tag_input
@@ -364,7 +380,15 @@ def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
     assert "build-s3-light-core-wheel.sh" not in workflow
     assert "build-s3-light-metapackage-wheel.sh" not in workflow
     assert '--expect-tt-metal-commit "${{ steps.ttmetal.outputs.sha }}"' in workflow
-    assert "EXPECTED_TT_METAL_COMMIT: ${{ inputs.tt_metal_sha }}" in workflow
+    # Device-validate must compare against the resolved full SHA embedded in the
+    # wheel (exported as a build-job output), not the raw dispatch input: a short
+    # SHA, tag, or branch would not equal build_info()["tt_metal"] and would fail
+    # the provenance check spuriously.
+    assert "ttmetal_sha: ${{ steps.ttmetal.outputs.sha }}" in workflow
+    assert (
+        "EXPECTED_TT_METAL_COMMIT: ${{ needs.build.outputs.ttmetal_sha }}" in workflow
+    )
+    assert "EXPECTED_TT_METAL_COMMIT: ${{ inputs.tt_metal_sha }}" not in workflow
 
 
 def test_light_core_builder_checks_tt_metal_provenance_when_exported() -> None:
@@ -428,12 +452,21 @@ def test_setup_py_removes_stale_native_payloads_before_wheel_install() -> None:
     )
 
 
-def test_s3_stable_tags_publish_clean_version_wheels() -> None:
+def test_s3_workflow_publishes_only_from_main_ref() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    trigger_block = workflow.split("\nconcurrency:", maxsplit=1)[0]
 
-    assert "push:" in workflow
-    assert "tags:" in workflow
-    assert "- 'v[0-9]+.[0-9]+.[0-9]+'" in workflow
+    assert "push:" not in trigger_block
+    assert "tags:" not in trigger_block
+    assert "- 'v[0-9]+.[0-9]+.[0-9]+'" not in trigger_block
+    assert "github.ref != 'refs/heads/main'" in workflow
+    assert "steps.resolve.outputs.docker_tag == ''" in workflow
+    assert "Publishing is restricted to refs/heads/main" in workflow
+    assert "Non-main dry runs must provide docker_tag" in workflow
+    assert (
+        "needs.preflight.outputs.dry_run == 'true' || github.ref == 'refs/heads/main'"
+        in workflow
+    )
 
 
 def test_check_wheel_ttnn_metadata_matches_requirement_name(tmp_path: Path) -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -21,6 +21,7 @@ from conftest import REPO_ROOT  # noqa: E402
 SCRIPTS_DIR = REPO_ROOT / ".github" / "scripts"
 CHECK_WHEEL_TTNN_METADATA = SCRIPTS_DIR / "check-wheel-ttnn-metadata.py"
 CHECK_LIGHT_METAPACKAGE = SCRIPTS_DIR / "check-light-metapackage.py"
+BUILD_S3_LIGHT_CORE_WHEEL = SCRIPTS_DIR / "build-s3-light-core-wheel.sh"
 COMPUTE_NIGHTLY_VERSION = SCRIPTS_DIR / "compute-nightly-version.py"
 CHECK_INSTALLED_TTNN = SCRIPTS_DIR / "check-installed-ttnn.py"
 CHECK_BUNDLED_PAYLOAD = SCRIPTS_DIR / "check-wheel-bundled-payload.py"
@@ -75,6 +76,11 @@ def _write_wheel(dist_dir: Path, filename: str, metadata: str) -> Path:
     return wheel_path
 
 
+def _add_config_py(wheel_path: Path, *, tt_metal_commit: str) -> None:
+    with zipfile.ZipFile(wheel_path, "a") as wheel:
+        wheel.writestr("ttl/config.py", f'TT_METAL_COMMIT = "{tt_metal_commit}"\n')
+
+
 def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
 
@@ -97,6 +103,7 @@ def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
 def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     workflow = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
 
+    assert "name: Build tt-lang-light per-tt-metal-SHA wheel (reusable)" in workflow
     assert "build-metapackage:" in workflow
     assert "matrix.python_tag == 'cp312'" not in workflow
     assert "name: ttmetal-light-metapackage" in workflow
@@ -123,6 +130,15 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert workflow.count("name: ttmetal-install") == 4
     assert "TTLANG_EXTERNAL_TT_METAL_DIR: /tmp/ttmetal-install" in workflow
     assert "TTMETAL_INSTALL_DIR: /tmp/ttmetal-install" in workflow
+    assert "ttmetal_sha: ${{ steps.ttmetal.outputs.sha }}" in workflow
+    assert "ttmetal_sha: ${{ needs.build-ttmetal.outputs.ttmetal_sha }}" in workflow
+    assert "TT_METAL_COMMIT: ${{ needs.build-ttmetal.outputs.ttmetal_sha }}" in workflow
+    assert "TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}" in workflow
+    assert (
+        "EXPECTED_TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}"
+        in workflow
+    )
+    assert 'actual = ttl.build_info()["tt_metal"]' in workflow
     # tar transfer (not a bare artifact) so the sfpi compiler keeps its +x bit;
     # unpacked by each of the three consumers.
     assert "Package tt-metal install" in workflow
@@ -147,6 +163,35 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
         in workflow
     )
     assert "Inject S3 index README" not in workflow
+
+
+def test_ttmetal_light_workflow_names_are_specific() -> None:
+    on_demand = TTMETAL_LIGHT_ON_DEMAND_WORKFLOW.read_text()
+    reusable = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
+    xla = TTMETAL_LIGHT_XLA_ON_DEMAND_WORKFLOW.read_text()
+    publish = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+
+    assert "name: Build tt-lang-light per-tt-metal-SHA wheel (on demand)" in on_demand
+    assert 'name: "Detect tt-lang-light per-tt-metal-SHA build"' in on_demand
+    assert 'name: "Build tt-lang-light per-tt-metal-SHA wheel"' in on_demand
+    assert "name: Build tt-lang-light per-tt-metal-SHA wheel (reusable)" in reusable
+
+    assert (
+        "name: Build tt-lang-light XLA per-tt-metal-SHA wheel (on demand)" in xla
+    )
+    assert (
+        'name: "Resolve tt-lang-light XLA per-tt-metal-SHA inputs"' in xla
+    )
+    assert (
+        'name: "Build Ubuntu tt-lang-light XLA per-tt-metal-SHA wheel"' in xla
+    )
+    assert (
+        'name: "Device-validate tt-lang-light XLA per-tt-metal-SHA wheel"'
+        in xla
+    )
+
+    assert 'name: "Detect tt-lang-light per-tt-metal-SHA build"' in publish
+    assert 'name: "Build tt-lang-light per-tt-metal-SHA wheel"' in publish
 
 
 def test_ttmetal_light_max_age_crosses_reusable_workflow_as_string() -> None:
@@ -306,7 +351,7 @@ def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
     assert "dist/xla/${{ steps.ttmetal.outputs.short }}" in workflow
     assert "tt-lang-light-xla-wheels" in workflow
     # The wheel is device-validated against the same tt-metal SHA it was built on.
-    assert "Device-validate XLA light wheel" in workflow
+    assert "Device-validate tt-lang-light XLA per-tt-metal-SHA wheel" in workflow
     assert "options: --device /dev/tenstorrent" in workflow
     assert "bash .github/scripts/run-tutorials.sh ." in workflow
     # tt-metal built once (build job), shared as a tar artifact preserving the
@@ -318,6 +363,15 @@ def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
     assert "tt-lang-wheel-manylinux-2-34" not in workflow
     assert "build-s3-light-core-wheel.sh" not in workflow
     assert "build-s3-light-metapackage-wheel.sh" not in workflow
+    assert '--expect-tt-metal-commit "${{ steps.ttmetal.outputs.sha }}"' in workflow
+    assert "EXPECTED_TT_METAL_COMMIT: ${{ inputs.tt_metal_sha }}" in workflow
+
+
+def test_light_core_builder_checks_tt_metal_provenance_when_exported() -> None:
+    script = BUILD_S3_LIGHT_CORE_WHEEL.read_text()
+
+    assert 'if [ -n "${TT_METAL_COMMIT:-}" ]; then' in script
+    assert '--expect-tt-metal-commit "$TT_METAL_COMMIT"' in script
 
 
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
@@ -418,6 +472,30 @@ def test_check_wheel_ttnn_metadata_rejects_external_payload(tmp_path: Path) -> N
     assert "external wheel must not bundle a ttnn payload" in result.stderr
 
 
+def test_check_wheel_ttnn_metadata_checks_tt_metal_commit(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    wheel_path = _write_wheel(
+        dist_dir,
+        "tt_lang-0.71.0.dev20260525+light-py3-none-any.whl",
+        "Metadata-Version: 2.1\n",
+    )
+    _add_config_py(wheel_path, tt_metal_commit="aaaaaaaa")
+
+    result = _run_script(
+        CHECK_WHEEL_TTNN_METADATA,
+        "--mode",
+        "external",
+        "--dist-dir",
+        str(dist_dir),
+        "--expect-tt-metal-commit",
+        "bbbbbbbb",
+    )
+
+    assert result.returncode != 0
+    assert "tt-metal provenance mismatch" in result.stderr
+
+
 def test_check_light_metapackage_parses_requires_dist(tmp_path: Path) -> None:
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir()
@@ -426,6 +504,7 @@ def test_check_light_metapackage_parses_requires_dist(tmp_path: Path) -> None:
         "tt_lang_light-0.71.0.dev20260525-py3-none-any.whl",
         (
             "Metadata-Version: 2.1\n"
+            "Requires-Python: >=3.10\n"
             "Requires-Dist: tt-lang == 0.71.0.dev20260525+light ; "
             'python_version >= "3.12"\n'
         ),
@@ -440,6 +519,30 @@ def test_check_light_metapackage_parses_requires_dist(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_check_light_metapackage_requires_python_metadata(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    _write_wheel(
+        dist_dir,
+        "tt_lang_light-0.71.0.dev20260525-py3-none-any.whl",
+        (
+            "Metadata-Version: 2.1\n"
+            "Requires-Dist: tt-lang == 0.71.0.dev20260525+light\n"
+        ),
+    )
+
+    result = _run_script(
+        CHECK_LIGHT_METAPACKAGE,
+        "--dist-dir",
+        str(dist_dir),
+        "--expect-ttlang-version",
+        "0.71.0.dev20260525+light",
+    )
+
+    assert result.returncode != 0
+    assert "Requires-Python: >=3.10" in result.stderr
 
 
 def test_compute_nightly_version_uses_latest_stable_tag(

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -138,10 +138,15 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert 'pytest -c /dev/null --rootdir "$PWD" test/python' not in workflow
     assert 'pytest -c /dev/null --rootdir "$PWD" test/me2e' not in workflow
     assert "simple_add" not in workflow
+    assert ".github/scripts/publish-s3-direct-wheels.sh" in workflow
+    assert '--prefix "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}"' in (
+        workflow
+    )
     assert (
-        '.github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist'
+        '--find-links-subdir "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}"'
         in workflow
     )
+    assert "Inject S3 index README" not in workflow
 
 
 def test_ttmetal_light_max_age_crosses_reusable_workflow_as_string() -> None:


### PR DESCRIPTION
### Problem description
The tt-lang-light S3 workflows needed cleanup after the per-tt-metal-SHA publish changes. Publishing from tags or feature branches could still reach S3-only steps, the published per-SHA layout did not match the desired `tt-lang/<ttmetal7>/` wheel directory, and the light wheel metadata/provenance checks were not strict enough to catch a wheel built against the wrong tt-metal SHA.

### What's changed
- Restrict S3 publishing and miss-marker writes to `refs/heads/main`; tag-triggered S3 publishing is removed, and non-main runs are dry-run only with an existing `docker_tag`.
- Publish per-SHA light wheels as a direct `--find-links` directory under `tt-lang/<ttmetal7>/`, containing the `tt-lang` `+light` core wheel, the `tt-lang-light` metapackage, `README.txt`, and a generated link listing.
- Build tt-metal at the requested SHA once, propagate the resolved full SHA through the wheel build, and verify `ttl.build_info()["tt_metal"]` during wheel metadata checks and device validation.
- Validate requested light-wheel Python tags up front; device validation requires `cp312`, and publish verification now honors the requested tag subset.
- Update the XLA on-demand workflow to resolve an existing IRD image tag, build standard `tt-lang-light` wheels from the Ubuntu IRD flow, reuse the built tt-metal install for device validation, and verify tt-metal provenance.
- Add/refresh helper-script coverage and CI docs for the new publishing behavior.

### Validation
- `BATS_LIB_PATH=/usr/local/lib/bats bats .github/scripts/tests` -> 376 passed.
- `python3 -m pytest -c /dev/null test/packaging/test_workflow_helper_scripts.py test/packaging/test_light_setup.py -q` -> 43 passed.
- Workflow YAML parse for the touched workflows passed.
- `git diff --check origin/main...HEAD` passed.
- Published-wheel local validation: installed the published `tt-lang-light` wheel plus cp312 `tt-lang` core wheel in `bnorris-ird-v1.1.4`, used the existing 13adda8 external tt-metal install, copied tutorials with `tt-lang-setup`, and ran `tutorials/elementwise/step_4_multinode_grid_full.py` on device successfully.

### Checklist
- [x] New/Existing tests provide coverage for changes
