### PR TITLE
[ci] Browsable per-SHA S3 wheel layout + s3-pypi-ops workflow

### DIFF
--- a/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
+++ b/.github/scripts/detect-ttmlir-ttmetal-uplift.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Detect whether tt-lang should build a light wheel for tt-mlir's pinned
-# tt-metal SHA, keyed by the tt-lang/<ttmetal7> S3 prefix.
+# tt-metal SHA, keyed by the tt-lang/ttmetal/<ttmetal7> S3 prefix.
 #
 # A SHA is skipped when a wheel is already published, and also when a prior
 # search recorded no compatible tt-lang AND the tt-lang HEAD it searched is
@@ -46,12 +46,12 @@ read_target_ttmetal_sha() {
 
 # Object basenames under the per-SHA wheel prefix. Overridable in tests.
 list_prefix_objects() {
-    aws s3 ls "s3://$S3_BUCKET/tt-lang/$1/" 2>/dev/null | awk '{print $NF}'
+    aws s3 ls "s3://$S3_BUCKET/tt-lang/ttmetal/$1/" 2>/dev/null | awk '{print $NF}'
 }
 
 # tt-lang HEAD from a prior miss marker, or empty. Overridable in tests.
 read_recorded_head() {
-    aws s3 cp "s3://$S3_BUCKET/tt-lang/$1/attempt.json" - 2>/dev/null \
+    aws s3 cp "s3://$S3_BUCKET/tt-lang/ttmetal/$1/attempt.json" - 2>/dev/null \
         | sed -n -E 's/.*"ttlang_head"[[:space:]]*:[[:space:]]*"([a-f0-9]+)".*/\1/p' \
         | head -n1
 }
@@ -111,7 +111,7 @@ main() {
         return 1
     fi
     short_sha="${target_sha:0:7}"
-    echo "tt-mlir targets tt-metal $target_sha (prefix tt-lang/$short_sha); tt-lang HEAD $ttlang_head" >&2
+    echo "tt-mlir targets tt-metal $target_sha (prefix tt-lang/ttmetal/$short_sha); tt-lang HEAD $ttlang_head" >&2
 
     if [[ "$assume_new" == true ]]; then
         echo "Assuming $short_sha is unbuilt (--assume-new); skipping S3 idempotency check." >&2
@@ -121,10 +121,10 @@ main() {
     fi
     case "$class" in
         published)
-            echo "Wheel already published under tt-lang/$short_sha; skipping." >&2
+            echo "Wheel already published under tt-lang/ttmetal/$short_sha; skipping." >&2
             emit "uplift=false" ;;
         doomed)
-            echo "Recorded miss under tt-lang/$short_sha for the current tt-lang HEAD; skipping." >&2
+            echo "Recorded miss under tt-lang/ttmetal/$short_sha for the current tt-lang HEAD; skipping." >&2
             emit "uplift=false" ;;
         retry|new)
             echo "Building for $short_sha ($class)." >&2

--- a/.github/scripts/inject-s3-index-readme.sh
+++ b/.github/scripts/inject-s3-index-readme.sh
@@ -59,10 +59,14 @@ fi
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 index_html="$tmpdir/index.html"
-aws_error="$tmpdir/aws-cp.err"
+aws_error="$tmpdir/aws-get.err"
 
-if ! aws s3 cp "s3://$bucket/$key" "$index_html" 2>"$aws_error"; then
-    if grep -Eq 'HeadObject.*404|404.*HeadObject|Key ".+" does not exist' "$aws_error"; then
+# Use s3api get-object/put-object rather than `s3 cp`: a key ending in "/"
+# (the s3pypi root index key for a prefixed publish) is a valid exact S3 key,
+# but `s3 cp` treats a trailing-slash destination as a directory and
+# re-appends the source basename, writing to the wrong key.
+if ! aws s3api get-object --bucket "$bucket" --key "$key" "$index_html" >/dev/null 2>"$aws_error"; then
+    if grep -Eq 'NoSuchKey|Not Found|404|does not exist' "$aws_error"; then
         echo "S3 index s3://$bucket/$key does not exist; creating a root index from $dist_dir." >&2
         rm -f "$index_html"
     else
@@ -75,5 +79,5 @@ python3 .github/scripts/inject_s3_index_readme.py \
     --create-from-dist "$dist_dir" \
     "$readme" \
     "$index_html"
-aws s3 cp "$index_html" "s3://$bucket/$key" \
-    --content-type "text/html; charset=utf-8"
+aws s3api put-object --bucket "$bucket" --key "$key" --body "$index_html" \
+    --content-type "text/html; charset=utf-8" >/dev/null

--- a/.github/scripts/inject-s3-index-readme.sh
+++ b/.github/scripts/inject-s3-index-readme.sh
@@ -61,10 +61,8 @@ trap 'rm -rf "$tmpdir"' EXIT
 index_html="$tmpdir/index.html"
 aws_error="$tmpdir/aws-get.err"
 
