### PR TITLE
[docs] Fix README markup typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </picture>
 
 </div>
-pl<br>
+<br>
 
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
 ![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.12-blue.svg)


### PR DESCRIPTION
### Problem description

The README contains stray `pl` text before a line break.

### What's changed

Remove the stray text.

### Checklist

- [x] Pre-commit checks pass for `README.md`.
