### PR TITLE
[ci][nfc] Allow manual PyPI publishing from a commit SHA; fix out of space errors

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,5 +5,5 @@ self-hosted-runner:
   labels:
     - mlir-large-runner-lang
     - n150
-    - n300-llmbox
+    - bh-loudbox-viommu
     - tt-ubuntu-2204-*-stable

--- a/.github/scripts/require-release-tag.sh
+++ b/.github/scripts/require-release-tag.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 ref="${1:-${GITHUB_REF:-}}"
 if [[ ! "$ref" =~ ^refs/tags/v[0-9] ]]; then
     echo "Release ref must be a v* tag (got '$ref')." >&2
+    echo "Create and push a tag like 'vX.Y.Z', or pass 'refs/tags/vX.Y.Z' as release-ref." >&2
     exit 1
 fi
 

--- a/.github/scripts/require-release-tag.sh
+++ b/.github/scripts/require-release-tag.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 ref="${1:-${GITHUB_REF:-}}"
 if [[ ! "$ref" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
-    echo "Release ref must match vX.Y.Z or vX.Y.Z-<prerelease> (got '$ref')." >&2
+    echo "Release ref must match refs/tags/vX.Y.Z or refs/tags/vX.Y.Z-<prerelease> (got '$ref')." >&2
     echo "Create and push a tag like 'vX.Y.Z', or pass 'refs/tags/vX.Y.Z' as release-ref." >&2
     exit 1
 fi

--- a/.github/scripts/require-release-tag.sh
+++ b/.github/scripts/require-release-tag.sh
@@ -2,20 +2,19 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Refuse to run unless GITHUB_REF points at a v[0-9]* release tag, then print
-# the version (tag with leading 'v' stripped) for downstream steps.
+# Refuse to run unless the supplied ref, or GITHUB_REF by default, points at a
+# v[0-9]* release tag, then print the version for downstream steps.
 #
-# Usage: .github/scripts/require-release-tag.sh
-# Reads:  $GITHUB_REF
+# Usage: .github/scripts/require-release-tag.sh [release-ref]
+# Reads:  $GITHUB_REF when release-ref is omitted
 # Writes: tag_version=<MAJOR.MINOR.PATCH...> to $GITHUB_OUTPUT (if set)
 # Stdout: <MAJOR.MINOR.PATCH...>
 
 set -euo pipefail
 
-ref="${GITHUB_REF:-}"
+ref="${1:-${GITHUB_REF:-}}"
 if [[ ! "$ref" =~ ^refs/tags/v[0-9] ]]; then
-    echo "This workflow must be dispatched from a v* tag (got '$ref')." >&2
-    echo "Create and push a tag like 'vX.Y.Z', then dispatch from that tag." >&2
+    echo "Release ref must be a v* tag (got '$ref')." >&2
     exit 1
 fi
 

--- a/.github/scripts/require-release-tag.sh
+++ b/.github/scripts/require-release-tag.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Refuse to run unless the supplied ref, or GITHUB_REF by default, points at a
-# v[0-9]* release tag, then print the version for downstream steps.
+# Refuse to run unless the supplied ref, or GITHUB_REF by default, identifies a
+# public PyPI release tag, then print the version for downstream steps.
 #
 # Usage: .github/scripts/require-release-tag.sh [release-ref]
 # Reads:  $GITHUB_REF when release-ref is omitted
@@ -13,8 +13,8 @@
 set -euo pipefail
 
 ref="${1:-${GITHUB_REF:-}}"
-if [[ ! "$ref" =~ ^refs/tags/v[0-9] ]]; then
-    echo "Release ref must be a v* tag (got '$ref')." >&2
+if [[ ! "$ref" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    echo "Release ref must match vX.Y.Z or vX.Y.Z-<prerelease> (got '$ref')." >&2
     echo "Create and push a tag like 'vX.Y.Z', or pass 'refs/tags/vX.Y.Z' as release-ref." >&2
     exit 1
 fi
@@ -23,9 +23,9 @@ tag_version_raw="${ref#refs/tags/v}"
 
 # Normalize to the PEP 440 canonical form so it matches what setuptools writes
 # into the wheel filename (tag 'vX.Y.Z-devYYYYMMDD' -> wheel version
-# 'X.Y.Z.devYYYYMMDD'; tag 'vX.Y.Z-rcN' -> 'X.Y.ZrcN'; tag 'vX.Y.Z+local'
-# unchanged). verify-wheel-version.sh compares the wheel filename's version
-# field to this output, so both must use the canonical form.
+# 'X.Y.Z.devYYYYMMDD'; tag 'vX.Y.Z-rcN' -> 'X.Y.ZrcN').
+# verify-wheel-version.sh compares the wheel filename's version field to this
+# output, so both must use the canonical form.
 set +e
 tag_version=$(python3 - "$tag_version_raw" <<'PY'
 import sys
@@ -41,7 +41,7 @@ set -e
 
 if [[ $rc -ne 0 ]]; then
     echo "Tag '${ref#refs/tags/}' is not a valid PEP 440 version." >&2
-    echo "  Use forms like vX.Y.Z, vX.Y.Z-rcN, vX.Y.Z-devYYYYMMDD, or vX.Y.Z+local." >&2
+    echo "  Use forms like vX.Y.Z, vX.Y.Z-rcN, or vX.Y.Z-devYYYYMMDD." >&2
     exit 1
 fi
 

--- a/.github/scripts/tests/test_require_release_tag.bats
+++ b/.github/scripts/tests/test_require_release_tag.bats
@@ -39,6 +39,11 @@ setup() {
     assert_failure
 }
 
+@test "explicit release ref overrides GITHUB_REF" {
+    GITHUB_REF="refs/heads/main" run -0 "$SCRIPT" "$REF"
+    assert_output "$BASE"
+}
+
 @test "rejects malformed PEP 440 segment with a clean message" {
     GITHUB_REF="${REF}-foobar" run --separate-stderr "$SCRIPT"
     assert_failure

--- a/.github/scripts/tests/test_require_release_tag.bats
+++ b/.github/scripts/tests/test_require_release_tag.bats
@@ -93,14 +93,14 @@ setup() {
     assert_output "${BASE}.post1"
 }
 
-@test "local version label (+uplift)" {
-    GITHUB_REF="${REF}+uplift" run -0 "$SCRIPT"
-    assert_output "${BASE}+uplift"
+@test "rejects local version label (+uplift)" {
+    GITHUB_REF="${REF}+uplift" run "$SCRIPT"
+    assert_failure
 }
 
-@test "dev + local combined" {
-    GITHUB_REF="${REF}-dev20260515+ci123" run -0 "$SCRIPT"
-    assert_output "${BASE}.dev20260515+ci123"
+@test "rejects dev + local combined" {
+    GITHUB_REF="${REF}-dev20260515+ci123" run "$SCRIPT"
+    assert_failure
 }
 
 # PEP 440 specifies that pre-release segment markers are case-insensitive and

--- a/.github/scripts/tests/test_require_release_tag.bats
+++ b/.github/scripts/tests/test_require_release_tag.bats
@@ -20,8 +20,10 @@ setup() {
 # --- Rejection cases ---
 
 @test "rejects branch ref" {
-    GITHUB_REF="refs/heads/main" run "$SCRIPT"
+    GITHUB_REF="refs/heads/main" run --separate-stderr "$SCRIPT"
     assert_failure
+    [[ "$stderr" == *"pass 'refs/tags/vX.Y.Z' as release-ref"* ]] \
+        || fail "stderr missing recovery instructions: $stderr"
 }
 
 @test "rejects empty ref" {

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -84,6 +84,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Maximize space
+        uses: tenstorrent/tt-github-actions/.github/actions/maximize_space@main
+
       - name: Checkout tt-lang
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -172,6 +172,12 @@ jobs:
           source /opt/ttlang-toolchain/venv/bin/activate
           python .github/scripts/check-wheel-bundled-payload.py --dist-dir dist
 
+      - name: Free disk space before wheel installation tests
+        run: |
+          rm -rf /tmp/ttlang-prefix build dist-raw .wheel-patch-src
+          python3.12 -m pip cache purge || true
+          df -h
+
       - name: Test tt-lang wheel
         run: |
           python3.12 -m venv /tmp/test-venv-hw
@@ -185,7 +191,7 @@ jobs:
 
       - name: Free disk space before remaining wheel tests
         run: |
-          rm -rf /tmp/test-venv-hw /tmp/ttlang-prefix build dist-raw
+          rm -rf /tmp/test-venv-hw
           python3.12 -m pip cache purge || true
           df -h
 

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -121,7 +121,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                runner: [n150, n300-llmbox]
+                runner: [n150, bh-loudbox-viommu]
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:

--- a/.github/workflows/call-test-dist-tutorials.yml
+++ b/.github/workflows/call-test-dist-tutorials.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: 'latest'
+      ttlang_sha_override:
+        description: 'tt-lang SHA/tag to test. Leave empty to use the caller ref.'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       runs-on:
@@ -35,6 +40,11 @@ on:
         required: false
         type: string
         default: 'latest'
+      ttlang_sha_override:
+        description: 'tt-lang SHA/tag to test. Leave empty to use the caller ref.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   checks: write
@@ -67,6 +77,7 @@ jobs:
       - name: Checkout (for test script)
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
           fetch-depth: 1
 
       - name: Run tutorial examples

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -61,7 +61,6 @@ jobs:
       RUNS_ON: ${{ inputs.runs-on }}
       PYTHONDONTWRITEBYTECODE: 1
       TTLANG_TEST_SEED: 42
-      HW_PYTEST_CHIPS: 1
 
     steps:
       - name: Checkout tt-lang

--- a/.github/workflows/debug-hardware.yml
+++ b/.github/workflows/debug-hardware.yml
@@ -10,10 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       runs-on:
-        description: 'Hardware type (runner suffix), e.g. n150, n300-llmbox'
+        description: 'Hardware type (runner suffix), e.g. n150, bh-loudbox-viommu'
         required: false
         type: string
-        default: 'n300-llmbox'
+        default: 'bh-loudbox-viommu'
       pytest_args:
         description: 'Pytest selection, e.g. test/python/test_reduce.py -k "reduce_multi_tile and fp32"'
         required: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,6 +13,10 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
     inputs:
+      ttlang_sha:
+        description: "Full SHA of the release-tagged tt-lang commit to publish."
+        type: string
+        required: true
       docker_tag:
         description: "Docker image tag for the ird container."
         type: string
@@ -35,12 +39,45 @@ jobs:
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Echo dispatch inputs
         if: github.event_name == 'workflow_dispatch'
         run: |
           echo "dry_run=${{ inputs.dry_run }}"
           echo "docker_tag=${{ inputs.docker_tag }}"
+          echo "ttlang_sha=${{ inputs.ttlang_sha }}"
+
+      - name: Validate tt-lang SHA
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TTLANG_SHA: ${{ inputs.ttlang_sha }}
+        run: |
+          if [[ ! "$TTLANG_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::ttlang_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+          if [[ "$(git rev-parse HEAD)" != "${TTLANG_SHA,,}" ]]; then
+            echo "::error::Checked-out commit does not match ttlang_sha."
+            exit 1
+          fi
+
+      - name: Require publish target from main
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != true }}
+        env:
+          TTLANG_SHA: ${{ inputs.ttlang_sha }}
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Public PyPI publishing is restricted to workflow dispatches from refs/heads/main."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$TTLANG_SHA" "$GITHUB_SHA"; then
+            echo "::error::ttlang_sha must be an ancestor of the dispatching main commit."
+            exit 1
+          fi
 
       - name: Install packaging (for PEP 440 normalization in require-release-tag.sh)
         if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
@@ -49,7 +86,19 @@ jobs:
       - name: Require release tag
         id: parse
         if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
-        run: .github/scripts/require-release-tag.sh
+        env:
+          TTLANG_SHA: ${{ inputs.ttlang_sha }}
+        run: |
+          release_ref="$GITHUB_REF"
+          if [[ -n "$TTLANG_SHA" ]]; then
+            mapfile -t release_tags < <(git tag --list 'v[0-9]*' --points-at "$TTLANG_SHA")
+            if [[ ${#release_tags[@]} -ne 1 ]]; then
+              echo "::error::ttlang_sha must have exactly one v* release tag; found ${#release_tags[@]}."
+              exit 1
+            fi
+            release_ref="refs/tags/${release_tags[0]}"
+          fi
+          .github/scripts/require-release-tag.sh "$release_ref"
 
       - name: Require PyPI ttnn alignment
         if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
@@ -66,6 +115,7 @@ jobs:
     secrets: inherit
     with:
       push: true
+      ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
   build-wheels:
     needs: [preflight, build-docker]
@@ -76,6 +126,7 @@ jobs:
     uses: ./.github/workflows/call-build-wheels.yml
     with:
       docker_tag: ${{ (github.event_name == 'workflow_dispatch' && inputs.docker_tag != '' && inputs.docker_tag) || needs.build-docker.outputs.docker-tag }}
+      ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
   test-dist-tutorials:
     needs: [preflight, build-docker, build-wheels]

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -37,30 +37,39 @@ jobs:
     outputs:
       tag_version: ${{ steps.parse.outputs.tag_version }}
     steps:
-      - name: Checkout tt-lang
+      - name: Checkout workflow source
+        uses: actions/checkout@v6
+
+      - name: Checkout release source
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ttlang_sha || github.sha }}
+          path: release-source
           fetch-depth: 0
           fetch-tags: true
 
       - name: Echo dispatch inputs
         if: github.event_name == 'workflow_dispatch'
+        env:
+          DISPATCH_DOCKER_TAG: ${{ inputs.docker_tag }}
+          DISPATCH_DRY_RUN: ${{ inputs.dry_run }}
+          TTLANG_SHA: ${{ inputs.ttlang_sha }}
         run: |
-          echo "dry_run=${{ inputs.dry_run }}"
-          echo "docker_tag=${{ inputs.docker_tag }}"
-          echo "ttlang_sha=${{ inputs.ttlang_sha }}"
+          echo "dry_run=$DISPATCH_DRY_RUN"
+          echo "docker_tag=$DISPATCH_DOCKER_TAG"
+          echo "ttlang_sha=$TTLANG_SHA"
 
       - name: Validate tt-lang SHA
         if: github.event_name == 'workflow_dispatch'
         env:
           TTLANG_SHA: ${{ inputs.ttlang_sha }}
         run: |
+          release_source="$GITHUB_WORKSPACE/release-source"
           if [[ ! "$TTLANG_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
             echo "::error::ttlang_sha must be a full 40-character commit SHA."
             exit 1
           fi
-          if [[ "$(git rev-parse HEAD)" != "${TTLANG_SHA,,}" ]]; then
+          if [[ "$(git -C "$release_source" rev-parse HEAD)" != "${TTLANG_SHA,,}" ]]; then
             echo "::error::Checked-out commit does not match ttlang_sha."
             exit 1
           fi
@@ -70,11 +79,12 @@ jobs:
         env:
           TTLANG_SHA: ${{ inputs.ttlang_sha }}
         run: |
+          release_source="$GITHUB_WORKSPACE/release-source"
           if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
             echo "::error::Public PyPI publishing is restricted to workflow dispatches from refs/heads/main."
             exit 1
           fi
-          if ! git merge-base --is-ancestor "$TTLANG_SHA" "$GITHUB_SHA"; then
+          if ! git -C "$release_source" merge-base --is-ancestor "$TTLANG_SHA" "$GITHUB_SHA"; then
             echo "::error::ttlang_sha must be an ancestor of the dispatching main commit."
             exit 1
           fi
@@ -87,11 +97,12 @@ jobs:
         id: parse
         if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
         env:
+          RELEASE_SOURCE: ${{ github.workspace }}/release-source
           TTLANG_SHA: ${{ inputs.ttlang_sha }}
         run: |
           release_ref="$GITHUB_REF"
           if [[ -n "$TTLANG_SHA" ]]; then
-            mapfile -t release_tags < <(git tag --list 'v[0-9]*' --points-at "$TTLANG_SHA")
+            mapfile -t release_tags < <(git -C "$RELEASE_SOURCE" tag --list 'v[0-9]*' --points-at "$TTLANG_SHA")
             if [[ ${#release_tags[@]} -ne 1 ]]; then
               echo "::error::ttlang_sha must have exactly one v* release tag; found ${#release_tags[@]}."
               exit 1
@@ -102,6 +113,8 @@ jobs:
 
       - name: Require PyPI ttnn alignment
         if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
+        env:
+          TTLANG_TT_METAL_VERSION_FILE: ${{ github.workspace }}/release-source/third-party/tt-metal-version
         run: .github/scripts/require-pypi-ttnn-alignment.sh
 
   build-docker:
@@ -140,11 +153,12 @@ jobs:
     with:
       runs-on: n150
       dist_docker_tag: ${{ (github.event_name == 'workflow_dispatch' && inputs.docker_tag != '' && inputs.docker_tag) || needs.build-docker.outputs.docker-tag }}
+      ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
   publish:
     name: "Publish to PyPI"
     needs: [preflight, build-wheels, test-dist-tutorials]
-    if: ${{ (github.event_name == 'push' || inputs.dry_run != true) && needs.test-dist-tutorials.result == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != true && needs.test-dist-tutorials.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -527,12 +527,12 @@ they cannot be distinguished by `pip install`. Prefer `-dev<YYYYMMDD>` or
 (publishing-to-pypi)=
 #### Publishing to PyPI
 
-`publish-pypi.yml` is the orchestrator that turns a release tag into a wheel
-on PyPI. It triggers automatically on push of `v*.*.*`, `v*.*.*-rc*`,
-`v*.*.*-dev*`, or `v*.*.*+*` tags, and can also be dispatched manually for
-re-runs and dry-runs. Manual dispatch takes the full SHA of the release-tagged
-commit to build. Non-dry-run dispatches must run from `refs/heads/main`, and
-the selected commit must be an ancestor of the dispatching main commit.
+`publish-pypi.yml` prepares release images and wheels on release-tag pushes,
+but PyPI upload requires a manual dispatch from `refs/heads/main`. Manual
+dispatch takes the full SHA of the release-tagged commit and an existing IRD
+Docker tag. The selected commit must be an ancestor of the dispatching main
+commit and must have exactly one supported public release tag (`vX.Y.Z` or
+`vX.Y.Z-<prerelease>`). Local-version tags containing `+` are rejected.
 
 ```text
    push release tag
@@ -540,7 +540,7 @@ the selected commit must be an ancestor of the dispatching main commit.
           |
           v
    +--------------+
-   |  preflight   |   resolve and verify the v* release tag
+   |  preflight   |   verify the selected source and release tag
    +--------------+   (release checks skipped if dry_run=true)
           |
           v
@@ -557,31 +557,34 @@ the selected commit must be an ancestor of the dispatching main commit.
           +-----------------------+
           v                       |
    +---------------------+        |
-   | test-dist-tutorials |        |  (skipped under dry_run=true)
+   | test-dist-tutorials |        |  (also runs for dry runs)
    +---------------------+        |
-          |                       |
+          | workflow_dispatch     |
+          | with dry_run=false    |
           +-----------------------+
           v                       v
    +--------------+        +------------------+
    |   publish    |        | dry-run-summary  |
    +--------------+        +------------------+
-   tag push or              workflow_dispatch
-   dry_run=false            with dry_run=true
+   workflow_dispatch        workflow_dispatch
+   from main with           with dry_run=true
+   dry_run=false
    (uploads to PyPI)        (lists artifacts only)
+
+   Release-tag pushes complete after test-dist-tutorials.
 ```
 
 Job-by-job:
 
-1. **`preflight`** — checks out the `ttlang_sha` input for manual runs, verifies
-   that publish targets are ancestors of the dispatching main commit, resolves
-   the commit's release tag, and runs `require-release-tag.sh`. It then runs
-   `require-pypi-ttnn-alignment.sh`, which fails when the public `ttnn` wheel
-   recorded in `third-party/tt-metal-version` was built from a different
-   tt-metal `vX.Y.Z` component than TT-Lang. Skipped under `dry_run: true`. Exposes
-   `tag_version` (tag with leading `v` stripped) for the wheel-version check.
-2. **`build-docker`** — calls `call-build-docker.yml` on tag push (where no
-   `docker_tag` input is supplied). Skipped on `workflow_dispatch`, which
-   requires `docker_tag`. Outputs the freshly built ird tag.
+1. **`preflight`** — keeps the workflow source checkout separate from the
+   selected release source. For manual publishing, it verifies that
+   `ttlang_sha` is an ancestor of the dispatching main commit and resolves the
+   release tag. Current workflow scripts validate that tag and the selected
+   source's `third-party/tt-metal-version`. Release checks are skipped under
+   `dry_run: true`. Exposes `tag_version` for the wheel-version check.
+2. **`build-docker`** — calls `call-build-docker.yml` on tag pushes and emits
+   the release Docker tag. Manual dispatch requires an existing `docker_tag`,
+   so this job is skipped.
 3. **`build-wheels`** — calls `call-build-wheels.yml` against either the
    `docker_tag` input (manual dispatch) or the `build-docker` output (tag
    push). Builds the wheel inside the ird container, runs
@@ -589,14 +592,15 @@ Job-by-job:
    + `tt-lang-sim-stats --help`), and runs the CMake-install regression test
    (`cmake --install` + `bin/tt-lang-sim --help` against the parallel-install
    layout). Uploads the result as the `tt-lang-wheels` artifact.
-4. **`test-dist-tutorials`**: calls `call-test-dist-tutorials.yml` against
-   the dist image at the resolved tag, running the tutorial suite on the
-   `n150` hardware runner. Gates `publish`. Skipped under `dry_run: true`.
-5. **`publish`**: runs on tag push or when `dry_run` is false **and**
-   `test-dist-tutorials` succeeded. Downloads the artifact, verifies every
-   wheel filename's version field matches `preflight.outputs.tag_version`,
-   and uploads via `pypa/gh-action-pypi-publish` using OIDC trusted
-   publishing (`environment: pypi`, `id-token: write`).
+4. **`test-dist-tutorials`**: checks out the selected source and calls
+   `call-test-dist-tutorials.yml` against the matching dist image on the
+   `n150` hardware runner. It runs during dry runs and must pass before
+   `publish`.
+5. **`publish`**: runs only for a manual dispatch from `main` when `dry_run` is
+   false and `test-dist-tutorials` succeeded. Downloads the artifact, verifies
+   every wheel filename's version field matches `preflight.outputs.tag_version`,
+   and uploads via `pypa/gh-action-pypi-publish` using OIDC trusted publishing
+   (`environment: pypi`, `id-token: write`).
 6. **`dry-run-summary`**: runs only on `workflow_dispatch` with
    `dry_run: true`. Downloads the artifact and lists what would have been
    uploaded. No `environment`, no PyPI credentials.
@@ -606,10 +610,10 @@ and `<DOCKER_TAG>` an existing ird image tag):
 
 | Trigger                                                          | docker_tag input | Result                                                              |
 | ---------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
-| `git push origin <TAG>`                                          | (n/a)            | Build docker, build wheel, publish to PyPI as the tag's version     |
+| `git push origin <TAG>`                                          | (n/a)            | Build and test the release images and wheels; do not upload to PyPI |
 | Dispatch from `main` with `ttlang_sha: <SHA>`                     | required         | Build the tagged commit and publish its version to PyPI             |
-| Dispatch with `ttlang_sha: <SHA>` and `dry_run: true`             | required         | Build the selected commit and skip PyPI upload                      |
-| Non-main dispatch with `ttlang_sha: <SHA>` and `dry_run: false`   | required         | Fails at `preflight`                                                |
+| Dispatch with `ttlang_sha: <SHA>` and `dry_run: true`             | required         | Build and test the selected commit; skip PyPI upload                |
+| Non-main dispatch with `ttlang_sha: <SHA>` and `dry_run: false`   | required         | Fail at `preflight`                                                 |
 
 (publishing-to-s3-pypi)=
 #### Publishing to S3 PyPI

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -530,7 +530,9 @@ they cannot be distinguished by `pip install`. Prefer `-dev<YYYYMMDD>` or
 `publish-pypi.yml` is the orchestrator that turns a release tag into a wheel
 on PyPI. It triggers automatically on push of `v*.*.*`, `v*.*.*-rc*`,
 `v*.*.*-dev*`, or `v*.*.*+*` tags, and can also be dispatched manually for
-re-runs and dry-runs.
+re-runs and dry-runs. Manual dispatch takes the full SHA of the release-tagged
+commit to build. Non-dry-run dispatches must run from `refs/heads/main`, and
+the selected commit must be an ancestor of the dispatching main commit.
 
 ```text
    push release tag
@@ -538,8 +540,8 @@ re-runs and dry-runs.
           |
           v
    +--------------+
-   |  preflight   |   verify GITHUB_REF is a v* tag
-   +--------------+   (skipped if dry_run=true)
+   |  preflight   |   resolve and verify the v* release tag
+   +--------------+   (release checks skipped if dry_run=true)
           |
           v
    +--------------+
@@ -570,8 +572,9 @@ re-runs and dry-runs.
 
 Job-by-job:
 
-1. **`preflight`** — runs `require-release-tag.sh`, which fails unless
-   `GITHUB_REF` looks like `refs/tags/v[0-9]...`, then runs
+1. **`preflight`** — checks out the `ttlang_sha` input for manual runs, verifies
+   that publish targets are ancestors of the dispatching main commit, resolves
+   the commit's release tag, and runs `require-release-tag.sh`. It then runs
    `require-pypi-ttnn-alignment.sh`, which fails when the public `ttnn` wheel
    recorded in `third-party/tt-metal-version` was built from a different
    tt-metal `vX.Y.Z` component than TT-Lang. Skipped under `dry_run: true`. Exposes
@@ -598,17 +601,15 @@ Job-by-job:
    `dry_run: true`. Downloads the artifact and lists what would have been
    uploaded. No `environment`, no PyPI credentials.
 
-Common scenarios:
+Common scenarios (`<TAG>` denotes a release tag, `<SHA>` its full commit SHA,
+and `<DOCKER_TAG>` an existing ird image tag):
 
-Common scenarios (`<TAG>` denotes a release tag, `<DOCKER_TAG>` an existing
-ird image tag):
-
-| Trigger                                                       | docker_tag input | Result                                                              |
-| ------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
-| `git push origin <TAG>`                                       | (n/a)            | Build docker, build wheel, publish to PyPI as the tag's version     |
-| Dispatch from a tag ref with `docker_tag: <DOCKER_TAG>`       | required         | Skip docker build, reuse the supplied ird image, publish to PyPI    |
-| Dispatch from a non-tag ref with `dry_run: true`              | required         | Build wheel against the supplied tag, skip PyPI upload              |
-| Dispatch from a non-tag ref with `dry_run: false`             | required         | Fails at `preflight` because `GITHUB_REF` is not a release tag      |
+| Trigger                                                          | docker_tag input | Result                                                              |
+| ---------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
+| `git push origin <TAG>`                                          | (n/a)            | Build docker, build wheel, publish to PyPI as the tag's version     |
+| Dispatch from `main` with `ttlang_sha: <SHA>`                     | required         | Build the tagged commit and publish its version to PyPI             |
+| Dispatch with `ttlang_sha: <SHA>` and `dry_run: true`             | required         | Build the selected commit and skip PyPI upload                      |
+| Non-main dispatch with `ttlang_sha: <SHA>` and `dry_run: false`   | required         | Fails at `preflight`                                                |
 
 (publishing-to-s3-pypi)=
 #### Publishing to S3 PyPI

--- a/test/packaging/test_ttlang_test_utils.py
+++ b/test/packaging/test_ttlang_test_utils.py
@@ -13,6 +13,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 from conftest import REPO_ROOT
 
 
@@ -112,3 +114,55 @@ def test_no_nodes_and_ttl_unimportable_is_unavailable(monkeypatch) -> None:
     # driver directory as available).
     module = _load_ttlang_test_utils(monkeypatch, ttl_importable=False)
     assert module.is_hardware_available() is False
+
+
+def test_fabric_1d_uses_linear_logical_mesh(monkeypatch) -> None:
+    module = _load_ttlang_test_utils(monkeypatch)
+    events = []
+
+    class MeshShape:
+        def __init__(self, shape):
+            self.shape = tuple(shape)
+
+    fabric_config = types.SimpleNamespace(FABRIC_1D="fabric-1d", DISABLED="disabled")
+    mesh_device = object()
+
+    def set_fabric_config(config):
+        events.append(("configure", config))
+
+    def open_mesh_device(shape):
+        events.append(("open", shape.shape))
+        return mesh_device
+
+    def close_mesh_device(mesh):
+        events.append(("close", mesh))
+
+    fake_ttnn = types.SimpleNamespace(
+        FabricConfig=fabric_config,
+        MeshShape=MeshShape,
+        get_num_devices=lambda: 8,
+        set_fabric_config=set_fabric_config,
+        open_mesh_device=open_mesh_device,
+        close_mesh_device=close_mesh_device,
+    )
+    monkeypatch.setattr(module, "_get_ttnn", lambda: fake_ttnn)
+
+    with module.open_fabric_mesh() as opened_mesh:
+        assert opened_mesh is mesh_device
+
+    assert events == [
+        ("configure", "fabric-1d"),
+        ("open", (1, 8)),
+        ("close", mesh_device),
+        ("configure", "disabled"),
+    ]
+
+
+def test_fabric_1d_rejects_non_linear_logical_mesh(monkeypatch) -> None:
+    module = _load_ttlang_test_utils(monkeypatch)
+    fake_ttnn = types.SimpleNamespace()
+    monkeypatch.setattr(module, "_get_ttnn", lambda: fake_ttnn)
+
+    with pytest.raises(ValueError, match="FABRIC_1D requires"):
+        with module.open_fabric_mesh((2, 2)):
+            pass

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -42,6 +42,9 @@ RECORD_TTMETAL_MISS = SCRIPTS_DIR / "record-ttmetal-miss.sh"
 CALL_BUILD_WHEELS_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-build-wheels.yml"
 )
+CALL_TEST_DIST_TUTORIALS_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "call-test-dist-tutorials.yml"
+)
 TTMETAL_LIGHT_ON_DEMAND_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "ttmetal-light-on-demand.yml"
 )
@@ -341,20 +344,42 @@ def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
 
 def test_publish_pypi_supports_release_sha_from_main() -> None:
     workflow = PUBLISH_PYPI_WORKFLOW.read_text()
+    preflight_job = workflow.split("\n  preflight:", 1)[1].split(
+        "\n  build-docker:", 1
+    )[0]
     publish_job = workflow.split("\n  publish:", 1)[1].split("\n  dry-run-summary:", 1)[
         0
     ]
 
     assert "ttlang_sha:" in workflow
     assert "ref: ${{ inputs.ttlang_sha || github.sha }}" in workflow
+    assert "path: release-source" in preflight_job
+    assert 'git -C "$release_source" rev-parse HEAD' in preflight_job
+    assert "TTLANG_TT_METAL_VERSION_FILE:" in preflight_job
     assert "ttlang_sha must be a full 40-character commit SHA" in workflow
-    assert 'git merge-base --is-ancestor "$TTLANG_SHA" "$GITHUB_SHA"' in workflow
-    assert "git tag --list 'v[0-9]*' --points-at" in workflow
+    assert (
+        'git -C "$release_source" merge-base --is-ancestor'
+        ' "$TTLANG_SHA" "$GITHUB_SHA"'
+    ) in workflow
+    assert "git -C \"$RELEASE_SOURCE\" tag --list 'v[0-9]*' --points-at" in workflow
     assert '.github/scripts/require-release-tag.sh "$release_ref"' in workflow
-    assert workflow.count("ttlang_sha_override: ${{ inputs.ttlang_sha }}") == 2
+    assert workflow.count("ttlang_sha_override: ${{ inputs.ttlang_sha }}") == 3
+    assert 'echo "dry_run=${{ inputs.dry_run }}"' not in workflow
+    assert 'echo "docker_tag=${{ inputs.docker_tag }}"' not in workflow
+    assert 'echo "ttlang_sha=${{ inputs.ttlang_sha }}"' not in workflow
+    assert "github.event_name == 'workflow_dispatch' && inputs.dry_run != true" in (
+        publish_job
+    )
     # The OIDC-enabled job runs verification code from the dispatch ref, not
     # from the older source commit.
     assert "inputs.ttlang_sha" not in publish_job
+
+
+def test_dist_tutorial_workflow_supports_pinned_ref() -> None:
+    workflow = CALL_TEST_DIST_TUTORIALS_WORKFLOW.read_text()
+
+    assert workflow.count("ttlang_sha_override:") == 2
+    assert "ref: ${{ inputs.ttlang_sha_override || github.sha }}" in workflow
 
 
 def test_call_build_wheels_supports_pinned_ref_and_patches() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -339,6 +339,24 @@ def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
     ) in workflow
 
 
+def test_publish_pypi_supports_release_sha_from_main() -> None:
+    workflow = PUBLISH_PYPI_WORKFLOW.read_text()
+    publish_job = workflow.split("\n  publish:", 1)[1].split("\n  dry-run-summary:", 1)[
+        0
+    ]
+
+    assert "ttlang_sha:" in workflow
+    assert "ref: ${{ inputs.ttlang_sha || github.sha }}" in workflow
+    assert "ttlang_sha must be a full 40-character commit SHA" in workflow
+    assert 'git merge-base --is-ancestor "$TTLANG_SHA" "$GITHUB_SHA"' in workflow
+    assert "git tag --list 'v[0-9]*' --points-at" in workflow
+    assert '.github/scripts/require-release-tag.sh "$release_ref"' in workflow
+    assert workflow.count("ttlang_sha_override: ${{ inputs.ttlang_sha }}") == 2
+    # The OIDC-enabled job runs verification code from the dispatch ref, not
+    # from the older source commit.
+    assert "inputs.ttlang_sha" not in publish_job
+
+
 def test_call_build_wheels_supports_pinned_ref_and_patches() -> None:
     workflow = CALL_BUILD_WHEELS_WORKFLOW.read_text()
     assert "ttlang_sha_override:" in workflow

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -159,21 +159,25 @@ class FabricMeshUnavailable(RuntimeError):
 
 @contextmanager
 def open_fabric_mesh(requested_mesh_shape: tuple[int, int] | None = None):
-    """Open a fabric-enabled mesh. With requested_mesh_shape=None, use the
-    control-plane-discovered shape (SystemMeshDescriptor); a forced shape that
-    mismatches the physical fabric can hang. Set TT_MESH_GRAPH_DESC_PATH to
-    override topology discovery.
-    """
+    """Open a linear fabric mesh spanning every visible device by default."""
     ttnn_module = _get_ttnn()
     if ttnn_module is None:
         raise FabricMeshUnavailable("TTNN not available")
 
     if requested_mesh_shape is None:
-        requested_mesh_shape = tuple(
-            ttnn_module._ttnn.multi_device.SystemMeshDescriptor().shape()
-        )
+        # FABRIC_1D requires a line topology even when physical discovery is 2-D.
+        requested_mesh_shape = (1, ttnn_module.get_num_devices())
     else:
         requested_mesh_shape = tuple(requested_mesh_shape)
+    if (
+        len(requested_mesh_shape) != 2
+        or requested_mesh_shape[0] != 1
+        or requested_mesh_shape[1] < 1
+    ):
+        raise ValueError(
+            "FABRIC_1D requires a logical mesh shape of (1, num_devices) with "
+            "num_devices greater than zero"
+        )
 
     mesh_device = None
     try:

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -159,13 +159,13 @@ class FabricMeshUnavailable(RuntimeError):
 
 @contextmanager
 def open_fabric_mesh(requested_mesh_shape: tuple[int, int] | None = None):
-    """Open a linear fabric mesh spanning every visible device by default."""
+    """Open a 1D fabric mesh spanning every visible device by default."""
     ttnn_module = _get_ttnn()
     if ttnn_module is None:
         raise FabricMeshUnavailable("TTNN not available")
 
     if requested_mesh_shape is None:
-        # FABRIC_1D requires a line topology even when physical discovery is 2-D.
+        # FABRIC_1D requires a 1D topology even when physical discovery is 2-D.
         requested_mesh_shape = (1, ttnn_module.get_num_devices())
     else:
         requested_mesh_shape = tuple(requested_mesh_shape)


### PR DESCRIPTION
### Problem description

PyPI trusted publishing permits the `main` ref, but the manual workflow could not publish an older release commit after `main` advanced.

Also wheel publishing CI runs out of disk space.

### What's changed

Add a required `ttlang_sha` input. Non-dry-run targets must be release-tagged ancestors of the dispatching `main` commit, and Docker and wheel builds use the selected SHA. The OIDC publish job continues to use workflow code from `main`.

Free up unused disk space between steps, use the maximize space action.

Also switched the 'n300-llmbox' runner (which is actually wormhole and not working well) to a blackhole multidevice runner, 'bh-loudbox-viommu'.

Fixes #748

### Checklist

- [x] New/Existing tests provide coverage for changes

Validation: `actionlint`, 22 Bats tests, 40 packaging tests, and pre-commit.
