### PR TITLE
[ci] Browsable per-month/release S3 wheel views over top-level objects

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+self-hosted-runner:
+  labels:
+    - mlir-large-runner-lang
+    - n150
+    - n300-llmbox
+    - tt-ubuntu-2204-*-stable

--- a/.github/scripts/build-s3-light-core-wheel.sh
+++ b/.github/scripts/build-s3-light-core-wheel.sh
@@ -21,7 +21,7 @@ Options:
   --build-dir <dir>               CMake build directory. Default: build-<python-tag>.
   --raw-dir <dir>                 Unrepaired wheel directory. Default: dist-raw-<python-tag>.
   --dist-dir <dir>                Final wheel directory. Default: dist.
-  --allow-final-internal-version  Allow final release versions for internal light wheels.
+  --allow-final-internal-version  Allow final release versions for S3 light wheels.
 EOF
     exit 2
 }

--- a/.github/scripts/build-s3-light-metapackage-wheel.sh
+++ b/.github/scripts/build-s3-light-metapackage-wheel.sh
@@ -16,7 +16,7 @@ Usage: build-s3-light-metapackage-wheel.sh --version <version> [options]
 
 Options:
   --dist-dir <dir>                Final wheel directory. Default: dist.
-  --allow-final-internal-version  Allow final release versions for internal light wheels.
+  --allow-final-internal-version  Allow final release versions for S3 light wheels.
 EOF
     exit 2
 }

--- a/.github/scripts/inject-s3-index-readme.sh
+++ b/.github/scripts/inject-s3-index-readme.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Restore the README into an S3 PyPI root index. If s3pypi omitted a prefixed
-# root index, create one from the wheel dist only for that missing-key case.
+# Restore the README into an S3 PyPI index. If allowed and the target index is
+# missing, create one from the wheel dist only for that missing-key case.
 
 set -euo pipefail
 
@@ -15,6 +15,7 @@ Options:
   --bucket <bucket>      S3 bucket. Default: tenstorrent-pypi.
   --readme <path>        README markdown path. Default: packaging/s3-index/README.md.
   --dist-dir <path>      Wheel dist dir used to create a missing root index. Default: dist.
+  --require-existing     Fail if the target index key does not already exist.
 EOF
     exit 2
 }
@@ -23,6 +24,7 @@ bucket=tenstorrent-pypi
 readme=packaging/s3-index/README.md
 dist_dir=dist
 key=""
+create_from_dist=true
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -46,6 +48,10 @@ while [[ $# -gt 0 ]]; do
             key="$2"
             shift 2
             ;;
+        --require-existing)
+            create_from_dist=false
+            shift
+            ;;
         *)
             usage
             ;;
@@ -61,10 +67,14 @@ trap 'rm -rf "$tmpdir"' EXIT
 index_html="$tmpdir/index.html"
 aws_error="$tmpdir/aws-get.err"
 
-# The key may end in "/" (s3pypi's prefixed root index is a slash-key); s3api
-# uses the exact key, whereas `s3 cp` treats a trailing slash as a directory.
+# The key may end in "/" (the directory listing is a slash-key); s3api uses the
+# exact key, whereas `s3 cp` treats a trailing slash as a directory.
 if ! aws s3api get-object --bucket "$bucket" --key "$key" "$index_html" >/dev/null 2>"$aws_error"; then
     if grep -Eq 'NoSuchKey|Not Found|404|does not exist' "$aws_error"; then
+        if [[ "$create_from_dist" == false ]]; then
+            echo "S3 index s3://$bucket/$key does not exist." >&2
+            exit 1
+        fi
         echo "S3 index s3://$bucket/$key does not exist; creating a root index from $dist_dir." >&2
         rm -f "$index_html"
     else
@@ -79,3 +89,10 @@ python3 .github/scripts/inject_s3_index_readme.py \
     "$index_html"
 aws s3api put-object --bucket "$bucket" --key "$key" --body "$index_html" \
     --content-type "text/html; charset=utf-8" >/dev/null
+if [[ "$key" == */ ]]; then
+    alias_key="${key%/}"
+    if [[ -n "$alias_key" ]]; then
+        aws s3api put-object --bucket "$bucket" --key "$alias_key" --body "$index_html" \
+            --content-type "text/html; charset=utf-8" >/dev/null
+    fi
+fi

