### PR TITLE
  [ttkernel] Add ttkernel-specialize-cores per-core specialization pass

### DIFF
--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -19,6 +19,7 @@ python my_kernel.py --no-ttl-maximize-dst
 | `--ttl-combine-pack-tiles` / `--no-ttl-combine-pack-tiles` | enabled | Combine consecutive `pack_tile` ops on the same DFB with contiguous DST and DFB indices into a single `pack_tile_block` call. |
 | `--ttl-strict-f32-acc` / `--no-ttl-strict-f32-acc` | disabled | Error at compile time if a `+=` accumulation loop's output block exceeds f32 DST capacity (4 tiles with double-buffering). When enabled, guarantees each accumulation step fits in a single DST section without subblocking. |
 | `--ttl-compiler-dfbs` / `--no-ttl-compiler-dfbs` | enabled | Insert compiler-allocated intermediate DFBs at fusion split points where an operation requires DFB-attached inputs (reduce, broadcast, matmul, transpose). When disabled, the compiler emits an error if any fused computation requires an intermediate DFB. |
+| `--ttl-specialize-cores` / `--no-ttl-specialize-cores` | disabled | Clone each TTKernel function whose control flow branches on a core coordinate once per launch coordinate (`ttkernel-specialize-cores`), replacing `my_logical_x_` / `my_logical_y_` with constants and tagging clones with `ttl.core_coord` for per-core dispatch. Opt-in. |
 
 ### Other Ways to Set These
 
@@ -115,6 +116,7 @@ ttlang-opt input.mlir -p 'ttl-to-ttkernel-pipeline{maximize-dst=true lower-to-em
 | `combine-pack-tiles` | bool | `true` | Combine consecutive `pack_tile` ops into `pack_tile_block`. |
 | `strict-f32-acc` | bool | `false` | Error if a `+=` accumulation loop's output block exceeds f32 DST capacity. |
 | `compiler-dfbs` | bool | `true` | Insert compiler-allocated intermediate DFBs for fused computations. Error if disabled and any operation requires one. |
+| `specialize-cores` | bool | `false` | Clone TTKernel functions that branch on a core coordinate once per launch coordinate (`ttkernel-specialize-cores`), then run `canonicalize` / `cse`. Maps from `--ttl-specialize-cores`. |
 | `lower-to-emitc` | bool | `false` | Run the TTKernel-to-EmitC backend (produces C++ source). |
 
 The pipeline runs these passes in order:
@@ -136,6 +138,7 @@ The pipeline runs these passes in order:
 - `ttkernel-insert-l1-accumulation` — insert `pack_reconfig_l1_acc` guards for `+=` and reduction loops
 - `ttkernel-combine-pack-tiles` — combine consecutive `pack_tile` into `pack_tile_block` *(only if `combine-pack-tiles=true`)*
 - Canonicalization and CSE cleanup
+- `ttkernel-specialize-cores`, then `canonicalize`, `cse` — per-core clone and const-fold of coordinate branches; tags clones with `ttl.core_coord` *(only if `specialize-cores=true`)*
 - *(if `lower-to-emitc=true`)* `lower-affine`, `convert-ttkernel-to-emitc`, `emitc-form-expressions`
 
 ### Individual Pass Options
@@ -206,4 +209,28 @@ Analyze dataflow buffer producer/consumer relationships and dump the flow graph.
 
 ```bash
 ttlang-opt input.mlir -p 'ttl-dump-cb-flow-graph{output="/tmp/cb_graph.json"}'
+```
+
+#### `ttkernel-specialize-cores`
+
+Clone TTKernel functions that branch on a core coordinate once per launch
+coordinate. Requires a module-level `ttl.launch_grid` attribute (an i64 array
+of length 2 with positive entries). Missing or malformed `ttl.launch_grid` is
+a hard error. A valid single-core grid (product <= 1) skips specialization.
+
+Only `scf.if` conditions derived from `ttkernel.my_logical_x_` /
+`ttkernel.my_logical_y_` trigger cloning. Functions with symbol uses (for
+example `func.call` targets) are left unspecialized with a warning so erasing
+the original does not leave dangling `SymbolRefAttr`s; unrelated functions in
+the module are still specialized. Each clone replaces coordinate reads with
+`arith.constant`s and is tagged with `ttl.core_coord` for runtime dispatch.
+Downstream `canonicalize` / `cse` fold the now-constant branches.
+
+This pass is off by default. Enable it through the pipeline option
+`specialize-cores` (Python: `--ttl-specialize-cores`):
+
+```bash
+ttlang-opt input.mlir -p 'ttl-to-ttkernel-pipeline{specialize-cores=true lower-to-emitc=true}'
+# Or stand-alone:
+ttlang-opt input.mlir -p 'builtin.module(ttkernel-specialize-cores,canonicalize,cse)'
 ```

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -99,8 +99,9 @@ constexpr llvm::StringLiteral kKernelThreadAttrName("ttl.kernel_thread");
 constexpr llvm::StringLiteral kUnrollFactorAttrName("ttl.unroll_factor");
 
 /// Func-level: NOC index (0 = reader/NCRISC, 1 = writer/BRISC) of a
-/// datamovement kernel; set by the frontend, read via getNocIndex.
-/// Mirrored in python/ttl/ttl_api.py.
+/// datamovement kernel; set by the frontend, read via getNocIndex during
+/// TTL->TTKernel lowering and by the ttnn runtime bridge for reader/writer
+/// config assignment. Mirrored in python/ttl/ttl_api.py.
 constexpr llvm::StringLiteral kNocIndexAttrName("ttl.noc_index");
 
 /// Marks an scf.for as a compiler-generated subblock loop. Integer value is

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -848,8 +848,9 @@ def TTKernelSpecializeCores
     branch conditions and delete untaken regions. The runtime bridge reads
     ttl.core_coord to build per-kernel core ranges for dispatch.
 
-    NOTE: functions with symbol uses (e.g. `func.call` targets) are skipped so erasing the
-    original does not leave dangling `SymbolRefAttr`s.
+    NOTE: functions with symbol uses (e.g. `func.call` targets) are left
+    unspecialized with a warning so erasing the original does not leave dangling
+    `SymbolRefAttr`s; unrelated functions in the module are still specialized.
 
     Example (`ttl.launch_grid = [1, 2]`):
     ```mlir

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -837,10 +837,65 @@ def TTKernelSpecializeCores
     : Pass<"ttkernel-specialize-cores", "::mlir::ModuleOp"> {
   let summary = "Clone kernels per core when control flow branches on a coordinate";
   let description = [{
-    Clone and rewrite the graph with ttl.node values propagated as constants
-    to leverage DCE and other upstream canolicalization passes. To minimize
-    clones we only clone kernels whose control flow branches on a core
-    coordinate. Clone functions once per coordinate.
+    Per-core specialization for TTKernel functions. Requires the 
+    `ttl.launch_grid` attribute, missing or malformed `ttl.launch_grid` is a hard error.
+
+    For each kernel whose scf.if region branches on a core coordinate, clones
+    the function once per launch coordinate, replaces
+    ttkernel.my_logical_x_ / ttkernel.my_logical_y_ with arith.constant's
+    for that core, and tags the cloned function with ttl.core_coord (the coordinate it
+    serves). Downstream canonicalize / cse then fold the now-constant
+    branch conditions and delete untaken regions. The runtime bridge reads
+    ttl.core_coord to build per-kernel core ranges for dispatch.
+
+    NOTE: functions with symbol uses (e.g. `func.call` targets) are skipped so erasing the
+    original does not leave dangling `SymbolRefAttr`s.
+
+    Example (`ttl.launch_grid = [1, 2]`):
+    ```mlir
+    // Before:
+    func.func @k() -> index {
+      %c0 = arith.constant 0 : index
+      %c7 = arith.constant 7 : index
+      %c9 = arith.constant 9 : index
+      %y = ttkernel.my_logical_y_ : () -> index
+      %pred = arith.cmpi eq, %y, %c0 : index
+      %r = scf.if %pred -> (index) {
+        scf.yield %c7 : index
+      } else {
+        scf.yield %c9 : index
+      }
+      return %r : index
+    }
+
+    // After:
+    func.func @k_c0_0() -> index attributes {ttl.core_coord = [[0, 0]]} {
+      %c0 = arith.constant 0 : index
+      %c7 = arith.constant 7 : index
+      %c9 = arith.constant 9 : index
+      %y = arith.constant 0 : index
+      %pred = arith.cmpi eq, %y, %c0 : index
+      %r = scf.if %pred -> (index) {
+        scf.yield %c7 : index
+      } else {
+        scf.yield %c9 : index
+      }
+      return %r : index
+    }
+    func.func @k_c0_1() -> index attributes {ttl.core_coord = [[0, 1]]} {
+      %c0 = arith.constant 0 : index
+      %c7 = arith.constant 7 : index
+      %c9 = arith.constant 9 : index
+      %y = arith.constant 1 : index
+      %pred = arith.cmpi eq, %y, %c0 : index
+      %r = scf.if %pred -> (index) {
+        scf.yield %c7 : index
+      } else {
+        scf.yield %c9 : index
+      }
+      return %r : index
+    }
+    ```
   }];
 
   let dependentDialects = [

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -837,7 +837,7 @@ def TTKernelSpecializeCores
     : Pass<"ttkernel-specialize-cores", "::mlir::ModuleOp"> {
   let summary = "Clone kernels per core when control flow branches on a coordinate";
   let description = [{
-    Per-core specialization for TTKernel functions. Requires the 
+    Per-core specialization for TTKernel functions. Requires the
     `ttl.launch_grid` attribute, missing or malformed `ttl.launch_grid` is a hard error.
 
     For each kernel whose scf.if region branches on a core coordinate, clones

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -833,6 +833,22 @@ def TTKernelInsertInits
   ];
 }
 
+def TTKernelSpecializeCores
+    : Pass<"ttkernel-specialize-cores", "::mlir::ModuleOp"> {
+  let summary = "Clone kernels per core when control flow branches on a coordinate";
+  let description = [{
+    Clone and rewrite the graph with ttl.node values propagated as constants
+    to leverage DCE and other upstream canolicalization passes. To minimize
+    clones we only clone kernels whose control flow branches on a core
+    coordinate. Clone functions once per coordinate.
+  }];
+
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::func::FuncDialect"
+  ];
+}
+
 def TTKernelCombinePackTiles
     : Pass<"ttkernel-combine-pack-tiles", "::mlir::func::FuncOp"> {
   let summary = "Combine consecutive pack_tile ops into pack_tile_block";

--- a/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
+++ b/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
@@ -54,6 +54,12 @@ struct TTLToTTKernelPipelineOptions
                      "computations. When disabled, emit an error if any "
                      "operation requires a compiler-allocated DFB."),
       llvm::cl::init(true)};
+  Option<bool> specializeCores{
+      *this, "specialize-cores",
+      llvm::cl::desc(
+          "Clone TTKernel functions that branch on a core coordinate once "
+          "per launch coordinate (ttkernel-specialize-cores)."),
+      llvm::cl::init(false)};
 };
 
 void createTTLToTTKernelPipeline(mlir::OpPassManager &pm,

--- a/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(TTLangTTKernelTransforms
   TTKernelInsertInits.cpp
   TTKernelInsertL1Accumulation.cpp
   TTKernelLowerScalarFpTypes.cpp
+  TTKernelSpecializeCores.cpp
 
   DEPENDS
   TTLangTTLTransformsIncGen

--- a/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//===----------------------------------------------------------------------===//
+// TTKernelSpecializeCores (per-core specialization)
+//
+// A single module pass that runs at the TTKernel level, right before EmitC
+// conversion. For every kernel function whose control flow branches on a core
+// coordinate (i.e. an `scf.if` whose condition is derived from
+// `ttkernel.my_logical_x_` / `ttkernel.my_logical_y_`), the pass clones the
+// function once per launch coordinate. In each clone, the coordinate reads are
+// replaced by `arith.constant`s for that core, so the following
+// `canonicalize` / `cse` fold the now-constant branch conditions and delete the
+// untaken regions. Each clone is tagged with a `ttl.core_coord` attribute (the
+// coordinate it serves) and the runtime bridge (ttl_api.py) turns that into a
+// per-kernel core range for dispatch.
+//===----------------------------------------------------------------------===//
+
+#include "ttlang/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
+#include "ttlang/Dialect/TTL/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+
+namespace ttk = mlir::tt::ttkernel;
+
+namespace mlir::tt::ttl {
+
+#define GEN_PASS_DEF_TTKERNELSPECIALIZECORES
+#include "ttlang/Dialect/TTL/Passes.h.inc"
+
+namespace {
+
+// Attribute names. These are part of the frontend / runtime contract and keep
+// the `ttl.` prefix even though this pass runs at the TTKernel level:
+// `ttl.launch_grid` (the launch extent) is set on the module by the Python
+// frontend, and `ttl.core_coord` is read back by the ttnn runtime bridge for
+// dispatch.
+constexpr llvm::StringLiteral LaunchGridAttrName = "ttl.launch_grid";
+constexpr llvm::StringLiteral CoreCoordAttrName = "ttl.core_coord";
+
+/// Parse the launch extent from an i64 array attribute into (gridX, gridY).
+///
+/// NOTE: operations.py specifies that only dims=2 is supported for now.
+///       this should be updated once operations.py is updated
+static bool readGrid(ArrayAttr attr, int64_t &gridX, int64_t &gridY) {
+  if (!attr || attr.size() != 2) {
+    return false;
+  }
+  auto x = llvm::dyn_cast<IntegerAttr>(attr[0]);
+  auto y = llvm::dyn_cast<IntegerAttr>(attr[1]);
+  if (!x || !y) {
+    return false;
+  }
+  gridX = x.getInt();
+  gridY = y.getInt();
+  return gridX > 0 && gridY > 0;
+}
+
+/// Return true when `condition` is derived from a core
+/// coordinate reads (`ttkernel.my_logical_x_` / `my_logical_y_`).
+static bool conditionDependsOnCore(Value condition) {
+  llvm::DenseSet<Value> visited;
+  SmallVector<Value> worklist{condition};
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second) {
+      continue;
+    }
+    Operation *op = value.getDefiningOp();
+    if (!op) {
+      continue;
+    }
+    if (isa<ttk::MyLogicalXOp, ttk::MyLogicalYOp>(op)) {
+      return true;
+    }
+    worklist.append(op->operand_begin(), op->operand_end());
+  }
+  return false;
+}
+
+/// Return true when `func` has any `scf.if` whose condition branches on a core
+/// coordinate. Only such functions need per-core clones.
+static bool funcBranchesOnCore(func::FuncOp func) {
+  bool found = false;
+  func.walk([&](scf::IfOp ifOp) {
+    if (conditionDependsOnCore(ifOp.getCondition())) {
+      found = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+/// Emit one clone of `func` for core `(x, y)`, replacing every coordinate read
+/// with the matching constant and tagging the clone with `ttl.core_coord`.
+/// TODO: See if we can leverage LaunchDomainAnalysis in an earlier pass
+/// to further minimize clones.
+static void emitCoreClone(func::FuncOp func, int64_t x, int64_t y,
+                          OpBuilder &moduleBuilder, Builder &builder) {
+  func::FuncOp clone = func.clone();
+  clone.setSymName(
+      (func.getSymName() + "_c" + Twine(x) + "_" + Twine(y)).str());
+
+  SmallVector<ttk::MyLogicalXOp> xReads;
+  SmallVector<ttk::MyLogicalYOp> yReads;
+  clone.walk([&](Operation *op) {
+    if (auto xr = dyn_cast<ttk::MyLogicalXOp>(op)) {
+      xReads.push_back(xr);
+    } else if (auto yr = dyn_cast<ttk::MyLogicalYOp>(op)) {
+      yReads.push_back(yr);
+    }
+  });
+  for (ttk::MyLogicalXOp xr : xReads) {
+    OpBuilder b(xr);
+    Value cst = arith::ConstantOp::create(b, xr.getLoc(), b.getIndexAttr(x));
+    xr.getResult().replaceAllUsesWith(cst);
+    xr.erase();
+  }
+  for (ttk::MyLogicalYOp yr : yReads) {
+    OpBuilder b(yr);
+    Value cst = arith::ConstantOp::create(b, yr.getLoc(), b.getIndexAttr(y));
+    yr.getResult().replaceAllUsesWith(cst);
+    yr.erase();
+  }
+
+  clone->setAttr(CoreCoordAttrName,
+                 builder.getArrayAttr({builder.getI64ArrayAttr({x, y})}));
+  moduleBuilder.insert(clone);
+}
+
+struct TTKernelSpecializeCoresPass
+    : impl::TTKernelSpecializeCoresBase<TTKernelSpecializeCoresPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    int64_t gridX = 0, gridY = 0;
+    if (!readGrid(module->getAttrOfType<ArrayAttr>(LaunchGridAttrName), gridX,
+                  gridY)) {
+      return;
+    }
+
+    if (gridX * gridY <= 1) {
+      return;
+    }
+
+    SmallVector<func::FuncOp> targets;
+    for (auto func : module.getOps<func::FuncOp>()) {
+      if (funcBranchesOnCore(func)) {
+        targets.push_back(func);
+      }
+    }
+
+    Builder builder(&getContext());
+    for (func::FuncOp func : targets) {
+      OpBuilder moduleBuilder(func);
+      for (int64_t y = 0; y < gridY; ++y) {
+        for (int64_t x = 0; x < gridX; ++x) {
+          emitCoreClone(func, x, y, moduleBuilder, builder);
+        }
+      }
+      func.erase();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
@@ -27,6 +27,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -150,8 +151,8 @@ struct TTKernelSpecializeCoresPass
       signalPassFailure();
       return;
     }
-    int64_t gridX = 0, gridY = 0;
-    if (!readGrid(gridAttr, gridX, gridY)) {
+    FailureOr<std::pair<int64_t, int64_t>> grid = readGrid(gridAttr);
+    if (failed(grid)) {
       module.emitOpError() << "`" << LaunchGridAttrName
                            << "` must be a length-2 array of positive i64 "
                               "extents";

