### PR TITLE
s3-pypi-ops: skip tag copy on move/copy (role lacks s3:GetObjectTagging)

### DIFF
--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -173,11 +173,14 @@ case "$operation" in
         ;;
     copy)
         assert_destructive_ok "$src"; assert_allowed "$dest"
-        run_aws s3 cp "s3://$bucket/$src/" "s3://$bucket/$dest/" --recursive
+        # --copy-props metadata-directive keeps content-type but skips the tag
+        # copy; the multipart path's s3:GetObjectTagging is not granted to the
+        # role, so without it mv/cp of objects over the multipart threshold fails.
+        run_aws s3 cp "s3://$bucket/$src/" "s3://$bucket/$dest/" --recursive --copy-props metadata-directive
         ;;
     move)
         assert_destructive_ok "$src"; assert_allowed "$dest"
-        run_aws s3 mv "s3://$bucket/$src/" "s3://$bucket/$dest/" --recursive
+        run_aws s3 mv "s3://$bucket/$src/" "s3://$bucket/$dest/" --recursive --copy-props metadata-directive
         ;;
     delete)
         assert_destructive_ok "$prefix"

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -127,13 +127,13 @@ EOF
 @test "move (dry-run false) runs recursive mv" {
     run -0 "$SCRIPT" --operation move --source tt-lang/13adda8 --dest tt-lang/ttmetal/13adda8 --dry-run false
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3 mv s3://tenstorrent-pypi/tt-lang/13adda8/ s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/ --recursive"
+    assert_output --partial "s3 mv s3://tenstorrent-pypi/tt-lang/13adda8/ s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/ --recursive --copy-props metadata-directive"
 }
 
 @test "copy (dry-run false) runs recursive cp" {
     run -0 "$SCRIPT" --operation copy --source tt-lang/a --dest tt-lang/b --dry-run false
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3 cp s3://tenstorrent-pypi/tt-lang/a/ s3://tenstorrent-pypi/tt-lang/b/ --recursive"
+    assert_output --partial "s3 cp s3://tenstorrent-pypi/tt-lang/a/ s3://tenstorrent-pypi/tt-lang/b/ --recursive --copy-props metadata-directive"
 }
 
 @test "inspect runs recursive ls" {


### PR DESCRIPTION
### Problem

`s3-pypi-ops.sh` `move`/`copy` run `aws s3 mv|cp --recursive`, which does a multipart server-side copy for objects above the CLI's multipart threshold (~8 MB). The multipart copy carries object tags across by first calling `s3:GetObjectTagging`. The `GitHubActionsS3AccessRole` the workflow assumes does not grant `s3:GetObjectTagging`, so any object over the threshold fails with `AccessDenied`, while small objects (single-part copy, no tagging call) succeed. This surfaced migrating the per-tt-metal-SHA light wheels (~76 MB each): the small index/README/metapackage objects moved but the two large wheels failed, leaving the directory half-migrated. The bats tests cannot catch this because the mock `aws` does not enforce IAM.

### What's changed

`move` and `copy` now pass `--copy-props metadata-directive`, which preserves object metadata (content-type) but skips copying tags, so the CLI never calls `s3:GetObjectTagging`. This lets the tool move or copy objects of any size with the existing role.

### Testing

The bats assertions for `move` and `copy` now require `--copy-props metadata-directive` on the emitted `aws s3 mv|cp` command; the suite passes and shellcheck is clean.