-# Use s3api get-object/put-object rather than `s3 cp`: a key ending in "/"
-# (the s3pypi root index key for a prefixed publish) is a valid exact S3 key,
-# but `s3 cp` treats a trailing-slash destination as a directory and
-# re-appends the source basename, writing to the wrong key.
+# The key may end in "/" (s3pypi's prefixed root index is a slash-key); s3api
+# uses the exact key, whereas `s3 cp` treats a trailing slash as a directory.
 if ! aws s3api get-object --bucket "$bucket" --key "$key" "$index_html" >/dev/null 2>"$aws_error"; then
     if grep -Eq 'NoSuchKey|Not Found|404|does not exist' "$aws_error"; then
         echo "S3 index s3://$bucket/$key does not exist; creating a root index from $dist_dir." >&2

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -10,7 +10,9 @@
 # Escape text for HTML element content and double-quoted attributes.
 _html_escape() {
     local s="$1"
-    s="${s//&/&amp;}"; s="${s//</&lt;}"; s="${s//>/&gt;}"; s="${s//\"/&quot;}"; s="${s//\'/&#39;}"
+    # Escape & as \& in each replacement: bash 5.2's patsub_replacement treats a
+    # bare & in a ${var//pat/repl} replacement as the matched text.
+    s="${s//&/\&amp;}"; s="${s//</\&lt;}"; s="${s//>/\&gt;}"; s="${s//\"/\&quot;}"; s="${s//\'/\&#39;}"
     printf '%s' "$s"
 }
 

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -26,18 +26,21 @@ s3_render_index() {
 
 # Emit one anchor line per immediate child of s3://<bucket>/<prefix>/.
 # `aws s3 ls` prints "PRE name/" for sub-prefixes and "<date> <time> <size> name"
-# for objects. Skip the slash-key object itself (empty name) and legacy index.html.
+# for objects. Names are HTML-escaped before being interpolated into anchor text/href.
 s3_child_anchors() {
-    local bucket="$1" prefix="$2" listing col1 col2 col3 name
+    local bucket="$1" prefix="$2" listing col1 col2 col3 name esc
     listing="$(aws s3 ls "s3://${bucket}/${prefix}/")" || return 1
-    # col3 (object size) is consumed only for field alignment, never read.
     # shellcheck disable=SC2034
     while read -r col1 col2 col3 name; do
         if [[ "$col1" == "PRE" ]]; then
             name="$col2"
+        else
+            # A find-links directory holds only wheels and the README; skip the
+            # slash-key object itself, index.html, attempt.json markers, etc.
+            [[ "$name" == *.whl || "$name" == "README.txt" ]] || continue
         fi
-        [[ -z "$name" || "$name" == "index.html" ]] && continue
-        printf '<a href="%s">%s</a><br>\n' "$name" "$name"
+        esc="${name//&/&amp;}"; esc="${esc//</&lt;}"; esc="${esc//>/&gt;}"
+        printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
     done <<< "$listing"
 }
 

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -7,9 +7,16 @@
 # only the exact key requested; an object at <prefix>/index.html does not answer
 # a request for <prefix>/.
 
+# Escape text for HTML element content and double-quoted attributes.
+_html_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"; s="${s//</&lt;}"; s="${s//>/&gt;}"; s="${s//\"/&quot;}"; s="${s//\'/&#39;}"
+    printf '%s' "$s"
+}
+
 # Wrap anchor lines (read from stdin) in the Package-Index HTML skeleton.
 s3_render_index() {
-    local title="$1"
+    local title; title="$(_html_escape "$1")"
     printf '%s\n' \
         '<!DOCTYPE html>' \
         '<html>' \
@@ -24,35 +31,38 @@ s3_render_index() {
         '</html>'
 }
 
-# Emit one anchor line per immediate child of s3://<bucket>/<prefix>/.
-# `aws s3 ls` prints "PRE name/" for sub-prefixes and "<date> <time> <size> name"
-# for objects. Wheel links include #sha256 fragments so pip can verify the
-# downloaded bytes against the directory listing.
+# Anchors for the immediate children of s3://<bucket>/<prefix>/, listed from S3.
+# Sub-prefixes and (wheels + README.txt); no sha256 (the hashed per-SHA listing
+# is generated at publish time from local files by s3_local_wheel_anchors).
 s3_child_anchors() {
-    local bucket="$1" prefix="$2" listing col1 col2 col3 name esc digest href
+    local bucket="$1" prefix="$2" listing col1 col2 col3 name esc
     listing="$(aws s3 ls "s3://${bucket}/${prefix}/")" || return 1
     # shellcheck disable=SC2034
     while read -r col1 col2 col3 name; do
         if [[ "$col1" == "PRE" ]]; then
             name="$col2"
-            esc="${name//&/&amp;}"; esc="${esc//</&lt;}"; esc="${esc//>/&gt;}"
-            printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
-            continue
-        fi
-        # A find-links directory holds only wheels and the README; skip the
-        # slash-key object itself, index.html, attempt.json markers, etc.
-        [[ "$name" == *.whl || "$name" == "README.txt" ]] || continue
-
-        esc="${name//&/&amp;}"; esc="${esc//</&lt;}"; esc="${esc//>/&gt;}"
-        href="$esc"
-        if [[ "$name" == *.whl ]]; then
-            digest="$(aws s3 cp "s3://${bucket}/${prefix}/${name}" - | sha256sum | awk '{print $1}')" || return 1
-            href="${esc}#sha256=${digest}"
         else
-            href="$esc"
+            # A find-links directory holds only wheels and the README; skip the
+            # slash-key object itself, index.html, attempt.json markers, etc.
+            [[ "$name" == *.whl || "$name" == "README.txt" ]] || continue
         fi
-        printf '<a href="%s">%s</a><br>\n' "$href" "$esc"
+        esc="$(_html_escape "$name")"
+        printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
     done <<< "$listing"
+}
+
+# Anchors for a local wheel dist: README.txt plus each *.whl with a #sha256
+# fragment computed from the local file (no download).
+s3_local_wheel_anchors() {
+    local dist_dir="$1" f name esc digest
+    esc="$(_html_escape "README.txt")"
+    printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+    for f in "$dist_dir"/*.whl; do
+        [[ -e "$f" ]] || continue
+        name="$(basename "$f")"; esc="$(_html_escape "$name")"
+        digest="$(sha256sum "$f" | awk '{print $1}')"
+        printf '<a href="%s#sha256=%s">%s</a><br>\n' "$esc" "$digest" "$esc"
+    done
 }
 
 # Upload an HTML file to the slash-key s3://<bucket>/<prefix>/ (trailing slash is

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -28,19 +28,17 @@ s3_render_index() {
 # `aws s3 ls` prints "PRE name/" for sub-prefixes and "<date> <time> <size> name"
 # for objects. Skip the slash-key object itself (empty name) and legacy index.html.
 s3_child_anchors() {
-    local bucket="$1" prefix="$2"
-    aws s3 ls "s3://${bucket}/${prefix}/" 2>/dev/null | while read -r col1 col2 rest; do
+    local bucket="$1" prefix="$2" listing col1 col2 col3 name
+    listing="$(aws s3 ls "s3://${bucket}/${prefix}/")" || return 1
+    # col3 (object size) is consumed only for field alignment, never read.
+    # shellcheck disable=SC2034
+    while read -r col1 col2 col3 name; do
         if [[ "$col1" == "PRE" ]]; then
-            local name="$col2"
-            printf '<a href="%s">%s</a><br>\n' "$name" "$name"
-        else
-            # object line: <date> <time> <size> <name...>; name is everything
-            # after the size column.
-            local name="${rest#* }"
-            [[ -z "$name" || "$name" == "index.html" ]] && continue
-            printf '<a href="%s">%s</a><br>\n' "$name" "$name"
+            name="$col2"
         fi
-    done
+        [[ -z "$name" || "$name" == "index.html" ]] && continue
+        printf '<a href="%s">%s</a><br>\n' "$name" "$name"
+    done <<< "$listing"
 }
 
 # Upload an HTML file to the slash-key s3://<bucket>/<prefix>/ (trailing slash is
@@ -55,12 +53,20 @@ s3_put_index() {
 }
 
 # Regenerate the slash-key listing for <prefix> from its current S3 children.
+# Refuses to write if the listing fails or comes back empty, so a transient
+# `aws s3 ls` failure can't overwrite a live index with a blank page.
 s3_regenerate_index() {
-    local bucket="$1" prefix="$2"
-    local tmp
+    local bucket="$1" prefix="$2" anchors tmp
+    anchors="$(s3_child_anchors "$bucket" "$prefix")" || {
+        echo "s3_regenerate_index: failed to list s3://${bucket}/${prefix}/" >&2
+        return 1
+    }
+    if [[ -z "$anchors" ]]; then
+        echo "s3_regenerate_index: refusing to write an empty index for ${prefix}" >&2
+        return 1
+    fi
     tmp="$(mktemp)"
-    s3_child_anchors "$bucket" "$prefix" \
-        | s3_render_index "tt-lang: ${prefix}" > "$tmp"
+    printf '%s\n' "$anchors" | s3_render_index "tt-lang: ${prefix}" > "$tmp"
     s3_put_index "$bucket" "$prefix" "$tmp"
     rm -f "$tmp"
 }

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -1,0 +1,66 @@
+# shellcheck shell=bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sourceable helpers for the tt-lang S3 "directory" listings. Listings are
+# written to a key ending in "/" (slash-key) because the pypi.eng CDN serves
+# only the exact key requested; an object at <prefix>/index.html does not answer
+# a request for <prefix>/.
+
+# Wrap anchor lines (read from stdin) in the Package-Index HTML skeleton.
+s3_render_index() {
+    local title="$1"
+    printf '%s\n' \
+        '<!DOCTYPE html>' \
+        '<html>' \
+        '  <head>' \
+        '    <meta charset="UTF-8">' \
+        "    <title>${title}</title>" \
+        '  </head>' \
+        '  <body>'
+    cat
+    printf '%s\n' \
+        '  </body>' \
+        '</html>'
+}
+
+# Emit one anchor line per immediate child of s3://<bucket>/<prefix>/.
+# `aws s3 ls` prints "PRE name/" for sub-prefixes and "<date> <time> <size> name"
+# for objects. Skip the slash-key object itself (empty name) and legacy index.html.
+s3_child_anchors() {
+    local bucket="$1" prefix="$2"
+    aws s3 ls "s3://${bucket}/${prefix}/" 2>/dev/null | while read -r col1 col2 rest; do
+        if [[ "$col1" == "PRE" ]]; then
+            local name="$col2"
+            printf '<a href="%s">%s</a><br>\n' "$name" "$name"
+        else
+            # object line: <date> <time> <size> <name...>; name is everything
+            # after the size column.
+            local name="${rest#* }"
+            [[ -z "$name" || "$name" == "index.html" ]] && continue
+            printf '<a href="%s">%s</a><br>\n' "$name" "$name"
+        fi
+    done
+}
+
+# Upload an HTML file to the slash-key s3://<bucket>/<prefix>/ (trailing slash is
+# the object key, so the directory URL resolves).
+s3_put_index() {
+    local bucket="$1" prefix="$2" html_file="$3"
+    aws s3api put-object \
+        --bucket "$bucket" \
+        --key "${prefix}/" \
+        --body "$html_file" \
+        --content-type "text/html; charset=utf-8" >/dev/null
+}
+
+# Regenerate the slash-key listing for <prefix> from its current S3 children.
+s3_regenerate_index() {
+    local bucket="$1" prefix="$2"
+    local tmp
+    tmp="$(mktemp)"
+    s3_child_anchors "$bucket" "$prefix" \
+        | s3_render_index "tt-lang: ${prefix}" > "$tmp"
+    s3_put_index "$bucket" "$prefix" "$tmp"
+    rm -f "$tmp"
+}

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -26,21 +26,32 @@ s3_render_index() {
 
 # Emit one anchor line per immediate child of s3://<bucket>/<prefix>/.
 # `aws s3 ls` prints "PRE name/" for sub-prefixes and "<date> <time> <size> name"
-# for objects. Names are HTML-escaped before being interpolated into anchor text/href.
+# for objects. Wheel links include #sha256 fragments so pip can verify the
+# downloaded bytes against the directory listing.
 s3_child_anchors() {
-    local bucket="$1" prefix="$2" listing col1 col2 col3 name esc
+    local bucket="$1" prefix="$2" listing col1 col2 col3 name esc digest href
     listing="$(aws s3 ls "s3://${bucket}/${prefix}/")" || return 1
     # shellcheck disable=SC2034
     while read -r col1 col2 col3 name; do
         if [[ "$col1" == "PRE" ]]; then
             name="$col2"
-        else
-            # A find-links directory holds only wheels and the README; skip the
-            # slash-key object itself, index.html, attempt.json markers, etc.
-            [[ "$name" == *.whl || "$name" == "README.txt" ]] || continue
+            esc="${name//&/&amp;}"; esc="${esc//</&lt;}"; esc="${esc//>/&gt;}"
+            printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+            continue
         fi
+        # A find-links directory holds only wheels and the README; skip the
+        # slash-key object itself, index.html, attempt.json markers, etc.
+        [[ "$name" == *.whl || "$name" == "README.txt" ]] || continue
+
         esc="${name//&/&amp;}"; esc="${esc//</&lt;}"; esc="${esc//>/&gt;}"
-        printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+        href="$esc"
+        if [[ "$name" == *.whl ]]; then
+            digest="$(aws s3 cp "s3://${bucket}/${prefix}/${name}" - | sha256sum | awk '{print $1}')" || return 1
+            href="${esc}#sha256=${digest}"
+        else
+            href="$esc"
+        fi
+        printf '<a href="%s">%s</a><br>\n' "$href" "$esc"
     done <<< "$listing"
 }
 

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -54,13 +54,13 @@ for wheel in "${wheels[@]}"; do
         --content-type "application/octet-stream"
 done
 
-# Wheels are already uploaded at this point; if index regeneration below fails,
-# the wheels are present but the directory is not browsable until
-# s3-pypi-ops.sh --operation put-index is re-run for this prefix.
-#
-# Write the browsable slash-key listing for this prefix and refresh the parent
-# so the SHA appears one level up.
-s3_regenerate_index "$bucket" "$prefix"
+# Per-SHA index: hash the local wheels (no re-download) and write the slash-key.
+# (Wheels upload first, so if this fails the wheels are present but the directory
+# is not browsable until s3-pypi-ops.sh --operation put-index is re-run.)
+index_html="$(mktemp)"; trap 'rm -f "$index_html"' EXIT
+s3_local_wheel_anchors "$dist_dir" | s3_render_index "tt-lang: $prefix" > "$index_html"
+s3_put_index "$bucket" "$prefix" "$index_html"
+
 parent="$(dirname "$prefix")"
 if [[ "$parent" != "." && "$parent" != "$prefix" ]]; then
     s3_regenerate_index "$bucket" "$parent"

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -55,8 +55,10 @@ for wheel in "${wheels[@]}"; do
 done
 
 # Per-SHA index: hash the local wheels (no re-download) and write the slash-key.
-# (Wheels upload first, so if this fails the wheels are present but the directory
-# is not browsable until s3-pypi-ops.sh --operation put-index is re-run.)
+# Wheels upload first, so if this write fails the directory is not browsable
+# until re-run. Re-running this script with the local dist restores the hashed
+# index; `s3-pypi-ops.sh --operation put-index` instead regenerates from S3
+# (s3_child_anchors), which produces a valid but hash-less index.
 index_html="$(mktemp)"; trap 'rm -f "$index_html"' EXIT
 s3_local_wheel_anchors "$dist_dir" | s3_render_index "tt-lang: $prefix" > "$index_html"
 s3_put_index "$bucket" "$prefix" "$index_html"

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -54,6 +54,10 @@ for wheel in "${wheels[@]}"; do
         --content-type "application/octet-stream"
 done
 
+# Wheels are already uploaded at this point; if index regeneration below fails,
+# the wheels are present but the directory is not browsable until
+# s3-pypi-ops.sh --operation put-index is re-run for this prefix.
+#
 # Write the browsable slash-key listing for this prefix and refresh the parent
 # so the SHA appears one level up.
 s3_regenerate_index "$bucket" "$prefix"

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -2,9 +2,11 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Upload wheel files directly under an S3 prefix and write an index.html file
-# listing in the same directory. This layout is for per-tt-metal-SHA wheel sets
-# that are consumed with pip --find-links, not as a PEP 503 package index.
+# Publish a per-tt-metal-SHA wheel set to a browsable slash-key directory under
+# <prefix> (e.g. tt-lang/ttmetal/<sha7>), consumed with pip --find-links. Wheels
+# and README.txt are uploaded as objects; the directory listing is written to the
+# slash-key <prefix>/ and the parent listing is regenerated so the new entry
+# shows up when browsing.
 #
 # Usage: publish-s3-direct-wheels.sh --prefix <prefix> [--readme <path>] <dist_dir>
 
@@ -12,6 +14,8 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
+# shellcheck source=lib/s3-index.sh
+. "$script_dir/lib/s3-index.sh"
 
 usage() {
     echo "Usage: $0 --prefix <prefix> [--readme <path>] <dist_dir>" >&2
@@ -23,23 +27,10 @@ prefix=""
 readme="$repo_root/packaging/s3-index/README.md"
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --prefix)
-            [[ $# -ge 2 ]] || usage
-            prefix="${2%/}"
-            shift 2
-            ;;
-        --readme)
-            [[ $# -ge 2 ]] || usage
-            readme="$2"
-            shift 2
-            ;;
-        -*)
-            echo "Unknown option: $1" >&2
-            usage
-            ;;
-        *)
-            break
-            ;;
+        --prefix) [[ $# -ge 2 ]] || usage; prefix="${2%/}"; shift 2 ;;
+        --readme) [[ $# -ge 2 ]] || usage; readme="$2"; shift 2 ;;
+        -*) echo "Unknown option: $1" >&2; usage ;;
+        *) break ;;
     esac
 done
 
@@ -55,58 +46,18 @@ if [[ "${#wheels[@]}" -eq 0 ]]; then
     exit 1
 fi
 
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
-index_html="$tmpdir/index.html"
-readme_txt="$tmpdir/README.txt"
-
-python3 - "$dist_dir" "$index_html" <<'PY'
-import hashlib
-import html
-import sys
-from pathlib import Path
-from urllib.parse import quote
-
-dist_dir = Path(sys.argv[1])
-index_path = Path(sys.argv[2])
-wheels = sorted(dist_dir.glob("*.whl"))
-
-anchors = ['    <a href="README.txt">README.txt</a><br>']
-for wheel in wheels:
-    hasher = hashlib.sha256()
-    with wheel.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            hasher.update(chunk)
-    digest = hasher.hexdigest()
-    name = wheel.name
-    href = f"{quote(name)}#sha256={digest}"
-    anchors.append(f'    <a href="{href}">{html.escape(name)}</a><br>')
-
-index_path.write_text(
-    "<!DOCTYPE html>\n"
-    "<html>\n"
-    "  <head>\n"
-    '    <meta charset="UTF-8">\n'
-    "    <title>tt-lang per-SHA wheels</title>\n"
-    "  </head>\n"
-    "  <body>\n"
-    + "\n".join(anchors)
-    + "\n  </body>\n"
-    "</html>\n",
-    encoding="utf-8",
-)
-PY
-
-python3 "$script_dir/inject_s3_index_readme.py" "$readme" "$index_html"
-cp "$readme" "$readme_txt"
-
-aws s3 cp "$readme_txt" "s3://$bucket/$prefix/README.txt" \
+# Upload the README (as README.txt) and each wheel as plain objects.
+aws s3 cp "$readme" "s3://$bucket/$prefix/README.txt" \
     --content-type "text/plain; charset=utf-8"
-
 for wheel in "${wheels[@]}"; do
     aws s3 cp "$wheel" "s3://$bucket/$prefix/$(basename "$wheel")" \
         --content-type "application/octet-stream"
 done
 
-aws s3 cp "$index_html" "s3://$bucket/$prefix/index.html" \
-    --content-type "text/html; charset=utf-8"
+# Write the browsable slash-key listing for this prefix and refresh the parent
+# so the SHA appears one level up.
+s3_regenerate_index "$bucket" "$prefix"
+parent="$(dirname "$prefix")"
+if [[ "$parent" != "." && "$parent" != "$prefix" ]]; then
+    s3_regenerate_index "$bucket" "$parent"
+fi

--- a/.github/scripts/publish-s3-summary.sh
+++ b/.github/scripts/publish-s3-summary.sh
@@ -5,7 +5,7 @@
 # Append a Markdown install summary to $GITHUB_STEP_SUMMARY for the S3 PyPI
 # publish workflow. With --dry-run, record that no upload occurred. With
 # --index-subdir <subdir>, point the install commands at the .../<subdir>/
-# simple index (year-month <YYYY-MM>/ for nightlies) instead of the flat root.
+# simple index (`tt-lang/<YYYY-MM>/` for nightlies) instead of the flat root.
 # --find-links-subdir <subdir> points install commands at a direct wheel
 # directory consumed with pip --find-links. With no $GITHUB_STEP_SUMMARY set,
 # output goes to stdout for local invocations/tests.

--- a/.github/scripts/record-ttmetal-miss.sh
+++ b/.github/scripts/record-ttmetal-miss.sh
@@ -4,7 +4,7 @@
 #
 # Record that no compatible tt-lang was found for a tt-metal SHA, so the nightly
 # detector skips re-attempting it until tt-lang HEAD advances. Writes a small
-# attempt.json marker under the tt-lang/<ttmetal7> S3 prefix.
+# attempt.json marker under the tt-lang/ttmetal/<ttmetal7> S3 prefix.
 #
 # Usage:
 #   record-ttmetal-miss.sh --ttmetal-sha <sha> --ttlang-head <sha>
@@ -46,7 +46,7 @@ attempt_date="${attempt_date:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 marker="$(printf '{"ttmetal_sha":"%s","ttlang_head":"%s","max_age_days":"%s","attempt_date":"%s","result":"no_compatible"}\n' \
     "$ttmetal_sha" "$ttlang_head" "$max_age_days" "$attempt_date")"
 
-printf '%s' "$marker" | aws s3 cp - "s3://$S3_BUCKET/tt-lang/$short/attempt.json" \
+printf '%s' "$marker" | aws s3 cp - "s3://$S3_BUCKET/tt-lang/ttmetal/$short/attempt.json" \
     --content-type "application/json"
 
-echo "Recorded miss for tt-lang/$short (tt-lang HEAD $ttlang_head)" >&2
+echo "Recorded miss for tt-lang/ttmetal/$short (tt-lang HEAD $ttlang_head)" >&2

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -20,7 +20,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
 ALLOWED_PREFIXES=(tt-lang/)
-READONLY_VERBS=("s3 ls" "s3api head-object" "s3api list-objects-v2" "s3api get-object")
+READONLY_VERBS=("s3 ls" "s3api head-object" "s3api list-objects-v2")
+READONLY_FLAGS=(--bucket --key --prefix --recursive --page-size --max-items --max-keys --delimiter --start-after --human-readable --summarize --no-paginate --output)
 
 operation="" prefix="" src="" dest="" confirm="" dry_run="true"
 readonly_args=()
@@ -39,6 +40,8 @@ while [[ $# -gt 0 ]]; do
         *)           die "Unknown argument: $1" ;;
     esac
 done
+
+[[ "$dry_run" == "true" || "$dry_run" == "false" ]] || die "--dry-run must be true or false: $dry_run"
 
 # Reject anything that is empty, absolute, an s3:// URI, contains "..", contains
 # characters outside a safe set, or does not start with an allowed prefix.
@@ -71,9 +74,17 @@ assert_destructive_ok() {
     die "internal: prefix passed allowlist but matched no root: $path"
 }
 
-# Every S3 target in a read command must resolve under s3://<bucket>/tt-lang/.
+_readonly_flag_ok() {
+    local f
+    for f in "${READONLY_FLAGS[@]}"; do [[ "$1" == "$f" ]] && return 0; done
+    return 1
+}
+
+# Every token in a read command must be a benign flag or a target under
+# s3://<bucket>/tt-lang/. Unknown flags (e.g. --endpoint-url, --profile) are
+# rejected so a read cannot redirect the signed request or leak its credential.
 assert_readonly_targets() {
-    local args=("$@") i=0 tok next verb
+    local args=("$@") i=0 tok flag val verb
     local saw_s3_uri=false saw_bucket=false saw_key=false saw_prefix=false
     verb="${args[0]} ${args[1]}"
     while [[ $i -lt ${#args[@]} ]]; do
@@ -81,44 +92,42 @@ assert_readonly_targets() {
         case "$tok" in
             s3://*)
                 saw_s3_uri=true
-                [[ "$tok" == "s3://$bucket/tt-lang" || "$tok" == "s3://$bucket/tt-lang/"* ]] \
+                [[ "$tok" == "s3://$bucket/tt-lang/"* ]] \
                     || die "read-only target must be under s3://$bucket/tt-lang/: $tok" ;;
-            --bucket)
-                next="${args[$((i+1))]:-}"
-                saw_bucket=true
-                [[ "$next" == "$bucket" ]] || die "read-only --bucket must be $bucket: $next"
-                i=$((i+1)) ;;
-            --bucket=*)
-                next="${tok#--bucket=}"
-                saw_bucket=true
-                [[ "$next" == "$bucket" ]] || die "read-only --bucket must be $bucket: $next" ;;
-            --key|--prefix)
-                next="${args[$((i+1))]:-}"
-                if [[ "$tok" == "--key" ]]; then
-                    saw_key=true
-                else
-                    saw_prefix=true
-                fi
-                [[ "$next" == "tt-lang" || "$next" == "tt-lang/"* ]] \
-                    || die "read-only --key/--prefix must be under tt-lang/: $next"
-                i=$((i+1)) ;;
-            --key=*)
-                next="${tok#--key=}"
-                saw_key=true
-                [[ "$next" == "tt-lang" || "$next" == "tt-lang/"* ]] \
-                    || die "read-only --key/--prefix must be under tt-lang/: $next" ;;
-            --prefix=*)
-                next="${tok#--prefix=}"
-                saw_prefix=true
-                [[ "$next" == "tt-lang" || "$next" == "tt-lang/"* ]] \
-                    || die "read-only --key/--prefix must be under tt-lang/: $next" ;;
+            --*=*)
+                flag="${tok%%=*}"; val="${tok#*=}"
+                _readonly_flag_ok "$flag" || die "read-only flag not allowed: $flag"
+                case "$flag" in
+                    --bucket)
+                        saw_bucket=true
+                        [[ "$val" == "$bucket" ]] || die "read-only --bucket must be $bucket: $val" ;;
+                    --key|--prefix)
+                        [[ "$flag" == "--key" ]] && saw_key=true || saw_prefix=true
+                        [[ "$val" == "tt-lang/"* ]] \
+                            || die "read-only --key/--prefix must be under tt-lang/: $val" ;;
+                esac ;;
+            -*)
+                _readonly_flag_ok "$tok" || die "read-only flag not allowed: $tok"
+                case "$tok" in
+                    --bucket)
+                        val="${args[$((i+1))]:-}"
+                        saw_bucket=true
+                        [[ "$val" == "$bucket" ]] || die "read-only --bucket must be $bucket: $val"
+                        i=$((i+1)) ;;
+                    --key|--prefix)
+                        val="${args[$((i+1))]:-}"
+                        [[ "$tok" == "--key" ]] && saw_key=true || saw_prefix=true
+                        [[ "$val" == "tt-lang/"* ]] \
+                            || die "read-only --key/--prefix must be under tt-lang/: $val"
+                        i=$((i+1)) ;;
+                esac ;;
         esac
         i=$((i+1))
     done
     case "$verb" in
         "s3 ls")
             [[ "$saw_s3_uri" == true ]] || die "read-only s3 ls requires an s3://$bucket/tt-lang/ target" ;;
-        "s3api head-object"|"s3api get-object")
+        "s3api head-object")
             [[ "$saw_bucket" == true ]] || die "read-only $verb requires --bucket $bucket"
             [[ "$saw_key" == true ]] || die "read-only $verb requires --key under tt-lang/" ;;
         "s3api list-objects-v2")
@@ -128,10 +137,10 @@ assert_readonly_targets() {
 }
 
 run_aws() {
-    if [[ "$dry_run" == "true" ]]; then
-        echo "DRY-RUN: aws $*"
-    else
+    if [[ "$dry_run" == "false" ]]; then
         aws "$@"
+    else
+        echo "DRY-RUN: aws $*"
     fi
 }
 
@@ -151,10 +160,10 @@ case "$operation" in
         ;;
     put-index)
         assert_allowed "$prefix"
-        if [[ "$dry_run" == "true" ]]; then
-            echo "DRY-RUN: regenerate slash-key index for $prefix"
-        else
+        if [[ "$dry_run" == "false" ]]; then
             s3_regenerate_index "$bucket" "$prefix"
+        else
+            echo "DRY-RUN: regenerate slash-key index for $prefix"
         fi
         ;;
     copy)

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -30,12 +30,12 @@ die() { echo "$1" >&2; exit 2; }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --operation) operation="$2"; shift 2 ;;
-        --prefix)    prefix="${2%/}"; shift 2 ;;
-        --source)    src="${2%/}"; shift 2 ;;
-        --dest)      dest="${2%/}"; shift 2 ;;
-        --confirm)   confirm="${2%/}"; shift 2 ;;
-        --dry-run)   dry_run="$2"; shift 2 ;;
+        --operation) [[ $# -ge 2 ]] || die "--operation requires a value"; operation="$2"; shift 2 ;;
+        --prefix)    [[ $# -ge 2 ]] || die "--prefix requires a value"; prefix="${2%/}"; shift 2 ;;
+        --source)    [[ $# -ge 2 ]] || die "--source requires a value"; src="${2%/}"; shift 2 ;;
+        --dest)      [[ $# -ge 2 ]] || die "--dest requires a value"; dest="${2%/}"; shift 2 ;;
+        --confirm)   [[ $# -ge 2 ]] || die "--confirm requires a value"; confirm="${2%/}"; shift 2 ;;
+        --dry-run)   [[ $# -ge 2 ]] || die "--dry-run requires a value"; dry_run="$2"; shift 2 ;;
         --)          shift; readonly_args=("$@"); break ;;
         *)           die "Unknown argument: $1" ;;
     esac
@@ -92,6 +92,7 @@ assert_readonly_targets() {
         case "$tok" in
             s3://*)
                 saw_s3_uri=true
+                [[ "$tok" != *..* ]] || die "read-only target must not contain '..': $tok"
                 [[ "$tok" == "s3://$bucket/tt-lang/"* ]] \
                     || die "read-only target must be under s3://$bucket/tt-lang/: $tok" ;;
             --*=*)
@@ -103,6 +104,8 @@ assert_readonly_targets() {
                         [[ "$val" == "$bucket" ]] || die "read-only --bucket must be $bucket: $val" ;;
                     --key|--prefix)
                         [[ "$flag" == "--key" ]] && saw_key=true || saw_prefix=true
+                        [[ "$val" != *..* ]] \
+                            || die "read-only --key/--prefix must not contain '..': $val"
                         [[ "$val" == "tt-lang/"* ]] \
                             || die "read-only --key/--prefix must be under tt-lang/: $val" ;;
                 esac ;;
@@ -117,6 +120,8 @@ assert_readonly_targets() {
                     --key|--prefix)
                         val="${args[$((i+1))]:-}"
                         [[ "$tok" == "--key" ]] && saw_key=true || saw_prefix=true
+                        [[ "$val" != *..* ]] \
+                            || die "read-only --key/--prefix must not contain '..': $val"
                         [[ "$val" == "tt-lang/"* ]] \
                             || die "read-only --key/--prefix must be under tt-lang/: $val"
                         i=$((i+1)) ;;
@@ -167,7 +172,7 @@ case "$operation" in
         fi
         ;;
     copy)
-        assert_allowed "$src"; assert_allowed "$dest"
+        assert_destructive_ok "$src"; assert_allowed "$dest"
         run_aws s3 cp "s3://$bucket/$src/" "s3://$bucket/$dest/" --recursive
         ;;
     move)

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -73,23 +73,58 @@ assert_destructive_ok() {
 
 # Every S3 target in a read command must resolve under s3://<bucket>/tt-lang/.
 assert_readonly_targets() {
-    local args=("$@") i=0 tok next
+    local args=("$@") i=0 tok next verb
+    local saw_s3_uri=false saw_bucket=false saw_key=false saw_prefix=false
+    verb="${args[0]} ${args[1]}"
     while [[ $i -lt ${#args[@]} ]]; do
         tok="${args[$i]}"
         case "$tok" in
             s3://*)
+                saw_s3_uri=true
                 [[ "$tok" == "s3://$bucket/tt-lang" || "$tok" == "s3://$bucket/tt-lang/"* ]] \
                     || die "read-only target must be under s3://$bucket/tt-lang/: $tok" ;;
             --bucket)
                 next="${args[$((i+1))]:-}"
+                saw_bucket=true
+                [[ "$next" == "$bucket" ]] || die "read-only --bucket must be $bucket: $next"
+                i=$((i+1)) ;;
+            --bucket=*)
+                next="${tok#--bucket=}"
+                saw_bucket=true
                 [[ "$next" == "$bucket" ]] || die "read-only --bucket must be $bucket: $next" ;;
             --key|--prefix)
                 next="${args[$((i+1))]:-}"
+                if [[ "$tok" == "--key" ]]; then
+                    saw_key=true
+                else
+                    saw_prefix=true
+                fi
+                [[ "$next" == "tt-lang" || "$next" == "tt-lang/"* ]] \
+                    || die "read-only --key/--prefix must be under tt-lang/: $next"
+                i=$((i+1)) ;;
+            --key=*)
+                next="${tok#--key=}"
+                saw_key=true
+                [[ "$next" == "tt-lang" || "$next" == "tt-lang/"* ]] \
+                    || die "read-only --key/--prefix must be under tt-lang/: $next" ;;
+            --prefix=*)
+                next="${tok#--prefix=}"
+                saw_prefix=true
                 [[ "$next" == "tt-lang" || "$next" == "tt-lang/"* ]] \
                     || die "read-only --key/--prefix must be under tt-lang/: $next" ;;
         esac
         i=$((i+1))
     done
+    case "$verb" in
+        "s3 ls")
+            [[ "$saw_s3_uri" == true ]] || die "read-only s3 ls requires an s3://$bucket/tt-lang/ target" ;;
+        "s3api head-object"|"s3api get-object")
+            [[ "$saw_bucket" == true ]] || die "read-only $verb requires --bucket $bucket"
+            [[ "$saw_key" == true ]] || die "read-only $verb requires --key under tt-lang/" ;;
+        "s3api list-objects-v2")
+            [[ "$saw_bucket" == true ]] || die "read-only $verb requires --bucket $bucket"
+            [[ "$saw_prefix" == true ]] || die "read-only $verb requires --prefix under tt-lang/" ;;
+    esac
 }
 
 run_aws() {

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -19,7 +19,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$script_dir/lib/s3-index.sh"
 
 bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
-ALLOWED_PREFIXES=(tt-lang/ tt-lang-light/ tt-lang-sim/)
+ALLOWED_PREFIXES=(tt-lang/)
 READONLY_VERBS=("s3 ls" "s3api head-object" "s3api list-objects-v2" "s3api get-object")
 
 operation="" prefix="" src="" dest="" confirm="" dry_run="true"

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Vetted S3 maintenance for the tt-lang prefixes of the shared tenstorrent-pypi
+# bucket. Write operations are constrained to a tt-lang prefix allowlist and are
+# dry-run by default; deletes require a confirm token. A read-only escape hatch
+# runs allowlisted aws read verbs with arguments passed as argv (no shell).
+#
+# Usage:
+#   s3-pypi-ops.sh --operation <inspect|put-index|move|copy|delete|readonly-cmd>
+#       [--prefix P] [--source S] [--dest D] [--confirm TOKEN]
+#       [--dry-run true|false] [-- <aws read args>]
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/s3-index.sh
+. "$script_dir/lib/s3-index.sh"
+
+bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
+ALLOWED_PREFIXES=(tt-lang/ tt-lang-light/ tt-lang-sim/)
+READONLY_VERBS=("s3 ls" "s3api head-object" "s3api list-objects-v2" "s3api get-object")
+
+operation="" prefix="" source="" dest="" confirm="" dry_run="true"
+readonly_args=()
+
+die() { echo "$1" >&2; exit 2; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --operation) operation="$2"; shift 2 ;;
+        --prefix)    prefix="${2%/}"; shift 2 ;;
+        --source)    source="${2%/}"; shift 2 ;;
+        --dest)      dest="${2%/}"; shift 2 ;;
+        --confirm)   confirm="$2"; shift 2 ;;
+        --dry-run)   dry_run="$2"; shift 2 ;;
+        --)          shift; readonly_args=("$@"); break ;;
+        *)           die "Unknown argument: $1" ;;
+    esac
+done
+
+# Reject anything that is empty, absolute, an s3:// URI, contains "..", contains
+# characters outside a safe set, or does not start with an allowed prefix.
+assert_allowed() {
+    local path="$1"
+    [[ -n "$path" ]] || die "empty prefix is not allowed"
+    [[ "$path" != /* && "$path" != s3://* ]] || die "prefix must be bucket-relative"
+    [[ "$path" != *..* ]] || die "prefix must not contain '..'"
+    [[ "$path" =~ ^[A-Za-z0-9._/-]+$ ]] || die "prefix has invalid characters: $path"
+    local allowed
+    for allowed in "${ALLOWED_PREFIXES[@]}"; do
+        [[ "$path/" == "$allowed"* ]] && return 0
+    done
+    die "prefix not in the tt-lang allowlist: $path"
+}
+
+# Destructive ops must target something strictly under an allowlist root.
+assert_destructive_ok() {
+    local path="$1"
+    assert_allowed "$path"
+    local allowed
+    for allowed in "${ALLOWED_PREFIXES[@]}"; do
+        # e.g. path "tt-lang/x" under "tt-lang/" -> "x" remains.
+        if [[ "$path/" == "$allowed"* ]]; then
+            local rest="${path#"${allowed%/}"/}"
+            [[ -n "$rest" && "$rest" != "$path" ]] || die "refusing destructive op on allowlist root: $path"
+            return 0
+        fi
+    done
+}
+
+run_aws() {
+    if [[ "$dry_run" == "true" ]]; then
+        echo "DRY-RUN: aws $*"
+    else
+        aws "$@"
+    fi
+}
+
+case "$operation" in
+    inspect)
+        assert_allowed "$prefix"
+        aws s3 ls "s3://$bucket/$prefix/" --recursive
+        ;;
+    readonly-cmd)
+        [[ "${#readonly_args[@]}" -ge 2 ]] || die "readonly-cmd needs an aws command after --"
+        verb="${readonly_args[0]} ${readonly_args[1]}"
+        allowed=false
+        for v in "${READONLY_VERBS[@]}"; do [[ "$verb" == "$v" ]] && allowed=true; done
+        [[ "$allowed" == true ]] || die "read-only verbs only: ${READONLY_VERBS[*]}"
+        aws "${readonly_args[@]}"
+        ;;
+    put-index)
+        assert_allowed "$prefix"
+        if [[ "$dry_run" == "true" ]]; then
+            echo "DRY-RUN: regenerate slash-key index for $prefix"
+        else
+            s3_regenerate_index "$bucket" "$prefix"
+        fi
+        ;;
+    copy)
+        assert_allowed "$source"; assert_allowed "$dest"
+        run_aws s3 cp "s3://$bucket/$source/" "s3://$bucket/$dest/" --recursive
+        ;;
+    move)
+        assert_destructive_ok "$source"; assert_allowed "$dest"
+        run_aws s3 mv "s3://$bucket/$source/" "s3://$bucket/$dest/" --recursive
+        ;;
+    delete)
+        assert_destructive_ok "$prefix"
+        [[ "$confirm" == "$prefix" ]] || die "delete requires --confirm to equal the prefix ($prefix)"
+        run_aws s3 rm "s3://$bucket/$prefix/" --recursive
+        ;;
+    *)
+        die "unknown operation: $operation"
+        ;;
+esac

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -22,7 +22,7 @@ bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
 ALLOWED_PREFIXES=(tt-lang/ tt-lang-light/ tt-lang-sim/)
 READONLY_VERBS=("s3 ls" "s3api head-object" "s3api list-objects-v2" "s3api get-object")
 
-operation="" prefix="" source="" dest="" confirm="" dry_run="true"
+operation="" prefix="" src="" dest="" confirm="" dry_run="true"
 readonly_args=()
 
 die() { echo "$1" >&2; exit 2; }
@@ -31,9 +31,9 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --operation) operation="$2"; shift 2 ;;
         --prefix)    prefix="${2%/}"; shift 2 ;;
-        --source)    source="${2%/}"; shift 2 ;;
+        --source)    src="${2%/}"; shift 2 ;;
         --dest)      dest="${2%/}"; shift 2 ;;
-        --confirm)   confirm="$2"; shift 2 ;;
+        --confirm)   confirm="${2%/}"; shift 2 ;;
         --dry-run)   dry_run="$2"; shift 2 ;;
         --)          shift; readonly_args=("$@"); break ;;
         *)           die "Unknown argument: $1" ;;
@@ -68,6 +68,7 @@ assert_destructive_ok() {
             return 0
         fi
     done
+    die "internal: prefix passed allowlist but matched no root: $path"
 }
 
 run_aws() {
@@ -100,12 +101,12 @@ case "$operation" in
         fi
         ;;
     copy)
-        assert_allowed "$source"; assert_allowed "$dest"
-        run_aws s3 cp "s3://$bucket/$source/" "s3://$bucket/$dest/" --recursive
+        assert_allowed "$src"; assert_allowed "$dest"
+        run_aws s3 cp "s3://$bucket/$src/" "s3://$bucket/$dest/" --recursive
         ;;
     move)
-        assert_destructive_ok "$source"; assert_allowed "$dest"
-        run_aws s3 mv "s3://$bucket/$source/" "s3://$bucket/$dest/" --recursive
+        assert_destructive_ok "$src"; assert_allowed "$dest"
+        run_aws s3 mv "s3://$bucket/$src/" "s3://$bucket/$dest/" --recursive
         ;;
     delete)
         assert_destructive_ok "$prefix"

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -71,6 +71,27 @@ assert_destructive_ok() {
     die "internal: prefix passed allowlist but matched no root: $path"
 }
 
+# Every S3 target in a read command must resolve under s3://<bucket>/tt-lang/.
+assert_readonly_targets() {
+    local args=("$@") i=0 tok next
+    while [[ $i -lt ${#args[@]} ]]; do
+        tok="${args[$i]}"
+        case "$tok" in
+            s3://*)
+                [[ "$tok" == "s3://$bucket/tt-lang" || "$tok" == "s3://$bucket/tt-lang/"* ]] \
+                    || die "read-only target must be under s3://$bucket/tt-lang/: $tok" ;;
+            --bucket)
+                next="${args[$((i+1))]:-}"
+                [[ "$next" == "$bucket" ]] || die "read-only --bucket must be $bucket: $next" ;;
+            --key|--prefix)
+                next="${args[$((i+1))]:-}"
+                [[ "$next" == "tt-lang" || "$next" == "tt-lang/"* ]] \
+                    || die "read-only --key/--prefix must be under tt-lang/: $next" ;;
+        esac
+        i=$((i+1))
+    done
+}
+
 run_aws() {
     if [[ "$dry_run" == "true" ]]; then
         echo "DRY-RUN: aws $*"
@@ -90,6 +111,7 @@ case "$operation" in
         allowed=false
         for v in "${READONLY_VERBS[@]}"; do [[ "$verb" == "$v" ]] && allowed=true; done
         [[ "$allowed" == true ]] || die "read-only verbs only: ${READONLY_VERBS[*]}"
+        assert_readonly_targets "${readonly_args[@]}"
         aws "${readonly_args[@]}"
         ;;
     put-index)

--- a/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
+++ b/.github/scripts/tests/test_detect_ttmlir_ttmetal_uplift.bats
@@ -80,7 +80,7 @@ setup() {
     assert_output "retry"
 }
 
-@test "default S3 object listing reads the tt-lang/<ttmetal7> prefix" {
+@test "default S3 object listing reads the tt-lang/ttmetal/<ttmetal7> prefix" {
     bindir="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$bindir"
     AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
@@ -95,10 +95,10 @@ EOF
     assert_output "tt_lang-1.0.0+light.whl"
 
     run cat "$AWS_ARGS"
-    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/$SHORT_SHA/"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/ttmetal/$SHORT_SHA/"
 }
 
-@test "default miss marker read uses the tt-lang/<ttmetal7> prefix" {
+@test "default miss marker read uses the tt-lang/ttmetal/<ttmetal7> prefix" {
     bindir="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$bindir"
     AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
@@ -113,7 +113,7 @@ EOF
     assert_output "$HEAD_A"
 
     run cat "$AWS_ARGS"
-    assert_output --partial "s3 cp s3://tenstorrent-pypi/tt-lang/$SHORT_SHA/attempt.json -"
+    assert_output --partial "s3 cp s3://tenstorrent-pypi/tt-lang/ttmetal/$SHORT_SHA/attempt.json -"
 }
 
 # --- main ---

--- a/.github/scripts/tests/test_inject_s3_index_readme_shell.bats
+++ b/.github/scripts/tests/test_inject_s3_index_readme_shell.bats
@@ -6,6 +6,9 @@
 
 load test_helper
 
+# Mock aws stores objects in a flat key->file map under $S3_ROOT (a key ending
+# in "/" is a valid S3 key but not a valid directory-free file path, so the
+# map replaces "/" with "__" rather than mkdir -p'ing the key).
 setup() {
     SCRIPT="$SCRIPTS_DIR/inject-s3-index-readme.sh"
     README="$BATS_TEST_TMPDIR/README.md"
@@ -14,7 +17,7 @@ setup() {
         "tt_lang_light-1.0.0-py3-none-any.whl")
     AWS_LOG="$BATS_TEST_TMPDIR/aws.log"
     S3_ROOT="$BATS_TEST_TMPDIR/s3"
-    mkdir -p "$S3_ROOT/2026-07"
+    mkdir -p "$S3_ROOT"
     cat > "$README" <<'EOF'
 # tt-lang internal index
 EOF
@@ -24,25 +27,57 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$AWS_LOG"
-if [[ "$1 $2" != "s3 cp" ]]; then
-    echo "unexpected aws command" >&2
-    exit 2
-fi
-src="$3"
-dst="$4"
-if [[ "$src" == s3://* ]]; then
-    key="${src#s3://tenstorrent-pypi/}"
-    source_path="$S3_ROOT/$key"
-    if [[ ! -f "$source_path" ]]; then
-        echo "fatal error: An error occurred (404) when calling the HeadObject operation: Key \"$key\" does not exist" >&2
-        exit 1
-    fi
-    cp "$source_path" "$dst"
-else
-    key="${dst#s3://tenstorrent-pypi/}"
-    mkdir -p "$(dirname "$S3_ROOT/$key")"
-    cp "$src" "$S3_ROOT/$key"
-fi
+verb="$1 $2"
+shift 2
+bucket=""
+key=""
+body=""
+outfile=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bucket)
+            bucket="$2"
+            shift 2
+            ;;
+        --key)
+            key="$2"
+            shift 2
+            ;;
+        --body)
+            body="$2"
+            shift 2
+            ;;
+        --content-type)
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            outfile="$1"
+            shift
+            ;;
+    esac
+done
+keyfile="$S3_ROOT/$(printf '%s' "$key" | sed 's#/#__#g')"
+case "$verb" in
+    "s3api get-object")
+        if [[ -f "$keyfile" ]]; then
+            cp "$keyfile" "$outfile"
+            echo '{"ContentLength":0}'
+        else
+            echo "An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist." >&2
+            exit 1
+        fi
+        ;;
+    "s3api put-object")
+        cp "$body" "$keyfile"
+        ;;
+    *)
+        echo "unexpected aws command: $verb" >&2
+        exit 2
+        ;;
+esac
 EOF
     chmod +x "$bindir/aws"
     export PATH="$bindir:$PATH"
@@ -50,16 +85,19 @@ EOF
 }
 
 @test "missing prefixed root index is created from dist and uploaded" {
-    run -0 "$SCRIPT" --key 2026-07/index.html --readme "$README" --dist-dir "$DIST_DIR"
+    run -0 "$SCRIPT" --key tt-lang/2026-07/ --readme "$README" --dist-dir "$DIST_DIR"
 
-    run cat "$S3_ROOT/2026-07/index.html"
+    run cat "$S3_ROOT/tt-lang__2026-07__"
     assert_output --partial 'href="tt-lang/"'
     assert_output --partial 'href="tt-lang-light/"'
     assert_output --partial 'id="ttlang-s3-readme"'
+
+    run cat "$AWS_LOG"
+    assert_output --partial 's3api put-object --bucket tenstorrent-pypi --key tt-lang/2026-07/'
 }
 
 @test "existing root index is preserved and uploaded" {
-    cat > "$S3_ROOT/2026-07/index.html" <<'EOF'
+    cat > "$S3_ROOT/tt-lang__2026-07__" <<'EOF'
 <!DOCTYPE html>
 <html>
 <body>
@@ -68,14 +106,14 @@ EOF
 </html>
 EOF
 
-    run -0 "$SCRIPT" --key 2026-07/index.html --readme "$README" --dist-dir "$DIST_DIR"
+    run -0 "$SCRIPT" --key tt-lang/2026-07/ --readme "$README" --dist-dir "$DIST_DIR"
 
-    run cat "$S3_ROOT/2026-07/index.html"
+    run cat "$S3_ROOT/tt-lang__2026-07__"
     assert_output --partial 'href="existing-package/"'
     assert_output --partial 'id="ttlang-s3-readme"'
 }
 
-@test "non-404 aws download failure is propagated" {
+@test "non-404 aws failure is propagated" {
     cat > "$BATS_TEST_TMPDIR/bin/aws" <<'EOF'
 #!/usr/bin/env bash
 echo "AccessDenied" >&2
@@ -83,7 +121,19 @@ exit 1
 EOF
     chmod +x "$BATS_TEST_TMPDIR/bin/aws"
 
-    run "$SCRIPT" --key 2026-07/index.html --readme "$README" --dist-dir "$DIST_DIR"
+    run "$SCRIPT" --key tt-lang/2026-07/ --readme "$README" --dist-dir "$DIST_DIR"
     assert_equal "$status" 1
     assert_output --partial "AccessDenied"
+}
+
+@test "no-prefix stable index round-trips at the exact index.html key" {
+    run -0 "$SCRIPT" --key index.html --readme "$README" --dist-dir "$DIST_DIR"
+
+    run cat "$S3_ROOT/index.html"
+    assert_output --partial 'href="tt-lang/"'
+    assert_output --partial 'href="tt-lang-light/"'
+    assert_output --partial 'id="ttlang-s3-readme"'
+
+    run cat "$AWS_LOG"
+    assert_output --partial 's3api put-object --bucket tenstorrent-pypi --key index.html'
 }

--- a/.github/scripts/tests/test_publish_s3_direct_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_direct_wheels.bats
@@ -11,83 +11,64 @@ make_aws_mock() {
     mkdir -p "$bindir"
     cat > "$bindir/aws" <<'EOF'
 #!/usr/bin/env bash
-set -euo pipefail
 printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
-if [[ "$1 $2" != "s3 cp" ]]; then
-    echo "unexpected aws command" >&2
-    exit 2
-fi
-src="$3"
-dst="$4"
-if [[ "$dst" == s3://tenstorrent-pypi/tt-lang/13adda8/index.html ]]; then
-    cp "$src" "$CAPTURED_INDEX"
-fi
-if [[ "$dst" == s3://tenstorrent-pypi/tt-lang/13adda8/README.txt ]]; then
-    cp "$src" "$CAPTURED_README"
+# `s3 ls` is used to regenerate parent/child listings; return the wheels + readme
+# for the SHA prefix, and the SHA dir for the parent prefix.
+if [[ "$1 $2" == "s3 ls" ]]; then
+    case "$3" in
+        *tt-lang/ttmetal/13adda8/) cat "$LS_SHA" ;;
+        *tt-lang/ttmetal/)         cat "$LS_PARENT" ;;
+    esac
 fi
 EOF
     chmod +x "$bindir/aws"
-    echo "$bindir"
+    export PATH="$bindir:$PATH"
 }
 
 setup() {
     SCRIPT="$SCRIPTS_DIR/publish-s3-direct-wheels.sh"
     FAKE_AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
-    CAPTURED_INDEX="$BATS_TEST_TMPDIR/index.html"
-    CAPTURED_README="$BATS_TEST_TMPDIR/README.capture.txt"
-    README="$BATS_TEST_TMPDIR/README.md"
+    LS_SHA="$BATS_TEST_TMPDIR/ls_sha"
+    LS_PARENT="$BATS_TEST_TMPDIR/ls_parent"
     : > "$FAKE_AWS_ARGS"
-    cat > "$README" <<'EOF'
-# tt-lang per-SHA wheels
-EOF
-    export FAKE_AWS_ARGS CAPTURED_INDEX CAPTURED_README
-    BINDIR=$(make_aws_mock)
-    export PATH="$BINDIR:$PATH"
+    printf '2026-07-04 00:00:00 321 README.txt\n2026-07-04 00:00:00 1 %s\n' \
+        "$(whl_light 1.0.0)" > "$LS_SHA"
+    printf '                           PRE 13adda8/\n' > "$LS_PARENT"
+    export FAKE_AWS_ARGS LS_SHA LS_PARENT
+    README="$BATS_TEST_TMPDIR/README.md"
+    printf '# tt-lang per-SHA wheels\n' > "$README"
+    make_aws_mock
 }
 
 @test "missing prefix -> usage error (exit 2)" {
-    dir=$(make_wheel_dir "tt_lang-1.0.0-py3-none-any.whl")
+    dir=$(make_wheel_dir "$(whl_light 1.0.0)")
     run -2 "$SCRIPT" "$dir"
 }
 
 @test "empty dist dir -> error (exit 1)" {
     dir=$(make_wheel_dir)
-    run -1 "$SCRIPT" --prefix tt-lang/13adda8 "$dir"
+    run -1 "$SCRIPT" --prefix tt-lang/ttmetal/13adda8 "$dir"
     assert_output --partial "No wheels found under $dir"
 }
 
-@test "uploads wheels and direct index under tt-lang sha prefix" {
-    dir=$(make_wheel_dir \
-        "tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl" \
-        "tt_lang_light-1.0.0-py3-none-any.whl")
-
-    run -0 "$SCRIPT" --prefix tt-lang/13adda8 --readme "$README" "$dir"
+@test "uploads wheels+README as objects and regenerates slash-key listings" {
+    dir=$(make_wheel_dir "$(whl_light_core_cp312 1.0.0)" "$(whl_light 1.0.0)")
+    run -0 "$SCRIPT" --prefix tt-lang/ttmetal/13adda8 --readme "$README" "$dir"
 
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3 cp $dir/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl s3://tenstorrent-pypi/tt-lang/13adda8/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl --content-type application/octet-stream"
-    assert_output --partial "s3 cp $dir/tt_lang_light-1.0.0-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/13adda8/tt_lang_light-1.0.0-py3-none-any.whl --content-type application/octet-stream"
-    assert_output --partial "s3://tenstorrent-pypi/tt-lang/13adda8/index.html --content-type text/html; charset=utf-8"
-    assert_output --partial "s3://tenstorrent-pypi/tt-lang/13adda8/README.txt --content-type text/plain; charset=utf-8"
-
-    run cat "$CAPTURED_INDEX"
-    assert_output --partial 'id="ttlang-s3-readme"'
-    assert_output --partial "tt-lang per-SHA wheels"
-    assert_output --partial 'href="README.txt"'
-    assert_output --partial 'href="tt_lang-1.0.0%2Blight-cp312-cp312-manylinux_2_34_x86_64.whl#sha256='
-    assert_output --partial 'href="tt_lang_light-1.0.0-py3-none-any.whl#sha256='
-    refute_output --partial 'href="tt-lang-light/"'
-    readme_line=$(grep -n 'href="README.txt"' "$CAPTURED_INDEX" | head -1 | cut -d: -f1)
-    wheel_line=$(grep -n 'href="tt_lang-' "$CAPTURED_INDEX" | head -1 | cut -d: -f1)
-    [ "$readme_line" -lt "$wheel_line" ]
-
-    run cat "$CAPTURED_README"
-    assert_output --partial "tt-lang per-SHA wheels"
+    # wheels + README uploaded as objects
+    assert_output --partial "s3 cp $dir/$(whl_light 1.0.0) s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/$(whl_light 1.0.0)"
+    assert_output --partial "s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/README.txt"
+    # slash-key listing for the SHA prefix and the parent, via put-object
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/"
+    # NEVER writes an index.html object
+    refute_output --partial "index.html"
 }
 
 @test "bucket is overridable via TTLANG_S3_BUCKET" {
-    dir=$(make_wheel_dir "tt_lang-1.0.0-py3-none-any.whl")
-    TTLANG_S3_BUCKET=other-bucket run -0 "$SCRIPT" --prefix tt-lang/13adda8 "$dir"
-
+    dir=$(make_wheel_dir "$(whl_light 1.0.0)")
+    TTLANG_S3_BUCKET=other-bucket run -0 "$SCRIPT" --prefix tt-lang/ttmetal/13adda8 --readme "$README" "$dir"
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3://other-bucket/tt-lang/13adda8/tt_lang-1.0.0-py3-none-any.whl"
+    assert_output --partial "s3://other-bucket/tt-lang/ttmetal/13adda8/$(whl_light 1.0.0)"
 }

--- a/.github/scripts/tests/test_publish_s3_direct_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_direct_wheels.bats
@@ -12,13 +12,24 @@ make_aws_mock() {
     cat > "$bindir/aws" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
-# `s3 ls` is used to regenerate parent/child listings; return the wheels + readme
-# for the SHA prefix, and the SHA dir for the parent prefix.
+# `s3 ls` is used to regenerate the parent listing; return the SHA dir.
 if [[ "$1 $2" == "s3 ls" ]]; then
     case "$3" in
-        *tt-lang/ttmetal/13adda8/) cat "$LS_SHA" ;;
-        *tt-lang/ttmetal/)         cat "$LS_PARENT" ;;
+        *tt-lang/ttmetal/) cat "$LS_PARENT" ;;
     esac
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    # Capture each uploaded index body under a filename derived from --key so
+    # tests can inspect its HTML content (the script deletes its tmpfile on exit).
+    shift 2
+    key="" body=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --key) key="$2"; shift 2 ;;
+            --body) body="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    cp "$body" "$PUT_BODIES_DIR/${key//\//_}"
 fi
 EOF
     chmod +x "$bindir/aws"
@@ -28,13 +39,12 @@ EOF
 setup() {
     SCRIPT="$SCRIPTS_DIR/publish-s3-direct-wheels.sh"
     FAKE_AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
-    LS_SHA="$BATS_TEST_TMPDIR/ls_sha"
     LS_PARENT="$BATS_TEST_TMPDIR/ls_parent"
+    PUT_BODIES_DIR="$BATS_TEST_TMPDIR/put_bodies"
+    mkdir -p "$PUT_BODIES_DIR"
     : > "$FAKE_AWS_ARGS"
-    printf '2026-07-04 00:00:00 321 README.txt\n2026-07-04 00:00:00 1 %s\n' \
-        "$(whl_light 1.0.0)" > "$LS_SHA"
     printf '                           PRE 13adda8/\n' > "$LS_PARENT"
-    export FAKE_AWS_ARGS LS_SHA LS_PARENT
+    export FAKE_AWS_ARGS LS_PARENT PUT_BODIES_DIR
     README="$BATS_TEST_TMPDIR/README.md"
     printf '# tt-lang per-SHA wheels\n' > "$README"
     make_aws_mock
@@ -64,6 +74,19 @@ setup() {
     assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/"
     # NEVER writes an index.html object
     refute_output --partial "index.html"
+    # No re-download of an uploaded wheel to compute its hash
+    refute_output --regexp 's3 cp s3://[^[:space:]]*\.whl -'
+}
+
+@test "per-SHA index HTML is hashed from local wheels, not downloaded from S3" {
+    empty_digest="$(sha256sum /dev/null | awk '{print $1}')"
+    dir=$(make_wheel_dir "$(whl_light_core_cp312 1.0.0)" "$(whl_light 1.0.0)")
+    run -0 "$SCRIPT" --prefix tt-lang/ttmetal/13adda8 --readme "$README" "$dir"
+
+    run cat "$PUT_BODIES_DIR/tt-lang_ttmetal_13adda8_"
+    assert_output --partial "<a href=\"README.txt\">README.txt</a><br>"
+    assert_output --partial "<a href=\"$(whl_light_core_cp312 1.0.0)#sha256=$empty_digest\">$(whl_light_core_cp312 1.0.0)</a><br>"
+    assert_output --partial "<a href=\"$(whl_light 1.0.0)#sha256=$empty_digest\">$(whl_light 1.0.0)</a><br>"
 }
 
 @test "bucket is overridable via TTLANG_S3_BUCKET" {

--- a/.github/scripts/tests/test_record_ttmetal_miss.bats
+++ b/.github/scripts/tests/test_record_ttmetal_miss.bats
@@ -39,12 +39,12 @@ setup() {
     run -2 "$SCRIPT" --ttmetal-sha "$FULL_SHA"
 }
 
-@test "writes attempt.json under tt-lang/<ttmetal7>" {
+@test "writes attempt.json under tt-lang/ttmetal/<ttmetal7>" {
     run -0 "$SCRIPT" --ttmetal-sha "$FULL_SHA" --ttlang-head "$HEAD_SHA" \
         --max-age-days 14 --date "2026-06-30T00:00:00Z"
 
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3 cp - s3://tenstorrent-pypi/tt-lang/$SHORT_SHA/attempt.json"
+    assert_output --partial "s3 cp - s3://tenstorrent-pypi/tt-lang/ttmetal/$SHORT_SHA/attempt.json"
     assert_output --partial "--content-type application/json"
 }
 
@@ -62,5 +62,5 @@ setup() {
     TTLANG_S3_BUCKET=other-bucket run -0 "$SCRIPT" \
         --ttmetal-sha "$FULL_SHA" --ttlang-head "$HEAD_SHA"
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3://other-bucket/tt-lang/$SHORT_SHA/attempt.json"
+    assert_output --partial "s3://other-bucket/tt-lang/ttmetal/$SHORT_SHA/attempt.json"
 }

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/lib/s3-index.sh.
+
+load test_helper
+
+setup() {
+    LIB="$SCRIPTS_DIR/lib/s3-index.sh"
+    # shellcheck disable=SC1090
+    source "$LIB"
+    FAKE_AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
+    : > "$FAKE_AWS_ARGS"
+    export FAKE_AWS_ARGS
+}
+
+# Install a mock `aws` on PATH. $1 is the stdout it prints for `s3 ls`.
+make_aws_mock() {
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    printf '%s' "$1" > "$BATS_TEST_TMPDIR/ls_output"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    cat "$BATS_TEST_TMPDIR/ls_output"
+fi
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+}
+
+@test "s3_render_index wraps anchors in a Package Index document" {
+    run bash -c 'source "'"$LIB"'"; printf "%s\n" "<a href=\"a/\">a</a><br>" | s3_render_index "T"'
+    assert_output --partial "<!DOCTYPE html>"
+    assert_output --partial "<title>T</title>"
+    assert_output --partial '<a href="a/">a</a><br>'
+    assert_output --partial "</html>"
+}
+
+@test "s3_child_anchors renders sub-prefixes as dir anchors and objects as file anchors" {
+    make_aws_mock "                           PRE 13adda8/
+2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00        321 README.txt
+2026-07-04 00:00:00        200 index.html
+"
+    run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
+    assert_line '<a href="13adda8/">13adda8/</a><br>'
+    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
+    assert_line '<a href="README.txt">README.txt</a><br>'
+    refute_output --partial 'index.html'
+}
+
+@test "s3_put_index uploads to the slash-key via put-object" {
+    make_aws_mock ""
+    printf '<html></html>\n' > "$BATS_TEST_TMPDIR/idx.html"
+    run s3_put_index tenstorrent-pypi tt-lang/ttmetal/13adda8 "$BATS_TEST_TMPDIR/idx.html"
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/ --body $BATS_TEST_TMPDIR/idx.html --content-type text/html; charset=utf-8"
+}
+
+@test "s3_regenerate_index lists, renders, and puts the slash-key" {
+    make_aws_mock "                           PRE 13adda8/
+"
+    run s3_regenerate_index tenstorrent-pypi tt-lang/ttmetal
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/ttmetal/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/"
+}

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -25,8 +25,6 @@ make_aws_mock() {
 printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
 if [[ "$1 $2" == "s3 ls" ]]; then
     cat "$BATS_TEST_TMPDIR/ls_output"
-elif [[ "$1 $2" == "s3 cp" && "$3" == *.whl && "$4" == "-" ]]; then
-    printf 'wheel-bytes'
 fi
 EOF
     chmod +x "$bindir/aws"
@@ -67,10 +65,10 @@ EOF
 2026-07-04 00:00:00         10 junk.txt
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
-    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
     assert_line '<a href="13adda8/">13adda8/</a><br>'
-    assert_line "<a href=\"tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
+    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
     assert_line '<a href="README.txt">README.txt</a><br>'
+    refute_output --partial '#sha256='
     refute_output --partial 'index.html'
     refute_output --partial 'attempt.json'
     refute_output --partial 'junk.txt'
@@ -80,9 +78,9 @@ EOF
     make_aws_mock "2026-07-04 00:00:00       1234 a&b.whl
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
-    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
-    assert_line "<a href=\"a&amp;b.whl#sha256=$digest\">a&amp;b.whl</a><br>"
+    assert_line '<a href="a&amp;b.whl">a&amp;b.whl</a><br>'
     refute_output --partial 'a&b.whl'
+    refute_output --partial '#sha256='
 }
 
 @test "s3_child_anchors keeps a literal '+' in a light wheel name (not percent-encoded)" {
@@ -90,8 +88,7 @@ EOF
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_success
-    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
-    assert_line "<a href=\"tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl#sha256=$digest\">tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl</a><br>"
+    assert_line '<a href="tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl">tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl</a><br>'
     refute_output --partial "%2B"
 }
 
@@ -118,8 +115,7 @@ EOF
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_success
-    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
-    assert_line "<a href=\"tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
+    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
     refute_output --partial 'href="234"'
 }
 
@@ -144,4 +140,34 @@ EOF
     assert_failure
     run cat "$FAKE_AWS_ARGS"
     refute_output --partial "put-object"
+}
+
+@test "s3_local_wheel_anchors hashes local wheels and always includes README.txt" {
+    dist_dir="$BATS_TEST_TMPDIR/dist"
+    mkdir -p "$dist_dir"
+    : > "$dist_dir/tt_lang_light-1.0.0-py3-none-any.whl"
+    : > "$dist_dir/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl"
+
+    run s3_local_wheel_anchors "$dist_dir"
+    assert_success
+    assert_line '<a href="README.txt">README.txt</a><br>'
+
+    digest="$(sha256sum "$dist_dir/tt_lang_light-1.0.0-py3-none-any.whl" | awk '{print $1}')"
+    assert_line "<a href=\"tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
+    assert_line --regexp '^<a href="tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl#sha256=[0-9a-f]{64}">tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl</a><br>$'
+}
+
+@test "s3_render_index HTML-escapes a title containing '&' and '\"'" {
+    run bash -c 'source "'"$LIB"'"; printf "%s\n" "<a href=\"a/\">a</a><br>" | s3_render_index "AT&T \"quote\""'
+    assert_success
+    assert_output --partial '<title>AT&amp;T &quot;quote&quot;</title>'
+    refute_output --partial '<title>AT&T'
+}
+
+@test "s3_child_anchors HTML-escapes a name containing '\"'" {
+    make_aws_mock '2026-07-04 00:00:00       1234 weird"name.whl
+'
+    run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
+    assert_success
+    assert_line '<a href="weird&quot;name.whl">weird&quot;name.whl</a><br>'
 }

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -85,6 +85,16 @@ EOF
     refute_output --partial 'a&b.whl'
 }
 
+@test "s3_child_anchors keeps a literal '+' in a light wheel name (not percent-encoded)" {
+    make_aws_mock "2026-07-04 00:00:00       1234 tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl
+"
+    run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
+    assert_success
+    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
+    assert_line "<a href=\"tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl#sha256=$digest\">tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl</a><br>"
+    refute_output --partial "%2B"
+}
+
 @test "s3_put_index uploads to the slash-key via put-object" {
     make_aws_mock ""
     printf '<html></html>\n' > "$BATS_TEST_TMPDIR/idx.html"

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -31,6 +31,23 @@ EOF
     export PATH="$bindir:$PATH"
 }
 
+# Install a mock `aws` on PATH whose `s3 ls` invocation exits 1 (simulates a
+# transient AWS failure: permissions, throttling, network).
+make_aws_mock_failing() {
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    echo "mock aws error" >&2
+    exit 1
+fi
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+}
+
 @test "s3_render_index wraps anchors in a Package Index document" {
     run bash -c 'source "'"$LIB"'"; printf "%s\n" "<a href=\"a/\">a</a><br>" | s3_render_index "T"'
     assert_output --partial "<!DOCTYPE html>"
@@ -67,4 +84,37 @@ EOF
     run cat "$FAKE_AWS_ARGS"
     assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/ttmetal/"
     assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/"
+}
+
+@test "s3_child_anchors skips the slash-key's own listing line (empty name)" {
+    make_aws_mock "2026-07-04 00:00:00        234
+2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
+"
+    run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
+    assert_success
+    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
+    refute_output --partial 'href="234"'
+}
+
+@test "s3_child_anchors fails when aws s3 ls fails" {
+    make_aws_mock_failing
+    run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
+    assert_failure
+}
+
+@test "s3_regenerate_index refuses to write when aws s3 ls fails" {
+    make_aws_mock_failing
+    run s3_regenerate_index tenstorrent-pypi tt-lang/ttmetal
+    assert_failure
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "put-object"
+}
+
+@test "s3_regenerate_index refuses to write when the listing is empty" {
+    make_aws_mock "2026-07-04 00:00:00        234
+"
+    run s3_regenerate_index tenstorrent-pypi tt-lang/ttmetal
+    assert_failure
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "put-object"
 }

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -61,12 +61,24 @@ EOF
 2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
 2026-07-04 00:00:00        321 README.txt
 2026-07-04 00:00:00        200 index.html
+2026-07-04 00:00:00         42 attempt.json
+2026-07-04 00:00:00         10 junk.txt
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_line '<a href="13adda8/">13adda8/</a><br>'
     assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
     assert_line '<a href="README.txt">README.txt</a><br>'
     refute_output --partial 'index.html'
+    refute_output --partial 'attempt.json'
+    refute_output --partial 'junk.txt'
+}
+
+@test "s3_child_anchors HTML-escapes names containing '&'" {
+    make_aws_mock "2026-07-04 00:00:00       1234 a&b.whl
+"
+    run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
+    assert_line '<a href="a&amp;b.whl">a&amp;b.whl</a><br>'
+    refute_output --partial 'a&b.whl'
 }
 
 @test "s3_put_index uploads to the slash-key via put-object" {

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -25,6 +25,8 @@ make_aws_mock() {
 printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
 if [[ "$1 $2" == "s3 ls" ]]; then
     cat "$BATS_TEST_TMPDIR/ls_output"
+elif [[ "$1 $2" == "s3 cp" && "$3" == *.whl && "$4" == "-" ]]; then
+    printf 'wheel-bytes'
 fi
 EOF
     chmod +x "$bindir/aws"
@@ -65,8 +67,9 @@ EOF
 2026-07-04 00:00:00         10 junk.txt
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
+    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
     assert_line '<a href="13adda8/">13adda8/</a><br>'
-    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
+    assert_line "<a href=\"tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
     assert_line '<a href="README.txt">README.txt</a><br>'
     refute_output --partial 'index.html'
     refute_output --partial 'attempt.json'
@@ -77,7 +80,8 @@ EOF
     make_aws_mock "2026-07-04 00:00:00       1234 a&b.whl
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
-    assert_line '<a href="a&amp;b.whl">a&amp;b.whl</a><br>'
+    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
+    assert_line "<a href=\"a&amp;b.whl#sha256=$digest\">a&amp;b.whl</a><br>"
     refute_output --partial 'a&b.whl'
 }
 
@@ -104,7 +108,8 @@ EOF
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_success
-    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
+    digest="$(printf 'wheel-bytes' | sha256sum | awk '{print $1}')"
+    assert_line "<a href=\"tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
     refute_output --partial 'href="234"'
 }
 

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -109,6 +109,41 @@ EOF
     assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/"
 }
 
+@test "s3_regenerate_index writes a hash-less body from an S3-sourced listing" {
+    CAPTURED_BODY="$BATS_TEST_TMPDIR/captured_body.html"
+    export CAPTURED_BODY
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    printf '%s' "                           PRE 13adda8/
+2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00        321 README.txt
+" > "$BATS_TEST_TMPDIR/ls_output"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    cat "$BATS_TEST_TMPDIR/ls_output"
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    args=("$@")
+    for ((i = 0; i < ${#args[@]}; i++)); do
+        if [[ "${args[$i]}" == "--body" ]]; then
+            cp "${args[$((i + 1))]}" "$CAPTURED_BODY"
+        fi
+    done
+fi
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+
+    run s3_regenerate_index tenstorrent-pypi tt-lang/ttmetal
+    assert_success
+    [ -f "$CAPTURED_BODY" ]
+    run cat "$CAPTURED_BODY"
+    assert_output --partial "tt_lang_light-1.0.0-py3-none-any.whl"
+    assert_output --partial "README.txt"
+    refute_output --partial "#sha256="
+}
+
 @test "s3_child_anchors skips the slash-key's own listing line (empty name)" {
     make_aws_mock "2026-07-04 00:00:00        234
 2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -202,3 +202,59 @@ EOF
     run cat "$FAKE_AWS_ARGS"
     assert_output --partial "s3api list-objects-v2 --bucket=tenstorrent-pypi --prefix=tt-lang/ttmetal/"
 }
+
+@test "readonly-cmd rejects an unlisted flag (space form)" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 ls s3://tenstorrent-pypi/tt-lang/ --endpoint-url http://x
+    assert_output --partial "flag not allowed"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd rejects an unlisted flag (= form)" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 ls s3://tenstorrent-pypi/tt-lang/ --endpoint-url=http://x
+    assert_output --partial "flag not allowed"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd rejects --profile" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 ls s3://tenstorrent-pypi/tt-lang/ --profile evil
+    assert_output --partial "flag not allowed"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd rejects an s3:// target missing the trailing slash" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 ls s3://tenstorrent-pypi/tt-lang
+    assert_output --partial "must be under s3://tenstorrent-pypi/tt-lang/"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd rejects a --prefix missing the trailing slash" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3api list-objects-v2 --bucket tenstorrent-pypi --prefix tt-lang
+    assert_output --partial "must be under tt-lang/"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd rejects get-object (verb dropped)" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3api get-object --bucket tenstorrent-pypi --key tt-lang/x out
+    assert_output --partial "read-only verbs only"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "dry-run rejects a non-boolean value" {
+    run -2 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8 --dry-run bogus
+    assert_output --partial "must be true or false"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "dry-run rejects a case-mismatched boolean value" {
+    run -2 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8 --dry-run FALSE
+    assert_output --partial "must be true or false"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -24,16 +24,53 @@ EOF
 @test "rejects a prefix outside the tt-lang allowlist" {
     run -2 "$SCRIPT" --operation delete --prefix ttnn/foo --confirm ttnn/foo --dry-run false
     assert_output --partial "not in the tt-lang allowlist"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
 }
 
 @test "rejects the bucket root and bare allowlist root for delete" {
     run -2 "$SCRIPT" --operation delete --prefix tt-lang/ --confirm tt-lang/ --dry-run false
     assert_output --partial "refusing destructive op"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
 }
 
 @test "rejects shell metacharacters in a prefix" {
     run -2 "$SCRIPT" --operation inspect --prefix 'tt-lang/x;rm -rf /'
     assert_output --partial "invalid characters"
+}
+
+@test "rejects an absolute path" {
+    run -2 "$SCRIPT" --operation inspect --prefix /etc/passwd
+    assert_output --partial "prefix must be bucket-relative"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "rejects an s3:// URI" {
+    run -2 "$SCRIPT" --operation inspect --prefix s3://tenstorrent-pypi/tt-lang
+    assert_output --partial "prefix must be bucket-relative"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "rejects '..' path traversal" {
+    run -2 "$SCRIPT" --operation inspect --prefix tt-lang/x/../ttnn
+    assert_output --partial ".."
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "rejects a prefix that only shares a leading substring with an allowlist entry" {
+    run -2 "$SCRIPT" --operation inspect --prefix tt-lang-evil/foo
+    assert_output --partial "not in the tt-lang allowlist"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+
+    run -2 "$SCRIPT" --operation inspect --prefix tt-langX/foo
+    assert_output --partial "not in the tt-lang allowlist"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
 }
 
 @test "delete requires a matching confirm token" {
@@ -43,6 +80,13 @@ EOF
     refute_output --partial "rm"
 }
 
+@test "move rejects a bare allowlist root as the source" {
+    run -2 "$SCRIPT" --operation move --source tt-lang --dest tt-lang/ttmetal/x --dry-run false
+    assert_output --partial "refusing destructive op"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
 @test "dry-run prints the plan and performs no writes" {
     run -0 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8
     assert_output --partial "DRY-RUN"
@@ -50,10 +94,36 @@ EOF
     refute_output --partial "mv"
 }
 
-@test "move (dry-run false) copies+deletes and reindexes" {
+@test "move (dry-run false) runs recursive mv" {
     run -0 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8 --dry-run false
     run cat "$FAKE_AWS_ARGS"
     assert_output --partial "s3 mv s3://tenstorrent-pypi/tt-lang/13adda8/ s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/ --recursive"
+}
+
+@test "copy (dry-run false) runs recursive cp" {
+    run -0 "$SCRIPT" --operation copy --source tt-lang/a --dest tt-lang/b --dry-run false
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 cp s3://tenstorrent-pypi/tt-lang/a/ s3://tenstorrent-pypi/tt-lang/b/ --recursive"
+}
+
+@test "inspect runs recursive ls" {
+    run -0 "$SCRIPT" --operation inspect --prefix tt-lang/x
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/x/ --recursive"
+}
+
+@test "put-index dry-run prints the plan and performs no writes" {
+    run -0 "$SCRIPT" --operation put-index --prefix tt-lang/ttmetal
+    assert_output --partial "DRY-RUN"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "put-object"
+}
+
+@test "rejects an unknown operation" {
+    run -2 "$SCRIPT" --operation bogus
+    assert_output --partial "unknown operation"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
 }
 
 @test "readonly-cmd allows ls but rejects rm" {
@@ -63,4 +133,18 @@ EOF
 
     run -2 "$SCRIPT" --operation readonly-cmd -- s3 rm s3://tenstorrent-pypi/tt-lang/x
     assert_output --partial "read-only"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "rm"
+}
+
+@test "readonly-cmd rejects other write verbs" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 cp x y
+    assert_output --partial "read-only"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3api put-object --bucket tenstorrent-pypi --key tt-lang/x --body f
+    assert_output --partial "read-only"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
 }

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -28,6 +28,15 @@ EOF
     refute_output --partial "s3"
 }
 
+@test "rejects the sibling tt-lang-light/ and tt-lang-sim/ package prefixes" {
+    run -2 "$SCRIPT" --operation put-index --prefix tt-lang-light/2026-07 --dry-run false
+    assert_output --partial "not in the tt-lang allowlist"
+    run -2 "$SCRIPT" --operation put-index --prefix tt-lang-sim/2026-07 --dry-run false
+    assert_output --partial "not in the tt-lang allowlist"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
 @test "rejects the bucket root and bare allowlist root for delete" {
     run -2 "$SCRIPT" --operation delete --prefix tt-lang/ --confirm tt-lang/ --dry-run false
     assert_output --partial "refusing destructive op"

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -165,6 +165,18 @@ EOF
     refute_output --partial "s3"
 }
 
+@test "readonly-cmd rejects bucket-root listing forms" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 ls
+    assert_output --partial "read-only s3 ls requires"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3api list-objects-v2 --bucket tenstorrent-pypi
+    assert_output --partial "requires --prefix under tt-lang/"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "list-objects-v2"
+}
+
 @test "readonly-cmd rejects a --key outside tt-lang/" {
     run -2 "$SCRIPT" --operation readonly-cmd -- s3api head-object --bucket tenstorrent-pypi --key ttnn/x
     assert_output --partial "read-only --key/--prefix must be under tt-lang/"
@@ -172,8 +184,21 @@ EOF
     refute_output --partial "s3"
 }
 
+@test "readonly-cmd rejects --arg=value targets outside tt-lang/" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3api list-objects-v2 --bucket=tenstorrent-pypi --prefix=ttnn/
+    assert_output --partial "read-only --key/--prefix must be under tt-lang/"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "list-objects-v2"
+}
+
 @test "readonly-cmd allows a --key under tt-lang/" {
     run -0 "$SCRIPT" --operation readonly-cmd -- s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.txt
     run cat "$FAKE_AWS_ARGS"
     assert_output --partial "s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.txt"
+}
+
+@test "readonly-cmd allows a --prefix under tt-lang/" {
+    run -0 "$SCRIPT" --operation readonly-cmd -- s3api list-objects-v2 --bucket=tenstorrent-pypi --prefix=tt-lang/ttmetal/
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3api list-objects-v2 --bucket=tenstorrent-pypi --prefix=tt-lang/ttmetal/"
 }

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/s3-pypi-ops.sh.
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/s3-pypi-ops.sh"
+    FAKE_AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
+    : > "$FAKE_AWS_ARGS"
+    export FAKE_AWS_ARGS
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+}
+
+@test "rejects a prefix outside the tt-lang allowlist" {
+    run -2 "$SCRIPT" --operation delete --prefix ttnn/foo --confirm ttnn/foo --dry-run false
+    assert_output --partial "not in the tt-lang allowlist"
+}
+
+@test "rejects the bucket root and bare allowlist root for delete" {
+    run -2 "$SCRIPT" --operation delete --prefix tt-lang/ --confirm tt-lang/ --dry-run false
+    assert_output --partial "refusing destructive op"
+}
+
+@test "rejects shell metacharacters in a prefix" {
+    run -2 "$SCRIPT" --operation inspect --prefix 'tt-lang/x;rm -rf /'
+    assert_output --partial "invalid characters"
+}
+
+@test "delete requires a matching confirm token" {
+    run -2 "$SCRIPT" --operation delete --prefix tt-lang/ttmetal/dead --confirm wrong --dry-run false
+    assert_output --partial "confirm"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "rm"
+}
+
+@test "dry-run prints the plan and performs no writes" {
+    run -0 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8
+    assert_output --partial "DRY-RUN"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "mv"
+}
+
+@test "move (dry-run false) copies+deletes and reindexes" {
+    run -0 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8 --dry-run false
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 mv s3://tenstorrent-pypi/tt-lang/13adda8/ s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/ --recursive"
+}
+
+@test "readonly-cmd allows ls but rejects rm" {
+    run -0 "$SCRIPT" --operation readonly-cmd -- s3 ls s3://tenstorrent-pypi/tt-lang/
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/"
+
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 rm s3://tenstorrent-pypi/tt-lang/x
+    assert_output --partial "read-only"
+}

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -96,6 +96,27 @@ EOF
     refute_output --partial "s3"
 }
 
+@test "copy rejects a bare allowlist root as the source" {
+    run -2 "$SCRIPT" --operation copy --source tt-lang --dest tt-lang/x --dry-run false
+    assert_output --partial "refusing destructive op"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "move rejects a dest outside the tt-lang allowlist" {
+    run -2 "$SCRIPT" --operation move --source tt-lang/x --dest ttnn/x --dry-run false
+    assert_output --partial "not in the tt-lang allowlist"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "copy rejects a dest outside the tt-lang allowlist" {
+    run -2 "$SCRIPT" --operation copy --source tt-lang/x --dest ttnn/x --dry-run false
+    assert_output --partial "not in the tt-lang allowlist"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
 @test "dry-run prints the plan and performs no writes" {
     run -0 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8
     assert_output --partial "DRY-RUN"
@@ -238,6 +259,20 @@ EOF
     refute_output --partial "s3"
 }
 
+@test "readonly-cmd rejects '..' in an s3:// target" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 ls s3://tenstorrent-pypi/tt-lang/../ttnn/
+    assert_output --partial ".."
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd rejects '..' in a --prefix value" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3api list-objects-v2 --bucket tenstorrent-pypi --prefix tt-lang/../ttnn
+    assert_output --partial ".."
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "list-objects-v2"
+}
+
 @test "readonly-cmd rejects get-object (verb dropped)" {
     run -2 "$SCRIPT" --operation readonly-cmd -- s3api get-object --bucket tenstorrent-pypi --key tt-lang/x out
     assert_output --partial "read-only verbs only"
@@ -255,6 +290,13 @@ EOF
 @test "dry-run rejects a case-mismatched boolean value" {
     run -2 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8 --dry-run FALSE
     assert_output --partial "must be true or false"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "rejects a value-taking flag with no value" {
+    run -2 "$SCRIPT" --operation
+    assert_output --partial "--operation requires a value"
     run cat "$FAKE_AWS_ARGS"
     refute_output --partial "s3"
 }

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -157,3 +157,23 @@ EOF
     run cat "$FAKE_AWS_ARGS"
     refute_output --partial "s3"
 }
+
+@test "readonly-cmd rejects an s3:// target outside tt-lang/" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3 ls s3://tenstorrent-pypi/ttnn/
+    assert_output --partial "read-only target must be under s3://tenstorrent-pypi/tt-lang/"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd rejects a --key outside tt-lang/" {
+    run -2 "$SCRIPT" --operation readonly-cmd -- s3api head-object --bucket tenstorrent-pypi --key ttnn/x
+    assert_output --partial "read-only --key/--prefix must be under tt-lang/"
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3"
+}
+
+@test "readonly-cmd allows a --key under tt-lang/" {
+    run -0 "$SCRIPT" --operation readonly-cmd -- s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.txt
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.txt"
+}

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -513,11 +513,11 @@ jobs:
       - name: Publish wheels
         run: |
           .github/scripts/publish-s3-direct-wheels.sh \
-            --prefix "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}" dist
+            --prefix "tt-lang/ttmetal/${{ needs.find-compatible.outputs.ttmetal_short }}" dist
 
       - name: Report install command
         run: |
           .github/scripts/publish-s3-summary.sh \
-            --find-links-subdir "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}" \
+            --find-links-subdir "tt-lang/ttmetal/${{ needs.find-compatible.outputs.ttmetal_short }}" \
             light \
             "${{ needs.find-compatible.outputs.winner_version }}"

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -476,7 +476,7 @@ jobs:
           bash .github/scripts/run-tutorials.sh .
 
   publish:
-    name: "Publish to S3 under tt-lang/<SHA> prefix"
+    name: "Publish to S3 under tt-lang/ttmetal/<SHA> prefix"
     continue-on-error: ${{ inputs.soft_fail }}
     needs: [preflight, find-compatible, build-wheels, build-metapackage, device-validate]
     if: ${{ needs.find-compatible.outputs.found == 'true' && inputs.dry_run != true && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -336,7 +336,7 @@ jobs:
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
         run: python3 -m pip install s3pypi
 
-      # Nightly dev wheels publish under <YYYY-MM>/; stable releases use root.
+      # Nightly dev wheels publish under tt-lang/<YYYY-MM>/; stable releases use root.
       - name: Derive publish prefix
         id: publish_prefix
         run: |

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -344,7 +344,7 @@ jobs:
           version="${{ needs.preflight.outputs.version_override }}"
           prefix=""
           if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.dev([0-9]{4})([0-9]{2})[0-9]{2} ]]; then
-            prefix="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+            prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
           fi
           echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
           echo "Publish prefix: ${prefix:-<root>}"

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -371,7 +371,7 @@ jobs:
           prefix="${{ steps.publish_prefix.outputs.prefix }}"
           key="index.html"
           if [ -n "$prefix" ]; then
-            key="$prefix/index.html"
+            key="$prefix/"
           fi
           .github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist
 

--- a/.github/workflows/s3-pypi-ops.yml
+++ b/.github/workflows/s3-pypi-ops.yml
@@ -77,6 +77,7 @@ jobs:
           exit 1
 
       - name: Configure AWS Credentials
+        if: ${{ inputs.dry_run != true || inputs.operation == 'inspect' || inputs.operation == 'readonly-cmd' }}
         uses: ./.github/actions/configure-tt-s3-credentials
 
       - name: Run operation

--- a/.github/workflows/s3-pypi-ops.yml
+++ b/.github/workflows/s3-pypi-ops.yml
@@ -76,8 +76,9 @@ jobs:
           echo "S3 writes are restricted to refs/heads/main (got ${GITHUB_REF}). Set dry_run=true for non-main validation." >&2
           exit 1
 
-      # Creds are configured only on main; a non-main run never assumes the
-      # shared-bucket role, even for reads or dry-run write operations.
+      # workflow_dispatch runs the selected ref's code; gating creds to main stops
+      # a branch-edited run from assuming the shared-bucket role and bypassing the
+      # tt-lang/ allowlist.
       - name: Configure AWS Credentials
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: ./.github/actions/configure-tt-s3-credentials

--- a/.github/workflows/s3-pypi-ops.yml
+++ b/.github/workflows/s3-pypi-ops.yml
@@ -76,8 +76,10 @@ jobs:
           echo "S3 writes are restricted to refs/heads/main (got ${GITHUB_REF}). Set dry_run=true for non-main validation." >&2
           exit 1
 
+      # Creds are configured only on main; a non-main run never assumes the
+      # shared-bucket role, even for reads or dry-run write operations.
       - name: Configure AWS Credentials
-        if: ${{ inputs.dry_run != true || inputs.operation == 'inspect' || inputs.operation == 'readonly-cmd' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: ./.github/actions/configure-tt-s3-credentials
 
       - name: Run operation

--- a/.github/workflows/s3-pypi-ops.yml
+++ b/.github/workflows/s3-pypi-ops.yml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Manual S3 maintenance for the tt-lang prefixes of tenstorrent-pypi: create or
+# refresh slash-key directory listings, move/copy/delete tt-lang prefixes, and
+# run read-only inspections. Writes require refs/heads/main; dry_run is the
+# default. Never touches other teams' prefixes or the bucket root.
+
+name: S3 PyPI ops (tt-lang)
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Operation to run."
+        required: true
+        type: choice
+        options: [inspect, put-index, move, copy, delete, readonly-cmd]
+      prefix:
+        description: "Bucket-relative prefix (inspect/put-index/delete), e.g. tt-lang/ttmetal/13adda8."
+        required: false
+        type: string
+        default: ""
+      source:
+        description: "Source prefix (move/copy)."
+        required: false
+        type: string
+        default: ""
+      dest:
+        description: "Destination prefix (move/copy)."
+        required: false
+        type: string
+        default: ""
+      confirm:
+        description: "For delete: must equal the prefix."
+        required: false
+        type: string
+        default: ""
+      readonly_args:
+        description: "For readonly-cmd: aws args, e.g. 's3 ls s3://tenstorrent-pypi/tt-lang/'."
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Print the plan without writing (default true)."
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: s3-pypi-ops
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: "Run S3 PyPI op"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+
+      - name: Require main ref for writes
+        if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "S3 writes are restricted to refs/heads/main (got ${GITHUB_REF}). Set dry_run=true for non-main validation." >&2
+          exit 1
+
+      - name: Configure AWS Credentials
+        uses: ./.github/actions/configure-tt-s3-credentials
+
+      - name: Run operation
+        env:
+          OP: ${{ inputs.operation }}
+          PREFIX: ${{ inputs.prefix }}
+          SOURCE: ${{ inputs.source }}
+          DEST: ${{ inputs.dest }}
+          CONFIRM: ${{ inputs.confirm }}
+          READONLY_ARGS: ${{ inputs.readonly_args }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=(--operation "$OP" --dry-run "$DRY_RUN")
+          [[ -n "$PREFIX" ]] && args+=(--prefix "$PREFIX")
+          [[ -n "$SOURCE" ]] && args+=(--source "$SOURCE")
+          [[ -n "$DEST" ]] && args+=(--dest "$DEST")
+          [[ -n "$CONFIRM" ]] && args+=(--confirm "$CONFIRM")
+          if [[ "$OP" == "readonly-cmd" ]]; then
+            # shellcheck disable=SC2206
+            read -r -a ro <<< "$READONLY_ARGS"
+            args+=(-- "${ro[@]}")
+          fi
+          .github/scripts/s3-pypi-ops.sh "${args[@]}"

--- a/.github/workflows/s3-pypi-ops.yml
+++ b/.github/workflows/s3-pypi-ops.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Require main ref for writes
-        if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}
+        if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' && inputs.operation != 'inspect' && inputs.operation != 'readonly-cmd' }}
         run: |
           echo "S3 writes are restricted to refs/heads/main (got ${GITHUB_REF}). Set dry_run=true for non-main validation." >&2
           exit 1

--- a/.github/workflows/s3-pypi-ops.yml
+++ b/.github/workflows/s3-pypi-ops.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Require main ref for writes
-        if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' && inputs.operation != 'inspect' && inputs.operation != 'readonly-cmd' }}
+        if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}
         run: |
           echo "S3 writes are restricted to refs/heads/main (got ${GITHUB_REF}). Set dry_run=true for non-main validation." >&2
           exit 1

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -683,10 +683,14 @@ scheduled per-tt-metal-SHA build in `publish-s3-pypi.yml` is best-effort and doe
 not fail the nightly publish.
 
 Successful per-SHA publishes place the wheel files (both tt-lang and
-tt-lang-light) directly under
-`https://pypi.eng.aws.tenstorrent.com/tt-lang/<ttmetal7>/`. Install from that
-directory with `--find-links`. The `tt-lang-light` wheel is a pure metapackage;
-the supported CPython ABIs and glibc floor are carried by the
+tt-lang-light) under `https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/<ttmetal7>/`
+as a browsable directory (the listing is written to the slash-key so the
+directory URL resolves; trailing slash required). Install from that directory
+with `--find-links`. Browse all published SHAs at
+`https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/`.
+
+The `tt-lang-light` wheel is a pure metapackage; the supported CPython ABIs and
+glibc floor are carried by the
 `tt_lang-<version>+light-cp310-cp310-manylinux_2_34_x86_64.whl` and
 `tt_lang-<version>+light-cp312-cp312-manylinux_2_34_x86_64.whl` files in the
 same directory. The same directory contains a brief `README.txt`.
@@ -730,6 +734,16 @@ The build job uploads the `tt_metal_sha` install as a tar artifact so executable
 bits are preserved. The device job installs the downloaded `tt-lang-light` wheel
 with that external tt-metal environment, then runs `test/python/smoketest.py`
 and the tutorial suite.
+
+#### S3 PyPI maintenance
+
+`s3-pypi-ops.yml` is a manual (`workflow_dispatch`) workflow for maintaining the
+tt-lang prefixes of `tenstorrent-pypi`: `inspect`, `put-index` (refresh a
+slash-key listing), `move`, `copy`, `delete`, and a read-only `readonly-cmd`.
+Writes require `refs/heads/main`; `dry_run` defaults to true. Operations are
+restricted to the `tt-lang/`, `tt-lang-light/`, and `tt-lang-sim/` prefixes and
+cannot touch other teams' packages or the bucket root. `delete` requires a
+`confirm` token equal to the prefix.
 
 #### Local internal wheel testing
 

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -741,9 +741,9 @@ and the tutorial suite.
 tt-lang prefixes of `tenstorrent-pypi`: `inspect`, `put-index` (refresh a
 slash-key listing), `move`, `copy`, `delete`, and a read-only `readonly-cmd`.
 Writes require `refs/heads/main`; `dry_run` defaults to true. Operations are
-restricted to the `tt-lang/`, `tt-lang-light/`, and `tt-lang-sim/` prefixes and
-cannot touch other teams' packages or the bucket root. `delete` requires a
-`confirm` token equal to the prefix.
+restricted to the `tt-lang/` prefix and cannot touch other teams' packages
+(including the sibling `tt-lang-light/` and `tt-lang-sim/` package indexes) or
+the bucket root. `delete` requires a `confirm` token equal to the prefix.
 
 #### Local internal wheel testing
 

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -61,13 +61,14 @@ S3 package index. A version selector is required because public PyPI also hosts
 `tt-lang`, and pip resolves candidates across all configured indexes. Available
 versions are listed at https://pypi.eng.aws.tenstorrent.com/.
 
-Development and per-SHA wheels use simple sub-indexes. The installed version
-determines the `--extra-index-url`:
+Development wheels use a simple sub-index (`--extra-index-url`); per-SHA light
+wheels are published as browsable directories (`--find-links`):
 
-- Nightly development wheels are under `<YYYY-MM>/`, the year-month of the
-  version's `devYYYYMMDD` suffix (e.g. version `X.Y.Z.dev20260615` -> `2026-06/`).
+- Nightly development wheels are under `tt-lang/<YYYY-MM>/`, the year-month of
+  the version's `devYYYYMMDD` suffix (e.g. version `X.Y.Z.dev20260615` ->
+  `tt-lang/2026-06/`).
 - Light wheels built and device-tested against a specific tt-metal commit are
-  under `<ttmetal7>/`, that commit's 7-character prefix.
+  under `tt-lang/ttmetal/<ttmetal7>/`, that commit's 7-character prefix.
 - Stable release wheels (`X.Y.Z`) stay at the root index.
 
 The bundled-wheel example below installs a nightly development wheel. Stable
@@ -82,7 +83,7 @@ runtime and copies the tutorials:
 ```bash
 TTLANG_VERSION=<published-internal-version>
 pip install \
-  --extra-index-url https://pypi.eng.aws.tenstorrent.com/<YYYY-MM>/ \
+  --extra-index-url https://pypi.eng.aws.tenstorrent.com/tt-lang/<YYYY-MM>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   "tt-lang==$TTLANG_VERSION"
 tt-lang-setup    # downloads sfpi into the bundled ttnn tree + copies tutorials
@@ -94,13 +95,14 @@ metapackage: `tt-lang-light==X` depends on the matching no-ttnn core wheel
 `tt-lang==X+light`. Install either `tt-lang` or `tt-lang-light` in an
 environment, not both.
 
-A per-tt-metal-SHA light wheel resolves from that commit's subdir; a nightly
-light wheel resolves from its `<YYYY-MM>/` subdir instead:
+A per-tt-metal-SHA light wheel resolves from that commit's directory with
+`--find-links`; a nightly light wheel resolves from its `tt-lang/<YYYY-MM>/`
+sub-index with `--extra-index-url` instead:
 
 ```bash
 TTLANG_VERSION=<published-internal-version>
 pip install \
-  --extra-index-url https://pypi.eng.aws.tenstorrent.com/<ttmetal7>/ \
+  --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/<ttmetal7>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   "tt-lang-light==$TTLANG_VERSION"
 tt-lang-setup    # copies tutorials only; sfpi is provided by the external tt-metal

--- a/packaging/s3-index/README.md
+++ b/packaging/s3-index/README.md
@@ -13,7 +13,7 @@ Nightly development wheels are grouped by year-month:
 
 ```bash
 pip install \
-  --extra-index-url https://pypi.eng.aws.tenstorrent.com/<YYYY-MM>/ \
+  --extra-index-url https://pypi.eng.aws.tenstorrent.com/tt-lang/<YYYY-MM>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   "tt-lang==<version>"
 ```

--- a/packaging/s3-index/README.md
+++ b/packaging/s3-index/README.md
@@ -19,21 +19,14 @@ pip install \
 ```
 
 Light wheels built and device-tested against a specific tt-metal commit are
-published as direct wheel directories under `tt-lang/<ttmetal7>/`, where
-`<ttmetal7>` is that commit's 7-character prefix. The directory contains both the
-`tt-lang` `+light` wheel and the `tt-lang-light` metapackage, plus this README as
-`README.txt`. The `tt-lang-light` wheel is a pure metapackage; the supported
-CPython ABIs and glibc floor are carried by the
-`tt_lang-<version>+light-cp310-cp310-manylinux_2_34_x86_64.whl` and
-`tt_lang-<version>+light-cp312-cp312-manylinux_2_34_x86_64.whl` files in the
-same directory. The `ttl.build_info()["tt_metal"]` value in each `tt-lang`
-wheel must equal `<ttmetal7>` expanded to the requested tt-metal commit. Use
-these when the environment already provides `ttnn` from an external tt-metal at
-that commit:
+published as browsable directories under `tt-lang/ttmetal/<ttmetal7>/`, where
+`<ttmetal7>` is that commit's 7-character prefix. Browse the set at
+`https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/` (trailing slash
+required). Install with `--find-links` pointed at the per-SHA directory:
 
 ```bash
 pip install \
-  --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/<ttmetal7>/ \
+  --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/<ttmetal7>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   "tt-lang-light==<version>"
 ```

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -425,10 +425,9 @@ def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
     assert "options: [inspect, put-index, move, copy, delete, readonly-cmd]" in workflow
     assert "id-token: write" in workflow
     assert "uses: ./.github/actions/configure-tt-s3-credentials" in workflow
-    assert (
-        "if: ${{ inputs.dry_run != true || inputs.operation == 'inspect' "
-        "|| inputs.operation == 'readonly-cmd' }}" in workflow
-    )
+    # Creds are configured only on main, so a non-main run never assumes the
+    # shared-bucket role, for any operation (read or write, dry-run or not).
+    assert "if: ${{ github.ref == 'refs/heads/main' }}" in workflow
     assert (
         "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}"
         in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -46,6 +46,7 @@ TTMETAL_LIGHT_ON_DEMAND_WORKFLOW = (
 TTMETAL_LIGHT_XLA_ON_DEMAND_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "ttmetal-light-xla-on-demand.yml"
 )
+S3_PYPI_OPS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "s3-pypi-ops.yml"
 MANYLINUX_WHEEL_DOCKERFILE = (
     REPO_ROOT / ".github" / "containers" / "Dockerfile.wheel-manylinux-2-34"
 )
@@ -390,6 +391,23 @@ def test_ttmetal_light_xla_workflow_uses_ubuntu_external_builder() -> None:
         "EXPECTED_TT_METAL_COMMIT: ${{ needs.build.outputs.ttmetal_sha }}" in workflow
     )
     assert "EXPECTED_TT_METAL_COMMIT: ${{ inputs.tt_metal_sha }}" not in workflow
+
+
+def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
+    workflow = S3_PYPI_OPS_WORKFLOW.read_text()
+
+    assert "name: S3 PyPI ops (tt-lang)" in workflow
+    assert "options: [inspect, put-index, move, copy, delete, readonly-cmd]" in workflow
+    assert "id-token: write" in workflow
+    assert "uses: ./.github/actions/configure-tt-s3-credentials" in workflow
+    assert (
+        "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}"
+        in workflow
+    )
+    assert ".github/scripts/s3-pypi-ops.sh" in workflow
+    # dry_run input defaults to true
+    dry_run_input = workflow.split("      dry_run:", 1)[1].split("concurrency:", 1)[0]
+    assert "default: true" in dry_run_input
 
 
 def test_light_core_builder_checks_tt_metal_provenance_when_exported() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -108,6 +108,14 @@ def test_nightly_publish_prefix_is_under_tt_lang() -> None:
     assert 'prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"' in workflow
 
 
+def test_prefixed_index_injection_targets_the_slash_key() -> None:
+    # s3pypi writes a prefixed root index to the slash-key "<prefix>/", not
+    # "<prefix>/index.html"; the injection step must upload to the same key.
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    assert 'key="$prefix/"' in workflow
+    assert 'key="$prefix/index.html"' not in workflow
+
+
 def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     workflow = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
 

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -101,6 +101,11 @@ def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     assert "standard_wheel_matrix" in workflow
 
 
+def test_nightly_publish_prefix_is_under_tt_lang() -> None:
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    assert 'prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"' in workflow
+
+
 def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     workflow = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
 

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -426,6 +426,10 @@ def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
     assert "id-token: write" in workflow
     assert "uses: ./.github/actions/configure-tt-s3-credentials" in workflow
     assert (
+        "if: ${{ inputs.dry_run != true || inputs.operation == 'inspect' "
+        "|| inputs.operation == 'readonly-cmd' }}" in workflow
+    )
+    assert (
         "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}"
         in workflow
     )

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -429,8 +429,10 @@ def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
         "if: ${{ inputs.dry_run != true || inputs.operation == 'inspect' "
         "|| inputs.operation == 'readonly-cmd' }}" in workflow
     )
+    # The main-ref gate applies to write ops only; inspect/readonly-cmd are reads.
     assert (
-        "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}"
+        "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' "
+        "&& inputs.operation != 'inspect' && inputs.operation != 'readonly-cmd' }}"
         in workflow
     )
     assert ".github/scripts/s3-pypi-ops.sh" in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -429,10 +429,8 @@ def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
         "if: ${{ inputs.dry_run != true || inputs.operation == 'inspect' "
         "|| inputs.operation == 'readonly-cmd' }}" in workflow
     )
-    # The main-ref gate applies to write ops only; inspect/readonly-cmd are reads.
     assert (
-        "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' "
-        "&& inputs.operation != 'inspect' && inputs.operation != 'readonly-cmd' }}"
+        "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}"
         in workflow
     )
     assert ".github/scripts/s3-pypi-ops.sh" in workflow

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -37,6 +37,8 @@ CALL_BUILD_WHEEL_IMAGES_WORKFLOW = (
 CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-ttmetal-light-wheel.yml"
 )
+DETECT_TTMLIR_TTMETAL_UPLIFT = SCRIPTS_DIR / "detect-ttmlir-ttmetal-uplift.sh"
+RECORD_TTMETAL_MISS = SCRIPTS_DIR / "record-ttmetal-miss.sh"
 CALL_BUILD_WHEELS_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-build-wheels.yml"
 )
@@ -189,6 +191,24 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
         in workflow
     )
     assert "Inject S3 index README" not in workflow
+
+
+def test_per_sha_prefix_is_consistent_across_publish_detect_record() -> None:
+    detect_script = DETECT_TTMLIR_TTMETAL_UPLIFT.read_text()
+    record_script = RECORD_TTMETAL_MISS.read_text()
+    workflow = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
+
+    assert "tt-lang/ttmetal/" in detect_script
+    assert "tt-lang/ttmetal/" in record_script
+    assert "tt-lang/ttmetal/" in workflow
+
+    old_forms = (
+        "s3://$S3_BUCKET/tt-lang/$1/",
+        "s3://$S3_BUCKET/tt-lang/$short/attempt.json",
+    )
+    for script_text in (detect_script, record_script):
+        for old_form in old_forms:
+            assert old_form not in script_text
 
 
 def test_ttmetal_light_workflow_names_are_specific() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -174,11 +174,12 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert (
         '--light-python-tags "${{ needs.preflight.outputs.python_tags }}"' in workflow
     )
-    assert '--prefix "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}"' in (
-        workflow
+    assert (
+        '--prefix "tt-lang/ttmetal/${{ needs.find-compatible.outputs.ttmetal_short }}"'
+        in (workflow)
     )
     assert (
-        '--find-links-subdir "tt-lang/${{ needs.find-compatible.outputs.ttmetal_short }}"'
+        '--find-links-subdir "tt-lang/ttmetal/${{ needs.find-compatible.outputs.ttmetal_short }}"'
         in workflow
     )
     assert "Inject S3 index README" not in workflow


### PR DESCRIPTION
### Problem

Per-tt-metal-SHA `tt-lang-light` wheels need a browsable, installable S3 location. The previous direct-upload flow wrote `tt-lang/<sha7>/index.html`, but the internal S3/CDN endpoint serves only exact object keys, so `https://pypi.eng.aws.tenstorrent.com/tt-lang/<sha7>/` returned 404 and the printed `pip --find-links` command found no wheels.

The per-SHA and nightly directories also lived at the top level of the shared bucket, and there was no constrained workflow for maintaining the `tt-lang/` area without hand-running `aws`.

### What's changed

- Publish per-SHA light wheels under `tt-lang/ttmetal/<sha7>/` and write the listing to the slash-key object `tt-lang/ttmetal/<sha7>/`, so the directory URL resolves.
- Generate filtered S3 listings with `README.txt`, subdirectories, and wheel links that include `#sha256=` fragments.
- Move nightly dev-wheel publishes under `tt-lang/<YYYY-MM>/`.
- Update the per-SHA detect/miss scripts to use `tt-lang/ttmetal/<sha7>/`.
- Add `s3-pypi-ops.yml` / `s3-pypi-ops.sh` for main-only, prefix-restricted `inspect`, `put-index`, `move`, `copy`, `delete`, and constrained read-only AWS commands.
- Update build docs, getting-started docs, and the internal S3 README.

### Testing

- Bats coverage for S3 index generation, direct wheel publishing, ops guardrails, detect, and miss recording.
- Pytest workflow assertions.
- Workflow YAML parse, `git diff --check`, and `shellcheck`.
- Live endpoint behavior was checked, and a published light wheel was installed via `--find-links` with `ttl.build_info()` provenance verified.

### Follow-ups

- After merge on main, verify `s3pypi --prefix tt-lang/<YYYY-MM>/` for nightly publishes.
- Migrate existing `tt-lang/<sha7>/` objects to `tt-lang/ttmetal/<sha7>/` and refresh the slash-key listings with the new ops workflow.