--- a/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
@@ -27,7 +27,6 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/SymbolTable.h"
-#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -144,12 +143,18 @@ struct TTKernelSpecializeCoresPass
   void runOnOperation() override {
     ModuleOp module = getOperation();
 
-    FailureOr<std::pair<int64_t, int64_t>> grid =
-        readGrid(module->getAttrOfType<ArrayAttr>(LaunchGridAttrName));
-    if (failed(grid)) {
-      module.emitOpError()
-          << "ttkernel-specialize-cores requires a `ttl.launch_grid` module "
-             "attribute (an i64 array of length 2 with positive entries)";
+    auto gridAttr = module->getAttrOfType<ArrayAttr>(LaunchGridAttrName);
+    if (!gridAttr) {
+      module.emitOpError() << "requires a `" << LaunchGridAttrName
+                           << "` module attribute";
+      signalPassFailure();
+      return;
+    }
+    int64_t gridX = 0, gridY = 0;
+    if (!readGrid(gridAttr, gridX, gridY)) {
+      module.emitOpError() << "`" << LaunchGridAttrName
+                           << "` must be a length-2 array of positive i64 "
+                              "extents";
       signalPassFailure();
       return;
     }
@@ -159,6 +164,11 @@ struct TTKernelSpecializeCoresPass
       return;
     }
 
+    // Cloning renames a target and erases the original; inter-function
+    // SymbolRefAttr fixups are not performed. A referenced function is left
+    // un-specialized (still a correct whole-grid binary via its runtime
+    // coordinate reads) rather than failing the whole pass, so unrelated
+    // functions still get specialized.
     SmallVector<func::FuncOp> targets;
     for (auto func : module.getOps<func::FuncOp>()) {
       if (!funcBranchesOnCore(func)) {
@@ -166,6 +176,8 @@ struct TTKernelSpecializeCoresPass
       }
       if (auto uses = SymbolTable::getSymbolUses(func, module);
           uses && !uses->empty()) {
+        func.emitWarning() << "not specializing '" << func.getSymName()
+                           << "': function has symbol uses";
         continue;
       }
       targets.push_back(func);

--- a/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
@@ -26,6 +26,8 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -52,18 +54,21 @@ constexpr llvm::StringLiteral CoreCoordAttrName = "ttl.core_coord";
 ///
 /// NOTE: operations.py specifies that only dims=2 is supported for now.
 ///       this should be updated once operations.py is updated
-static bool readGrid(ArrayAttr attr, int64_t &gridX, int64_t &gridY) {
+static FailureOr<std::pair<int64_t, int64_t>> readGrid(ArrayAttr attr) {
   if (!attr || attr.size() != 2) {
-    return false;
+    return failure();
   }
   auto x = llvm::dyn_cast<IntegerAttr>(attr[0]);
   auto y = llvm::dyn_cast<IntegerAttr>(attr[1]);
   if (!x || !y) {
-    return false;
+    return failure();
   }
-  gridX = x.getInt();
-  gridY = y.getInt();
-  return gridX > 0 && gridY > 0;
+  int64_t gridX = x.getInt();
+  int64_t gridY = y.getInt();
+  if (gridX <= 0 || gridY <= 0) {
+    return failure();
+  }
+  return std::pair<int64_t, int64_t>{gridX, gridY};
 }
 
 /// Return true when `condition` is derived from a core
@@ -102,40 +107,35 @@ static bool funcBranchesOnCore(func::FuncOp func) {
   return found;
 }
 
-/// Emit one clone of `func` for core `(x, y)`, replacing every coordinate read
-/// with the matching constant and tagging the clone with `ttl.core_coord`.
+/// Replace every CoordOp in func clone with an arith.constant of coord.
+template <typename CoordOp>
+static void replaceCoordReads(func::FuncOp clone, int64_t coord) {
+  SmallVector<CoordOp> reads;
+  clone.walk([&](CoordOp op) { reads.push_back(op); });
+  for (CoordOp op : reads) {
+    OpBuilder b(op);
+    Value cst =
+        arith::ConstantOp::create(b, op.getLoc(), b.getIndexAttr(coord));
+    op.getResult().replaceAllUsesWith(cst);
+    op.erase();
+  }
+}
+
+/// Emit one clone of func for core (x, y), replacing every coordinate read
+/// with the matching constant and tagging the clone with ttl.core_coord.
 /// TODO: See if we can leverage LaunchDomainAnalysis in an earlier pass
 /// to further minimize clones.
 static void emitCoreClone(func::FuncOp func, int64_t x, int64_t y,
-                          OpBuilder &moduleBuilder, Builder &builder) {
+                          OpBuilder &moduleBuilder) {
   func::FuncOp clone = func.clone();
   clone.setSymName(
       (func.getSymName() + "_c" + Twine(x) + "_" + Twine(y)).str());
 
-  SmallVector<ttk::MyLogicalXOp> xReads;
-  SmallVector<ttk::MyLogicalYOp> yReads;
-  clone.walk([&](Operation *op) {
-    if (auto xr = dyn_cast<ttk::MyLogicalXOp>(op)) {
-      xReads.push_back(xr);
-    } else if (auto yr = dyn_cast<ttk::MyLogicalYOp>(op)) {
-      yReads.push_back(yr);
-    }
-  });
-  for (ttk::MyLogicalXOp xr : xReads) {
-    OpBuilder b(xr);
-    Value cst = arith::ConstantOp::create(b, xr.getLoc(), b.getIndexAttr(x));
-    xr.getResult().replaceAllUsesWith(cst);
-    xr.erase();
-  }
-  for (ttk::MyLogicalYOp yr : yReads) {
-    OpBuilder b(yr);
-    Value cst = arith::ConstantOp::create(b, yr.getLoc(), b.getIndexAttr(y));
-    yr.getResult().replaceAllUsesWith(cst);
-    yr.erase();
-  }
+  replaceCoordReads<ttk::MyLogicalXOp>(clone, x);
+  replaceCoordReads<ttk::MyLogicalYOp>(clone, y);
 
-  clone->setAttr(CoreCoordAttrName,
-                 builder.getArrayAttr({builder.getI64ArrayAttr({x, y})}));
+  clone->setAttr(CoreCoordAttrName, moduleBuilder.getArrayAttr(
+                                        {moduleBuilder.getI64ArrayAttr({x, y})}));
   moduleBuilder.insert(clone);
 }
 
@@ -144,11 +144,16 @@ struct TTKernelSpecializeCoresPass
   void runOnOperation() override {
     ModuleOp module = getOperation();
 
-    int64_t gridX = 0, gridY = 0;
-    if (!readGrid(module->getAttrOfType<ArrayAttr>(LaunchGridAttrName), gridX,
-                  gridY)) {
+    FailureOr<std::pair<int64_t, int64_t>> grid =
+        readGrid(module->getAttrOfType<ArrayAttr>(LaunchGridAttrName));
+    if (failed(grid)) {
+      module.emitOpError()
+          << "ttkernel-specialize-cores requires a `ttl.launch_grid` module "
+             "attribute (an i64 array of length 2 with positive entries)";
+      signalPassFailure();
       return;
     }
+    auto [gridX, gridY] = *grid;
 
     if (gridX * gridY <= 1) {
       return;
@@ -156,17 +161,21 @@ struct TTKernelSpecializeCoresPass
 
     SmallVector<func::FuncOp> targets;
     for (auto func : module.getOps<func::FuncOp>()) {
-      if (funcBranchesOnCore(func)) {
-        targets.push_back(func);
+      if (!funcBranchesOnCore(func)) {
+        continue;
       }
+      if (auto uses = SymbolTable::getSymbolUses(func, module);
+          uses && !uses->empty()) {
+        continue;
+      }
+      targets.push_back(func);
     }
 
-    Builder builder(&getContext());
     for (func::FuncOp func : targets) {
       OpBuilder moduleBuilder(func);
       for (int64_t y = 0; y < gridY; ++y) {
         for (int64_t x = 0; x < gridX; ++x) {
-          emitCoreClone(func, x, y, moduleBuilder, builder);
+          emitCoreClone(func, x, y, moduleBuilder);
         }
       }
       func.erase();

--- a/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelSpecializeCores.cpp
@@ -134,8 +134,9 @@ static void emitCoreClone(func::FuncOp func, int64_t x, int64_t y,
   replaceCoordReads<ttk::MyLogicalXOp>(clone, x);
   replaceCoordReads<ttk::MyLogicalYOp>(clone, y);
 
-  clone->setAttr(CoreCoordAttrName, moduleBuilder.getArrayAttr(
-                                        {moduleBuilder.getI64ArrayAttr({x, y})}));
+  clone->setAttr(
+      CoreCoordAttrName,
+      moduleBuilder.getArrayAttr({moduleBuilder.getI64ArrayAttr({x, y})}));
   moduleBuilder.insert(clone);
 }
 

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -68,6 +68,11 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
   }
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
+  if (options.specializeCores) {
+    pm.addPass(createTTKernelSpecializeCores());
+    pm.addPass(createCanonicalizerPass());
+    pm.addPass(createCSEPass());
+  }
   if (options.lowerToEmitC) {
     pm.addPass(createLowerAffinePass());
     pm.addNestedPass<func::FuncOp>(::mlir::tt::createConvertTTKernelToEmitC());

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1224,7 +1224,6 @@ struct FuncKernelFinalize : OpRewritePattern<FuncOp> {
       return failure();
     }
     op->removeAttr(kKernelThreadAttrName);
-    op->removeAttr(kNocIndexAttrName);
     op->setAttr("ttkernel.thread", ttlAttr);
 
     // If function has arguments, we need to transform them

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -91,6 +91,15 @@ def _make_parser() -> argparse.ArgumentParser:
         help="Insert compiler-allocated intermediate DFBs for fused computations (default: enabled).",
     )
     p.add_argument(
+        "--ttl-specialize-cores",
+        default=None,
+        dest="specialize_cores",
+        action=argparse.BooleanOptionalAction,
+        help="Clone each kernel that branches on a core coordinate once per "
+        "launch coordinate, const-folding core_x / core_y so dead branches are "
+        "removed (ttkernel-specialize-cores). Opt-in (default: disabled).",
+    )
+    p.add_argument(
         "--ttl-l1-budget",
         default=None,
         dest="l1_budget",
@@ -145,6 +154,7 @@ class CompilerOptions:
     matmul_full_fp32: bool = True
     strict_f32_acc: bool = False
     compiler_dfbs: bool = True
+    specialize_cores: bool = False
     l1_budget: int = dataclasses.field(default=0, compare=False, hash=False)
 
     # Fields that were explicitly provided (not defaulted). Excluded from

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -205,8 +205,8 @@ def build_kernel_descriptors(
         else:
             kernel_compile_time_args = cb_indices + list(tensor_accessor_args)
 
-        # Note: core_range is used outside this function to dispatch the kernel to the correct cores
-        # and should not be overridden
+        # Prefer per-kernel core_ranges (specialize-cores clones); otherwise
+        # fall back to the whole-grid core_ranges.
         kernel_ranges = (
             spec.core_ranges if spec.core_ranges is not None else core_ranges
         )
@@ -621,6 +621,47 @@ def _dtype_to_ttnn_str(data_format) -> str:
     return "ttnn.bfloat16"
 
 
+def _serialize_core_ranges(
+    core_ranges: Optional[Any],
+) -> Optional[List[Tuple[Tuple[int, int], Tuple[int, int]]]]:
+    """Serialize a ttnn.CoreRangeSet to nested ((sx, sy), (ex, ey)) tuples.
+
+    Returns None when core_ranges is None (whole-grid fallback in the runner).
+    """
+    if core_ranges is None:
+        return None
+    serialized = []
+    for core_range in core_ranges.ranges():
+        serialized.append(
+            (
+                (int(core_range.start.x), int(core_range.start.y)),
+                (int(core_range.end.x), int(core_range.end.y)),
+            )
+        )
+    return serialized
+
+
+def _serialize_noc_role(spec: KernelSpec) -> Optional[int]:
+    """Map KernelSpec.config to the ttl.noc_index role for the emitted runner.
+
+    Returns None for compute, 0 for reader, 1 for writer. The emitted file has
+    no MLIR module, so the role already resolved from ttl.noc_index in
+    _compile_ttnn_kernel is baked in here (same idea as KERNEL_CORE_RANGES).
+    """
+    if spec.thread_type == "compute":
+        return None
+    _ensure_ttnn()
+    if ttnn is None:
+        raise RuntimeError("ttnn is not available")
+    if isinstance(spec.config, ttnn.ReaderConfigDescriptor):
+        return 0
+    if isinstance(spec.config, ttnn.WriterConfigDescriptor):
+        return 1
+    raise TypeError(
+        f"Unsupported NOC config on kernel '{spec.path}': {type(spec.config)!r}"
+    )
+
+
 def emit_runner_source(
     kernel_specs: List[KernelSpec],
     cb_configs: List[Any],
@@ -680,6 +721,25 @@ def emit_runner_source(
     lines.append("KERNEL_TENSOR_INDICES = [")
     for spec in kernel_specs:
         lines.append(f"    {spec.tensor_indices!r},  # {spec.thread_type}")
+    lines.append("]")
+    lines.append("")
+
+    # Per-kernel dispatch ranges from KernelSpec.core_ranges. None means use
+    # the whole-grid core_ranges below; a list of ((sx, sy), (ex, ey)) pairs
+    # rebuilds a CoreRangeSet for specialize-cores clones.
+    lines.append("KERNEL_CORE_RANGES = [")
+    for spec in kernel_specs:
+        lines.append(
+            f"    {_serialize_core_ranges(spec.core_ranges)!r},  # {spec.thread_type}"
+        )
+    lines.append("]")
+    lines.append("")
+
+    # Per-kernel NOC roles from KernelSpec.config (set from ttl.noc_index in
+    # _compile_ttnn_kernel). None = compute, 0 = reader, 1 = writer.
+    lines.append("KERNEL_NOC_INDICES = [")
+    for spec in kernel_specs:
+        lines.append(f"    {_serialize_noc_role(spec)!r},  # {spec.thread_type}")
     lines.append("]")
     lines.append("")
 
@@ -743,20 +803,28 @@ def emit_runner_source(
     lines.append("        cb_descriptors.append(cb_desc)")
     lines.append("")
 
+    lines.append("    def _core_ranges_from_spec(ranges_spec):")
+    lines.append("        if ranges_spec is None:")
+    lines.append("            return None")
+    lines.append("        return ttnn.CoreRangeSet([")
+    lines.append("            ttnn.CoreRange(")
+    lines.append("                ttnn.CoreCoord(sx, sy), ttnn.CoreCoord(ex, ey)")
+    lines.append("            )")
+    lines.append("            for (sx, sy), (ex, ey) in ranges_spec")
+    lines.append("        ])")
+    lines.append("")
     lines.append("    kernel_specs = []")
-    lines.append("    noc_idx = 0")
     lines.append("")
     lines.append(
         "    for kernel_idx, (kernel_path, thread_type) in enumerate(KERNEL_PATHS):"
     )
-    lines.append("        if thread_type == 'compute':")
+    lines.append("        noc_index = KERNEL_NOC_INDICES[kernel_idx]")
+    lines.append("        if thread_type == 'compute' or noc_index is None:")
     lines.append("            config = ttnn.ComputeConfigDescriptor()")
+    lines.append("        elif noc_index == 0:")
+    lines.append("            config = ttnn.ReaderConfigDescriptor()")
     lines.append("        else:")
-    lines.append("            if noc_idx == 0:")
-    lines.append("                config = ttnn.ReaderConfigDescriptor()")
-    lines.append("            else:")
-    lines.append("                config = ttnn.WriterConfigDescriptor()")
-    lines.append("            noc_idx += 1")
+    lines.append("            config = ttnn.WriterConfigDescriptor()")
     lines.append("")
     lines.append("        kernel_specs.append(")
     lines.append("            KernelSpec(")
@@ -764,6 +832,10 @@ def emit_runner_source(
     lines.append("                thread_type=thread_type,")
     lines.append("                tensor_indices=KERNEL_TENSOR_INDICES[kernel_idx],")
     lines.append("                config=config,")
+    lines.append(
+        "                core_ranges=_core_ranges_from_spec("
+        "KERNEL_CORE_RANGES[kernel_idx]),"
+    )
     lines.append("            )")
     lines.append("        )")
     lines.append("    kernel_descriptors = build_kernel_descriptors(")

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -96,12 +96,16 @@ class KernelSpec:
             common_runtime_args, in order.
         config: Kernel config descriptor (ComputeConfigDescriptor,
             ReaderConfigDescriptor, WriterConfigDescriptor, or EthernetConfigDescriptor).
+        core_ranges: Optional per-kernel ttnn.CoreRangeSet. When set, this
+            specialized kernel binary is dispatched only to these cores. When None,
+            the whole-grid core_ranges passed to build_kernel_descriptors is used.
     """
 
     path: str
     thread_type: str
     tensor_indices: List[int]
     config: Any
+    core_ranges: Optional[Any] = None
 
 
 @dataclass
@@ -201,9 +205,15 @@ def build_kernel_descriptors(
         else:
             kernel_compile_time_args = cb_indices + list(tensor_accessor_args)
 
+        # Note: core_range is used outside this function to dispatch the kernel to the correct cores
+        # and should not be overridden
+        kernel_ranges = (
+            spec.core_ranges if spec.core_ranges is not None else core_ranges
+        )
+
         kernel_desc = ttnn.KernelDescriptor(
             kernel_source=spec.path,
-            core_ranges=core_ranges,
+            core_ranges=kernel_ranges,
             compile_time_args=kernel_compile_time_args,
             common_runtime_args=common_runtime_args,
             config=spec.config,

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -789,13 +789,15 @@ def _get_kernel_core_coords(module, kernel_name: str):
 def _get_kernel_noc_index(module, kernel_name: str):
     """Read the `ttl.noc_index` attribute (0 = reader, 1 = writer).
 
-    Returns None when the attribute is absent so callers can fall back to the
-    positional reader/writer assignment used by the default path.
+    The frontend tags every datamovement thread with this attribute, required here so
+    reader/writer role assignment is attribute-based rather than positional.
     """
     operation = _lookup_kernel_func_op(module, kernel_name)
     attr = operation.attributes.get("ttl.noc_index", None)
     if attr is None:
-        return None
+        raise ValueError(
+            f"Missing 'ttl.noc_index' on datamovement kernel '{kernel_name}'"
+        )
     return int(IntegerAttr(attr).value)
 
 
@@ -938,7 +940,6 @@ def _compile_ttnn_kernel(
     # Build CoreRangeSet from grid dimensions
     # Grid is (cols, rows) = (x, y), matching tt-metal CoreCoord convention
     grid_cols, grid_rows = grid
-    all_cores = [(x, y) for y in range(grid_rows) for x in range(grid_cols)]
     core_start = ttnn.CoreCoord(0, 0)
     core_end = ttnn.CoreCoord(grid_cols - 1, grid_rows - 1)
     core_range = ttnn.CoreRange(core_start, core_end)
@@ -953,8 +954,6 @@ def _compile_ttnn_kernel(
     # read from ttl.crta_indices. Both stay aligned with kernel_info order.
     kernel_core_ranges = []
     specialized_tensor_indices = []
-    # Per-core NOC role counter
-    noc_role_per_core = {}
     kernel_config_attrs = {
         name: {
             "fp32_dest_acc_en": _get_kernel_bool_attr(module, name, "fp32_dest_acc_en"),
@@ -976,8 +975,7 @@ def _compile_ttnn_kernel(
         kernel_paths.append((kernel_path, thread_type))
 
         # The specialized clone's launch coordinates (None on the default,
-        # whole-grid path). Used both for the per-core reader/writer fallback
-        # below and to build the dispatch range further down.
+        # whole-grid path). Used to build the per-kernel dispatch range below.
         coords = kernel_coords[idx]
 
         if thread_type == "compute":
@@ -999,11 +997,6 @@ def _compile_ttnn_kernel(
             thread_to_kernel["TRISC_2"] = name
         elif thread_type == "noc":
             noc_role = _get_kernel_noc_index(module, name)
-            if noc_role is None:
-                covered = coords if coords is not None else all_cores
-                noc_role = max(noc_role_per_core.get(c, 0) for c in covered)
-                for c in covered:
-                    noc_role_per_core[c] = noc_role + 1
             if noc_role == 0:
                 config = ttnn.ReaderConfigDescriptor()
                 thread_to_kernel["NCRISC"] = name  # Reader
@@ -1725,8 +1718,8 @@ def _lower_program_to_kernel(
                 ctx,
             )
 
-            # Tag noc functions with their index so pipe semaphore
-            # allocation can distinguish threads.
+            # Tag noc functions with their index so pipe semaphore allocation
+            # and TTNN reader/writer role assignment can distinguish threads.
             if ct.kernel_type == "datamovement":
                 ct.func_entry.attributes["ttl.noc_index"] = IntegerAttr.get(
                     IntegerType.get_signless(32, ctx), noc_kernel_idx

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -547,6 +547,7 @@ class CompiledTTNNKernel:
         num_tensors,
         core_ranges,
         kernel_tensor_indices,
+        kernel_core_ranges=None,
         cb_configs=None,
         program_hash=None,
         source_lines=None,
@@ -567,6 +568,10 @@ class CompiledTTNNKernel:
             num_tensors: Number of input/output tensors
             core_ranges: CoreRangeSet for kernel execution
             kernel_tensor_indices: List of global tensor indices used by each kernel
+            kernel_core_ranges: Optional list of per-kernel CoreRangeSet aligned
+                with kernel_paths. Set by the per-core specialization path so
+                each specialized clone is dispatched only to its own core; None
+                entries fall back to the whole-grid core_ranges.
             cb_configs: List of (shape, block_count) tuples for each CB, indexed by cb_index
             program_hash: Hash for tt-metal program cache
             source_lines: Source code lines for auto-profiling reports (deprecated)
@@ -586,6 +591,7 @@ class CompiledTTNNKernel:
         self.num_tensors = num_tensors
         self.core_ranges = core_ranges
         self.kernel_tensor_indices = kernel_tensor_indices
+        self.kernel_core_ranges = kernel_core_ranges or [None] * len(kernel_paths)
         self.cb_configs = cb_configs or []
         self.program_hash = program_hash
         self.source_lines = source_lines
@@ -623,6 +629,7 @@ class CompiledTTNNKernel:
                 thread_type=thread_type,
                 tensor_indices=tensor_indices,
                 config=config,
+                core_ranges=self.kernel_core_ranges[kernel_idx],
             )
             kernel_specs.append(spec)
 
@@ -747,6 +754,70 @@ def _get_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
     return list(attr)
 
 
+def _get_kernel_core_coords(module, kernel_name: str):
+    """Read the `ttl.core_coord` attribute set by `ttkernel-specialize-cores`.
+
+    We expect the aray to be of length 2 since node dim currently only supports 2D.
+    The attribute is the launch coordinates a kernel is dispatched to.
+
+    Returns the list of `(x, y)` launch coordinates for a specialized clone, or
+    None when the kernel was not specialized (the whole-grid default path).
+    """
+    operation = _lookup_kernel_func_op(module, kernel_name)
+    attr = operation.attributes.get("ttl.core_coord", None)
+    if attr is None:
+        return None
+    if not isinstance(attr, ArrayAttr):
+        raise ValueError(
+            f"Expected an array for 'ttl.core_coord' on kernel "
+            f"'{kernel_name}', got {attr}"
+        )
+    coords = []
+    for pair in attr:
+        pair = ArrayAttr(pair)
+        if len(pair) != 2:
+            raise ValueError(
+                f"Expected length-2 [x, y] entries in 'ttl.core_coord' on "
+                f"kernel '{kernel_name}', got {pair}"
+            )
+        coords.append(
+            (int(IntegerAttr(pair[0]).value), int(IntegerAttr(pair[1]).value))
+        )
+    return coords
+
+
+def _get_kernel_noc_index(module, kernel_name: str):
+    """Read the `ttl.noc_index` attribute (0 = reader, 1 = writer).
+
+    Returns None when the attribute is absent so callers can fall back to the
+    positional reader/writer assignment used by the default path.
+    """
+    operation = _lookup_kernel_func_op(module, kernel_name)
+    attr = operation.attributes.get("ttl.noc_index", None)
+    if attr is None:
+        return None
+    return int(IntegerAttr(attr).value)
+
+
+def _get_kernel_crta_indices(module, kernel_name: str):
+    """Read the `ttl.crta_indices` attribute as a list of global tensor indices.
+
+    Used by the per-core specialization path where clones cannot be aligned
+    positionally with the original thread list. Returns an empty list when the
+    attribute is missing.
+    """
+    operation = _lookup_kernel_func_op(module, kernel_name)
+    attr = operation.attributes.get("ttl.crta_indices", None)
+    if attr is None:
+        raise ValueError(f"No CRTA indices found for kernel {kernel_name}")
+    if not isinstance(attr, ArrayAttr):
+        raise ValueError(
+            f"Expected ArrayAttr for 'ttl.crta_indices' on kernel "
+            f"'{kernel_name}', got {attr}"
+        )
+    return [int(IntegerAttr(idx).value) for idx in attr]
+
+
 def _compile_ttnn_kernel(
     module,
     args,
@@ -810,17 +881,45 @@ def _compile_ttnn_kernel(
                     f"Use ttnn.to_layout(tensor, ttnn.TILE_LAYOUT) to convert."
                 )
 
-    # Validate kernel count: for now we must have exactly 3 kernels (1 compute + 2 data movement).
-    # Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts.
-    # TODO: in the future we should figure out how to map arbitrary kernels.
-    if len(kernel_info) != 3:
-        compute_count = sum(1 for _, t in kernel_info if t == "compute")
-        dm_count = sum(1 for _, t in kernel_info if t == "noc")
-        raise ValueError(
-            f"TTNN interop requires exactly 3 kernels (1 compute + 2 data movement), "
-            f"got {len(kernel_info)} kernels ({compute_count} compute, {dm_count} data movement). "
-            f"Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts."
-        )
+    # Detect the per-core specialization path: ttkernel-specialize-cores tags each
+    # clone with ttl.core_coord (the list of coordinates the clone serves).
+    # When present, get_ttkernel_names returns per-coordinate clones instead of
+    # a single (compute + reader + writer) triple.
+    kernel_coords = [_get_kernel_core_coords(module, name) for name, _ in kernel_info]
+    specialize_cores = any(coords is not None for coords in kernel_coords)
+
+    compute_count = sum(1 for _, t in kernel_info if t == "compute")
+    dm_count = sum(1 for _, t in kernel_info if t == "noc")
+    if not specialize_cores:
+        # Validate kernel count: for now we must have exactly 3 kernels (1 compute + 2 data movement).
+        # Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts.
+        # TODO: in the future we should figure out how to map arbitrary kernels.
+        if len(kernel_info) != 3:
+            raise ValueError(
+                f"TTNN interop requires exactly 3 kernels (1 compute + 2 data movement), "
+                f"got {len(kernel_info)} kernels ({compute_count} compute, {dm_count} data movement). "
+                f"Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts."
+            )
+    else:
+        # Check no core has more than one compute or two NOC kernels.
+        grid_cols, grid_rows = grid
+        all_cores = [(x, y) for y in range(grid_rows) for x in range(grid_cols)]
+        per_core_counts = {}
+        for (name, thread_type), coords in zip(kernel_info, kernel_coords):
+            covered = coords if coords is not None else all_cores
+            for coord in covered:
+                counts = per_core_counts.setdefault(tuple(coord), [0, 0])
+                if thread_type == "compute":
+                    counts[0] += 1
+                elif thread_type == "noc":
+                    counts[1] += 1
+        for coord, (n_compute, n_noc) in per_core_counts.items():
+            if n_compute > 1 or n_noc > 2:
+                raise ValueError(
+                    f"Per-core specialization assigned {n_compute} compute and "
+                    f"{n_noc} data movement kernels to core {coord}. Each core "
+                    f"supports at most one compute and two NOC kernels."
+                )
 
     if verbose:
         print("=" * 60)
@@ -840,6 +939,7 @@ def _compile_ttnn_kernel(
     # Build CoreRangeSet from grid dimensions
     # Grid is (cols, rows) = (x, y), matching tt-metal CoreCoord convention
     grid_cols, grid_rows = grid
+    all_cores = [(x, y) for y in range(grid_rows) for x in range(grid_cols)]
     core_start = ttnn.CoreCoord(0, 0)
     core_end = ttnn.CoreCoord(grid_cols - 1, grid_rows - 1)
     core_range = ttnn.CoreRange(core_start, core_end)
@@ -850,7 +950,12 @@ def _compile_ttnn_kernel(
     kernel_paths = []
     kernel_configs = []
     kernel_arg_specs = []
-    noc_kernel_idx = 0
+    # Per-kernel single-core ranges (specialization path) and tensor indices
+    # read from ttl.crta_indices. Both stay aligned with kernel_info order.
+    kernel_core_ranges = []
+    specialized_tensor_indices = []
+    # Per-core NOC role counter
+    noc_role_per_core = {}
     kernel_config_attrs = {
         name: {
             "fp32_dest_acc_en": _get_kernel_bool_attr(module, name, "fp32_dest_acc_en"),
@@ -866,10 +971,15 @@ def _compile_ttnn_kernel(
     # Maps RISC thread names to kernel names
     thread_to_kernel = {}
 
-    for name, thread_type in kernel_info:
+    for idx, (name, thread_type) in enumerate(kernel_info):
         cpp_source = ttkernel_to_cpp_by_name(module, name)
         kernel_path = _write_kernel_to_tmp(name, cpp_source)
         kernel_paths.append((kernel_path, thread_type))
+
+        # The specialized clone's launch coordinates (None on the default,
+        # whole-grid path). Used both for the per-core reader/writer fallback
+        # below and to build the dispatch range further down.
+        coords = kernel_coords[idx]
 
         if thread_type == "compute":
             config = ttnn.ComputeConfigDescriptor()
@@ -889,16 +999,40 @@ def _compile_ttnn_kernel(
             thread_to_kernel["TRISC_1"] = name
             thread_to_kernel["TRISC_2"] = name
         elif thread_type == "noc":
-            if noc_kernel_idx == 0:
+            noc_role = _get_kernel_noc_index(module, name)
+            if noc_role is None:
+                covered = coords if coords is not None else all_cores
+                noc_role = max(noc_role_per_core.get(c, 0) for c in covered)
+                for c in covered:
+                    noc_role_per_core[c] = noc_role + 1
+            if noc_role == 0:
                 config = ttnn.ReaderConfigDescriptor()
                 thread_to_kernel["NCRISC"] = name  # Reader
             else:
                 config = ttnn.WriterConfigDescriptor()
                 thread_to_kernel["BRISC"] = name  # Writer
-            noc_kernel_idx += 1
         else:
             config = ttnn.ReaderConfigDescriptor()
         kernel_configs.append(config)
+
+        # Turn the specialized clone's coordinates into a CoreRangeSet
+        if coords is not None:
+            kernel_core_ranges.append(
+                ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(cx, cy), ttnn.CoreCoord(cx, cy))
+                        for (cx, cy) in coords
+                    ]
+                )
+            )
+        else:
+            kernel_core_ranges.append(None)
+        # Clones cannot be aligned positionally with the original thread list,
+        # so recover each kernel's global tensor indices from ttl.crta_indices.
+        # Only needed on the specialization path; the default path uses the
+        # positional thread_tensor_indices instead.
+        if specialize_cores:
+            specialized_tensor_indices.append(_get_kernel_crta_indices(module, name))
 
         # Extract runtime args from kernel's arg_spec attribute
         arg_spec = get_ttkernel_arg_spec(module, name)
@@ -908,13 +1042,21 @@ def _compile_ttnn_kernel(
         else:
             kernel_arg_specs.append([])
 
+    # On the specialization path get_ttkernel_names returns 3*N clones, so the
+    # positional thread_tensor_indices (one entry per original thread) no longer
+    # lines up; use the per-clone indices recovered from ttl.crta_indices.
+    kernel_tensor_indices = (
+        specialized_tensor_indices if specialize_cores else thread_tensor_indices
+    )
+
     compiled_kernel = CompiledTTNNKernel(
         kernel_paths=kernel_paths,
         kernel_configs=kernel_configs,
         kernel_arg_specs=kernel_arg_specs,
         num_tensors=len(args),
         core_ranges=core_ranges,
-        kernel_tensor_indices=thread_tensor_indices,
+        kernel_tensor_indices=kernel_tensor_indices,
+        kernel_core_ranges=kernel_core_ranges,
         cb_configs=cb_configs,
         program_hash=program_hash,
         source_lines=source_lines,
@@ -1731,6 +1873,14 @@ def _lower_program_to_kernel(
             "cse",
             "lower-affine",
             "ttl-lower-signpost-to-emitc",
+        ]
+        if compiler_options.specialize_cores:
+            pipeline_passes += [
+                "ttkernel-specialize-cores",
+                "canonicalize",
+                "cse",
+            ]
+        pipeline_passes += [
             "func.func(convert-ttkernel-to-emitc)",
             "symbol-dce",
         ]

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -757,7 +757,7 @@ def _get_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
 def _get_kernel_core_coords(module, kernel_name: str):
     """Read the `ttl.core_coord` attribute set by `ttkernel-specialize-cores`.
 
-    We expect the aray to be of length 2 since node dim currently only supports 2D.
+    We expect the array to be of length 2 since node dim currently only supports 2D.
     The attribute is the launch coordinates a kernel is dispatched to.
 
     Returns the list of `(x, y)` launch coordinates for a specialized clone, or
@@ -803,8 +803,7 @@ def _get_kernel_crta_indices(module, kernel_name: str):
     """Read the `ttl.crta_indices` attribute as a list of global tensor indices.
 
     Used by the per-core specialization path where clones cannot be aligned
-    positionally with the original thread list. Returns an empty list when the
-    attribute is missing.
+    positionally with the original thread list. Raises an error if the attribute is missing.
     """
     operation = _lookup_kernel_func_op(module, kernel_name)
     attr = operation.attributes.get("ttl.crta_indices", None)
@@ -1076,12 +1075,13 @@ def _compile_ttnn_kernel(
     if emit_runner_path:
         kernel_specs_for_emit = []
         for kernel_idx, (kernel_path, thread_type) in enumerate(kernel_paths):
-            tensor_indices = thread_tensor_indices[kernel_idx]
+            tensor_indices = kernel_tensor_indices[kernel_idx]
             spec = KernelSpec(
                 path=kernel_path,
                 thread_type=thread_type,
                 tensor_indices=tensor_indices,
                 config=kernel_configs[kernel_idx],
+                core_ranges=kernel_core_ranges[kernel_idx],
             )
             kernel_specs_for_emit.append(spec)
 

--- a/test/me2e/builder/pipeline.py
+++ b/test/me2e/builder/pipeline.py
@@ -20,6 +20,7 @@ def compile_ttl_to_ttkernel(
     device: Optional[Any] = None,
     maximize_dst: bool = True,
     enable_fpu_binary_ops: bool = True,
+    specialize_cores: bool = False,
 ) -> Module:
     """
     Run the TTL-to-TTKernel pass pipeline on the module.
@@ -31,6 +32,8 @@ def compile_ttl_to_ttkernel(
         device: Optional TTNN device (unused, kept for API compat).
         maximize_dst: Enable DST maximization (subblocking + scheduling).
         enable_fpu_binary_ops: Enable FPU binary op detection (add_tiles, etc).
+        specialize_cores: Clone kernels that branch on a core coordinate
+            once per launch coordinate (ttkernel-specialize-cores).
 
     Returns:
         Compiled module with TTKernel/EmitC ops.
@@ -58,6 +61,10 @@ def compile_ttl_to_ttkernel(
         func_passes.append("ttl-schedule-operations")
     func_pipeline = ",".join(func_passes)
 
+    specialize_passes = ""
+    if specialize_cores:
+        specialize_passes = "ttkernel-specialize-cores,canonicalize,cse,"
+
     pipeline_str = (
         f"builtin.module("
         f"func.func({func_pipeline}),"
@@ -71,6 +78,7 @@ def compile_ttl_to_ttkernel(
         f"ttkernel-insert-inits,"
         f"canonicalize,"
         f"cse,"
+        f"{specialize_passes}"
         f"lower-affine,"
         f"func.func(convert-ttkernel-to-emitc),"
         f"canonicalize"

--- a/test/python/specialize_cores_fold.py
+++ b/test/python/specialize_cores_fold.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: env TTLANG_FINAL_MLIR=%t.final.mlir %python %s > %t.out 2>&1
+# RUN: FileCheck %s < %t.final.mlir --implicit-check-not='emitc.if' --implicit-check-not='scf.if'
+# RUN: FileCheck %s --check-prefix=RUNTIME < %t.out
+
+"""Per-core specialization folds the coordinate branch in the real emitted kernel.
+
+The reader swaps two tile-columns based on core_x, so it is cloned per launch
+coordinate and each clone's branch is const-folded. This test both executes the
+specialized kernel (correctness vs a torch column-swap reference) and FileChecks
+the emitted MLIR to show the fold and the dead-read elimination. The MLIR-only
+pass check on toy IR lives in
+test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir.
+"""
+
+import torch
+import ttnn
+
+import ttl
+from ttlang_test_utils import assert_pcc, require_hardware, to_dram
+
+TILE = 32
+GRID_X, GRID_Y = 2, 2
+
+
+@ttl.operation(grid=(GRID_X, GRID_Y))
+def branch_swap(a, out):
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
+            o.store(a_tile)
+
+    @ttl.datamovement()
+    def dm_read():
+        x, y = ttl.node(dims=2)
+        with a_dfb.reserve() as blk:
+            tx = ttl.copy(a[y, 0], blk)
+            if x == 0:
+                tx = ttl.copy(a[y, 1], blk)
+            tx.wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        x, y = ttl.node(dims=2)
+        with out_dfb.wait() as blk:
+            tx = ttl.copy(blk, out[y, x])
+            tx.wait()
+
+
+# No emitc.if / scf.if survives anywhere (asserted via --implicit-check-not on
+# the RUN line): every clone's coordinate branch is const-folded.
+#
+# core_x == 0 takes the branch, so its clone reads column 0 then column 1 --
+# two async_reads.
+# CHECK-LABEL: func.func @dm_read_c0_0
+# CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 0]]
+# CHECK:         async_read(
+# CHECK:         async_read(
+# CHECK:         return
+#
+# core_x == 1 does not take the branch, so the column-1 read is eliminated --
+# a single async_read remains (CHECK-NOT bounded by the trailing return).
+# CHECK-LABEL: func.func @dm_read_c1_0
+# CHECK-SAME:    ttl.core_coord = {{\[\[}}1, 0]]
+# CHECK:         async_read(
+# CHECK-NOT:     async_read(
+# CHECK:         return
+
+# RUNTIME: specialize-cores correctness OK
+
+if __name__ == "__main__":
+    require_hardware()
+    device = ttnn.open_device(device_id=0)
+    try:
+        shape = (GRID_Y * TILE, GRID_X * TILE)
+        a_torch = torch.randn(shape, dtype=torch.bfloat16)
+        # Reference: swap the two tile-columns (GRID_X == 2).
+        expected = torch.cat(
+            [a_torch[:, TILE:], a_torch[:, :TILE]], dim=1
+        ).contiguous()
+
+        a = to_dram(a_torch, device)
+        out = to_dram(torch.zeros(shape, dtype=torch.bfloat16), device)
+        branch_swap(a, out, options="--ttl-specialize-cores")
+
+        assert_pcc(expected, ttnn.to_torch(out))
+        print("specialize-cores correctness OK")
+    finally:
+        ttnn.close_device(device)

--- a/test/python/specialize_cores_fold.py
+++ b/test/python/specialize_cores_fold.py
@@ -82,9 +82,7 @@ if __name__ == "__main__":
         shape = (GRID_Y * TILE, GRID_X * TILE)
         a_torch = torch.randn(shape, dtype=torch.bfloat16)
         # Reference: swap the two tile-columns (GRID_X == 2).
-        expected = torch.cat(
-            [a_torch[:, TILE:], a_torch[:, :TILE]], dim=1
-        ).contiguous()
+        expected = torch.cat([a_torch[:, TILE:], a_torch[:, :TILE]], dim=1).contiguous()
 
         a = to_dram(a_torch, device)
         out = to_dram(torch.zeros(shape, dtype=torch.bfloat16), device)

--- a/test/python/test_compiler_options.py
+++ b/test/python/test_compiler_options.py
@@ -19,6 +19,7 @@ class TestDefaults:
         assert opts.maximize_dst is True
         assert opts.enable_fpu_binary_ops is True
         assert opts.subblock_sync is False
+        assert opts.specialize_cores is False
         assert opts._explicit == frozenset()
 
     def test_frozen(self):
@@ -51,6 +52,11 @@ class TestFromString:
         opts = CompilerOptions.from_string("--ttl-subblock-sync")
         assert opts.subblock_sync is True
         assert "subblock_sync" in opts._explicit
+
+    def test_enable_specialize_cores(self):
+        opts = CompilerOptions.from_string("--ttl-specialize-cores")
+        assert opts.specialize_cores is True
+        assert "specialize_cores" in opts._explicit
 
     def test_enable_flags_explicitly(self):
         opts = CompilerOptions.from_string("--ttl-maximize-dst --ttl-fpu-binary-ops")

--- a/test/python/test_specialize_cores.py
+++ b/test/python/test_specialize_cores.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end test for the per-core specialization path.
+
+Per-core specialization is opt-in via the compiler option `specialize_cores`
+(enable with `--ttl-specialize-cores`; disabled by default). It is a single
+module pass (`ttkernel-specialize-cores`) run at the TTKernel level right before
+EmitC: for each kernel that branches on a core coordinate it emits one clone
+per launch coordinate, replacing the coordinate reads with constants and
+tagging each clone with `ttl.core_coord`. The runtime bridge
+(`_compile_ttnn_kernel`) turns each `ttl.core_coord` into a per-kernel core
+range for dispatch.
+
+Crucially, a kernel is cloned only when it *branches* on a core coordinate
+(`scf.if` on `ttkernel.my_logical_x_` / `my_logical_y_`). Kernels that use the
+coordinate only as data (e.g. addressing `a[y, x]`) are left as a single
+whole-grid binary, because the runtime coordinate reads already give each core
+its own coordinate -- no clone is needed. Modules that use pipes are never
+specialized (cloning a pipe endpoint deadlocks at runtime).
+
+The matmul kernel below addresses its operands through the coordinate but never
+branches on it, so specialization is a correctness-preserving no-op for it. That
+test therefore verifies that:
+  * The specialized result matches a torch reference (numerical correctness).
+  * The specialized result matches the default (unspecialized) path.
+  * The dumped final MLIR shows these data-addressing kernels are NOT cloned
+    (no `ttl.core_coord`), i.e. specialization safely declines to clone them.
+
+A third kernel (`branch_swap_*`) *does* branch on the coordinate: its reader
+selects a different source column depending on `core_x`, so specialization
+clones the reader per core and const-folds the branch. That test exercises the
+full clone-and-dispatch path end to end (the MLIR-only clone/fold checks live in
+the lit test test/ttlang/Dialect/TTL/Transforms/specialize_cores.mlir).
+"""
+
+import os
+import re
+
+import pytest
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import torch
+
+import ttl
+from ttlang_test_utils import assert_pcc, to_dram
+
+TILE_SIZE = 32
+
+# Small grid keeps the clone count (3 kernels * GRID_X * GRID_Y) modest.
+GRID_X = 2
+GRID_Y = 2
+
+
+def _assert_not_cloned(final_mlir_path):
+    """Confirm the dumped final MLIR shows no per-core clones.
+
+    The kernels here use the coordinate only for addressing, never for a branch,
+    so specialization must decline to clone them: no `ttl.core_coord` clone tag
+    and no `_c<x>_<y>` clone suffixes should appear.
+    """
+    with open(final_mlir_path) as fd:
+        mlir = fd.read()
+    assert (
+        "ttl.core_coord" not in mlir
+    ), "data-addressing kernels must not be cloned (found ttl.core_coord)"
+    clones = re.findall(r"func\.func @\w+_c\d+_\d+", mlir)
+    assert not clones, f"expected no per-core clones, got {clones}"
+
+
+# The motivating case from the specialization epic: a 2D grid matmul where
+# core (x, y) computes output tile out[y, x] = a[y, 0] @ b[0, x]. The reader
+# and writer address a, b, and out through their ttl.node coordinate, so
+# specialization must const-fold each clone's core_x / core_y to the right
+# tile. A single K tile per core is used because multicore K-accumulation is
+# not supported yet (see the matmul_multinode TODO and issue #652).
+@ttl.operation(grid=(GRID_X, GRID_Y))
+def matmul_default(a, b, out):
+    """Per-core single-tile matmul, compiled through the normal pipeline."""
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def mm_compute():
+        a_blk = a_dfb.wait()
+        b_blk = b_dfb.wait()
+        with out_dfb.reserve() as o:
+            o.store(a_blk @ b_blk)
+        a_blk.pop()
+        b_blk.pop()
+
+    @ttl.datamovement()
+    def dm_read():
+        x, y = ttl.node(dims=2)
+        with a_dfb.reserve() as a_blk:
+            tx = ttl.copy(a[y, 0], a_blk)
+            tx.wait()
+        with b_dfb.reserve() as b_blk:
+            tx = ttl.copy(b[0, x], b_blk)
+            tx.wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        x, y = ttl.node(dims=2)
+        with out_dfb.wait() as o:
+            tx = ttl.copy(o, out[y, x])
+            tx.wait()
+
+
+# Separate op object so its compilation cache is independent from the default
+# matmul. This one is always invoked with options="--ttl-specialize-cores".
+@ttl.operation(grid=(GRID_X, GRID_Y))
+def matmul_specialized(a, b, out):
+    """Identical body to matmul_default; invoked with specialization on."""
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def mm_compute():
+        a_blk = a_dfb.wait()
+        b_blk = b_dfb.wait()
+        with out_dfb.reserve() as o:
+            o.store(a_blk @ b_blk)
+        a_blk.pop()
+        b_blk.pop()
+
+    @ttl.datamovement()
+    def dm_read():
+        x, y = ttl.node(dims=2)
+        with a_dfb.reserve() as a_blk:
+            tx = ttl.copy(a[y, 0], a_blk)
+            tx.wait()
+        with b_dfb.reserve() as b_blk:
+            tx = ttl.copy(b[0, x], b_blk)
+            tx.wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        x, y = ttl.node(dims=2)
+        with out_dfb.wait() as o:
+            tx = ttl.copy(o, out[y, x])
+            tx.wait()
+
+
+def _make_matmul_inputs(device):
+    M = GRID_Y * TILE_SIZE
+    N = GRID_X * TILE_SIZE
+    K = TILE_SIZE  # single K tile per core
+    a_torch = torch.randn((M, K), dtype=torch.bfloat16)
+    b_torch = torch.randn((K, N), dtype=torch.bfloat16)
+    expected = (a_torch.float() @ b_torch.float()).to(torch.bfloat16)
+    a = to_dram(a_torch, device)
+    b = to_dram(b_torch, device)
+    return a, b, expected
+
+
+def test_specialize_cores_matmul_matches_reference(device, monkeypatch, tmp_path):
+    """Specialized per-core matmul matches torch and the unspecialized path."""
+    a, b, expected = _make_matmul_inputs(device)
+    out_default = to_dram(torch.zeros_like(expected), device)
+    out_spec = to_dram(torch.zeros_like(expected), device)
+
+    # Unspecialized baseline (specialization off by default).
+    matmul_default(a, b, out_default)
+    default_result = ttnn.to_torch(out_default)
+
+    # Specialized path (opt in). Dump the final MLIR so we can confirm the
+    # pass ran.
+    final_mlir = tmp_path / "matmul_specialized_final.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir))
+    matmul_specialized(a, b, out_spec, options="--ttl-specialize-cores")
+    spec_result = ttnn.to_torch(out_spec)
+
+    # Numerical correctness vs torch, and equivalence to the default path.
+    assert_pcc(expected, spec_result, threshold=0.999)
+    assert_pcc(default_result, spec_result, threshold=0.999)
+
+    # These kernels address through the coordinate but never branch on it, so
+    # specialization must leave them un-cloned.
+    _assert_not_cloned(str(final_mlir))
+
+
+# A kernel that actually branches on the core coordinate. The reader swaps the
+# two tile-columns: core (x, y) reads source column `1 - x`, so the output is
+# the input with its two column-blocks swapped. The branch (`if x == 0`) lowers
+# to an scf.if on the coordinate, so specialization clones the reader per core
+# and const-folds each clone's branch. The compute and writer never branch, so
+# they stay whole-grid -- this also exercises the mixed cloned/uncloned kernel
+# validation path. The column-swap assumes GRID_X == 2.
+@ttl.operation(grid=(GRID_X, GRID_Y))
+def branch_swap_default(a, out):
+    """Reader branches on core_x to swap columns; normal (unspecialized) path."""
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
+            o.store(a_tile)
+
+    @ttl.datamovement()
+    def dm_read():
+        x, y = ttl.node(dims=2)
+        with a_dfb.reserve() as blk:
+            # Default (x == 1) reads column 0; column-0 cores read column 1.
+            tx = ttl.copy(a[y, 0], blk)
+            if x == 0:
+                tx = ttl.copy(a[y, 1], blk)
+            tx.wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        x, y = ttl.node(dims=2)
+        with out_dfb.wait() as blk:
+            tx = ttl.copy(blk, out[y, x])
+            tx.wait()
+
+
+# Separate op object so its compilation cache is independent from the default
+# branch kernel. This one is always invoked with options="--ttl-specialize-cores".
+@ttl.operation(grid=(GRID_X, GRID_Y))
+def branch_swap_specialized(a, out):
+    """Identical body to branch_swap_default; invoked with specialization on."""
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
+            o.store(a_tile)
+
+    @ttl.datamovement()
+    def dm_read():
+        x, y = ttl.node(dims=2)
+        with a_dfb.reserve() as blk:
+            tx = ttl.copy(a[y, 0], blk)
+            if x == 0:
+                tx = ttl.copy(a[y, 1], blk)
+            tx.wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        x, y = ttl.node(dims=2)
+        with out_dfb.wait() as blk:
+            tx = ttl.copy(blk, out[y, x])
+            tx.wait()
+
+
+def _make_swap_inputs(device):
+    assert GRID_X == 2, "branch_swap column-swap reference assumes GRID_X == 2"
+    shape = (GRID_Y * TILE_SIZE, GRID_X * TILE_SIZE)
+    a_torch = torch.randn(shape, dtype=torch.bfloat16)
+    left = a_torch[:, :TILE_SIZE]
+    right = a_torch[:, TILE_SIZE:]
+    expected = torch.cat([right, left], dim=1).contiguous()
+    a = to_dram(a_torch, device)
+    return a, expected
+
+
+def _assert_reader_cloned(final_mlir_path):
+    """Confirm the branching reader was cloned once per core.
+
+    Only the reader branches on the coordinate, so there must be exactly one
+    clone per launch coordinate (compute and writer stay whole-grid), each
+    tagged with `ttl.core_coord`, and the clones must cover every coordinate.
+    """
+    with open(final_mlir_path) as fd:
+        mlir = fd.read()
+    assert (
+        "ttl.core_coord" in mlir
+    ), "a kernel that branches on the coordinate must be cloned (no ttl.core_coord)"
+    clones = re.findall(r"func\.func @\w+_c(\d+)_(\d+)", mlir)
+    coords = {(int(x), int(y)) for x, y in clones}
+    expected_coords = {(x, y) for y in range(GRID_Y) for x in range(GRID_X)}
+    assert coords == expected_coords, (
+        f"reader clones cover {sorted(coords)}, expected " f"{sorted(expected_coords)}"
+    )
+    assert len(clones) == GRID_X * GRID_Y, (
+        f"expected exactly {GRID_X * GRID_Y} clones (reader only), got "
+        f"{len(clones)}: {clones}"
+    )
+
+
+def test_specialize_cores_branch_matches_reference(device, monkeypatch, tmp_path):
+    """A coordinate-branching kernel is cloned per core and stays correct."""
+    a, expected = _make_swap_inputs(device)
+    out_default = to_dram(torch.zeros_like(expected), device)
+    out_spec = to_dram(torch.zeros_like(expected), device)
+
+    # Unspecialized baseline: the runtime coordinate read + scf.if already
+    # produce the swap correctly on the default path.
+    branch_swap_default(a, out_default)
+    default_result = ttnn.to_torch(out_default)
+
+    # Specialized path (opt in). Dump the final MLIR so we can confirm the
+    # reader was cloned per core.
+    final_mlir = tmp_path / "branch_specialized_final.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir))
+    branch_swap_specialized(a, out_spec, options="--ttl-specialize-cores")
+    spec_result = ttnn.to_torch(out_spec)
+
+    # Numerical correctness vs torch, and equivalence to the default path.
+    assert_pcc(expected, spec_result)
+    assert_pcc(default_result, spec_result)
+
+    # The reader branches on core_x, so it must be cloned once per core.
+    _assert_reader_cloned(str(final_mlir))
+
+
+if __name__ == "__main__":
+    # Manual repro: run the specialized path directly (no pytest) and print a
+    # summary plus the specialized-vs-torch comparison.
+    from ttlang_test_utils import require_hardware
+
+    print("=== Per-core specialization repro ===")
+    require_hardware()
+
+    final_mlir = "/tmp/specialize_cores_final.mlir"
+    os.environ["TTLANG_FINAL_MLIR"] = final_mlir
+
+    dev = ttnn.open_device(device_id=0)
+    try:
+        a, b, expected = _make_matmul_inputs(dev)
+        out = to_dram(torch.zeros_like(expected), dev)
+
+        print(
+            f"Grid: {GRID_X}x{GRID_Y} "
+            f"(these kernels address through the coordinate but never branch on "
+            f"it, so specialization is a no-op: no clones expected)"
+        )
+        matmul_specialized(a, b, out, options="--ttl-specialize-cores")
+
+        result = ttnn.to_torch(out)
+        assert_pcc(expected, result, threshold=0.999)
+        _assert_not_cloned(final_mlir)
+        print(f"OK: specialized result matches torch reference (no clones).")
+        print(f"Final MLIR written to {final_mlir}")
+    finally:
+        ttnn.close_device(dev)

--- a/test/python/test_specialize_cores.py
+++ b/test/python/test_specialize_cores.py
@@ -29,8 +29,8 @@ Coverage:
     `test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir`).
   * emit_runner_no_crash: `TTLANG_EMIT_RUNNER` must not IndexError when
     kernels are cloned (per-clone tensor indices / core ranges).
-  * emit_runner_executes: strict xfail until the emitted runner template can
-    express per-clone dispatch on a cold program cache.
+  * emit_runner_executes: emitted runner, run cold, reproduces the swap
+    (per-kernel core ranges and NOC roles baked into the template).
 """
 
 import os
@@ -282,21 +282,13 @@ def test_specialize_cores_emit_runner_no_crash(device, monkeypatch, tmp_path):
     assert runner_path.exists(), "no runner emitted"
 
 
-@pytest.mark.xfail(
-    reason="emitted runner template cannot express per-clone dispatch: it "
-    "re-derives reader/writer from a positional counter and passes only the "
-    "whole-grid core_ranges, so every clone lands on every core and tt-metal "
-    "rejects it with TT_FATAL: Illegal NOC usage. Needs per-kernel core-range "
-    "and NOC-role constants in emit_runner_file.",
-    strict=True,
-    raises=RuntimeError,
-)
 def test_specialize_cores_emit_runner_executes(device, monkeypatch, tmp_path):
     """The emitted runner, run standalone on a cold cache, must reproduce the swap.
 
     Compile-only so the op never executes and warms the program cache; otherwise
-    the runner's custom_program_hash reuses the cached program and masks the
-    misdispatch. Strict xfail so it flags when the template is fixed.
+    the runner's custom_program_hash could reuse a cached in-process program and
+    mask a template bug. The emitted runner must carry per-kernel core ranges
+    and NOC roles so clones dispatch correctly when built cold.
     """
     import importlib.util
 

--- a/test/python/test_specialize_cores.py
+++ b/test/python/test_specialize_cores.py
@@ -5,27 +5,32 @@
 """End-to-end test for the per-core specialization path.
 
 Per-core specialization is opt-in via the compiler option `specialize_cores`
-(enable with --ttl-specialize-cores; disabled by default). It is a single
-module pass (ttkernel-specialize-cores) run at the TTKernel level right before
-EmitC: for each kernel that branches on a core coordinate it emits one clone
-per launch coordinate, replacing the coordinate reads with constants and
-tagging each clone with ttl.core_coord. The runtime bridge
-(_compile_ttnn_kernel) turns each ttl.core_coord into a per-kernel core
+(enable with `--ttl-specialize-cores`; disabled by default). It is a single
+module pass (`ttkernel-specialize-cores`) run at the TTKernel level right
+before EmitC: for each kernel that branches on a core coordinate it emits one
+clone per launch coordinate, replacing the coordinate reads with constants and
+tagging each clone with `ttl.core_coord`. The runtime bridge
+(`_compile_ttnn_kernel`) turns each `ttl.core_coord` into a per-kernel core
 range for dispatch.
 
-The matmul kernel below addresses its operands through the coordinate but never
-branches on it, so specialization skips cloning for it. That test therefore
-verifies that:
-  * The specialized result matches a torch reference (numerical correctness).
-  * The specialized result matches the default (unspecialized) path.
-  * The dumped final MLIR shows these data-addressing kernels are NOT cloned
-    (no `ttl.core_coord`), i.e. specialization safely declines to clone them.
+Op bodies are built by `_make_matmul_op` / `_make_branch_swap_op` so default
+and specialized runs get distinct op objects (and compilation caches) without
+duplicating the kernel source. Env-var-dependent emit-runner tests call the
+factory again for a fresh cache, because the key does not include
+`TTLANG_EMIT_RUNNER` / `TTLANG_COMPILE_ONLY`.
 
-A second kernel (branch_swap_*) *does* branch on the coordinate: its reader
-selects a different source column depending on core_x, so specialization
-clones the reader per core and const-folds the branch. That test exercises the
-full clone-and-dispatch path end to end (the MLIR-only clone/fold checks live in
-the lit test test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir).
+Coverage:
+  * matmul: addresses through the coordinate but never branches, so
+    specialization skips cloning. Checks torch PCC, match vs unspecialized,
+    and final MLIR has no `ttl.core_coord` / `_c<x>_<y>` clones.
+  * branch_swap: reader branches on `core_x` to swap columns, so the reader is
+    cloned per core. Checks torch PCC, match vs unspecialized, and that clones
+    cover the launch grid (MLIR-only clone/fold checks live in
+    `test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir`).
+  * emit_runner_no_crash: `TTLANG_EMIT_RUNNER` must not IndexError when
+    kernels are cloned (per-clone tensor indices / core ranges).
+  * emit_runner_executes: strict xfail until the emitted runner template can
+    express per-clone dispatch on a cold program cache.
 """
 
 import os
@@ -69,74 +74,48 @@ def _assert_not_cloned(final_mlir_path):
 # specialization must const-fold each clone's core_x / core_y to the right
 # tile. A single K tile per core is used because multicore K-accumulation is
 # not supported yet (see the matmul_multinode TODO and issue #652).
-@ttl.operation(grid=(GRID_X, GRID_Y))
-def matmul_default(a, b, out):
-    """Per-core single-tile matmul, compiled through the normal pipeline."""
-    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
-    b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)
-    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+#
+# Two op objects share this body so each has an independent compilation cache:
+# matmul_default runs unspecialized; matmul_specialized is always invoked with
+# options="--ttl-specialize-cores".
+def _make_matmul_op():
+    @ttl.operation(grid=(GRID_X, GRID_Y))
+    def matmul(a, b, out):
+        a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+        b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)
+        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
 
-    @ttl.compute()
-    def mm_compute():
-        a_blk = a_dfb.wait()
-        b_blk = b_dfb.wait()
-        with out_dfb.reserve() as o:
-            o.store(a_blk @ b_blk)
-        a_blk.pop()
-        b_blk.pop()
+        @ttl.compute()
+        def mm_compute():
+            a_blk = a_dfb.wait()
+            b_blk = b_dfb.wait()
+            with out_dfb.reserve() as o:
+                o.store(a_blk @ b_blk)
+            a_blk.pop()
+            b_blk.pop()
 
-    @ttl.datamovement()
-    def dm_read():
-        x, y = ttl.node(dims=2)
-        with a_dfb.reserve() as a_blk:
-            tx = ttl.copy(a[y, 0], a_blk)
-            tx.wait()
-        with b_dfb.reserve() as b_blk:
-            tx = ttl.copy(b[0, x], b_blk)
-            tx.wait()
+        @ttl.datamovement()
+        def dm_read():
+            x, y = ttl.node(dims=2)
+            with a_dfb.reserve() as a_blk:
+                tx = ttl.copy(a[y, 0], a_blk)
+                tx.wait()
+            with b_dfb.reserve() as b_blk:
+                tx = ttl.copy(b[0, x], b_blk)
+                tx.wait()
 
-    @ttl.datamovement()
-    def dm_write():
-        x, y = ttl.node(dims=2)
-        with out_dfb.wait() as o:
-            tx = ttl.copy(o, out[y, x])
-            tx.wait()
+        @ttl.datamovement()
+        def dm_write():
+            x, y = ttl.node(dims=2)
+            with out_dfb.wait() as o:
+                tx = ttl.copy(o, out[y, x])
+                tx.wait()
+
+    return matmul
 
 
-# Separate op object so its compilation cache is independent from the default
-# matmul. This one is always invoked with options="--ttl-specialize-cores".
-@ttl.operation(grid=(GRID_X, GRID_Y))
-def matmul_specialized(a, b, out):
-    """Identical body to matmul_default; invoked with specialization on."""
-    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
-    b_dfb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)
-    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
-
-    @ttl.compute()
-    def mm_compute():
-        a_blk = a_dfb.wait()
-        b_blk = b_dfb.wait()
-        with out_dfb.reserve() as o:
-            o.store(a_blk @ b_blk)
-        a_blk.pop()
-        b_blk.pop()
-
-    @ttl.datamovement()
-    def dm_read():
-        x, y = ttl.node(dims=2)
-        with a_dfb.reserve() as a_blk:
-            tx = ttl.copy(a[y, 0], a_blk)
-            tx.wait()
-        with b_dfb.reserve() as b_blk:
-            tx = ttl.copy(b[0, x], b_blk)
-            tx.wait()
-
-    @ttl.datamovement()
-    def dm_write():
-        x, y = ttl.node(dims=2)
-        with out_dfb.wait() as o:
-            tx = ttl.copy(o, out[y, x])
-            tx.wait()
+matmul_default = _make_matmul_op()
+matmul_specialized = _make_matmul_op()
 
 
 def _make_matmul_inputs(device):
@@ -184,63 +163,44 @@ def test_specialize_cores_matmul_matches_reference(device, monkeypatch, tmp_path
 # and const-folds each clone's branch. The compute and writer never branch, so
 # they stay whole-grid -- this also exercises the mixed cloned/uncloned kernel
 # validation path. The column-swap assumes GRID_X == 2.
-@ttl.operation(grid=(GRID_X, GRID_Y))
-def branch_swap_default(a, out):
-    """Reader branches on core_x to swap columns; normal (unspecialized) path."""
-    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
-    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+#
+# Fresh op objects share this body so each has an independent compilation
+# cache. The cache is keyed on tensor properties, not on env vars like
+# TTLANG_EMIT_RUNNER / TTLANG_COMPILE_ONLY, so tests that toggle those must
+# call _make_branch_swap_op() again rather than reuse branch_swap_*.
+def _make_branch_swap_op():
+    @ttl.operation(grid=(GRID_X, GRID_Y))
+    def branch_swap(a, out):
+        a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
 
-    @ttl.compute()
-    def compute_fn():
-        with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
-            o.store(a_tile)
+        @ttl.compute()
+        def compute_fn():
+            with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
+                o.store(a_tile)
 
-    @ttl.datamovement()
-    def dm_read():
-        x, y = ttl.node(dims=2)
-        with a_dfb.reserve() as blk:
-            # Default (x == 1) reads column 0; column-0 cores read column 1.
-            tx = ttl.copy(a[y, 0], blk)
-            if x == 0:
-                tx = ttl.copy(a[y, 1], blk)
-            tx.wait()
+        @ttl.datamovement()
+        def dm_read():
+            x, y = ttl.node(dims=2)
+            with a_dfb.reserve() as blk:
+                # Default (x == 1) reads column 0; column-0 cores read column 1.
+                tx = ttl.copy(a[y, 0], blk)
+                if x == 0:
+                    tx = ttl.copy(a[y, 1], blk)
+                tx.wait()
 
-    @ttl.datamovement()
-    def dm_write():
-        x, y = ttl.node(dims=2)
-        with out_dfb.wait() as blk:
-            tx = ttl.copy(blk, out[y, x])
-            tx.wait()
+        @ttl.datamovement()
+        def dm_write():
+            x, y = ttl.node(dims=2)
+            with out_dfb.wait() as blk:
+                tx = ttl.copy(blk, out[y, x])
+                tx.wait()
+
+    return branch_swap
 
 
-# Separate op object so its compilation cache is independent from the default
-# branch kernel. This one is always invoked with options="--ttl-specialize-cores".
-@ttl.operation(grid=(GRID_X, GRID_Y))
-def branch_swap_specialized(a, out):
-    """Identical body to branch_swap_default; invoked with specialization on."""
-    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
-    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
-
-    @ttl.compute()
-    def compute_fn():
-        with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
-            o.store(a_tile)
-
-    @ttl.datamovement()
-    def dm_read():
-        x, y = ttl.node(dims=2)
-        with a_dfb.reserve() as blk:
-            tx = ttl.copy(a[y, 0], blk)
-            if x == 0:
-                tx = ttl.copy(a[y, 1], blk)
-            tx.wait()
-
-    @ttl.datamovement()
-    def dm_write():
-        x, y = ttl.node(dims=2)
-        with out_dfb.wait() as blk:
-            tx = ttl.copy(blk, out[y, x])
-            tx.wait()
+branch_swap_default = _make_branch_swap_op()
+branch_swap_specialized = _make_branch_swap_op()
 
 
 def _make_swap_inputs(device):
@@ -302,43 +262,6 @@ def test_specialize_cores_branch_matches_reference(device, monkeypatch, tmp_path
 
     # The reader branches on core_x, so it must be cloned once per core.
     _assert_reader_cloned(str(final_mlir))
-
-
-def _make_branch_swap_op():
-    """Return a fresh column-swap op with its own compilation cache.
-
-    The cache is keyed on tensor properties, not on env vars like
-    TTLANG_EMIT_RUNNER / TTLANG_COMPILE_ONLY, so tests that toggle those must
-    use distinct op objects or the cache hit skips the env-dependent codegen.
-    """
-
-    @ttl.operation(grid=(GRID_X, GRID_Y))
-    def branch_swap(a, out):
-        a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
-        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
-
-        @ttl.compute()
-        def compute_fn():
-            with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
-                o.store(a_tile)
-
-        @ttl.datamovement()
-        def dm_read():
-            x, y = ttl.node(dims=2)
-            with a_dfb.reserve() as blk:
-                tx = ttl.copy(a[y, 0], blk)
-                if x == 0:
-                    tx = ttl.copy(a[y, 1], blk)
-                tx.wait()
-
-        @ttl.datamovement()
-        def dm_write():
-            x, y = ttl.node(dims=2)
-            with out_dfb.wait() as blk:
-                tx = ttl.copy(blk, out[y, x])
-                tx.wait()
-
-    return branch_swap
 
 
 def test_specialize_cores_emit_runner_no_crash(device, monkeypatch, tmp_path):

--- a/test/python/test_specialize_cores.py
+++ b/test/python/test_specialize_cores.py
@@ -5,34 +5,27 @@
 """End-to-end test for the per-core specialization path.
 
 Per-core specialization is opt-in via the compiler option `specialize_cores`
-(enable with `--ttl-specialize-cores`; disabled by default). It is a single
-module pass (`ttkernel-specialize-cores`) run at the TTKernel level right before
+(enable with --ttl-specialize-cores; disabled by default). It is a single
+module pass (ttkernel-specialize-cores) run at the TTKernel level right before
 EmitC: for each kernel that branches on a core coordinate it emits one clone
 per launch coordinate, replacing the coordinate reads with constants and
-tagging each clone with `ttl.core_coord`. The runtime bridge
-(`_compile_ttnn_kernel`) turns each `ttl.core_coord` into a per-kernel core
+tagging each clone with ttl.core_coord. The runtime bridge
+(_compile_ttnn_kernel) turns each ttl.core_coord into a per-kernel core
 range for dispatch.
 
-Crucially, a kernel is cloned only when it *branches* on a core coordinate
-(`scf.if` on `ttkernel.my_logical_x_` / `my_logical_y_`). Kernels that use the
-coordinate only as data (e.g. addressing `a[y, x]`) are left as a single
-whole-grid binary, because the runtime coordinate reads already give each core
-its own coordinate -- no clone is needed. Modules that use pipes are never
-specialized (cloning a pipe endpoint deadlocks at runtime).
-
 The matmul kernel below addresses its operands through the coordinate but never
-branches on it, so specialization is a correctness-preserving no-op for it. That
-test therefore verifies that:
+branches on it, so specialization skips cloning for it. That test therefore
+verifies that:
   * The specialized result matches a torch reference (numerical correctness).
   * The specialized result matches the default (unspecialized) path.
   * The dumped final MLIR shows these data-addressing kernels are NOT cloned
     (no `ttl.core_coord`), i.e. specialization safely declines to clone them.
 
-A third kernel (`branch_swap_*`) *does* branch on the coordinate: its reader
-selects a different source column depending on `core_x`, so specialization
+A second kernel (branch_swap_*) *does* branch on the coordinate: its reader
+selects a different source column depending on core_x, so specialization
 clones the reader per core and const-folds the branch. That test exercises the
 full clone-and-dispatch path end to end (the MLIR-only clone/fold checks live in
-the lit test test/ttlang/Dialect/TTL/Transforms/specialize_cores.mlir).
+the lit test test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir).
 """
 
 import os

--- a/test/python/test_specialize_cores.py
+++ b/test/python/test_specialize_cores.py
@@ -304,6 +304,94 @@ def test_specialize_cores_branch_matches_reference(device, monkeypatch, tmp_path
     _assert_reader_cloned(str(final_mlir))
 
 
+def _make_branch_swap_op():
+    """Return a fresh column-swap op with its own compilation cache.
+
+    The cache is keyed on tensor properties, not on env vars like
+    TTLANG_EMIT_RUNNER / TTLANG_COMPILE_ONLY, so tests that toggle those must
+    use distinct op objects or the cache hit skips the env-dependent codegen.
+    """
+
+    @ttl.operation(grid=(GRID_X, GRID_Y))
+    def branch_swap(a, out):
+        a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute_fn():
+            with a_dfb.wait() as a_tile, out_dfb.reserve() as o:
+                o.store(a_tile)
+
+        @ttl.datamovement()
+        def dm_read():
+            x, y = ttl.node(dims=2)
+            with a_dfb.reserve() as blk:
+                tx = ttl.copy(a[y, 0], blk)
+                if x == 0:
+                    tx = ttl.copy(a[y, 1], blk)
+                tx.wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            x, y = ttl.node(dims=2)
+            with out_dfb.wait() as blk:
+                tx = ttl.copy(blk, out[y, x])
+                tx.wait()
+
+    return branch_swap
+
+
+def test_specialize_cores_emit_runner_no_crash(device, monkeypatch, tmp_path):
+    """Regression: TTLANG_EMIT_RUNNER must stay clone-aligned.
+
+    The emit block indexed thread_tensor_indices (one per original thread)
+    against kernel_paths (one per clone), so it raised IndexError.
+    """
+    monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")
+    runner_path = tmp_path / "runner.py"
+    monkeypatch.setenv("TTLANG_EMIT_RUNNER", str(runner_path))
+    a, _ = _make_swap_inputs(device)
+    out = to_dram(
+        torch.zeros((GRID_Y * TILE_SIZE, GRID_X * TILE_SIZE), dtype=torch.bfloat16),
+        device,
+    )
+    _make_branch_swap_op()(a, out, options="--ttl-specialize-cores")
+    assert runner_path.exists(), "no runner emitted"
+
+
+@pytest.mark.xfail(
+    reason="emitted runner template cannot express per-clone dispatch: it "
+    "re-derives reader/writer from a positional counter and passes only the "
+    "whole-grid core_ranges, so every clone lands on every core and tt-metal "
+    "rejects it with TT_FATAL: Illegal NOC usage. Needs per-kernel core-range "
+    "and NOC-role constants in emit_runner_file.",
+    strict=True,
+    raises=RuntimeError,
+)
+def test_specialize_cores_emit_runner_executes(device, monkeypatch, tmp_path):
+    """The emitted runner, run standalone on a cold cache, must reproduce the swap.
+
+    Compile-only so the op never executes and warms the program cache; otherwise
+    the runner's custom_program_hash reuses the cached program and masks the
+    misdispatch. Strict xfail so it flags when the template is fixed.
+    """
+    import importlib.util
+
+    monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")
+    runner_path = tmp_path / "runner.py"
+    monkeypatch.setenv("TTLANG_EMIT_RUNNER", str(runner_path))
+    a, expected = _make_swap_inputs(device)
+    out = to_dram(torch.zeros_like(expected), device)
+    _make_branch_swap_op()(a, out, options="--ttl-specialize-cores")
+
+    spec = importlib.util.spec_from_file_location("emitted_runner", str(runner_path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.delenv("TTLANG_COMPILE_ONLY", raising=False)
+    module.run([a, out], device=device)
+    assert_pcc(expected, ttnn.to_torch(out))
+
+
 if __name__ == "__main__":
     # Manual repro: run the specialized path directly (no pytest) and print a
     # summary plus the specialized-vs-torch comparison.

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir
@@ -1,4 +1,4 @@
-t // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores)' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores)' | FileCheck %s
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores,canonicalize,cse)' | FileCheck %s --check-prefix=FOLDED
 
 // Summary: per-core specialization is a single module pass run at the TTKernel

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir
@@ -1,0 +1,152 @@
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores)' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores,canonicalize,cse)' | FileCheck %s --check-prefix=FOLDED
+
+// Summary: per-core specialization is a single module pass run at the TTKernel
+// level. For every kernel whose control flow branches on a core coordinate (an
+// `scf.if` whose condition is derived from `ttkernel.my_logical_x_` /
+// `my_logical_y_`), it clones the function once per launch coordinate, replaces
+// the coordinate reads with constants for that core, and tags the clone with
+// `ttl.core_coord`. Downstream canonicalize/cse fold the now-constant
+// conditions and delete the untaken regions. Kernels that only use coordinates
+// as data (no branch) are left as a single whole-grid binary. The pass does not
+// special-case pipe participants: any kernel that branches on a coordinate is
+// cloned, whether or not the module uses pipes.
+
+// -- Test 1: coordinate used only as data -> no branch, no specialization. ----
+// The coordinates feed an addi that reaches the return (a data use) and drive
+// no control flow, so the pass leaves the function as a single whole-grid
+// kernel with its coordinate reads intact.
+
+// CHECK-LABEL: func.func @kdata
+// CHECK-NOT:     ttl.core_coord
+// CHECK:         my_logical_x_
+// CHECK-NOT:   func.func @kdata_c
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @kdata() -> index {
+    %x = "ttkernel.my_logical_x_"() : () -> index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %s = arith.addi %x, %y : index
+    return %s : index
+  }
+}
+
+// -----
+
+// -- Test 2: coordinate drives a predicate -> per-core clones. ----------------
+// core_y feeds an scf.if condition, so the 1x4 grid yields four clones (one per
+// row). In each clone the coordinate read is replaced by a constant and the
+// clone is tagged with the single coordinate it serves. canonicalize/cse then
+// fold the condition: c0_0 takes the "then" (7); the rest take the "else" (9).
+
+// CHECK-NOT:   func.func @k2()
+// CHECK-LABEL: func.func @k2_c0_0
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 0]]
+// CHECK-NOT:     my_logical_y_
+// CHECK-LABEL: func.func @k2_c0_1
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 1]]
+// CHECK-LABEL: func.func @k2_c0_2
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 2]]
+// CHECK-LABEL: func.func @k2_c0_3
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 3]]
+
+// FOLDED-LABEL: func.func @k2_c0_0
+// FOLDED:         %[[C7:.*]] = arith.constant 7 : index
+// FOLDED:         return %[[C7]] : index
+// FOLDED-LABEL: func.func @k2_c0_1
+// FOLDED:         %[[C9:.*]] = arith.constant 9 : index
+// FOLDED:         return %[[C9]] : index
+// FOLDED-LABEL: func.func @k2_c0_2
+// FOLDED:         %[[C9A:.*]] = arith.constant 9 : index
+// FOLDED:         return %[[C9A]] : index
+// FOLDED-LABEL: func.func @k2_c0_3
+// FOLDED:         %[[C9B:.*]] = arith.constant 9 : index
+// FOLDED:         return %[[C9B]] : index
+
+module attributes {ttl.launch_grid = [1 : i64, 4 : i64]} {
+  func.func @k2() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+}
+
+// -----
+
+// -- Test 3: folding eliminates the untaken control-flow path. ---------------
+// Each branch holds a uniquely identifiable op that cannot be constant-folded
+// (it depends on the runtime %arg): `arith.muli` in the "then" path and
+// `arith.addi` in the "else" path. This isolates dead-path elimination from
+// constant folding of the yielded values. After the pass forces each clone's
+// coordinate constant, canonicalize deletes the untaken region (and its
+// now-unused op) and cse cleans up. Grid is 1x3, so y == 0 takes the "then"
+// (muli) and y in {1, 2} take the "else" (addi); no scf.if survives.
+
+// FOLDED-LABEL: func.func @sel_c0_0
+// FOLDED:         arith.muli
+// FOLDED-NOT:     arith.addi
+// FOLDED-NOT:     scf.if
+// FOLDED-LABEL: func.func @sel_c0_1
+// FOLDED:         arith.addi
+// FOLDED-NOT:     arith.muli
+// FOLDED-NOT:     scf.if
+// FOLDED-LABEL: func.func @sel_c0_2
+// FOLDED:         arith.addi
+// FOLDED-NOT:     arith.muli
+// FOLDED-NOT:     scf.if
+
+module attributes {ttl.launch_grid = [1 : i64, 3 : i64]} {
+  func.func @sel(%arg: index) -> index {
+    %c0 = arith.constant 0 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      %hot = arith.muli %arg, %arg : index
+      scf.yield %hot : index
+    } else {
+      %cold = arith.addi %arg, %arg : index
+      scf.yield %cold : index
+    }
+    return %r : index
+  }
+}
+
+// -----
+
+// -- Test 4: pipe participants are specialized like any other kernel. --------
+// The module used a pipe, so a semaphore op is present. The pass no longer
+// special-cases pipes: because core_y drives an scf.if, the 1x2 grid is cloned
+// per row. The semaphore op is carried into each clone unchanged.
+
+// CHECK-NOT:   func.func @kpipe()
+// CHECK-LABEL: func.func @kpipe_c0_0
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 0]]
+// CHECK:         ttkernel.get_semaphore
+// CHECK-LABEL: func.func @kpipe_c0_1
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 1]]
+// CHECK:         ttkernel.get_semaphore
+
+module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
+  func.func @kpipe() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
+    %sem = ttkernel.get_semaphore(%c0) : (index) -> !ttkernel.local_semaphore
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+}

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores)' | FileCheck %s
+t // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores)' | FileCheck %s
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttkernel-specialize-cores,canonicalize,cse)' | FileCheck %s --check-prefix=FOLDED
 
 // Summary: per-core specialization is a single module pass run at the TTKernel
@@ -140,6 +140,83 @@ module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
     %c7 = arith.constant 7 : index
     %c9 = arith.constant 9 : index
     %sem = ttkernel.get_semaphore(%c0) : (index) -> !ttkernel.local_semaphore
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+}
+
+// -----
+
+// -- Test 5: single-core launch grid is a legitimate no-op. ------------------
+// A valid `ttl.launch_grid` whose product is <= 1 has nothing to specialize
+// CHECK-LABEL: func.func @ksingle
+// CHECK-NOT:     ttl.core_coord
+// CHECK:         my_logical_y_
+// CHECK-NOT:   func.func @ksingle_c
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @ksingle() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+}
+
+// -----
+
+// -- Test 6: functions with symbol uses are skipped, others still clone. -----
+// `kcallee` branches on a coordinate but is referenced by `kcaller`, so it is
+// left unspecialized (erasing it would leave a dangling call). `kleaf` has no
+// symbol uses and is still cloned per core.
+
+// CHECK-LABEL: func.func @kcallee
+// CHECK-NOT:     ttl.core_coord
+// CHECK:         my_logical_y_
+// CHECK-NOT:   func.func @kcallee_c
+// CHECK-LABEL: func.func @kcaller
+// CHECK:         call @kcallee
+// CHECK-NOT:   func.func @kleaf()
+// CHECK-LABEL: func.func @kleaf_c0_0
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 0]]
+// CHECK-LABEL: func.func @kleaf_c0_1
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 1]]
+
+module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
+  func.func @kcallee() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+  func.func @kcaller() -> index {
+    %r = func.call @kcallee() : () -> index
+    return %r : index
+  }
+  func.func @kleaf() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
     %y = "ttkernel.my_logical_y_"() : () -> index
     %pred = arith.cmpi eq, %y, %c0 : index
     %r = scf.if %pred -> (index) {

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_idempotent.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_idempotent.mlir
@@ -1,0 +1,37 @@
+// Summary: ttkernel-specialize-cores is idempotent. The first run clones a
+// branching kernel per launch coordinate and replaces coordinate reads with
+// constants, so clones no longer branch on my_logical_*. A second run must be
+// a no-op: same clone set, no double-suffixed symbols like @k_c0_0_c0_0, and
+// re-running on the once-specialized IR must be a bit-identical no-op.
+
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-cores)' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-cores,ttkernel-specialize-cores)' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-cores)' -o %t.once
+// RUN: ttlang-opt %t.once -pass-pipeline='builtin.module(ttkernel-specialize-cores)' | diff -u %t.once -
+
+// CHECK-NOT:   func.func @k()
+// CHECK-LABEL: func.func @k_c0_0
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 0]]
+// CHECK-LABEL: func.func @k_c1_0
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}1, 0]]
+// CHECK-LABEL: func.func @k_c0_1
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}0, 1]]
+// CHECK-LABEL: func.func @k_c1_1
+// CHECK-SAME:    ttl.core_coord = {{\[\[}}1, 1]]
+// CHECK-NOT:   func.func @k_c{{.*}}_c
+
+module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
+  func.func @k() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
+    %x = "ttkernel.my_logical_x_"() : () -> index
+    %pred = arith.cmpi eq, %x, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+}

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_invalid.mlir
@@ -1,0 +1,90 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttkernel-specialize-cores)'
+
+// Negative cases for ttkernel-specialize-cores. The pass is opt-in
+// (--ttl-specialize-cores), so a launch grid it cannot use, or a function it
+// cannot safely clone, must be a diagnostic rather than a silent no-op.
+
+// -- Missing launch grid. -----------------------------------------------------
+// A kernel branches on the coordinate but the module carries no
+// `ttl.launch_grid`, so the pass has no per-core extent to specialize over.
+
+// expected-error @+1 {{requires a `ttl.launch_grid`}}
+module {
+  func.func @no_grid() -> index {
+    %c0 = arith.constant 0 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c0 : index
+    } else {
+      scf.yield %y : index
+    }
+    return %r : index
+  }
+}
+
+// -----
+
+// -- Malformed launch grid: wrong length. -------------------------------------
+
+// expected-error @+1 {{length-2 array of positive}}
+module attributes {ttl.launch_grid = [2 : i64]} {
+  func.func @bad_len() -> index {
+    %c0 = arith.constant 0 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c0 : index
+    } else {
+      scf.yield %y : index
+    }
+    return %r : index
+  }
+}
+
+// -----
+
+// -- Malformed launch grid: non-positive extent. ------------------------------
+
+// expected-error @+1 {{length-2 array of positive}}
+module attributes {ttl.launch_grid = [2 : i64, 0 : i64]} {
+  func.func @zero_extent() -> index {
+    %c0 = arith.constant 0 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c0 : index
+    } else {
+      scf.yield %y : index
+    }
+    return %r : index
+  }
+}
+
+// -----
+
+// -- Function with symbol uses is skipped, not fatal. -------------------------
+// Cloning renames the function and erases the original, leaving any caller
+// dangling. Since inter-function SymbolRefAttr fixups are not performed, the
+// pass leaves such a function un-specialized (a warning, not an error) so
+// unrelated functions still get specialized. If it wrongly cloned and erased
+// @helper, @caller's call would dangle and surface here as an unexpected error.
+
+module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
+  // expected-warning @+1 {{not specializing}}
+  func.func @helper() -> index {
+    %c0 = arith.constant 0 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c0 : index
+    } else {
+      scf.yield %y : index
+    }
+    return %r : index
+  }
+  func.func @caller() -> index {
+    %v = func.call @helper() : () -> index
+    return %v : index
+  }
+}

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_skip.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_skip.mlir
@@ -1,0 +1,48 @@
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-cores)' --verify-diagnostics
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-cores)' 2>/dev/null | FileCheck %s
+
+// Skipping one function does not block the others. `@used` branches on a
+// coordinate but has a caller, so it is left un-specialized (warning, not
+// fatal). `@free` branches too but has no caller, so it is still cloned per
+// launch coordinate. The 1x2 grid yields @free_c0_0 and @free_c0_1; @used and
+// its caller are untouched.
+
+// CHECK-DAG: func.func @used()
+// CHECK-DAG: func.func @caller()
+// CHECK-DAG: func.func @free_c0_0
+// CHECK-DAG: func.func @free_c0_1
+// CHECK-NOT: func.func @used_c
+
+module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
+  // expected-warning @+1 {{not specializing}}
+  func.func @used() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+  func.func @caller() -> index {
+    %v = func.call @used() : () -> index
+    return %v : index
+  }
+  func.func @free() -> index {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    %c9 = arith.constant 9 : index
+    %y = "ttkernel.my_logical_y_"() : () -> index
+    %pred = arith.cmpi eq, %y, %c0 : index
+    %r = scf.if %pred -> (index) {
+      scf.yield %c7 : index
+    } else {
+      scf.yield %c9 : index
+    }
+    return %r : index
+  }
+}


### PR DESCRIPTION
### Problem description
A kernel's core coordinate (ttl.node) is only known per-core at runtime (it lowers to the hardware reads ttkernel.my_logical_x_ / my_logical_y_), so kernels cannot constant-fold control flow that branches on it. By cloning such a kernel per launch coordinate and replacing the coordinate reads with per-core constants, the branch conditions become constant and upstream passes like CSE can be leveraged  (dead code elimination/constant folding can go brrrrrr).

The specialized clones also need a runtime path that can dispatch more than one reader/writer binary: each clone must keep its NOC role and launch only on its own cores. NOC kernels roles need to be updated to be determined via `noc_kernel_idx` rather than position.

### What's changed

- Add an opt-in ModuleOp pass that runs at the TTKernel level, right before EmitC. For every kernel whose control flow branches on a core coordinate (an scf.if whose condition derives from ttkernel.my_logical_x_ / my_logical_y_), the pass clones the function per launch coordinate to leverage canonicalize/cse. 
- Wire --ttl-specialize-cores through the C++ / Python / ME2E pipelines (disabled by default).
- Runtime bridge (_compile_ttnn_kernel): assign Reader/Writer from ttl.noc_index instead of using positional counter, and dispatch each clone with a per-kernel CoreRangeSet from ttl.core_coord / ttl.crta_indices
- Emitted runner: bake per-kernel core ranges and NOC roles into the generated template so standalone cold runs match in-process dispatch.

NOTE: This pass is disable by default as I wasn't sure if we wanted it to be part of the main pipeline yet or not

**TODOs:**

-  Currently the pass clones the function once per launch coordinate but we should consider leveraging LaunchDomainAnalysis from TTL to further minimize clones, or do further analysis so clones are not duplicate

- Per-core compile-time / runtime arg specialization and inter-function `SymbolRefAttr` fixups are not performed.

Tests:
- Lit coverage for per-core cloning, dead-branch folding, the data-only no-clone case, and pipe participants.
- End-to-end add/matmul (coordinate used only for addressing, so no clone) and a column-swap reader that branches on core_x (cloned per core, matches a torch reference and the unspecialized path).


### Ticket
[Link](https://github.com/tenstorrent/tt-lang-ops-and-models/issues/6) 
