### PR TITLE
[uplift-B] Uplift tt-metal to v0.75.0-dev20260715 (S3-only)

### DIFF
--- a/third-party/patches/ttmetal-precompile-fw-not-all.patch
+++ b/third-party/patches/ttmetal-precompile-fw-not-all.patch
@@ -1,27 +1,27 @@
 diff --git a/tt_metal/tools/precompile_fw/CMakeLists.txt b/tt_metal/tools/precompile_fw/CMakeLists.txt
-index 5611f6c0a7..1d39f4b00f 100644
+index 73206d206f7..b2ddbcc7081 100644
 --- a/tt_metal/tools/precompile_fw/CMakeLists.txt
 +++ b/tt_metal/tools/precompile_fw/CMakeLists.txt
-@@ -24,7 +24,12 @@ add_custom_command(
-     OUTPUT
-         ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp
-     COMMAND
--        ${CMAKE_COMMAND} -E env ASAN_OPTIONS=detect_odr_violation=0 $<TARGET_FILE:precompile_fw>
-+        ${CMAKE_COMMAND} -E env
-+            ASAN_OPTIONS=detect_odr_violation=0
-+            TT_METAL_RUNTIME_ROOT=${PROJECT_SOURCE_DIR}
-+            TT_METAL_HOME=${PROJECT_SOURCE_DIR}
-+            TT_METAL_CACHE=${PROJECT_BINARY_DIR}/tt-metal-cache
-+            $<TARGET_FILE:precompile_fw>
-     COMMAND
-         ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp
-     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-@@ -33,7 +38,7 @@ add_custom_command(
-     COMMENT "Pre-compiling firmware binaries"
- )
+@@ -24,7 +24,12 @@ if(NOT TT_METAL_SKIP_LINKING)
+         OUTPUT
+             ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp
+         COMMAND
+-            ${CMAKE_COMMAND} -E env ASAN_OPTIONS=detect_odr_violation=0 $<TARGET_FILE:precompile_fw>
++            ${CMAKE_COMMAND} -E env
++                ASAN_OPTIONS=detect_odr_violation=0
++                TT_METAL_RUNTIME_ROOT=${PROJECT_SOURCE_DIR}
++                TT_METAL_HOME=${PROJECT_SOURCE_DIR}
++                TT_METAL_CACHE=${PROJECT_BINARY_DIR}/tt-metal-cache
++                $<TARGET_FILE:precompile_fw>
+         COMMAND
+             ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+@@ -33,7 +38,7 @@ if(NOT TT_METAL_SKIP_LINKING)
+         COMMENT "Pre-compiling firmware binaries"
+     )
 
--add_custom_target(precompile-fw ALL DEPENDS ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp)
-+add_custom_target(precompile-fw DEPENDS ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp)
-
- if(TT_INSTALL)
-     install(
+-    add_custom_target(precompile-fw ALL DEPENDS ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp)
++    add_custom_target(precompile-fw DEPENDS ${PROJECT_BINARY_DIR}/tt_metal/pre-compiled/.stamp)
+ else()
+     add_custom_target(precompile-fw ALL)
+ endif()

--- a/third-party/tt-metal-version
+++ b/third-party/tt-metal-version
@@ -36,4 +36,7 @@
 
 TTNN_PYPI="0.74.0"
 TTNN_PYPI_TT_METAL_TAG="v0.74.0"
-TT_METAL_TAG="v0.74.0"
+# DANGER: public PyPI publish is blocked until TT_METAL_TAG and
+# TTNN_PYPI_TT_METAL_TAG share the same vX.Y.Z component. See
+# docs/sphinx/build.md#publishing-to-s3-pypi.
+TT_METAL_TAG="v0.75.0-dev20260715"


### PR DESCRIPTION
### Problem description

Building on the PyPI-aligned base in `[uplift-A]`, the S3 development wheels should track the latest tagged tt-metal build. Public `ttnn` has nothing newer than `0.74.0`, so advancing `TT_METAL_TAG` past it intentionally keeps this wheel S3-only until a matching public `ttnn` ships. Splitting the work this way means `[uplift-A]` can still cut a public PyPI release while this change picks up the newest tt-metal.

### What's changed

- Bump `third-party/tt-metal` to `v0.75.0-dev20260715` (`e908c31332b6`) and set `TT_METAL_TAG` accordingly. `TTNN_PYPI` and `TTNN_PYPI_TT_METAL_TAG` stay at `0.74.0` and `v0.74.0`, so the two tags diverge on their `vX.Y.Z` component and the wheel remains S3-only. LLVM is unchanged from `[uplift-A]`.
- Restore the `DANGER` note recording that public PyPI publishing is blocked at this pin.
- Regenerate `third-party/patches/ttmetal-precompile-fw-not-all.patch` for the v0.75 line, where the `precompile_fw` block moved under an `if(NOT TT_METAL_SKIP_LINKING)` guard so the previous patch context no longer matched and the toolchain configure aborted. The regenerated patch preserves both original edits: the `TT_METAL_*` env expansion of the `precompile_fw` invocation, and dropping `ALL` from the `precompile-fw` target so firmware precompilation stays out of the default build.

### Testing

Built the v0.75 toolchain into a separate prefix and built tt-lang against it; `check-ttlang-mlir` passes with 171 of 172 tests and one expected failure. Both tt-metal patches apply cleanly at `v0.75.0-dev20260715`. Stacked on `[uplift-A]`, which carries the shared LLVM bump.