--- a/.github/scripts/inject_s3_index_readme.py
+++ b/.github/scripts/inject_s3_index_readme.py
@@ -2,11 +2,11 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Inject the S3-index README into an s3pypi root index.html.
+"""Inject the S3-index README into a slash-key or root index.
 
-s3pypi rewrites root indexes on upload. This restores the README above package
-anchors without changing pip resolution; repeated runs replace the existing
-sentinel-delimited block.
+Direct S3 wheel-directory publishes regenerate slash-key listings. This restores
+the README above anchors without changing pip resolution; repeated runs replace
+the existing sentinel-delimited block.
 
 Usage:
   inject_s3_index_readme.py [--create-from-dist <dist_dir>] <readme.md> <index.html>
@@ -37,6 +37,24 @@ def render_markdown(text: str) -> str:
 def build_block(readme_md: str) -> str:
     fragment = render_markdown(readme_md)
     return f'{START}\n<section id="ttlang-s3-readme">\n{fragment}\n</section>\n{END}\n'
+
+
+def build_standalone_readme(readme_md: str) -> str:
+    fragment = render_markdown(readme_md)
+    return (
+        "<!DOCTYPE html>\n"
+        "<html>\n"
+        "<head>\n"
+        '<meta charset="UTF-8">\n'
+        "<title>tt-lang Tenstorrent S3 PyPI index</title>\n"
+        "</head>\n"
+        "<body>\n"
+        '<section id="ttlang-s3-readme">\n'
+        f"{fragment}\n"
+        "</section>\n"
+        "</body>\n"
+        "</html>\n"
+    )
 
 
 def normalize_project_name(distribution_name: str) -> str:
@@ -90,6 +108,11 @@ def main(argv: list[str]) -> int:
             "index.html is absent."
         ),
     )
+    parser.add_argument(
+        "--render-readme-html",
+        action="store_true",
+        help="Render the README as a standalone HTML file at the index path.",
+    )
     parser.add_argument("readme")
     parser.add_argument("index")
     args = parser.parse_args(argv[1:])
@@ -99,6 +122,11 @@ def main(argv: list[str]) -> int:
 
     with open(readme_path, encoding="utf-8") as handle:
         readme_md = handle.read()
+    if args.render_readme_html:
+        with open(index_path, "w", encoding="utf-8") as handle:
+            handle.write(build_standalone_readme(readme_md))
+        return 0
+
     if index_path.exists():
         with open(index_path, encoding="utf-8") as handle:
             index_html = handle.read()

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -7,6 +7,22 @@
 # only the exact key requested; an object at <prefix>/index.html does not answer
 # a request for <prefix>/.
 
+# Absolute base URL for month-view anchors (top-level objects, not ../).
+S3_INDEX_BASE_URL="${S3_INDEX_BASE_URL:-https://pypi.eng.aws.tenstorrent.com}"
+
+S3_INDEX_README_NAME="${S3_INDEX_README_NAME:-README.html}"
+
+_s3_is_readme_name() {
+    [[ "$1" == "$S3_INDEX_README_NAME" ||
+        "$1" == "README.html" ]]
+}
+
+# Root compatibility is limited to final X.Y.Z releases; dev wheels resolve
+# from their year-month directories.
+_s3_is_stable_release_wheel_name() {
+    [[ "$1" =~ ^[A-Za-z0-9_]+-[0-9]+\.[0-9]+\.[0-9]+(\+[^-]+)?-[^-]+-[^-]+-[^-]+\.whl$ ]]
+}
+
 # Escape text for HTML element content and double-quoted attributes.
 _html_escape() {
     local s="$1"
@@ -34,9 +50,23 @@ s3_render_index() {
 }
 
 # Anchors for the immediate children of s3://<bucket>/<prefix>/, listed from S3.
-# Sub-prefixes and (wheels + README.txt); no sha256 (the hashed per-SHA listing
-# is generated at publish time from local files by s3_local_wheel_anchors).
+# Sub-prefixes and wheels plus the per-directory README; no sha256 (the hashed
+# per-SHA listing is generated at publish time from local files by
+# s3_local_wheel_anchors).
 s3_child_anchors() {
+    local dirs_only=false
+    local hidden_stable_wheels=false
+    while [[ "${1:-}" == --* ]]; do
+        case "$1" in
+            --directories-only) dirs_only=true ;;
+            --hidden-stable-wheels) hidden_stable_wheels=true ;;
+            *)
+                echo "s3_child_anchors: unknown option: $1" >&2
+                return 2
+                ;;
+        esac
+        shift
+    done
     local bucket="$1" prefix="$2" listing col1 col2 col3 name esc
     listing="$(aws s3 ls "s3://${bucket}/${prefix}/")" || return 1
     # shellcheck disable=SC2034
@@ -44,21 +74,38 @@ s3_child_anchors() {
         if [[ "$col1" == "PRE" ]]; then
             name="$col2"
         else
+            if [[ "$dirs_only" == true &&
+                "$hidden_stable_wheels" == true &&
+                "$name" == *.whl ]] &&
+                _s3_is_stable_release_wheel_name "$name"; then
+                esc="$(_html_escape "$name")"
+                # Absolute href: relative would 404 from the no-slash root alias.
+                printf '<a href="%s/%s/%s" style="display:none" data-ttlang-hidden-stable-wheel="true">%s</a>\n' "$S3_INDEX_BASE_URL" "$prefix" "$esc" "$esc"
+                continue
+            fi
+            [[ "$dirs_only" == false ]] || continue
             # A find-links directory holds only wheels and the README; skip the
             # slash-key object itself, index.html, attempt.json markers, etc.
-            [[ "$name" == *.whl || "$name" == "README.txt" ]] || continue
+            [[ "$name" == *.whl ]] || _s3_is_readme_name "$name" || continue
         fi
         esc="$(_html_escape "$name")"
         printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
     done <<< "$listing"
 }
 
-# Anchors for a local wheel dist: README.txt plus each *.whl with a #sha256
-# fragment computed from the local file (no download).
+# Anchors for a local wheel dist: optional README plus each *.whl with a
+# #sha256 fragment computed from the local file (no download).
 s3_local_wheel_anchors() {
+    local include_readme=true
+    if [[ "${1:-}" == "--no-readme" ]]; then
+        include_readme=false
+        shift
+    fi
     local dist_dir="$1" f name esc digest
-    esc="$(_html_escape "README.txt")"
-    printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+    if [[ "$include_readme" == true ]]; then
+        esc="$(_html_escape "$S3_INDEX_README_NAME")"
+        printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+    fi
     for f in "$dist_dir"/*.whl; do
         [[ -e "$f" ]] || continue
         name="$(basename "$f")"; esc="$(_html_escape "$name")"
@@ -67,13 +114,19 @@ s3_local_wheel_anchors() {
     done
 }
 
-# Upload an HTML file to the slash-key s3://<bucket>/<prefix>/ (trailing slash is
-# the object key, so the directory URL resolves).
+# Upload an HTML file to both the slash-key s3://<bucket>/<prefix>/ and the
+# no-slash alias s3://<bucket>/<prefix>. The CDN serves exact object keys, while
+# pip users commonly omit the trailing slash in --find-links URLs.
 s3_put_index() {
     local bucket="$1" prefix="$2" html_file="$3"
     aws s3api put-object \
         --bucket "$bucket" \
         --key "${prefix}/" \
+        --body "$html_file" \
+        --content-type "text/html; charset=utf-8" >/dev/null
+    aws s3api put-object \
+        --bucket "$bucket" \
+        --key "$prefix" \
         --body "$html_file" \
         --content-type "text/html; charset=utf-8" >/dev/null
 }
@@ -82,8 +135,24 @@ s3_put_index() {
 # Refuses to write if the listing fails or comes back empty, so a transient
 # `aws s3 ls` failure can't overwrite a live index with a blank page.
 s3_regenerate_index() {
+    local dirs_only=false
+    local hidden_stable_wheels=false
+    while [[ "${1:-}" == --* ]]; do
+        case "$1" in
+            --directories-only) dirs_only=true ;;
+            --hidden-stable-wheels) hidden_stable_wheels=true ;;
+            *)
+                echo "s3_regenerate_index: unknown option: $1" >&2
+                return 2
+                ;;
+        esac
+        shift
+    done
     local bucket="$1" prefix="$2" anchors tmp
-    anchors="$(s3_child_anchors "$bucket" "$prefix")" || {
+    local anchor_args=()
+    [[ "$dirs_only" == true ]] && anchor_args+=(--directories-only)
+    [[ "$hidden_stable_wheels" == true ]] && anchor_args+=(--hidden-stable-wheels)
+    anchors="$(s3_child_anchors "${anchor_args[@]}" "$bucket" "$prefix")" || {
         echo "s3_regenerate_index: failed to list s3://${bucket}/${prefix}/" >&2
         return 1
     }
@@ -95,4 +164,72 @@ s3_regenerate_index() {
     printf '%s\n' "$anchors" | s3_render_index "tt-lang: ${prefix}" > "$tmp"
     s3_put_index "$bucket" "$prefix" "$tmp"
     rm -f "$tmp"
+}
+
+_s3_top_level_wheel_view_anchors() {
+    local bucket="$1" view_kind="$2" selector="${3:-}"
+    local year_month="${selector/-/}"
+    local listing col1 col2 col3 name esc
+    listing="$(aws s3 ls "s3://${bucket}/tt-lang/")" || return 1
+    # shellcheck disable=SC2034
+    while read -r col1 col2 col3 name; do
+        [[ "$col1" == "PRE" ]] && continue
+        [[ "$name" == *.whl ]] || continue
+        case "$view_kind" in
+            month)
+                [[ "$name" == *"dev${year_month}"* ]] || continue
+                ;;
+            releases)
+                _s3_is_stable_release_wheel_name "$name" || continue
+                ;;
+            *)
+                echo "_s3_top_level_wheel_view_anchors: unknown view kind: $view_kind" >&2
+                return 2
+                ;;
+        esac
+        esc="$(_html_escape "$name")"
+        printf '<a href="%s/tt-lang/%s">%s</a><br>\n' "$S3_INDEX_BASE_URL" "$esc" "$esc"
+    done <<< "$listing"
+}
+
+# Absolute href, not ../: s3_put_index's no-slash alias would resolve a
+# relative ../ one level too high.
+s3_month_view_anchors() {
+    local bucket="$1" month="$2"
+    _s3_top_level_wheel_view_anchors "$bucket" month "$month"
+}
+
+s3_release_view_anchors() {
+    local bucket="$1"
+    _s3_top_level_wheel_view_anchors "$bucket" releases
+}
+
+_s3_regenerate_top_level_wheel_view() {
+    local bucket="$1" prefix="$2" view_kind="$3" selector="${4:-}"
+    local anchors tmp
+    anchors="$(_s3_top_level_wheel_view_anchors "$bucket" "$view_kind" "$selector")" || {
+        echo "s3_regenerate_${view_kind}_view: failed to list top-level wheels for ${prefix}" >&2
+        return 1
+    }
+    if [[ -z "$anchors" ]]; then
+        echo "s3_regenerate_${view_kind}_view: refusing to write an empty view for ${prefix}" >&2
+        return 1
+    fi
+    tmp="$(mktemp)"
+    printf '%s\n' "$anchors" | s3_render_index "tt-lang: ${prefix}" > "$tmp"
+    s3_put_index "$bucket" "$prefix" "$tmp"
+    rm -f "$tmp"
+}
+
+# Refuses to write an empty view: a transient ls failure or a wheel-less
+# selector must not blank a live page.
+s3_regenerate_month_view() {
+    local bucket="$1" prefix="$2" month
+    month="${prefix#tt-lang/}"
+    _s3_regenerate_top_level_wheel_view "$bucket" "$prefix" month "$month"
+}
+
+s3_regenerate_release_view() {
+    local bucket="$1"
+    _s3_regenerate_top_level_wheel_view "$bucket" "tt-lang/releases" releases
 }

--- a/.github/scripts/lib/s3-index.sh
+++ b/.github/scripts/lib/s3-index.sh
@@ -89,28 +89,33 @@ s3_child_anchors() {
             [[ "$name" == *.whl ]] || _s3_is_readme_name "$name" || continue
         fi
         esc="$(_html_escape "$name")"
-        printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+        if [[ "$col1" == "PRE" ]]; then
+            printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+        else
+            printf '<a href="%s/%s/%s">%s</a><br>\n' "$S3_INDEX_BASE_URL" "$prefix" "$esc" "$esc"
+        fi
     done <<< "$listing"
 }
 
 # Anchors for a local wheel dist: optional README plus each *.whl with a
-# #sha256 fragment computed from the local file (no download).
+# #sha256 fragment computed from the local file (no download). Absolute hrefs
+# under <prefix>: relative would 404 from the no-slash root alias.
 s3_local_wheel_anchors() {
     local include_readme=true
     if [[ "${1:-}" == "--no-readme" ]]; then
         include_readme=false
         shift
     fi
-    local dist_dir="$1" f name esc digest
+    local prefix="$1" dist_dir="$2" f name esc digest
     if [[ "$include_readme" == true ]]; then
         esc="$(_html_escape "$S3_INDEX_README_NAME")"
-        printf '<a href="%s">%s</a><br>\n' "$esc" "$esc"
+        printf '<a href="%s/%s/%s">%s</a><br>\n' "$S3_INDEX_BASE_URL" "$prefix" "$esc" "$esc"
     fi
     for f in "$dist_dir"/*.whl; do
         [[ -e "$f" ]] || continue
         name="$(basename "$f")"; esc="$(_html_escape "$name")"
         digest="$(sha256sum "$f" | awk '{print $1}')"
-        printf '<a href="%s#sha256=%s">%s</a><br>\n' "$esc" "$digest" "$esc"
+        printf '<a href="%s/%s/%s#sha256=%s">%s</a><br>\n' "$S3_INDEX_BASE_URL" "$prefix" "$esc" "$digest" "$esc"
     done
 }
 

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -4,7 +4,7 @@
 #
 # Publish a per-tt-metal-SHA wheel set to a browsable slash-key directory under
 # <prefix> (e.g. tt-lang/ttmetal/<sha7>), consumed with pip --find-links. Wheels
-# and README.txt are uploaded as objects; the directory listing is written to the
+# and README.html are uploaded as objects; the directory listing is written to the
 # slash-key <prefix>/ and the parent listing is regenerated so the new entry
 # shows up when browsing.
 #
@@ -46,9 +46,17 @@ if [[ "${#wheels[@]}" -eq 0 ]]; then
     exit 1
 fi
 
-# Upload the README (as README.txt) and each wheel as plain objects.
-aws s3 cp "$readme" "s3://$bucket/$prefix/README.txt" \
-    --content-type "text/plain; charset=utf-8"
+readme_html="$(mktemp)"
+index_html="$(mktemp)"
+trap 'rm -f "$readme_html" "$index_html"' EXIT
+
+# Upload the README and each wheel as plain objects.
+python3 "$script_dir/inject_s3_index_readme.py" \
+    --render-readme-html \
+    "$readme" \
+    "$readme_html"
+aws s3 cp "$readme_html" "s3://$bucket/$prefix/$S3_INDEX_README_NAME" \
+    --content-type "text/html; charset=utf-8"
 for wheel in "${wheels[@]}"; do
     aws s3 cp "$wheel" "s3://$bucket/$prefix/$(basename "$wheel")" \
         --content-type "application/octet-stream"
@@ -59,7 +67,6 @@ done
 # until re-run. Re-running this script with the local dist restores the hashed
 # index; `s3-pypi-ops.sh --operation put-index` instead regenerates from S3
 # (s3_child_anchors), which produces a valid but hash-less index.
-index_html="$(mktemp)"; trap 'rm -f "$index_html"' EXIT
 s3_local_wheel_anchors "$dist_dir" | s3_render_index "tt-lang: $prefix" > "$index_html"
 s3_put_index "$bucket" "$prefix" "$index_html"
 

--- a/.github/scripts/publish-s3-direct-wheels.sh
+++ b/.github/scripts/publish-s3-direct-wheels.sh
@@ -67,7 +67,7 @@ done
 # until re-run. Re-running this script with the local dist restores the hashed
 # index; `s3-pypi-ops.sh --operation put-index` instead regenerates from S3
 # (s3_child_anchors), which produces a valid but hash-less index.
-s3_local_wheel_anchors "$dist_dir" | s3_render_index "tt-lang: $prefix" > "$index_html"
+s3_local_wheel_anchors "$prefix" "$dist_dir" | s3_render_index "tt-lang: $prefix" > "$index_html"
 s3_put_index "$bucket" "$prefix" "$index_html"
 
 parent="$(dirname "$prefix")"

--- a/.github/scripts/publish-s3-summary.sh
+++ b/.github/scripts/publish-s3-summary.sh
@@ -4,11 +4,11 @@
 #
 # Append a Markdown install summary to $GITHUB_STEP_SUMMARY for the S3 PyPI
 # publish workflow. With --dry-run, record that no upload occurred. With
-# --index-subdir <subdir>, point the install commands at the .../<subdir>/
-# simple index (`tt-lang/<YYYY-MM>/` for nightlies) instead of the flat root.
-# --find-links-subdir <subdir> points install commands at a direct wheel
-# directory consumed with pip --find-links. With no $GITHUB_STEP_SUMMARY set,
-# output goes to stdout for local invocations/tests.
+# --index-subdir <subdir> points install commands at a simple index. Use
+# --find-links-subdir <subdir> for generated wheel views consumed with
+# pip --find-links, including `tt-lang/<YYYY-MM>/` and `tt-lang/releases/`.
+# With no $GITHUB_STEP_SUMMARY set, output goes to stdout for local
+# invocations/tests.
 #
 # Usage: publish-s3-summary.sh [--dry-run] [--index-subdir <subdir>] [--find-links-subdir <subdir>] <wheel_variant> <version_override>
 

--- a/.github/scripts/publish-s3-wheels.sh
+++ b/.github/scripts/publish-s3-wheels.sh
@@ -2,18 +2,21 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Upload every wheel under <dist_dir> to the tenstorrent-pypi S3 PyPI index
-# via s3pypi. With --overwrite, pass --force to allow replacing an existing
-# wheel/version. With --prefix <p>, publish under the S3 key prefix <p> (a
-# self-contained simple index at <p>/) instead of the flat root; omitting it
-# preserves the flat-root layout.
+# Upload every wheel under <dist_dir> to the top-level tt-lang/ wheel directory.
+# tt-lang/<YYYY-MM>/ and tt-lang/releases/ are generated find-links views over
+# those top-level wheel objects, not physical copies. With --overwrite, replace
+# existing direct wheel objects.
 #
-# Usage: publish-s3-wheels.sh [--overwrite] [--prefix <prefix>] <dist_dir>
+# Usage: publish-s3-wheels.sh [--overwrite] --prefix <tt-lang/YYYY-MM|tt-lang/releases> <dist_dir>
 
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/s3-index.sh
+. "$script_dir/lib/s3-index.sh"
+
 usage() {
-    echo "Usage: $0 [--overwrite] [--prefix <prefix>] <dist_dir>" >&2
+    echo "Usage: $0 [--overwrite] --prefix <tt-lang/YYYY-MM|tt-lang/releases> <dist_dir>" >&2
     exit 2
 }
 
@@ -40,21 +43,36 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ $# -ne 1 ]]; then
+if [[ $# -ne 1 || -z "$prefix" ]]; then
     usage
+fi
+if [[ ! "$prefix" =~ ^tt-lang/[0-9]{4}-[0-9]{2}$ && "$prefix" != "tt-lang/releases" ]]; then
+    echo "Publish prefix must be tt-lang/<YYYY-MM> or tt-lang/releases: $prefix" >&2
+    exit 2
 fi
 
 dist_dir="$1"
+bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
 
-# --prefix maps to s3pypi's key prefix (self-contained simple index under
-# <prefix>/); requires an s3pypi version that supports --prefix.
-upload_args=(--put-root-index --bucket tenstorrent-pypi)
-if [[ -n "$prefix" ]]; then
-    upload_args+=(--prefix "$prefix")
-fi
-if [[ "$overwrite" -eq 1 ]]; then
-    upload_args+=(--force)
-fi
+assert_object_absent_or_overwrite() {
+    local key="$1" head_error
+    if [[ "$overwrite" -eq 1 ]]; then
+        return 0
+    fi
+    head_error="$(mktemp)"
+    if aws s3api head-object --bucket "$bucket" --key "$key" >/dev/null 2>"$head_error"; then
+        rm -f "$head_error"
+        echo "S3 object already exists: s3://$bucket/$key (pass --overwrite to replace it)." >&2
+        exit 1
+    fi
+    if grep -Eq 'NoSuchKey|Not Found|404|does not exist' "$head_error"; then
+        rm -f "$head_error"
+        return 0
+    fi
+    cat "$head_error" >&2
+    rm -f "$head_error"
+    exit 1
+}
 
 shopt -s nullglob
 wheels=("$dist_dir"/*.whl)
@@ -63,6 +81,22 @@ if [[ "${#wheels[@]}" -eq 0 ]]; then
     exit 1
 fi
 
+top_level="$(dirname "$prefix")"
+
 for wheel in "${wheels[@]}"; do
-    s3pypi upload "$wheel" "${upload_args[@]}"
+    wheel_key="$top_level/$(basename "$wheel")"
+    assert_object_absent_or_overwrite "$wheel_key"
 done
+
+for wheel in "${wheels[@]}"; do
+    wheel_key="$top_level/$(basename "$wheel")"
+    aws s3 cp "$wheel" "s3://$bucket/$wheel_key" \
+        --content-type "application/octet-stream"
+done
+
+if [[ "$prefix" == "tt-lang/releases" ]]; then
+    s3_regenerate_release_view "$bucket"
+else
+    s3_regenerate_month_view "$bucket" "$prefix"
+fi
+s3_regenerate_index --directories-only --hidden-stable-wheels "$bucket" "$top_level"

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -108,7 +108,7 @@ esac
 
 if is_stable_version "$version_override" && variant_includes_bundled "$wheel_variant" && pypi_aligned; then
     echo "Refusing to publish bundled tt-lang==$version_override to S3 because public PyPI publishing is aligned for this tt-metal tag." >&2
-    echo "Use the light or pypi S3 variant, or use a distinct internal version." >&2
+    echo "Use the light or pypi S3 variant, or use a distinct S3 version." >&2
     exit 1
 fi
 

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -166,7 +166,19 @@ case "$operation" in
     put-index)
         assert_allowed "$prefix"
         if [[ "$dry_run" == "false" ]]; then
-            s3_regenerate_index "$bucket" "$prefix"
+            if [[ "$prefix" == "tt-lang" ]]; then
+                s3_regenerate_index --directories-only --hidden-stable-wheels "$bucket" "$prefix"
+                "$script_dir/inject-s3-index-readme.sh" \
+                    --bucket "$bucket" \
+                    --key "$prefix/" \
+                    --require-existing
+            elif [[ "$prefix" == "tt-lang/releases" ]]; then
+                s3_regenerate_release_view "$bucket"
+            elif [[ "$prefix" =~ ^tt-lang/[0-9]{4}-[0-9]{2}$ ]]; then
+                s3_regenerate_month_view "$bucket" "$prefix"
+            else
+                s3_regenerate_index "$bucket" "$prefix"
+            fi
         else
             echo "DRY-RUN: regenerate slash-key index for $prefix"
         fi

--- a/.github/scripts/tests/test_inject_s3_index_readme.bats
+++ b/.github/scripts/tests/test_inject_s3_index_readme.bats
@@ -6,8 +6,8 @@
 
 load test_helper
 
-# Write a minimal s3pypi-style root index (a <body> with two package anchors)
-# to $INDEX and a short README to $README.
+# Write a minimal root index (a <body> with two package anchors) to $INDEX and
+# a short README to $README.
 setup() {
     SCRIPT="$SCRIPTS_DIR/inject_s3_index_readme.py"
     INDEX="$BATS_TEST_TMPDIR/index.html"
@@ -22,7 +22,7 @@ setup() {
 </html>
 EOF
     cat > "$README" <<'EOF'
-# tt-lang internal index
+# tt-lang S3 index
 
 Install with `pip install tt-lang`.
 EOF
@@ -38,7 +38,7 @@ run_inject() { python3 "$SCRIPT" "$README" "$INDEX"; }
     run -0 run_inject
     run cat "$INDEX"
     assert_output --partial 'id="ttlang-s3-readme"'
-    assert_output --partial "tt-lang internal index"
+    assert_output --partial "tt-lang S3 index"
     # The injected section must appear before the first package anchor.
     section_line=$(grep -n 'ttlang-s3-readme' "$INDEX" | head -1 | cut -d: -f1)
     anchor_line=$(grep -n 'href="tt-lang/"' "$INDEX" | head -1 | cut -d: -f1)
@@ -81,4 +81,14 @@ run_inject() { python3 "$SCRIPT" "$README" "$INDEX"; }
     assert_output --partial 'href="tt-lang-light/"'
     assert_output --partial 'href="tt-lang-sim/"'
     assert_output --partial 'id="ttlang-s3-readme"'
+}
+
+@test "--render-readme-html writes a standalone HTML README" {
+    rm "$INDEX"
+    run -0 python3 "$SCRIPT" --render-readme-html "$README" "$INDEX"
+    run cat "$INDEX"
+    assert_output --partial "<!DOCTYPE html>"
+    assert_output --partial '<section id="ttlang-s3-readme">'
+    assert_output --partial "tt-lang S3 index"
+    refute_output --partial 'href="tt-lang/"'
 }

--- a/.github/scripts/tests/test_inject_s3_index_readme_shell.bats
+++ b/.github/scripts/tests/test_inject_s3_index_readme_shell.bats
@@ -19,7 +19,7 @@ setup() {
     S3_ROOT="$BATS_TEST_TMPDIR/s3"
     mkdir -p "$S3_ROOT"
     cat > "$README" <<'EOF'
-# tt-lang internal index
+# tt-lang S3 index
 EOF
     bindir="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$bindir"
@@ -92,8 +92,13 @@ EOF
     assert_output --partial 'href="tt-lang-light/"'
     assert_output --partial 'id="ttlang-s3-readme"'
 
+    run cat "$S3_ROOT/tt-lang__2026-07"
+    assert_output --partial 'href="tt-lang/"'
+    assert_output --partial 'id="ttlang-s3-readme"'
+
     run cat "$AWS_LOG"
     assert_output --partial 's3api put-object --bucket tenstorrent-pypi --key tt-lang/2026-07/'
+    assert_output --partial 's3api put-object --bucket tenstorrent-pypi --key tt-lang/2026-07 --body'
 }
 
 @test "existing root index is preserved and uploaded" {
@@ -111,6 +116,10 @@ EOF
     run cat "$S3_ROOT/tt-lang__2026-07__"
     assert_output --partial 'href="existing-package/"'
     assert_output --partial 'id="ttlang-s3-readme"'
+
+    run cat "$S3_ROOT/tt-lang__2026-07"
+    assert_output --partial 'href="existing-package/"'
+    assert_output --partial 'id="ttlang-s3-readme"'
 }
 
 @test "non-404 aws failure is propagated" {
@@ -124,6 +133,12 @@ EOF
     run "$SCRIPT" --key tt-lang/2026-07/ --readme "$README" --dist-dir "$DIST_DIR"
     assert_equal "$status" 1
     assert_output --partial "AccessDenied"
+}
+
+@test "--require-existing fails instead of creating a missing index" {
+    run "$SCRIPT" --key tt-lang/ --require-existing --readme "$README" --dist-dir "$DIST_DIR"
+    assert_equal "$status" 1
+    assert_output --partial "does not exist"
 }
 
 @test "no-prefix stable index round-trips at the exact index.html key" {

--- a/.github/scripts/tests/test_publish_s3_direct_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_direct_wheels.bats
@@ -68,7 +68,8 @@ setup() {
     run cat "$FAKE_AWS_ARGS"
     # wheels + README uploaded as objects
     assert_output --partial "s3 cp $dir/$(whl_light 1.0.0) s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/$(whl_light 1.0.0)"
-    assert_output --partial "s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/README.txt"
+    assert_output --partial "s3://tenstorrent-pypi/tt-lang/ttmetal/13adda8/README.html"
+    assert_output --partial "--content-type text/html; charset=utf-8"
     # slash-key listing for the SHA prefix and the parent, via put-object
     assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/"
     assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/"
@@ -84,7 +85,7 @@ setup() {
     run -0 "$SCRIPT" --prefix tt-lang/ttmetal/13adda8 --readme "$README" "$dir"
 
     run cat "$PUT_BODIES_DIR/tt-lang_ttmetal_13adda8_"
-    assert_output --partial "<a href=\"README.txt\">README.txt</a><br>"
+    assert_output --partial "<a href=\"README.html\">README.html</a><br>"
     assert_output --partial "<a href=\"$(whl_light_core_cp312 1.0.0)#sha256=$empty_digest\">$(whl_light_core_cp312 1.0.0)</a><br>"
     assert_output --partial "<a href=\"$(whl_light 1.0.0)#sha256=$empty_digest\">$(whl_light 1.0.0)</a><br>"
 }

--- a/.github/scripts/tests/test_publish_s3_direct_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_direct_wheels.bats
@@ -85,9 +85,12 @@ setup() {
     run -0 "$SCRIPT" --prefix tt-lang/ttmetal/13adda8 --readme "$README" "$dir"
 
     run cat "$PUT_BODIES_DIR/tt-lang_ttmetal_13adda8_"
-    assert_output --partial "<a href=\"README.html\">README.html</a><br>"
-    assert_output --partial "<a href=\"$(whl_light_core_cp312 1.0.0)#sha256=$empty_digest\">$(whl_light_core_cp312 1.0.0)</a><br>"
-    assert_output --partial "<a href=\"$(whl_light 1.0.0)#sha256=$empty_digest\">$(whl_light 1.0.0)</a><br>"
+    assert_output --partial "<a href=\"https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/13adda8/README.html\">README.html</a><br>"
+    assert_output --partial "<a href=\"https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/13adda8/$(whl_light_core_cp312 1.0.0)#sha256=$empty_digest\">$(whl_light_core_cp312 1.0.0)</a><br>"
+    assert_output --partial "<a href=\"https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/13adda8/$(whl_light 1.0.0)#sha256=$empty_digest\">$(whl_light 1.0.0)</a><br>"
+    # No-slash alias resolution: absolute href is pip-resolvable without the
+    # trailing slash on the base URL.
+    assert_output --partial 'href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/13adda8/'
 }
 
 @test "bucket is overridable via TTLANG_S3_BUCKET" {

--- a/.github/scripts/tests/test_publish_s3_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_wheels.bats
@@ -6,18 +6,38 @@
 
 load test_helper
 
-# Install a fake `s3pypi` on PATH that records its full argv to
-# $FAKE_S3PYPI_ARGS (one invocation per line). Echoes the bindir.
-make_s3pypi_mock() {
-    local bindir="$BATS_TEST_TMPDIR/bin"
-    mkdir -p "$bindir"
-    cat > "$bindir/s3pypi" <<'EOF'
+make_aws_mock() {
+    cat > "$BINDIR/aws" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' "$*" >> "$FAKE_S3PYPI_ARGS"
-exit 0
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    case "$3" in
+        *tt-lang/) cat "$LS_PARENT" ;;
+    esac
+elif [[ "$1 $2" == "s3api head-object" ]]; then
+    if [[ "${HEAD_OBJECT_EXISTS:-false}" == true ]]; then
+        exit 0
+    fi
+    if [[ -n "${HEAD_OBJECT_EXISTS_KEY:-}" && "$*" == *"$HEAD_OBJECT_EXISTS_KEY"* ]]; then
+        exit 0
+    fi
+    echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
+    exit 1
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    shift 2
+    key="" body=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --key) key="$2"; shift 2 ;;
+            --body) body="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    cp "$body" "$PUT_BODIES_DIR/${key//\//_}"
+fi
 EOF
-    chmod +x "$bindir/s3pypi"
-    echo "$bindir"
+    chmod +x "$BINDIR/aws"
 }
 
 # Create a temp dist dir containing the named (empty) wheel files. Echoes the
@@ -33,10 +53,23 @@ make_dist_dir() {
 
 setup() {
     SCRIPT="$SCRIPTS_DIR/publish-s3-wheels.sh"
-    FAKE_S3PYPI_ARGS="$BATS_TEST_TMPDIR/s3pypi_args"
-    : > "$FAKE_S3PYPI_ARGS"
-    export FAKE_S3PYPI_ARGS
-    BINDIR=$(make_s3pypi_mock)
+    FAKE_AWS_ARGS="$BATS_TEST_TMPDIR/aws_args"
+    LS_PARENT="$BATS_TEST_TMPDIR/ls_parent"
+    PUT_BODIES_DIR="$BATS_TEST_TMPDIR/put_bodies"
+    : > "$FAKE_AWS_ARGS"
+    mkdir -p "$PUT_BODIES_DIR"
+    cat > "$LS_PARENT" <<EOF
+                           PRE 2026-07/
+                           PRE releases/
+2026-07-04 00:00:00       1234 tt_lang-0.0.1-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-0.0.1.dev20260704-py3-none-any.whl
+EOF
+    export FAKE_AWS_ARGS LS_PARENT PUT_BODIES_DIR
+    export HEAD_OBJECT_EXISTS=false
+    export HEAD_OBJECT_EXISTS_KEY=""
+    BINDIR="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$BINDIR"
+    make_aws_mock
     export PATH="$BINDIR:$PATH"
 }
 
@@ -50,81 +83,216 @@ setup() {
 
 @test "empty dist dir -> error (exit 1)" {
     dir=$(make_dist_dir)
-    run -1 "$SCRIPT" "$dir"
+    run -1 "$SCRIPT" --prefix tt-lang/2026-07 "$dir"
     assert_output --partial "No wheels found under $dir"
 }
 
-@test "single wheel uploaded with default flags" {
+@test "--prefix is required" {
     dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
-    run -0 "$SCRIPT" "$dir"
-
-    run cat "$FAKE_S3PYPI_ARGS"
-    assert_output --partial "upload $dir/tt_lang-1.0-py3-none-any.whl"
-    assert_output --partial "--put-root-index"
-    assert_output --partial "--bucket tenstorrent-pypi"
-    refute_output --partial "--force"
+    run -2 "$SCRIPT" "$dir"
+    assert_output --partial "Usage:"
 }
 
-@test "multiple wheels each get their own s3pypi invocation" {
+@test "--prefix must be a supported generated tt-lang wheel view" {
+    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
+    run -2 "$SCRIPT" --prefix tt-lang-light/2026-07 "$dir"
+    assert_output --partial "Publish prefix must be tt-lang/<YYYY-MM> or tt-lang/releases"
+    run -2 "$SCRIPT" --prefix tt-lang/ttmetal "$dir"
+    assert_output --partial "Publish prefix must be tt-lang/<YYYY-MM> or tt-lang/releases"
+}
+
+@test "--prefix publishes top-level wheels and regenerates a month view" {
     dir=$(make_dist_dir \
-        "tt_lang-1.0-py3-none-any.whl" \
-        "tt_lang_sim-1.0-py3-none-any.whl")
-    run -0 "$SCRIPT" "$dir"
+        "tt_lang-1.0.0.dev20260705-py3-none-any.whl" \
+        "tt_lang_light-1.0.0.dev20260705-py3-none-any.whl")
+    cat > "$LS_PARENT" <<EOF
+                           PRE 2026-07/
+                           PRE releases/
+2026-07-04 00:00:00       1234 tt_lang-0.0.1-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-0.9.0.dev20260704-py3-none-any.whl
+2026-07-05 00:00:00       1234 tt_lang-1.0.0.dev20260705-py3-none-any.whl
+2026-07-05 00:00:00       1234 tt_lang_light-1.0.0.dev20260705-py3-none-any.whl
+EOF
+    run -0 "$SCRIPT" --prefix tt-lang/2026-07 "$dir"
 
-    run wc -l < "$FAKE_S3PYPI_ARGS"
-    assert_output "2"
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 cp $dir/tt_lang-1.0.0.dev20260705-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/tt_lang-1.0.0.dev20260705-py3-none-any.whl"
+    assert_output --partial "s3 cp $dir/tt_lang_light-1.0.0.dev20260705-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/tt_lang_light-1.0.0.dev20260705-py3-none-any.whl"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/2026-07/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/2026-07 --body"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang --body"
 
-    run cat "$FAKE_S3PYPI_ARGS"
-    assert_output --partial "tt_lang-1.0-py3-none-any.whl"
-    assert_output --partial "tt_lang_sim-1.0-py3-none-any.whl"
+    run cat "$PUT_BODIES_DIR/tt-lang_2026-07_"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-0.9.0.dev20260704-py3-none-any.whl"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0.dev20260705-py3-none-any.whl"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang_light-1.0.0.dev20260705-py3-none-any.whl"
+    refute_output --partial "#sha256="
+    refute_output --partial "README"
+    refute_output --partial "tt_lang-0.0.1-py3-none-any.whl\">"
+
+    run cat "$PUT_BODIES_DIR/tt-lang_"
+    assert_output --partial '<a href="2026-07/">2026-07/</a><br>'
+    assert_output --partial '<a href="releases/">releases/</a><br>'
+    assert_output --partial '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-0.0.1-py3-none-any.whl" style="display:none" data-ttlang-hidden-stable-wheel="true">tt_lang-0.0.1-py3-none-any.whl</a>'
+    refute_output --partial "tt_lang-0.0.1.dev20260704-py3-none-any.whl"
+
+    run cat "$PUT_BODIES_DIR/tt-lang"
+    assert_output --partial '<a href="2026-07/">2026-07/</a><br>'
+    assert_output --partial '<a href="releases/">releases/</a><br>'
+    assert_output --partial '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-0.0.1-py3-none-any.whl" style="display:none" data-ttlang-hidden-stable-wheel="true">tt_lang-0.0.1-py3-none-any.whl</a>'
+    refute_output --partial "tt_lang-0.0.1.dev20260704-py3-none-any.whl"
 }
 
-@test "--overwrite adds --force flag" {
-    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
-    run -0 "$SCRIPT" --overwrite "$dir"
+@test "--prefix tt-lang/releases publishes top-level wheels and regenerates release view" {
+    dir=$(make_dist_dir \
+        "tt_lang-1.0.0-py3-none-any.whl" \
+        "tt_lang_light-1.0.0-py3-none-any.whl")
+    cat > "$LS_PARENT" <<EOF
+                           PRE 2026-07/
+                           PRE releases/
+2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0.dev20260704-py3-none-any.whl
+EOF
+    run -0 "$SCRIPT" --prefix tt-lang/releases "$dir"
 
-    run cat "$FAKE_S3PYPI_ARGS"
-    assert_output --partial "--force"
-}
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 cp $dir/tt_lang-1.0.0-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/tt_lang-1.0.0-py3-none-any.whl"
+    assert_output --partial "s3 cp $dir/tt_lang_light-1.0.0-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/tt_lang_light-1.0.0-py3-none-any.whl"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/releases/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/releases --body"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/"
 
-@test "--prefix adds --prefix flag to s3pypi" {
-    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
-    run -0 "$SCRIPT" --prefix 2026-06 "$dir"
+    run cat "$PUT_BODIES_DIR/tt-lang_releases_"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0-py3-none-any.whl"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang_light-1.0.0-py3-none-any.whl"
+    refute_output --partial "dev20260704"
 
-    run cat "$FAKE_S3PYPI_ARGS"
-    assert_output --partial "--prefix 2026-06"
-    assert_output --partial "--put-root-index"
-    assert_output --partial "--bucket tenstorrent-pypi"
-}
-
-@test "no --prefix keeps the flat-root layout (no --prefix flag)" {
-    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
-    run -0 "$SCRIPT" "$dir"
-
-    run cat "$FAKE_S3PYPI_ARGS"
-    refute_output --partial "--prefix"
+    run cat "$PUT_BODIES_DIR/tt-lang_"
+    assert_output --partial '<a href="releases/">releases/</a><br>'
+    assert_output --partial '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0-py3-none-any.whl" style="display:none" data-ttlang-hidden-stable-wheel="true">tt_lang-1.0.0-py3-none-any.whl</a>'
+    refute_output --partial "tt_lang-1.0.0.dev20260704-py3-none-any.whl"
 }
 
 @test "--prefix composes with --overwrite" {
     dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
-    run -0 "$SCRIPT" --overwrite --prefix abc1234 "$dir"
+    run -0 "$SCRIPT" --overwrite --prefix tt-lang/2026-07 "$dir"
 
-    run cat "$FAKE_S3PYPI_ARGS"
-    assert_output --partial "--prefix abc1234"
-    assert_output --partial "--force"
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3://tenstorrent-pypi/tt-lang/tt_lang-1.0-py3-none-any.whl"
+}
+
+@test "--prefix without --overwrite rejects an existing wheel object" {
+    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
+    HEAD_OBJECT_EXISTS=true run -1 "$SCRIPT" --prefix tt-lang/2026-07 "$dir"
+    assert_output --partial "S3 object already exists"
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3api head-object --bucket tenstorrent-pypi --key tt-lang/tt_lang-1.0-py3-none-any.whl"
+    refute_output --partial "s3 cp"
+}
+
+@test "--prefix preflights all destination keys before uploading" {
+    dir=$(make_dist_dir \
+        "tt_lang-1.0-py3-none-any.whl" \
+        "tt_lang_light-1.0-py3-none-any.whl")
+    HEAD_OBJECT_EXISTS_KEY="tt_lang_light-1.0-py3-none-any.whl" \
+        run -1 "$SCRIPT" --prefix tt-lang/2026-07 "$dir"
+    assert_output --partial "S3 object already exists"
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3api head-object --bucket tenstorrent-pypi --key tt-lang/tt_lang-1.0-py3-none-any.whl"
+    assert_output --partial "s3api head-object --bucket tenstorrent-pypi --key tt-lang/tt_lang_light-1.0-py3-none-any.whl"
+    refute_output --partial "s3 cp"
 }
 
 @test "--prefix without a value -> usage error (exit 2)" {
     run -2 "$SCRIPT" --prefix
 }
 
-@test "s3pypi failure aborts and propagates" {
-    cat > "$BINDIR/s3pypi" <<'EOF'
+# Persistent fake S3: a flat key->size manifest, driven by real s3 cp/put-object
+# writes and read back by s3 ls, so two sequential publishes into the same
+# month actually accumulate instead of relying on a hand-authored ls fixture.
+@test "publishing twice into the same month accumulates both dev wheels at top-level keys" {
+    OBJSTORE="$BATS_TEST_TMPDIR/objstore.tsv"
+    : > "$OBJSTORE"
+    export OBJSTORE
+    cat > "$BINDIR/aws" <<'EOF'
 #!/usr/bin/env bash
-exit 3
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+strip_key() { local u="$1"; u="${u#s3://}"; echo "${u#*/}"; }
+put() {
+    local key="$1" size="$2"
+    grep -v -F -- "$(printf '%s\t' "$key")" "$OBJSTORE" > "$OBJSTORE.tmp" 2>/dev/null || true
+    mv "$OBJSTORE.tmp" "$OBJSTORE"
+    printf '%s\t%s\n' "$key" "$size" >> "$OBJSTORE"
+}
+case "$1 $2" in
+    "s3 cp")
+        src="$3"; key="$(strip_key "$4")"
+        put "$key" "$(wc -c < "$src")"
+        ;;
+    "s3api head-object")
+        shift 2; key=""
+        while [[ $# -gt 0 ]]; do case "$1" in --key) key="$2"; shift 2 ;; *) shift ;; esac; done
+        grep -q -F -- "$(printf '%s\t' "$key")" "$OBJSTORE" 2>/dev/null && exit 0
+        echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
+        exit 1
+        ;;
+    "s3api put-object")
+        shift 2; key="" body=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --key) key="$2"; shift 2 ;;
+                --body) body="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        put "$key" "$(wc -c < "$body")"
+        cp "$body" "$PUT_BODIES_DIR/${key//\//_}"
+        ;;
+    "s3 ls")
+        prefix="$(strip_key "$3")"
+        declare -A is_dir=() printed=()
+        while IFS=$'\t' read -r key size; do
+            [[ "$key" == "$prefix"* ]] || continue
+            rest="${key#"$prefix"}"
+            [[ -n "$rest" ]] || continue
+            [[ "$rest" == */* ]] && is_dir["${rest%%/*}"]=1
+        done < "$OBJSTORE"
+        while IFS=$'\t' read -r key size; do
+            [[ "$key" == "$prefix"* ]] || continue
+            rest="${key#"$prefix"}"
+            [[ -n "$rest" ]] || continue
+            if [[ "$rest" == */* ]]; then
+                seg="${rest%%/*}"
+                [[ -n "${printed[$seg]:-}" ]] && continue
+                printed["$seg"]=1
+                printf '                           PRE %s/\n' "$seg"
+            else
+                [[ -n "${is_dir[$rest]:-}" ]] && continue
+                printf '2026-01-01 00:00:00 %8d %s\n' "$size" "$rest"
+            fi
+        done < "$OBJSTORE"
+        ;;
+esac
 EOF
-    chmod +x "$BINDIR/s3pypi"
-    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
-    run "$SCRIPT" "$dir"
-    assert_equal "$status" 3
+    chmod +x "$BINDIR/aws"
+
+    dir1=$(make_dist_dir "tt_lang-1.0.0.dev20260704-py3-none-any.whl")
+    run -0 "$SCRIPT" --prefix tt-lang/2026-07 "$dir1"
+
+    dir2=$(make_dist_dir "tt_lang_light-1.0.0.dev20260705-py3-none-any.whl")
+    run -0 "$SCRIPT" --prefix tt-lang/2026-07 "$dir2"
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 cp $dir1/tt_lang-1.0.0.dev20260704-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/tt_lang-1.0.0.dev20260704-py3-none-any.whl"
+    assert_output --partial "s3 cp $dir2/tt_lang_light-1.0.0.dev20260705-py3-none-any.whl s3://tenstorrent-pypi/tt-lang/tt_lang_light-1.0.0.dev20260705-py3-none-any.whl"
+
+    run cat "$PUT_BODIES_DIR/tt-lang_2026-07_"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0.dev20260704-py3-none-any.whl"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang_light-1.0.0.dev20260705-py3-none-any.whl"
 }

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -67,8 +67,8 @@ EOF
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_line '<a href="13adda8/">13adda8/</a><br>'
-    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
-    assert_line '<a href="README.html">README.html</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/README.html">README.html</a><br>'
     refute_output --partial '#sha256='
     refute_output --partial 'README.txt'
     refute_output --partial 'index.html'
@@ -80,7 +80,7 @@ EOF
     make_aws_mock "2026-07-04 00:00:00       1234 a&b.whl
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
-    assert_line '<a href="a&amp;b.whl">a&amp;b.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/a&amp;b.whl">a&amp;b.whl</a><br>'
     refute_output --partial 'a&b.whl'
     refute_output --partial '#sha256='
 }
@@ -90,7 +90,7 @@ EOF
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_success
-    assert_line '<a href="tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl">tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl">tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl</a><br>'
     refute_output --partial "%2B"
 }
 
@@ -249,7 +249,7 @@ EOF
 "
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_success
-    assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
     refute_output --partial 'href="234"'
 }
 
@@ -282,13 +282,17 @@ EOF
     : > "$dist_dir/tt_lang_light-1.0.0-py3-none-any.whl"
     : > "$dist_dir/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl"
 
-    run s3_local_wheel_anchors "$dist_dir"
+    run s3_local_wheel_anchors tt-lang/ttmetal/13adda8 "$dist_dir"
     assert_success
-    assert_line '<a href="README.html">README.html</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/13adda8/README.html">README.html</a><br>'
 
     digest="$(sha256sum "$dist_dir/tt_lang_light-1.0.0-py3-none-any.whl" | awk '{print $1}')"
-    assert_line "<a href=\"tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
-    assert_line --regexp '^<a href="tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl#sha256=[0-9a-f]{64}">tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl</a><br>$'
+    assert_line "<a href=\"https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/13adda8/tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
+    assert_line --regexp '^<a href="https://pypi\.eng\.aws\.tenstorrent\.com/tt-lang/ttmetal/13adda8/tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl#sha256=[0-9a-f]{64}">tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl</a><br>$'
+
+    # No-slash alias resolution: absolute href is pip-resolvable without the
+    # trailing slash on the base URL.
+    assert_output --partial 'href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/13adda8/'
 }
 
 @test "s3_local_wheel_anchors can omit README for monthly wheel directories" {
@@ -296,10 +300,10 @@ EOF
     mkdir -p "$dist_dir"
     : > "$dist_dir/tt_lang-1.0.0-py3-none-any.whl"
 
-    run s3_local_wheel_anchors --no-readme "$dist_dir"
+    run s3_local_wheel_anchors --no-readme tt-lang/ttmetal/2026-07 "$dist_dir"
     assert_success
     refute_output --partial "README"
-    assert_line --regexp '^<a href="tt_lang-1\.0\.0-py3-none-any\.whl#sha256=[0-9a-f]{64}">tt_lang-1\.0\.0-py3-none-any\.whl</a><br>$'
+    assert_line --regexp '^<a href="https://pypi\.eng\.aws\.tenstorrent\.com/tt-lang/ttmetal/2026-07/tt_lang-1\.0\.0-py3-none-any\.whl#sha256=[0-9a-f]{64}">tt_lang-1\.0\.0-py3-none-any\.whl</a><br>$'
 }
 
 @test "s3_render_index HTML-escapes a title containing '&' and '\"'" {
@@ -314,7 +318,7 @@ EOF
 '
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_success
-    assert_line '<a href="weird&quot;name.whl">weird&quot;name.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/weird&quot;name.whl">weird&quot;name.whl</a><br>'
 }
 
 @test "s3_month_view_anchors lists only the requested month's top-level wheels, with absolute hrefs" {

--- a/.github/scripts/tests/test_s3_index_lib.bats
+++ b/.github/scripts/tests/test_s3_index_lib.bats
@@ -59,6 +59,7 @@ EOF
 @test "s3_child_anchors renders sub-prefixes as dir anchors and objects as file anchors" {
     make_aws_mock "                           PRE 13adda8/
 2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00        321 README.html
 2026-07-04 00:00:00        321 README.txt
 2026-07-04 00:00:00        200 index.html
 2026-07-04 00:00:00         42 attempt.json
@@ -67,8 +68,9 @@ EOF
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_line '<a href="13adda8/">13adda8/</a><br>'
     assert_line '<a href="tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
-    assert_line '<a href="README.txt">README.txt</a><br>'
+    assert_line '<a href="README.html">README.html</a><br>'
     refute_output --partial '#sha256='
+    refute_output --partial 'README.txt'
     refute_output --partial 'index.html'
     refute_output --partial 'attempt.json'
     refute_output --partial 'junk.txt'
@@ -92,12 +94,41 @@ EOF
     refute_output --partial "%2B"
 }
 
+@test "s3_child_anchors directories-only skips root wheel objects" {
+    make_aws_mock "                           PRE 2026-07/
+                           PRE ttmetal/
+2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+"
+    run s3_child_anchors --directories-only tenstorrent-pypi tt-lang
+    assert_success
+    assert_line '<a href="2026-07/">2026-07/</a><br>'
+    assert_line '<a href="ttmetal/">ttmetal/</a><br>'
+    refute_output --partial "tt_lang-1.0.0-py3-none-any.whl"
+}
+
+@test "s3_child_anchors directories-only can keep stable root wheel anchors hidden" {
+    make_aws_mock "                           PRE 2026-07/
+                           PRE releases/
+                           PRE ttmetal/
+2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0.dev20260704-py3-none-any.whl
+"
+    run s3_child_anchors --hidden-stable-wheels --directories-only tenstorrent-pypi tt-lang
+    assert_success
+    assert_line '<a href="2026-07/">2026-07/</a><br>'
+    assert_line '<a href="releases/">releases/</a><br>'
+    assert_line '<a href="ttmetal/">ttmetal/</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0-py3-none-any.whl" style="display:none" data-ttlang-hidden-stable-wheel="true">tt_lang-1.0.0-py3-none-any.whl</a>'
+    refute_output --partial "tt_lang-1.0.0.dev20260704-py3-none-any.whl"
+}
+
 @test "s3_put_index uploads to the slash-key via put-object" {
     make_aws_mock ""
     printf '<html></html>\n' > "$BATS_TEST_TMPDIR/idx.html"
     run s3_put_index tenstorrent-pypi tt-lang/ttmetal/13adda8 "$BATS_TEST_TMPDIR/idx.html"
     run cat "$FAKE_AWS_ARGS"
     assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/ --body $BATS_TEST_TMPDIR/idx.html --content-type text/html; charset=utf-8"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8 --body $BATS_TEST_TMPDIR/idx.html --content-type text/html; charset=utf-8"
 }
 
 @test "s3_regenerate_index lists, renders, and puts the slash-key" {
@@ -107,7 +138,75 @@ EOF
     run cat "$FAKE_AWS_ARGS"
     assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/ttmetal/"
     assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/ttmetal --body"
 }
+
+@test "s3_regenerate_index directories-only writes only sub-prefixes" {
+    CAPTURED_BODY="$BATS_TEST_TMPDIR/captured_body.html"
+    export CAPTURED_BODY
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    printf '%s' "                           PRE 2026-07/
+2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+" > "$BATS_TEST_TMPDIR/ls_output"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    cat "$BATS_TEST_TMPDIR/ls_output"
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    args=("$@")
+    for ((i = 0; i < ${#args[@]}; i++)); do
+        if [[ "${args[$i]}" == "--body" ]]; then
+            cp "${args[$((i + 1))]}" "$CAPTURED_BODY"
+        fi
+    done
+fi
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+
+    run s3_regenerate_index --directories-only tenstorrent-pypi tt-lang
+    assert_success
+    run cat "$CAPTURED_BODY"
+    assert_output --partial "2026-07/"
+    refute_output --partial "tt_lang-1.0.0-py3-none-any.whl"
+}
+
+@test "s3_regenerate_index directories-only can keep stable root wheel anchors hidden" {
+    CAPTURED_BODY="$BATS_TEST_TMPDIR/captured_body.html"
+    export CAPTURED_BODY
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    printf '%s' "                           PRE 2026-07/
+2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0.dev20260704-py3-none-any.whl
+" > "$BATS_TEST_TMPDIR/ls_output"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    cat "$BATS_TEST_TMPDIR/ls_output"
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    args=("$@")
+    for ((i = 0; i < ${#args[@]}; i++)); do
+        if [[ "${args[$i]}" == "--body" ]]; then
+            cp "${args[$((i + 1))]}" "$CAPTURED_BODY"
+        fi
+    done
+fi
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+
+    run s3_regenerate_index --hidden-stable-wheels --directories-only tenstorrent-pypi tt-lang
+    assert_success
+    run cat "$CAPTURED_BODY"
+    assert_output --partial '<a href="2026-07/">2026-07/</a><br>'
+    assert_output --partial '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0-py3-none-any.whl" style="display:none" data-ttlang-hidden-stable-wheel="true">tt_lang-1.0.0-py3-none-any.whl</a>'
+    refute_output --partial "tt_lang-1.0.0.dev20260704-py3-none-any.whl"
+}
+
 
 @test "s3_regenerate_index writes a hash-less body from an S3-sourced listing" {
     CAPTURED_BODY="$BATS_TEST_TMPDIR/captured_body.html"
@@ -116,7 +215,7 @@ EOF
     mkdir -p "$bindir"
     printf '%s' "                           PRE 13adda8/
 2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
-2026-07-04 00:00:00        321 README.txt
+2026-07-04 00:00:00        321 README.html
 " > "$BATS_TEST_TMPDIR/ls_output"
     cat > "$bindir/aws" <<'EOF'
 #!/usr/bin/env bash
@@ -140,7 +239,7 @@ EOF
     [ -f "$CAPTURED_BODY" ]
     run cat "$CAPTURED_BODY"
     assert_output --partial "tt_lang_light-1.0.0-py3-none-any.whl"
-    assert_output --partial "README.txt"
+    assert_output --partial "README.html"
     refute_output --partial "#sha256="
 }
 
@@ -177,7 +276,7 @@ EOF
     refute_output --partial "put-object"
 }
 
-@test "s3_local_wheel_anchors hashes local wheels and always includes README.txt" {
+@test "s3_local_wheel_anchors hashes local wheels and includes README.html by default" {
     dist_dir="$BATS_TEST_TMPDIR/dist"
     mkdir -p "$dist_dir"
     : > "$dist_dir/tt_lang_light-1.0.0-py3-none-any.whl"
@@ -185,11 +284,22 @@ EOF
 
     run s3_local_wheel_anchors "$dist_dir"
     assert_success
-    assert_line '<a href="README.txt">README.txt</a><br>'
+    assert_line '<a href="README.html">README.html</a><br>'
 
     digest="$(sha256sum "$dist_dir/tt_lang_light-1.0.0-py3-none-any.whl" | awk '{print $1}')"
     assert_line "<a href=\"tt_lang_light-1.0.0-py3-none-any.whl#sha256=$digest\">tt_lang_light-1.0.0-py3-none-any.whl</a><br>"
     assert_line --regexp '^<a href="tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl#sha256=[0-9a-f]{64}">tt_lang-1\.0\.0\+light-cp312-cp312-manylinux_2_34_x86_64\.whl</a><br>$'
+}
+
+@test "s3_local_wheel_anchors can omit README for monthly wheel directories" {
+    dist_dir="$BATS_TEST_TMPDIR/dist"
+    mkdir -p "$dist_dir"
+    : > "$dist_dir/tt_lang-1.0.0-py3-none-any.whl"
+
+    run s3_local_wheel_anchors --no-readme "$dist_dir"
+    assert_success
+    refute_output --partial "README"
+    assert_line --regexp '^<a href="tt_lang-1\.0\.0-py3-none-any\.whl#sha256=[0-9a-f]{64}">tt_lang-1\.0\.0-py3-none-any\.whl</a><br>$'
 }
 
 @test "s3_render_index HTML-escapes a title containing '&' and '\"'" {
@@ -205,4 +315,97 @@ EOF
     run s3_child_anchors tenstorrent-pypi tt-lang/ttmetal
     assert_success
     assert_line '<a href="weird&quot;name.whl">weird&quot;name.whl</a><br>'
+}
+
+@test "s3_month_view_anchors lists only the requested month's top-level wheels, with absolute hrefs" {
+    make_aws_mock "                           PRE 2026-06/
+                           PRE 2026-07/
+2026-07-04 00:00:00        234
+2026-06-01 00:00:00       1234 tt_lang-1.0.0.dev20260601-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0.dev20260704-py3-none-any.whl
+2026-07-05 00:00:00       1234 tt_lang_light-1.0.0.dev20260705-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+"
+    run s3_month_view_anchors tenstorrent-pypi 2026-07
+    assert_success
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0.dev20260704-py3-none-any.whl">tt_lang-1.0.0.dev20260704-py3-none-any.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang_light-1.0.0.dev20260705-py3-none-any.whl">tt_lang_light-1.0.0.dev20260705-py3-none-any.whl</a><br>'
+    refute_output --partial "dev20260601"
+    refute_output --partial "tt_lang-1.0.0-py3-none-any.whl\">"
+    refute_output --partial "2026-06/"
+    refute_output --partial "2026-07/"
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/"
+}
+
+@test "s3_month_view_anchors honors an S3_INDEX_BASE_URL override" {
+    make_aws_mock "2026-07-04 00:00:00       1234 tt_lang-1.0.0.dev20260704-py3-none-any.whl
+"
+    S3_INDEX_BASE_URL="https://example.test" run s3_month_view_anchors tenstorrent-pypi 2026-07
+    assert_success
+    assert_line '<a href="https://example.test/tt-lang/tt_lang-1.0.0.dev20260704-py3-none-any.whl">tt_lang-1.0.0.dev20260704-py3-none-any.whl</a><br>'
+    refute_output --partial "pypi.eng.aws.tenstorrent.com"
+}
+
+@test "s3_release_view_anchors lists only top-level stable release wheels" {
+    make_aws_mock "                           PRE 2026-07/
+                           PRE releases/
+2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl
+2026-07-04 00:00:00       1234 tt_lang_light-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0.dev20260704-py3-none-any.whl
+"
+    run s3_release_view_anchors tenstorrent-pypi
+    assert_success
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0-py3-none-any.whl">tt_lang-1.0.0-py3-none-any.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl">tt_lang-1.0.0+light-cp312-cp312-manylinux_2_34_x86_64.whl</a><br>'
+    assert_line '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang_light-1.0.0-py3-none-any.whl">tt_lang_light-1.0.0-py3-none-any.whl</a><br>'
+    refute_output --partial "dev20260704"
+    refute_output --partial "2026-07/"
+    refute_output --partial "releases/"
+}
+
+@test "s3_regenerate_release_view writes slash and no-slash release views" {
+    CAPTURED_BODY_SLASH="$BATS_TEST_TMPDIR/captured_body_slash.html"
+    CAPTURED_BODY_ALIAS="$BATS_TEST_TMPDIR/captured_body_alias.html"
+    export CAPTURED_BODY_SLASH CAPTURED_BODY_ALIAS
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    printf '%s' "2026-07-04 00:00:00       1234 tt_lang-1.0.0-py3-none-any.whl
+2026-07-04 00:00:00       1234 tt_lang-1.0.0.dev20260704-py3-none-any.whl
+" > "$BATS_TEST_TMPDIR/ls_output"
+    cat > "$bindir/aws" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    cat "$BATS_TEST_TMPDIR/ls_output"
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    args=("$@")
+    key=""
+    body=""
+    for ((i = 0; i < ${#args[@]}; i++)); do
+        if [[ "${args[$i]}" == "--key" ]]; then
+            key="${args[$((i + 1))]}"
+        elif [[ "${args[$i]}" == "--body" ]]; then
+            body="${args[$((i + 1))]}"
+        fi
+    done
+    case "$key" in
+        tt-lang/releases/) cp "$body" "$CAPTURED_BODY_SLASH" ;;
+        tt-lang/releases) cp "$body" "$CAPTURED_BODY_ALIAS" ;;
+    esac
+fi
+EOF
+    chmod +x "$bindir/aws"
+    export PATH="$bindir:$PATH"
+
+    run s3_regenerate_release_view tenstorrent-pypi
+    assert_success
+    run cat "$CAPTURED_BODY_SLASH"
+    assert_output --partial '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0-py3-none-any.whl">tt_lang-1.0.0-py3-none-any.whl</a><br>'
+    refute_output --partial "dev20260704"
+    run cat "$CAPTURED_BODY_ALIAS"
+    assert_output --partial '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-1.0.0-py3-none-any.whl">tt_lang-1.0.0-py3-none-any.whl</a><br>'
+    refute_output --partial "dev20260704"
 }

--- a/.github/scripts/tests/test_s3_pypi_ops.bats
+++ b/.github/scripts/tests/test_s3_pypi_ops.bats
@@ -149,6 +149,95 @@ EOF
     refute_output --partial "put-object"
 }
 
+@test "top-level put-index hides stable root wheels and keeps README" {
+    S3_BODY="$BATS_TEST_TMPDIR/tt-lang-index.html"
+    export S3_BODY
+    cat > "$BATS_TEST_TMPDIR/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    printf '                           PRE 2026-07/\n'
+    printf '                           PRE releases/\n'
+    printf '                           PRE ttmetal/\n'
+    printf '2026-07-04 00:00:00       1234 tt_lang-0.0.1-py3-none-any.whl\n'
+    printf '2026-07-04 00:00:00       1234 tt_lang-0.0.1.dev20260704-py3-none-any.whl\n'
+elif [[ "$1 $2" == "s3api get-object" ]]; then
+    cp "$S3_BODY" "${@: -1}"
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    shift 2
+    body=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --body) body="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    cp "$body" "$S3_BODY"
+fi
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/aws"
+
+    run -0 "$SCRIPT" --operation put-index --prefix tt-lang --dry-run false
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang --body"
+    assert_output --partial "s3api get-object --bucket tenstorrent-pypi --key tt-lang/"
+
+    run cat "$S3_BODY"
+    assert_output --partial 'id="ttlang-s3-readme"'
+    assert_output --partial '<a href="2026-07/">2026-07/</a><br>'
+    assert_output --partial '<a href="releases/">releases/</a><br>'
+    assert_output --partial '<a href="ttmetal/">ttmetal/</a><br>'
+    assert_output --partial '<a href="https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-0.0.1-py3-none-any.whl" style="display:none" data-ttlang-hidden-stable-wheel="true">tt_lang-0.0.1-py3-none-any.whl</a>'
+    refute_output --partial "tt_lang-0.0.1.dev20260704-py3-none-any.whl"
+}
+
+@test "releases put-index rebuilds the stable release view" {
+    S3_RELEASE_BODY="$BATS_TEST_TMPDIR/tt-lang-releases-index.html"
+    export S3_RELEASE_BODY
+    cat > "$BATS_TEST_TMPDIR/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_AWS_ARGS"
+if [[ "$1 $2" == "s3 ls" ]]; then
+    printf '                           PRE 2026-07/\n'
+    printf '                           PRE releases/\n'
+    printf '2026-07-04 00:00:00       1234 tt_lang-0.0.1-py3-none-any.whl\n'
+    printf '2026-07-04 00:00:00       1234 tt_lang_light-0.0.1-py3-none-any.whl\n'
+    printf '2026-07-04 00:00:00       1234 tt_lang-0.0.1.dev20260704-py3-none-any.whl\n'
+elif [[ "$1 $2" == "s3api put-object" ]]; then
+    shift 2
+    key="" body=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --key) key="$2"; shift 2 ;;
+            --body) body="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    case "$key" in
+        tt-lang/releases | tt-lang/releases/) cp "$body" "$S3_RELEASE_BODY" ;;
+    esac
+fi
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/aws"
+
+    run -0 "$SCRIPT" --operation put-index --prefix tt-lang/releases --dry-run false
+
+    run cat "$FAKE_AWS_ARGS"
+    assert_output --partial "s3 ls s3://tenstorrent-pypi/tt-lang/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/releases/"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/releases --body"
+
+    run cat "$S3_RELEASE_BODY"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang-0.0.1-py3-none-any.whl"
+    assert_output --partial "https://pypi.eng.aws.tenstorrent.com/tt-lang/tt_lang_light-0.0.1-py3-none-any.whl"
+    refute_output --partial "dev20260704"
+}
+
 @test "rejects an unknown operation" {
     run -2 "$SCRIPT" --operation bogus
     assert_output --partial "unknown operation"
@@ -213,9 +302,9 @@ EOF
 }
 
 @test "readonly-cmd allows a --key under tt-lang/" {
-    run -0 "$SCRIPT" --operation readonly-cmd -- s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.txt
+    run -0 "$SCRIPT" --operation readonly-cmd -- s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.html
     run cat "$FAKE_AWS_ARGS"
-    assert_output --partial "s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.txt"
+    assert_output --partial "s3api head-object --bucket tenstorrent-pypi --key tt-lang/ttmetal/13adda8/README.html"
 }
 
 @test "readonly-cmd allows a --prefix under tt-lang/" {

--- a/.github/scripts/verify-s3-wheel-versions.sh
+++ b/.github/scripts/verify-s3-wheel-versions.sh
@@ -5,7 +5,7 @@
 # Verify the wheel versions produced by the S3 PyPI publish workflow. The light
 # variant publishes cp310/cp312 tt-lang wheels with a +light local version plus
 # the tt-lang-light metapackage; bundled and pypi variants publish all wheels at
-# the requested internal version.
+# the requested S3 version.
 #
 # Usage: verify-s3-wheel-versions.sh [--no-sim] [--python-tags cp310,cp312] <wheel_variant> <version_override> <dist_dir>
 

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -90,13 +90,13 @@ jobs:
           fi
           .github/containers/build-docker-images.sh --image-type base "${FLAGS[@]}" | tee docker.log
 
-          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+          if [ "${PIPESTATUS[0]}" -ne 0 ]; then
             echo "ERROR: Docker build failed"
             exit 1
           fi
 
-          DOCKER_IMAGE_BASE=$(cat .docker-image-base)
-          echo "docker-image-base=$DOCKER_IMAGE_BASE" >> $GITHUB_OUTPUT
+          DOCKER_IMAGE_BASE="$(cat .docker-image-base)"
+          echo "docker-image-base=$DOCKER_IMAGE_BASE" >> "$GITHUB_OUTPUT"
           echo "Base image built successfully: $DOCKER_IMAGE_BASE"
 
   # Builds LLVM + tt-metal on the host (via docker run with base image),
@@ -135,12 +135,12 @@ jobs:
       - name: Extract Docker tag
         id: docker-tag
         run: |
-          DOCKER_TAG=$(.github/containers/get-version-tag.sh)
-          echo "docker-tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+          DOCKER_TAG="$(.github/containers/get-version-tag.sh)"
+          echo "docker-tag=$DOCKER_TAG" >> "$GITHUB_OUTPUT"
           echo "Docker tag: $DOCKER_TAG"
 
       - name: Prepare toolchain directory
-        run: sudo install -d -o $(id -u) -g $(id -g) /opt/ttlang-toolchain
+        run: sudo install -d -o "$(id -u)" -g "$(id -g)" /opt/ttlang-toolchain
 
       - name: Restore toolchain cache
         uses: actions/cache/restore@v5
@@ -160,13 +160,13 @@ jobs:
           # runs when the resolved tag already points at an existing image).
           BASE_IMAGE="ghcr.io/${{ github.repository }}/tt-lang-base-ubuntu-24-04:${{ steps.docker-tag.outputs.docker-tag }}"
           .github/scripts/pull-image-retry.sh "$BASE_IMAGE"
-          echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV
+          echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
       - name: Configure tt-lang
         run: |
           df -h
           docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
+            -v "${{ github.workspace }}:/workspace" \
             -v /opt/ttlang-toolchain:/opt/ttlang-toolchain \
             -w /workspace \
             -e TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain \
@@ -178,7 +178,7 @@ jobs:
       - name: Normalize toolchain
         run: |
           docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
+            -v "${{ github.workspace }}:/workspace" \
             -v /opt/ttlang-toolchain:/opt/ttlang-toolchain \
             -w /workspace \
             "$BASE_IMAGE" \
@@ -199,7 +199,7 @@ jobs:
           echo "=== Building tt-lang ==="
           df -h
           docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
+            -v "${{ github.workspace }}:/workspace" \
             -v /opt/ttlang-toolchain:/opt/ttlang-toolchain \
             -w /workspace \
             -e TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain \
@@ -211,7 +211,7 @@ jobs:
       - name: Cleanup dist toolchain
         run: |
           docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
+            -v "${{ github.workspace }}:/workspace" \
             -v /opt/ttlang-toolchain:/opt/ttlang-toolchain \
             -w /workspace \
             "$BASE_IMAGE" \
@@ -240,15 +240,15 @@ jobs:
           set -x
           .github/containers/build-docker-images.sh --image-type dist --no-push | tee docker.log
 
-          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+          if [ "${PIPESTATUS[0]}" -ne 0 ]; then
             echo "ERROR: Docker build failed"
             exit 1
           fi
 
-          LOCAL_IMAGE=$(cat .docker-image-name)
+          LOCAL_IMAGE="$(cat .docker-image-name)"
           REGISTRY_IMAGE="ghcr.io/tenstorrent/tt-lang/${LOCAL_IMAGE}"
-          echo "local-image=$LOCAL_IMAGE" >> $GITHUB_OUTPUT
-          echo "docker-image=$REGISTRY_IMAGE" >> $GITHUB_OUTPUT
+          echo "local-image=$LOCAL_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "docker-image=$REGISTRY_IMAGE" >> "$GITHUB_OUTPUT"
           echo "Dist image built locally: $LOCAL_IMAGE"
           df -h
 
@@ -298,15 +298,15 @@ jobs:
           set -x
           .github/containers/build-docker-images.sh --image-type ird --no-push | tee docker-ird.log
 
-          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+          if [ "${PIPESTATUS[0]}" -ne 0 ]; then
             echo "ERROR: Docker build failed"
             exit 1
           fi
 
-          LOCAL_IMAGE=$(cat .docker-image-ird)
+          LOCAL_IMAGE="$(cat .docker-image-ird)"
           REGISTRY_IMAGE="ghcr.io/tenstorrent/tt-lang/${LOCAL_IMAGE}"
-          echo "local-image=$LOCAL_IMAGE" >> $GITHUB_OUTPUT
-          echo "docker-image=$REGISTRY_IMAGE" >> $GITHUB_OUTPUT
+          echo "local-image=$LOCAL_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "docker-image=$REGISTRY_IMAGE" >> "$GITHUB_OUTPUT"
           echo "IRD image built locally: $LOCAL_IMAGE"
           df -h
 

--- a/.github/workflows/call-build-toolchain.yml
+++ b/.github/workflows/call-build-toolchain.yml
@@ -36,7 +36,7 @@ jobs:
           LLVM_SHA=$(git ls-tree HEAD third-party/llvm-project | awk '{print substr($3,1,7)}')
           TTMETAL_SHA=$(git ls-tree HEAD third-party/tt-metal | awk '{print substr($3,1,7)}')
           CACHE_KEY="Linux-toolchain_llvm-${LLVM_SHA}_ttmetal-${TTMETAL_SHA}"
-          echo "cache-key=$CACHE_KEY" >> $GITHUB_OUTPUT
+          echo "cache-key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
           echo "Cache key: $CACHE_KEY"
 
       - name: Look up toolchain cache (no download)
@@ -133,7 +133,7 @@ jobs:
 
       - name: Prepare toolchain directory
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
-        run: sudo install -d -o $(id -u) -g $(id -g) /opt/ttlang-toolchain
+        run: sudo install -d -o "$(id -u)" -g "$(id -g)" /opt/ttlang-toolchain
 
       - name: Configure (builds LLVM + tt-metal)
         if: steps.cache-toolchain.outputs.cache-hit != 'true'

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -56,11 +56,18 @@ jobs:
 
             - name: Configure tt-lang
               run: |
-                  cmake -G Ninja -B build \
-                      -DCMAKE_BUILD_TYPE=Release \
-                      -DTTLANG_USE_TOOLCHAIN=ON \
-                      -DTTLANG_ENABLE_PERF_TRACE=ON \
-                      $CMAKE_EXTRA_CONFIG_OPTIONS
+                  cmake_args=(
+                      -G Ninja
+                      -B build
+                      -DCMAKE_BUILD_TYPE=Release
+                      -DTTLANG_USE_TOOLCHAIN=ON
+                      -DTTLANG_ENABLE_PERF_TRACE=ON
+                  )
+                  if [ -n "${CMAKE_EXTRA_CONFIG_OPTIONS:-}" ]; then
+                      read -r -a extra_cmake_options <<< "$CMAKE_EXTRA_CONFIG_OPTIONS"
+                      cmake_args+=("${extra_cmake_options[@]}")
+                  fi
+                  cmake "${cmake_args[@]}"
 
             - name: Setup ccache
               uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -510,6 +510,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure-tt-s3-credentials
 
+      - name: Install Markdown renderer
+        run: python3 -m pip install markdown
+
       - name: Publish wheels
         run: |
           .github/scripts/publish-s3-direct-wheels.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,11 @@ jobs:
     needs: build-docs
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    # Serialize Pages deployments across runs so a second one waits instead of
+    # failing with "Deployment failed, try again later".
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -328,26 +328,23 @@ jobs:
             dist \
             "${prepare_args[@]}"
 
-      - name: Configure AWS Credentials
-        if: ${{ needs.preflight.outputs.dry_run != 'true' }}
-        uses: ./.github/actions/configure-tt-s3-credentials
-
-      - name: Install s3pypi
-        if: ${{ needs.preflight.outputs.dry_run != 'true' }}
-        run: python3 -m pip install s3pypi
-
-      # Nightly dev wheels publish under tt-lang/<YYYY-MM>/; stable releases use root.
+      # Regular S3 publishes upload wheel objects under tt-lang/. Dev versions
+      # use a generated year-month view; final versions use the releases view.
       - name: Derive publish prefix
         id: publish_prefix
         run: |
           set -euo pipefail
           version="${{ needs.preflight.outputs.version_override }}"
-          prefix=""
+          prefix="tt-lang/releases"
           if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.dev([0-9]{4})([0-9]{2})[0-9]{2} ]]; then
             prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
           fi
           echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
-          echo "Publish prefix: ${prefix:-<root>}"
+          echo "Publish prefix: $prefix"
+
+      - name: Configure AWS Credentials
+        if: ${{ needs.preflight.outputs.dry_run != 'true' }}
+        uses: ./.github/actions/configure-tt-s3-credentials
 
       - name: Publish wheels
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
@@ -357,23 +354,23 @@ jobs:
           if [ "${{ needs.preflight.outputs.overwrite_releases }}" = "true" ]; then
             publish_args+=(--overwrite)
           fi
-          if [ -n "${{ steps.publish_prefix.outputs.prefix }}" ]; then
-            publish_args+=(--prefix "${{ steps.publish_prefix.outputs.prefix }}")
-          fi
+          publish_args+=(--prefix "${{ steps.publish_prefix.outputs.prefix }}")
           .github/scripts/publish-s3-wheels.sh "${publish_args[@]}" dist
 
-      # s3pypi rewrites the index on upload; restore the README afterward.
+      # Direct monthly publishes regenerate the tt-lang/ slash-key listing.
+      # Restore the README afterward.
       - name: Inject S3 index README
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
         run: |
           set -euo pipefail
           python3 -m pip install markdown
           prefix="${{ steps.publish_prefix.outputs.prefix }}"
-          key="index.html"
-          if [ -n "$prefix" ]; then
-            key="$prefix/"
-          fi
-          .github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist
+          parent="$(dirname "$prefix")"
+          key="$parent/"
+          .github/scripts/inject-s3-index-readme.sh \
+            --key "$key" \
+            --require-existing \
+            --dist-dir dist
 
       - name: Report install command
         run: |
@@ -382,9 +379,7 @@ jobs:
           if [ "${{ needs.preflight.outputs.dry_run }}" = "true" ]; then
             summary_args+=(--dry-run)
           fi
-          if [ -n "${{ steps.publish_prefix.outputs.prefix }}" ]; then
-            summary_args+=(--index-subdir "${{ steps.publish_prefix.outputs.prefix }}")
-          fi
+          summary_args+=(--find-links-subdir "${{ steps.publish_prefix.outputs.prefix }}")
           .github/scripts/publish-s3-summary.sh \
             "${summary_args[@]}" \
             "${{ needs.preflight.outputs.wheel_variant }}" \

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -6,7 +6,7 @@ name: Publish S3 PyPI Wheels
 
 on:
   schedule:
-    # Nightly S3-only internal wheel publish. GitHub cron uses UTC.
+    # Nightly S3-only wheel publish. GitHub cron uses UTC.
     - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
@@ -16,7 +16,7 @@ on:
         default: ""
         required: false
       version_override:
-        description: "PEP 440 version for the internal wheel. Leave empty to compute a nightly dev version."
+        description: "PEP 440 version for the S3 wheel. Leave empty to compute a nightly dev version."
         type: string
         default: ""
         required: false
@@ -202,9 +202,11 @@ jobs:
           TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ needs.preflight.outputs.allow_final_internal_version }}
         run: |
           # inputs.ttlang_ref may be a tag or branch; record the resolved commit.
-          export TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"
+          TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"
+          export TTLANG_GIT_COMMIT
           # Submodules aren't checked out here; read tt-metal's commit from the gitlink.
-          export TT_METAL_COMMIT="$(git rev-parse HEAD:third-party/tt-metal)"
+          TT_METAL_COMMIT="$(git rev-parse HEAD:third-party/tt-metal)"
+          export TT_METAL_COMMIT
           .github/scripts/build-s3-light-core-wheel.sh --python-tag "${{ matrix.python_tag }}" --version "${{ needs.preflight.outputs.version_override }}" --dist-dir dist
 
       - name: Build tt-lang-light metapackage

--- a/.github/workflows/s3-pypi-ops.yml
+++ b/.github/workflows/s3-pypi-ops.yml
@@ -8,6 +8,7 @@
 # default. Never touches other teams' prefixes or the bucket root.
 
 name: S3 PyPI ops (tt-lang)
+run-name: "S3 PyPI ops: ${{ inputs.operation }} (dry_run=${{ inputs.dry_run }})"
 
 on:
   workflow_dispatch:
@@ -70,6 +71,33 @@ jobs:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
 
+      - name: Summarize operation
+        env:
+          OP: ${{ inputs.operation }}
+          PREFIX: ${{ inputs.prefix }}
+          SOURCE: ${{ inputs.source }}
+          DEST: ${{ inputs.dest }}
+          CONFIRM: ${{ inputs.confirm }}
+          READONLY_ARGS: ${{ inputs.readonly_args }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### S3 PyPI operation"
+            echo
+            echo '```text'
+            printf 'operation=%s\n' "$OP"
+            printf 'dry_run=%s\n' "$DRY_RUN"
+            printf 'ref=%s\n' "$GITHUB_REF"
+            printf 'actor=%s\n' "$GITHUB_ACTOR"
+            [[ -n "$PREFIX" ]] && printf 'prefix=%s\n' "$PREFIX"
+            [[ -n "$SOURCE" ]] && printf 'source=%s\n' "$SOURCE"
+            [[ -n "$DEST" ]] && printf 'dest=%s\n' "$DEST"
+            [[ -n "$CONFIRM" ]] && printf 'confirm=%s\n' "$CONFIRM"
+            [[ -n "$READONLY_ARGS" ]] && printf 'readonly_args=%s\n' "$READONLY_ARGS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Require main ref for writes
         if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}
         run: |
@@ -82,6 +110,10 @@ jobs:
       - name: Configure AWS Credentials
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: ./.github/actions/configure-tt-s3-credentials
+
+      - name: Install Markdown renderer
+        if: ${{ inputs.operation == 'put-index' && inputs.dry_run != true && (inputs.prefix == 'tt-lang' || inputs.prefix == 'tt-lang/') }}
+        run: python3 -m pip install markdown
 
       - name: Run operation
         env:

--- a/.github/workflows/ttmetal-light-xla-on-demand.yml
+++ b/.github/workflows/ttmetal-light-xla-on-demand.yml
@@ -124,6 +124,7 @@ jobs:
             .github/scripts/build-ttmetal-at-sha.sh
             .github/wheel-patches
             scripts/install-ttmetal.sh
+            scripts/copy-ttmetal-runtime-artifacts.sh
           sparse-checkout-cone-mode: false
 
       - name: Apply wheel patches

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -448,9 +448,9 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-For a dated dev release (preview of an in-flight version, typically used
-after a toolchain uplift lands on `main` and before the next final tag),
-follow the tt-metal convention: SemVer pre-release identifier of the form
+For a dated dev release (preview of an in-flight version, typically used after a
+toolchain uplift lands on `main` and before the next final tag), follow the
+tt-metal convention: a hyphenated development identifier of the form
 `-dev<YYYYMMDD>`:
 
 ```bash

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -256,7 +256,7 @@ TT_METAL_TAG="<tt-metal-tag>"
 `TTNN_PYPI_TT_METAL_TAG` records the tt-metal tag used to build the public
 `ttnn` wheel. `TT_METAL_TAG` records the tt-metal tag used to build TT-Lang.
 Public PyPI publishing requires these tags to have the same `vX.Y.Z` component;
-internal S3 bundled wheels can use a newer `TT_METAL_TAG` before a compatible
+S3-hosted bundled wheels can use a newer `TT_METAL_TAG` before a compatible
 public `ttnn` wheel is available.
 
 Background: `third-party/tt-metal-version` is the single source of truth for
@@ -559,36 +559,41 @@ ird image tag):
 (publishing-to-s3-pypi)=
 #### Publishing to S3 PyPI
 
-`publish-s3-pypi.yml` publishes internal wheels to the Tenstorrent S3 PyPI
+`publish-s3-pypi.yml` publishes S3-hosted wheels to the Tenstorrent S3 PyPI
 index at `https://pypi.eng.aws.tenstorrent.com/`. It runs nightly on a GitHub
 schedule and can also be dispatched manually. Publishing is restricted to
 workflow runs on `refs/heads/main` because the AWS OIDC role is limited to
 main-branch refs; a manual dispatch from another ref can only perform a dry run.
-The workflow uses
-GitHub OIDC for AWS access, then uploads with
-`s3pypi upload --put-root-index --bucket tenstorrent-pypi`.
+The workflow uses GitHub OIDC for AWS access. Regular publishes upload wheel
+objects directly under `tt-lang/` and write generated slash-key views consumed
+with `pip --find-links`: development wheels use `tt-lang/<YYYY-MM>/`, and final
+S3 release wheels use `tt-lang/releases/`.
+The top-level `tt-lang/` listing shows only the README and subdirectories in a
+browser, but it keeps hidden anchors for final-release root wheels so
+`pip --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang` remains
+backward-compatible for `X.Y.Z` S3 releases.
 Non-main dry runs must provide an existing `docker_tag`. If `docker_tag` is
 empty, the workflow builds and pushes GHCR IRD and manylinux wheel-builder images
 before the wheel build; that image publication is also restricted to
 `refs/heads/main`.
 
-The workflow prevents publishing a bundled internal `tt-lang` wheel with the
+The workflow prevents publishing a bundled S3 `tt-lang` wheel with the
 same package name and version as the public PyPI wheel when public PyPI
 publishing is already valid for that tt-metal tag. This avoids having two
 indexes expose `tt-lang==X.Y.Z` artifacts with different dependency metadata.
 
 S3 publishing uses this policy:
 
-- Tag pushes are not S3 publishing triggers. Stable internal publishes use
+- Tag pushes are not S3 publishing triggers. Stable S3 publishes use
   manual dispatch from `refs/heads/main` with an explicit `version_override`.
 - Manual stable-version S3 publishes that include the bundled variant are
   rejected when public PyPI publishing is aligned for the same tt-metal tag.
 - The S3 resolver passes `TTLANG_ALLOW_FINAL_INTERNAL_VERSION=true` to the wheel
-  builder only after this conflict check has passed, so final-version internal
+  builder only after this conflict check has passed, so final-version S3
   wheels cannot bypass the release guard.
 - Do not mix public PyPI and S3 indexes for a `tt-lang` version whose artifacts
   have different dependency semantics. Use the S3 install command emitted by the
-  workflow summary for internal release wheels.
+  workflow summary for S3 release wheels.
 - Nightly builds do not create Git tags. The scheduled workflow computes a
   PEP 440 development version of the form `<MAJOR.MINOR.PATCH>.dev<YYYYMMDD>`,
   where the base version matches the latest stable tag reachable from `HEAD`,
@@ -608,13 +613,13 @@ pushes the matching manylinux_2_34 wheel-builder images for Python 3.10 and
 Python 3.12 light wheels. The workflow verifies all wheel versions before
 publishing the combined result to S3 PyPI.
 
-For a manual bundled internal wheel with an existing IRD image, dispatch the
+For a manual bundled S3 wheel with an existing IRD image, dispatch the
 workflow with:
 
 ```text
 docker_tag: <existing-ird-tag>
 wheel_variant: bundled
-version_override: <internal-version>
+version_override: <s3-version>
 ```
 
 The reusable wheel build sets `TTLANG_TTNN_DEP_MODE=bundled`,
@@ -629,7 +634,7 @@ bundled or public `ttnn` wheel, dispatch the workflow with:
 
 ```text
 wheel_variant: light
-version_override: <internal-version>
+version_override: <s3-version>
 ```
 
 The workflow maps this publish selection to the manylinux_2_34 light wheel
@@ -643,7 +648,7 @@ To publish bundled and light wheels from the same workflow run, dispatch with:
 
 ```text
 wheel_variant: bundled-and-light
-version_override: <internal-version>
+version_override: <s3-version>
 ```
 
 The workflow builds the bundled and light wheel sets separately, uploads
@@ -658,7 +663,7 @@ dependencies no longer resolve:
 
 ```text
 wheel_variant: light
-version_override: <internal-version>
+version_override: <s3-version>
 ttlang_ref: <tt-lang SHA or tag>
 apply_patches: true
 ```
@@ -693,7 +698,7 @@ The `tt-lang-light` wheel is a pure metapackage; the supported CPython ABIs and
 glibc floor are carried by the
 `tt_lang-<version>+light-cp310-cp310-manylinux_2_34_x86_64.whl` and
 `tt_lang-<version>+light-cp312-cp312-manylinux_2_34_x86_64.whl` files in the
-same directory. The same directory contains a brief `README.txt`.
+same directory. The same directory contains a brief `README.html`.
 The `ttl.build_info()["tt_metal"]` value in each `tt-lang` wheel must equal
 `<ttmetal7>` expanded to the requested tt-metal commit.
 
@@ -745,7 +750,7 @@ restricted to the `tt-lang/` prefix and cannot touch other teams' packages
 (including the sibling `tt-lang-light/` and `tt-lang-sim/` package indexes) or
 the bucket root. `delete` requires a `confirm` token equal to the prefix.
 
-#### Local internal wheel testing
+#### Local S3 wheel testing
 
 Use the same environment variables as the reusable workflow when validating the
 wheel build locally.
@@ -754,7 +759,7 @@ Bundled wheel:
 
 ```bash
 source /opt/ttlang-toolchain/venv/bin/activate
-TTLANG_VERSION=<internal-version>
+TTLANG_VERSION=<s3-version>
 
 TTLANG_VERSION_OVERRIDE="$TTLANG_VERSION" \
 cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DTTLANG_USE_TOOLCHAIN=ON
@@ -772,7 +777,7 @@ Light wheels:
 
 ```bash
 scripts/build-s3-light-wheels-local.sh \
-  --version <internal-version> \
+  --version <s3-version> \
   --build-images
 ```
 
@@ -781,7 +786,7 @@ copies tutorials into `./tutorials/` and skips sfpi installation for light
 installs because the external tt-metal tree provides sfpi:
 
 ```bash
-TTLANG_VERSION=<internal-version>
+TTLANG_VERSION=<s3-version>
 python3.12 -m venv /tmp/ttlang-light-test
 source /tmp/ttlang-light-test/bin/activate
 pip install --find-links=/tmp/ttlang-s3-light-wheels/dist \

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -51,7 +51,7 @@ tt-lang-setup                     # copy bundled tutorials to ./tutorials/
 For finer control, `tt-lang-setup-sfpi` runs only the sfpi step and
 `tt-lang-setup-tutorials -t <DIR>` only the tutorials copy.
 
-### Internal S3 wheels
+### Tenstorrent S3 wheels
 
 More frequently updated development versions of `tt-lang` are available from
 Tenstorrent's S3 PyPI index.
@@ -59,31 +59,30 @@ Tenstorrent's S3 PyPI index.
 Set `TTLANG_VERSION` to a published version from the workflow summary or the
 S3 package index. A version selector is required because public PyPI also hosts
 `tt-lang`, and pip resolves candidates across all configured indexes. Available
-versions are listed at https://pypi.eng.aws.tenstorrent.com/.
+versions are listed at https://pypi.eng.aws.tenstorrent.com/tt-lang/.
 
-Development wheels use a simple sub-index (`--extra-index-url`); per-SHA light
-wheels are published as browsable directories (`--find-links`):
+Tenstorrent S3 wheels use browsable wheel views (`--find-links`):
 
 - Nightly development wheels are under `tt-lang/<YYYY-MM>/`, the year-month of
   the version's `devYYYYMMDD` suffix (e.g. version `X.Y.Z.dev20260615` ->
   `tt-lang/2026-06/`).
+- Stable S3 release wheels are under `tt-lang/releases/`.
 - Light wheels built and device-tested against a specific tt-metal commit are
   under `tt-lang/ttmetal/<ttmetal7>/`, that commit's 7-character prefix.
-- Stable release wheels (`X.Y.Z`) stay at the root index.
 
 The bundled-wheel example below installs a nightly development wheel. Stable
-internal releases use `TTLANG_VERSION=X.Y.Z` and the root index URL
-`https://pypi.eng.aws.tenstorrent.com/`.
+S3 releases use `TTLANG_VERSION=X.Y.Z` and
+`https://pypi.eng.aws.tenstorrent.com/tt-lang/releases/`.
 
-The default internal `tt-lang` wheel bundles the `ttnn` artifacts from the
+The default S3-hosted `tt-lang` wheel bundles the `ttnn` artifacts from the
 toolchain used to build the wheel, so `pip install` does not pull `ttnn` from
 PyPI. As with the public wheel, `tt-lang-setup` then installs the matching sfpi
 runtime and copies the tutorials:
 
 ```bash
-TTLANG_VERSION=<published-internal-version>
+TTLANG_VERSION=<published-s3-version>
 pip install \
-  --extra-index-url https://pypi.eng.aws.tenstorrent.com/tt-lang/<YYYY-MM>/ \
+  --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/<YYYY-MM>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   "tt-lang==$TTLANG_VERSION"
 tt-lang-setup    # downloads sfpi into the bundled ttnn tree + copies tutorials
@@ -97,10 +96,10 @@ environment, not both.
 
 A per-tt-metal-SHA light wheel resolves from that commit's directory with
 `--find-links`; a nightly light wheel resolves from its `tt-lang/<YYYY-MM>/`
-sub-index with `--extra-index-url` instead:
+directory with `--find-links` as well:
 
 ```bash
-TTLANG_VERSION=<published-internal-version>
+TTLANG_VERSION=<published-s3-version>
 pip install \
   --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/<ttmetal7>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \

--- a/packaging/s3-index/README.md
+++ b/packaging/s3-index/README.md
@@ -1,22 +1,34 @@
-# tt-lang internal S3 PyPI index
+# tt-lang Tenstorrent S3 PyPI index
 
-This is Tenstorrent's internal PyPI index for pre-release `tt-lang` wheels. Public
-releases are on [PyPI](https://pypi.org/project/tt-lang/); this index hosts the
-more frequently updated development builds.
+This is Tenstorrent's S3 PyPI index for `tt-lang` wheels. Public releases are
+on [PyPI](https://pypi.org/project/tt-lang/); this index hosts more frequently
+updated development builds and selected S3 release wheels.
 
 ## Install
 
-Pick a published version from the workflow summary or the package list below, then
-select it explicitly (public PyPI also hosts `tt-lang`):
+Pick a published version from the workflow summary or the directory listing
+below, then select it explicitly (public PyPI also hosts `tt-lang`):
 
-Nightly development wheels are grouped by year-month:
+Development wheels are grouped by year-month:
 
 ```bash
 pip install \
-  --extra-index-url https://pypi.eng.aws.tenstorrent.com/tt-lang/<YYYY-MM>/ \
+  --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/<YYYY-MM>/ \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   "tt-lang==<version>"
 ```
+
+Final S3 release wheels are in the releases view:
+
+```bash
+pip install \
+  --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang/releases/ \
+  --extra-index-url https://download.pytorch.org/whl/cpu \
+  "tt-lang==<version>"
+```
+
+The top-level `tt-lang/` URL remains installable for existing final-release root
+wheels, but new documentation should use `tt-lang/releases/`.
 
 Light wheels built and device-tested against a specific tt-metal commit are
 published as browsable directories under `tt-lang/ttmetal/<ttmetal7>/`, where
@@ -58,5 +70,5 @@ the getting-started guide linked below.
 ## More
 
 - [Getting started](https://github.com/tenstorrent/tt-lang/blob/main/docs/sphinx/getting-started.md)
-  (internal S3 wheels section)
+  (Tenstorrent S3 wheels section)
 - [Documentation](https://docs.tenstorrent.com/tt-lang/)

--- a/scripts/install-ttmetal.sh
+++ b/scripts/install-ttmetal.sh
@@ -107,7 +107,8 @@ if [ -x "$COPY_SCRIPT" ]; then
     fi
     bash "$COPY_SCRIPT" --restore "$SRC" "$INSTALL"
 else
-    echo "WARNING: copy-ttmetal-runtime-artifacts.sh not found at $COPY_SCRIPT"
+    echo "ERROR: required helper not found at $COPY_SCRIPT; the install would ship without sfpi and other runtime artifacts, failing at device init." >&2
+    exit 1
 fi
 
 # --- JIT source trees (headers and firmware .cc files) ---

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -96,24 +96,34 @@ def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     assert ".github/scripts/build-s3-light-core-wheel.sh" in workflow
     assert ".github/scripts/build-s3-light-metapackage-wheel.sh" in workflow
     assert ".github/scripts/test-s3-light-wheels.sh" in workflow
+    assert ".github/scripts/inject-s3-index-readme.sh" in workflow
+    assert '--key "$key"' in workflow
+    assert "--require-existing" in workflow
     assert (
-        '.github/scripts/inject-s3-index-readme.sh --key "$key" --dist-dir dist'
-        in workflow
+        '--find-links-subdir "${{ steps.publish_prefix.outputs.prefix }}"' in workflow
     )
+    assert "python3 -m pip install s3pypi" not in workflow
     assert "standard_wheel_matrix" in workflow
 
 
-def test_nightly_publish_prefix_is_under_tt_lang() -> None:
+def test_regular_s3_publish_prefix_routes_dev_to_month_and_final_to_releases() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    assert 'prefix="tt-lang/releases"' in workflow
     assert 'prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"' in workflow
+    assert (
+        'publish_args+=(--prefix "${{ steps.publish_prefix.outputs.prefix }}")'
+        in workflow
+    )
 
 
-def test_prefixed_index_injection_targets_the_slash_key() -> None:
-    # s3pypi writes a prefixed root index to the slash-key "<prefix>/", not
-    # "<prefix>/index.html"; the injection step must upload to the same key.
+def test_regular_s3_index_injection_targets_parent_slash_key() -> None:
+    # Regular direct publishing regenerates the top tt-lang/ slash-key listing;
+    # the README injection must target that parent listing, not the month dir.
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
-    assert 'key="$prefix/"' in workflow
+    assert 'parent="$(dirname "$prefix")"' in workflow
+    assert 'key="$parent/"' in workflow
     assert 'key="$prefix/index.html"' not in workflow
+    assert 'key="$prefix/"' not in workflow
 
 
 def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
@@ -187,6 +197,7 @@ def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
     assert 'pytest -c /dev/null --rootdir "$PWD" test/me2e' not in workflow
     assert "simple_add" not in workflow
     assert ".github/scripts/publish-s3-direct-wheels.sh" in workflow
+    assert "Install Markdown renderer" in workflow
     assert (
         '--light-python-tags "${{ needs.preflight.outputs.python_tags }}"' in workflow
     )
@@ -430,6 +441,10 @@ def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
     workflow = S3_PYPI_OPS_WORKFLOW.read_text()
 
     assert "name: S3 PyPI ops (tt-lang)" in workflow
+    assert (
+        'run-name: "S3 PyPI ops: ${{ inputs.operation }} '
+        '(dry_run=${{ inputs.dry_run }})"'
+    ) in workflow
     assert "options: [inspect, put-index, move, copy, delete, readonly-cmd]" in workflow
     assert "id-token: write" in workflow
     assert "uses: ./.github/actions/configure-tt-s3-credentials" in workflow
@@ -440,6 +455,20 @@ def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
         "if: ${{ inputs.dry_run != true && github.ref != 'refs/heads/main' }}"
         in workflow
     )
+    assert "### S3 PyPI operation" in workflow
+    assert "GITHUB_STEP_SUMMARY" in workflow
+    assert "printf 'operation=%s\\n' \"$OP\"" in workflow
+    assert "printf 'dry_run=%s\\n' \"$DRY_RUN\"" in workflow
+    assert "printf 'ref=%s\\n' \"$GITHUB_REF\"" in workflow
+    assert "printf 'actor=%s\\n' \"$GITHUB_ACTOR\"" in workflow
+    assert workflow.index("- name: Summarize operation") < workflow.index(
+        "- name: Require main ref for writes"
+    )
+    assert "Install Markdown renderer" in workflow
+    assert (
+        "inputs.operation == 'put-index' && inputs.dry_run != true && "
+        "(inputs.prefix == 'tt-lang' || inputs.prefix == 'tt-lang/')"
+    ) in workflow
     assert ".github/scripts/s3-pypi-ops.sh" in workflow
     # dry_run input defaults to true
     dry_run_input = workflow.split("      dry_run:", 1)[1].split("concurrency:", 1)[0]

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -330,7 +330,8 @@ def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
         ' --target-dir "$GITHUB_WORKSPACE"'
     ) in workflow
     # TTLANG_GIT_COMMIT records the resolved commit, not a tag/branch name.
-    assert 'export TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"' in workflow
+    assert 'TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"' in workflow
+    assert "export TTLANG_GIT_COMMIT" in workflow
     assert "TTLANG_GIT_COMMIT: ${{ inputs.ttlang_ref" not in workflow
     # apply_patches stays a valid boolean on push/schedule (no dispatch inputs).
     assert (


### PR DESCRIPTION
Reworks tt-lang's internal S3 PyPI layout so wheels are browsable and installable without ever moving objects. Wheel files live once at the top level under `tt-lang/`; the year-month directories `tt-lang/<YYYY-MM>/` and `tt-lang/releases/` are generated `--find-links` index views over them, so nightly dev wheels resolve from their `devYYYYMMDD` month and final `X.Y.Z` releases from `releases/`, while per-tt-metal-SHA light wheels keep `tt-lang/ttmetal/<sha7>/`. `tt-lang/` itself becomes a browsable README-plus-subdirectories listing instead of a flat wheel dump. Views regenerate in place from the current S3 listing and objects never move, so republishing within a month accumulates rather than overwrites and every wheel stays addressable by its exact URL.

The S3 maintenance workflow now surfaces the operation, ref, actor, dry-run flag, and inputs in its run title and job summary instead of only in the logs; per-directory READMEs are rendered to browsable HTML; and the documentation Pages deploy is serialized with a Pages concurrency group so overlapping deployments no longer fail with "Deployment failed, try again later".

Testing: the bats suites for the index library, direct and per-SHA publish, monthly publish, ops, and README-injection scripts plus the pytest workflow assertions pass; view generation, stable-release classification, the directories-only browse, two-publish month accumulation, and no-slash `--find-links` resolution were exercised against a fake S3.
