### PR TITLE
[ttl][pipes] Compact selected PipeNet transfer lowering [pipes-8]

### DIFF
--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -53,6 +53,38 @@ only within the static producer domain for that DFB index). The
 verifier reads the IR and emits diagnostics; it does not rewrite the
 program.
 
+## PipeNet callbacks and generated code
+
+A PipeNet record is one `ttl.Pipe` declaration: one source coordinate and one
+point-to-point destination or collective destination range. The Python
+frontend represents `net.if_src(callback)` and `net.if_dst(callback)` with one
+`ttl.pipenet_foreach_src` or `ttl.pipenet_foreach_dst` region. The region owns
+the ordered record list and contains one copy of the callback body. At runtime,
+each launch node executes that body once for every record in which the node has
+the requested source or destination role. Multiple matching records execute in
+PipeNet construction order.
+
+TTKernel conversion uses two representations:
+
+- For one to four records, conversion emits one static pipe and one coordinate
+  condition per record. This avoids loop and table-lookup overhead for small
+  PipeNets.
+- For five or more records, conversion emits one loop over immutable coordinate
+  and resource tables. `ttl.select_pipe_src` or `ttl.select_pipe_dst`
+  represents the current record inside the loop. This table-driven form emits
+  one callback and transfer protocol body; only the immutable table contents
+  grow with the number of records.
+
+The immutable tables become C++ template arguments and static compile-time
+storage; they do not create kernel stack arrays. Pipe graph analysis still
+creates one transfer node per record. Resource planning stores each record's
+address-table entry and synchronization indices in record order, and the loop
+index selects the corresponding values. The table-driven form currently uses
+receiver-published destination addresses and receiver-post synchronization.
+Computed receiver addresses and capacity counters are supported only when each
+record has its own `ttl.pipe_transfer.*` operations because the associated
+proof and runtime state belong to one transfer.
+
 ## Semantics
 
 Lowering selects the destination-address mechanism independently from
@@ -1197,11 +1229,13 @@ only the storage class changes. The compiler records the final local and global 
 Receiver completion is cumulative across repeated executions of a transfer
 node: sends increment its shared counter, and waits consume it with
 monotonically increasing `wait_min` thresholds instead of resetting it per
-execution. Pipe lowering initializes a separate kernel-local wait-progress
-value to 0 for each completion counter used by a receiver function. Transfers
-that share a physical receiver never share a completion counter. Address-table
-storage and synchronization counters are allocated independently, so address
-publication does not consume local semaphore ids.
+execution. Each receive post increments a kernel-local sequence for its
+completion counter and returns that sequence in the transfer token. The wait
+uses the token directly, so storing or reordering tokens does not associate a
+wait with a later post. Transfers that share a physical receiver never share a
+completion counter. Address-table storage and synchronization counters are
+allocated independently, so address publication does not consume local
+semaphore ids.
 
 Here, `wait_min` means the receiver waits until the semaphore value is at
 least the expected count; it does not require the semaphore to equal that
@@ -1232,11 +1266,11 @@ feature in the current TT-Metal NoC architecture.
 `ttl.wait` on the transfer handle returned by `ttl.copy(pipe, dst_blk)`
 expands to `ttl.pipe_transfer.wait`. TTKernel lowering resolves the defining
 receive post to its transfer node and waits on that transfer's cumulative
-completion state. The receiver keeps a local runtime counter and waits until
-the receiver-completion counter is at least that local count, so repeated
-point-to-point and collective receives in loops advance across iterations
-without reusing stale completion state. Completion of another transfer in the
-same PipeNet cannot satisfy this wait.
+completion state. The receive post returns its next sequence value in the
+transfer token. The wait blocks until the receiver-completion counter reaches
+that value, so repeated point-to-point and collective receives in loops do not
+reuse stale completion state. Completion of another transfer in the same
+PipeNet cannot satisfy this wait.
 
 `RA/RP` fixes the multi-iteration write-pointer issue by making
 the receiver-owned DFB address authoritative. It also makes same-thread
@@ -1284,7 +1318,6 @@ owns the payload-write barrier and receiver-completion signal.
 
 ```mlir
 %transfer = ttl.pipe_transfer.create %pipe {
-  expectedReceivers = 1 : i64,
   kind = #ttl.pipe_transfer_kind<point_to_point>
 } : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
     -> !ttl.pipe_transfer
@@ -1311,10 +1344,9 @@ ttl.if_src %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
 
 For `RA/RP`, TTKernel lowering emits receiver-side code that publishes
 the destination DFB address to the source-node address table and
-increments the sender-ready counter. Each receiver keeps a local count of how
-many payload completions it has consumed for this transfer node. On each
-receive wait, lowering increments that local count and waits until the
-transfer-specific receiver-completion counter is at least that value.
+increments the sender-ready counter. Each receive post also increments a local
+sequence for its completion counter and returns that value in the transfer
+token. A receive wait uses the token as the required completion count.
 The TTKernel snippets below show only pipe-protocol operations and omit
 type annotations.
 
@@ -1322,11 +1354,11 @@ This example uses three synchronization values:
 
 | Name | Storage | Initial value | Updated by | Read by |
 | --- | --- | --- | --- | --- |
-| Sender-ready counter | Source-node local semaphore or GlobalSemaphore-backed SRAM address. | 0 | Each receiver post increments it by 1 after publishing the destination DFB address. The sender resets it to 0 after waiting for all expected posts. | Sender send waits for it to equal `%expected_receivers`. |
-| Receiver-completion counter | Destination-node local semaphore or GlobalSemaphore-backed SRAM address assigned to this transfer node. | 0 | Each dynamic execution of that transfer's send increments it by 1 after the payload write barrier. | The matching receiver wait uses `semaphore_wait_min` against its next expected cumulative count. |
-| Receiver wait-progress counter | Kernel-local `memref<1xi32>` on the receiver, shared only by waits that use the same completion counter. | 0 at function entry | Each matching `ttl.pipe_transfer.wait` increments it by 1 before waiting. | The receiver uses it as the threshold for `semaphore_wait_min`. |
+| Sender-ready counter | Source-node semaphore at `%ready_sem_index`. If local semaphore ids are exhausted, this is a GlobalSemaphore-backed SRAM address passed as a common runtime argument. | 0 | Each receiver post increments it by 1 after publishing the destination DFB address. The sender resets it to 0 after waiting for all expected posts. | Sender send waits for it to equal `%expected_receivers`. |
+| Receiver-completion counter | Destination-node local semaphore or GlobalSemaphore-backed SRAM address, assigned to one transfer node at this receiver. | 0 | Each dynamic execution of that transfer's send increments it by 1 after the payload write barrier. | The matching receiver wait uses `semaphore_wait_min` with the sequence stored in its transfer token. |
+| Receiver post-sequence counter | Kernel-local `memref<1xi32>` for a static completion counter. A table-driven receiver uses one `memref<Nxi32>`, where `N` is the number of distinct completion counters referenced by the records. | 0 at function entry | Each matching `ttl.pipe_transfer.post` increments the element for its completion counter. | The post returns the new value in its transfer token; the corresponding wait uses that token as its completion threshold. |
 
-The sender-ready counter is a reusable pre-send rendezvous counter. The
+The sender-ready counter is a reusable pre-send synchronization counter. The
 receiver-completion counter is cumulative across executions of its transfer
 node for the whole kernel execution and is not reset by pipe lowering.
 
@@ -1343,15 +1375,15 @@ ttkernel.noc_async_write_barrier(%noc)
 %ready_noc_addr = ttkernel.get_noc_addr(%src_x, %src_y, %ready_addr, %noc)
 ttkernel.noc_semaphore_inc(%ready_noc_addr, %one, %noc)
 
-// Advance the receiver's local cumulative wait threshold.
-%old_count = memref.load %recv_counter[%zero]
-%new_count = arith.addi %old_count, %one_i32 : i32
-memref.store %new_count, %recv_counter[%zero]
+// Assign this post's completion sequence before its token can be reordered.
+%old_sequence = memref.load %post_sequence[%zero]
+%token_sequence = arith.addi %old_sequence, %one_i32 : i32
+memref.store %token_sequence, %post_sequence[%zero]
 
-// Read the receiver-completion counter until it is at least %new_count.
+// A later wait consumes the sequence returned by this post.
 %completion_addr = ttkernel.get_semaphore(%completion_sem_index)
 %completion_ptr = ttkernel.reinterpret_cast<tt_l1_ptr uint32_t*>(%completion_addr)
-ttkernel.experimental::semaphore_wait_min(%completion_ptr, %new_count)
+ttkernel.experimental::semaphore_wait_min(%completion_ptr, %token_sequence)
 ```
 
 The sender-side code waits until the receiver has published the address,

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -75,15 +75,15 @@ TTKernel conversion uses two representations:
   one callback and transfer protocol body; only the immutable table contents
   grow with the number of records.
 
-The immutable tables become C++ template arguments and static compile-time
-storage; they do not create kernel stack arrays. Pipe graph analysis still
-creates one transfer node per record. Resource planning stores each record's
-address-table entry and synchronization indices in record order, and the loop
-index selects the corresponding values. The table-driven form currently uses
-receiver-published destination addresses and receiver-post synchronization.
-Computed receiver addresses and capacity counters are supported only when each
-record has its own `ttl.pipe_transfer.*` operations because the associated
-proof and runtime state belong to one transfer.
+The immutable tables become bit-packed C++ template arguments stored outside
+the kernel stack. Pipe graph analysis still creates one transfer node per
+record. Resource planning stores each record's address-table entry and
+synchronization indices in record order, and the loop index selects the
+corresponding values. The table-driven form currently uses receiver-published
+destination addresses and receiver-post synchronization. Computed receiver
+addresses and capacity counters are supported only when each record has its
+own `ttl.pipe_transfer.*` operations because the associated proof and runtime
+state belong to one transfer.
 
 ## Semantics
 
@@ -406,13 +406,14 @@ Pipe lowering first expands high-level pipe operations to Pipe Transfer IR:
 
 A transfer node represents one payload transfer: one send, one receiver post
 for each destination, and receiver completion. Sender and receiver callbacks
-may create separate `ttl.create_pipe` values. Correspondence analysis matches
-the send and receiver posts into one transfer node. A dynamic transfer instance
-is one runtime execution of that node, such as one loop iteration. In `RP`, an
-instance is live after its receiver posts and before the send consumes their
-sender-ready count. In `RA/RP`, its published address is live for the same
-interval. Resource allocation treats the sender-ready counter and address-table
-entry as live from the earliest receiver post through the send.
+may use separate static pipe values or selected-record operations.
+Correspondence analysis matches the send and receiver posts into one transfer
+node. A dynamic transfer instance is one runtime execution of that node, such
+as one loop iteration. In `RP`, an instance is live after its receiver posts
+and before the send consumes their sender-ready count. In `RA/RP`, its
+published address is live for the same interval. Resource allocation treats
+the sender-ready counter and address-table entry as live from the earliest
+receiver post through the send.
 
 A `PipeKey` contains the declared source coordinate, receiver rectangle, and
 PipeNet id. It identifies a communication relation, not one transfer node.
@@ -1611,10 +1612,10 @@ closure, and module-scope PipeNets through `__globals__`. See the
 [language specification](https://github.com/tenstorrent/tt-lang/blob/main/docs/sphinx/specs/TTLangSpecification.md) for
 the enclosing-scope capture rule.
 
-Operation-local ids keep `ttl.create_pipe` ids stable across invocations and
-keep graph construction deterministic. Completion counters are allocated from
-transfer nodes and their physical receiver sets. The
-`OperationPipeNets`
+Operation-local PipeNet ids keep static pipe values and record tables stable
+across invocations and keep graph construction deterministic. Completion
+counters are allocated from transfer nodes and their physical receiver sets.
+The `OperationPipeNets`
 instance is built and validated before MLIR emission on the compiler
 side and before `Program(...)` runs on the simulator side.
 `PipeNet.__init__` also builds a one-PipeNet `OperationPipeNets` and
@@ -1896,7 +1897,7 @@ error: 'ttl.copy' op this `ttl.copy(buffer, pipe)` sends data on PipeNet 0
        from a node that is not a source of any pipe in that net; wrap the
        copy in `net_0.if_src(...)` or guard with `if net_0.is_src(): ...`
 note: example node where the guard does not hold: node=(1, 0)
-note: PipeNet 0 declared here  (at create_pipe location)
+note: PipeNet 0 declared here  (at PipeNet declaration location)
 note: suggested guard: `net_0.is_src()`
 ```
 
@@ -1962,7 +1963,7 @@ The verifier relies on these input properties.
 | Invariant | Rationale |
 | --- | --- |
 | `ttl.launch_grid` module attribute present | Subset checks require a finite launch-coordinate domain. The pass emits a module-level error and fails if the attribute is missing. |
-| `ttl.create_pipe` source/destination coordinates are static `I64Attr`s, encoded both on the op and in the result `PipeType` | Domain construction reads the attributes directly to materialize each pipe's source unit box and destination range as concrete `Coord` sets, and `PipeLowering.cpp` emits `arith.ConstantIndexOp` for each coordinate when building per-node source and destination predicates. The static-attribute encoding is a property of today's IR, not a fundamental constraint of the verifier or lowering; see "Future work: parametric PipeNets" for the approach to runtime-bound coordinates. |
+| PipeNet source/destination coordinates are static `I64Attr`s in `ttl.create_pipe` or `#ttl.pipe_record` | Domain construction materializes each source coordinate and destination range as concrete `Coord` sets. Lowering emits constants for direct records and immutable lookup tables for larger record lists. The static encoding is a property of today's IR, not a fundamental constraint; see "Future work: parametric PipeNets" for runtime-bound coordinates. |
 | Every DFB has a concrete, unique provisional index | DFB wait checks associate producers and consumers before physical index reuse. `ttl-insert-intermediate-dfbs` assigns new compiler-created DFBs the next unused provisional index. |
 | One operation per module | The verifier walks all pipes in the module to compute role domains; co-compiling multiple operations would require per-operation scoping. |
 
@@ -2354,18 +2355,14 @@ The shared graph and proof must preserve these fabric invariants:
 * Parametric PipeNets - runtime-bound pipe coordinates resolved at
   kernel-launch time rather than `@ttl.operation` decoration time. The
   current pipeline resolves `ttl.Pipe(src=..., dst=...)` arguments to
-  Python `int` / `slice` literals during frontend tracing, materializes
-  them as `I64Attr`s on `ttl.create_pipe`, and embeds them into the
-  result `PipeType`. A parametric variant requires three coordinated
-  changes:
-  1. IR: extend `ttl.create_pipe` with an alternative form whose
-     source/destination coordinates are SSA `index` operands rather
-     than attributes, and replace the static coordinate fields on
-     `PipeType` with a static bounding-box attribute (so the verifier
-     and downstream passes still have a coarse-grained type
-     invariant). The static form remains the lowering target for
-     `@ttl.operation` invocations whose coordinates are known at
-     trace time.
+  Python `int` / `slice` literals during frontend tracing and
+  materializes them as attributes on `ttl.create_pipe` or
+  `#ttl.pipe_record`. A parametric variant requires three coordinated changes:
+  1. IR: add a representation whose source/destination coordinates are SSA
+     `index` values rather than attributes. Static bounds must remain available
+     so verification and downstream analyses retain a finite launch-node
+     domain. The current attribute form remains appropriate when coordinates
+     are known during frontend tracing.
   2. Verifier: replace the `std::set<Coord>` `Domain` with a symbolic
      representation, either an upstream Presburger set
      (`mlir::presburger::IntegerRelation`) or a structured
@@ -2378,16 +2375,13 @@ The shared graph and proof must preserve these fabric invariants:
      `ttl.is_dst` / `ttl.is_active` recognition stays structural; the
      per-coord enumeration in `evalBool` becomes a constraint
      constructor.
-  3. Lowering: `PipeLowering.cpp` materializes pipe source/destination
-     coordinates as `arith.ConstantIndexOp` from `PipeType::getSrcX/Y`
-     and the destination range bounds. Threading SSA values through to
-     `noc_async_write_multicast` and the per-pipe match expressions is
-     mechanical: tt-metal's multicast NoC primitives already accept
-     runtime coordinates, and `IsSrcLowering` / `IsDstLowering` already
-     construct per-pipe `arith.cmpi` / `arith.andi` / `arith.ori`
-     chains over the pipe's coordinate values; they currently chain
-     against constants but would chain against the SSA operands
-     instead.
+  3. Lowering: direct records currently become constant coordinates, while
+     larger record lists become immutable coordinate tables. Runtime-bound
+     coordinates must instead remain SSA values through source/destination
+     matching and NoC operation creation. TT-Metal's multicast NoC primitives
+     already accept runtime coordinates, and `IsSrcLowering` /
+     `IsDstLowering` already construct `arith.cmpi` / `arith.andi` /
+     `arith.ori` expressions over pipe coordinates.
 
   Frontend surface: `ttl.Pipe(src=ttl.runtime_arg("M"), ...)` or a
   similar SSA-typed coordinate, with the `OperationPipeNets`

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -77,13 +77,16 @@ TTKernel conversion uses two representations:
 
 The immutable tables become bit-packed C++ template arguments stored outside
 the kernel stack. Pipe graph analysis still creates one transfer node per
-record. Resource planning stores each record's address-table entry and
-synchronization indices in record order, and the loop index selects the
-corresponding values. The table-driven form currently uses receiver-published
-destination addresses and receiver-post synchronization. Computed receiver
-addresses and capacity counters are supported only when each record has its
-own `ttl.pipe_transfer.*` operations because the associated proof and runtime
-state belong to one transfer.
+record. A selected-pipe type identifies whether iteration selected the record
+by its source or destination coordinates; copy operand position determines
+whether that record is used for a send or receive. Launch-domain verification
+proves that the selected callback executes on the required endpoint.
+
+Resource planning stores each record's address-table entry and synchronization
+indices in record order, and the loop index selects the corresponding values.
+Pipe graph analysis maps the shared protocol operation and record index to a
+distinct transfer node, so each record retains its own address-sequence proof
+and runtime resources.
 
 ## Semantics
 

--- a/include/ttlang/Conversion/Passes.td
+++ b/include/ttlang/Conversion/Passes.td
@@ -7,7 +7,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ConvertTTKernelToEmitC : Pass<"convert-ttkernel-to-emitc", "::mlir::func::FuncOp"> {
+def ConvertTTKernelToEmitC : Pass<"convert-ttkernel-to-emitc", "::mlir::ModuleOp"> {
   let summary = "Convert TTKernel dialect to EmitC dialect.";
   let dependentDialects = ["mlir::emitc::EmitCDialect", "mlir::func::FuncDialect",
                            "mlir::tt::ttkernel::TTKernelDialect"];

--- a/include/ttlang/Dialect/TTKernel/IR/CMakeLists.txt
+++ b/include/ttlang/Dialect/TTKernel/IR/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect(TTKernelOps ttkernel)
 add_mlir_doc(TTKernelBase TTKernelDialect src/autogen/md/Dialect/ -gen-dialect-doc)
-add_mlir_doc(TTKernelOps TTKernelOp src/autogen/md/Dialect/ -gen-op-doc)
+add_mlir_doc(TTKernelOps TTKernelOp src/autogen/md/Dialect/ -gen-op-doc
+             -dialect=ttkernel)
 add_mlir_doc(TTKernelOpsTypes TTKernelAttr src/autogen/md/Dialect/ -gen-attrdef-doc)
 add_mlir_doc(TTKernelOpsTypes TTKernelType src/autogen/md/Dialect/ -gen-typedef-doc)
 

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4057,10 +4057,10 @@ def TTKernel_ConstantTableLookupOp
     : TTKernel_Op<"experimental.constant_table_lookup", [Pure]> {
     let summary = "Look up an element in an immutable compile-time table.";
     let description = [{
-      Returns the element at `index` from the non-empty `values` table. The
-      index must be within the table bounds, and every table value must be
-      non-negative. The table is immutable kernel metadata and does not consume
-      runtime stack storage.
+      Returns the element at `index` from the non-empty `values` table. Every
+      table value must be non-negative. A constant index is verified to be
+      within the table bounds; a dynamic index must satisfy the same
+      precondition.
     }];
 
     let arguments = (ins Index:$index, DenseI64ArrayAttr:$values);

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4053,6 +4053,26 @@ def TTKernel_GetCompileArgValOp : TTKernel_Op<"get_compile_time_arg_val",
     }];
 }
 
+def TTKernel_ConstantTableLookupOp
+    : TTKernel_Op<"experimental.constant_table_lookup", [Pure]> {
+    let summary = "Look up an element in an immutable compile-time table.";
+    let description = [{
+      Returns the element at `index` from the non-empty `values` table. The
+      index must be within the table bounds, and every table value must be
+      non-negative. The table is immutable kernel metadata and does not consume
+      runtime stack storage.
+    }];
+
+    let arguments = (ins Index:$index, DenseI64ArrayAttr:$values);
+    let results = (outs Index:$result);
+
+    let assemblyFormat = [{
+      $index `,` $values attr-dict `:` type($index)
+    }];
+    let hasFolder = 1;
+    let hasVerifier = 1;
+}
+
 
 //===----------------------------------------------------------------------===//
 // TTKernel Helper functions
@@ -4087,6 +4107,21 @@ def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast"> {
 
     let assemblyFormat = [{
       `(` $addr `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
+def TTKernel_CastToL1AddrOp : TTKernel_Op<"cast_to_l1_addr", [Pure]> {
+    let summary = "Normalize a value to an L1 address.";
+    let description = [{
+      Converts an integer L1 address, typed L1 address, or local semaphore
+      address to `l1_addr` without changing its representation.
+    }];
+
+    let arguments = (ins AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$addr);
+    let results = (outs TTKernel_L1Addr:$result);
+
+    let assemblyFormat = [{
+      $addr attr-dict `:` type($addr) `to` type($result)
     }];
 }
 

--- a/include/ttlang/Dialect/TTL/IR/CMakeLists.txt
+++ b/include/ttlang/Dialect/TTL/IR/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_mlir_dialect(TTLOps ttl)
 add_mlir_doc(TTLBase TTLDialect src/autogen/md/Dialect/ -gen-dialect-doc)
-add_mlir_doc(TTLOps TTLOp src/autogen/md/Dialect/ -gen-op-doc)
+add_mlir_doc(TTLOps TTLOp src/autogen/md/Dialect/ -gen-op-doc -dialect=ttl)
 add_mlir_doc(TTLOpsTypes TTLType src/autogen/md/Dialect/ -gen-typedef-doc)
 
 set(LLVM_TARGET_DEFINITIONS TTLInterfaces.td)

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -725,6 +725,9 @@ def TTL_SelectPipeSrcOp : TTL_Op<"select_pipe_src", [Pure]> {
     operands contain the selected record fields for the current foreach
     iteration. `$recordIndex` identifies the record in `$records`; the
     remaining operands contain that record's coordinates and receiver count.
+    `$srcInDstRange` is true when the source coordinate belongs to the
+    destination range. `$records` identifies the PipeNet and its transfer
+    contract.
   }];
 
   let arguments = (ins
@@ -744,7 +747,6 @@ def TTL_SelectPipeSrcOp : TTL_Op<"select_pipe_src", [Pure]> {
     `record` `(` $recordIndex `)` `src` `(` $srcX `,` $srcY `)` `dst` `(` $dstStartX `,` $dstStartY `)` `to` `(` $dstEndX `,` $dstEndY `)`
     `num_dests` `(` $numDests `)` `src_in_dst` `(` $srcInDstRange `)` attr-dict `:` type($pipe)
   }];
-  let hasVerifier = 1;
 }
 
 def TTL_SelectPipeDstOp : TTL_Op<"select_pipe_dst", [Pure]> {
@@ -754,6 +756,9 @@ def TTL_SelectPipeDstOp : TTL_Op<"select_pipe_dst", [Pure]> {
     operands contain the selected record fields for the current foreach
     iteration. `$recordIndex` identifies the record in `$records`; the
     remaining operands contain that record's coordinates and receiver count.
+    `$srcInDstRange` is true when the source coordinate belongs to the
+    destination range. `$records` identifies the PipeNet and its transfer
+    contract.
   }];
 
   let arguments = (ins
@@ -773,7 +778,6 @@ def TTL_SelectPipeDstOp : TTL_Op<"select_pipe_dst", [Pure]> {
     `record` `(` $recordIndex `)` `src` `(` $srcX `,` $srcY `)` `dst` `(` $dstStartX `,` $dstStartY `)` `to` `(` $dstEndX `,` $dstEndY `)`
     `num_dests` `(` $numDests `)` `src_in_dst` `(` $srcInDstRange `)` attr-dict `:` type($pipe)
   }];
-  let hasVerifier = 1;
 }
 
 def TTL_PipeTransferCreateOp : TTL_Op<"pipe_transfer.create", [Pure]> {

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -719,15 +719,14 @@ def TTL_PipeNetForeachDstOp : TTL_Op<"pipenet_foreach_dst",
 }
 
 def TTL_SelectPipeSrcOp : TTL_Op<"select_pipe_src", [Pure]> {
-  let summary = "Represent a selected source pipe";
+  let summary = "Represent a record selected by source iteration";
   let description = [{
-    Represents a source pipe selected from a PipeNet record table. The
-    operands contain the selected record fields for the current foreach
-    iteration. `$recordIndex` identifies the record in `$records`; the
-    remaining operands contain that record's coordinates and receiver count.
-    `$srcInDstRange` is true when the source coordinate belongs to the
-    destination range. `$records` identifies the PipeNet and its transfer
-    contract.
+    Represents a PipeNet record selected because the current launch node is its
+    source. The operands contain the selected record fields. `$recordIndex`
+    identifies the record in `$records`; the remaining operands contain that
+    record's coordinates and receiver count. `$srcInDstRange` is true when the
+    source coordinate belongs to the destination range. `$records` identifies
+    the PipeNet and its transfer contract.
   }];
 
   let arguments = (ins
@@ -750,15 +749,14 @@ def TTL_SelectPipeSrcOp : TTL_Op<"select_pipe_src", [Pure]> {
 }
 
 def TTL_SelectPipeDstOp : TTL_Op<"select_pipe_dst", [Pure]> {
-  let summary = "Represent a selected destination pipe";
+  let summary = "Represent a record selected by destination iteration";
   let description = [{
-    Represents a destination pipe selected from a PipeNet record table. The
-    operands contain the selected record fields for the current foreach
-    iteration. `$recordIndex` identifies the record in `$records`; the
-    remaining operands contain that record's coordinates and receiver count.
-    `$srcInDstRange` is true when the source coordinate belongs to the
-    destination range. `$records` identifies the PipeNet and its transfer
-    contract.
+    Represents a PipeNet record selected because the current launch node is one
+    of its destinations. The operands contain the selected record fields.
+    `$recordIndex` identifies the record in `$records`; the remaining operands
+    contain that record's coordinates and receiver count. `$srcInDstRange` is
+    true when the source coordinate belongs to the destination range.
+    `$records` identifies the PipeNet and its transfer contract.
   }];
 
   let arguments = (ins

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -341,11 +341,13 @@ def TTL_ComputeOp : TTL_Op<"compute", [
 
 def TTL_YieldOp : TTL_Op<"yield", [ReturnLike, Terminator,
     ParentOneOf<["ComputeOp", "DstSectionOp", "IfSrcOp", "IfDstOp",
+                 "PipeNetForeachSrcOp", "PipeNetForeachDstOp",
                  "PipeNetScopeOp", "AccumulationScopeOp"]>]> {
   let summary = "Terminate a TTL region body";
   let description = [{
     `ttl.yield` terminates the body of `ttl.compute`, `ttl.dst_section`,
-    `ttl.if_src`, `ttl.if_dst`, `ttl.pipenet_scope`, and
+    `ttl.if_src`, `ttl.if_dst`, `ttl.pipenet_foreach_src`,
+    `ttl.pipenet_foreach_dst`, `ttl.pipenet_scope`, and
     `ttl.accumulation_scope`. In `ttl.accumulation_scope`, it carries one
     updated value per accumulation output. Other TTL regions use an
     operand-less terminator.
@@ -670,6 +672,110 @@ def TTL_IfDstOp : TTL_Op<"if_dst",
   }];
 }
 
+def TTL_PipeNetForeachSrcOp : TTL_Op<"pipenet_foreach_src",
+    [SingleBlockImplicitTerminator<"YieldOp">,
+     DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+  let summary = "Iterate over source pipe records in a PipeNet";
+  let description = [{
+    Executes the body region once for each static PipeNet record whose source
+    coordinate matches the current launch node. The body receives a
+    `!ttl.selected_pipe_src` argument representing the selected record for that
+    iteration.
+
+    The records in `$records` are ordered by user PipeNet construction
+    order. That order defines program order for a launch node that matches
+    multiple records.
+  }];
+
+  let arguments = (ins
+    TTL_PipeNetRecordsAttr:$records
+  );
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "attr-dict-with-keyword $body";
+  let hasVerifier = 1;
+}
+
+def TTL_PipeNetForeachDstOp : TTL_Op<"pipenet_foreach_dst",
+    [SingleBlockImplicitTerminator<"YieldOp">,
+     DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+  let summary = "Iterate over destination pipe records in a PipeNet";
+  let description = [{
+    Executes the body region once for each static PipeNet record whose
+    destination range contains the current launch node. The body receives a
+    `!ttl.selected_pipe_dst` argument representing the selected record for that
+    iteration.
+
+    The records in `$records` are ordered by user PipeNet construction
+    order. That order defines program order for a launch node that matches
+    multiple records.
+  }];
+
+  let arguments = (ins
+    TTL_PipeNetRecordsAttr:$records
+  );
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "attr-dict-with-keyword $body";
+  let hasVerifier = 1;
+}
+
+def TTL_SelectPipeSrcOp : TTL_Op<"select_pipe_src", [Pure]> {
+  let summary = "Represent a selected source pipe";
+  let description = [{
+    Represents a source pipe selected from a PipeNet record table. The
+    operands contain the selected record fields for the current foreach
+    iteration. `$recordIndex` identifies the record in `$records`; the
+    remaining operands contain that record's coordinates and receiver count.
+  }];
+
+  let arguments = (ins
+    Index:$recordIndex,
+    Index:$srcX,
+    Index:$srcY,
+    Index:$dstStartX,
+    Index:$dstStartY,
+    Index:$dstEndX,
+    Index:$dstEndY,
+    Index:$numDests,
+    I1:$srcInDstRange,
+    TTL_PipeNetRecordsAttr:$records
+  );
+  let results = (outs TTL_SelectedPipeSrc:$pipe);
+  let assemblyFormat = [{
+    `record` `(` $recordIndex `)` `src` `(` $srcX `,` $srcY `)` `dst` `(` $dstStartX `,` $dstStartY `)` `to` `(` $dstEndX `,` $dstEndY `)`
+    `num_dests` `(` $numDests `)` `src_in_dst` `(` $srcInDstRange `)` attr-dict `:` type($pipe)
+  }];
+  let hasVerifier = 1;
+}
+
+def TTL_SelectPipeDstOp : TTL_Op<"select_pipe_dst", [Pure]> {
+  let summary = "Represent a selected destination pipe";
+  let description = [{
+    Represents a destination pipe selected from a PipeNet record table. The
+    operands contain the selected record fields for the current foreach
+    iteration. `$recordIndex` identifies the record in `$records`; the
+    remaining operands contain that record's coordinates and receiver count.
+  }];
+
+  let arguments = (ins
+    Index:$recordIndex,
+    Index:$srcX,
+    Index:$srcY,
+    Index:$dstStartX,
+    Index:$dstStartY,
+    Index:$dstEndX,
+    Index:$dstEndY,
+    Index:$numDests,
+    I1:$srcInDstRange,
+    TTL_PipeNetRecordsAttr:$records
+  );
+  let results = (outs TTL_SelectedPipeDst:$pipe);
+  let assemblyFormat = [{
+    `record` `(` $recordIndex `)` `src` `(` $srcX `,` $srcY `)` `dst` `(` $dstStartX `,` $dstStartY `)` `to` `(` $dstEndX `,` $dstEndY `)`
+    `num_dests` `(` $numDests `)` `src_in_dst` `(` $srcInDstRange `)` attr-dict `:` type($pipe)
+  }];
+  let hasVerifier = 1;
+}
+
 def TTL_PipeTransferCreateOp : TTL_Op<"pipe_transfer.create", [Pure]> {
   let summary = "Create a pipe transfer reference";
   let description = [{
@@ -680,9 +786,8 @@ def TTL_PipeTransferCreateOp : TTL_Op<"pipe_transfer.create", [Pure]> {
     point-to-point or collective contract.
   }];
   let arguments = (ins
-    TTL_Pipe:$pipe,
-    TTL_PipeTransferKindAttr:$kind,
-    I64Attr:$expectedReceivers
+    TTL_PipeReference:$pipe,
+    TTL_PipeTransferKindAttr:$kind
   );
   let results = (outs TTL_PipeTransfer:$transfer);
   let assemblyFormat = "$pipe attr-dict `:` type($pipe) `->` type($transfer)";

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -7,6 +7,7 @@
 
 include "ttlang/Dialect/TTL/IR/TTLBase.td"
 include "ttlang/Dialect/TTL/IR/TTLOpsEnums.td"
+include "mlir/IR/AttrTypeBase.td"
 
 //===----------------------------------------------------------------------===//
 // TTL attribute definitions
@@ -91,6 +92,55 @@ def TTL_LayoutAttr : TTL_Attr<"Layout", "layout"> {
                        " `memory` `=` $memoryLayout `>`";
 
   let genVerifyDecl = 1;
+}
+
+def TTL_PipeRecordAttr : TTL_Attr<"PipeRecord", "pipe_record"> {
+  let summary = "Static PipeNet pipe record";
+  let description = [{
+    Encodes one static PipeNet record for PipeNet foreach ops. The owning
+    `#ttl.pipenet_records` attribute contains the PipeNet id; each record
+    contains source and destination coordinates plus a flag selecting
+    point-to-point or collective semantics.
+
+    `isCollective` is a frontend-supplied flag, not derived from coordinates:
+    `slice(i, i + 1)` is a singleton collective record with one destination
+    node, but it must preserve the PipeNet-level collective contract.
+  }];
+
+  let parameters = (ins
+    "int64_t":$srcX,
+    "int64_t":$srcY,
+    "int64_t":$dstStartX,
+    "int64_t":$dstStartY,
+    "int64_t":$dstEndX,
+    "int64_t":$dstEndY,
+    DefaultValuedParameter<"bool", "false">:$isCollective
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+  let genVerifyDecl = 1;
+}
+
+def TTL_PipeNetRecordsAttr : TTL_Attr<"PipeNetRecords", "pipenet_records"> {
+  let summary = "Identifies a PipeNet and contains its static pipe records";
+  let description = [{
+    Identifies a PipeNet by id and contains the ordered list of
+    `#ttl.pipe_record` attributes that make up the net. PipeNet foreach ops use
+    this attribute to represent callback iteration without creating one
+    source-level operation per record.
+
+    `pipes` is in user PipeNet construction order. A launch node that matches
+    multiple records executes them in this order.
+  }];
+
+  let parameters = (ins
+    "int64_t":$pipeNetId,
+    OptionalParameter<"::mlir::StringAttr">:$pipeNetName,
+    ArrayRefParameter<"::mlir::tt::ttl::PipeRecordAttr">:$pipes
+  );
+
+  let assemblyFormat = "`<` `net` $pipeNetId (`name` $pipeNetName^)? "
+                       "`pipes` `[` $pipes `]` `>`";
 }
 
 #endif // TTLANG_DIALECT_TTL_IR_TTLOPSATTRS_TD

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -130,7 +130,8 @@ def TTL_PipeNetRecordsAttr : TTL_Attr<"PipeNetRecords", "pipenet_records"> {
     source-level operation per record.
 
     `pipes` is in user PipeNet construction order. A launch node that matches
-    multiple records executes them in this order.
+    multiple records executes them in this order. Duplicate records are
+    distinct entries and execute as separate callback invocations.
   }];
 
   let parameters = (ins

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -141,6 +141,7 @@ def TTL_PipeNetRecordsAttr : TTL_Attr<"PipeNetRecords", "pipenet_records"> {
 
   let assemblyFormat = "`<` `net` $pipeNetId (`name` $pipeNetName^)? "
                        "`pipes` `[` $pipes `]` `>`";
+  let genVerifyDecl = 1;
 }
 
 #endif // TTLANG_DIALECT_TTL_IR_TTLOPSATTRS_TD

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
@@ -166,20 +166,24 @@ def TTL_Pipe : TTL_Type<"Pipe", "pipe"> {
 }
 
 def TTL_SelectedPipeSrc : TTL_Type<"SelectedPipeSrc", "selected_pipe_src"> {
-  let summary = "Selected source pipe for PipeNet foreach iteration";
+  let summary = "PipeNet record selected by source iteration";
   let description = [{
-    Represents a PipeNet record selected for source-side use. The type does not
-    encode the PipeNet id or coordinates; the enclosing foreach operation or
-    defining select operation supplies them.
+    Represents a PipeNet record selected because the current launch node is its
+    source. The selected record may be used for a send or receive; copy operand
+    position determines the transfer direction. The enclosing foreach
+    operation or defining select operation supplies the PipeNet id and
+    coordinates.
   }];
 }
 
 def TTL_SelectedPipeDst : TTL_Type<"SelectedPipeDst", "selected_pipe_dst"> {
-  let summary = "Selected destination pipe for PipeNet foreach iteration";
+  let summary = "PipeNet record selected by destination iteration";
   let description = [{
-    Represents a PipeNet record selected for destination-side use. The type
-    does not encode the PipeNet id or coordinates; the enclosing foreach
-    operation or defining select operation supplies them.
+    Represents a PipeNet record selected because the current launch node is one
+    of its destinations. The selected record may be used for a send or receive;
+    copy operand position determines the transfer direction. The enclosing
+    foreach operation or defining select operation supplies the PipeNet id and
+    coordinates.
   }];
 }
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
@@ -165,4 +165,37 @@ def TTL_Pipe : TTL_Type<"Pipe", "pipe"> {
   }];
 }
 
+def TTL_SelectedPipeSrc : TTL_Type<"SelectedPipeSrc", "selected_pipe_src"> {
+  let summary = "Selected source pipe for PipeNet foreach iteration";
+  let description = [{
+    Represents a PipeNet record selected for source-side use. The type does not
+    encode the PipeNet id or coordinates; the enclosing foreach operation or
+    defining select operation supplies them.
+  }];
+}
+
+def TTL_SelectedPipeDst : TTL_Type<"SelectedPipeDst", "selected_pipe_dst"> {
+  let summary = "Selected destination pipe for PipeNet foreach iteration";
+  let description = [{
+    Represents a PipeNet record selected for destination-side use. The type
+    does not encode the PipeNet id or coordinates; the enclosing foreach
+    operation or defining select operation supplies them.
+  }];
+}
+
+def TTL_SelectedPipe : TypeConstraint<
+    Or<[
+      CPred<"llvm::isa<mlir::tt::ttl::SelectedPipeSrcType>($_self)">,
+      CPred<"llvm::isa<mlir::tt::ttl::SelectedPipeDstType>($_self)">
+    ]>,
+    "selected PipeNet iteration pipe">;
+
+def TTL_PipeReference : TypeConstraint<
+    Or<[
+      CPred<"llvm::isa<mlir::tt::ttl::PipeType>($_self)">,
+      CPred<"llvm::isa<mlir::tt::ttl::SelectedPipeSrcType>($_self)">,
+      CPred<"llvm::isa<mlir::tt::ttl::SelectedPipeDstType>($_self)">
+    ]>,
+    "static pipe or selected PipeNet iteration pipe">;
+
 #endif // TTLANG_DIALECT_TTL_IR_TTLOPSTYPES_TD

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -27,6 +27,21 @@
 
 namespace mlir::tt::ttl {
 
+/// PipeNet records associated with a selected-pipe value. `maybeForeachOp`
+/// identifies the enclosing foreach operation when the value is its block
+/// argument.
+struct SelectedPipeRecords {
+  PipeNetRecordsAttr records;
+  Operation *maybeForeachOp = nullptr;
+};
+
+/// Return the records associated with a selected-pipe value.
+///
+/// Supported values are results of `ttl.select_pipe_src` or
+/// `ttl.select_pipe_dst`, and the pipe block argument of
+/// `ttl.pipenet_foreach_src` or `ttl.pipenet_foreach_dst`.
+FailureOr<SelectedPipeRecords> getSelectedPipeRecords(Value pipe);
+
 /// Return the enclosing kernel-thread `func.func` (tagged with
 /// `ttl.kernel_thread`), or null if `op` is not inside one.
 inline mlir::func::FuncOp getEnclosingKernelThread(mlir::Operation *op) {

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -255,14 +255,16 @@ inline mlir::Value getAttachedCB(mlir::Value tensor) {
 
 /// Returns true when `op` receives from a pipe into DFB-backed storage.
 inline bool isPipeReceiveCopy(CopyOp op) {
-  return mlir::isa<PipeType>(op.getSrc().getType()) &&
+  return mlir::isa<PipeType, SelectedPipeSrcType, SelectedPipeDstType>(
+             op.getSrc().getType()) &&
          getAttachedCB(op.getDst());
 }
 
 /// Returns true when `op` sends from a DFB into a pipe.
 inline bool isPipeSendCopy(CopyOp op) {
   return mlir::isa<CircularBufferType>(op.getSrc().getType()) &&
-         mlir::isa<PipeType>(op.getDst().getType());
+         mlir::isa<PipeType, SelectedPipeSrcType, SelectedPipeDstType>(
+             op.getDst().getType());
 }
 
 /// Normalize a Python-style dim (allowing negative indices) against `rank`

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -169,6 +169,11 @@ def TTLConvertTTLToTTKernel
     PipeNet counters use local semaphore ids before GlobalSemaphore storage by
     default; the global-only option preserves all local semaphore ids for
     application use.
+
+    PipeNet IR must first pass `ttl-verify-pipenet-guards` and
+    `ttl-verify-pipenet-schedule`. Those passes establish endpoint containment,
+    exact launch-node domains, and single-block event regions required by
+    protocol planning.
   }];
 
   let options = [

--- a/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
@@ -113,6 +113,14 @@ bool launchNodeDomainsOverlap(const LaunchNodeDomain &lhs,
 bool knownLaunchNodeDomainContains(const LaunchNodeDomain &domain,
                                    LaunchNodeCoord coord);
 
+LaunchNodeDomain getPipeRecordSourceLaunchNodeDomain(PipeRecordAttr record);
+
+LaunchNodeDomain
+getPipeRecordDestinationLaunchNodeDomain(PipeRecordAttr record);
+
+LaunchNodeDomain getPipeRecordsRoleLaunchNodeDomain(PipeNetRecordsAttr records,
+                                                    PipeRole role);
+
 /// Read the PipeNet ids selected by a `ttl.pipenet_scope`.
 bool readPipeNetScopeIds(PipeNetScopeOp scopeOp, SmallVectorImpl<int64_t> &ids);
 
@@ -124,10 +132,10 @@ struct PipeNetScopeLaunchNodeDomains {
 
 /// Module-wide launch-grid and PipeNet role domains used by the analysis.
 ///
-/// `initialize` records the PipeNet source and destination domains from
-/// `ttl.create_pipe` ops. It also parses `ttl.launch_grid`; malformed or
-/// missing launch-grid attributes leave `hasLaunchGrid` false so each verifier
-/// can emit diagnostics with pass-specific context.
+/// `initialize` records PipeNet source and destination domains from static pipe
+/// declarations and PipeNet record tables. It also parses `ttl.launch_grid`;
+/// malformed or missing launch-grid attributes leave `hasLaunchGrid` false so
+/// each verifier can emit diagnostics with pass-specific context.
 struct LaunchNodeDomainState {
   LaunchNodeDomain baseDomain;
   llvm::DenseMap<int64_t, LaunchNodeDomain> netSourceDomains;
@@ -155,6 +163,13 @@ struct LaunchNodeDomainState {
   /// Return the launch nodes that have `role` for `netId`, or an unknown
   /// domain when no `ttl.create_pipe` declares that PipeNet.
   LaunchNodeDomain getRoleDomain(int64_t netId, PipeRole role) const;
+
+  /// Both declaration forms update the same domains so validation is
+  /// independent of declaration order.
+  void recordPipeNet(PipeType pipeType, Location loc,
+                     std::optional<StringRef> name = std::nullopt);
+
+  void recordPipeNetRecords(PipeNetRecordsAttr records, Location loc);
 
   /// Populate launch-grid and PipeNet role domains from the module.
   void initialize(ModuleOp module);
@@ -263,8 +278,9 @@ struct LaunchNodeDomainAnalysisOptions {
 /// structured control flow.
 ///
 /// Region branch transfers narrow domains for `scf.if`, `affine.if`,
-/// `ttl.if_src`, `ttl.if_dst`, and `ttl.pipenet_scope`. Other operations carry
-/// the incoming domain through unchanged.
+/// `ttl.if_src`, `ttl.if_dst`, `ttl.pipenet_foreach_src`,
+/// `ttl.pipenet_foreach_dst`, and `ttl.pipenet_scope`. Other operations
+/// propagate the incoming domain unchanged.
 class LaunchNodeDomainAnalysis
     : public dataflow::DenseForwardDataFlowAnalysis<LaunchNodeDomainLattice> {
 public:

--- a/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
@@ -272,6 +272,12 @@ struct LaunchNodeDomainAnalysisOptions {
   std::function<void(PipeNetScopeOp, const LaunchNodeDomain &, Operation *,
                      const PipeNetScopeLaunchNodeDomains &)>
       pipeNetScopeCallback;
+
+  /// Return the launch nodes that may enter a generated region across all of
+  /// its dynamic invocations. Returning `std::nullopt` uses the region
+  /// operation's standard control-flow semantics.
+  std::function<std::optional<LaunchNodeDomain>(Operation *, unsigned)>
+      computeRegionDomain;
 };
 
 /// Forward dataflow analysis that propagates launch-node domains through

--- a/include/ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h
+++ b/include/ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h
@@ -52,6 +52,8 @@ getActivePipeNetRecordIndex(ArrayRef<ActivePipeNetRecord> activeRecords,
 /// PipeNet callback loops execute their complete body once for each matching
 /// record. `resolveGeneratedRecordLoop` identifies loops created by lowering;
 /// high-level PipeNet foreach operations are recognized directly.
+/// Every region whose operations the callback interprets in execution order
+/// must contain one block so lexical traversal represents that order.
 ///
 /// `executionCountDivisor` is the product of matching record counts for the
 /// enclosing callback loops. It is unknown if that product overflows.

--- a/include/ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h
+++ b/include/ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h
@@ -1,0 +1,84 @@
+//===- PipeNetExecutionUtils.h - PipeNet execution utilities ----*- C++ -*-===//
+//
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares utilities for visiting PipeNet callbacks in their
+// per-record execution order.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_PIPENETEXECUTIONUTILS_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_PIPENETEXECUTIONUTILS_H
+
+#include "mlir/IR/Operation.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+#include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace mlir::tt::ttl {
+
+/// Whether a callback loop selects records by source or destination.
+enum class PipeNetRecordSelection { Source, Destination };
+
+/// A loop that executes one PipeNet callback for each matching record.
+struct PipeNetRecordLoop {
+  PipeNetRecordsAttr records;
+  PipeNetRecordSelection selection;
+};
+
+/// The record selected by one active PipeNet callback loop.
+struct ActivePipeNetRecord {
+  Operation *loopOp = nullptr;
+  std::uint64_t recordIndex = 0;
+};
+
+/// Return the active record selected by `loopOp`, if present.
+std::optional<std::uint64_t>
+getActivePipeNetRecordIndex(ArrayRef<ActivePipeNetRecord> activeRecords,
+                            Operation *loopOp);
+
+/// Visit operations in their execution order at `coord`.
+///
+/// PipeNet callback loops execute their complete body once for each matching
+/// record. `resolveGeneratedRecordLoop` identifies loops created by lowering;
+/// high-level PipeNet foreach operations are recognized directly.
+///
+/// `executionCountDivisor` is the product of matching record counts for the
+/// enclosing callback loops. It is unknown if that product overflows.
+WalkResult walkPipeNetOpsInProgramOrder(
+    Operation *root, LaunchNodeCoord coord,
+    llvm::function_ref<std::optional<PipeNetRecordLoop>(Operation *)>
+        resolveGeneratedRecordLoop,
+    llvm::function_ref<
+        WalkResult(Operation *, ArrayRef<ActivePipeNetRecord>,
+                   std::optional<std::uint64_t> executionCountDivisor)>
+        visitOperation);
+
+/// Visit operations within an enclosing PipeNet callback execution.
+///
+/// This overload composes record traversal with another execution expansion,
+/// such as direct function calls. `activeRecords` is restored before return.
+WalkResult walkPipeNetOpsInProgramOrder(
+    Operation *root, LaunchNodeCoord coord,
+    llvm::function_ref<std::optional<PipeNetRecordLoop>(Operation *)>
+        resolveGeneratedRecordLoop,
+    llvm::function_ref<
+        WalkResult(Operation *, ArrayRef<ActivePipeNetRecord>,
+                   std::optional<std::uint64_t> executionCountDivisor)>
+        visitOperation,
+    SmallVectorImpl<ActivePipeNetRecord> &activeRecords,
+    std::optional<std::uint64_t> executionCountDivisor);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_PIPENETEXECUTIONUTILS_H

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_constant_table.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_constant_table.h
@@ -6,13 +6,25 @@
 #define TTLANG_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_CONSTANT_TABLE_H
 
 #include <cstddef>
+#include <cstdint>
 
 namespace experimental {
 
-template <std::size_t... Values>
+template <std::size_t BitsPerValue, std::uint64_t... PackedWords>
 FORCE_INLINE std::size_t constant_table_lookup(std::size_t index) {
-  static constexpr std::size_t table[] = {Values...};
-  return table[index];
+  static_assert(BitsPerValue > 0 && BitsPerValue < 64);
+  // Packed words limit generated source size without allocating a runtime
+  // table in kernel stack storage.
+  static constexpr std::uint64_t packed_table[] = {PackedWords...};
+  constexpr std::uint64_t value_mask = (std::uint64_t{1} << BitsPerValue) - 1;
+  const std::size_t bit_offset = index * BitsPerValue;
+  const std::size_t word_index = bit_offset / 64;
+  const std::size_t offset_in_word = bit_offset % 64;
+  std::uint64_t value = packed_table[word_index] >> offset_in_word;
+  if (offset_in_word + BitsPerValue > 64) {
+    value |= packed_table[word_index + 1] << (64 - offset_in_word);
+  }
+  return value & value_mask;
 }
 
 } // namespace experimental

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_constant_table.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_constant_table.h
@@ -10,12 +10,10 @@
 
 namespace experimental {
 
-template <std::size_t BitsPerValue, std::uint64_t... PackedWords>
-FORCE_INLINE std::size_t constant_table_lookup(std::size_t index) {
+template <std::size_t BitsPerValue>
+FORCE_INLINE std::size_t
+constant_table_lookup(std::size_t index, const std::uint64_t *packed_table) {
   static_assert(BitsPerValue > 0 && BitsPerValue < 64);
-  // Packed words limit generated source size without allocating a runtime
-  // table in kernel stack storage.
-  static constexpr std::uint64_t packed_table[] = {PackedWords...};
   constexpr std::uint64_t value_mask = (std::uint64_t{1} << BitsPerValue) - 1;
   const std::size_t bit_offset = index * BitsPerValue;
   const std::size_t word_index = bit_offset / 64;

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_constant_table.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_constant_table.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_CONSTANT_TABLE_H
+#define TTLANG_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_CONSTANT_TABLE_H
+
+#include <cstddef>
+
+namespace experimental {
+
+template <std::size_t... Values>
+FORCE_INLINE std::size_t constant_table_lookup(std::size_t index) {
+  static constexpr std::size_t table[] = {Values...};
+  return table[index];
+}
+
+} // namespace experimental
+
+#endif

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -91,7 +91,7 @@ void ttlangRegisterPasses() {
 bool ttlangRunTTKernelToEmitC(MlirModule module) {
   Operation *op = unwrap(mlirModuleGetOperation(module));
   PassManager passManager(op->getName());
-  passManager.addNestedPass<func::FuncOp>(tt::createConvertTTKernelToEmitC());
+  passManager.addPass(tt::createConvertTTKernelToEmitC());
   return succeeded(passManager.run(op));
 }
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -556,6 +556,22 @@ public:
 } // namespace
 
 namespace {
+class TTKernelCastToL1AddrOpToEmitCOpRewriter
+    : public OpConversionPattern<ttkernel::CastToL1AddrOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttkernel::CastToL1AddrOp op,
+                  ttkernel::CastToL1AddrOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // The type converter maps every accepted operand to the same i32 address
+    // representation, so the normalization requires no emitted C++ operation.
+    rewriter.replaceOp(op, adaptor.getAddr());
+    return success();
+  }
+};
+
 class TTKernelCastToL1PtrOpToEmitCOpRewriter
     : public OpConversionPattern<ttkernel::CastToL1PtrOp> {
 
@@ -1167,6 +1183,44 @@ public:
 
 private:
   std::string opName;
+};
+} // namespace
+
+namespace {
+class TTKernelConstantTableLookupOpRewriter
+    : public OpConversionPattern<ttkernel::ConstantTableLookupOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttkernel::ConstantTableLookupOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "failed to convert result type");
+    }
+    if (op.getValues().empty()) {
+      return rewriter.notifyMatchFailure(op,
+                                         "constant table must not be empty");
+    }
+
+    SmallVector<Attribute> templateArgs;
+    templateArgs.reserve(op.getValues().size());
+    for (int64_t value : op.getValues()) {
+      if (value < 0) {
+        return rewriter.notifyMatchFailure(
+            op, "constant table values must be non-negative");
+      }
+      templateArgs.push_back(
+          emitc::OpaqueAttr::get(op.getContext(), std::to_string(value)));
+    }
+    auto call = emitc::CallOpaqueOp::create(
+        rewriter, op.getLoc(), resultType,
+        "experimental::constant_table_lookup", ArrayAttr(),
+        rewriter.getArrayAttr(templateArgs), adaptor.getIndex());
+    rewriter.replaceOp(op, call.getResult(0));
+    return success();
+  }
 };
 } // namespace
 
@@ -2789,6 +2843,7 @@ public:
     populateMemRefToEmitCConversionPatterns(patterns, typeConverter);
 
     patterns.add<TTKernelBitcastOpRewriter>(typeConverter, context, &state);
+    patterns.add<TTKernelConstantTableLookupOpRewriter>(typeConverter, context);
     patterns
         .add<TTKernelMatmulInitToEmitCRewriter<ttkernel::MatmulInitOp>,
              TTKernelMatmulInitToEmitCRewriter<ttkernel::MatmulBlockInitOp>>(
@@ -2808,6 +2863,7 @@ public:
         TTKernelToEmitCGetMyLogicalMeshPositionOpRewriter,
         TTKernelMacroOpToEmitCOpRewriter<ttkernel::MemZerosBaseOp>,
         TTKernelMacroOpToEmitCOpRewriter<ttkernel::MemZerosSizeOp>,
+        TTKernelCastToL1AddrOpToEmitCOpRewriter,
         TTKernelCastToL1PtrOpToEmitCOpRewriter,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetSemaphoreOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetOp>,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
@@ -30,6 +31,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/bit.h"
+#include "llvm/Support/xxhash.h"
 
 #include <array>
 #include <functional>
@@ -1205,6 +1207,64 @@ static SmallVector<uint64_t> packConstantTable(ArrayRef<int64_t> values,
   return packedWords;
 }
 
+static std::string getConstantTableSymbolName(ArrayRef<uint64_t> packedWords) {
+  SmallString<128> serializedWords;
+  for (uint64_t packedWord : packedWords) {
+    serializedWords += llvm::utohexstr(packedWord);
+    serializedWords += '_';
+  }
+  return "__ttlang_constant_table_" +
+         llvm::utohexstr(llvm::xxh3_64bits(StringRef(serializedWords)));
+}
+
+static emitc::GlobalOp
+getOrCreateConstantTableGlobal(ConversionPatternRewriter &rewriter,
+                               Operation *anchor,
+                               ArrayRef<uint64_t> packedWords) {
+  // Static storage keeps device-compiler parsing independent of table length;
+  // a template argument for every packed word scales parsing with the table.
+  ModuleOp module = anchor->getParentOfType<ModuleOp>();
+  assert(module && "constant table lookup must be nested in a module");
+
+  IntegerType wordType = IntegerType::get(
+      rewriter.getContext(), 64, IntegerType::SignednessSemantics::Unsigned);
+  auto arrayType = emitc::ArrayType::get(
+      {static_cast<int64_t>(packedWords.size())}, wordType);
+  std::string initializerText = "{";
+  for (auto [wordIndex, packedWord] : llvm::enumerate(packedWords)) {
+    if (wordIndex != 0) {
+      initializerText += ", ";
+    }
+    initializerText += "0x" + llvm::utohexstr(packedWord) + "ULL";
+  }
+  initializerText += "}";
+  auto initializer =
+      emitc::OpaqueAttr::get(rewriter.getContext(), initializerText);
+
+  std::string baseName = getConstantTableSymbolName(packedWords);
+  std::string symbolName = baseName;
+  for (unsigned suffix = 0;; ++suffix) {
+    Operation *existing = SymbolTable::lookupSymbolIn(module, symbolName);
+    if (!existing) {
+      break;
+    }
+    auto global = dyn_cast<emitc::GlobalOp>(existing);
+    if (global && global.getType() == arrayType &&
+        global.getInitialValueAttr() == initializer) {
+      return global;
+    }
+    symbolName = baseName + "_" + std::to_string(suffix + 1);
+  }
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(module.getBody());
+  return emitc::GlobalOp::create(rewriter, anchor->getLoc(), symbolName,
+                                 arrayType, initializer,
+                                 /*externSpecifier=*/false,
+                                 /*staticSpecifier=*/true,
+                                 /*constSpecifier=*/true);
+}
+
 class TTKernelConstantTableLookupOpRewriter
     : public OpConversionPattern<ttkernel::ConstantTableLookupOp> {
 public:
@@ -1235,20 +1295,20 @@ public:
     SmallVector<uint64_t> packedWords =
         packConstantTable(op.getValues(), bitsPerValue);
 
+    emitc::GlobalOp table =
+        getOrCreateConstantTableGlobal(rewriter, op, packedWords);
+    auto tableRef = emitc::GetGlobalOp::create(
+        rewriter, op.getLoc(), table.getType(), table.getSymName());
+
     SmallVector<Attribute> templateArgs;
-    templateArgs.reserve(packedWords.size() + 1);
+    templateArgs.reserve(1);
     templateArgs.push_back(
         emitc::OpaqueAttr::get(op.getContext(), std::to_string(bitsPerValue)));
-    // Hex literals preserve the packed bits without signed conversion and use
-    // fewer source characters than one decimal argument per table element.
-    for (uint64_t packedWord : packedWords) {
-      templateArgs.push_back(emitc::OpaqueAttr::get(
-          op.getContext(), "0x" + llvm::utohexstr(packedWord) + "ULL"));
-    }
     auto call = emitc::CallOpaqueOp::create(
         rewriter, op.getLoc(), resultType,
         "experimental::constant_table_lookup", ArrayAttr(),
-        rewriter.getArrayAttr(templateArgs), adaptor.getIndex());
+        rewriter.getArrayAttr(templateArgs),
+        ValueRange{adaptor.getIndex(), tableRef});
     rewriter.replaceOp(op, call.getResult(0));
     return success();
   }
@@ -2818,12 +2878,20 @@ public:
       ConvertTTKernelToEmitCPass>::ConvertTTKernelToEmitCBase;
 
   void runOnOperation() final {
-    func::FuncOp funcOp = getOperation();
+    ModuleOp module = getOperation();
     TTKernelToEmitCConversionState state;
-    ConversionPlan config(funcOp.getContext(), state);
-    if (failed(visit(funcOp, config))) {
-      signalPassFailure();
-      return;
+    ConversionPlan config(module.getContext(), state);
+    for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
+      if (!funcOp->hasAttr(ttkernel::ThreadTypeAttr::name)) {
+        continue;
+      }
+      if (mayHaveRuntimeCBArgs(funcOp)) {
+        assignRuntimeCBArgIndices(funcOp);
+      }
+      if (failed(applyFullConversion(funcOp, config.target, config.patterns))) {
+        signalPassFailure();
+        return;
+      }
     }
   }
 
@@ -2849,17 +2917,6 @@ public:
     TTKernelToEmitCTypeConverter typeConverter;
     FrozenRewritePatternSet patterns;
   };
-
-  static LogicalResult visit(func::FuncOp funcOp, ConversionPlan &config) {
-    if (!funcOp->hasAttr(ttkernel::ThreadTypeAttr::name)) {
-      return success();
-    }
-
-    if (mayHaveRuntimeCBArgs(funcOp)) {
-      assignRuntimeCBArgIndices(funcOp);
-    }
-    return applyFullConversion(funcOp, config.target, config.patterns);
-  }
 
   static FrozenRewritePatternSet
   buildPatterns(MLIRContext *context,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/bit.h"
 
 #include <array>
 #include <functional>
@@ -1187,6 +1188,23 @@ private:
 } // namespace
 
 namespace {
+static SmallVector<uint64_t> packConstantTable(ArrayRef<int64_t> values,
+                                               unsigned bitsPerValue) {
+  std::size_t totalBits = values.size() * bitsPerValue;
+  SmallVector<uint64_t> packedWords((totalBits + 63) / 64, 0);
+  for (auto [index, signedValue] : llvm::enumerate(values)) {
+    uint64_t value = static_cast<uint64_t>(signedValue);
+    std::size_t bitOffset = index * bitsPerValue;
+    std::size_t wordIndex = bitOffset / 64;
+    unsigned offsetInWord = bitOffset % 64;
+    packedWords[wordIndex] |= value << offsetInWord;
+    if (offsetInWord + bitsPerValue > 64) {
+      packedWords[wordIndex + 1] |= value >> (64 - offsetInWord);
+    }
+  }
+  return packedWords;
+}
+
 class TTKernelConstantTableLookupOpRewriter
     : public OpConversionPattern<ttkernel::ConstantTableLookupOp> {
 public:
@@ -1204,15 +1222,28 @@ public:
                                          "constant table must not be empty");
     }
 
-    SmallVector<Attribute> templateArgs;
-    templateArgs.reserve(op.getValues().size());
+    uint64_t maxValue = 0;
     for (int64_t value : op.getValues()) {
       if (value < 0) {
         return rewriter.notifyMatchFailure(
             op, "constant table values must be non-negative");
       }
-      templateArgs.push_back(
-          emitc::OpaqueAttr::get(op.getContext(), std::to_string(value)));
+      maxValue = std::max(maxValue, static_cast<uint64_t>(value));
+    }
+    unsigned bitsPerValue =
+        std::max(1, llvm::bit_width(static_cast<uint64_t>(maxValue)));
+    SmallVector<uint64_t> packedWords =
+        packConstantTable(op.getValues(), bitsPerValue);
+
+    SmallVector<Attribute> templateArgs;
+    templateArgs.reserve(packedWords.size() + 1);
+    templateArgs.push_back(
+        emitc::OpaqueAttr::get(op.getContext(), std::to_string(bitsPerValue)));
+    // Hex literals preserve the packed bits without signed conversion and use
+    // fewer source characters than one decimal argument per table element.
+    for (uint64_t packedWord : packedWords) {
+      templateArgs.push_back(emitc::OpaqueAttr::get(
+          op.getContext(), "0x" + llvm::utohexstr(packedWord) + "ULL"));
     }
     auto call = emitc::CallOpaqueOp::create(
         rewriter, op.getLoc(), resultType,

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "llvm/ADT/STLExtras.h"
@@ -588,6 +589,15 @@ LogicalResult ConstantTableLookupOp::verify() {
   }
   if (llvm::any_of(values, [](int64_t value) { return value < 0; })) {
     return emitOpError("requires non-negative table values");
+  }
+  APInt indexValue;
+  if (matchPattern(getIndex(), m_ConstantInt(&indexValue))) {
+    int64_t index = indexValue.getSExtValue();
+    if (index < 0 || static_cast<std::size_t>(index) >= values.size()) {
+      return emitOpError() << "constant index " << index
+                           << " is outside the table bounds [0, "
+                           << values.size() << ")";
+    }
   }
   return success();
 }

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
+#include "llvm/ADT/STLExtras.h"
 
 #include <limits>
 
@@ -565,6 +566,30 @@ void MyLogicalYOp::inferResultRanges(
     mlir::SetIntRangeFn setResultRange) {
   setResultRange(getResult(),
                  getIndexRange(0, std::numeric_limits<uint32_t>::max()));
+}
+
+OpFoldResult ConstantTableLookupOp::fold(FoldAdaptor adaptor) {
+  auto indexAttr = dyn_cast_or_null<IntegerAttr>(adaptor.getIndex());
+  if (!indexAttr) {
+    return {};
+  }
+  int64_t index = indexAttr.getInt();
+  ArrayRef<int64_t> values = getValues();
+  if (index < 0 || static_cast<std::size_t>(index) >= values.size()) {
+    return {};
+  }
+  return IntegerAttr::get(getResult().getType(), values[index]);
+}
+
+LogicalResult ConstantTableLookupOp::verify() {
+  ArrayRef<int64_t> values = getValues();
+  if (values.empty()) {
+    return emitOpError("requires at least one table value");
+  }
+  if (llvm::any_of(values, [](int64_t value) { return value < 0; })) {
+    return emitOpError("requires non-negative table values");
+  }
+  return success();
 }
 
 void NocAsyncReadBarrierOp::getCanonicalizationPatterns(

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -132,6 +132,28 @@ LayoutAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
   return llvm::success();
 }
 
+llvm::LogicalResult
+PipeRecordAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+                       int64_t srcX, int64_t srcY, int64_t dstStartX,
+                       int64_t dstStartY, int64_t dstEndX, int64_t dstEndY,
+                       bool isCollective) {
+  if (srcX < 0 || srcY < 0) {
+    return emitError() << "source coordinates must be non-negative";
+  }
+  if (dstStartX < 0 || dstStartY < 0 || dstEndX < 0 || dstEndY < 0) {
+    return emitError() << "destination coordinates must be non-negative";
+  }
+  if (dstStartX > dstEndX || dstStartY > dstEndY) {
+    return emitError()
+           << "destination start must not exceed destination end on any axis";
+  }
+  if (!isCollective && (dstStartX != dstEndX || dstStartY != dstEndY)) {
+    return emitError()
+           << "point-to-point pipe record must have exactly one receiver";
+  }
+  return llvm::success();
+}
+
 } // namespace mlir::tt::ttl
 
 mlir::LogicalResult mlir::tt::ttl::BindCBOp::verify() {
@@ -256,19 +278,35 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
   const bool dstIsCb = mlir::isa<CircularBufferType>(dstTy);
   const bool srcIsSlice = getSrc().getDefiningOp<TensorSliceOp>() != nullptr;
   const bool dstIsSlice = getDst().getDefiningOp<TensorSliceOp>() != nullptr;
-  const bool srcIsPipe = mlir::isa<PipeType>(srcTy);
-  const bool dstIsPipe = mlir::isa<PipeType>(dstTy);
+  const bool srcIsStaticPipe = mlir::isa<PipeType>(srcTy);
+  const bool dstIsStaticPipe = mlir::isa<PipeType>(dstTy);
+  const bool srcIsSelectedPipeSrc = mlir::isa<SelectedPipeSrcType>(srcTy);
+  const bool srcIsSelectedPipeDst = mlir::isa<SelectedPipeDstType>(srcTy);
+  const bool dstIsSelectedPipeSrc = mlir::isa<SelectedPipeSrcType>(dstTy);
+  const bool dstIsSelectedPipeDst = mlir::isa<SelectedPipeDstType>(dstTy);
+  const bool srcIsPipe =
+      srcIsStaticPipe || srcIsSelectedPipeSrc || srcIsSelectedPipeDst;
+  const bool dstIsPipe =
+      dstIsStaticPipe || dstIsSelectedPipeSrc || dstIsSelectedPipeDst;
 
   if (srcIsPipe || dstIsPipe) {
     if (srcIsPipe && dstIsPipe) {
       return emitOpError() << "cannot copy directly between pipes";
     }
     if (dstIsPipe) {
+      if (dstIsSelectedPipeDst) {
+        return emitOpError()
+               << "destination-selected pipe cannot be used as a send target";
+      }
       if (!srcIsCb) {
         return emitOpError()
                << "pipe send requires source operand to be !ttl.cb";
       }
       return success();
+    }
+    if (srcIsSelectedPipeSrc) {
+      return emitOpError()
+             << "source-selected pipe cannot be used as a receive source";
     }
     if (!findCBReserveForPipeReceive(getDst())) {
       return emitOpError() << "pipe receive requires a cb_reserve destination";
@@ -355,25 +393,153 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
   return success();
 }
 
-mlir::LogicalResult mlir::tt::ttl::PipeTransferCreateOp::verify() {
-  auto pipeType = mlir::cast<PipeType>(getPipe().getType());
-  int64_t expectedReceivers = static_cast<int64_t>(getExpectedReceivers());
-  if (expectedReceivers <= 0) {
-    return emitOpError() << "requires positive expectedReceivers";
+static mlir::LogicalResult verifyPipeNetForeachBody(
+    mlir::Operation *op, mlir::Region &body, mlir::Type expectedArgType,
+    llvm::function_ref<bool(mlir::OpOperand &, mlir::BlockArgument)>
+        isValidUse) {
+  if (!body.hasOneBlock()) {
+    return op->emitOpError() << "requires a single-block body";
   }
-  if (expectedReceivers != pipeType.getNumDests()) {
-    return emitOpError()
-           << "expectedReceivers must match the pipe receiver count";
+  mlir::Block &block = body.front();
+  if (block.getNumArguments() != 1) {
+    return op->emitOpError()
+           << "body must have exactly one selected-pipe argument";
+  }
+  mlir::BlockArgument pipeArg = block.getArgument(0);
+  if (pipeArg.getType() != expectedArgType) {
+    return op->emitOpError()
+           << "body argument must have type " << expectedArgType << ", got "
+           << pipeArg.getType();
+  }
+  for (mlir::OpOperand &use : pipeArg.getUses()) {
+    if (isValidUse(use, pipeArg)) {
+      continue;
+    }
+    return op->emitOpError() << "selected pipe argument has unsupported use by "
+                             << use.getOwner()->getName();
+  }
+  return mlir::success();
+}
+
+static mlir::LogicalResult
+verifyPipeNetForeachRecords(mlir::Operation *op,
+                            mlir::tt::ttl::PipeNetRecordsAttr records) {
+  ::llvm::ArrayRef<mlir::tt::ttl::PipeRecordAttr> pipes = records.getPipes();
+  if (pipes.empty()) {
+    return op->emitOpError() << "requires at least one pipe record";
+  }
+  bool isCollective = pipes.front().getIsCollective();
+  for (mlir::tt::ttl::PipeRecordAttr record : pipes) {
+    if (record.getIsCollective() != isCollective) {
+      return op->emitOpError()
+             << "all pipe records must be either point-to-point or collective";
+    }
+  }
+  return mlir::success();
+}
+
+mlir::LogicalResult mlir::tt::ttl::PipeNetForeachSrcOp::verify() {
+  if (failed(verifyPipeNetForeachRecords(getOperation(), getRecords()))) {
+    return failure();
+  }
+  return verifyPipeNetForeachBody(
+      getOperation(), getBody(), SelectedPipeSrcType::get(getContext()),
+      [](mlir::OpOperand &use, mlir::BlockArgument pipeArg) {
+        auto copy = mlir::dyn_cast<CopyOp>(use.getOwner());
+        if (!copy) {
+          return false;
+        }
+        return copy.getDst() == pipeArg;
+      });
+}
+
+mlir::LogicalResult mlir::tt::ttl::PipeNetForeachDstOp::verify() {
+  if (failed(verifyPipeNetForeachRecords(getOperation(), getRecords()))) {
+    return failure();
+  }
+  return verifyPipeNetForeachBody(
+      getOperation(), getBody(), SelectedPipeDstType::get(getContext()),
+      [](mlir::OpOperand &use, mlir::BlockArgument pipeArg) {
+        auto copy = mlir::dyn_cast<CopyOp>(use.getOwner());
+        if (!copy) {
+          return false;
+        }
+        return copy.getSrc() == pipeArg;
+      });
+}
+
+mlir::LogicalResult mlir::tt::ttl::SelectPipeSrcOp::verify() {
+  return verifyPipeNetForeachRecords(getOperation(), getRecords());
+}
+
+mlir::LogicalResult mlir::tt::ttl::SelectPipeDstOp::verify() {
+  return verifyPipeNetForeachRecords(getOperation(), getRecords());
+}
+
+static mlir::Operation *getSelectedPipeDef(mlir::Value pipe) {
+  pipe = mlir::tt::ttl::traceUnrealizedCasts(pipe);
+  if (auto selectedSrc = pipe.getDefiningOp<mlir::tt::ttl::SelectPipeSrcOp>()) {
+    return selectedSrc.getOperation();
+  }
+  if (auto selectedDst = pipe.getDefiningOp<mlir::tt::ttl::SelectPipeDstOp>()) {
+    return selectedDst.getOperation();
+  }
+  return nullptr;
+}
+
+static mlir::LogicalResult verifySelectedPipeDirectDef(mlir::Operation *op,
+                                                       mlir::Value pipe) {
+  if (mlir::isa<mlir::tt::ttl::PipeType>(pipe.getType())) {
+    return mlir::success();
+  }
+  if (getSelectedPipeDef(pipe)) {
+    return mlir::success();
+  }
+  return op->emitOpError()
+         << "selected pipe operand must be a direct result of "
+            "ttl.select_pipe_src or ttl.select_pipe_dst";
+}
+
+static bool
+selectedPipeKindMatchesTransfer(mlir::Value pipe,
+                                mlir::tt::ttl::PipeTransferKind kind) {
+  pipe = mlir::tt::ttl::traceUnrealizedCasts(pipe);
+  mlir::tt::ttl::PipeNetRecordsAttr records;
+  if (auto selectedSrc = pipe.getDefiningOp<mlir::tt::ttl::SelectPipeSrcOp>()) {
+    records = selectedSrc.getRecords();
+  } else if (auto selectedDst =
+                 pipe.getDefiningOp<mlir::tt::ttl::SelectPipeDstOp>()) {
+    records = selectedDst.getRecords();
+  } else {
+    return true;
   }
 
-  switch (getKind().getValue()) {
-  case PipeTransferKind::PointToPoint:
-    if (!pipeType.hasSingleReceiver()) {
-      return emitOpError() << "point_to_point transfer requires one receiver";
+  bool isCollective = records.getPipes().front().getIsCollective();
+  return isCollective == (kind == mlir::tt::ttl::PipeTransferKind::Collective);
+}
+
+mlir::LogicalResult mlir::tt::ttl::PipeTransferCreateOp::verify() {
+  if (failed(verifySelectedPipeDirectDef(getOperation(), getPipe()))) {
+    return failure();
+  }
+
+  Value pipe = traceUnrealizedCasts(getPipe());
+  if (auto pipeType = mlir::dyn_cast<PipeType>(pipe.getType())) {
+    switch (getKind().getValue()) {
+    case PipeTransferKind::PointToPoint:
+      if (!pipeType.hasSingleReceiver()) {
+        return emitOpError() << "point_to_point transfer requires one receiver";
+      }
+      break;
+    case PipeTransferKind::Collective:
+      break;
     }
-    break;
-  case PipeTransferKind::Collective:
-    break;
+    return success();
+  }
+
+  if (!selectedPipeKindMatchesTransfer(getPipe(), getKind().getValue())) {
+    return emitOpError()
+           << "selected pipe transfer kind must match the records kind";
   }
 
   return success();
@@ -2086,6 +2252,26 @@ void mlir::tt::ttl::IfSrcOp::getSuccessorRegions(
 }
 
 void mlir::tt::ttl::IfDstOp::getSuccessorRegions(
+    RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
+  if (point.isParent()) {
+    regions.push_back(RegionSuccessor(&getBody()));
+    regions.push_back(RegionSuccessor(getOperation()));
+    return;
+  }
+  regions.push_back(RegionSuccessor(getOperation()));
+}
+
+void mlir::tt::ttl::PipeNetForeachSrcOp::getSuccessorRegions(
+    RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
+  if (point.isParent()) {
+    regions.push_back(RegionSuccessor(&getBody()));
+    regions.push_back(RegionSuccessor(getOperation()));
+    return;
+  }
+  regions.push_back(RegionSuccessor(getOperation()));
+}
+
+void mlir::tt::ttl::PipeNetForeachDstOp::getSuccessorRegions(
     RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
   if (point.isParent()) {
     regions.push_back(RegionSuccessor(&getBody()));

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -154,6 +154,22 @@ PipeRecordAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
   return llvm::success();
 }
 
+llvm::LogicalResult PipeNetRecordsAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError, int64_t pipeNetId,
+    StringAttr pipeNetName, ArrayRef<PipeRecordAttr> pipes) {
+  if (pipes.empty()) {
+    return emitError() << "requires at least one pipe record";
+  }
+  bool isCollective = pipes.front().getIsCollective();
+  if (llvm::any_of(pipes, [&](PipeRecordAttr record) {
+        return record.getIsCollective() != isCollective;
+      })) {
+    return emitError()
+           << "all pipe records must be either point-to-point or collective";
+  }
+  return llvm::success();
+}
+
 } // namespace mlir::tt::ttl
 
 mlir::LogicalResult mlir::tt::ttl::BindCBOp::verify() {
@@ -421,27 +437,7 @@ static mlir::LogicalResult verifyPipeNetForeachBody(
   return mlir::success();
 }
 
-static mlir::LogicalResult
-verifyPipeNetForeachRecords(mlir::Operation *op,
-                            mlir::tt::ttl::PipeNetRecordsAttr records) {
-  ::llvm::ArrayRef<mlir::tt::ttl::PipeRecordAttr> pipes = records.getPipes();
-  if (pipes.empty()) {
-    return op->emitOpError() << "requires at least one pipe record";
-  }
-  bool isCollective = pipes.front().getIsCollective();
-  for (mlir::tt::ttl::PipeRecordAttr record : pipes) {
-    if (record.getIsCollective() != isCollective) {
-      return op->emitOpError()
-             << "all pipe records must be either point-to-point or collective";
-    }
-  }
-  return mlir::success();
-}
-
 mlir::LogicalResult mlir::tt::ttl::PipeNetForeachSrcOp::verify() {
-  if (failed(verifyPipeNetForeachRecords(getOperation(), getRecords()))) {
-    return failure();
-  }
   return verifyPipeNetForeachBody(
       getOperation(), getBody(), SelectedPipeSrcType::get(getContext()),
       [](mlir::OpOperand &use, mlir::BlockArgument pipeArg) {
@@ -454,9 +450,6 @@ mlir::LogicalResult mlir::tt::ttl::PipeNetForeachSrcOp::verify() {
 }
 
 mlir::LogicalResult mlir::tt::ttl::PipeNetForeachDstOp::verify() {
-  if (failed(verifyPipeNetForeachRecords(getOperation(), getRecords()))) {
-    return failure();
-  }
   return verifyPipeNetForeachBody(
       getOperation(), getBody(), SelectedPipeDstType::get(getContext()),
       [](mlir::OpOperand &use, mlir::BlockArgument pipeArg) {
@@ -466,14 +459,6 @@ mlir::LogicalResult mlir::tt::ttl::PipeNetForeachDstOp::verify() {
         }
         return copy.getSrc() == pipeArg;
       });
-}
-
-mlir::LogicalResult mlir::tt::ttl::SelectPipeSrcOp::verify() {
-  return verifyPipeNetForeachRecords(getOperation(), getRecords());
-}
-
-mlir::LogicalResult mlir::tt::ttl::SelectPipeDstOp::verify() {
-  return verifyPipeNetForeachRecords(getOperation(), getRecords());
 }
 
 static mlir::Operation *getSelectedPipeDef(mlir::Value pipe) {

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -294,35 +294,21 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
   const bool dstIsCb = mlir::isa<CircularBufferType>(dstTy);
   const bool srcIsSlice = getSrc().getDefiningOp<TensorSliceOp>() != nullptr;
   const bool dstIsSlice = getDst().getDefiningOp<TensorSliceOp>() != nullptr;
-  const bool srcIsStaticPipe = mlir::isa<PipeType>(srcTy);
-  const bool dstIsStaticPipe = mlir::isa<PipeType>(dstTy);
-  const bool srcIsSelectedPipeSrc = mlir::isa<SelectedPipeSrcType>(srcTy);
-  const bool srcIsSelectedPipeDst = mlir::isa<SelectedPipeDstType>(srcTy);
-  const bool dstIsSelectedPipeSrc = mlir::isa<SelectedPipeSrcType>(dstTy);
-  const bool dstIsSelectedPipeDst = mlir::isa<SelectedPipeDstType>(dstTy);
   const bool srcIsPipe =
-      srcIsStaticPipe || srcIsSelectedPipeSrc || srcIsSelectedPipeDst;
+      mlir::isa<PipeType, SelectedPipeSrcType, SelectedPipeDstType>(srcTy);
   const bool dstIsPipe =
-      dstIsStaticPipe || dstIsSelectedPipeSrc || dstIsSelectedPipeDst;
+      mlir::isa<PipeType, SelectedPipeSrcType, SelectedPipeDstType>(dstTy);
 
   if (srcIsPipe || dstIsPipe) {
     if (srcIsPipe && dstIsPipe) {
       return emitOpError() << "cannot copy directly between pipes";
     }
     if (dstIsPipe) {
-      if (dstIsSelectedPipeDst) {
-        return emitOpError()
-               << "destination-selected pipe cannot be used as a send target";
-      }
       if (!srcIsCb) {
         return emitOpError()
                << "pipe send requires source operand to be !ttl.cb";
       }
       return success();
-    }
-    if (srcIsSelectedPipeSrc) {
-      return emitOpError()
-             << "source-selected pipe cannot be used as a receive source";
     }
     if (!findCBReserveForPipeReceive(getDst())) {
       return emitOpError() << "pipe receive requires a cb_reserve destination";
@@ -409,10 +395,9 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
   return success();
 }
 
-static mlir::LogicalResult verifyPipeNetForeachBody(
-    mlir::Operation *op, mlir::Region &body, mlir::Type expectedArgType,
-    llvm::function_ref<bool(mlir::OpOperand &, mlir::BlockArgument)>
-        isValidUse) {
+static mlir::LogicalResult
+verifyPipeNetForeachBody(mlir::Operation *op, mlir::Region &body,
+                         mlir::Type expectedArgType) {
   if (!body.hasOneBlock()) {
     return op->emitOpError() << "requires a single-block body";
   }
@@ -428,7 +413,8 @@ static mlir::LogicalResult verifyPipeNetForeachBody(
            << pipeArg.getType();
   }
   for (mlir::OpOperand &use : pipeArg.getUses()) {
-    if (isValidUse(use, pipeArg)) {
+    auto copy = mlir::dyn_cast<mlir::tt::ttl::CopyOp>(use.getOwner());
+    if (copy && (copy.getSrc() == pipeArg || copy.getDst() == pipeArg)) {
       continue;
     }
     return op->emitOpError() << "selected pipe argument has unsupported use by "
@@ -438,27 +424,13 @@ static mlir::LogicalResult verifyPipeNetForeachBody(
 }
 
 mlir::LogicalResult mlir::tt::ttl::PipeNetForeachSrcOp::verify() {
-  return verifyPipeNetForeachBody(
-      getOperation(), getBody(), SelectedPipeSrcType::get(getContext()),
-      [](mlir::OpOperand &use, mlir::BlockArgument pipeArg) {
-        auto copy = mlir::dyn_cast<CopyOp>(use.getOwner());
-        if (!copy) {
-          return false;
-        }
-        return copy.getDst() == pipeArg;
-      });
+  return verifyPipeNetForeachBody(getOperation(), getBody(),
+                                  SelectedPipeSrcType::get(getContext()));
 }
 
 mlir::LogicalResult mlir::tt::ttl::PipeNetForeachDstOp::verify() {
-  return verifyPipeNetForeachBody(
-      getOperation(), getBody(), SelectedPipeDstType::get(getContext()),
-      [](mlir::OpOperand &use, mlir::BlockArgument pipeArg) {
-        auto copy = mlir::dyn_cast<CopyOp>(use.getOwner());
-        if (!copy) {
-          return false;
-        }
-        return copy.getSrc() == pipeArg;
-      });
+  return verifyPipeNetForeachBody(getOperation(), getBody(),
+                                  SelectedPipeDstType::get(getContext()));
 }
 
 static mlir::Operation *getSelectedPipeDef(mlir::Value pipe) {

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -303,6 +303,14 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
     if (srcIsPipe && dstIsPipe) {
       return emitOpError() << "cannot copy directly between pipes";
     }
+    Value pipe = srcIsPipe ? getSrc() : getDst();
+    if (!mlir::isa<PipeType>(pipe.getType()) &&
+        failed(getSelectedPipeRecords(pipe))) {
+      return emitOpError()
+             << "selected pipe operand must be defined by ttl.select_pipe_src, "
+                "ttl.select_pipe_dst, ttl.pipenet_foreach_src, or "
+                "ttl.pipenet_foreach_dst";
+    }
     if (dstIsPipe) {
       if (!srcIsCb) {
         return emitOpError()

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -138,6 +138,29 @@ FailureOr<ttkernel::ReduceDim> getReduceDimension(ArrayRef<int64_t> dims,
   return failure();
 }
 
+FailureOr<SelectedPipeRecords> getSelectedPipeRecords(Value pipe) {
+  pipe = traceUnrealizedCasts(pipe);
+  if (auto selectedSrc = pipe.getDefiningOp<SelectPipeSrcOp>()) {
+    return SelectedPipeRecords{selectedSrc.getRecords(), nullptr};
+  }
+  if (auto selectedDst = pipe.getDefiningOp<SelectPipeDstOp>()) {
+    return SelectedPipeRecords{selectedDst.getRecords(), nullptr};
+  }
+
+  auto blockArgument = mlir::dyn_cast<BlockArgument>(pipe);
+  if (!blockArgument || blockArgument.getArgNumber() != 0) {
+    return failure();
+  }
+  Operation *owner = blockArgument.getOwner()->getParentOp();
+  if (auto foreachSrc = mlir::dyn_cast<PipeNetForeachSrcOp>(owner)) {
+    return SelectedPipeRecords{foreachSrc.getRecords(), owner};
+  }
+  if (auto foreachDst = mlir::dyn_cast<PipeNetForeachDstOp>(owner)) {
+    return SelectedPipeRecords{foreachDst.getRecords(), owner};
+  }
+  return failure();
+}
+
 //===----------------------------------------------------------------------===//
 // DST access interface defaults
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -89,7 +89,7 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
   }
   if (options.lowerToEmitC) {
     pm.addPass(createLowerAffinePass());
-    pm.addNestedPass<func::FuncOp>(::mlir::tt::createConvertTTKernelToEmitC());
+    pm.addPass(::mlir::tt::createConvertTTKernelToEmitC());
     pm.addPass(createCanonicalizerPass());
     pm.addPass(mlir::emitc::createFormExpressionsPass());
   }

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   DFBConcurrentKernelLivenessAnalysis.cpp
   DFBPhysicalAllocationPlan.cpp
   InterferenceGraphColoring.cpp
+  PipeNetExecutionUtils.cpp
   PipeGraph.cpp
   PipeLowering.cpp
   PipePlanning.cpp

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   PipeLowering.cpp
   PipePlanning.cpp
   PipeTransferAnalysis.cpp
+  PipeTransferExpansion.cpp
   ConvertTTLToCompute.cpp
   ConvertTTLComputeToSCF.cpp
   ConvertTTLTileOpsToTTKernel.cpp

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -833,6 +833,8 @@ lowerPipeNetForeachSrc(PipeNetForeachSrcOp op, RewriterBase &rewriter,
       arith::ConstantIndexOp::create(rewriter, loc, records.getPipes().size());
   Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
   auto forOp = scf::ForOp::create(rewriter, loc, lower, upper, step);
+  foreachLoweringInfo.recordLoops[forOp] =
+      PipeNetRecordLoop{records, PipeNetRecordSelection::Source};
 
   rewriter.setInsertionPointToStart(forOp.getBody());
   Value recordIndex = forOp.getInductionVar();
@@ -876,6 +878,8 @@ lowerPipeNetForeachDst(PipeNetForeachDstOp op, RewriterBase &rewriter,
       arith::ConstantIndexOp::create(rewriter, loc, records.getPipes().size());
   Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
   auto forOp = scf::ForOp::create(rewriter, loc, lower, upper, step);
+  foreachLoweringInfo.recordLoops[forOp] =
+      PipeNetRecordLoop{records, PipeNetRecordSelection::Destination};
 
   rewriter.setInsertionPointToStart(forOp.getBody());
   Value recordIndex = forOp.getInductionVar();

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -7,6 +7,7 @@
 #include "PipeGraph.h"
 #include "PipeLowering.h"
 #include "PipePlanning.h"
+#include "PipeTransferExpansion.h"
 #include "ttlang/Dialect/TTKernel/Transforms/TTKernelCleanupPatterns.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -558,86 +559,6 @@ static std::optional<TransferKind> getTransferKindFromHandleType(Type t) {
   return transferHandle.getKind();
 }
 
-static FailureOr<CopyOp> findPipeReceiveCopy(ValueOriginAnalysis &analysis,
-                                             Value value) {
-  return analysis.getOrigins(value).uniqueDefiningOp<CopyOp>(isPipeReceiveCopy);
-}
-
-static PipeTransferKind getPipeTransferKind(PipeTransferContract contract) {
-  return isCollectiveTransfer(contract) ? PipeTransferKind::Collective
-                                        : PipeTransferKind::PointToPoint;
-}
-
-/// Return the contract shared by every possible value of a pipe operand.
-///
-/// Create and selected-pipe operations preserve an explicit collective
-/// contract. A block argument has no defining pipe op, so its type supplies
-/// the contract.
-static FailureOr<PipeTransferContract>
-getPipeTransferContractForPipeValue(ValueOriginAnalysis &analysis, Value pipe) {
-  return analysis.getOrigins(pipe).uniqueMapped<PipeTransferContract>(
-      [](Value origin) -> FailureOr<PipeTransferContract> {
-        if (auto createPipe = origin.getDefiningOp<CreatePipeOp>()) {
-          return getPipeTransferContract(createPipe);
-        }
-        if (auto selectedSrc = origin.getDefiningOp<SelectPipeSrcOp>()) {
-          return getPipeTransferContract(
-              selectedSrc.getRecords().getPipes().front());
-        }
-        if (auto selectedDst = origin.getDefiningOp<SelectPipeDstOp>()) {
-          return getPipeTransferContract(
-              selectedDst.getRecords().getPipes().front());
-        }
-        if (isa<BlockArgument>(origin) && isa<PipeType>(origin.getType())) {
-          return cast<PipeType>(origin.getType()).hasMultipleReceivers()
-                     ? PipeTransferContract::Collective
-                     : PipeTransferContract::PointToPoint;
-        }
-        return failure();
-      });
-}
-
-static PipeTransferCreateOp createPipeTransfer(OpBuilder &builder, Location loc,
-                                               Value pipe,
-                                               PipeTransferContract contract) {
-  auto kindAttr = PipeTransferKindAttr::get(builder.getContext(),
-                                            getPipeTransferKind(contract));
-  return PipeTransferCreateOp::create(
-      builder, loc, PipeTransferType::get(builder.getContext()), pipe,
-      kindAttr);
-}
-
-static FailureOr<int64_t> getPipeNetIdForPipeValue(Operation *op, Value pipe) {
-  FailureOr<PipeReference> pipeRef = getPipeReference(op, pipe);
-  if (failed(pipeRef)) {
-    return failure();
-  }
-  return (*pipeRef).getPipeNetId();
-}
-
-static Value getOrCreatePipeTransfer(
-    OpBuilder &builder, Location loc, Value pipe, PipeTransferContract contract,
-    llvm::MapVector<Value, Value> &transferByDirectCreatePipe) {
-  Value key = traceUnrealizedCasts(pipe);
-  if (auto createPipe = key.getDefiningOp<CreatePipeOp>()) {
-    auto it = transferByDirectCreatePipe.find(key);
-    if (it != transferByDirectCreatePipe.end()) {
-      return it->second;
-    }
-    OpBuilder::InsertionGuard guard(builder);
-    builder.setInsertionPointAfter(createPipe);
-    auto transferOp =
-        createPipeTransfer(builder, createPipe.getLoc(), key, contract);
-    transferByDirectCreatePipe[key] = transferOp.getTransfer();
-    return transferOp.getTransfer();
-  }
-
-  // Non-direct pipe values can be block arguments or region results. A shared
-  // cached transfer for those values would need dominance analysis; creating it
-  // at the use site keeps the transfer local to the post/send that consumes it.
-  return createPipeTransfer(builder, loc, pipe, contract).getTransfer();
-}
-
 static Value buildConstantTableLookup(OpBuilder &builder, Location loc,
                                       ArrayRef<int64_t> values,
                                       Value recordIndex) {
@@ -948,170 +869,6 @@ lowerPipeNetForeachOps(ModuleOp mod,
                                    rewriter, foreachLoweringInfo))) {
       return failure();
     }
-  }
-}
-
-/// High-level pipe copy and its proven transfer contract.
-struct PipeCopyExpansion {
-  CopyOp copy;
-  PipeTransferContract contract;
-  std::optional<int64_t> pipeNetId;
-};
-
-/// Receive-handle wait and the PipeNet id used to create its typed token.
-struct PipeReceiveWaitExpansion {
-  WaitOp wait;
-  int64_t pipeNetId = 0;
-};
-
-/// Operations replaced when high-level pipe copies become Pipe Transfer IR.
-struct PipeTransferExpansionPlan {
-  SmallVector<CreatePipeOp> createPipes;
-  SmallVector<PipeCopyExpansion> receiveCopies;
-  SmallVector<PipeCopyExpansion> sendCopies;
-  SmallVector<PipeReceiveWaitExpansion> receiveWaits;
-  SmallVector<WaitOp> unreachableReceiveWaits;
-};
-
-static FailureOr<PipeTransferExpansionPlan>
-buildPipeTransferExpansionPlan(ModuleOp mod, ValueOriginAnalysis &analysis) {
-  PipeTransferExpansionPlan plan;
-  mod.walk([&](CreatePipeOp op) { plan.createPipes.push_back(op); });
-
-  LogicalResult result = success();
-  mod.walk([&](CopyOp op) {
-    if (isPipeReceiveCopy(op)) {
-      FailureOr<PipeTransferContract> contract =
-          getPipeTransferContractForPipeValue(analysis, op.getSrc());
-      if (failed(contract)) {
-        op.emitError()
-            << "requires a consistent transfer contract for all possible "
-               "pipe values";
-        result = failure();
-      } else {
-        FailureOr<int64_t> pipeNetId =
-            getPipeNetIdForPipeValue(op, op.getSrc());
-        if (failed(pipeNetId)) {
-          result = failure();
-        } else {
-          plan.receiveCopies.push_back({op, *contract, *pipeNetId});
-        }
-      }
-      return;
-    }
-    if (isPipeSendCopy(op)) {
-      FailureOr<PipeTransferContract> contract =
-          getPipeTransferContractForPipeValue(analysis, op.getDst());
-      if (failed(contract)) {
-        op.emitError()
-            << "requires a consistent transfer contract for all possible "
-               "pipe values";
-        result = failure();
-      } else {
-        plan.sendCopies.push_back({op, *contract, std::nullopt});
-      }
-    }
-  });
-  if (failed(result)) {
-    return failure();
-  }
-
-  mod.walk([&](WaitOp waitOp) {
-    auto handleType =
-        mlir::dyn_cast<TransferHandleType>(waitOp.getXf().getType());
-    if (!handleType || handleType.getKind()) {
-      return;
-    }
-    if (analysis.getOrigins(waitOp.getXf()).empty()) {
-      plan.unreachableReceiveWaits.push_back(waitOp);
-      return;
-    }
-    FailureOr<CopyOp> maybeCopyOp =
-        findPipeReceiveCopy(analysis, waitOp.getXf());
-    if (failed(maybeCopyOp)) {
-      waitOp.emitError() << "untyped transfer handle wait requires every "
-                            "possible source to be the same pipe receive "
-                            "ttl.copy";
-      result = failure();
-      return;
-    }
-    CopyOp copyOp = *maybeCopyOp;
-    FailureOr<int64_t> pipeNetId =
-        getPipeNetIdForPipeValue(waitOp, copyOp.getSrc());
-    if (failed(pipeNetId)) {
-      result = failure();
-      return;
-    }
-    plan.receiveWaits.push_back({waitOp, *pipeNetId});
-  });
-  if (failed(result)) {
-    return failure();
-  }
-
-  return plan;
-}
-
-static void
-applyPipeTransferExpansionPlan(ModuleOp mod,
-                               const PipeTransferExpansionPlan &plan) {
-  // Origin analysis proved that no reachable transfer handle reaches these
-  // waits, so they have no observable effect.
-  for (WaitOp waitOp : plan.unreachableReceiveWaits) {
-    waitOp.erase();
-  }
-
-  OpBuilder builder(mod.getContext());
-  llvm::MapVector<Value, Value> transferByDirectCreatePipe;
-  for (CreatePipeOp createPipe : plan.createPipes) {
-    builder.setInsertionPointAfter(createPipe);
-    auto transferOp =
-        createPipeTransfer(builder, createPipe.getLoc(), createPipe.getResult(),
-                           getPipeTransferContract(createPipe));
-    transferByDirectCreatePipe[createPipe.getResult()] =
-        transferOp.getTransfer();
-  }
-
-  for (const PipeCopyExpansion &expansion : plan.receiveCopies) {
-    CopyOp copyOp = expansion.copy;
-    assert(expansion.pipeNetId && "receiver expansion is missing PipeNet id");
-    builder.setInsertionPoint(copyOp);
-    Value transfer =
-        getOrCreatePipeTransfer(builder, copyOp.getLoc(), copyOp.getSrc(),
-                                expansion.contract, transferByDirectCreatePipe);
-    auto postOp = PipeTransferPostOp::create(
-        builder, copyOp.getLoc(),
-        PipeTokenType::get(builder.getContext(), *expansion.pipeNetId),
-        transfer, copyOp.getDst());
-    auto handleCast = UnrealizedConversionCastOp::create(
-        builder, copyOp.getLoc(), copyOp.getResult().getType(),
-        ValueRange{postOp.getToken()});
-    copyOp.getResult().replaceAllUsesWith(handleCast.getResult(0));
-    copyOp->erase();
-  }
-
-  for (const PipeCopyExpansion &expansion : plan.sendCopies) {
-    CopyOp copyOp = expansion.copy;
-    builder.setInsertionPoint(copyOp);
-    Value transfer =
-        getOrCreatePipeTransfer(builder, copyOp.getLoc(), copyOp.getDst(),
-                                expansion.contract, transferByDirectCreatePipe);
-    auto sendOp = PipeTransferSendOp::create(builder, copyOp.getLoc(),
-                                             copyOp.getResult().getType(),
-                                             transfer, copyOp.getSrc());
-    copyOp.getResult().replaceAllUsesWith(sendOp.getXf());
-    copyOp->erase();
-  }
-
-  for (const PipeReceiveWaitExpansion &wait : plan.receiveWaits) {
-    WaitOp waitOp = wait.wait;
-    builder.setInsertionPoint(waitOp);
-    auto tokenCast = UnrealizedConversionCastOp::create(
-        builder, waitOp.getLoc(),
-        PipeTokenType::get(builder.getContext(), wait.pipeNetId),
-        ValueRange{waitOp.getXf()});
-    PipeTransferWaitOp::create(builder, waitOp.getLoc(),
-                               tokenCast.getResult(0));
-    waitOp->erase();
   }
 }
 
@@ -2090,12 +1847,9 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
     if (failed(verifyTransferProvenance(mod, preExpansionAnalysis))) {
       return failure();
     }
-    FailureOr<PipeTransferExpansionPlan> maybeExpansionPlan =
-        buildPipeTransferExpansionPlan(mod, preExpansionAnalysis);
-    if (failed(maybeExpansionPlan)) {
+    if (failed(expandPipeTransfers(mod, preExpansionAnalysis))) {
       return failure();
     }
-    applyPipeTransferExpansionPlan(mod, *maybeExpansionPlan);
   }
 
   // All remaining provenance consumers share this root-scoped cache.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LogicalResult.h"
@@ -42,8 +43,10 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Casting.h"
 #include <cstdlib>
+#include <optional>
 #include <utility>
 
 namespace mlir::tt::ttl {
@@ -61,6 +64,10 @@ namespace ttk = mlir::tt::ttkernel;
 constexpr llvm::StringLiteral kCRTAIndicesAttr = "ttl.crta_indices";
 constexpr llvm::StringLiteral kExpandLinearizeIndexAttr =
     "ttlang.expand_linearize_index";
+// Duplicating up to four callback bodies avoids table lookups for small nets.
+// Larger nets use one loop so the transfer protocol body is not duplicated for
+// every record.
+constexpr size_t kPipeNetForeachDirectRecordLimit = 4;
 
 // PipeGraph is defined in PipeGraph.h.
 
@@ -93,10 +100,10 @@ public:
     addConversion([](PipeTokenType type) -> Type {
       return IntegerType::get(type.getContext(), 32);
     });
-    // High-level pipe copies return TransferHandleType. Their post sequence may
-    // pass through SCF or tensor containers. DMA handles use the same runtime
-    // representation, but their waits depend only on precomputed provenance
-    // and lower to barriers without inspecting this value.
+    // Public pipe copies expose TransferHandleType and may preserve the dynamic
+    // post sequence through SCF or tensor containers. DMA handles use the same
+    // runtime representation, but their waits depend only on precomputed
+    // provenance and lower to barriers without inspecting this value.
     addConversion([](TransferHandleType type) -> Type {
       return IntegerType::get(type.getContext(), 32);
     });
@@ -314,16 +321,33 @@ struct BindCBLowering : OpConversionPattern<BindCBOp> {
 // CB synchronization operation lowering patterns
 //===----------------------------------------------------------------------===//
 
+// Trace through unrealized casts to get the original TTL CB type.
+static CircularBufferType getTTLCBType(Value cb) {
+  if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(cb.getType())) {
+    return ttlCbTy;
+  }
+  if (auto castOp = cb.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp.getInputs().size() == 1) {
+      if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(
+              castOp.getInputs()[0].getType())) {
+        return ttlCbTy;
+      }
+    }
+  }
+  return nullptr;
+}
+
 // Tile count: use the `num_tiles` attribute if present (per-subblock
 // reserve/push), otherwise derive from the DFB type shape (full block).
-static Value computeNumTiles(Operation *sourceOp, CircularBufferType dfbType,
+static Value computeNumTiles(Operation *sourceOp, Value cb,
                              ConversionPatternRewriter &rewriter,
                              Location loc) {
   if (auto attr = sourceOp->getAttrOfType<IntegerAttr>("num_tiles")) {
     return arith::ConstantIntOp::create(rewriter, loc, attr.getInt(), 32);
   }
-  return arith::ConstantIntOp::create(rewriter, loc,
-                                      dfbType.getElementsPerBlock(), 32);
+  auto ttlCbTy = getTTLCBType(cb);
+  int64_t numTiles = ttlCbTy ? ttlCbTy.getElementsPerBlock() : 1;
+  return arith::ConstantIntOp::create(rewriter, loc, numTiles, 32);
 }
 
 template <typename SourceOp, typename TargetOp, bool HasResult>
@@ -335,9 +359,8 @@ struct CBOpLowering : OpConversionPattern<SourceOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     Value originalCb = op.getCb();
-    FailureOr<CircularBufferType> maybeDFBType =
-        utils::getTTLCircularBufferType(originalCb);
-    if (failed(maybeDFBType)) {
+    auto ttlCbTy = getTTLCBType(originalCb);
+    if (!ttlCbTy) {
       return rewriter.notifyMatchFailure(op, "failed to get TTL CB type");
     }
 
@@ -347,7 +370,7 @@ struct CBOpLowering : OpConversionPattern<SourceOp> {
       return rewriter.notifyMatchFailure(op, "failed to convert CB operand");
     }
 
-    Value numTiles = computeNumTiles(op, *maybeDFBType, rewriter, loc);
+    Value numTiles = computeNumTiles(op, originalCb, rewriter, loc);
     TargetOp::create(rewriter, loc, *convertedCb, numTiles);
 
     if constexpr (HasResult) {
@@ -527,7 +550,8 @@ static CopyOperandKind classifyOperand(Value v) {
   if (llvm::isa<CircularBufferType>(v.getType())) {
     return CopyOperandKind::CircularBuffer;
   }
-  if (llvm::isa<PipeType>(v.getType())) {
+  if (llvm::isa<PipeType, SelectedPipeSrcType, SelectedPipeDstType>(
+          v.getType())) {
     return CopyOperandKind::Pipe;
   }
   if (v.getDefiningOp<TensorSliceOp>()) {
@@ -563,14 +587,23 @@ static PipeTransferKind getPipeTransferKind(PipeTransferContract contract) {
 
 /// Return the contract shared by every possible value of a pipe operand.
 ///
-/// A defining create op preserves a degenerate one-receiver collective. A
-/// block argument has no create op, so its pipe type supplies the contract.
+/// Create and selected-pipe operations preserve an explicit collective
+/// contract. A block argument has no defining pipe op, so its type supplies
+/// the contract.
 static FailureOr<PipeTransferContract>
 getPipeTransferContractForPipeValue(ValueOriginAnalysis &analysis, Value pipe) {
   return analysis.getOrigins(pipe).uniqueMapped<PipeTransferContract>(
       [](Value origin) -> FailureOr<PipeTransferContract> {
         if (auto createPipe = origin.getDefiningOp<CreatePipeOp>()) {
           return getPipeTransferContract(createPipe);
+        }
+        if (auto selectedSrc = origin.getDefiningOp<SelectPipeSrcOp>()) {
+          return getPipeTransferContract(
+              selectedSrc.getRecords().getPipes().front());
+        }
+        if (auto selectedDst = origin.getDefiningOp<SelectPipeDstOp>()) {
+          return getPipeTransferContract(
+              selectedDst.getRecords().getPipes().front());
         }
         if (isa<BlockArgument>(origin) && isa<PipeType>(origin.getType())) {
           return cast<PipeType>(origin.getType()).hasMultipleReceivers()
@@ -584,14 +617,19 @@ getPipeTransferContractForPipeValue(ValueOriginAnalysis &analysis, Value pipe) {
 static PipeTransferCreateOp createPipeTransfer(OpBuilder &builder, Location loc,
                                                Value pipe,
                                                PipeTransferContract contract) {
-  auto pipeType = mlir::cast<PipeType>(traceUnrealizedCasts(pipe).getType());
   auto kindAttr = PipeTransferKindAttr::get(builder.getContext(),
                                             getPipeTransferKind(contract));
-  auto expectedReceiversAttr =
-      builder.getI64IntegerAttr(pipeType.getNumDests());
   return PipeTransferCreateOp::create(
-      builder, loc, PipeTransferType::get(builder.getContext()), pipe, kindAttr,
-      expectedReceiversAttr);
+      builder, loc, PipeTransferType::get(builder.getContext()), pipe,
+      kindAttr);
+}
+
+static FailureOr<int64_t> getPipeNetIdForPipeValue(Operation *op, Value pipe) {
+  FailureOr<PipeReference> pipeRef = getPipeReference(op, pipe);
+  if (failed(pipeRef)) {
+    return failure();
+  }
+  return (*pipeRef).getPipeNetId();
 }
 
 static Value getOrCreatePipeTransfer(
@@ -617,10 +655,291 @@ static Value getOrCreatePipeTransfer(
   return createPipeTransfer(builder, loc, pipe, contract).getTransfer();
 }
 
+static Value buildConstantTableLookup(OpBuilder &builder, Location loc,
+                                      ArrayRef<int64_t> values,
+                                      Value recordIndex) {
+  assert(!values.empty() && "PipeNet foreach records must not be empty");
+  return ttk::ConstantTableLookupOp::create(
+      builder, loc, builder.getIndexType(), recordIndex,
+      builder.getDenseI64ArrayAttr(values));
+}
+
+static bool shouldLowerPipeNetForeachDirect(PipeNetRecordsAttr records) {
+  return records.getPipes().size() <= kPipeNetForeachDirectRecordLimit;
+}
+
+struct PipeForeachTables {
+  SmallVector<int64_t> srcX;
+  SmallVector<int64_t> srcY;
+  SmallVector<int64_t> dstStartX;
+  SmallVector<int64_t> dstStartY;
+  SmallVector<int64_t> dstEndX;
+  SmallVector<int64_t> dstEndY;
+  SmallVector<int64_t> numDests;
+  SmallVector<int64_t> srcInDstRange;
+};
+
+static PipeForeachTables buildPipeForeachTables(OpBuilder &builder,
+                                                PipeNetRecordsAttr records) {
+  SmallVector<int64_t> srcX;
+  SmallVector<int64_t> srcY;
+  SmallVector<int64_t> dstStartX;
+  SmallVector<int64_t> dstStartY;
+  SmallVector<int64_t> dstEndX;
+  SmallVector<int64_t> dstEndY;
+  SmallVector<int64_t> numDests;
+  SmallVector<int64_t> srcInDstRange;
+  MLIRContext *context = builder.getContext();
+  for (PipeRecordAttr record : records.getPipes()) {
+    PipeType pipeType =
+        getPipeTypeFromRecord(context, record, records.getPipeNetId());
+    srcX.push_back(pipeType.getSrcX());
+    srcY.push_back(pipeType.getSrcY());
+    dstStartX.push_back(pipeType.getDstStartX());
+    dstStartY.push_back(pipeType.getDstStartY());
+    dstEndX.push_back(pipeType.getDstEndX());
+    dstEndY.push_back(pipeType.getDstEndY());
+    numDests.push_back(pipeType.getNumDests());
+    srcInDstRange.push_back(pipeType.srcInDstRange() ? 1 : 0);
+  }
+  return PipeForeachTables{std::move(srcX),      std::move(srcY),
+                           std::move(dstStartX), std::move(dstStartY),
+                           std::move(dstEndX),   std::move(dstEndY),
+                           std::move(numDests),  std::move(srcInDstRange)};
+}
+
+template <typename SelectOp, typename SelectedType>
+static SelectOp
+buildSelectedPipe(OpBuilder &builder, Location loc, PipeNetRecordsAttr records,
+                  const PipeForeachTables &tables, Value recordIndex) {
+  Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value srcInDstRangeIndex =
+      buildConstantTableLookup(builder, loc, tables.srcInDstRange, recordIndex);
+  Value srcInDstRange = arith::CmpIOp::create(
+      builder, loc, arith::CmpIPredicate::ne, srcInDstRangeIndex, zero);
+  return SelectOp::create(
+      builder, loc, SelectedType::get(builder.getContext()), recordIndex,
+      buildConstantTableLookup(builder, loc, tables.srcX, recordIndex),
+      buildConstantTableLookup(builder, loc, tables.srcY, recordIndex),
+      buildConstantTableLookup(builder, loc, tables.dstStartX, recordIndex),
+      buildConstantTableLookup(builder, loc, tables.dstStartY, recordIndex),
+      buildConstantTableLookup(builder, loc, tables.dstEndX, recordIndex),
+      buildConstantTableLookup(builder, loc, tables.dstEndY, recordIndex),
+      buildConstantTableLookup(builder, loc, tables.numDests, recordIndex),
+      srcInDstRange, records);
+}
+
+template <typename ForeachOp>
+static void clonePipeForeachBody(ForeachOp foreachOp, Value selectedPipe,
+                                 OpBuilder &builder) {
+  IRMapping mapping;
+  Block &sourceBlock = foreachOp.getBody().front();
+  mapping.map(sourceBlock.getArgument(0), selectedPipe);
+  for (Operation &bodyOp : sourceBlock) {
+    if (mlir::isa<YieldOp>(bodyOp)) {
+      continue;
+    }
+    builder.clone(bodyOp, mapping);
+  }
+}
+
+static Value buildIntegerMatch(RewriterBase &rewriter, Location loc, Value lhs,
+                               int64_t rhs) {
+  Value rhsValue = arith::ConstantIndexOp::create(rewriter, loc, rhs);
+  return arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq, lhs,
+                               rhsValue);
+}
+
+static Value buildIntegerRangeMatch(RewriterBase &rewriter, Location loc,
+                                    Value value, int64_t start, int64_t end) {
+  Value startValue = arith::ConstantIndexOp::create(rewriter, loc, start);
+  Value endValue = arith::ConstantIndexOp::create(rewriter, loc, end);
+  Value atStart = arith::CmpIOp::create(
+      rewriter, loc, arith::CmpIPredicate::sge, value, startValue);
+  Value atEnd = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sle,
+                                      value, endValue);
+  return arith::AndIOp::create(rewriter, loc, atStart, atEnd);
+}
+
+static Value buildRecordSrcMatch(RewriterBase &rewriter, Location loc,
+                                 Value nodeX, Value nodeY,
+                                 PipeRecordAttr record) {
+  Value xMatches = buildIntegerMatch(rewriter, loc, nodeX, record.getSrcX());
+  Value yMatches = buildIntegerMatch(rewriter, loc, nodeY, record.getSrcY());
+  return arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
+}
+
+static Value buildRecordDstMatch(RewriterBase &rewriter, Location loc,
+                                 Value nodeX, Value nodeY,
+                                 PipeRecordAttr record) {
+  Value xMatches = buildIntegerRangeMatch(
+      rewriter, loc, nodeX, record.getDstStartX(), record.getDstEndX());
+  Value yMatches = buildIntegerRangeMatch(
+      rewriter, loc, nodeY, record.getDstStartY(), record.getDstEndY());
+  return arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
+}
+
+static CreatePipeOp buildStaticPipeForRecord(RewriterBase &rewriter,
+                                             Location loc,
+                                             PipeNetRecordsAttr records,
+                                             PipeRecordAttr record) {
+  PipeType pipeType =
+      getPipeTypeFromRecord(rewriter.getContext(), record,
+                            static_cast<int64_t>(records.getPipeNetId()));
+  BoolAttr isCollectiveAttr =
+      record.getIsCollective() ? rewriter.getBoolAttr(true) : BoolAttr();
+  return CreatePipeOp::create(
+      rewriter, loc, pipeType, rewriter.getI64IntegerAttr(record.getSrcX()),
+      rewriter.getI64IntegerAttr(record.getSrcY()),
+      rewriter.getI64IntegerAttr(record.getDstStartX()),
+      rewriter.getI64IntegerAttr(record.getDstStartY()),
+      rewriter.getI64IntegerAttr(record.getDstEndX()),
+      rewriter.getI64IntegerAttr(record.getDstEndY()),
+      rewriter.getI64IntegerAttr(records.getPipeNetId()),
+      records.getPipeNetName(), isCollectiveAttr);
+}
+
+template <typename ForeachOp>
+static LogicalResult lowerPipeNetForeachDirect(
+    ForeachOp op, RewriterBase &rewriter,
+    llvm::function_ref<Value(RewriterBase &, Location, Value, Value,
+                             PipeRecordAttr)>
+        buildRecordMatch) {
+  Location loc = op.getLoc();
+  PipeNetRecordsAttr records = op.getRecords();
+  rewriter.setInsertionPoint(op);
+  Value nodeX =
+      ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+  Value nodeY =
+      ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+  for (PipeRecordAttr record : records.getPipes()) {
+    Value staticPipe =
+        buildStaticPipeForRecord(rewriter, loc, records, record).getResult();
+    Value isActiveRecord =
+        buildRecordMatch(rewriter, loc, nodeX, nodeY, record);
+    auto ifOp = scf::IfOp::create(rewriter, loc, isActiveRecord,
+                                  /*withElseRegion=*/false);
+    rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+    clonePipeForeachBody(op, staticPipe, rewriter);
+    rewriter.setInsertionPointAfter(ifOp);
+  }
+  rewriter.eraseOp(op);
+  return success();
+}
+
+static LogicalResult lowerPipeNetForeachSrc(PipeNetForeachSrcOp op,
+                                            RewriterBase &rewriter) {
+  Location loc = op.getLoc();
+  rewriter.setInsertionPoint(op);
+  PipeNetRecordsAttr records = op.getRecords();
+  if (shouldLowerPipeNetForeachDirect(records)) {
+    return lowerPipeNetForeachDirect(op, rewriter, buildRecordSrcMatch);
+  }
+
+  PipeForeachTables tables = buildPipeForeachTables(rewriter, records);
+  Value lower = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value upper =
+      arith::ConstantIndexOp::create(rewriter, loc, records.getPipes().size());
+  Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
+  auto forOp = scf::ForOp::create(rewriter, loc, lower, upper, step);
+
+  rewriter.setInsertionPointToStart(forOp.getBody());
+  Value recordIndex = forOp.getInductionVar();
+  auto selectedPipe = buildSelectedPipe<SelectPipeSrcOp, SelectedPipeSrcType>(
+      rewriter, loc, records, tables, recordIndex);
+  Value nodeX =
+      ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+  Value nodeY =
+      ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+  Value xMatches = arith::CmpIOp::create(
+      rewriter, loc, arith::CmpIPredicate::eq, nodeX, selectedPipe.getSrcX());
+  Value yMatches = arith::CmpIOp::create(
+      rewriter, loc, arith::CmpIPredicate::eq, nodeY, selectedPipe.getSrcY());
+  Value isSrc = arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
+  auto ifOp = scf::IfOp::create(rewriter, loc, isSrc,
+                                /*withElseRegion=*/false);
+  rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+  clonePipeForeachBody(op, selectedPipe.getPipe(), rewriter);
+  rewriter.eraseOp(op);
+  return success();
+}
+
+static LogicalResult lowerPipeNetForeachDst(PipeNetForeachDstOp op,
+                                            RewriterBase &rewriter) {
+  Location loc = op.getLoc();
+  rewriter.setInsertionPoint(op);
+  PipeNetRecordsAttr records = op.getRecords();
+  if (shouldLowerPipeNetForeachDirect(records)) {
+    return lowerPipeNetForeachDirect(op, rewriter, buildRecordDstMatch);
+  }
+
+  PipeForeachTables tables = buildPipeForeachTables(rewriter, records);
+  Value lower = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value upper =
+      arith::ConstantIndexOp::create(rewriter, loc, records.getPipes().size());
+  Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
+  auto forOp = scf::ForOp::create(rewriter, loc, lower, upper, step);
+
+  rewriter.setInsertionPointToStart(forOp.getBody());
+  Value recordIndex = forOp.getInductionVar();
+  auto selectedPipe = buildSelectedPipe<SelectPipeDstOp, SelectedPipeDstType>(
+      rewriter, loc, records, tables, recordIndex);
+  Value nodeX =
+      ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+  Value nodeY =
+      ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+  Value xAtStart =
+      arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sge, nodeX,
+                            selectedPipe.getDstStartX());
+  Value xAtEnd = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sle,
+                                       nodeX, selectedPipe.getDstEndX());
+  Value yAtStart =
+      arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sge, nodeY,
+                            selectedPipe.getDstStartY());
+  Value yAtEnd = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sle,
+                                       nodeY, selectedPipe.getDstEndY());
+  Value xInRange = arith::AndIOp::create(rewriter, loc, xAtStart, xAtEnd);
+  Value yInRange = arith::AndIOp::create(rewriter, loc, yAtStart, yAtEnd);
+  Value isDst = arith::AndIOp::create(rewriter, loc, xInRange, yInRange);
+  auto ifOp = scf::IfOp::create(rewriter, loc, isDst,
+                                /*withElseRegion=*/false);
+  rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+  clonePipeForeachBody(op, selectedPipe.getPipe(), rewriter);
+  rewriter.eraseOp(op);
+  return success();
+}
+
+static LogicalResult lowerPipeNetForeachOps(ModuleOp mod) {
+  SmallVector<Operation *> foreachOps;
+  mod.walk<WalkOrder::PostOrder>([&](Operation *op) {
+    if (mlir::isa<PipeNetForeachSrcOp, PipeNetForeachDstOp>(op)) {
+      foreachOps.push_back(op);
+    }
+  });
+
+  // A module-wide greedy rewrite also deletes unrelated unused pure reads.
+  // Rewrite only foreach operations so this expansion cannot change other IR.
+  IRRewriter rewriter(mod.getContext());
+  for (Operation *op : foreachOps) {
+    if (auto foreachSrcOp = mlir::dyn_cast<PipeNetForeachSrcOp>(op)) {
+      if (failed(lowerPipeNetForeachSrc(foreachSrcOp, rewriter))) {
+        return failure();
+      }
+      continue;
+    }
+    if (failed(lowerPipeNetForeachDst(mlir::cast<PipeNetForeachDstOp>(op),
+                                      rewriter))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
 /// High-level pipe copy and its proven transfer contract.
 struct PipeCopyExpansion {
   CopyOp copy;
   PipeTransferContract contract;
+  std::optional<int64_t> pipeNetId;
 };
 
 /// Receive-handle wait and the PipeNet id used to create its typed token.
@@ -654,7 +973,13 @@ buildPipeTransferExpansionPlan(ModuleOp mod, ValueOriginAnalysis &analysis) {
                "pipe values";
         result = failure();
       } else {
-        plan.receiveCopies.push_back({op, *contract});
+        FailureOr<int64_t> pipeNetId =
+            getPipeNetIdForPipeValue(op, op.getSrc());
+        if (failed(pipeNetId)) {
+          result = failure();
+        } else {
+          plan.receiveCopies.push_back({op, *contract, *pipeNetId});
+        }
       }
       return;
     }
@@ -667,7 +992,7 @@ buildPipeTransferExpansionPlan(ModuleOp mod, ValueOriginAnalysis &analysis) {
                "pipe values";
         result = failure();
       } else {
-        plan.sendCopies.push_back({op, *contract});
+        plan.sendCopies.push_back({op, *contract, std::nullopt});
       }
     }
   });
@@ -695,13 +1020,18 @@ buildPipeTransferExpansionPlan(ModuleOp mod, ValueOriginAnalysis &analysis) {
       return;
     }
     CopyOp copyOp = *maybeCopyOp;
-    auto pipeType =
-        mlir::cast<PipeType>(traceUnrealizedCasts(copyOp.getSrc()).getType());
-    plan.receiveWaits.push_back({waitOp, pipeType.getPipeNetId()});
+    FailureOr<int64_t> pipeNetId =
+        getPipeNetIdForPipeValue(waitOp, copyOp.getSrc());
+    if (failed(pipeNetId)) {
+      result = failure();
+      return;
+    }
+    plan.receiveWaits.push_back({waitOp, *pipeNetId});
   });
   if (failed(result)) {
     return failure();
   }
+
   return plan;
 }
 
@@ -727,16 +1057,16 @@ applyPipeTransferExpansionPlan(ModuleOp mod,
 
   for (const PipeCopyExpansion &expansion : plan.receiveCopies) {
     CopyOp copyOp = expansion.copy;
-    auto pipeType =
-        mlir::cast<PipeType>(traceUnrealizedCasts(copyOp.getSrc()).getType());
+    assert(expansion.pipeNetId && "receiver expansion is missing PipeNet id");
     builder.setInsertionPoint(copyOp);
     Value transfer =
         getOrCreatePipeTransfer(builder, copyOp.getLoc(), copyOp.getSrc(),
                                 expansion.contract, transferByDirectCreatePipe);
     auto postOp = PipeTransferPostOp::create(
         builder, copyOp.getLoc(),
-        PipeTokenType::get(builder.getContext(), pipeType.getPipeNetId()),
-        transfer, copyOp.getDst());
+        PipeTokenType::get(builder.getContext(), *expansion.pipeNetId),
+        transfer,
+        copyOp.getDst());
     auto handleCast = UnrealizedConversionCastOp::create(
         builder, copyOp.getLoc(), copyOp.getResult().getType(),
         ValueRange{postOp.getToken()});
@@ -768,6 +1098,7 @@ applyPipeTransferExpansionPlan(ModuleOp mod,
                                tokenCast.getResult(0));
     waitOp->erase();
   }
+
 }
 
 /// Compute CTA index for a tensor function argument.
@@ -936,16 +1267,15 @@ static LogicalResult lowerTensorCBCopy(CopyOp op, TensorSliceOp sliceOp,
     return failure();
   }
 
-  FailureOr<CircularBufferType> maybeDFBType =
-      utils::getTTLCircularBufferType(cb);
-  if (failed(maybeDFBType)) {
+  auto cbType = getTTLCBType(cb);
+  if (!cbType) {
     return rewriter.notifyMatchFailure(op, "failed to get CB type");
   }
 
   SmallVector<int64_t> tensorGridShape = getTileGridShapeFromValue(tensor);
   unsigned tensorRank = tensorGridShape.size();
 
-  auto cbShape = (*maybeDFBType).getShape();
+  auto cbShape = cbType.getShape();
 
   if (startIndices.size() != tensorRank) {
     return rewriter.notifyMatchFailure(op, [&](Diagnostic &diag) {
@@ -1131,32 +1461,35 @@ struct CopyLowering : OpConversionPattern<CopyOp> {
 };
 
 struct PipeTransferPostLowering : OpConversionPattern<PipeTransferPostOp> {
-  PipeTransferPostLowering(const TypeConverter &typeConverter,
-                           MLIRContext *context,
-                           const PipeModulePlan &pipeModulePlan,
-                           const PipeCounterProgressMap &counters,
-                           const PipeResourcePlan &pipeResourcePlan)
+  PipeTransferPostLowering(
+      const TypeConverter &typeConverter, MLIRContext *context,
+      const PipeModulePlan &pipeModulePlan,
+      const PipeCounterProgressMap &counters,
+      const PipeSelectedPostSequenceMap &selectedPostSequenceCounters,
+      const PipeResourcePlan &pipeResourcePlan)
       : OpConversionPattern(typeConverter, context),
         pipeModulePlan(pipeModulePlan), counters(counters),
+        selectedPostSequenceCounters(selectedPostSequenceCounters),
         pipeResourcePlan(pipeResourcePlan) {}
 
   LogicalResult
   matchAndRewrite(PipeTransferPostOp op, OpAdaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Slice-offset materialization requires the original destination tensor,
-    // while the plan supplies the already-resolved receiver DFB.
     if (pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation())) {
       lowerInactivePipeTransferPost(op, rewriter);
       return success();
     }
+    // Slice-offset materialization requires the original destination tensor,
+    // while the plan supplies the already-resolved receiver DFB.
     return lowerPipeTransferPost(
         op, op.getDst(), pipeModulePlan.getTransferPlan(op.getOperation()),
-        counters, pipeResourcePlan, rewriter);
+        counters, selectedPostSequenceCounters, pipeResourcePlan, rewriter);
   }
 
 private:
   const PipeModulePlan &pipeModulePlan;
   const PipeCounterProgressMap &counters;
+  const PipeSelectedPostSequenceMap &selectedPostSequenceCounters;
   const PipeResourcePlan &pipeResourcePlan;
 };
 
@@ -1198,18 +1531,27 @@ private:
 struct PipeTransferWaitLowering : OpConversionPattern<PipeTransferWaitOp> {
   PipeTransferWaitLowering(const TypeConverter &typeConverter,
                            MLIRContext *context,
+                           const PipeModulePlan &pipeModulePlan,
                            const PipeResourcePlan &pipeResourcePlan)
       : OpConversionPattern(typeConverter, context),
+        pipeModulePlan(pipeModulePlan),
         pipeResourcePlan(pipeResourcePlan) {}
 
   LogicalResult
   matchAndRewrite(PipeTransferWaitOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    return lowerPipeTransferWait(op, adaptor.getToken(), pipeResourcePlan,
-                                 rewriter);
+    if (pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation())) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    return lowerPipeTransferWait(
+        op, adaptor.getToken(),
+        pipeModulePlan.getTransferPlan(op.getOperation()), pipeResourcePlan,
+        rewriter);
   }
 
 private:
+  const PipeModulePlan &pipeModulePlan;
   const PipeResourcePlan &pipeResourcePlan;
 };
 
@@ -1229,8 +1571,8 @@ struct WaitLowering : OpConversionPattern<WaitOp> {
       return success();
     }
 
-    // TODO(ttl): Lower ttl.wait to the TRID-specific barrier selected by the
-    // transfer handle direction (read or write). Issue: #87.
+    // TODO(ttl): Lower ttl.wait to TRID-specific barriers keyed by the transfer
+    // handle (read vs write barrier based on transfer direction). Issue: #87.
     //
     // MVP behavior: emit the corresponding global barrier based on transfer
     // direction. Pipe receive waits are expanded to ttl.pipe_transfer.wait
@@ -1685,7 +2027,8 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
                          func::FuncDialect, ttkernel::TTKernelDialect>();
 
   // Structural ops remain legal (converted elsewhere or kept as-is).
-  target.addLegalOp<ComputeOp, YieldOp, AttachCBOp, DstIndexOp>();
+  target.addLegalOp<ComputeOp, YieldOp, AttachCBOp, DstIndexOp, SelectPipeSrcOp,
+                    SelectPipeDstOp>();
   target.addLegalOp<PipeTransferCreateOp>();
 
   // DST lifecycle ops are not tile compute ops; keep them legal until the
@@ -1718,6 +2061,10 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
     return typeConverter.isSignatureLegal(op.getFunctionType()) &&
            typeConverter.isLegal(&op.getBody());
   });
+
+  if (failed(lowerPipeNetForeachOps(mod))) {
+    return failure();
+  }
 
   // Validate explicit transfer IR and resolve every high-level pipe copy before
   // expansion mutates the values used by the analysis.
@@ -1778,7 +2125,9 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
   initializePipeCapacityCounters(pipeCapacityPlan, pipeResourcePlan,
                                  senderCapacityCounters);
   PipeCounterProgressMap postSequenceCounters;
-  initializePipePostSequenceCounters(pipeResourcePlan, postSequenceCounters);
+  PipeSelectedPostSequenceMap selectedPostSequenceCounters;
+  initializePipePostSequenceCounters(pipeResourcePlan, postSequenceCounters,
+                                     selectedPostSequenceCounters);
   PipeComputedAddressCounterMap computedAddressCounters;
   initializePipeComputedAddressCounters(pipeResourcePlan,
                                         computedAddressCounters);
@@ -1793,13 +2142,14 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
                TensorOpTypeConversion<tensor::ExtractOp>,
                TensorOpTypeConversion<tensor::CastOp>>(typeConverter, &ctx);
   patterns.add<CopyLowering>(typeConverter, &ctx);
-  patterns.add<PipeTransferPostLowering>(typeConverter, &ctx, pipeModulePlan,
-                                         postSequenceCounters,
-                                         pipeResourcePlan);
+  patterns.add<PipeTransferPostLowering>(
+      typeConverter, &ctx, pipeModulePlan, postSequenceCounters,
+      selectedPostSequenceCounters, pipeResourcePlan);
   patterns.add<PipeTransferSendLowering>(
       typeConverter, &ctx, pipeModulePlan, pipeResourcePlan, pipeCapacityPlan,
       senderCapacityCounters, computedAddressCounters);
-  patterns.add<PipeTransferWaitLowering>(typeConverter, &ctx, pipeResourcePlan);
+  patterns.add<PipeTransferWaitLowering>(typeConverter, &ctx, pipeModulePlan,
+                                         pipeResourcePlan);
   patterns.add<WaitLowering>(typeConverter, &ctx,
                              pipeModulePlan.getCompletedPipeSendWaits());
   patterns.add<BindCBLowering, TensorSliceLowering, CBReserveLowering,
@@ -1832,6 +2182,16 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
     op.erase();
   }
 
+  SmallVector<Operation *> deadSelectedPipes;
+  mod.walk([&](Operation *op) {
+    if (mlir::isa<SelectPipeSrcOp, SelectPipeDstOp>(op) && op->use_empty()) {
+      deadSelectedPipes.push_back(op);
+    }
+  });
+  for (Operation *op : deadSelectedPipes) {
+    op->erase();
+  }
+
   // Greedy cleanup also erases dead unrealized casts used as temporary
   // transfer-token materializations.
   RewritePatternSet cleanupPatterns(&ctx);
@@ -1844,7 +2204,7 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
   return success();
 }
 
-/// Lower tile compute operations and DST lifecycle operations to TTKernel.
+/// Phase 2: Lower tile compute ops and DST lifecycle ops to TTKernel.
 /// Tile compute ops are identified by TTLTileComputeOpTrait. ttl.compute is
 /// kept legal here because it is lowered to loops in an earlier pass
 /// (ttl-lower-to-loops).

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -21,7 +21,6 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LogicalResult.h"
@@ -321,33 +320,16 @@ struct BindCBLowering : OpConversionPattern<BindCBOp> {
 // CB synchronization operation lowering patterns
 //===----------------------------------------------------------------------===//
 
-// Trace through unrealized casts to get the original TTL CB type.
-static CircularBufferType getTTLCBType(Value cb) {
-  if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(cb.getType())) {
-    return ttlCbTy;
-  }
-  if (auto castOp = cb.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (castOp.getInputs().size() == 1) {
-      if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(
-              castOp.getInputs()[0].getType())) {
-        return ttlCbTy;
-      }
-    }
-  }
-  return nullptr;
-}
-
 // Tile count: use the `num_tiles` attribute if present (per-subblock
 // reserve/push), otherwise derive from the DFB type shape (full block).
-static Value computeNumTiles(Operation *sourceOp, Value cb,
+static Value computeNumTiles(Operation *sourceOp, CircularBufferType dfbType,
                              ConversionPatternRewriter &rewriter,
                              Location loc) {
   if (auto attr = sourceOp->getAttrOfType<IntegerAttr>("num_tiles")) {
     return arith::ConstantIntOp::create(rewriter, loc, attr.getInt(), 32);
   }
-  auto ttlCbTy = getTTLCBType(cb);
-  int64_t numTiles = ttlCbTy ? ttlCbTy.getElementsPerBlock() : 1;
-  return arith::ConstantIntOp::create(rewriter, loc, numTiles, 32);
+  return arith::ConstantIntOp::create(rewriter, loc,
+                                      dfbType.getElementsPerBlock(), 32);
 }
 
 template <typename SourceOp, typename TargetOp, bool HasResult>
@@ -359,8 +341,9 @@ struct CBOpLowering : OpConversionPattern<SourceOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     Value originalCb = op.getCb();
-    auto ttlCbTy = getTTLCBType(originalCb);
-    if (!ttlCbTy) {
+    FailureOr<CircularBufferType> maybeDFBType =
+        utils::getTTLCircularBufferType(originalCb);
+    if (failed(maybeDFBType)) {
       return rewriter.notifyMatchFailure(op, "failed to get TTL CB type");
     }
 
@@ -370,7 +353,7 @@ struct CBOpLowering : OpConversionPattern<SourceOp> {
       return rewriter.notifyMatchFailure(op, "failed to convert CB operand");
     }
 
-    Value numTiles = computeNumTiles(op, originalCb, rewriter, loc);
+    Value numTiles = computeNumTiles(op, *maybeDFBType, rewriter, loc);
     TargetOp::create(rewriter, loc, *convertedCb, numTiles);
 
     if constexpr (HasResult) {
@@ -801,7 +784,8 @@ static CreatePipeOp buildStaticPipeForRecord(RewriterBase &rewriter,
 
 template <typename ForeachOp>
 static LogicalResult lowerPipeNetForeachDirect(
-    ForeachOp op, RewriterBase &rewriter,
+    ForeachOp op, RewriterBase &rewriter, PipeRole role,
+    PipeForeachLoweringInfo &foreachLoweringInfo,
     llvm::function_ref<Value(RewriterBase &, Location, Value, Value,
                              PipeRecordAttr)>
         buildRecordMatch) {
@@ -819,6 +803,11 @@ static LogicalResult lowerPipeNetForeachDirect(
         buildRecordMatch(rewriter, loc, nodeX, nodeY, record);
     auto ifOp = scf::IfOp::create(rewriter, loc, isActiveRecord,
                                   /*withElseRegion=*/false);
+    foreachLoweringInfo.controlOps.push_back(ifOp);
+    foreachLoweringInfo.ifThenDomains[ifOp] =
+        role == PipeRole::Source
+            ? getPipeRecordSourceLaunchNodeDomain(record)
+            : getPipeRecordDestinationLaunchNodeDomain(record);
     rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
     clonePipeForeachBody(op, staticPipe, rewriter);
     rewriter.setInsertionPointAfter(ifOp);
@@ -827,13 +816,15 @@ static LogicalResult lowerPipeNetForeachDirect(
   return success();
 }
 
-static LogicalResult lowerPipeNetForeachSrc(PipeNetForeachSrcOp op,
-                                            RewriterBase &rewriter) {
+static LogicalResult
+lowerPipeNetForeachSrc(PipeNetForeachSrcOp op, RewriterBase &rewriter,
+                       PipeForeachLoweringInfo &foreachLoweringInfo) {
   Location loc = op.getLoc();
   rewriter.setInsertionPoint(op);
   PipeNetRecordsAttr records = op.getRecords();
   if (shouldLowerPipeNetForeachDirect(records)) {
-    return lowerPipeNetForeachDirect(op, rewriter, buildRecordSrcMatch);
+    return lowerPipeNetForeachDirect(op, rewriter, PipeRole::Source,
+                                     foreachLoweringInfo, buildRecordSrcMatch);
   }
 
   PipeForeachTables tables = buildPipeForeachTables(rewriter, records);
@@ -858,19 +849,25 @@ static LogicalResult lowerPipeNetForeachSrc(PipeNetForeachSrcOp op,
   Value isSrc = arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
   auto ifOp = scf::IfOp::create(rewriter, loc, isSrc,
                                 /*withElseRegion=*/false);
+  foreachLoweringInfo.controlOps.push_back(forOp);
+  foreachLoweringInfo.controlOps.push_back(ifOp);
+  foreachLoweringInfo.ifThenDomains[ifOp] =
+      getPipeRecordsRoleLaunchNodeDomain(records, PipeRole::Source);
   rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
   clonePipeForeachBody(op, selectedPipe.getPipe(), rewriter);
   rewriter.eraseOp(op);
   return success();
 }
 
-static LogicalResult lowerPipeNetForeachDst(PipeNetForeachDstOp op,
-                                            RewriterBase &rewriter) {
+static LogicalResult
+lowerPipeNetForeachDst(PipeNetForeachDstOp op, RewriterBase &rewriter,
+                       PipeForeachLoweringInfo &foreachLoweringInfo) {
   Location loc = op.getLoc();
   rewriter.setInsertionPoint(op);
   PipeNetRecordsAttr records = op.getRecords();
   if (shouldLowerPipeNetForeachDirect(records)) {
-    return lowerPipeNetForeachDirect(op, rewriter, buildRecordDstMatch);
+    return lowerPipeNetForeachDirect(op, rewriter, PipeRole::Destination,
+                                     foreachLoweringInfo, buildRecordDstMatch);
   }
 
   PipeForeachTables tables = buildPipeForeachTables(rewriter, records);
@@ -903,36 +900,51 @@ static LogicalResult lowerPipeNetForeachDst(PipeNetForeachDstOp op,
   Value isDst = arith::AndIOp::create(rewriter, loc, xInRange, yInRange);
   auto ifOp = scf::IfOp::create(rewriter, loc, isDst,
                                 /*withElseRegion=*/false);
+  foreachLoweringInfo.controlOps.push_back(forOp);
+  foreachLoweringInfo.controlOps.push_back(ifOp);
+  foreachLoweringInfo.ifThenDomains[ifOp] =
+      getPipeRecordsRoleLaunchNodeDomain(records, PipeRole::Destination);
   rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
   clonePipeForeachBody(op, selectedPipe.getPipe(), rewriter);
   rewriter.eraseOp(op);
   return success();
 }
 
-static LogicalResult lowerPipeNetForeachOps(ModuleOp mod) {
-  SmallVector<Operation *> foreachOps;
-  mod.walk<WalkOrder::PostOrder>([&](Operation *op) {
-    if (mlir::isa<PipeNetForeachSrcOp, PipeNetForeachDstOp>(op)) {
-      foreachOps.push_back(op);
-    }
-  });
-
+static LogicalResult
+lowerPipeNetForeachOps(ModuleOp mod,
+                       PipeForeachLoweringInfo &foreachLoweringInfo) {
   // A module-wide greedy rewrite also deletes unrelated unused pure reads.
   // Rewrite only foreach operations so this expansion cannot change other IR.
   IRRewriter rewriter(mod.getContext());
-  for (Operation *op : foreachOps) {
-    if (auto foreachSrcOp = mlir::dyn_cast<PipeNetForeachSrcOp>(op)) {
-      if (failed(lowerPipeNetForeachSrc(foreachSrcOp, rewriter))) {
+  while (true) {
+    Operation *foreachOp = nullptr;
+    mod.walk<WalkOrder::PreOrder>([&](Operation *candidate) {
+      if (!mlir::isa<PipeNetForeachSrcOp, PipeNetForeachDstOp>(candidate)) {
+        return WalkResult::advance();
+      }
+      foreachOp = candidate;
+      return WalkResult::interrupt();
+    });
+    if (!foreachOp) {
+      return success();
+    }
+
+    // Lower an outer callback before its nested callbacks. The outer rewrite
+    // clones its body, so any recorded control operations then remain in the
+    // module and continue to identify the generated record selection.
+    if (auto foreachSrcOp = mlir::dyn_cast<PipeNetForeachSrcOp>(foreachOp)) {
+      if (failed(lowerPipeNetForeachSrc(foreachSrcOp, rewriter,
+                                        foreachLoweringInfo))) {
         return failure();
       }
       continue;
     }
-    if (failed(lowerPipeNetForeachDst(mlir::cast<PipeNetForeachDstOp>(op),
-                                      rewriter))) {
+    if (failed(
+            lowerPipeNetForeachDst(mlir::cast<PipeNetForeachDstOp>(foreachOp),
+                                   rewriter, foreachLoweringInfo))) {
       return failure();
     }
   }
-  return success();
 }
 
 /// High-level pipe copy and its proven transfer contract.
@@ -1065,8 +1077,7 @@ applyPipeTransferExpansionPlan(ModuleOp mod,
     auto postOp = PipeTransferPostOp::create(
         builder, copyOp.getLoc(),
         PipeTokenType::get(builder.getContext(), *expansion.pipeNetId),
-        transfer,
-        copyOp.getDst());
+        transfer, copyOp.getDst());
     auto handleCast = UnrealizedConversionCastOp::create(
         builder, copyOp.getLoc(), copyOp.getResult().getType(),
         ValueRange{postOp.getToken()});
@@ -1098,7 +1109,6 @@ applyPipeTransferExpansionPlan(ModuleOp mod,
                                tokenCast.getResult(0));
     waitOp->erase();
   }
-
 }
 
 /// Compute CTA index for a tensor function argument.
@@ -1267,15 +1277,16 @@ static LogicalResult lowerTensorCBCopy(CopyOp op, TensorSliceOp sliceOp,
     return failure();
   }
 
-  auto cbType = getTTLCBType(cb);
-  if (!cbType) {
+  FailureOr<CircularBufferType> maybeDFBType =
+      utils::getTTLCircularBufferType(cb);
+  if (failed(maybeDFBType)) {
     return rewriter.notifyMatchFailure(op, "failed to get CB type");
   }
 
   SmallVector<int64_t> tensorGridShape = getTileGridShapeFromValue(tensor);
   unsigned tensorRank = tensorGridShape.size();
 
-  auto cbShape = cbType.getShape();
+  auto cbShape = (*maybeDFBType).getShape();
 
   if (startIndices.size() != tensorRank) {
     return rewriter.notifyMatchFailure(op, [&](Diagnostic &diag) {
@@ -1534,8 +1545,7 @@ struct PipeTransferWaitLowering : OpConversionPattern<PipeTransferWaitOp> {
                            const PipeModulePlan &pipeModulePlan,
                            const PipeResourcePlan &pipeResourcePlan)
       : OpConversionPattern(typeConverter, context),
-        pipeModulePlan(pipeModulePlan),
-        pipeResourcePlan(pipeResourcePlan) {}
+        pipeModulePlan(pipeModulePlan), pipeResourcePlan(pipeResourcePlan) {}
 
   LogicalResult
   matchAndRewrite(PipeTransferWaitOp op, OpAdaptor adaptor,
@@ -2062,7 +2072,10 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
            typeConverter.isLegal(&op.getBody());
   });
 
-  if (failed(lowerPipeNetForeachOps(mod))) {
+  // Preserve the generated record-selection regions so pipe graph ordering
+  // does not mistake them for independent user control flow.
+  PipeForeachLoweringInfo foreachLoweringInfo;
+  if (failed(lowerPipeNetForeachOps(mod, foreachLoweringInfo))) {
     return failure();
   }
 
@@ -2095,7 +2108,8 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
 
   // Validate receiver DFB consistency before lowering emits the pipe
   // synchronization protocol.
-  auto pipeGraphOrErr = PipeGraph::build(mod, transferIndex);
+  auto pipeGraphOrErr =
+      PipeGraph::build(mod, transferIndex, foreachLoweringInfo);
   if (failed(pipeGraphOrErr)) {
     return failure();
   }

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -476,7 +476,8 @@ static bool dependsOnCoord(Value value, llvm::DenseMap<Value, bool> &cache) {
   Operation *op = value.getDefiningOp();
   bool result = false;
   if (op) {
-    if (mlir::isa<CoreXOp, CoreYOp, PipeNetPredicateOpInterface>(op)) {
+    if (mlir::isa<CoreXOp, CoreYOp, PipeNetPredicateOpInterface,
+                  ttkernel::MyLogicalXOp, ttkernel::MyLogicalYOp>(op)) {
       result = true;
     } else {
       for (Value operand : op->getOperands()) {
@@ -1059,6 +1060,17 @@ void LaunchNodeDomainAnalysis::visitRegionBranchControlFlowTransfer(
   Operation *op = branch.getOperation();
   LaunchNodeDomain narrowed = before.getDomain();
   Operation *unanalyzableOp = before.getUnanalyzableOp();
+
+  if (options.computeRegionDomain) {
+    std::optional<LaunchNodeDomain> computedDomain =
+        options.computeRegionDomain(op, *regionTo);
+    if (computedDomain) {
+      narrowed = before.getDomain().intersectWith(*computedDomain);
+      ChangeResult result = after->setDomain(narrowed, unanalyzableOp);
+      propagateIfChanged(after, result);
+      return;
+    }
+  }
 
   TypeSwitch<Operation *>(op)
       .Case<scf::IfOp>([&](scf::IfOp ifOp) {

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -10,6 +10,7 @@
 
 #include "ttlang/Analysis/ExecutionCountAnalysis.h"
 #include "ttlang/Analysis/IntegerExpressionEvaluator.h"
+#include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -165,6 +166,38 @@ bool knownLaunchNodeDomainContains(const LaunchNodeDomain &domain,
   return domain.known && domain.nodes.find(coord) != domain.nodes.end();
 }
 
+LaunchNodeDomain getPipeRecordSourceLaunchNodeDomain(PipeRecordAttr record) {
+  LaunchNodeDomain result;
+  result.nodes.insert({record.getSrcX(), record.getSrcY()});
+  return result;
+}
+
+LaunchNodeDomain
+getPipeRecordDestinationLaunchNodeDomain(PipeRecordAttr record) {
+  LaunchNodeDomain result;
+  for (int64_t nodeX = record.getDstStartX(); nodeX <= record.getDstEndX();
+       ++nodeX) {
+    for (int64_t nodeY = record.getDstStartY(); nodeY <= record.getDstEndY();
+         ++nodeY) {
+      result.nodes.insert({nodeX, nodeY});
+    }
+  }
+  return result;
+}
+
+LaunchNodeDomain getPipeRecordsRoleLaunchNodeDomain(PipeNetRecordsAttr records,
+                                                    PipeRole role) {
+  LaunchNodeDomain result;
+  for (PipeRecordAttr record : records.getPipes()) {
+    LaunchNodeDomain recordDomain =
+        role == PipeRole::Source
+            ? getPipeRecordSourceLaunchNodeDomain(record)
+            : getPipeRecordDestinationLaunchNodeDomain(record);
+    result = result.unionWith(recordDomain);
+  }
+  return result;
+}
+
 /// Normalize integer-array attributes before verifier-specific interpretation.
 static bool readI64ArrayAttr(Operation *op, llvm::StringLiteral name,
                              SmallVectorImpl<int64_t> &values) {
@@ -226,6 +259,55 @@ LaunchNodeDomain LaunchNodeDomainState::getRoleDomain(int64_t netId,
   return src.unionWith(dst);
 }
 
+void LaunchNodeDomainState::recordPipeNet(PipeType pipeType, Location loc,
+                                          std::optional<StringRef> name) {
+  int64_t pipeNetId = pipeType.getPipeNetId();
+  LaunchNodeDomain sourceDomain = getPipeSourceLaunchNodeDomain(pipeType);
+  if (!sourceDomain.isSubsetOf(baseDomain)) {
+    sourceDomain = LaunchNodeDomain::unknown();
+  }
+  netSourceDomains[pipeNetId] =
+      netSourceDomains[pipeNetId].unionWith(sourceDomain);
+  netDestinationDomains[pipeNetId] = netDestinationDomains[pipeNetId].unionWith(
+      getPipeDestinationLaunchNodeDomain(pipeType, baseDomain));
+  pipeNetLocs[pipeNetId].push_back(loc);
+  auto &storedName = pipeNetNames[pipeNetId];
+  if (storedName.empty() && name && !name->empty()) {
+    storedName = name->str();
+  }
+}
+
+void LaunchNodeDomainState::recordPipeNetRecords(PipeNetRecordsAttr records,
+                                                 Location loc) {
+  std::optional<StringRef> name;
+  if (StringAttr attr = records.getPipeNetName()) {
+    name = attr.getValue();
+  }
+  int64_t pipeNetId = records.getPipeNetId();
+  for (PipeRecordAttr record : records.getPipes()) {
+    PipeType pipeType = PipeType::get(
+        records.getContext(), record.getSrcX(), record.getSrcY(),
+        record.getDstStartX(), record.getDstStartY(), record.getDstEndX(),
+        record.getDstEndY(), pipeNetId);
+    LaunchNodeDomain sourceDomain = getPipeSourceLaunchNodeDomain(pipeType);
+    if (!sourceDomain.isSubsetOf(baseDomain)) {
+      sourceDomain = LaunchNodeDomain::unknown();
+    }
+    netSourceDomains[pipeNetId] =
+        netSourceDomains[pipeNetId].unionWith(sourceDomain);
+    netDestinationDomains[pipeNetId] =
+        netDestinationDomains[pipeNetId].unionWith(
+            getPipeDestinationLaunchNodeDomain(pipeType, baseDomain));
+  }
+  // One location identifies the declaration; recording it per row would
+  // duplicate every diagnostic note for the same PipeNet.
+  pipeNetLocs[pipeNetId].push_back(loc);
+  auto &storedName = pipeNetNames[pipeNetId];
+  if (storedName.empty() && name && !name->empty()) {
+    storedName = name->str();
+  }
+}
+
 void LaunchNodeDomainState::initialize(ModuleOp module) {
   executionCountAnalysesByFunctionAndCoord.clear();
   if (!module->hasAttr(kLaunchGridAttrName)) {
@@ -243,34 +325,36 @@ void LaunchNodeDomainState::initialize(ModuleOp module) {
   }
 
   module.walk([&](CreatePipeOp pipe) {
-    PipeType pipeType = mlir::cast<PipeType>(pipe.getResult().getType());
-    int64_t pipeNetId = pipeType.getPipeNetId();
-    LaunchNodeDomain sourceDomain = getPipeSourceLaunchNodeDomain(pipeType);
-    if (!sourceDomain.isSubsetOf(baseDomain)) {
-      sourceDomain = LaunchNodeDomain::unknown();
+    std::optional<StringRef> name;
+    if (auto attr = pipe.getPipeNetNameAttr()) {
+      name = attr.getValue();
     }
-    netSourceDomains[pipeNetId] =
-        netSourceDomains[pipeNetId].unionWith(sourceDomain);
-    netDestinationDomains[pipeNetId] =
-        netDestinationDomains[pipeNetId].unionWith(
-            getPipeDestinationLaunchNodeDomain(pipeType, baseDomain));
-    pipeNetLocs[pipeNetId].push_back(pipe.getLoc());
-    auto &name = pipeNetNames[pipeNetId];
-    if (name.empty()) {
-      if (auto attr = pipe.getPipeNetNameAttr()) {
-        name = attr.getValue().str();
-      }
-    }
+    recordPipeNet(mlir::cast<PipeType>(pipe.getResult().getType()),
+                  pipe.getLoc(), name);
+  });
+  module.walk([&](PipeNetForeachSrcOp op) {
+    recordPipeNetRecords(op.getRecords(), op.getLoc());
+  });
+  module.walk([&](PipeNetForeachDstOp op) {
+    recordPipeNetRecords(op.getRecords(), op.getLoc());
+  });
+  module.walk([&](SelectPipeSrcOp op) {
+    recordPipeNetRecords(op.getRecords(), op.getLoc());
+  });
+  module.walk([&](SelectPipeDstOp op) {
+    recordPipeNetRecords(op.getRecords(), op.getLoc());
   });
 }
 
 static std::optional<llvm::APInt>
 evaluateLaunchNodeContextValue(Value value, LaunchNodeCoord coord,
                                const LaunchNodeDomainState *state) {
-  if (value.getDefiningOp<CoreXOp>()) {
+  if (value.getDefiningOp<CoreXOp>() ||
+      value.getDefiningOp<ttkernel::MyLogicalXOp>()) {
     return llvm::APInt(IndexType::kInternalStorageBitWidth, coord.x);
   }
-  if (value.getDefiningOp<CoreYOp>()) {
+  if (value.getDefiningOp<CoreYOp>() ||
+      value.getDefiningOp<ttkernel::MyLogicalYOp>()) {
     return llvm::APInt(IndexType::kInternalStorageBitWidth, coord.y);
   }
   if (state) {
@@ -329,6 +413,21 @@ getRegionInvocationCountAtLaunchNode(Region &region, LaunchNodeCoord coord,
                coord)
                ? 1
                : 0;
+  }
+  if (auto foreachSrcOp = dyn_cast<PipeNetForeachSrcOp>(parent)) {
+    return llvm::count_if(
+        foreachSrcOp.getRecords().getPipes(), [&](PipeRecordAttr record) {
+          return record.getSrcX() == coord.x && record.getSrcY() == coord.y;
+        });
+  }
+  if (auto foreachDstOp = dyn_cast<PipeNetForeachDstOp>(parent)) {
+    return llvm::count_if(foreachDstOp.getRecords().getPipes(),
+                          [&](PipeRecordAttr record) {
+                            return coord.x >= record.getDstStartX() &&
+                                   coord.x <= record.getDstEndX() &&
+                                   coord.y >= record.getDstStartY() &&
+                                   coord.y <= record.getDstEndY();
+                          });
   }
   if (auto affineIfOp = dyn_cast<affine::AffineIfOp>(parent)) {
     LaunchNodeDomainResult trueDomain =
@@ -992,6 +1091,16 @@ void LaunchNodeDomainAnalysis::visitRegionBranchControlFlowTransfer(
         auto pipeType = mlir::cast<PipeType>(ifDst.getPipe().getType());
         narrowed = before.getDomain().intersectWith(
             getPipeDestinationLaunchNodeDomain(pipeType, state.baseDomain));
+      })
+      .Case<PipeNetForeachSrcOp>([&](PipeNetForeachSrcOp foreachSrc) {
+        narrowed =
+            before.getDomain().intersectWith(getPipeRecordsRoleLaunchNodeDomain(
+                foreachSrc.getRecords(), PipeRole::Source));
+      })
+      .Case<PipeNetForeachDstOp>([&](PipeNetForeachDstOp foreachDst) {
+        narrowed =
+            before.getDomain().intersectWith(getPipeRecordsRoleLaunchNodeDomain(
+                foreachDst.getRecords(), PipeRole::Destination));
       })
       .Case<PipeNetScopeOp>([&](PipeNetScopeOp scopeOp) {
         auto scope = getPipeNetScopeLaunchNodeDomains(

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -285,10 +285,10 @@ void LaunchNodeDomainState::recordPipeNetRecords(PipeNetRecordsAttr records,
   }
   int64_t pipeNetId = records.getPipeNetId();
   for (PipeRecordAttr record : records.getPipes()) {
-    PipeType pipeType = PipeType::get(
-        records.getContext(), record.getSrcX(), record.getSrcY(),
-        record.getDstStartX(), record.getDstStartY(), record.getDstEndX(),
-        record.getDstEndY(), pipeNetId);
+    PipeType pipeType =
+        PipeType::get(records.getContext(), record.getSrcX(), record.getSrcY(),
+                      record.getDstStartX(), record.getDstStartY(),
+                      record.getDstEndX(), record.getDstEndY(), pipeNetId);
     LaunchNodeDomain sourceDomain = getPipeSourceLaunchNodeDomain(pipeType);
     if (!sourceDomain.isSubsetOf(baseDomain)) {
       sourceDomain = LaunchNodeDomain::unknown();

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -396,22 +396,28 @@ static ReceiverPostsByDFB collectReceiverPostsByDFB(
   for (PipeTransferPostOp postOp : analysisState.receiverPosts) {
     PipeTransferCreateOp createOp =
         transferIndex.getTransferCreate(postOp.getOperation());
-    PipeKey pipe =
-        getPipeKey(mlir::cast<PipeType>(createOp.getPipe().getType()));
+    FailureOr<PipeReference> pipeRef =
+        getPipeReference(postOp, createOp.getPipe());
+    assert(succeeded(pipeRef) &&
+           "pipe transfer graph validated pipe references");
     auto receiverIt = receiverDFBByPost.find(postOp.getOperation());
     if (receiverIt == receiverDFBByPost.end()) {
       continue;
     }
     LaunchNodeDomain postDomain =
         lookupOperationLaunchDomain(postOp.getOperation(), analysisState);
-    pipe.forEachReceiver([&](PipeReceiverCoord receiver) {
-      if (postDomain.known && !knownLaunchNodeDomainContains(
-                                  postDomain, getLaunchNodeCoord(receiver))) {
-        return;
-      }
-      PipeReceiverDFBKey receiverDFB{receiver, receiverIt->second.dfbIndex};
-      postsByReceiverDFB[receiverDFB].push_back(postOp);
-    });
+    for (PipeType pipeType :
+         getPipeTypesFromReference(postOp.getContext(), *pipeRef)) {
+      PipeKey pipe = getPipeKey(pipeType);
+      pipe.forEachReceiver([&](PipeReceiverCoord receiver) {
+        if (postDomain.known && !knownLaunchNodeDomainContains(
+                                    postDomain, getLaunchNodeCoord(receiver))) {
+          return;
+        }
+        PipeReceiverDFBKey receiverDFB{receiver, receiverIt->second.dfbIndex};
+        postsByReceiverDFB[receiverDFB].push_back(postOp);
+      });
+    }
   }
   return postsByReceiverDFB;
 }
@@ -463,6 +469,11 @@ struct ReceiverProducerState {
 };
 
 } // namespace
+
+static std::optional<std::uint64_t>
+getConcreteTransferExecutionCount(Operation *op, LaunchNodeCoord coord,
+                                  const PipeReference &pipeRef,
+                                  PipeGraphAnalysisState &analysisState);
 
 static InFlightDiagnostic
 emitReceiverReservationPastDFBEnd(const ReceiverDFBInfo &receiverInfo,
@@ -543,19 +554,25 @@ LogicalResult PipeGraph::assignReceiverAddressSequences(
     auto postOp = llvm::cast<PipeTransferPostOp>(postOperation);
     PipeTransferCreateOp createOp =
         transferIndex.getTransferCreate(postOp.getOperation());
-    PipeKey pipe =
-        getPipeKey(mlir::cast<PipeType>(createOp.getPipe().getType()));
-    pipe.forEachReceiver([&](PipeReceiverCoord receiver) {
-      PipeReceiverDFBKey receiverDFB{receiver, receiverDFBIndex};
-      auto postIt = postsByReceiverDFB.find(receiverDFB);
-      ArrayRef<PipeTransferPostOp> posts;
-      if (postIt != postsByReceiverDFB.end()) {
-        posts = postIt->second;
-      }
-      scheduleContextByReceiverDFB.try_emplace(
-          receiverDFB,
-          getProvenReceiverScheduleContext(receiverDFB, posts, analysisState));
-    });
+    FailureOr<PipeReference> pipeRef =
+        getPipeReference(postOp, createOp.getPipe());
+    assert(succeeded(pipeRef) &&
+           "pipe transfer graph validated pipe references");
+    for (PipeType pipeType :
+         getPipeTypesFromReference(postOp.getContext(), *pipeRef)) {
+      PipeKey pipe = getPipeKey(pipeType);
+      pipe.forEachReceiver([&](PipeReceiverCoord receiver) {
+        PipeReceiverDFBKey receiverDFB{receiver, receiverDFBIndex};
+        auto postIt = postsByReceiverDFB.find(receiverDFB);
+        ArrayRef<PipeTransferPostOp> posts;
+        if (postIt != postsByReceiverDFB.end()) {
+          posts = postIt->second;
+        }
+        scheduleContextByReceiverDFB.try_emplace(
+            receiverDFB, getProvenReceiverScheduleContext(receiverDFB, posts,
+                                                          analysisState));
+      });
+    }
   }
 
   // Recurrence facts accumulated for one endpoint during the producer walk.
@@ -572,82 +589,96 @@ LogicalResult PipeGraph::assignReceiverAddressSequences(
   llvm::DenseMap<PipeReceiverEndpointId, EndpointSlotAssignment>
       assignmentByEndpoint;
   auto processPost = [&](PipeTransferPostOp postOp) -> LogicalResult {
-    const PipeTransferNode *transferNode =
-        getPipeTransferNodeForProtocolOp(postOp.getOperation());
-    if (!transferNode) {
+    ArrayRef<PipeTransferNodeId> transferNodeIds =
+        getPipeTransferNodeIdsForProtocolOp(postOp.getOperation());
+    if (transferNodeIds.empty()) {
       return success();
     }
 
-    const PipeKey &pipeKey = transferNode->pipe;
     auto receiverReserveOp = findCBReserveForPipeReceive(postOp.getDst());
     assert(receiverReserveOp &&
            "receiver post must trace to the reserve recorded by PipeGraph");
+    PipeTransferCreateOp createOp =
+        transferIndex.getTransferCreate(postOp.getOperation());
+    FailureOr<PipeReference> pipeRef =
+        getPipeReference(postOp, createOp.getPipe());
+    assert(succeeded(pipeRef) &&
+           "pipe transfer graph validated pipe references");
 
     LaunchNodeDomain postDomain =
         lookupOperationLaunchDomain(postOp.getOperation(), analysisState);
-    bool hasReceiver = false;
-    LogicalResult result = success();
-    pipeKey.forEachReceiver([&](PipeReceiverCoord receiver) {
-      if (failed(result) ||
-          (postDomain.known && !knownLaunchNodeDomainContains(
+    for (PipeTransferNodeId transferNodeId : transferNodeIds) {
+      const PipeTransferNode &transferNode =
+          getPipeTransferNode(transferNodeId);
+      const PipeKey &pipeKey = transferNode.pipe;
+      bool hasReceiver = false;
+      LogicalResult result = success();
+      pipeKey.forEachReceiver([&](PipeReceiverCoord receiver) {
+        if (failed(result) || (postDomain.known &&
+                               !knownLaunchNodeDomainContains(
                                    postDomain, getLaunchNodeCoord(receiver)))) {
-        return;
-      }
-      hasReceiver = true;
-      auto endpointIt = llvm::find_if(
-          transferNode->receiverEndpoints,
-          [&](PipeReceiverEndpointId endpointId) {
-            return getPipeReceiverEndpoint(endpointId).receiver == receiver;
-          });
-      assert(endpointIt != transferNode->receiverEndpoints.end() &&
-             "pipe transfer node is missing a receiver endpoint");
-      const PipeReceiverEndpoint &endpoint =
-          getPipeReceiverEndpoint(*endpointIt);
-      const ReceiverDFBInfo &receiverInfo = endpoint.receiverDFBInfo;
-      PipeReceiverDFBKey receiverDFB{receiver, receiverInfo.dfbIndex};
-      EndpointSlotAssignment &endpointAssignment =
-          assignmentByEndpoint[*endpointIt];
-      if (!scheduleContextByReceiverDFB.lookup(receiverDFB)) {
-        endpointAssignment.valid = false;
-        return;
-      }
-      auto &slotByReserve = slotByReceiverReserve[receiverDFB];
-      auto reserveIt = slotByReserve.find(receiverReserveOp.getOperation());
-      int64_t slot = 0;
-      if (reserveIt == slotByReserve.end()) {
-        FailureOr<int64_t> assignedSlot = assignReceiverPhysicalSlot(
-            receiverInfo, producerStateByReceiverDFB[receiverDFB]);
-        if (failed(assignedSlot)) {
-          result = failure();
           return;
         }
-        slot = *assignedSlot;
-        slotByReserve[receiverReserveOp.getOperation()] = slot;
-      } else {
-        slot = reserveIt->second;
+        hasReceiver = true;
+        auto endpointIt = llvm::find_if(
+            transferNode.receiverEndpoints,
+            [&](PipeReceiverEndpointId endpointId) {
+              return getPipeReceiverEndpoint(endpointId).receiver == receiver;
+            });
+        assert(endpointIt != transferNode.receiverEndpoints.end() &&
+               "pipe transfer node is missing a receiver endpoint");
+        const PipeReceiverEndpoint &endpoint =
+            getPipeReceiverEndpoint(*endpointIt);
+        const ReceiverDFBInfo &receiverInfo = endpoint.receiverDFBInfo;
+        PipeReceiverDFBKey receiverDFB{receiver, receiverInfo.dfbIndex};
+        EndpointSlotAssignment &endpointAssignment =
+            assignmentByEndpoint[*endpointIt];
+        if (!scheduleContextByReceiverDFB.lookup(receiverDFB)) {
+          endpointAssignment.valid = false;
+          return;
+        }
+        auto &slotByReserve = slotByReceiverReserve[receiverDFB];
+        auto reserveIt = slotByReserve.find(receiverReserveOp.getOperation());
+        int64_t slot = 0;
+        // A table-driven reserve executes once per matching record, so each
+        // callback execution advances the producer reservation position.
+        if ((*pipeRef).isSelected() || reserveIt == slotByReserve.end()) {
+          FailureOr<int64_t> assignedSlot = assignReceiverPhysicalSlot(
+              receiverInfo, producerStateByReceiverDFB[receiverDFB]);
+          if (failed(assignedSlot)) {
+            result = failure();
+            return;
+          }
+          slot = *assignedSlot;
+          if ((*pipeRef).isStatic()) {
+            slotByReserve[receiverReserveOp.getOperation()] = slot;
+          }
+        } else {
+          slot = reserveIt->second;
+        }
+        if (!postDomain.known) {
+          endpointAssignment.valid = false;
+          return;
+        }
+        std::optional<std::uint64_t> maybeExecutionCount =
+            getConcreteTransferExecutionCount(postOp.getOperation(),
+                                              getLaunchNodeCoord(receiver),
+                                              *pipeRef, analysisState);
+        if (endpointAssignment.initialSlot) {
+          endpointAssignment.valid = false;
+          return;
+        }
+        endpointAssignment.initialSlot = slot;
+        endpointAssignment.executionCount = maybeExecutionCount;
+      });
+      if (failed(result)) {
+        return failure();
       }
-      if (!postDomain.known) {
-        endpointAssignment.valid = false;
-        return;
-      }
-      std::optional<std::uint64_t> maybeExecutionCount =
-          getExactExecutionCountAtLaunchNode(postOp.getOperation(),
-                                             getLaunchNodeCoord(receiver),
-                                             analysisState);
-      if (endpointAssignment.initialSlot) {
-        endpointAssignment.valid = false;
-        return;
-      }
-      endpointAssignment.initialSlot = slot;
-      endpointAssignment.executionCount = maybeExecutionCount;
-    });
-    if (failed(result)) {
-      return failure();
-    }
-    if (!hasReceiver) {
-      for (PipeReceiverEndpointId endpointId :
-           transferNode->receiverEndpoints) {
-        assignmentByEndpoint[endpointId].valid = false;
+      if (!hasReceiver) {
+        for (PipeReceiverEndpointId endpointId :
+             transferNode.receiverEndpoints) {
+          assignmentByEndpoint[endpointId].valid = false;
+        }
       }
     }
     return success();
@@ -1019,18 +1050,45 @@ const PipeReceiverEndpoint *PipeGraph::getProvenReceiverAddressEndpoint(
   return representative;
 }
 
+static std::optional<std::uint64_t>
+getConcreteTransferExecutionCount(Operation *op, LaunchNodeCoord coord,
+                                  const PipeReference &pipeRef,
+                                  PipeGraphAnalysisState &analysisState) {
+  std::optional<std::uint64_t> maybeTotalCount =
+      getExactExecutionCountAtLaunchNode(op, coord, analysisState);
+  if (!maybeTotalCount || pipeRef.isStatic()) {
+    return maybeTotalCount;
+  }
+
+  std::uint64_t matchingRecordCount = llvm::count_if(
+      pipeRef.getRecords().getPipes(), [&](PipeRecordAttr record) {
+        if (pipeRef.isSelectedSrc()) {
+          return record.getSrcX() == coord.x && record.getSrcY() == coord.y;
+        }
+        return coord.x >= record.getDstStartX() &&
+               coord.x <= record.getDstEndX() &&
+               coord.y >= record.getDstStartY() &&
+               coord.y <= record.getDstEndY();
+      });
+  if (matchingRecordCount == 0 || *maybeTotalCount % matchingRecordCount != 0) {
+    return std::nullopt;
+  }
+  // The shared operation count includes every matching record. Graph nodes
+  // represent individual records and therefore use the per-record count.
+  return *maybeTotalCount / matchingRecordCount;
+}
+
 LogicalResult
 PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
                                 PipeGraphAnalysisState &analysisState) {
   pipeTransferNodes.clear();
-  transferNodeIdByProtocolOp.clear();
+  transferNodeIdsByProtocolOp.clear();
   pipeReceiverEndpoints.clear();
   receiverDFBNodes.clear();
 
   // Sends and receiver posts that declare the same logical pipe relation.
   // Correspondence analysis matches them into individual transfers.
   struct PipeTransferCandidates {
-    PipeType pipeType;
     SmallVector<PipeTransferSendOp> sends;
     llvm::DenseMap<PipeReceiverCoord, SmallVector<PipeTransferPostOp>>
         postsByReceiver;
@@ -1041,8 +1099,11 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
     if (auto sendOp = dyn_cast<PipeTransferSendOp>(op)) {
       PipeTransferCreateOp createOp =
           transferIndex.getTransferCreate(sendOp.getOperation());
-      auto pipeType = mlir::cast<PipeType>(createOp.getPipe().getType());
-      PipeKey pipeKey = getPipeKey(pipeType);
+      FailureOr<PipeReference> pipeRef =
+          getPipeReference(sendOp, createOp.getPipe());
+      if (failed(pipeRef)) {
+        return failure();
+      }
       LaunchNodeDomain sendDomain =
           lookupOperationLaunchDomain(sendOp.getOperation(), analysisState);
       if (!sendDomain.known && analysisState.hasLaunchGrid) {
@@ -1050,22 +1111,22 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
                          "this send");
         return failure();
       }
-      if (sendDomain.known && !knownLaunchNodeDomainContains(
-                                  sendDomain, {pipeKey.srcX, pipeKey.srcY})) {
-        continue;
+      for (PipeType pipeType :
+           getPipeTypesFromReference(sendOp.getContext(), *pipeRef)) {
+        PipeKey pipeKey = getPipeKey(pipeType);
+        LaunchNodeCoord source{pipeKey.srcX, pipeKey.srcY};
+        if (sendDomain.known &&
+            !knownLaunchNodeDomainContains(sendDomain, source)) {
+          continue;
+        }
+        std::optional<std::uint64_t> maybeExecutionCount =
+            getConcreteTransferExecutionCount(sendOp.getOperation(), source,
+                                              *pipeRef, analysisState);
+        if (maybeExecutionCount && *maybeExecutionCount == 0) {
+          continue;
+        }
+        candidatesByPipe[pipeKey].sends.push_back(sendOp);
       }
-      std::optional<std::uint64_t> maybeExecutionCount =
-          getExactExecutionCountAtLaunchNode(sendOp.getOperation(),
-                                             {pipeKey.srcX, pipeKey.srcY},
-                                             analysisState);
-      if (maybeExecutionCount && *maybeExecutionCount == 0) {
-        continue;
-      }
-      PipeTransferCandidates &candidates = candidatesByPipe[pipeKey];
-      if (!candidates.pipeType) {
-        candidates.pipeType = pipeType;
-      }
-      candidates.sends.push_back(sendOp);
       continue;
     }
 
@@ -1075,8 +1136,11 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
     }
     PipeTransferCreateOp createOp =
         transferIndex.getTransferCreate(postOp.getOperation());
-    auto pipeType = mlir::cast<PipeType>(createOp.getPipe().getType());
-    PipeKey pipeKey = getPipeKey(pipeType);
+    FailureOr<PipeReference> pipeRef =
+        getPipeReference(postOp, createOp.getPipe());
+    if (failed(pipeRef)) {
+      return failure();
+    }
     LaunchNodeDomain postDomain =
         lookupOperationLaunchDomain(postOp.getOperation(), analysisState);
     if (!postDomain.known && analysisState.hasLaunchGrid) {
@@ -1084,29 +1148,26 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
           "cannot determine which pipe receivers execute this post");
       return failure();
     }
-    SmallVector<PipeReceiverCoord> activeReceivers;
-    pipeKey.forEachReceiver([&](PipeReceiverCoord receiver) {
-      if (postDomain.known && !knownLaunchNodeDomainContains(
-                                  postDomain, getLaunchNodeCoord(receiver))) {
-        return;
+    for (PipeType pipeType :
+         getPipeTypesFromReference(postOp.getContext(), *pipeRef)) {
+      PipeKey pipeKey = getPipeKey(pipeType);
+      PipeTransferCandidates &candidates = candidatesByPipe[pipeKey];
+      pipeKey.forEachReceiver([&](PipeReceiverCoord receiver) {
+        LaunchNodeCoord receiverCoord = getLaunchNodeCoord(receiver);
+        if (postDomain.known &&
+            !knownLaunchNodeDomainContains(postDomain, receiverCoord)) {
+          return;
+        }
+        std::optional<std::uint64_t> maybeExecutionCount =
+            getConcreteTransferExecutionCount(
+                postOp.getOperation(), receiverCoord, *pipeRef, analysisState);
+        if (!maybeExecutionCount || *maybeExecutionCount != 0) {
+          candidates.postsByReceiver[receiver].push_back(postOp);
+        }
+      });
+      if (candidates.postsByReceiver.empty() && candidates.sends.empty()) {
+        candidatesByPipe.erase(pipeKey);
       }
-      std::optional<std::uint64_t> maybeExecutionCount =
-          getExactExecutionCountAtLaunchNode(postOp.getOperation(),
-                                             getLaunchNodeCoord(receiver),
-                                             analysisState);
-      if (!maybeExecutionCount || *maybeExecutionCount != 0) {
-        activeReceivers.push_back(receiver);
-      }
-    });
-    if (activeReceivers.empty()) {
-      continue;
-    }
-    PipeTransferCandidates &candidates = candidatesByPipe[pipeKey];
-    if (!candidates.pipeType) {
-      candidates.pipeType = pipeType;
-    }
-    for (PipeReceiverCoord receiver : activeReceivers) {
-      candidates.postsByReceiver[receiver].push_back(postOp);
     }
   }
 
@@ -1149,20 +1210,64 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
            ++sendIndex) {
         PipeTransferSendOp sendOp = candidates.sends[sendIndex];
         PipeTransferPostOp postOp = postsIt->second[sendIndex];
-        if (!proveEqualExecutionCountAtLaunchNodes(
-                sendOp.getOperation(), {pipeKey.srcX, pipeKey.srcY},
-                postOp.getOperation(), getLaunchNodeCoord(receiver),
-                analysisState)) {
+        PipeTransferCreateOp sendCreate =
+            transferIndex.getTransferCreate(sendOp.getOperation());
+        PipeTransferCreateOp postCreate =
+            transferIndex.getTransferCreate(postOp.getOperation());
+        FailureOr<PipeReference> sendPipeRef =
+            getPipeReference(sendOp, sendCreate.getPipe());
+        FailureOr<PipeReference> postPipeRef =
+            getPipeReference(postOp, postCreate.getPipe());
+        assert(succeeded(sendPipeRef) && succeeded(postPipeRef) &&
+               "pipe transfer graph validated pipe references");
+        bool haveEqualExecutionCounts = false;
+        std::optional<std::uint64_t> maybeSendCount;
+        std::optional<std::uint64_t> maybePostCount;
+        if ((*sendPipeRef).isStatic() && (*postPipeRef).isStatic()) {
+          // Static pipe operations can have matching loop and branch structure
+          // even when an exact execution count cannot be evaluated.
+          haveEqualExecutionCounts = proveEqualExecutionCountAtLaunchNodes(
+              sendOp.getOperation(), {pipeKey.srcX, pipeKey.srcY},
+              postOp.getOperation(), getLaunchNodeCoord(receiver),
+              analysisState);
+        } else {
+          // Selected operations represent several records, so compare their
+          // per-record counts rather than their shared operation counts.
+          maybeSendCount = getConcreteTransferExecutionCount(
+              sendOp.getOperation(), {pipeKey.srcX, pipeKey.srcY}, *sendPipeRef,
+              analysisState);
+          maybePostCount = getConcreteTransferExecutionCount(
+              postOp.getOperation(), getLaunchNodeCoord(receiver), *postPipeRef,
+              analysisState);
+          haveEqualExecutionCounts = maybeSendCount && maybePostCount &&
+                                     *maybeSendCount == *maybePostCount;
+        }
+        if (!haveEqualExecutionCounts) {
           auto diag = postOp.emitError()
                       << "cannot prove matching execution counts for this "
                          "receiver post and its pipe send";
+          if ((*sendPipeRef).isSelected() || (*postPipeRef).isSelected()) {
+            diag << "; receiver post count is ";
+            if (maybePostCount) {
+              diag << *maybePostCount;
+            } else {
+              diag << "unknown";
+            }
+            diag << " and pipe send count is ";
+            if (maybeSendCount) {
+              diag << *maybeSendCount;
+            } else {
+              diag << "unknown";
+            }
+          }
           diag.attachNote(sendOp.getLoc()) << "corresponding pipe send is here";
           correspondenceResult = failure();
           return;
         }
         auto [existing, inserted] =
             sendIndexByPost.try_emplace(postOp.getOperation(), sendIndex);
-        if (!inserted && existing->second != sendIndex) {
+        if (!inserted && existing->second != sendIndex &&
+            (*postPipeRef).isStatic()) {
           postOp.emitError(
               "one receiver post cannot correspond to two pipe transfers");
           correspondenceResult = failure();
@@ -1199,7 +1304,8 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
                                                    {},
                                                    {}});
       PipeTransferNode &transferNode = pipeTransferNodes.back();
-      transferNodeIdByProtocolOp[sendOp.getOperation()] = transferNodeId;
+      transferNodeIdsByProtocolOp[sendOp.getOperation()].push_back(
+          transferNodeId);
       llvm::SmallSetVector<Operation *, 4> uniquePostOps;
 
       for (auto [receiver, postOp] : endpointsBySend[sendIndex]) {
@@ -1208,7 +1314,11 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
                "receiver post must have DFB geometry");
         const ReceiverDFBInfo &receiverInfo = infoIt->second;
         uniquePostOps.insert(postOp.getOperation());
-        transferNodeIdByProtocolOp[postOp.getOperation()] = transferNodeId;
+        SmallVector<PipeTransferNodeId> &postTransferNodeIds =
+            transferNodeIdsByProtocolOp[postOp.getOperation()];
+        if (!llvm::is_contained(postTransferNodeIds, transferNodeId)) {
+          postTransferNodeIds.push_back(transferNodeId);
+        }
         PipeReceiverDFBKey receiverDFB{receiver, receiverInfo.dfbIndex};
         auto nodeIt = nodeIdByReceiverDFB.find(receiverDFB);
         PipeReceiverDFBNodeId receiverDFBNodeId = 0;
@@ -1243,6 +1353,46 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
     }
   }
   return success();
+}
+
+FailureOr<PipeReference> getPipeReference(Operation *op, Value pipe) {
+  Value tracedPipe = traceUnrealizedCasts(pipe);
+  if (auto pipeType = mlir::dyn_cast<PipeType>(tracedPipe.getType())) {
+    return PipeReference{PipeReference::Kind::Static, pipeType,
+                         SelectPipeSrcOp(), SelectPipeDstOp()};
+  }
+  if (auto selectedSrc = tracedPipe.getDefiningOp<SelectPipeSrcOp>()) {
+    return PipeReference{PipeReference::Kind::SelectedSrc, PipeType(),
+                         selectedSrc, SelectPipeDstOp()};
+  }
+  if (auto selectedDst = tracedPipe.getDefiningOp<SelectPipeDstOp>()) {
+    return PipeReference{PipeReference::Kind::SelectedDst, PipeType(),
+                         SelectPipeSrcOp(), selectedDst};
+  }
+  return op->emitError() << "selected pipe operand must be a direct result of "
+                            "ttl.select_pipe_src or ttl.select_pipe_dst";
+}
+
+FailureOr<PipeReference>
+getPipeReferenceForProtocolOp(Operation *protocolOp,
+                              const PipeTransferIndex &transferIndex) {
+  return getPipeReference(
+      protocolOp, transferIndex.getTransferCreate(protocolOp).getPipe());
+}
+
+SmallVector<PipeType> getPipeTypesFromReference(MLIRContext *context,
+                                                const PipeReference &ref) {
+  if (ref.isStatic()) {
+    return SmallVector<PipeType>{ref.pipeType};
+  }
+  SmallVector<PipeType> pipeTypes;
+  PipeNetRecordsAttr records = ref.getRecords();
+  pipeTypes.reserve(records.getPipes().size());
+  for (PipeRecordAttr record : records.getPipes()) {
+    pipeTypes.push_back(
+        getPipeTypeFromRecord(context, record, records.getPipeNetId()));
+  }
+  return pipeTypes;
 }
 
 static LogicalResult

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -561,9 +561,9 @@ verifyReceiverReservationSequence(const ReceiverAddressSequenceProof &sequence,
   }
   return success();
 }
+
 LogicalResult PipeGraph::assignReceiverAddressSequences(
-    ModuleOp mod,
-    const PipeTransferIndex &transferIndex,
+    ModuleOp mod, const PipeTransferIndex &transferIndex,
     PipeGraphAnalysisState &analysisState) {
   ReceiverPostsByDFB postsByReceiverDFB = collectReceiverPostsByDFB(
       transferIndex, receiverDFBByPost, analysisState);
@@ -1677,9 +1677,9 @@ LogicalResult PipeGraph::addPipeReceiver(Operation *op,
   return success();
 }
 
-FailureOr<PipeGraph> PipeGraph::build(
-    ModuleOp mod, const PipeTransferIndex &transferIndex,
-    const PipeForeachLoweringInfo &foreachLoweringInfo) {
+FailureOr<PipeGraph>
+PipeGraph::build(ModuleOp mod, const PipeTransferIndex &transferIndex,
+                 const PipeForeachLoweringInfo &foreachLoweringInfo) {
   PipeGraph graph;
   PipeGraphAnalysisState analysisState;
   if (failed(collectPipeGraphOperations(mod, transferIndex, analysisState))) {

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -44,6 +44,8 @@ struct PipeGraphAnalysisState : LaunchNodeDomainState {
   llvm::DenseMap<int64_t, SmallVector<PipeTransferPostOp>>
       receiverPostsByStream;
   llvm::DenseMap<int64_t, SmallVector<CBPushOp>> pushesByStream;
+  llvm::SmallPtrSet<Operation *, 16> pipeRecordControlOps;
+  llvm::DenseMap<Operation *, LaunchNodeDomain> pipeRecordIfThenDomains;
 };
 
 namespace {
@@ -62,6 +64,18 @@ static LogicalResult collectLaunchNodeDomains(ModuleOp mod,
   options.operationCallback = [&](Operation *op, const LaunchNodeDomain &domain,
                                   Operation * /*unanalyzableOp*/) {
     state.operationLaunchDomains[op] = domain;
+  };
+  options.computeRegionDomain =
+      [&](Operation *op,
+          unsigned regionNumber) -> std::optional<LaunchNodeDomain> {
+    if (regionNumber != 0) {
+      return std::nullopt;
+    }
+    auto domainIt = state.pipeRecordIfThenDomains.find(op);
+    if (domainIt == state.pipeRecordIfThenDomains.end()) {
+      return std::nullopt;
+    }
+    return domainIt->second;
   };
   solver.load<LaunchNodeDomainAnalysis>(state, options);
   if (failed(solver.initializeAndRun(mod))) {
@@ -307,6 +321,13 @@ getReceiverControlContext(Operation *op, PipeReceiverCoord receiver,
       context.function = function;
       break;
     }
+    // The graph already represents each PipeNet record separately. Ignoring
+    // generated foreach control preserves the callback's order relative to
+    // operations before and after it.
+    if (analysisState.pipeRecordControlOps.contains(parent)) {
+      current = parent;
+      continue;
+    }
     if (parent && isTransparentReceiverScope(parent, receiver, analysisState)) {
       current = parent;
       continue;
@@ -540,6 +561,31 @@ verifyReceiverReservationSequence(const ReceiverAddressSequenceProof &sequence,
   return success();
 }
 
+static bool
+reserveRepeatsForPipeRecord(Operation *reserveOp, Operation *postOp,
+                            const PipeGraphAnalysisState &analysisState) {
+  // The nearest generated control selects this pipe record. An enclosing
+  // callback may contain a reserve shared by every nested record.
+  Operation *recordControl = nullptr;
+  for (Operation *parent = postOp->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (analysisState.pipeRecordControlOps.contains(parent)) {
+      recordControl = parent;
+      break;
+    }
+  }
+  if (!recordControl) {
+    return false;
+  }
+  for (Operation *parent = reserveOp->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (parent == recordControl) {
+      return true;
+    }
+  }
+  return false;
+}
+
 LogicalResult PipeGraph::assignReceiverAddressSequences(
     const PipeTransferIndex &transferIndex,
     PipeGraphAnalysisState &analysisState) {
@@ -640,9 +686,12 @@ LogicalResult PipeGraph::assignReceiverAddressSequences(
         auto &slotByReserve = slotByReceiverReserve[receiverDFB];
         auto reserveIt = slotByReserve.find(receiverReserveOp.getOperation());
         int64_t slot = 0;
-        // A table-driven reserve executes once per matching record, so each
-        // callback execution advances the producer reservation position.
-        if ((*pipeRef).isSelected() || reserveIt == slotByReserve.end()) {
+        bool reserveRepeatsPerRecord = reserveRepeatsForPipeRecord(
+            receiverReserveOp, postOp, analysisState);
+        // A reserve inside this callback advances once per matching record. A
+        // reserve outside this callback retains one slot even when an outer
+        // PipeNet callback contains both operations.
+        if (reserveRepeatsPerRecord || reserveIt == slotByReserve.end()) {
           FailureOr<int64_t> assignedSlot = assignReceiverPhysicalSlot(
               receiverInfo, producerStateByReceiverDFB[receiverDFB]);
           if (failed(assignedSlot)) {
@@ -650,7 +699,7 @@ LogicalResult PipeGraph::assignReceiverAddressSequences(
             return;
           }
           slot = *assignedSlot;
-          if ((*pipeRef).isStatic()) {
+          if (!reserveRepeatsPerRecord) {
             slotByReserve[receiverReserveOp.getOperation()] = slot;
           }
         } else {
@@ -1358,16 +1407,13 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
 FailureOr<PipeReference> getPipeReference(Operation *op, Value pipe) {
   Value tracedPipe = traceUnrealizedCasts(pipe);
   if (auto pipeType = mlir::dyn_cast<PipeType>(tracedPipe.getType())) {
-    return PipeReference{PipeReference::Kind::Static, pipeType,
-                         SelectPipeSrcOp(), SelectPipeDstOp()};
+    return PipeReference(pipeType);
   }
   if (auto selectedSrc = tracedPipe.getDefiningOp<SelectPipeSrcOp>()) {
-    return PipeReference{PipeReference::Kind::SelectedSrc, PipeType(),
-                         selectedSrc, SelectPipeDstOp()};
+    return PipeReference(selectedSrc);
   }
   if (auto selectedDst = tracedPipe.getDefiningOp<SelectPipeDstOp>()) {
-    return PipeReference{PipeReference::Kind::SelectedDst, PipeType(),
-                         SelectPipeSrcOp(), selectedDst};
+    return PipeReference(selectedDst);
   }
   return op->emitError() << "selected pipe operand must be a direct result of "
                             "ttl.select_pipe_src or ttl.select_pipe_dst";
@@ -1383,7 +1429,7 @@ getPipeReferenceForProtocolOp(Operation *protocolOp,
 SmallVector<PipeType> getPipeTypesFromReference(MLIRContext *context,
                                                 const PipeReference &ref) {
   if (ref.isStatic()) {
-    return SmallVector<PipeType>{ref.pipeType};
+    return SmallVector<PipeType>{ref.getStaticPipeType()};
   }
   SmallVector<PipeType> pipeTypes;
   PipeNetRecordsAttr records = ref.getRecords();
@@ -1581,13 +1627,19 @@ LogicalResult PipeGraph::addPipeReceiver(Operation *op,
   return success();
 }
 
-FailureOr<PipeGraph> PipeGraph::build(ModuleOp mod,
-                                      const PipeTransferIndex &transferIndex) {
+FailureOr<PipeGraph> PipeGraph::build(
+    ModuleOp mod, const PipeTransferIndex &transferIndex,
+    const PipeForeachLoweringInfo &foreachLoweringInfo) {
   PipeGraph graph;
   PipeGraphAnalysisState analysisState;
   if (failed(collectPipeGraphOperations(mod, transferIndex, analysisState))) {
     return failure();
   }
+
+  analysisState.pipeRecordControlOps.insert(
+      foreachLoweringInfo.controlOps.begin(),
+      foreachLoweringInfo.controlOps.end());
+  analysisState.pipeRecordIfThenDomains = foreachLoweringInfo.ifThenDomains;
 
   for (PipeTransferPostOp postOp : analysisState.receiverPosts) {
     PipeTransferCreateOp createOp =
@@ -1596,7 +1648,6 @@ FailureOr<PipeGraph> PipeGraph::build(ModuleOp mod,
       return failure();
     }
   }
-
   if (failed(collectLaunchNodeDomains(mod, analysisState))) {
     return failure();
   }

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -46,6 +46,7 @@ struct PipeGraphAnalysisState : LaunchNodeDomainState {
   llvm::DenseMap<int64_t, SmallVector<CBPushOp>> pushesByStream;
   llvm::SmallPtrSet<Operation *, 16> pipeRecordControlOps;
   llvm::DenseMap<Operation *, LaunchNodeDomain> pipeRecordIfThenDomains;
+  llvm::DenseMap<Operation *, PipeNetRecordLoop> pipeRecordLoops;
 };
 
 namespace {
@@ -560,33 +561,8 @@ verifyReceiverReservationSequence(const ReceiverAddressSequenceProof &sequence,
   }
   return success();
 }
-
-static bool
-reserveRepeatsForPipeRecord(Operation *reserveOp, Operation *postOp,
-                            const PipeGraphAnalysisState &analysisState) {
-  // The nearest generated control selects this pipe record. An enclosing
-  // callback may contain a reserve shared by every nested record.
-  Operation *recordControl = nullptr;
-  for (Operation *parent = postOp->getParentOp(); parent;
-       parent = parent->getParentOp()) {
-    if (analysisState.pipeRecordControlOps.contains(parent)) {
-      recordControl = parent;
-      break;
-    }
-  }
-  if (!recordControl) {
-    return false;
-  }
-  for (Operation *parent = reserveOp->getParentOp(); parent;
-       parent = parent->getParentOp()) {
-    if (parent == recordControl) {
-      return true;
-    }
-  }
-  return false;
-}
-
 LogicalResult PipeGraph::assignReceiverAddressSequences(
+    ModuleOp mod,
     const PipeTransferIndex &transferIndex,
     PipeGraphAnalysisState &analysisState) {
   ReceiverPostsByDFB postsByReceiverDFB = collectReceiverPostsByDFB(
@@ -634,13 +610,14 @@ LogicalResult PipeGraph::assignReceiverAddressSequences(
       slotByReceiverReserve;
   llvm::DenseMap<PipeReceiverEndpointId, EndpointSlotAssignment>
       assignmentByEndpoint;
-  auto processPost = [&](PipeTransferPostOp postOp) -> LogicalResult {
-    ArrayRef<PipeTransferNodeId> transferNodeIds =
-        getPipeTransferNodeIdsForProtocolOp(postOp.getOperation());
-    if (transferNodeIds.empty()) {
+  auto processPost =
+      [&](PipeTransferPostOp postOp, LaunchNodeCoord coord,
+          ArrayRef<ActivePipeNetRecord> activeRecords) -> LogicalResult {
+    LaunchNodeDomain postDomain =
+        lookupOperationLaunchDomain(postOp.getOperation(), analysisState);
+    if (postDomain.known && !knownLaunchNodeDomainContains(postDomain, coord)) {
       return success();
     }
-
     auto receiverReserveOp = findCBReserveForPipeReceive(postOp.getDst());
     assert(receiverReserveOp &&
            "receiver post must trace to the reserve recorded by PipeGraph");
@@ -651,91 +628,125 @@ LogicalResult PipeGraph::assignReceiverAddressSequences(
     assert(succeeded(pipeRef) &&
            "pipe transfer graph validated pipe references");
 
-    LaunchNodeDomain postDomain =
-        lookupOperationLaunchDomain(postOp.getOperation(), analysisState);
+    SmallVector<PipeTransferNodeId, 1> selectedTransferNodeIds;
+    ArrayRef<PipeTransferNodeId> transferNodeIds;
+    Operation *selectedRecordLoop = nullptr;
+    if (pipeRef->isStatic()) {
+      transferNodeIds =
+          getPipeTransferNodeIdsForProtocolOp(postOp.getOperation());
+    } else {
+      selectedRecordLoop = pipeRef->getSelectedOperation()->getParentOp();
+      while (selectedRecordLoop &&
+             !analysisState.pipeRecordLoops.contains(selectedRecordLoop)) {
+        selectedRecordLoop = selectedRecordLoop->getParentOp();
+      }
+      assert(selectedRecordLoop &&
+             "selected pipe operation must be nested in its record loop");
+      std::optional<std::uint64_t> activeRecordIndex =
+          getActivePipeNetRecordIndex(activeRecords, selectedRecordLoop);
+      assert(activeRecordIndex &&
+             "selected pipe operation must execute in an active record");
+      auto transferIt = transferNodeIdByProtocolOpAndRecord.find(
+          std::make_pair(postOp.getOperation(), *activeRecordIndex));
+      assert(transferIt != transferNodeIdByProtocolOpAndRecord.end() &&
+             "selected receiver record must have a transfer node");
+      selectedTransferNodeIds.push_back(transferIt->second);
+      transferNodeIds = selectedTransferNodeIds;
+    }
+    if (transferNodeIds.empty()) {
+      return success();
+    }
+
+    PipeReceiverCoord receiver{coord.x, coord.y};
     for (PipeTransferNodeId transferNodeId : transferNodeIds) {
       const PipeTransferNode &transferNode =
           getPipeTransferNode(transferNodeId);
       const PipeKey &pipeKey = transferNode.pipe;
-      bool hasReceiver = false;
-      LogicalResult result = success();
-      pipeKey.forEachReceiver([&](PipeReceiverCoord receiver) {
-        if (failed(result) || (postDomain.known &&
-                               !knownLaunchNodeDomainContains(
-                                   postDomain, getLaunchNodeCoord(receiver)))) {
-          return;
-        }
-        hasReceiver = true;
-        auto endpointIt = llvm::find_if(
-            transferNode.receiverEndpoints,
-            [&](PipeReceiverEndpointId endpointId) {
-              return getPipeReceiverEndpoint(endpointId).receiver == receiver;
-            });
-        assert(endpointIt != transferNode.receiverEndpoints.end() &&
-               "pipe transfer node is missing a receiver endpoint");
-        const PipeReceiverEndpoint &endpoint =
-            getPipeReceiverEndpoint(*endpointIt);
-        const ReceiverDFBInfo &receiverInfo = endpoint.receiverDFBInfo;
-        PipeReceiverDFBKey receiverDFB{receiver, receiverInfo.dfbIndex};
-        EndpointSlotAssignment &endpointAssignment =
-            assignmentByEndpoint[*endpointIt];
-        if (!scheduleContextByReceiverDFB.lookup(receiverDFB)) {
-          endpointAssignment.valid = false;
-          return;
-        }
-        auto &slotByReserve = slotByReceiverReserve[receiverDFB];
-        auto reserveIt = slotByReserve.find(receiverReserveOp.getOperation());
-        int64_t slot = 0;
-        bool reserveRepeatsPerRecord = reserveRepeatsForPipeRecord(
-            receiverReserveOp, postOp, analysisState);
-        // A reserve inside this callback advances once per matching record. A
-        // reserve outside this callback retains one slot even when an outer
-        // PipeNet callback contains both operations.
-        if (reserveRepeatsPerRecord || reserveIt == slotByReserve.end()) {
-          FailureOr<int64_t> assignedSlot = assignReceiverPhysicalSlot(
-              receiverInfo, producerStateByReceiverDFB[receiverDFB]);
-          if (failed(assignedSlot)) {
-            result = failure();
-            return;
-          }
-          slot = *assignedSlot;
-          if (!reserveRepeatsPerRecord) {
-            slotByReserve[receiverReserveOp.getOperation()] = slot;
-          }
-        } else {
-          slot = reserveIt->second;
-        }
-        if (!postDomain.known) {
-          endpointAssignment.valid = false;
-          return;
-        }
-        std::optional<std::uint64_t> maybeExecutionCount =
-            getConcreteTransferExecutionCount(postOp.getOperation(),
-                                              getLaunchNodeCoord(receiver),
-                                              *pipeRef, analysisState);
-        if (endpointAssignment.initialSlot) {
-          endpointAssignment.valid = false;
-          return;
-        }
-        endpointAssignment.initialSlot = slot;
-        endpointAssignment.executionCount = maybeExecutionCount;
-      });
-      if (failed(result)) {
-        return failure();
+      if (!pipeKey.containsReceiver(receiver)) {
+        continue;
       }
-      if (!hasReceiver) {
-        for (PipeReceiverEndpointId endpointId :
-             transferNode.receiverEndpoints) {
-          assignmentByEndpoint[endpointId].valid = false;
-        }
+      auto endpointIt = llvm::find_if(
+          transferNode.receiverEndpoints,
+          [&](PipeReceiverEndpointId endpointId) {
+            return getPipeReceiverEndpoint(endpointId).receiver == receiver;
+          });
+      assert(endpointIt != transferNode.receiverEndpoints.end() &&
+             "pipe transfer node is missing a receiver endpoint");
+      const PipeReceiverEndpoint &endpoint =
+          getPipeReceiverEndpoint(*endpointIt);
+      const ReceiverDFBInfo &receiverInfo = endpoint.receiverDFBInfo;
+      PipeReceiverDFBKey receiverDFB{receiver, receiverInfo.dfbIndex};
+      EndpointSlotAssignment &endpointAssignment =
+          assignmentByEndpoint[*endpointIt];
+      if (!scheduleContextByReceiverDFB.lookup(receiverDFB)) {
+        endpointAssignment.valid = false;
+        continue;
       }
+      auto &slotByReserve = slotByReceiverReserve[receiverDFB];
+      auto reserveIt = slotByReserve.find(receiverReserveOp.getOperation());
+      int64_t slot = 0;
+      bool reserveRepeatsPerRecord =
+          selectedRecordLoop && selectedRecordLoop->isProperAncestor(
+                                    receiverReserveOp.getOperation());
+      // A reserve inside the selected record loop executes once per matching
+      // record. A reserve outside it retains one slot across those callbacks.
+      if (reserveRepeatsPerRecord || reserveIt == slotByReserve.end()) {
+        FailureOr<int64_t> assignedSlot = assignReceiverPhysicalSlot(
+            receiverInfo, producerStateByReceiverDFB[receiverDFB]);
+        if (failed(assignedSlot)) {
+          return failure();
+        }
+        slot = *assignedSlot;
+        if (!reserveRepeatsPerRecord) {
+          slotByReserve[receiverReserveOp.getOperation()] = slot;
+        }
+      } else {
+        slot = reserveIt->second;
+      }
+      if (!postDomain.known) {
+        endpointAssignment.valid = false;
+        continue;
+      }
+      std::optional<std::uint64_t> maybeExecutionCount =
+          getConcreteTransferExecutionCount(postOp.getOperation(), coord,
+                                            *pipeRef, analysisState);
+      if (endpointAssignment.initialSlot) {
+        endpointAssignment.valid = false;
+        continue;
+      }
+      endpointAssignment.initialSlot = slot;
+      endpointAssignment.executionCount = maybeExecutionCount;
     }
     return success();
   };
 
-  for (PipeTransferPostOp postOp : analysisState.receiverPosts) {
-    if (failed(processPost(postOp))) {
-      return failure();
+  llvm::SmallSetVector<PipeReceiverCoord, 8> receiverCoords;
+  for (const PipeReceiverEndpoint &endpoint : pipeReceiverEndpoints) {
+    receiverCoords.insert(endpoint.receiver);
+  }
+  for (func::FuncOp funcOp : mod.getOps<func::FuncOp>()) {
+    for (PipeReceiverCoord receiver : receiverCoords) {
+      LaunchNodeCoord coord = getLaunchNodeCoord(receiver);
+      WalkResult walkResult = walkPipeNetOpsInProgramOrder(
+          funcOp, coord,
+          [&](Operation *op) -> std::optional<PipeNetRecordLoop> {
+            auto recordLoopIt = analysisState.pipeRecordLoops.find(op);
+            return recordLoopIt == analysisState.pipeRecordLoops.end()
+                       ? std::nullopt
+                       : std::optional<PipeNetRecordLoop>(recordLoopIt->second);
+          },
+          [&](Operation *op, ArrayRef<ActivePipeNetRecord> activeRecords,
+              std::optional<std::uint64_t>) {
+            if (auto postOp = dyn_cast<PipeTransferPostOp>(op)) {
+              return failed(processPost(postOp, coord, activeRecords))
+                         ? WalkResult::interrupt()
+                         : WalkResult::advance();
+            }
+            return WalkResult::advance();
+          });
+      if (walkResult.wasInterrupted()) {
+        return failure();
+      }
     }
   }
 
@@ -1127,19 +1138,41 @@ getConcreteTransferExecutionCount(Operation *op, LaunchNodeCoord coord,
   return *maybeTotalCount / matchingRecordCount;
 }
 
+/// A protocol operation and the selected record it represents.
+template <typename ProtocolOp>
+struct PipeProtocolCandidate {
+  ProtocolOp op;
+  std::optional<std::uint64_t> recordIndex;
+};
+
+void PipeGraph::recordTransferNodeForProtocolRecord(
+    Operation *op, std::optional<std::uint64_t> recordIndex,
+    PipeTransferNodeId transferNodeId) {
+  if (!recordIndex) {
+    return;
+  }
+  auto [recordIt, inserted] = transferNodeIdByProtocolOpAndRecord.try_emplace(
+      std::make_pair(op, *recordIndex), transferNodeId);
+  assert((inserted || recordIt->second == transferNodeId) &&
+         "selected protocol record maps to different transfers");
+}
+
 LogicalResult
 PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
                                 PipeGraphAnalysisState &analysisState) {
   pipeTransferNodes.clear();
   transferNodeIdsByProtocolOp.clear();
+  transferNodeIdByProtocolOpAndRecord.clear();
   pipeReceiverEndpoints.clear();
   receiverDFBNodes.clear();
 
   // Sends and receiver posts that declare the same logical pipe relation.
   // Correspondence analysis matches them into individual transfers.
+  using PipeSendCandidate = PipeProtocolCandidate<PipeTransferSendOp>;
+  using PipePostCandidate = PipeProtocolCandidate<PipeTransferPostOp>;
   struct PipeTransferCandidates {
-    SmallVector<PipeTransferSendOp> sends;
-    llvm::DenseMap<PipeReceiverCoord, SmallVector<PipeTransferPostOp>>
+    SmallVector<PipeSendCandidate> sends;
+    llvm::DenseMap<PipeReceiverCoord, SmallVector<PipePostCandidate>>
         postsByReceiver;
   };
 
@@ -1160,8 +1193,9 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
                          "this send");
         return failure();
       }
-      for (PipeType pipeType :
-           getPipeTypesFromReference(sendOp.getContext(), *pipeRef)) {
+      SmallVector<PipeType> pipeTypes =
+          getPipeTypesFromReference(sendOp.getContext(), *pipeRef);
+      for (auto [recordIndex, pipeType] : llvm::enumerate(pipeTypes)) {
         PipeKey pipeKey = getPipeKey(pipeType);
         LaunchNodeCoord source{pipeKey.srcX, pipeKey.srcY};
         if (sendDomain.known &&
@@ -1174,7 +1208,10 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
         if (maybeExecutionCount && *maybeExecutionCount == 0) {
           continue;
         }
-        candidatesByPipe[pipeKey].sends.push_back(sendOp);
+        candidatesByPipe[pipeKey].sends.push_back(
+            {sendOp, pipeRef->isSelected()
+                         ? std::optional<std::uint64_t>(recordIndex)
+                         : std::nullopt});
       }
       continue;
     }
@@ -1197,8 +1234,12 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
           "cannot determine which pipe receivers execute this post");
       return failure();
     }
-    for (PipeType pipeType :
-         getPipeTypesFromReference(postOp.getContext(), *pipeRef)) {
+    SmallVector<PipeType> pipeTypes =
+        getPipeTypesFromReference(postOp.getContext(), *pipeRef);
+    for (auto [recordIndex, pipeType] : llvm::enumerate(pipeTypes)) {
+      std::optional<std::uint64_t> selectedRecordIndex =
+          pipeRef->isSelected() ? std::optional<std::uint64_t>(recordIndex)
+                                : std::nullopt;
       PipeKey pipeKey = getPipeKey(pipeType);
       PipeTransferCandidates &candidates = candidatesByPipe[pipeKey];
       pipeKey.forEachReceiver([&](PipeReceiverCoord receiver) {
@@ -1211,7 +1252,8 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
             getConcreteTransferExecutionCount(
                 postOp.getOperation(), receiverCoord, *pipeRef, analysisState);
         if (!maybeExecutionCount || *maybeExecutionCount != 0) {
-          candidates.postsByReceiver[receiver].push_back(postOp);
+          candidates.postsByReceiver[receiver].push_back(
+              {postOp, selectedRecordIndex});
         }
       });
       if (candidates.postsByReceiver.empty() && candidates.sends.empty()) {
@@ -1225,12 +1267,13 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
     PipeKey pipeKey = candidateEntry.first;
     PipeTransferCandidates &candidates = candidateEntry.second;
     if (candidates.sends.empty()) {
-      Operation *postOp = candidates.postsByReceiver.begin()->second.front();
+      Operation *postOp =
+          candidates.postsByReceiver.begin()->second.front().op.getOperation();
       postOp->emitError("pipe receiver post has no corresponding send");
       return failure();
     }
 
-    SmallVector<SmallVector<std::pair<PipeReceiverCoord, PipeTransferPostOp>>>
+    SmallVector<SmallVector<std::pair<PipeReceiverCoord, PipePostCandidate>>>
         endpointsBySend(candidates.sends.size());
     llvm::DenseMap<Operation *, std::size_t> sendIndexByPost;
     LogicalResult correspondenceResult = success();
@@ -1243,9 +1286,9 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
                                   ? 0
                                   : postsIt->second.size();
       if (postCount != candidates.sends.size()) {
-        Operation *diagnosticOp = postCount == 0
-                                      ? candidates.sends.front().getOperation()
-                                      : postsIt->second.front().getOperation();
+        Operation *diagnosticOp =
+            postCount == 0 ? candidates.sends.front().op.getOperation()
+                           : postsIt->second.front().op.getOperation();
         diagnosticOp->emitError()
             << "cannot prove one receiver post per pipe transfer for receiver "
             << "(" << receiver.x << ", " << receiver.y << "); found "
@@ -1257,8 +1300,8 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
 
       for (std::size_t sendIndex = 0; sendIndex < candidates.sends.size();
            ++sendIndex) {
-        PipeTransferSendOp sendOp = candidates.sends[sendIndex];
-        PipeTransferPostOp postOp = postsIt->second[sendIndex];
+        PipeTransferSendOp sendOp = candidates.sends[sendIndex].op;
+        PipeTransferPostOp postOp = postsIt->second[sendIndex].op;
         PipeTransferCreateOp sendCreate =
             transferIndex.getTransferCreate(sendOp.getOperation());
         PipeTransferCreateOp postCreate =
@@ -1322,20 +1365,22 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
           correspondenceResult = failure();
           return;
         }
-        endpointsBySend[sendIndex].push_back({receiver, postOp});
+        endpointsBySend[sendIndex].push_back(
+            {receiver, postsIt->second[sendIndex]});
       }
     });
     if (failed(correspondenceResult)) {
       return failure();
     }
 
-    for (auto [sendIndex, sendOp] : llvm::enumerate(candidates.sends)) {
+    for (auto [sendIndex, sendCandidate] : llvm::enumerate(candidates.sends)) {
+      PipeTransferSendOp sendOp = sendCandidate.op;
       PipeTransferCreateOp sendCreate =
           transferIndex.getTransferCreate(sendOp.getOperation());
       PipeTransferContract transferContract =
           getPipeTransferContract(sendCreate);
       for (const auto &endpoint : endpointsBySend[sendIndex]) {
-        PipeTransferPostOp postOp = endpoint.second;
+        PipeTransferPostOp postOp = endpoint.second.op;
         PipeTransferCreateOp postCreate =
             transferIndex.getTransferCreate(postOp.getOperation());
         if (getPipeTransferContract(postCreate) != transferContract) {
@@ -1355,9 +1400,12 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
       PipeTransferNode &transferNode = pipeTransferNodes.back();
       transferNodeIdsByProtocolOp[sendOp.getOperation()].push_back(
           transferNodeId);
+      recordTransferNodeForProtocolRecord(
+          sendOp.getOperation(), sendCandidate.recordIndex, transferNodeId);
       llvm::SmallSetVector<Operation *, 4> uniquePostOps;
 
-      for (auto [receiver, postOp] : endpointsBySend[sendIndex]) {
+      for (auto [receiver, postCandidate] : endpointsBySend[sendIndex]) {
+        PipeTransferPostOp postOp = postCandidate.op;
         auto infoIt = receiverDFBByPost.find(postOp.getOperation());
         assert(infoIt != receiverDFBByPost.end() &&
                "receiver post must have DFB geometry");
@@ -1368,6 +1416,8 @@ PipeGraph::rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
         if (!llvm::is_contained(postTransferNodeIds, transferNodeId)) {
           postTransferNodeIds.push_back(transferNodeId);
         }
+        recordTransferNodeForProtocolRecord(
+            postOp.getOperation(), postCandidate.recordIndex, transferNodeId);
         PipeReceiverDFBKey receiverDFB{receiver, receiverInfo.dfbIndex};
         auto nodeIt = nodeIdByReceiverDFB.find(receiverDFB);
         PipeReceiverDFBNodeId receiverDFBNodeId = 0;
@@ -1640,6 +1690,7 @@ FailureOr<PipeGraph> PipeGraph::build(
       foreachLoweringInfo.controlOps.begin(),
       foreachLoweringInfo.controlOps.end());
   analysisState.pipeRecordIfThenDomains = foreachLoweringInfo.ifThenDomains;
+  analysisState.pipeRecordLoops = foreachLoweringInfo.recordLoops;
 
   for (PipeTransferPostOp postOp : analysisState.receiverPosts) {
     PipeTransferCreateOp createOp =
@@ -1655,8 +1706,8 @@ FailureOr<PipeGraph> PipeGraph::build(
   if (failed(graph.rebuildEndpointGraph(transferIndex, analysisState))) {
     return failure();
   }
-  if (failed(
-          graph.assignReceiverAddressSequences(transferIndex, analysisState))) {
+  if (failed(graph.assignReceiverAddressSequences(mod, transferIndex,
+                                                  analysisState))) {
     return failure();
   }
   if (failed(graph.provePipeOnlyReceiverProducerStreams(analysisState))) {

--- a/lib/Dialect/TTL/Transforms/PipeGraph.h
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.h
@@ -85,6 +85,11 @@ struct PipeKey {
     return dstStartX == dstEndX && dstStartY == dstEndY;
   }
 
+  bool containsReceiver(PipeReceiverCoord receiver) const {
+    return receiver.x >= dstStartX && receiver.x <= dstEndX &&
+           receiver.y >= dstStartY && receiver.y <= dstEndY;
+  }
+
   template <typename Fn>
   void forEachReceiver(Fn &&callback) const {
     for (int64_t receiverY = dstStartY; receiverY <= dstEndY; ++receiverY) {
@@ -256,6 +261,83 @@ inline PipeTransferContract getPipeTransferContract(PipeTransferCreateOp op) {
              : PipeTransferContract::PointToPoint;
 }
 
+inline PipeTransferContract getPipeTransferContract(PipeRecordAttr record) {
+  return record.getIsCollective() ? PipeTransferContract::Collective
+                                  : PipeTransferContract::PointToPoint;
+}
+
+inline PipeKey getPipeKey(PipeRecordAttr record, int64_t pipeNetId) {
+  return {record.getSrcX(),
+          record.getSrcY(),
+          record.getDstStartX(),
+          record.getDstStartY(),
+          record.getDstEndX(),
+          record.getDstEndY(),
+          pipeNetId};
+}
+
+inline PipeType getPipeTypeFromRecord(MLIRContext *context,
+                                      PipeRecordAttr record,
+                                      int64_t pipeNetId) {
+  return PipeType::get(context, record.getSrcX(), record.getSrcY(),
+                       record.getDstStartX(), record.getDstStartY(),
+                       record.getDstEndX(), record.getDstEndY(), pipeNetId);
+}
+
+struct PipeReference {
+  enum class Kind {
+    Static,
+    SelectedSrc,
+    SelectedDst,
+  };
+
+  Kind kind = Kind::Static;
+  PipeType pipeType;
+  SelectPipeSrcOp selectedSrc;
+  SelectPipeDstOp selectedDst;
+
+  bool isStatic() const { return kind == Kind::Static; }
+  bool isSelected() const { return !isStatic(); }
+  bool isSelectedSrc() const { return kind == Kind::SelectedSrc; }
+  bool isSelectedDst() const { return kind == Kind::SelectedDst; }
+
+  PipeNetRecordsAttr getRecords() const {
+    assert(isSelected() && "static pipe has no records attr");
+    if (selectedSrc) {
+      SelectPipeSrcOp op = selectedSrc;
+      return op.getRecords();
+    }
+    SelectPipeDstOp op = selectedDst;
+    return op.getRecords();
+  }
+
+  int64_t getPipeNetId() const {
+    if (pipeType) {
+      return pipeType.getPipeNetId();
+    }
+    if (selectedSrc) {
+      SelectPipeSrcOp op = selectedSrc;
+      return op.getRecords().getPipeNetId();
+    }
+    SelectPipeDstOp op = selectedDst;
+    return op.getRecords().getPipeNetId();
+  }
+};
+
+/// Return a static or selected pipe reference after tracing only unrealized
+/// conversion casts. Requiring direct select results keeps each selected value
+/// tied to the record table that defines it.
+FailureOr<PipeReference> getPipeReference(Operation *op, Value pipe);
+
+/// Return the pipe referenced by a send, receiver post, or receiver wait.
+FailureOr<PipeReference>
+getPipeReferenceForProtocolOp(Operation *protocolOp,
+                              const PipeTransferIndex &transferIndex);
+
+/// Enumerate the static pipe types represented by a pipe reference.
+SmallVector<PipeType> getPipeTypesFromReference(MLIRContext *context,
+                                                const PipeReference &ref);
+
 /// Graph of transfer definitions, receiver endpoints, physical receiver DFBs,
 /// and proven receiver address sequences.
 /// Built after pipe receive copies have been expanded to pipe transfer ops.
@@ -283,12 +365,16 @@ public:
     return pipeTransferNodes[id];
   }
 
-  const PipeTransferNode *
-  getPipeTransferNodeForProtocolOp(Operation *op) const {
-    auto it = transferNodeIdByProtocolOp.find(op);
-    return it == transferNodeIdByProtocolOp.end()
-               ? nullptr
-               : &pipeTransferNodes[it->second];
+  ArrayRef<PipeTransferNodeId>
+  getPipeTransferNodeIdsForProtocolOp(Operation *op) const {
+    auto it = transferNodeIdsByProtocolOp.find(op);
+    return it == transferNodeIdsByProtocolOp.end()
+               ? ArrayRef<PipeTransferNodeId>{}
+               : ArrayRef<PipeTransferNodeId>{it->second};
+  }
+
+  bool hasPipeTransferNodeForProtocolOp(Operation *op) const {
+    return !getPipeTransferNodeIdsForProtocolOp(op).empty();
   }
 
   ArrayRef<PipeReceiverEndpointId>
@@ -357,7 +443,9 @@ private:
 
   llvm::MapVector<Operation *, ReceiverDFBInfo> receiverDFBByPost;
   SmallVector<PipeTransferNode, 0> pipeTransferNodes;
-  llvm::DenseMap<Operation *, PipeTransferNodeId> transferNodeIdByProtocolOp;
+  // A table-driven protocol operation represents one transfer node per record.
+  llvm::DenseMap<Operation *, SmallVector<PipeTransferNodeId>>
+      transferNodeIdsByProtocolOp;
   SmallVector<PipeReceiverEndpoint> pipeReceiverEndpoints;
   SmallVector<PipeReceiverDFBNode> receiverDFBNodes;
   bool hasAnalyzedLaunchGrid = false;

--- a/lib/Dialect/TTL/Transforms/PipeGraph.h
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.h
@@ -390,9 +390,9 @@ public:
   /// receiver DFB address geometry.
   /// `foreachLoweringInfo` identifies compiler-generated record control so it
   /// is not interpreted as independent user control.
-  static FailureOr<PipeGraph> build(
-      ModuleOp mod, const PipeTransferIndex &transferIndex,
-      const PipeForeachLoweringInfo &foreachLoweringInfo);
+  static FailureOr<PipeGraph>
+  build(ModuleOp mod, const PipeTransferIndex &transferIndex,
+        const PipeForeachLoweringInfo &foreachLoweringInfo);
 
   /// Check if any pipes were found.
   bool hasPipes() const { return !pipeTransferNodes.empty(); }

--- a/lib/Dialect/TTL/Transforms/PipeGraph.h
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.h
@@ -28,12 +28,23 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <variant>
 
 namespace mlir::tt::ttl {
 
 class PipeTransferIndex;
 
 struct PipeGraphAnalysisState;
+
+/// Compiler-generated control flow that implements PipeNet foreach callbacks.
+///
+/// `controlOps` identifies loops and conditions that select records rather than
+/// independent user control. `ifThenDomains` records the launch nodes that may
+/// enter each generated `scf.if` across all record-loop iterations.
+struct PipeForeachLoweringInfo {
+  SmallVector<Operation *> controlOps;
+  llvm::DenseMap<Operation *, LaunchNodeDomain> ifThenDomains;
+};
 
 //===----------------------------------------------------------------------===//
 // Pipe Graph: Tracks static transfers, receiver endpoints, physical receiver
@@ -284,44 +295,63 @@ inline PipeType getPipeTypeFromRecord(MLIRContext *context,
                        record.getDstEndX(), record.getDstEndY(), pipeNetId);
 }
 
-struct PipeReference {
-  enum class Kind {
-    Static,
-    SelectedSrc,
-    SelectedDst,
-  };
+/// A pipe operand represented either by a static type or by one selected
+/// source or destination record.
+class PipeReference {
+public:
+  PipeReference() = delete;
+  explicit PipeReference(PipeType pipeType) : value(pipeType) {
+    assert(pipeType && "static pipe reference requires a pipe type");
+  }
+  explicit PipeReference(SelectPipeSrcOp selectedSrc) : value(selectedSrc) {
+    assert(selectedSrc && "selected source reference requires an operation");
+  }
+  explicit PipeReference(SelectPipeDstOp selectedDst) : value(selectedDst) {
+    assert(selectedDst &&
+           "selected destination reference requires an operation");
+  }
 
-  Kind kind = Kind::Static;
-  PipeType pipeType;
-  SelectPipeSrcOp selectedSrc;
-  SelectPipeDstOp selectedDst;
-
-  bool isStatic() const { return kind == Kind::Static; }
+  bool isStatic() const { return std::holds_alternative<PipeType>(value); }
   bool isSelected() const { return !isStatic(); }
-  bool isSelectedSrc() const { return kind == Kind::SelectedSrc; }
-  bool isSelectedDst() const { return kind == Kind::SelectedDst; }
+  bool isSelectedSrc() const {
+    return std::holds_alternative<SelectPipeSrcOp>(value);
+  }
+  bool isSelectedDst() const {
+    return std::holds_alternative<SelectPipeDstOp>(value);
+  }
+
+  PipeType getStaticPipeType() const {
+    assert(isStatic() && "selected pipe reference has no static pipe type");
+    return std::get<PipeType>(value);
+  }
+
+  SelectPipeSrcOp getSelectedSrc() const {
+    assert(isSelectedSrc() && "pipe reference is not a selected source");
+    return std::get<SelectPipeSrcOp>(value);
+  }
+
+  SelectPipeDstOp getSelectedDst() const {
+    assert(isSelectedDst() && "pipe reference is not a selected destination");
+    return std::get<SelectPipeDstOp>(value);
+  }
 
   PipeNetRecordsAttr getRecords() const {
     assert(isSelected() && "static pipe has no records attr");
-    if (selectedSrc) {
-      SelectPipeSrcOp op = selectedSrc;
-      return op.getRecords();
+    if (isSelectedSrc()) {
+      return getSelectedSrc().getRecords();
     }
-    SelectPipeDstOp op = selectedDst;
-    return op.getRecords();
+    return getSelectedDst().getRecords();
   }
 
   int64_t getPipeNetId() const {
-    if (pipeType) {
-      return pipeType.getPipeNetId();
+    if (isStatic()) {
+      return getStaticPipeType().getPipeNetId();
     }
-    if (selectedSrc) {
-      SelectPipeSrcOp op = selectedSrc;
-      return op.getRecords().getPipeNetId();
-    }
-    SelectPipeDstOp op = selectedDst;
-    return op.getRecords().getPipeNetId();
+    return getRecords().getPipeNetId();
   }
+
+private:
+  std::variant<PipeType, SelectPipeSrcOp, SelectPipeDstOp> value;
 };
 
 /// Return a static or selected pipe reference after tracing only unrealized
@@ -346,8 +376,11 @@ public:
   /// Analyze a module to find all pipe receivers and build the graph.
   /// Returns failure if validation detects invalid transfer correspondence or
   /// receiver DFB address geometry.
-  static FailureOr<PipeGraph> build(ModuleOp mod,
-                                    const PipeTransferIndex &transferIndex);
+  /// `foreachLoweringInfo` identifies compiler-generated record control so it
+  /// is not interpreted as independent user control.
+  static FailureOr<PipeGraph> build(
+      ModuleOp mod, const PipeTransferIndex &transferIndex,
+      const PipeForeachLoweringInfo &foreachLoweringInfo);
 
   /// Check if any pipes were found.
   bool hasPipes() const { return !pipeTransferNodes.empty(); }

--- a/lib/Dialect/TTL/Transforms/PipeGraph.h
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.h
@@ -14,6 +14,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
+#include "ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
@@ -41,9 +42,12 @@ struct PipeGraphAnalysisState;
 /// `controlOps` identifies loops and conditions that select records rather than
 /// independent user control. `ifThenDomains` records the launch nodes that may
 /// enter each generated `scf.if` across all record-loop iterations.
+/// `recordLoops` identifies table-driven loops whose bodies execute once per
+/// matching PipeNet record.
 struct PipeForeachLoweringInfo {
   SmallVector<Operation *> controlOps;
   llvm::DenseMap<Operation *, LaunchNodeDomain> ifThenDomains;
+  llvm::DenseMap<Operation *, PipeNetRecordLoop> recordLoops;
 };
 
 //===----------------------------------------------------------------------===//
@@ -350,6 +354,14 @@ public:
     return getRecords().getPipeNetId();
   }
 
+  Operation *getSelectedOperation() const {
+    assert(isSelected() && "static pipe reference has no selection operation");
+    if (isSelectedSrc()) {
+      return getSelectedSrc().getOperation();
+    }
+    return getSelectedDst().getOperation();
+  }
+
 private:
   std::variant<PipeType, SelectPipeSrcOp, SelectPipeDstOp> value;
 };
@@ -456,6 +468,12 @@ public:
   getDFBAcquireReleaseIndex(Operation *operation) const;
 
 private:
+  /// Associate a selected protocol operation and record with one transfer.
+  void
+  recordTransferNodeForProtocolRecord(Operation *op,
+                                      std::optional<std::uint64_t> recordIndex,
+                                      PipeTransferNodeId transferNodeId);
+
   /// Record the DFB geometry and destination offset for one receive post.
   LogicalResult addPipeReceiver(Operation *op,
                                 PipeTransferCreateOp transferCreateOp,
@@ -465,7 +483,8 @@ private:
   /// sequential order. Unproven point-to-point sequences use
   /// receiver-published addresses.
   LogicalResult
-  assignReceiverAddressSequences(const PipeTransferIndex &transferIndex,
+  assignReceiverAddressSequences(ModuleOp mod,
+                                 const PipeTransferIndex &transferIndex,
                                  PipeGraphAnalysisState &state);
 
   LogicalResult rebuildEndpointGraph(const PipeTransferIndex &transferIndex,
@@ -479,6 +498,10 @@ private:
   // A table-driven protocol operation represents one transfer node per record.
   llvm::DenseMap<Operation *, SmallVector<PipeTransferNodeId>>
       transferNodeIdsByProtocolOp;
+  // Selected protocol operations execute once for each matching record. This
+  // map preserves that identity when equal PipeKeys occur more than once.
+  llvm::DenseMap<std::pair<Operation *, std::uint64_t>, PipeTransferNodeId>
+      transferNodeIdByProtocolOpAndRecord;
   SmallVector<PipeReceiverEndpoint> pipeReceiverEndpoints;
   SmallVector<PipeReceiverDFBNode> receiverDFBNodes;
   bool hasAnalyzedLaunchGrid = false;

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -50,6 +50,21 @@ static constexpr int64_t kPipeSramScratchAlignmentBytes = 32;
 // Helpers
 //===----------------------------------------------------------------------===//
 
+static CircularBufferType getTTLCBType(Value cb) {
+  if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(cb.getType())) {
+    return ttlCbTy;
+  }
+  if (auto castOp = cb.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp.getInputs().size() == 1) {
+      if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(
+              castOp.getInputs()[0].getType())) {
+        return ttlCbTy;
+      }
+    }
+  }
+  return nullptr;
+}
+
 static Value makeZeroI32(Location loc, ConversionPatternRewriter &rewriter) {
   return arith::ConstantIntOp::create(rewriter, loc, 0, 32);
 }
@@ -81,15 +96,6 @@ namespace mlir::tt::ttl {
 
 static PipeSourceKey getPipeSourceKey(PipeType pipeType) {
   return {pipeType.getSrcX(), pipeType.getSrcY()};
-}
-
-static const PipeResourceInfo &
-lookupPipeResourceInfo(Operation *protocolOp,
-                       const PipeResourcePlan &pipeResourcePlan) {
-  auto it = pipeResourcePlan.resources.find(protocolOp);
-  assert(it != pipeResourcePlan.resources.end() &&
-         "active pipe transfer must have a resource allocation");
-  return it->second;
 }
 
 static int64_t alignTo(int64_t value, int64_t alignment) {
@@ -189,6 +195,107 @@ static Value buildPipeCounterPtr(Location loc, FuncOp func,
   return ttk::CastToL1PtrOp::create(builder, loc, l1PtrTy, address).getResult();
 }
 
+static Value loadIndexTableEntry(Location loc, ArrayRef<int64_t> values,
+                                 Value recordIndex,
+                                 ConversionPatternRewriter &rewriter);
+
+static Value buildSelectedPipeCounterAddress(
+    Operation *op, Location loc, ArrayRef<PipeCounterInfo> counters,
+    Value recordIndex, const PipeResourcePlan &pipeResourcePlan,
+    ConversionPatternRewriter &rewriter) {
+  assert(!counters.empty() && "selected pipe counter table is empty");
+
+  FuncOp func = op->getParentOfType<FuncOp>();
+  assert(func && "selected pipe operation must be inside a function");
+  bool hasLocalCounter = llvm::any_of(counters, [](PipeCounterInfo counter) {
+    return counter.getStorage() == PipeCounterStorage::LocalSemaphore;
+  });
+  bool hasGlobalCounter = llvm::any_of(counters, [](PipeCounterInfo counter) {
+    return counter.getStorage() == PipeCounterStorage::GlobalSemaphore;
+  });
+  if (!hasGlobalCounter) {
+    SmallVector<int64_t> localIndices = llvm::map_to_vector(
+        counters, [](PipeCounterInfo counter) { return counter.getIndex(); });
+    Value semaphoreIndex =
+        loadIndexTableEntry(loc, localIndices, recordIndex, rewriter);
+    return ttk::GetSemaphoreOp::create(rewriter, loc, semaphoreIndex)
+        .getResult();
+  }
+  auto getGlobalArgIndex = [&](PipeCounterInfo counter) {
+    return getPipeRuntimeCommonArgIndex(
+        func, getFirstPipeGlobalSemaphoreArgOffset(pipeResourcePlan) +
+                  counter.getIndex());
+  };
+  if (!hasLocalCounter) {
+    SmallVector<int64_t> globalArgIndices =
+        llvm::map_to_vector(counters, getGlobalArgIndex);
+    Value commonArgIndex =
+        loadIndexTableEntry(loc, globalArgIndices, recordIndex, rewriter);
+    return ttk::GetCommonArgValOp::create(rewriter, loc, rewriter.getI32Type(),
+                                          commonArgIndex)
+        .getResult();
+  }
+
+  PipeCounterInfo validLocalCounter =
+      *llvm::find_if(counters, [](PipeCounterInfo counter) {
+        return counter.getStorage() == PipeCounterStorage::LocalSemaphore;
+      });
+  PipeCounterInfo validGlobalCounter =
+      *llvm::find_if(counters, [](PipeCounterInfo counter) {
+        return counter.getStorage() == PipeCounterStorage::GlobalSemaphore;
+      });
+  SmallVector<int64_t> isGlobal;
+  SmallVector<int64_t> localIndices;
+  SmallVector<int64_t> globalArgIndices;
+  for (PipeCounterInfo counter : counters) {
+    bool usesGlobal =
+        counter.getStorage() == PipeCounterStorage::GlobalSemaphore;
+    isGlobal.push_back(usesGlobal ? 1 : 0);
+    localIndices.push_back(
+        (usesGlobal ? validLocalCounter : counter).getIndex());
+    globalArgIndices.push_back(
+        getGlobalArgIndex(usesGlobal ? counter : validGlobalCounter));
+  }
+
+  // arith.select cannot prevent either address operation from executing. Use
+  // an existing index in the unused storage class so both addresses are valid.
+  Value localIndex =
+      loadIndexTableEntry(loc, localIndices, recordIndex, rewriter);
+  Value localAddress =
+      ttk::GetSemaphoreOp::create(rewriter, loc, localIndex).getResult();
+  Value typedLocalAddress =
+      ttk::CastToL1AddrOp::create(rewriter, loc, localAddress);
+  Value globalArgIndex =
+      loadIndexTableEntry(loc, globalArgIndices, recordIndex, rewriter);
+  Value globalAddress =
+      ttk::GetCommonArgValOp::create(rewriter, loc, rewriter.getI32Type(),
+                                     globalArgIndex)
+          .getResult();
+  Value typedGlobalAddress =
+      ttk::CastToL1AddrOp::create(rewriter, loc, globalAddress);
+  Value storageKind = loadIndexTableEntry(loc, isGlobal, recordIndex, rewriter);
+  Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value usesGlobal = arith::CmpIOp::create(
+      rewriter, loc, arith::CmpIPredicate::ne, storageKind, zero);
+  return arith::SelectOp::create(rewriter, loc, usesGlobal, typedGlobalAddress,
+                                 typedLocalAddress);
+}
+
+static Value buildSelectedReadyCounterAddress(
+    Operation *op, Location loc, ArrayRef<PipeResourceInfo> resources,
+    Value recordIndex, const PipeResourcePlan &pipeResourcePlan,
+    ConversionPatternRewriter &rewriter) {
+  SmallVector<PipeCounterInfo> counters;
+  counters.reserve(resources.size());
+  for (const PipeResourceInfo &resource : resources) {
+    assert(resource.readyCounter &&
+           "selected pipe missing sender-ready counter");
+    counters.push_back(*resource.readyCounter);
+  }
+  return buildSelectedPipeCounterAddress(op, loc, counters, recordIndex,
+                                         pipeResourcePlan, rewriter);
+}
+
 /// Add a static byte offset to an L1 address without changing the address
 /// representation.
 static Value addByteOffset(Location loc, Value baseAddress, int64_t byteOffset,
@@ -201,6 +308,23 @@ static Value addByteOffset(Location loc, Value baseAddress, int64_t byteOffset,
                                 rewriter.getI32IntegerAttr(byteOffset));
   return arith::AddIOp::create(rewriter, loc, baseAddress, offsetValue)
       .getResult();
+}
+
+static Value addByteOffset(Location loc, Value baseAddress, Value byteOffset,
+                           ConversionPatternRewriter &rewriter) {
+  Value byteOffsetI32 = arith::IndexCastOp::create(
+      rewriter, loc, rewriter.getI32Type(), byteOffset);
+  return arith::AddIOp::create(rewriter, loc, baseAddress, byteOffsetI32)
+      .getResult();
+}
+
+static Value loadIndexTableEntry(Location loc, ArrayRef<int64_t> values,
+                                 Value recordIndex,
+                                 ConversionPatternRewriter &rewriter) {
+  assert(!values.empty() && "selected pipe resource table must not be empty");
+  return ttk::ConstantTableLookupOp::create(
+      rewriter, loc, rewriter.getIndexType(), recordIndex,
+      rewriter.getDenseI64ArrayAttr(values));
 }
 
 /// Source-core address-table entry selected for one transfer allocation unit.
@@ -233,6 +357,26 @@ static Value buildAddressTableAddress(Location loc,
   Value scratchBase = buildPipeRuntimeCommonArg(
       loc, rewriter, info.scratchRuntimeCommonArgIndex);
   return addByteOffset(loc, scratchBase, info.byteOffset, rewriter);
+}
+
+static Value buildSelectedAddressTableAddress(
+    Operation *op, Location loc, ArrayRef<PipeResourceInfo> resources,
+    Value recordIndex, ConversionPatternRewriter &rewriter) {
+  SmallVector<int64_t> byteOffsets;
+  byteOffsets.reserve(resources.size());
+  for (const PipeResourceInfo &resource : resources) {
+    assert(resource.addressStorage.mode ==
+               PipeAddressMode::ReceiverPublishedAddressTable &&
+           "selected pipe requires receiver-published addressing");
+    assert(resource.addressStorage.sramAddressTable.has_value() &&
+           "selected pipe missing address-table storage");
+    byteOffsets.push_back(resource.addressStorage.sramAddressTable->byteOffset);
+  }
+  Value byteOffset =
+      loadIndexTableEntry(loc, byteOffsets, recordIndex, rewriter);
+  Value scratchBase = buildPipeRuntimeCommonArg(
+      loc, rewriter, getPipeRuntimeCommonArgIndex(op, 0));
+  return addByteOffset(loc, scratchBase, byteOffset, rewriter);
 }
 
 /// Load the receiver-published destination DFB address from this pipe's
@@ -339,6 +483,62 @@ static void lowerPipeCapacityRelease(Location loc, FuncOp func,
                                  releaseCount, nocVal, /*posted=*/BoolAttr());
 }
 
+static Value
+buildAddressTableDestinationAddress(Location loc, Value tableAddress,
+                                    ConversionPatternRewriter &rewriter) {
+  auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
+  auto tablePtr =
+      ttk::CastToL1PtrOp::create(rewriter, loc, l1PtrTy, tableAddress);
+  auto zeroI32 = arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                           rewriter.getI32IntegerAttr(0));
+  return ttk::LoadFromL1Op::create(rewriter, loc, rewriter.getI32Type(),
+                                   tablePtr, zeroI32)
+      .getResult();
+}
+
+struct SelectedPipeFields {
+  Value recordIndex;
+  Value srcX;
+  Value srcY;
+  Value dstStartX;
+  Value dstStartY;
+  Value dstEndX;
+  Value dstEndY;
+  Value numDests;
+  Value srcInDstRange;
+  bool isCollective;
+};
+
+static SelectedPipeFields getSelectedPipeFields(const PipeReference &pipeRef) {
+  assert(pipeRef.isSelected() && "expected selected pipe reference");
+  if (pipeRef.isSelectedSrc()) {
+    SelectPipeSrcOp op = pipeRef.selectedSrc;
+    return SelectedPipeFields{
+        op.getRecordIndex(),
+        op.getSrcX(),
+        op.getSrcY(),
+        op.getDstStartX(),
+        op.getDstStartY(),
+        op.getDstEndX(),
+        op.getDstEndY(),
+        op.getNumDests(),
+        op.getSrcInDstRange(),
+        op.getRecords().getPipes().front().getIsCollective()};
+  }
+  SelectPipeDstOp op = pipeRef.selectedDst;
+  return SelectedPipeFields{
+      op.getRecordIndex(),
+      op.getSrcX(),
+      op.getSrcY(),
+      op.getDstStartX(),
+      op.getDstStartY(),
+      op.getDstEndX(),
+      op.getDstEndY(),
+      op.getNumDests(),
+      op.getSrcInDstRange(),
+      op.getRecords().getPipes().front().getIsCollective()};
+}
+
 /// Compute the exact DFB address selected by ttl.copy(pipe, dst). Receivers
 /// publish this address so senders do not have to infer receiver DFB state.
 static Value
@@ -363,9 +563,9 @@ buildReceiverPublishedAddress(Value dst, Location loc,
 
   auto tileOffsetI32 = arith::IndexCastOp::create(
       rewriter, loc, rewriter.getI32Type(), globalTileIndex);
-  auto pageSizeBytes =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
-                                rewriter.getI32IntegerAttr(info.tileSizeBytes));
+  auto pageSizeBytes = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32Type(),
+      rewriter.getI32IntegerAttr(info.tileSizeBytes));
   auto byteOffset =
       arith::MulIOp::create(rewriter, loc, tileOffsetI32, pageSizeBytes);
   return arith::AddIOp::create(rewriter, loc, receiverWritePtr, byteOffset)
@@ -394,12 +594,8 @@ public:
   virtual void emitCompletionSignalBarrier() = 0;
 };
 
-class NocPipeTransportEmitter final : public PipeTransportEmitter {
-  struct LogicalCore {
-    Value x;
-    Value y;
-  };
-
+class NocPipeTransportEmitterBase : public PipeTransportEmitter {
+protected:
   struct TranslatedCore {
     Value x;
     Value y;
@@ -413,48 +609,22 @@ class NocPipeTransportEmitter final : public PipeTransportEmitter {
   };
 
 public:
-  NocPipeTransportEmitter(Operation *op, PipeType pipeType,
-                          ConversionPatternRewriter &rewriter)
-      : loc(op->getLoc()), pipeType(pipeType), rewriter(rewriter),
-        nocIdx(getNocIndex(op)),
+  NocPipeTransportEmitterBase(Operation *op,
+                              ConversionPatternRewriter &rewriter)
+      : loc(op->getLoc()), rewriter(rewriter), nocIdx(getNocIndex(op)),
         nocVal(arith::ConstantOp::create(rewriter, loc, rewriter.getI8Type(),
                                          rewriter.getI8IntegerAttr(nocIdx))) {}
 
   LogicalResult emitReceiverAddressPublish(Value senderTableAddress,
                                            Value publishedAddress) override {
     TranslatedCore sourceCore = getSourceCore();
-    if (!pipeType.srcInDstRange()) {
-      emitRemoteReceiverAddressPublish(senderTableAddress, publishedAddress,
-                                       sourceCore);
-      return success();
-    }
-    if (pipeType.hasSingleReceiver()) {
-      emitLocalReceiverAddressPublish(senderTableAddress, publishedAddress);
-      return success();
-    }
-
-    LogicalCore logicalSourceCore = getSourceLogicalCore();
-    Value currentX =
-        ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
-    Value currentY =
-        ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
-    Value xMatches = arith::CmpIOp::create(
-        rewriter, loc, arith::CmpIPredicate::eq, currentX, logicalSourceCore.x);
-    Value yMatches = arith::CmpIOp::create(
-        rewriter, loc, arith::CmpIPredicate::eq, currentY, logicalSourceCore.y);
-    Value receiverIsSource =
-        arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
-    auto localPublish = scf::IfOp::create(rewriter, loc, receiverIsSource,
-                                          /*withElseRegion=*/true);
-    {
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPointToStart(&localPublish.getThenRegion().front());
-      emitLocalReceiverAddressPublish(senderTableAddress, publishedAddress);
-      rewriter.setInsertionPointToStart(&localPublish.getElseRegion().front());
-      emitRemoteReceiverAddressPublish(senderTableAddress, publishedAddress,
-                                       sourceCore);
-    }
-    rewriter.setInsertionPointAfter(localPublish);
+    auto byteEnableAll = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI8Type(), rewriter.getI8IntegerAttr(0xF));
+    // [Device 2.0] The receiver writes its DFB address to the sender's typed
+    // address table. Only this operation selects the inline NoC write.
+    ttk::NocInlineDwWriteOp::create(rewriter, loc, sourceCore.x, sourceCore.y,
+                                    senderTableAddress, publishedAddress,
+                                    byteEnableAll, nocVal);
     return success();
   }
 
@@ -475,6 +645,49 @@ public:
         readyCounterIncrement, nocVal, /*posted=*/BoolAttr());
     return success();
   }
+
+  void emitPayloadWriteBarrier() override {
+    ttk::NocAsyncWriteBarrierOp::create(rewriter, loc, nocVal);
+  }
+
+  void emitCompletionSignalBarrier() override {
+    ttk::NocAsyncAtomicBarrierOp::create(rewriter, loc, nocVal);
+  }
+
+protected:
+  virtual TranslatedCore getSourceCore() = 0;
+
+  TranslatedCore buildTranslatedCore(Value logicalX, Value logicalY) {
+    auto translatedX = ttk::ConvertLogicalXToTranslatedOp::create(
+        rewriter, loc, rewriter.getIndexType(), logicalX);
+    auto translatedY = ttk::ConvertLogicalYToTranslatedOp::create(
+        rewriter, loc, rewriter.getIndexType(), logicalY);
+    return {translatedX, translatedY};
+  }
+
+  TranslatedCore buildTranslatedCore(int64_t logicalX, int64_t logicalY) {
+    auto logicalXValue =
+        arith::ConstantIndexOp::create(rewriter, loc, logicalX);
+    auto logicalYValue =
+        arith::ConstantIndexOp::create(rewriter, loc, logicalY);
+    auto translatedX = ttk::ConvertLogicalXToTranslatedOp::create(
+        rewriter, loc, rewriter.getIndexType(), logicalXValue);
+    auto translatedY = ttk::ConvertLogicalYToTranslatedOp::create(
+        rewriter, loc, rewriter.getIndexType(), logicalYValue);
+    return {translatedX, translatedY};
+  }
+
+  Location loc;
+  ConversionPatternRewriter &rewriter;
+  int64_t nocIdx;
+  Value nocVal;
+};
+
+class NocPipeTransportEmitter final : public NocPipeTransportEmitterBase {
+public:
+  NocPipeTransportEmitter(Operation *op, PipeType pipeType,
+                          ConversionPatternRewriter &rewriter)
+      : NocPipeTransportEmitterBase(op, rewriter), pipeType(pipeType) {}
 
   void preparePayloadWrite() override {
     // Materialize destination coordinates before computing the payload address
@@ -563,50 +776,8 @@ public:
     return success();
   }
 
-  void emitCompletionSignalBarrier() override {
-    ttk::NocAsyncAtomicBarrierOp::create(rewriter, loc, nocVal);
-  }
-
 private:
-  void emitLocalReceiverAddressPublish(Value senderTableAddress,
-                                       Value publishedAddress) {
-    auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
-    Value tablePtr =
-        ttk::CastToL1PtrOp::create(rewriter, loc, l1PtrTy, senderTableAddress);
-    Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
-    ttk::StoreToL1Op::create(rewriter, loc, publishedAddress, tablePtr, zero);
-  }
-
-  void emitRemoteReceiverAddressPublish(Value senderTableAddress,
-                                        Value publishedAddress,
-                                        TranslatedCore sourceCore) {
-    auto byteEnableAll = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getI8Type(), rewriter.getI8IntegerAttr(0xF));
-    // Inline NoC writes do not update the sender's local SRAM when the sender
-    // is also this receiver, so that case uses a direct L1 store.
-    ttk::NocInlineDwWriteOp::create(rewriter, loc, sourceCore.x, sourceCore.y,
-                                    senderTableAddress, publishedAddress,
-                                    byteEnableAll, nocVal);
-  }
-
-  LogicalCore getSourceLogicalCore() {
-    return {arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcX()),
-            arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcY())};
-  }
-
-  TranslatedCore buildTranslatedCore(int64_t logicalX, int64_t logicalY) {
-    auto logicalXValue =
-        arith::ConstantIndexOp::create(rewriter, loc, logicalX);
-    auto logicalYValue =
-        arith::ConstantIndexOp::create(rewriter, loc, logicalY);
-    auto translatedX = ttk::ConvertLogicalXToTranslatedOp::create(
-        rewriter, loc, rewriter.getIndexType(), logicalXValue);
-    auto translatedY = ttk::ConvertLogicalYToTranslatedOp::create(
-        rewriter, loc, rewriter.getIndexType(), logicalYValue);
-    return {translatedX, translatedY};
-  }
-
-  TranslatedCore getSourceCore() {
+  TranslatedCore getSourceCore() override {
     if (!sourceCore) {
       sourceCore = buildTranslatedCore(pipeType.getSrcX(), pipeType.getSrcY());
     }
@@ -630,6 +801,8 @@ private:
     auto [dstStartX, dstStartY] = dstStartTranslatedCore;
     auto [dstEndX, dstEndY] =
         buildTranslatedCore(pipeType.getDstEndX(), pipeType.getDstEndY());
+    // NoC 1 traverses the grid in reverse coordinate order, while multicast
+    // operations require their endpoints in traversal order.
     if (nocIdx == 1) {
       std::swap(dstStartX, dstEndX);
       std::swap(dstStartY, dstEndY);
@@ -638,11 +811,225 @@ private:
     return *destinationRange;
   }
 
-  Location loc;
   PipeType pipeType;
-  ConversionPatternRewriter &rewriter;
-  int64_t nocIdx;
-  Value nocVal;
+  std::optional<TranslatedCore> sourceCore;
+  std::optional<TranslatedCore> dstStartCore;
+  std::optional<DestinationRange> destinationRange;
+};
+
+/// Emit one protocol body for every record in a PipeNet table. Record fields
+/// select the required unicast, multicast, and loopback hardware operations;
+/// the conditions are transport semantics, not special cases for record
+/// indices.
+class SelectedNocPipeTransportEmitter final
+    : public NocPipeTransportEmitterBase {
+public:
+  SelectedNocPipeTransportEmitter(Operation *op, SelectedPipeFields fields,
+                                  ConversionPatternRewriter &rewriter)
+      : NocPipeTransportEmitterBase(op, rewriter), fields(fields) {}
+
+  void preparePayloadWrite() override {
+    // Coordinate translations must dominate the conditional regions emitted
+    // below, so cache the applicable coordinates before creating those regions.
+    if (fields.isCollective) {
+      getDestinationRange();
+      return;
+    }
+    getDstStartCore();
+  }
+
+  LogicalResult emitPayloadWrite(Value srcAddr, Value dstAddr,
+                                 Value totalSizeBytes) override {
+    if (!fields.isCollective) {
+      emitUnicastPayloadWrite(srcAddr, dstAddr, totalSizeBytes);
+      return success();
+    }
+
+    DestinationRange destinationRange = getDestinationRange();
+    Value numDests = getNumDests();
+    // A one-receiver collective uses unicast hardware operations. This also
+    // avoids a zero-recipient multicast completion for local loopback.
+    auto singleReceiverIf = scf::IfOp::create(
+        rewriter, loc, getHasSingleReceiver(), /*withElseRegion=*/true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(
+          &singleReceiverIf.getThenRegion().front());
+      emitUnicastPayloadWrite(srcAddr, dstAddr, totalSizeBytes);
+      rewriter.setInsertionPointToStart(
+          &singleReceiverIf.getElseRegion().front());
+      emitMulticastPayloadWrite(srcAddr, dstAddr, totalSizeBytes, numDests,
+                                destinationRange);
+    }
+    rewriter.setInsertionPointAfter(singleReceiverIf);
+    return success();
+  }
+
+  LogicalResult emitReceiverCompletionIncrement(
+      Value receiverCompletionCounterAddr) override {
+    auto completionIncrement = arith::ConstantIndexOp::create(rewriter, loc, 1);
+
+    if (!fields.isCollective) {
+      emitUnicastCompletionIncrement(receiverCompletionCounterAddr,
+                                     completionIncrement);
+      return success();
+    }
+
+    DestinationRange destinationRange = getDestinationRange();
+    Value numDests = getNumDests();
+    auto singleReceiverIf = scf::IfOp::create(
+        rewriter, loc, getHasSingleReceiver(), /*withElseRegion=*/true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(
+          &singleReceiverIf.getThenRegion().front());
+      emitUnicastCompletionIncrement(receiverCompletionCounterAddr,
+                                     completionIncrement);
+      rewriter.setInsertionPointToStart(
+          &singleReceiverIf.getElseRegion().front());
+      emitMulticastCompletionIncrement(receiverCompletionCounterAddr,
+                                       completionIncrement, numDests,
+                                       destinationRange);
+    }
+    rewriter.setInsertionPointAfter(singleReceiverIf);
+    return success();
+  }
+
+private:
+  void emitUnicastPayloadWrite(Value srcAddr, Value dstAddr,
+                               Value totalSizeBytes) {
+    TranslatedCore dstStartCore = getDstStartCore();
+    ttk::NocAsyncWriteOp::create(rewriter, loc, srcAddr,
+                                 ValueRange{dstStartCore.x, dstStartCore.y},
+                                 ValueRange{}, dstAddr, totalSizeBytes, nocVal);
+  }
+
+  void emitMulticastPayloadWrite(Value srcAddr, Value dstAddr,
+                                 Value totalSizeBytes, Value numDests,
+                                 DestinationRange destinationRange) {
+    // Standard multicast does not write the sender's local memory, so a
+    // receiver range containing the sender requires the loopback operation.
+    auto loopbackIf = scf::IfOp::create(rewriter, loc, fields.srcInDstRange,
+                                        /*withElseRegion=*/true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&loopbackIf.getThenRegion().front());
+      ttk::NocAsyncWriteMulticastLoopbackSrcOp::create(
+          rewriter, loc, srcAddr, totalSizeBytes, numDests,
+          destinationRange.startX, destinationRange.startY,
+          destinationRange.endX, destinationRange.endY, dstAddr, nocVal,
+          /*linked=*/nullptr);
+      rewriter.setInsertionPointToStart(&loopbackIf.getElseRegion().front());
+      ttk::NocAsyncWriteMulticastOp::create(
+          rewriter, loc, srcAddr, totalSizeBytes, numDests,
+          destinationRange.startX, destinationRange.startY,
+          destinationRange.endX, destinationRange.endY, dstAddr, nocVal,
+          /*linked=*/nullptr);
+    }
+    rewriter.setInsertionPointAfter(loopbackIf);
+  }
+
+  void emitUnicastCompletionIncrement(Value receiverCompletionCounterAddr,
+                                      Value completionIncrement) {
+    TranslatedCore dstStartCore = getDstStartCore();
+    auto receiverCompletionNocAddr =
+        ttk::GetNocAddrOp::create(rewriter, loc, dstStartCore.x, dstStartCore.y,
+                                  receiverCompletionCounterAddr, nocVal);
+    ttk::NocSemaphoreIncOp::create(
+        rewriter, loc, receiverCompletionNocAddr.getResult(),
+        completionIncrement, nocVal, /*posted=*/BoolAttr());
+  }
+
+  void emitMulticastCompletionIncrement(Value receiverCompletionCounterAddr,
+                                        Value completionIncrement,
+                                        Value numDests,
+                                        DestinationRange destinationRange) {
+    // The multicast atomic updates only remote receivers. If the sender is also
+    // a receiver, exclude it from that count and update it with a local atomic.
+    auto one = arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                         rewriter.getI32IntegerAttr(1));
+    Value numRemoteWithLoopback =
+        arith::SubIOp::create(rewriter, loc, numDests, one);
+    Value numRemoteDests = arith::SelectOp::create(
+        rewriter, loc, fields.srcInDstRange, numRemoteWithLoopback, numDests);
+    auto remoteReceiverCompletionMcastNocAddr =
+        ttk::GetNocMulticastAddrOp::create(
+            rewriter, loc, destinationRange.startX, destinationRange.startY,
+            destinationRange.endX, destinationRange.endY,
+            receiverCompletionCounterAddr, nocVal);
+    ttk::NocSemaphoreIncMulticastOp::create(
+        rewriter, loc, remoteReceiverCompletionMcastNocAddr.getResult(),
+        completionIncrement, numRemoteDests, nocVal, /*posted=*/BoolAttr());
+
+    auto localIncrementIf = scf::IfOp::create(
+        rewriter, loc, fields.srcInDstRange, /*withElseRegion=*/false);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(
+          &localIncrementIf.getThenRegion().front());
+      TranslatedCore sourceCore = getSourceCore();
+      auto localReceiverCompletionNocAddr =
+          ttk::GetNocAddrOp::create(rewriter, loc, sourceCore.x, sourceCore.y,
+                                    receiverCompletionCounterAddr, nocVal);
+      ttk::NocSemaphoreIncOp::create(
+          rewriter, loc, localReceiverCompletionNocAddr.getResult(),
+          completionIncrement, nocVal, /*posted=*/BoolAttr());
+    }
+    rewriter.setInsertionPointAfter(localIncrementIf);
+  }
+
+  Value getHasSingleReceiver() {
+    if (!hasSingleReceiver) {
+      Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
+      hasSingleReceiver = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::eq, fields.numDests, one);
+    }
+    return hasSingleReceiver;
+  }
+
+  TranslatedCore getSourceCore() override {
+    if (!sourceCore) {
+      sourceCore = buildTranslatedCore(fields.srcX, fields.srcY);
+    }
+    return *sourceCore;
+  }
+
+  TranslatedCore getDstStartCore() {
+    if (!dstStartCore) {
+      dstStartCore = buildTranslatedCore(fields.dstStartX, fields.dstStartY);
+    }
+    return *dstStartCore;
+  }
+
+  DestinationRange getDestinationRange() {
+    if (destinationRange) {
+      return *destinationRange;
+    }
+    TranslatedCore dstStartTranslatedCore = getDstStartCore();
+    auto [dstStartX, dstStartY] = dstStartTranslatedCore;
+    auto [dstEndX, dstEndY] =
+        buildTranslatedCore(fields.dstEndX, fields.dstEndY);
+    // NoC 1 traverses the grid in reverse coordinate order, while multicast
+    // operations require their endpoints in traversal order.
+    if (nocIdx == 1) {
+      std::swap(dstStartX, dstEndX);
+      std::swap(dstStartY, dstEndY);
+    }
+    destinationRange = DestinationRange{dstStartX, dstStartY, dstEndX, dstEndY};
+    return *destinationRange;
+  }
+
+  Value getNumDests() {
+    if (!numDests) {
+      numDests = arith::IndexCastOp::create(
+          rewriter, loc, rewriter.getI32Type(), fields.numDests);
+    }
+    return numDests;
+  }
+
+  SelectedPipeFields fields;
+  Value hasSingleReceiver;
+  Value numDests;
   std::optional<TranslatedCore> sourceCore;
   std::optional<TranslatedCore> dstStartCore;
   std::optional<DestinationRange> destinationRange;
@@ -656,8 +1043,9 @@ private:
 
 void initializePipePostSequenceCounters(
     const PipeResourcePlan &pipeResourcePlan,
-    PipeCounterProgressMap &postSequenceCounters) {
-  llvm::MapVector<FuncOp, SmallVector<PipeCounterInfo>> countersByFunc;
+    PipeCounterProgressMap &postSequenceCounters,
+    PipeSelectedPostSequenceMap &selectedPostSequenceCounters) {
+  llvm::MapVector<FuncOp, SmallVector<PipeCounterInfo>> staticCountersByFunc;
   for (const auto &[protocolOp, resource] : pipeResourcePlan.resources) {
     auto postOp = dyn_cast<PipeTransferPostOp>(protocolOp);
     if (!postOp) {
@@ -665,34 +1053,75 @@ void initializePipePostSequenceCounters(
     }
     FuncOp func = postOp->getParentOfType<FuncOp>();
     assert(func && "pipe transfer post must be inside a function");
-    SmallVector<PipeCounterInfo> &counters = countersByFunc[func];
+    SmallVector<PipeCounterInfo> &counters = staticCountersByFunc[func];
     if (!llvm::is_contained(counters, resource.completion.counter)) {
       counters.push_back(resource.completion.counter);
     }
   }
 
-  for (auto &[func, counters] : countersByFunc) {
+  llvm::MapVector<FuncOp, SmallVector<PipeCounterInfo>> selectedCountersByFunc;
+  for (const auto &[protocolOp, resources] :
+       pipeResourcePlan.selectedResources) {
+    auto postOp = dyn_cast<PipeTransferPostOp>(protocolOp);
+    if (!postOp) {
+      continue;
+    }
+    FuncOp func = postOp->getParentOfType<FuncOp>();
+    assert(func && "pipe transfer post must be inside a function");
+    SmallVector<PipeCounterInfo> &counters = selectedCountersByFunc[func];
+    for (const PipeResourceInfo &resource : resources) {
+      if (!llvm::is_contained(counters, resource.completion.counter)) {
+        counters.push_back(resource.completion.counter);
+      }
+    }
+  }
+
+  auto sortCounters = [](SmallVectorImpl<PipeCounterInfo> &counters) {
+    llvm::sort(counters, [](PipeCounterInfo lhs, PipeCounterInfo rhs) {
+      return std::make_pair(lhs.getStorage(), lhs.getIndex()) <
+             std::make_pair(rhs.getStorage(), rhs.getIndex());
+    });
+  };
+
+  for (auto &[func, counters] : staticCountersByFunc) {
     // These entry-block values dominate posts nested in receiver control flow.
     OpBuilder builder(func.getContext());
     builder.setInsertionPointToStart(&func.getBody().front());
     Location loc = func.getLoc();
     auto memrefTy = MemRefType::get({1}, builder.getI32Type());
-    auto i32Ty = builder.getI32Type();
-    Value zeroIdx = arith::ConstantIndexOp::create(builder, loc, 0);
-    Value zeroI32 = arith::ConstantOp::create(builder, loc, i32Ty,
-                                              builder.getI32IntegerAttr(0));
+    Value zeroIndex = arith::ConstantIndexOp::create(builder, loc, 0);
+    Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
     auto &countersForFunc = postSequenceCounters[func];
-    llvm::sort(counters, [](PipeCounterInfo lhs, PipeCounterInfo rhs) {
-      return std::make_pair(lhs.getStorage(), lhs.getIndex()) <
-             std::make_pair(rhs.getStorage(), rhs.getIndex());
-    });
+    sortCounters(counters);
     for (PipeCounterInfo counterInfo : counters) {
-      auto counter = memref::AllocaOp::create(builder, loc, memrefTy);
-      memref::StoreOp::create(builder, loc, zeroI32, counter,
-                              ValueRange{zeroIdx});
+      Value sequenceCounter = memref::AllocaOp::create(builder, loc, memrefTy);
+      memref::StoreOp::create(builder, loc, zero, sequenceCounter,
+                              ValueRange{zeroIndex});
       countersForFunc.push_back(
-          PipeCounterProgress{counterInfo, counter.getResult()});
+          PipeCounterProgress{counterInfo, sequenceCounter});
     }
+  }
+
+  for (auto &[func, counters] : selectedCountersByFunc) {
+    // One function-local table lets every selected post preserve progress for
+    // shared completion counters without expanding one branch per record.
+    OpBuilder builder(func.getContext());
+    builder.setInsertionPointToStart(&func.getBody().front());
+    Location loc = func.getLoc();
+    sortCounters(counters);
+    auto memrefType = MemRefType::get({static_cast<int64_t>(counters.size())},
+                                      builder.getI32Type());
+    Value completionSequences =
+        memref::AllocaOp::create(builder, loc, memrefType);
+    Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+    for (std::size_t counterIndex = 0; counterIndex < counters.size();
+         ++counterIndex) {
+      Value index = arith::ConstantIndexOp::create(builder, loc, counterIndex);
+      memref::StoreOp::create(builder, loc, zero, completionSequences,
+                              ValueRange{index});
+    }
+    selectedPostSequenceCounters[func] = PipeSelectedPostSequenceCounters{
+        completionSequences, std::move(counters)};
   }
 }
 
@@ -772,7 +1201,7 @@ void initializePipeComputedAddressCounters(
   }
 }
 
-static FailureOr<Value>
+static FailureOr<PipeCounterProgress>
 lookupPipeCounterProgress(const PipeCounterProgressMap &progress, FuncOp func,
                           PipeCounterInfo counter) {
   auto funcIt = progress.find(func);
@@ -786,27 +1215,125 @@ lookupPipeCounterProgress(const PipeCounterProgressMap &progress, FuncOp func,
   if (progressIt == funcIt->second.end()) {
     return failure();
   }
-  return progressIt->value;
+  return *progressIt;
 }
 
+/// Assign a completion sequence when posting the receive. Tokens may be stored
+/// or reordered, so each token must retain the sequence of its own post.
+static Value incrementPipePostSequence(Location loc, Value sequenceCounter,
+                                       Value sequenceIndex,
+                                       ConversionPatternRewriter &rewriter) {
+  Value previousSequence = memref::LoadOp::create(
+      rewriter, loc, sequenceCounter, ValueRange{sequenceIndex});
+  Value one = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
+  Value tokenSequence =
+      arith::AddIOp::create(rewriter, loc, previousSequence, one);
+  memref::StoreOp::create(rewriter, loc, tokenSequence, sequenceCounter,
+                          ValueRange{sequenceIndex});
+  return tokenSequence;
+}
+
+static LogicalResult
+lowerSelectedPipeTransferSend(PipeTransferSendOp op, Value srcCB,
+                              const PipeTransferPlan &transferPlan,
+                              const PipeResourcePlan &pipeResourcePlan,
+                              ConversionPatternRewriter &rewriter) {
+  auto loc = op.getLoc();
+  const PipeReference &pipeRef = transferPlan.getPipeReference();
+  SelectedPipeFields fields = getSelectedPipeFields(pipeRef);
+  ArrayRef<PipeResourceInfo> resources =
+      transferPlan.getSelectedResources();
+  const PipeSendPlan &sendPlan = transferPlan.getSend();
+
+  auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
+  SelectedNocPipeTransportEmitter nocTransport(op, fields, rewriter);
+  PipeTransportEmitter &transport = nocTransport;
+
+  Value senderSemAddr = buildSelectedReadyCounterAddress(
+      op, loc, resources, fields.recordIndex, pipeResourcePlan, rewriter);
+  auto senderSemPtr =
+      ttk::CastToL1PtrOp::create(rewriter, loc, l1PtrTy, senderSemAddr);
+  Value expectedSignals;
+  if (fields.isCollective) {
+    expectedSignals = arith::IndexCastOp::create(
+        rewriter, loc, rewriter.getI32Type(), fields.numDests);
+  } else {
+    expectedSignals = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
+  }
+  ttk::SemaphoreWaitOp::create(rewriter, loc, senderSemPtr, expectedSignals);
+  auto zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  ttk::NocSemaphoreSetOp::create(rewriter, loc, senderSemPtr, zeroIdx);
+
+  auto cbConverted = utils::convertTTLCBToTTKernel(srcCB, rewriter, loc);
+  assert(succeeded(cbConverted) && "preflight checked source DFB type");
+  Value srcPtrIdx;
+  if (sendPlan.usesReadPointer) {
+    auto cbReadPtr = ttk::GetReadPtrOp::create(rewriter, loc, *cbConverted);
+    srcPtrIdx = arith::IndexCastOp::create(rewriter, loc,
+                                           rewriter.getIndexType(), cbReadPtr);
+  } else {
+    auto srcWritePtr = ttk::GetWritePtrOp::create(rewriter, loc, *cbConverted);
+    srcPtrIdx = arith::IndexCastOp::create(
+        rewriter, loc, rewriter.getIndexType(), srcWritePtr);
+  }
+
+  Value srcAddr = arith::IndexCastOp::create(rewriter, loc,
+                                             rewriter.getI32Type(), srcPtrIdx);
+  auto totalSizeVal = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32Type(),
+      rewriter.getI32IntegerAttr(sendPlan.payloadSizeBytes));
+  transport.preparePayloadWrite();
+
+  Value tableAddress = buildSelectedAddressTableAddress(
+      op, loc, resources, fields.recordIndex, rewriter);
+  Value dstAddr =
+      buildAddressTableDestinationAddress(loc, tableAddress, rewriter);
+  if (failed(transport.emitPayloadWrite(srcAddr, dstAddr, totalSizeVal))) {
+    return failure();
+  }
+  transport.emitPayloadWriteBarrier();
+
+  SmallVector<PipeCounterInfo> completionCounters =
+      llvm::map_to_vector(resources, [](const PipeResourceInfo &resource) {
+        return resource.completion.counter;
+      });
+  Value completionCounterAddress = buildSelectedPipeCounterAddress(
+      op, loc, completionCounters, fields.recordIndex, pipeResourcePlan,
+      rewriter);
+  if (failed(transport.emitReceiverCompletionIncrement(
+          completionCounterAddress))) {
+    return failure();
+  }
+  transport.emitCompletionSignalBarrier();
+
+  rewriter.replaceOp(op, makeZeroI32(loc, rewriter));
+  return success();
+}
+
+/// Lower CB -> Pipe copy: write source DFB data to the selected destination
+/// address, then signal arrival.
 void lowerInactivePipeTransferSend(PipeTransferSendOp op,
                                    ConversionPatternRewriter &rewriter) {
   rewriter.replaceOp(op, makeZeroI32(op.getLoc(), rewriter));
 }
 
-/// Write source DFB data to the selected destination and signal completion.
 LogicalResult lowerPipeTransferSend(
     PipeTransferSendOp op, Value srcCB, const PipeTransferPlan &transferPlan,
     const PipeResourcePlan &pipeResourcePlan,
     const PipeCapacityPlan &pipeCapacityPlan,
     const PipeCounterProgressMap &senderCapacityCounters,
     const PipeComputedAddressCounterMap &computedAddressCounters,
-    ConversionPatternRewriter &rewriter) {
+  ConversionPatternRewriter &rewriter) {
   auto loc = op.getLoc();
   assert(!pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation()) &&
-         "inactive send must not use an active transfer plan");
-  assert(transferPlan.isSend() && "send operation has a receiver-post plan");
-  PipeType pipeType = transferPlan.getPipeType();
+         "inactive sender must not use an active transfer plan");
+  assert(transferPlan.isSend() && "sender operation has a non-send plan");
+  const PipeReference &pipeRef = transferPlan.getPipeReference();
+  if (pipeRef.isSelected()) {
+    return lowerSelectedPipeTransferSend(op, srcCB, transferPlan,
+                                         pipeResourcePlan, rewriter);
+  }
+  PipeType pipeType = pipeRef.pipeType;
   const PipeResourceInfo &pipeResource = transferPlan.getResources();
   const PipeSendPlan &sendPlan = transferPlan.getSend();
   PipeCompletionInfo completionInfo = pipeResource.completion;
@@ -814,8 +1341,9 @@ LogicalResult lowerPipeTransferSend(
   NocPipeTransportEmitter nocTransport(op, pipeType, rewriter);
   PipeTransportEmitter &transport = nocTransport;
 
-  bool usesCapacityProtocol = transferPlan.getSynchronizationProtocol() ==
-                              PipeSynchronizationProtocol::Capacity;
+  bool usesCapacityProtocol =
+      transferPlan.getSynchronizationProtocol() ==
+      PipeSynchronizationProtocol::Capacity;
   ArrayRef<PipeCapacityAcquireInfo> capacityAcquires =
       pipeCapacityPlan.lookupAcquires(op);
   assert(usesCapacityProtocol == !capacityAcquires.empty() &&
@@ -825,7 +1353,7 @@ LogicalResult lowerPipeTransferSend(
   SmallVector<Value> capacityCounters;
   if (!capacityAcquires.empty()) {
     for (const PipeCapacityAcquireInfo &capacityAcquire : capacityAcquires) {
-      FailureOr<Value> maybeCounter = lookupPipeCounterProgress(
+      FailureOr<PipeCounterProgress> maybeCounter = lookupPipeCounterProgress(
           senderCapacityCounters, senderFunc, capacityAcquire.counter);
       if (failed(maybeCounter)) {
         op.emitError("pipe capacity acquire without sender counter; "
@@ -833,7 +1361,7 @@ LogicalResult lowerPipeTransferSend(
                      "convert-ttl-to-ttkernel");
         return failure();
       }
-      capacityCounters.push_back(*maybeCounter);
+      capacityCounters.push_back(maybeCounter->value);
     }
   }
   int64_t numDests = pipeType.getNumDests();
@@ -843,7 +1371,7 @@ LogicalResult lowerPipeTransferSend(
 
   auto cbConverted = utils::convertTTLCBToTTKernel(srcCB, rewriter, loc);
   assert(succeeded(cbConverted) &&
-         "getTTLCBType guarantees a convertible source DFB");
+         "pipe send planning guarantees a convertible source DFB");
 
   if (usesCapacityProtocol) {
     Value zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
@@ -950,28 +1478,98 @@ void lowerInactivePipeTransferPost(PipeTransferPostOp op,
   rewriter.replaceOp(op, token.getResult(0));
 }
 
-LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
-                                    const PipeTransferPlan &transferPlan,
-                                    const PipeCounterProgressMap &counters,
-                                    const PipeResourcePlan &pipeResourcePlan,
-                                    ConversionPatternRewriter &rewriter) {
+static LogicalResult lowerSelectedPipeTransferPost(
+    PipeTransferPostOp op, Value dst, const PipeTransferPlan &transferPlan,
+    const PipeSelectedPostSequenceMap &selectedPostSequenceCounters,
+    const PipeResourcePlan &pipeResourcePlan,
+  ConversionPatternRewriter &rewriter) {
+  auto loc = op.getLoc();
+  const PipeReference &pipeRef = transferPlan.getPipeReference();
+  SelectedPipeFields fields = getSelectedPipeFields(pipeRef);
+  ArrayRef<PipeResourceInfo> resources =
+      transferPlan.getSelectedResources();
+  FuncOp func = op->getParentOfType<FuncOp>();
+  assert(func && "pipe transfer post must be inside a function");
+  auto sequenceIt = selectedPostSequenceCounters.find(func);
+  if (sequenceIt == selectedPostSequenceCounters.end()) {
+    op.emitError(
+        "table-driven pipe receive has no completion sequence counters");
+    return failure();
+  }
+  SmallVector<int64_t> sequenceIndices;
+  for (const PipeResourceInfo &resource : resources) {
+    auto counterIt =
+        llvm::find(sequenceIt->second.counters, resource.completion.counter);
+    if (counterIt == sequenceIt->second.counters.end()) {
+      op.emitError(
+          "table-driven pipe receive has no completion sequence counter");
+      return failure();
+    }
+    sequenceIndices.push_back(
+        std::distance(sequenceIt->second.counters.begin(), counterIt));
+  }
+  const PipePostPlan &postPlan = transferPlan.getPost();
+  assert(postPlan.addressPublication &&
+         "selected receiver post requires published addressing");
+
+  SelectedNocPipeTransportEmitter nocTransport(op, fields, rewriter);
+  PipeTransportEmitter &transport = nocTransport;
+
+  Value publishedAddress =
+      buildReceiverPublishedAddress(dst, loc, *postPlan.addressPublication,
+                                    rewriter);
+  Value tableAddress = buildSelectedAddressTableAddress(
+      op, loc, resources, fields.recordIndex, rewriter);
+  if (failed(transport.emitReceiverAddressPublish(tableAddress,
+                                                  publishedAddress))) {
+    return failure();
+  }
+  transport.emitAddressPublishBarrier();
+
+  Value senderSemAddr = buildSelectedReadyCounterAddress(
+      op, loc, resources, fields.recordIndex, pipeResourcePlan, rewriter);
+  if (failed(transport.emitSenderReadyIncrement(senderSemAddr))) {
+    return failure();
+  }
+
+  Value sequenceIndex =
+      loadIndexTableEntry(loc, sequenceIndices, fields.recordIndex, rewriter);
+  Value tokenSequence = incrementPipePostSequence(
+      loc, sequenceIt->second.completionSequences, sequenceIndex, rewriter);
+  rewriter.replaceOp(op, tokenSequence);
+  return success();
+}
+
+LogicalResult lowerPipeTransferPost(
+    PipeTransferPostOp op, Value dst, const PipeTransferPlan &transferPlan,
+    const PipeCounterProgressMap &counters,
+    const PipeSelectedPostSequenceMap &selectedPostSequenceCounters,
+    const PipeResourcePlan &pipeResourcePlan,
+    ConversionPatternRewriter &rewriter) {
   auto loc = op.getLoc();
   assert(!pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation()) &&
          "inactive receiver post must not use an active transfer plan");
-  assert(!transferPlan.isSend() && "receiver post has a send plan");
-  PipeType pipeType = transferPlan.getPipeType();
+  assert(transferPlan.isPost() && "receiver post has another operation plan");
+  const PipeReference &pipeRef = transferPlan.getPipeReference();
+  if (pipeRef.isSelected()) {
+    return lowerSelectedPipeTransferPost(op, dst, transferPlan,
+                                         selectedPostSequenceCounters,
+                                         pipeResourcePlan, rewriter);
+  }
+  PipeType pipeType = pipeRef.pipeType;
   const PipeResourceInfo &pipeResource = transferPlan.getResources();
   const PipePostPlan &postPlan = transferPlan.getPost();
   auto func = op->getParentOfType<func::FuncOp>();
   assert(func && "pipe transfer post must be inside a function");
-  FailureOr<Value> maybeSequenceCounter = lookupPipeCounterProgress(
-      counters, func, pipeResource.completion.counter);
+  FailureOr<PipeCounterProgress> maybeSequenceCounter =
+      lookupPipeCounterProgress(counters, func,
+                                pipeResource.completion.counter);
   if (failed(maybeSequenceCounter)) {
     op.emitError("pipe receive post has no sequence counter for its completion "
                  "counter");
     return failure();
   }
-  Value sequenceCounter = *maybeSequenceCounter;
+  Value sequenceCounter = maybeSequenceCounter->value;
 
   NocPipeTransportEmitter nocTransport(op, pipeType, rewriter);
   PipeTransportEmitter &transport = nocTransport;
@@ -1000,27 +1598,23 @@ LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
     }
   }
 
-  auto zeroIndex = arith::ConstantIndexOp::create(rewriter, loc, 0);
-  auto previousSequence = memref::LoadOp::create(rewriter, loc, sequenceCounter,
-                                                 ValueRange{zeroIndex});
-  auto oneI32 = arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
-                                          rewriter.getI32IntegerAttr(1));
-  auto tokenSequence =
-      arith::AddIOp::create(rewriter, loc, previousSequence, oneI32);
-  memref::StoreOp::create(rewriter, loc, tokenSequence, sequenceCounter,
-                          ValueRange{zeroIndex});
-  rewriter.replaceOp(op, tokenSequence.getResult());
+  Value sequenceIndex = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value tokenSequence =
+      incrementPipePostSequence(loc, sequenceCounter, sequenceIndex, rewriter);
+  rewriter.replaceOp(op, tokenSequence);
   return success();
 }
 
-static Value computeDFBPopNumTiles(CBPopOp op, CircularBufferType dfbType,
+static Value computeDFBPopNumTiles(CBPopOp op, Value originalCb,
                                    ConversionPatternRewriter &rewriter,
                                    Location loc) {
   if (auto attr = op.getNumTilesAttr()) {
     return arith::ConstantIntOp::create(rewriter, loc, attr.getInt(), 32);
   }
+  auto ttlCbTy = getTTLCBType(originalCb);
+  assert(ttlCbTy && "lowerCBPop already verified the DFB type");
   return arith::ConstantIntOp::create(rewriter, loc,
-                                      dfbType.getElementsPerBlock(), 32);
+                                      ttlCbTy.getElementsPerBlock(), 32);
 }
 
 LogicalResult lowerCBPop(CBPopOp op, Value cb,
@@ -1029,9 +1623,8 @@ LogicalResult lowerCBPop(CBPopOp op, Value cb,
                          ConversionPatternRewriter &rewriter) {
   Location loc = op.getLoc();
   Value originalCb = op.getCb();
-  FailureOr<CircularBufferType> maybeDFBType =
-      utils::getTTLCircularBufferType(originalCb);
-  if (failed(maybeDFBType)) {
+  auto ttlCbTy = getTTLCBType(originalCb);
+  if (!ttlCbTy) {
     return rewriter.notifyMatchFailure(op, "failed to get TTL DFB type");
   }
 
@@ -1040,7 +1633,7 @@ LogicalResult lowerCBPop(CBPopOp op, Value cb,
     return rewriter.notifyMatchFailure(op, "failed to convert DFB operand");
   }
 
-  Value numTiles = computeDFBPopNumTiles(op, *maybeDFBType, rewriter, loc);
+  Value numTiles = computeDFBPopNumTiles(op, originalCb, rewriter, loc);
   ttk::CBPopFrontOp::create(rewriter, loc, *convertedCb, numTiles);
 
   // A receiver DFB pop makes one slot available to its sender. Emit the
@@ -1067,23 +1660,39 @@ LogicalResult lowerCBPop(CBPopOp op, Value cb,
 
 /// Lower the receiver completion wait using the posted token's sequence.
 LogicalResult lowerPipeTransferWait(PipeTransferWaitOp op, Value tokenSequence,
+                                    const PipeTransferPlan &transferPlan,
                                     const PipeResourcePlan &pipeResourcePlan,
                                     ConversionPatternRewriter &rewriter) {
-  if (pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation())) {
-    rewriter.eraseOp(op);
-    return success();
-  }
+  assert(!pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation()) &&
+         "inactive receiver wait must not use an active transfer plan");
+  assert(transferPlan.isWait() && "receiver wait has another operation plan");
   auto loc = op.getLoc();
-  PipeCompletionInfo completionInfo =
-      lookupPipeResourceInfo(op.getOperation(), pipeResourcePlan).completion;
-
   FuncOp func = op->getParentOfType<FuncOp>();
   assert(func && "pipe transfer wait must be inside a function");
+  Value receiverCompletionCounterAddress;
+  if (transferPlan.isSelected()) {
+    SelectedPipeFields fields =
+        getSelectedPipeFields(transferPlan.getPipeReference());
+    SmallVector<PipeCounterInfo> completionCounters = llvm::map_to_vector(
+        transferPlan.getSelectedResources(),
+        [](const PipeResourceInfo &resource) {
+          return resource.completion.counter;
+        });
+    receiverCompletionCounterAddress = buildSelectedPipeCounterAddress(
+        op, loc, completionCounters, fields.recordIndex, pipeResourcePlan,
+        rewriter);
+  } else {
+    PipeCompletionInfo completionInfo =
+        transferPlan.getResources().completion;
+    receiverCompletionCounterAddress = buildPipeCounterAddress(
+        loc, func, completionInfo.counter, pipeResourcePlan, rewriter);
+  }
+
+  auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
   // [Device 2.0] Completion waits should consume the allocated completion
   // object directly once device APIs expose typed semaphore waits.
-  Value receiverCompletionCounterPtr = buildPipeCounterPtr(
-      loc, func, completionInfo.counter, pipeResourcePlan, rewriter);
-
+  Value receiverCompletionCounterPtr = ttk::CastToL1PtrOp::create(
+      rewriter, loc, l1PtrTy, receiverCompletionCounterAddress);
   ttk::SemaphoreWaitMinOp::create(rewriter, loc, receiverCompletionCounterPtr,
                                   tokenSequence);
 
@@ -1291,28 +1900,32 @@ void buildPipeNetIndex(ModuleOp mod, PipeNetIndex &index) {
   // Transfer IR expansion so duplicate static pipes from cloned regions merge
   // into one predicate entry.
   mod.walk([&](PipeTransferCreateOp op) {
-    auto pipeType = mlir::cast<PipeType>(op.getPipe().getType());
-    int64_t netId = pipeType.getPipeNetId();
-    PipeKey key{pipeType.getSrcX(),      pipeType.getSrcY(),
-                pipeType.getDstStartX(), pipeType.getDstStartY(),
-                pipeType.getDstEndX(),   pipeType.getDstEndY()};
+    FailureOr<PipeReference> pipeRef = getPipeReference(op, op.getPipe());
+    assert(succeeded(pipeRef) && "pipe transfer create verifier failed");
     PipeTransferContract contract = getPipeTransferContract(op);
-    if (seenPerNet[netId].insert(key)) {
-      index[netId].push_back(PipeInfo{pipeType, contract});
-      return;
-    }
-    if (!isCollectiveTransfer(contract)) {
-      return;
-    }
-    for (PipeInfo &pipeInfo : index[netId]) {
-      PipeType existingType = pipeInfo.pipeType;
-      PipeKey existingKey{
-          existingType.getSrcX(),      existingType.getSrcY(),
-          existingType.getDstStartX(), existingType.getDstStartY(),
-          existingType.getDstEndX(),   existingType.getDstEndY()};
-      if (existingKey == key) {
-        pipeInfo.transferContract = PipeTransferContract::Collective;
-        break;
+    for (PipeType pipeType :
+         getPipeTypesFromReference(op.getContext(), *pipeRef)) {
+      int64_t netId = pipeType.getPipeNetId();
+      PipeKey key{pipeType.getSrcX(),      pipeType.getSrcY(),
+                  pipeType.getDstStartX(), pipeType.getDstStartY(),
+                  pipeType.getDstEndX(),   pipeType.getDstEndY()};
+      if (seenPerNet[netId].insert(key)) {
+        index[netId].push_back(PipeInfo{pipeType, contract});
+        continue;
+      }
+      if (!isCollectiveTransfer(contract)) {
+        continue;
+      }
+      for (PipeInfo &pipeInfo : index[netId]) {
+        PipeType existingType = pipeInfo.pipeType;
+        PipeKey existingKey{
+            existingType.getSrcX(),      existingType.getSrcY(),
+            existingType.getDstStartX(), existingType.getDstStartY(),
+            existingType.getDstEndX(),   existingType.getDstEndY()};
+        if (existingKey == key) {
+          pipeInfo.transferContract = PipeTransferContract::Collective;
+          break;
+        }
       }
     }
   });
@@ -1330,6 +1943,8 @@ struct PipeTransferAllocationUnit {
   Operation *sendOp = nullptr;
   /// Send, receiver-post, and receiver-wait operations for this transfer.
   SmallVector<Operation *> protocolOps;
+  /// Record indices distinguish graph nodes that share one protocol operation.
+  SmallVector<std::pair<Operation *, unsigned>> selectedProtocolRecords;
 
   /// Logical pipe whose source node owns this unit's rendezvous resources.
   PipeKey pipe;
@@ -1362,6 +1977,10 @@ struct PipeTransferAllocationUnit {
   }
 };
 
+static bool isSelectedTransferUnit(const PipeTransferAllocationUnit &unit) {
+  return !unit.selectedProtocolRecords.empty();
+}
+
 } // namespace
 
 static bool pipeTransferIntervalsOverlap(const PipeTransferAllocationUnit &lhs,
@@ -1370,20 +1989,31 @@ static bool pipeTransferIntervalsOverlap(const PipeTransferAllocationUnit &lhs,
   return intervalsOverlap(lhs.interval, rhs.interval, dominanceInfo);
 }
 
-static FailureOr<SmallVector<PipeTransferAllocationUnit>>
+static bool pipeResourceUnitsInterfere(const PipeTransferAllocationUnit &lhs,
+                                       const PipeTransferAllocationUnit &rhs,
+                                       const DominanceInfo &dominanceInfo) {
+  if (isSelectedTransferUnit(lhs) || isSelectedTransferUnit(rhs)) {
+    // One protocol operation executes for several records, so its
+    // operation-level live interval cannot prove that two records are disjoint.
+    return true;
+  }
+  return pipeTransferIntervalsOverlap(lhs, rhs, dominanceInfo);
+}
+
+static FailureOr<SmallVector<PipeTransferAllocationUnit, 0>>
 collectPipeTransferAllocationUnits(
     ModuleOp mod, const PipeTransferIndex &transferIndex,
     const PipeGraph &pipeGraph, const DominanceInfo &dominanceInfo,
     const PostDominanceInfo &postDominanceInfo,
     llvm::SmallPtrSetImpl<Operation *> &staticallyInactiveOps) {
-  SmallVector<PipeTransferAllocationUnit> units;
+  SmallVector<PipeTransferAllocationUnit, 0> units;
   llvm::DenseMap<Operation *, int64_t> operationOrdinals;
   llvm::DenseMap<Operation *, SmallVector<Operation *>> waitOpsByPost;
   int64_t nextOperationOrdinal = 0;
   WalkResult provenanceWalkResult = mod.walk([&](Operation *op) {
     if (isa<PipeTransferPostOp, PipeTransferSendOp>(op)) {
       operationOrdinals[op] = nextOperationOrdinal++;
-      if (!pipeGraph.getPipeTransferNodeForProtocolOp(op)) {
+      if (!pipeGraph.hasPipeTransferNodeForProtocolOp(op)) {
         staticallyInactiveOps.insert(op);
       }
       return WalkResult::advance();
@@ -1398,7 +2028,7 @@ collectPipeTransferAllocationUnits(
         return WalkResult::interrupt();
       }
       Operation *postOp = possiblePosts.front();
-      if (!pipeGraph.getPipeTransferNodeForProtocolOp(postOp)) {
+      if (!pipeGraph.hasPipeTransferNodeForProtocolOp(postOp)) {
         staticallyInactiveOps.insert(op);
         return WalkResult::advance();
       }
@@ -1410,32 +2040,76 @@ collectPipeTransferAllocationUnits(
     return failure();
   }
 
+  llvm::DenseMap<Operation *, llvm::DenseMap<PipeKey, unsigned>>
+      selectedOccurrencesByProtocolOp;
+  auto recordSelectedProtocolRow = [&](PipeTransferAllocationUnit &unit,
+                                       Operation *protocolOp) -> LogicalResult {
+    FailureOr<PipeReference> pipeRef =
+        getPipeReferenceForProtocolOp(protocolOp, transferIndex);
+    if (failed(pipeRef)) {
+      return failure();
+    }
+    if ((*pipeRef).isStatic()) {
+      return success();
+    }
+
+    // Repeated identical records have the same PipeKey. Count earlier matches
+    // so each graph node maps back to its original record index.
+    unsigned selectedOccurrence =
+        selectedOccurrencesByProtocolOp[protocolOp][unit.pipe]++;
+    unsigned matchingOccurrence = 0;
+    for (auto [recordIndex, record] :
+         llvm::enumerate((*pipeRef).getRecords().getPipes())) {
+      if (!(getPipeKey(record, (*pipeRef).getPipeNetId()) == unit.pipe)) {
+        continue;
+      }
+      if (matchingOccurrence++ == selectedOccurrence) {
+        unit.selectedProtocolRecords.push_back(
+            {protocolOp, static_cast<unsigned>(recordIndex)});
+        return success();
+      }
+    }
+    return protocolOp->emitError(
+        "selected pipe record does not match its transfer graph node");
+  };
+
   units.reserve(pipeGraph.getPipeTransferNodes().size());
   for (const PipeTransferNode &transferNode :
        pipeGraph.getPipeTransferNodes()) {
     assert(transferNode.sendOp &&
            "pipe transfer graph node must have a send operation");
     auto sendOp = cast<PipeTransferSendOp>(transferNode.sendOp);
-    PipeTransferCreateOp createOp =
-        transferIndex.getTransferCreate(sendOp.getOperation());
-
     PipeTransferAllocationUnit unit;
     unit.transferNodeId = transferNode.id;
     unit.sendOp = sendOp.getOperation();
     unit.pipe = transferNode.pipe;
-    unit.pipeType = mlir::cast<PipeType>(createOp.getPipe().getType());
+    unit.pipeType = PipeType::get(mod.getContext(), unit.pipe.srcX,
+                                  unit.pipe.srcY, unit.pipe.dstStartX,
+                                  unit.pipe.dstStartY, unit.pipe.dstEndX,
+                                  unit.pipe.dstEndY, unit.pipe.pipeNetId);
     unit.transferContract = transferNode.transferContract;
     unit.ordinal = static_cast<int64_t>(transferNode.id);
     unit.protocolOps.push_back(sendOp.getOperation());
+    if (failed(recordSelectedProtocolRow(unit, sendOp.getOperation()))) {
+      return failure();
+    }
     updateIntervalEnd(unit.interval, sendOp.getOperation(), dominanceInfo);
     for (Operation *postOp : transferNode.receiverPostOps) {
       auto ordinalIt = operationOrdinals.find(postOp);
       assert(ordinalIt != operationOrdinals.end() &&
              "receiver post is missing an operation ordinal");
       unit.protocolOps.push_back(postOp);
+      if (failed(recordSelectedProtocolRow(unit, postOp))) {
+        return failure();
+      }
       auto waitIt = waitOpsByPost.find(postOp);
       if (waitIt != waitOpsByPost.end()) {
         unit.protocolOps.append(waitIt->second.begin(), waitIt->second.end());
+        for (Operation *waitOp : waitIt->second) {
+          if (failed(recordSelectedProtocolRow(unit, waitOp))) {
+            return failure();
+          }
+        }
       }
       updateIntervalStart(unit.interval, postOp, ordinalIt->second,
                           dominanceInfo);
@@ -1468,8 +2142,8 @@ assignLiveIntervalColors(MutableArrayRef<PipeTransferAllocationUnit> units,
                                                              units[rhsIndex]);
             },
             [&](std::size_t lhsIndex, std::size_t rhsIndex) {
-              return pipeTransferIntervalsOverlap(
-                  units[lhsIndex], units[rhsIndex], dominanceInfo);
+              return pipeResourceUnitsInterfere(units[lhsIndex],
+                                                units[rhsIndex], dominanceInfo);
             });
 
     for (auto indexedColor : llvm::enumerate(colorUsers)) {
@@ -1510,10 +2184,12 @@ static int64_t allocateCompletionCounterColor(
   return static_cast<int64_t>(pipesByCounterColor.size() - 1);
 }
 
-static bool usesSenderReadyCounter(
-    const PipeTransferAllocationUnit &unit,
-    const PipeSynchronizationSelection *synchronizationSelection) {
-  if (!synchronizationSelection) {
+static bool usesSenderReadyCounter(const PipeTransferAllocationUnit &unit,
+                                   const PipeSynchronizationSelection
+                                       *synchronizationSelection) {
+  // Selected transfers publish receiver addresses, so their sender must wait
+  // until the matching table entry has been initialized.
+  if (!synchronizationSelection || isSelectedTransferUnit(unit)) {
     return true;
   }
   return !synchronizationSelection->usesCapacityProtocol(
@@ -1613,6 +2289,12 @@ buildComputedAddressPlan(MutableArrayRef<PipeTransferAllocationUnit> units,
 
   for (auto indexedUnit : llvm::enumerate(units)) {
     PipeTransferAllocationUnit &unit = indexedUnit.value();
+    // One loop body serves every record, so computed addresses would require
+    // record-specific DFB sequence state. Published addresses preserve the
+    // receiver's runtime reservation without adding that state to the loop.
+    if (isSelectedTransferUnit(unit)) {
+      continue;
+    }
     const PipeTransferNode &transferNode =
         pipeGraph.getPipeTransferNode(unit.transferNodeId);
     const PipeReceiverEndpoint *receiverEndpoint =
@@ -1688,8 +2370,8 @@ buildComputedAddressPlan(MutableArrayRef<PipeTransferAllocationUnit> units,
 }
 
 // Compact the per-source colors whose units need a resource into a dense
-// 0..N-1 index range. The result maps each original color index to its
-// compacted index and includes the maximum compacted count across sources.
+// 0..N-1 index range, keyed by original color index. Returns the compacted map
+// and the maximum compacted count across sources.
 template <typename PredT>
 static std::pair<
     llvm::MapVector<PipeSourceKey, llvm::DenseMap<std::size_t, int64_t>>,
@@ -1727,7 +2409,7 @@ LogicalResult buildPipeResourcePlan(
   if (failed(maybeUnits)) {
     return failure();
   }
-  SmallVector<PipeTransferAllocationUnit> &units = *maybeUnits;
+  SmallVector<PipeTransferAllocationUnit, 0> &units = *maybeUnits;
   SourceColorMap colorUsersBySource =
       assignLiveIntervalColors(units, dominanceInfo);
   ComputedAddressPlan computedAddressPlan;
@@ -1782,6 +2464,8 @@ LogicalResult buildPipeResourcePlan(
       });
   int64_t maxAddressTableBytes =
       maxAddressColorsPerSource * kPipeAddressWordBytes;
+  llvm::MapVector<Operation *, SmallVector<std::optional<PipeResourceInfo>>>
+      selectedResources;
 
   for (auto indexedUnit : llvm::enumerate(units)) {
     const PipeTransferAllocationUnit &unit = indexedUnit.value();
@@ -1822,12 +2506,47 @@ LogicalResult buildPipeResourcePlan(
         maybeReadyCounter,
         addressStorage,
     };
+    llvm::SmallPtrSet<Operation *, 4> selectedProtocolOps;
+    for (auto [protocolOp, recordIndex] : unit.selectedProtocolRecords) {
+      selectedProtocolOps.insert(protocolOp);
+      SmallVector<std::optional<PipeResourceInfo>> &resources =
+          selectedResources[protocolOp];
+      if (resources.empty()) {
+        FailureOr<PipeReference> pipeRef =
+            getPipeReferenceForProtocolOp(protocolOp, transferIndex);
+        assert(succeeded(pipeRef) &&
+               "pipe transfer graph validated pipe reference");
+        resources.resize((*pipeRef).getRecords().getPipes().size());
+      }
+      assert(recordIndex < resources.size() && "selected record index invalid");
+      resources[recordIndex] = pipeResource;
+    }
     for (Operation *protocolOp : unit.protocolOps) {
+      if (selectedProtocolOps.contains(protocolOp)) {
+        continue;
+      }
       auto [resourceIt, inserted] =
           info.resources.insert({protocolOp, pipeResource});
       assert((inserted || resourceIt->second.pipe == pipeResource.pipe) &&
              "pipe protocol operation assigned to two transfers");
     }
+  }
+
+  for (auto &[protocolOp, optionalResources] : selectedResources) {
+    SmallVector<PipeResourceInfo> resources;
+    resources.reserve(optionalResources.size());
+    auto firstActiveResource = llvm::find_if(
+        optionalResources, [](const std::optional<PipeResourceInfo> &resource) {
+          return resource.has_value();
+        });
+    assert(firstActiveResource != optionalResources.end() &&
+           "selected resource table has no active records");
+    for (const std::optional<PipeResourceInfo> &resource : optionalResources) {
+      // A record proven inactive at this operation never reads its table row.
+      // Reusing an active row keeps every table aligned with record indices.
+      resources.push_back(resource.value_or(**firstActiveResource));
+    }
+    info.selectedResources.insert({protocolOp, std::move(resources)});
   }
 
   info.sramScratch.bytes =
@@ -1849,6 +2568,15 @@ getPipeResourceRequirements(const PipeResourcePlan &info,
     }
   }
 
+  for (const auto &[protocolOp, resources] : info.selectedResources) {
+    (void)protocolOp;
+    for (const PipeResourceInfo &resource : resources) {
+      counts.include(resource.completion.counter);
+      if (resource.readyCounter) {
+        counts.include(*resource.readyCounter);
+      }
+    }
+  }
   if (pipeCapacityPlan) {
     PipeCounterAllocationCounts capacityCounts =
         pipeCapacityPlan->getCounterAllocationCounts();
@@ -1857,7 +2585,6 @@ getPipeResourceRequirements(const PipeResourcePlan &info,
            "capacity allocation must continue after pipe resource allocation");
     counts = capacityCounts;
   }
-
   return PipeResourceRequirements{
       counts.localSemaphoreCount,
       counts.globalSemaphoreCount,

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -2447,7 +2447,7 @@ LogicalResult buildPipeResourcePlan(
     const PipeSynchronizationSelection *synchronizationSelection) {
   DominanceInfo dominanceInfo(mod);
   PostDominanceInfo postDominanceInfo(mod);
-  FailureOr<SmallVector<PipeTransferAllocationUnit>> maybeUnits =
+  FailureOr<SmallVector<PipeTransferAllocationUnit, 0>> maybeUnits =
       collectPipeTransferAllocationUnits(mod, transferIndex, pipeGraph,
                                          dominanceInfo, postDominanceInfo,
                                          info.staticallyInactiveOps);

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -50,21 +50,6 @@ static constexpr int64_t kPipeSramScratchAlignmentBytes = 32;
 // Helpers
 //===----------------------------------------------------------------------===//
 
-static CircularBufferType getTTLCBType(Value cb) {
-  if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(cb.getType())) {
-    return ttlCbTy;
-  }
-  if (auto castOp = cb.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (castOp.getInputs().size() == 1) {
-      if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(
-              castOp.getInputs()[0].getType())) {
-        return ttlCbTy;
-      }
-    }
-  }
-  return nullptr;
-}
-
 static Value makeZeroI32(Location loc, ConversionPatternRewriter &rewriter) {
   return arith::ConstantIntOp::create(rewriter, loc, 0, 32);
 }
@@ -512,7 +497,7 @@ struct SelectedPipeFields {
 static SelectedPipeFields getSelectedPipeFields(const PipeReference &pipeRef) {
   assert(pipeRef.isSelected() && "expected selected pipe reference");
   if (pipeRef.isSelectedSrc()) {
-    SelectPipeSrcOp op = pipeRef.selectedSrc;
+    SelectPipeSrcOp op = pipeRef.getSelectedSrc();
     return SelectedPipeFields{
         op.getRecordIndex(),
         op.getSrcX(),
@@ -525,7 +510,7 @@ static SelectedPipeFields getSelectedPipeFields(const PipeReference &pipeRef) {
         op.getSrcInDstRange(),
         op.getRecords().getPipes().front().getIsCollective()};
   }
-  SelectPipeDstOp op = pipeRef.selectedDst;
+  SelectPipeDstOp op = pipeRef.getSelectedDst();
   return SelectedPipeFields{
       op.getRecordIndex(),
       op.getSrcX(),
@@ -548,7 +533,7 @@ buildReceiverPublishedAddress(Value dst, Location loc,
   auto receiverCBConverted =
       utils::convertTTLCBToTTKernel(info.receiverDFB, rewriter, loc);
   assert(succeeded(receiverCBConverted) &&
-         "getTTLCBType guarantees a convertible receiver DFB");
+         "pipe post planning guarantees a convertible receiver DFB");
 
   auto receiverWritePtr =
       ttk::GetWritePtrOp::create(rewriter, loc, *receiverCBConverted);
@@ -563,9 +548,9 @@ buildReceiverPublishedAddress(Value dst, Location loc,
 
   auto tileOffsetI32 = arith::IndexCastOp::create(
       rewriter, loc, rewriter.getI32Type(), globalTileIndex);
-  auto pageSizeBytes = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32Type(),
-      rewriter.getI32IntegerAttr(info.tileSizeBytes));
+  auto pageSizeBytes =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                rewriter.getI32IntegerAttr(info.tileSizeBytes));
   auto byteOffset =
       arith::MulIOp::create(rewriter, loc, tileOffsetI32, pageSizeBytes);
   return arith::AddIOp::create(rewriter, loc, receiverWritePtr, byteOffset)
@@ -596,6 +581,11 @@ public:
 
 class NocPipeTransportEmitterBase : public PipeTransportEmitter {
 protected:
+  struct LogicalCore {
+    Value x;
+    Value y;
+  };
+
   struct TranslatedCore {
     Value x;
     Value y;
@@ -617,15 +607,52 @@ public:
 
   LogicalResult emitReceiverAddressPublish(Value senderTableAddress,
                                            Value publishedAddress) override {
+    LogicalCore sourceCore = getSourceLogicalCore();
+    // The remote publish and the following ready signal reuse the translated
+    // source coordinates, so they must be created before either branch.
+    getSourceCore();
+    Value currentX =
+        ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+    Value currentY =
+        ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+    Value xMatches = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, currentX, sourceCore.x);
+    Value yMatches = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, currentY, sourceCore.y);
+    Value receiverIsSource =
+        arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
+    auto localPublish = scf::IfOp::create(rewriter, loc, receiverIsSource,
+                                          /*withElseRegion=*/true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&localPublish.getThenRegion().front());
+      emitLocalReceiverAddressPublish(senderTableAddress, publishedAddress);
+      rewriter.setInsertionPointToStart(&localPublish.getElseRegion().front());
+      emitRemoteReceiverAddressPublish(senderTableAddress, publishedAddress);
+    }
+    rewriter.setInsertionPointAfter(localPublish);
+    return success();
+  }
+
+  void emitLocalReceiverAddressPublish(Value senderTableAddress,
+                                       Value publishedAddress) {
+    auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
+    Value tablePtr =
+        ttk::CastToL1PtrOp::create(rewriter, loc, l1PtrTy, senderTableAddress);
+    Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+    ttk::StoreToL1Op::create(rewriter, loc, publishedAddress, tablePtr, zero);
+  }
+
+  void emitRemoteReceiverAddressPublish(Value senderTableAddress,
+                                        Value publishedAddress) {
     TranslatedCore sourceCore = getSourceCore();
     auto byteEnableAll = arith::ConstantOp::create(
         rewriter, loc, rewriter.getI8Type(), rewriter.getI8IntegerAttr(0xF));
-    // [Device 2.0] The receiver writes its DFB address to the sender's typed
-    // address table. Only this operation selects the inline NoC write.
+    // An inline NoC write does not update the sender's local SRAM when the
+    // sender is also this receiver, so that case uses a direct L1 store.
     ttk::NocInlineDwWriteOp::create(rewriter, loc, sourceCore.x, sourceCore.y,
                                     senderTableAddress, publishedAddress,
                                     byteEnableAll, nocVal);
-    return success();
   }
 
   void emitAddressPublishBarrier() override {
@@ -655,6 +682,7 @@ public:
   }
 
 protected:
+  virtual LogicalCore getSourceLogicalCore() = 0;
   virtual TranslatedCore getSourceCore() = 0;
 
   TranslatedCore buildTranslatedCore(Value logicalX, Value logicalY) {
@@ -688,6 +716,20 @@ public:
   NocPipeTransportEmitter(Operation *op, PipeType pipeType,
                           ConversionPatternRewriter &rewriter)
       : NocPipeTransportEmitterBase(op, rewriter), pipeType(pipeType) {}
+
+  LogicalResult emitReceiverAddressPublish(Value senderTableAddress,
+                                           Value publishedAddress) override {
+    if (!pipeType.srcInDstRange()) {
+      emitRemoteReceiverAddressPublish(senderTableAddress, publishedAddress);
+      return success();
+    }
+    if (pipeType.hasSingleReceiver()) {
+      emitLocalReceiverAddressPublish(senderTableAddress, publishedAddress);
+      return success();
+    }
+    return NocPipeTransportEmitterBase::emitReceiverAddressPublish(
+        senderTableAddress, publishedAddress);
+  }
 
   void preparePayloadWrite() override {
     // Materialize destination coordinates before computing the payload address
@@ -777,6 +819,11 @@ public:
   }
 
 private:
+  LogicalCore getSourceLogicalCore() override {
+    return {arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcX()),
+            arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcY())};
+  }
+
   TranslatedCore getSourceCore() override {
     if (!sourceCore) {
       sourceCore = buildTranslatedCore(pipeType.getSrcX(), pipeType.getSrcY());
@@ -985,6 +1032,10 @@ private:
           rewriter, loc, arith::CmpIPredicate::eq, fields.numDests, one);
     }
     return hasSingleReceiver;
+  }
+
+  LogicalCore getSourceLogicalCore() override {
+    return {fields.srcX, fields.srcY};
   }
 
   TranslatedCore getSourceCore() override {
@@ -1241,8 +1292,7 @@ lowerSelectedPipeTransferSend(PipeTransferSendOp op, Value srcCB,
   auto loc = op.getLoc();
   const PipeReference &pipeRef = transferPlan.getPipeReference();
   SelectedPipeFields fields = getSelectedPipeFields(pipeRef);
-  ArrayRef<PipeResourceInfo> resources =
-      transferPlan.getSelectedResources();
+  ArrayRef<PipeResourceInfo> resources = transferPlan.getSelectedResources();
   const PipeSendPlan &sendPlan = transferPlan.getSend();
 
   auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
@@ -1323,7 +1373,7 @@ LogicalResult lowerPipeTransferSend(
     const PipeCapacityPlan &pipeCapacityPlan,
     const PipeCounterProgressMap &senderCapacityCounters,
     const PipeComputedAddressCounterMap &computedAddressCounters,
-  ConversionPatternRewriter &rewriter) {
+    ConversionPatternRewriter &rewriter) {
   auto loc = op.getLoc();
   assert(!pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation()) &&
          "inactive sender must not use an active transfer plan");
@@ -1333,7 +1383,7 @@ LogicalResult lowerPipeTransferSend(
     return lowerSelectedPipeTransferSend(op, srcCB, transferPlan,
                                          pipeResourcePlan, rewriter);
   }
-  PipeType pipeType = pipeRef.pipeType;
+  PipeType pipeType = pipeRef.getStaticPipeType();
   const PipeResourceInfo &pipeResource = transferPlan.getResources();
   const PipeSendPlan &sendPlan = transferPlan.getSend();
   PipeCompletionInfo completionInfo = pipeResource.completion;
@@ -1341,9 +1391,8 @@ LogicalResult lowerPipeTransferSend(
   NocPipeTransportEmitter nocTransport(op, pipeType, rewriter);
   PipeTransportEmitter &transport = nocTransport;
 
-  bool usesCapacityProtocol =
-      transferPlan.getSynchronizationProtocol() ==
-      PipeSynchronizationProtocol::Capacity;
+  bool usesCapacityProtocol = transferPlan.getSynchronizationProtocol() ==
+                              PipeSynchronizationProtocol::Capacity;
   ArrayRef<PipeCapacityAcquireInfo> capacityAcquires =
       pipeCapacityPlan.lookupAcquires(op);
   assert(usesCapacityProtocol == !capacityAcquires.empty() &&
@@ -1482,12 +1531,11 @@ static LogicalResult lowerSelectedPipeTransferPost(
     PipeTransferPostOp op, Value dst, const PipeTransferPlan &transferPlan,
     const PipeSelectedPostSequenceMap &selectedPostSequenceCounters,
     const PipeResourcePlan &pipeResourcePlan,
-  ConversionPatternRewriter &rewriter) {
+    ConversionPatternRewriter &rewriter) {
   auto loc = op.getLoc();
   const PipeReference &pipeRef = transferPlan.getPipeReference();
   SelectedPipeFields fields = getSelectedPipeFields(pipeRef);
-  ArrayRef<PipeResourceInfo> resources =
-      transferPlan.getSelectedResources();
+  ArrayRef<PipeResourceInfo> resources = transferPlan.getSelectedResources();
   FuncOp func = op->getParentOfType<FuncOp>();
   assert(func && "pipe transfer post must be inside a function");
   auto sequenceIt = selectedPostSequenceCounters.find(func);
@@ -1515,9 +1563,8 @@ static LogicalResult lowerSelectedPipeTransferPost(
   SelectedNocPipeTransportEmitter nocTransport(op, fields, rewriter);
   PipeTransportEmitter &transport = nocTransport;
 
-  Value publishedAddress =
-      buildReceiverPublishedAddress(dst, loc, *postPlan.addressPublication,
-                                    rewriter);
+  Value publishedAddress = buildReceiverPublishedAddress(
+      dst, loc, *postPlan.addressPublication, rewriter);
   Value tableAddress = buildSelectedAddressTableAddress(
       op, loc, resources, fields.recordIndex, rewriter);
   if (failed(transport.emitReceiverAddressPublish(tableAddress,
@@ -1556,7 +1603,7 @@ LogicalResult lowerPipeTransferPost(
                                          selectedPostSequenceCounters,
                                          pipeResourcePlan, rewriter);
   }
-  PipeType pipeType = pipeRef.pipeType;
+  PipeType pipeType = pipeRef.getStaticPipeType();
   const PipeResourceInfo &pipeResource = transferPlan.getResources();
   const PipePostPlan &postPlan = transferPlan.getPost();
   auto func = op->getParentOfType<func::FuncOp>();
@@ -1605,16 +1652,14 @@ LogicalResult lowerPipeTransferPost(
   return success();
 }
 
-static Value computeDFBPopNumTiles(CBPopOp op, Value originalCb,
+static Value computeDFBPopNumTiles(CBPopOp op, CircularBufferType dfbType,
                                    ConversionPatternRewriter &rewriter,
                                    Location loc) {
   if (auto attr = op.getNumTilesAttr()) {
     return arith::ConstantIntOp::create(rewriter, loc, attr.getInt(), 32);
   }
-  auto ttlCbTy = getTTLCBType(originalCb);
-  assert(ttlCbTy && "lowerCBPop already verified the DFB type");
   return arith::ConstantIntOp::create(rewriter, loc,
-                                      ttlCbTy.getElementsPerBlock(), 32);
+                                      dfbType.getElementsPerBlock(), 32);
 }
 
 LogicalResult lowerCBPop(CBPopOp op, Value cb,
@@ -1623,8 +1668,9 @@ LogicalResult lowerCBPop(CBPopOp op, Value cb,
                          ConversionPatternRewriter &rewriter) {
   Location loc = op.getLoc();
   Value originalCb = op.getCb();
-  auto ttlCbTy = getTTLCBType(originalCb);
-  if (!ttlCbTy) {
+  FailureOr<CircularBufferType> maybeDFBType =
+      utils::getTTLCircularBufferType(originalCb);
+  if (failed(maybeDFBType)) {
     return rewriter.notifyMatchFailure(op, "failed to get TTL DFB type");
   }
 
@@ -1633,7 +1679,7 @@ LogicalResult lowerCBPop(CBPopOp op, Value cb,
     return rewriter.notifyMatchFailure(op, "failed to convert DFB operand");
   }
 
-  Value numTiles = computeDFBPopNumTiles(op, originalCb, rewriter, loc);
+  Value numTiles = computeDFBPopNumTiles(op, *maybeDFBType, rewriter, loc);
   ttk::CBPopFrontOp::create(rewriter, loc, *convertedCb, numTiles);
 
   // A receiver DFB pop makes one slot available to its sender. Emit the
@@ -1673,17 +1719,16 @@ LogicalResult lowerPipeTransferWait(PipeTransferWaitOp op, Value tokenSequence,
   if (transferPlan.isSelected()) {
     SelectedPipeFields fields =
         getSelectedPipeFields(transferPlan.getPipeReference());
-    SmallVector<PipeCounterInfo> completionCounters = llvm::map_to_vector(
-        transferPlan.getSelectedResources(),
-        [](const PipeResourceInfo &resource) {
-          return resource.completion.counter;
-        });
+    SmallVector<PipeCounterInfo> completionCounters =
+        llvm::map_to_vector(transferPlan.getSelectedResources(),
+                            [](const PipeResourceInfo &resource) {
+                              return resource.completion.counter;
+                            });
     receiverCompletionCounterAddress = buildSelectedPipeCounterAddress(
         op, loc, completionCounters, fields.recordIndex, pipeResourcePlan,
         rewriter);
   } else {
-    PipeCompletionInfo completionInfo =
-        transferPlan.getResources().completion;
+    PipeCompletionInfo completionInfo = transferPlan.getResources().completion;
     receiverCompletionCounterAddress = buildPipeCounterAddress(
         loc, func, completionInfo.counter, pipeResourcePlan, rewriter);
   }
@@ -1946,7 +1991,7 @@ struct PipeTransferAllocationUnit {
   /// Record indices distinguish graph nodes that share one protocol operation.
   SmallVector<std::pair<Operation *, unsigned>> selectedProtocolRecords;
 
-  /// Logical pipe whose source node owns this unit's rendezvous resources.
+  /// Logical pipe whose source owns this unit's address and ready resources.
   PipeKey pipe;
 
   PipeType pipeType;
@@ -1956,7 +2001,7 @@ struct PipeTransferAllocationUnit {
   /// Stable tie-breaker for deterministic allocation.
   int64_t ordinal = 0;
 
-  /// Conservative post-to-send lifetime for source-node rendezvous resources.
+  /// Conservative post-to-send lifetime for sender-owned resources.
   OperationLiveInterval interval;
 
   /// Assigned first-fit color within the source node's allocation group.
@@ -2184,9 +2229,9 @@ static int64_t allocateCompletionCounterColor(
   return static_cast<int64_t>(pipesByCounterColor.size() - 1);
 }
 
-static bool usesSenderReadyCounter(const PipeTransferAllocationUnit &unit,
-                                   const PipeSynchronizationSelection
-                                       *synchronizationSelection) {
+static bool usesSenderReadyCounter(
+    const PipeTransferAllocationUnit &unit,
+    const PipeSynchronizationSelection *synchronizationSelection) {
   // Selected transfers publish receiver addresses, so their sender must wait
   // until the matching table entry has been initialized.
   if (!synchronizationSelection || isSelectedTransferUnit(unit)) {

--- a/lib/Dialect/TTL/Transforms/PipeLowering.h
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.h
@@ -117,6 +117,18 @@ struct PipeCounterProgress {
 using PipeCounterProgressMap =
     llvm::MapVector<func::FuncOp, SmallVector<PipeCounterProgress>>;
 
+struct PipeSelectedPostSequenceCounters {
+  /// Indexed by `counters` so runtime record selection does not require one
+  /// control-flow branch per transfer definition.
+  Value completionSequences;
+  SmallVector<PipeCounterInfo> counters;
+};
+
+/// Per-function state keeps completion progress cumulative when selected
+/// records reuse a counter.
+using PipeSelectedPostSequenceMap =
+    llvm::MapVector<func::FuncOp, PipeSelectedPostSequenceCounters>;
+
 /// Initial value for one sender-local computed-address slot counter.
 struct PipeComputedAddressCounterInitInfo {
   int64_t counterIndex = 0;
@@ -145,11 +157,14 @@ struct PipeResourcePlan {
   /// Maps each pipe send, receiver post, and receiver wait to the resources
   /// shared by that transfer definition.
   llvm::MapVector<Operation *, PipeResourceInfo> resources;
+  /// Record order is retained so runtime indices address the corresponding
+  /// resources.
+  llvm::MapVector<Operation *, SmallVector<PipeResourceInfo>> selectedResources;
   /// Protocol operations proven unreachable at their pipe endpoint. Lowering
-  /// removes these operations without allocating rendezvous resources.
+  /// removes these operations without allocating synchronization resources.
   llvm::SmallPtrSet<Operation *, 8> staticallyInactiveOps;
-  /// One entry-block counter preserves slot state across repeated sends from
-  /// the same transfer definition.
+  /// Each entry-block counter preserves slot state across repeated sends that
+  /// share one computed-address allocation unit.
   llvm::MapVector<func::FuncOp, SmallVector<PipeComputedAddressCounterInitInfo>>
       computedAddressCounterInitializations;
   /// Receiver DFB indices supplied as common runtime arguments to each sender.
@@ -202,7 +217,8 @@ void initializePipeComputedAddressCounters(
 /// for every completion counter used by that function.
 void initializePipePostSequenceCounters(
     const PipeResourcePlan &pipeResourcePlan,
-    PipeCounterProgressMap &postSequenceCounters);
+    PipeCounterProgressMap &postSequenceCounters,
+    PipeSelectedPostSequenceMap &selectedPostSequenceCounters);
 
 /// Remove a sender operation proven unreachable at its pipe endpoint.
 void lowerInactivePipeTransferSend(PipeTransferSendOp op,
@@ -221,12 +237,12 @@ LogicalResult lowerPipeTransferSend(
 void lowerInactivePipeTransferPost(PipeTransferPostOp op,
                                    ConversionPatternRewriter &rewriter);
 
-/// Lower the receiver-side pipe rendezvous.
-LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
-                                    const PipeTransferPlan &transferPlan,
-                                    const PipeCounterProgressMap &counters,
-                                    const PipeResourcePlan &pipeResourcePlan,
-                                    ConversionPatternRewriter &rewriter);
+LogicalResult lowerPipeTransferPost(
+    PipeTransferPostOp op, Value dst, const PipeTransferPlan &transferPlan,
+    const PipeCounterProgressMap &counters,
+    const PipeSelectedPostSequenceMap &selectedPostSequenceCounters,
+    const PipeResourcePlan &pipeResourcePlan,
+    ConversionPatternRewriter &rewriter);
 
 /// Lower a dataflow buffer pop and emit any proven pipe capacity releases.
 LogicalResult lowerCBPop(CBPopOp op, Value cb,
@@ -236,6 +252,7 @@ LogicalResult lowerCBPop(CBPopOp op, Value cb,
 
 /// Lower the receiver-side pipe receive completion wait.
 LogicalResult lowerPipeTransferWait(PipeTransferWaitOp op, Value tokenSequence,
+                                    const PipeTransferPlan &transferPlan,
                                     const PipeResourcePlan &pipeResourcePlan,
                                     ConversionPatternRewriter &rewriter);
 

--- a/lib/Dialect/TTL/Transforms/PipeNetExecutionUtils.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetExecutionUtils.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h"
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/CheckedArithmetic.h"
+
+namespace mlir::tt::ttl {
+
+std::optional<std::uint64_t>
+getActivePipeNetRecordIndex(ArrayRef<ActivePipeNetRecord> activeRecords,
+                            Operation *loopOp) {
+  auto activeIt = llvm::find_if(llvm::reverse(activeRecords),
+                                [&](const ActivePipeNetRecord &active) {
+                                  return active.loopOp == loopOp;
+                                });
+  if (activeIt == activeRecords.rend()) {
+    return std::nullopt;
+  }
+  return activeIt->recordIndex;
+}
+
+namespace {
+
+static std::optional<PipeNetRecordLoop> getHighLevelRecordLoop(Operation *op) {
+  if (auto foreachSrc = mlir::dyn_cast<PipeNetForeachSrcOp>(op)) {
+    return PipeNetRecordLoop{foreachSrc.getRecords(),
+                             PipeNetRecordSelection::Source};
+  }
+  if (auto foreachDst = mlir::dyn_cast<PipeNetForeachDstOp>(op)) {
+    return PipeNetRecordLoop{foreachDst.getRecords(),
+                             PipeNetRecordSelection::Destination};
+  }
+  return std::nullopt;
+}
+
+static SmallVector<std::uint64_t>
+getMatchingRecordIndices(const PipeNetRecordLoop &recordLoop,
+                         LaunchNodeCoord coord) {
+  SmallVector<std::uint64_t> matchingRecordIndices;
+  for (auto [recordIndex, record] :
+       llvm::enumerate(recordLoop.records.getPipes())) {
+    LaunchNodeDomain recordDomain =
+        recordLoop.selection == PipeNetRecordSelection::Source
+            ? getPipeRecordSourceLaunchNodeDomain(record)
+            : getPipeRecordDestinationLaunchNodeDomain(record);
+    if (knownLaunchNodeDomainContains(recordDomain, coord)) {
+      matchingRecordIndices.push_back(recordIndex);
+    }
+  }
+  return matchingRecordIndices;
+}
+
+static WalkResult walkPipeNetOpsInProgramOrderImpl(
+    Operation *op, LaunchNodeCoord coord,
+    llvm::function_ref<std::optional<PipeNetRecordLoop>(Operation *)>
+        resolveGeneratedRecordLoop,
+    llvm::function_ref<
+        WalkResult(Operation *, ArrayRef<ActivePipeNetRecord>,
+                   std::optional<std::uint64_t> executionCountDivisor)>
+        visitOperation,
+    SmallVectorImpl<ActivePipeNetRecord> &activeRecords,
+    std::optional<std::uint64_t> executionCountDivisor) {
+  std::optional<PipeNetRecordLoop> maybeRecordLoop = getHighLevelRecordLoop(op);
+  if (!maybeRecordLoop) {
+    maybeRecordLoop = resolveGeneratedRecordLoop(op);
+  }
+  if (maybeRecordLoop) {
+    SmallVector<std::uint64_t> matchingRecordIndices =
+        getMatchingRecordIndices(*maybeRecordLoop, coord);
+    std::optional<std::uint64_t> nestedExecutionCountDivisor =
+        executionCountDivisor;
+    if (executionCountDivisor) {
+      nestedExecutionCountDivisor = llvm::checkedMulUnsigned(
+          *executionCountDivisor,
+          static_cast<std::uint64_t>(matchingRecordIndices.size()));
+    }
+
+    for (std::uint64_t recordIndex : matchingRecordIndices) {
+      activeRecords.push_back({op, recordIndex});
+      llvm::scope_exit restoreActiveRecords([&] { activeRecords.pop_back(); });
+      for (Region &region : op->getRegions()) {
+        for (Block &block : region) {
+          for (Operation &nestedOp : block) {
+            if (walkPipeNetOpsInProgramOrderImpl(
+                    &nestedOp, coord, resolveGeneratedRecordLoop,
+                    visitOperation, activeRecords, nestedExecutionCountDivisor)
+                    .wasInterrupted()) {
+              return WalkResult::interrupt();
+            }
+          }
+        }
+      }
+    }
+    return WalkResult::advance();
+  }
+
+  if (visitOperation(op, activeRecords, executionCountDivisor)
+          .wasInterrupted()) {
+    return WalkResult::interrupt();
+  }
+  for (Region &region : op->getRegions()) {
+    for (Block &block : region) {
+      for (Operation &nestedOp : block) {
+        if (walkPipeNetOpsInProgramOrderImpl(
+                &nestedOp, coord, resolveGeneratedRecordLoop, visitOperation,
+                activeRecords, executionCountDivisor)
+                .wasInterrupted()) {
+          return WalkResult::interrupt();
+        }
+      }
+    }
+  }
+  return WalkResult::advance();
+}
+
+} // namespace
+
+WalkResult walkPipeNetOpsInProgramOrder(
+    Operation *root, LaunchNodeCoord coord,
+    llvm::function_ref<std::optional<PipeNetRecordLoop>(Operation *)>
+        resolveGeneratedRecordLoop,
+    llvm::function_ref<
+        WalkResult(Operation *, ArrayRef<ActivePipeNetRecord>,
+                   std::optional<std::uint64_t> executionCountDivisor)>
+        visitOperation) {
+  SmallVector<ActivePipeNetRecord> activeRecords;
+  return walkPipeNetOpsInProgramOrderImpl(
+      root, coord, resolveGeneratedRecordLoop, visitOperation, activeRecords,
+      /*executionCountDivisor=*/1);
+}
+
+WalkResult walkPipeNetOpsInProgramOrder(
+    Operation *root, LaunchNodeCoord coord,
+    llvm::function_ref<std::optional<PipeNetRecordLoop>(Operation *)>
+        resolveGeneratedRecordLoop,
+    llvm::function_ref<
+        WalkResult(Operation *, ArrayRef<ActivePipeNetRecord>,
+                   std::optional<std::uint64_t> executionCountDivisor)>
+        visitOperation,
+    SmallVectorImpl<ActivePipeNetRecord> &activeRecords,
+    std::optional<std::uint64_t> executionCountDivisor) {
+  return walkPipeNetOpsInProgramOrderImpl(
+      root, coord, resolveGeneratedRecordLoop, visitOperation, activeRecords,
+      executionCountDivisor);
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/PipePlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.cpp
@@ -83,14 +83,6 @@ PipeModulePlan::getTransferPlan(Operation *operation) const {
   return planIt->second;
 }
 
-static PipeType getPipeType(MLIRContext *context,
-                            const PipeResourceInfo &resources) {
-  const PipeKey &pipe = resources.pipe;
-  return PipeType::get(context, pipe.srcX, pipe.srcY, pipe.dstStartX,
-                       pipe.dstStartY, pipe.dstEndX, pipe.dstEndY,
-                       pipe.pipeNetId);
-}
-
 static FailureOr<PipeSendPlan>
 buildPipeSendPlan(PipeTransferSendOp sendOp,
                   const DominanceInfo &dominanceInfo) {
@@ -378,26 +370,25 @@ buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
   });
 
   DominanceInfo dominanceInfo(module);
-  for (const auto &resourceEntry : plan.resourcePlan.resources) {
-    Operation *operation = resourceEntry.first;
-    const PipeResourceInfo &resources = resourceEntry.second;
+  auto addTransferPlan =
+      [&](Operation *operation, PipeReference pipeReference,
+          PipeTransferPlan::Resources resources) -> LogicalResult {
     auto sendOp = dyn_cast<PipeTransferSendOp>(operation);
     auto postOp = dyn_cast<PipeTransferPostOp>(operation);
-    if (!sendOp && !postOp) {
-      assert(isa<PipeTransferWaitOp>(operation) &&
-             "pipe resources assigned to an unsupported operation");
-      continue;
-    }
+    auto waitOp = dyn_cast<PipeTransferWaitOp>(operation);
+    assert((sendOp || postOp || waitOp) &&
+           "pipe resources assigned to an unsupported operation");
     bool usesCapacityProtocol =
+        (sendOp || postOp) &&
         synchronizationSelection.usesCapacityProtocol(operation);
     PipeSynchronizationProtocol synchronizationProtocol =
         usesCapacityProtocol ? PipeSynchronizationProtocol::Capacity
                              : PipeSynchronizationProtocol::ReceiverPost;
 
-    auto addTransferPlan = [&](auto operationPlan) {
-      PipeTransferPlan transferPlan(getPipeType(module.getContext(), resources),
-                                    resources, synchronizationProtocol,
-                                    std::move(operationPlan));
+    auto insertTransferPlan = [&](PipeTransferPlan::OperationPlan operationPlan) {
+      PipeTransferPlan transferPlan(
+          std::move(pipeReference), std::move(resources),
+          synchronizationProtocol, std::move(operationPlan));
       auto [planIt, inserted] =
           plan.transferPlans.insert({operation, std::move(transferPlan)});
       (void)planIt;
@@ -410,14 +401,49 @@ buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
       if (failed(maybeSendPlan)) {
         return failure();
       }
-      addTransferPlan(*maybeSendPlan);
-    } else {
+      insertTransferPlan(*maybeSendPlan);
+    } else if (postOp) {
+      const PipeResourceInfo &postResources =
+          std::holds_alternative<PipeResourceInfo>(resources)
+              ? std::get<PipeResourceInfo>(resources)
+              : std::get<SmallVector<PipeResourceInfo>>(resources).front();
       FailureOr<PipePostPlan> maybePostPlan =
-          buildPipePostPlan(postOp, resources);
+          buildPipePostPlan(postOp, postResources);
       if (failed(maybePostPlan)) {
         return failure();
       }
-      addTransferPlan(*maybePostPlan);
+      insertTransferPlan(*maybePostPlan);
+    } else {
+      insertTransferPlan(PipeWaitPlan{});
+    }
+    return success();
+  };
+
+  for (const auto &[operation, resources] : plan.resourcePlan.resources) {
+    FailureOr<PipeReference> maybePipeReference =
+        getPipeReferenceForProtocolOp(operation, transferIndex);
+    if (failed(maybePipeReference)) {
+      return failure();
+    }
+    assert(maybePipeReference->isStatic() &&
+           "static resources require a static pipe reference");
+    if (failed(addTransferPlan(operation, std::move(*maybePipeReference),
+                               resources))) {
+      return failure();
+    }
+  }
+  for (const auto &[operation, resources] :
+       plan.resourcePlan.selectedResources) {
+    FailureOr<PipeReference> maybePipeReference =
+        getPipeReferenceForProtocolOp(operation, transferIndex);
+    if (failed(maybePipeReference)) {
+      return failure();
+    }
+    assert(maybePipeReference->isSelected() &&
+           "selected resources require a selected pipe reference");
+    if (failed(addTransferPlan(operation, std::move(*maybePipeReference),
+                               SmallVector<PipeResourceInfo>(resources)))) {
+      return failure();
     }
   }
 

--- a/lib/Dialect/TTL/Transforms/PipePlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.cpp
@@ -385,15 +385,16 @@ buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
         usesCapacityProtocol ? PipeSynchronizationProtocol::Capacity
                              : PipeSynchronizationProtocol::ReceiverPost;
 
-    auto insertTransferPlan = [&](PipeTransferPlan::OperationPlan operationPlan) {
-      PipeTransferPlan transferPlan(
-          std::move(pipeReference), std::move(resources),
-          synchronizationProtocol, std::move(operationPlan));
-      auto [planIt, inserted] =
-          plan.transferPlans.insert({operation, std::move(transferPlan)});
-      (void)planIt;
-      assert(inserted && "pipe operation has more than one transfer plan");
-    };
+    auto insertTransferPlan =
+        [&](PipeTransferPlan::OperationPlan operationPlan) {
+          PipeTransferPlan transferPlan(
+              std::move(pipeReference), std::move(resources),
+              synchronizationProtocol, std::move(operationPlan));
+          auto [planIt, inserted] =
+              plan.transferPlans.insert({operation, std::move(transferPlan)});
+          (void)planIt;
+          assert(inserted && "pipe operation has more than one transfer plan");
+        };
 
     if (sendOp) {
       FailureOr<PipeSendPlan> maybeSendPlan =

--- a/lib/Dialect/TTL/Transforms/PipePlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.cpp
@@ -12,6 +12,7 @@
 #include "ttlang/Dialect/Utils/ConversionUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/CheckedArithmetic.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "ttl-pipe-capacity-analysis"
@@ -83,19 +84,49 @@ PipeModulePlan::getTransferPlan(Operation *operation) const {
   return planIt->second;
 }
 
-static FailureOr<PipeSendPlan>
-buildPipeSendPlan(PipeTransferSendOp sendOp,
-                  const DominanceInfo &dominanceInfo) {
+FailureOr<PipeTransferPayload> getPipeTransferPayload(PipeTransferSendOp sendOp,
+                                                      int64_t blockSpan) {
   FailureOr<CircularBufferType> maybeDFBType =
       utils::getTTLCircularBufferType(sendOp.getSrc());
   if (failed(maybeDFBType)) {
     sendOp.emitError("pipe transfer source must have a TTL DFB type");
     return failure();
   }
-  auto tileType =
-      llvm::dyn_cast<ttcore::TileType>((*maybeDFBType).getElementType());
+  CircularBufferType dfbType = *maybeDFBType;
+  auto tileType = llvm::dyn_cast<ttcore::TileType>(dfbType.getElementType());
   if (!tileType) {
     sendOp.emitError("pipe transfer source DFB element type must be tile");
+    return failure();
+  }
+  if (blockSpan <= 0 || dfbType.getBlockCount() % blockSpan != 0) {
+    sendOp.emitError("source DFB block count must be divisible by pipe "
+                     "transfer block span");
+    return failure();
+  }
+
+  std::optional<int64_t> maybeElementCount =
+      llvm::checkedMul(dfbType.getElementsPerBlock(), blockSpan);
+  if (!maybeElementCount) {
+    sendOp.emitError("pipe transfer element count exceeds int64_t");
+    return failure();
+  }
+  int64_t elementSizeBytes = tileType.getSizeBytes();
+  std::optional<int64_t> maybeSizeBytes =
+      llvm::checkedMul(*maybeElementCount, elementSizeBytes);
+  if (!maybeSizeBytes) {
+    sendOp.emitError("pipe transfer payload size exceeds int64_t");
+    return failure();
+  }
+  return PipeTransferPayload{*maybeElementCount, elementSizeBytes,
+                             *maybeSizeBytes};
+}
+
+static FailureOr<PipeSendPlan>
+buildPipeSendPlan(PipeTransferSendOp sendOp,
+                  const DominanceInfo &dominanceInfo) {
+  FailureOr<PipeTransferPayload> maybePayload =
+      getPipeTransferPayload(sendOp, /*blockSpan=*/1);
+  if (failed(maybePayload)) {
     return failure();
   }
 
@@ -105,12 +136,7 @@ buildPipeSendPlan(PipeTransferSendOp sendOp,
                dominanceInfo.dominates(user, sendOp);
       });
 
-  int64_t elementCount = 1;
-  for (int64_t dimension : (*maybeDFBType).getShape()) {
-    elementCount *= dimension;
-  }
-  return PipeSendPlan{readFromDFB, elementCount * static_cast<int64_t>(
-                                                      tileType.getSizeBytes())};
+  return PipeSendPlan{readFromDFB, maybePayload->sizeBytes};
 }
 
 static FailureOr<PipePostPlan>

--- a/lib/Dialect/TTL/Transforms/PipePlanning.h
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.h
@@ -141,6 +141,17 @@ enum class PipeSynchronizationProtocol {
   Capacity,
 };
 
+/// Element count and byte size transferred by one sender operation.
+struct PipeTransferPayload {
+  int64_t elementCount = 0;
+  int64_t elementSizeBytes = 0;
+  int64_t sizeBytes = 0;
+};
+
+/// Return the payload represented by `blockSpan` consecutive source DFB blocks.
+FailureOr<PipeTransferPayload> getPipeTransferPayload(PipeTransferSendOp sendOp,
+                                                      int64_t blockSpan);
+
 /// Sender-side DFB access and payload size for one transfer.
 struct PipeSendPlan {
   bool usesReadPointer = false;

--- a/lib/Dialect/TTL/Transforms/PipePlanning.h
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.h
@@ -158,14 +158,33 @@ struct PipePostPlan {
   std::optional<PipeReceiverAddressPublicationPlan> addressPublication;
 };
 
-/// Complete lowering decisions for one send or receiver post operation.
+/// Receiver-wait lowering has no operation-specific decisions.
+struct PipeWaitPlan {};
+
+/// Complete lowering decisions for one active pipe protocol operation.
 class PipeTransferPlan {
 public:
-  /// Return the transfer's source, receiver range, and PipeNet id.
-  PipeType getPipeType() const { return pipeType; }
+  /// Return the static or record-selected pipe represented by this operation.
+  const PipeReference &getPipeReference() const { return pipeReference; }
 
-  /// Return the completion, readiness, and address resources.
-  const PipeResourceInfo &getResources() const { return resources; }
+  /// Return whether runtime record selection determines the transfer.
+  bool isSelected() const {
+    return std::holds_alternative<SmallVector<PipeResourceInfo>>(resources);
+  }
+
+  /// Return resources for a statically known transfer.
+  const PipeResourceInfo &getResources() const {
+    assert(!isSelected() &&
+           "static resources requested for a selected transfer");
+    return std::get<PipeResourceInfo>(resources);
+  }
+
+  /// Return the record-indexed resources for a selected transfer.
+  ArrayRef<PipeResourceInfo> getSelectedResources() const {
+    assert(isSelected() &&
+           "selected resources requested for a static transfer");
+    return std::get<SmallVector<PipeResourceInfo>>(resources);
+  }
 
   /// Return the selected sender-readiness protocol.
   PipeSynchronizationProtocol getSynchronizationProtocol() const {
@@ -177,6 +196,16 @@ public:
     return std::holds_alternative<PipeSendPlan>(operationPlan);
   }
 
+  /// Return whether this plan describes a receiver-post operation.
+  bool isPost() const {
+    return std::holds_alternative<PipePostPlan>(operationPlan);
+  }
+
+  /// Return whether this plan describes a receiver-wait operation.
+  bool isWait() const {
+    return std::holds_alternative<PipeWaitPlan>(operationPlan);
+  }
+
   /// Return sender-only lowering information.
   const PipeSendPlan &getSend() const {
     assert(isSend() && "send plan requested for a receiver post");
@@ -185,7 +214,7 @@ public:
 
   /// Return receiver-post-only lowering information.
   const PipePostPlan &getPost() const {
-    assert(!isSend() && "receiver-post plan requested for a send");
+    assert(isPost() && "receiver-post plan requested for another operation");
     return std::get<PipePostPlan>(operationPlan);
   }
 
@@ -195,24 +224,22 @@ private:
                       const PipeTransferIndex &, const PipeGraph &,
                       const PipePlanningOptions &);
 
-  PipeTransferPlan(PipeType pipeType, const PipeResourceInfo &resources,
-                   PipeSynchronizationProtocol synchronizationProtocol,
-                   PipeSendPlan sendPlan)
-      : pipeType(pipeType), resources(resources),
-        synchronizationProtocol(synchronizationProtocol),
-        operationPlan(std::move(sendPlan)) {}
+  using Resources =
+      std::variant<PipeResourceInfo, SmallVector<PipeResourceInfo>>;
+  using OperationPlan = std::variant<PipeSendPlan, PipePostPlan, PipeWaitPlan>;
 
-  PipeTransferPlan(PipeType pipeType, const PipeResourceInfo &resources,
+  PipeTransferPlan(PipeReference pipeReference, Resources resources,
                    PipeSynchronizationProtocol synchronizationProtocol,
-                   PipePostPlan postPlan)
-      : pipeType(pipeType), resources(resources),
+                   OperationPlan operationPlan)
+      : pipeReference(std::move(pipeReference)),
+        resources(std::move(resources)),
         synchronizationProtocol(synchronizationProtocol),
-        operationPlan(std::move(postPlan)) {}
+        operationPlan(std::move(operationPlan)) {}
 
-  PipeType pipeType;
-  PipeResourceInfo resources;
+  PipeReference pipeReference;
+  Resources resources;
   PipeSynchronizationProtocol synchronizationProtocol;
-  std::variant<PipeSendPlan, PipePostPlan> operationPlan;
+  OperationPlan operationPlan;
 };
 
 /// PipeNet decisions shared by all lowering patterns for one module.
@@ -237,7 +264,7 @@ public:
     return completedPipeSendWaits;
   }
 
-  /// Return the lowering plan for an active send or receiver post.
+  /// Return the lowering plan for an active pipe protocol operation.
   const PipeTransferPlan &getTransferPlan(Operation *operation) const;
 
 private:

--- a/lib/Dialect/TTL/Transforms/PipeTransferExpansion.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeTransferExpansion.cpp
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "PipeTransferExpansion.h"
+
+#include "PipeGraph.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "ttlang/Analysis/ValueOriginAnalysis.h"
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+#include "ttlang/Dialect/TTL/Transforms/TransferProvenance.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace mlir::tt::ttl {
+namespace {
+
+/// Convert a semantic transfer contract to its explicit IR enum.
+static PipeTransferKind getPipeTransferKind(PipeTransferContract contract) {
+  return isCollectiveTransfer(contract) ? PipeTransferKind::Collective
+                                        : PipeTransferKind::PointToPoint;
+}
+
+/// Return the contract shared by every possible value of a pipe operand.
+///
+/// Create and selected-pipe operations preserve an explicit collective
+/// contract. A block argument has no defining pipe op, so its type supplies
+/// the contract.
+static FailureOr<PipeTransferContract>
+getPipeTransferContractForPipeValue(ValueOriginAnalysis &analysis, Value pipe) {
+  return analysis.getOrigins(pipe).uniqueMapped<PipeTransferContract>(
+      [](Value origin) -> FailureOr<PipeTransferContract> {
+        if (auto createPipe = origin.getDefiningOp<CreatePipeOp>()) {
+          return getPipeTransferContract(createPipe);
+        }
+        if (auto selectedSrc = origin.getDefiningOp<SelectPipeSrcOp>()) {
+          return getPipeTransferContract(
+              selectedSrc.getRecords().getPipes().front());
+        }
+        if (auto selectedDst = origin.getDefiningOp<SelectPipeDstOp>()) {
+          return getPipeTransferContract(
+              selectedDst.getRecords().getPipes().front());
+        }
+        if (isa<BlockArgument>(origin) && isa<PipeType>(origin.getType())) {
+          return cast<PipeType>(origin.getType()).hasMultipleReceivers()
+                     ? PipeTransferContract::Collective
+                     : PipeTransferContract::PointToPoint;
+        }
+        return failure();
+      });
+}
+
+/// Create one scalar transfer reference for `pipe`.
+static PipeTransferCreateOp createPipeTransfer(OpBuilder &builder,
+                                               Location location, Value pipe,
+                                               PipeTransferContract contract) {
+  auto kindAttr = PipeTransferKindAttr::get(builder.getContext(),
+                                            getPipeTransferKind(contract));
+  return PipeTransferCreateOp::create(
+      builder, location, PipeTransferType::get(builder.getContext()), pipe,
+      kindAttr);
+}
+
+/// Return the PipeNet id encoded by a static or selected pipe value.
+static FailureOr<int64_t> getPipeNetIdForPipeValue(Operation *operation,
+                                                   Value pipe) {
+  FailureOr<PipeReference> pipeRef = getPipeReference(operation, pipe);
+  if (failed(pipeRef)) {
+    return failure();
+  }
+  return pipeRef->getPipeNetId();
+}
+
+/// Reuse a transfer for a direct create op or create one at the use site.
+static Value getOrCreatePipeTransfer(
+    OpBuilder &builder, Location location, Value pipe,
+    PipeTransferContract contract,
+    llvm::MapVector<Value, Value> &transferByDirectCreatePipe) {
+  Value key = traceUnrealizedCasts(pipe);
+  if (auto createPipe = key.getDefiningOp<CreatePipeOp>()) {
+    auto transferIt = transferByDirectCreatePipe.find(key);
+    if (transferIt != transferByDirectCreatePipe.end()) {
+      return transferIt->second;
+    }
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointAfter(createPipe);
+    auto transferOp =
+        createPipeTransfer(builder, createPipe.getLoc(), key, contract);
+    transferByDirectCreatePipe[key] = transferOp.getTransfer();
+    return transferOp.getTransfer();
+  }
+
+  // A shared transfer for block arguments and region results would require a
+  // new dominance choice. Keeping it at the use preserves current semantics.
+  return createPipeTransfer(builder, location, pipe, contract).getTransfer();
+}
+
+/// High-level pipe copy and its proven transfer contract.
+struct PipeCopyExpansion {
+  CopyOp copy;
+  PipeTransferContract contract;
+  std::optional<int64_t> pipeNetId;
+};
+
+/// Receive-handle wait and the PipeNet id used to create its typed token.
+struct PipeReceiveWaitExpansion {
+  WaitOp wait;
+  int64_t pipeNetId = 0;
+};
+
+/// Operations replaced when high-level pipe copies become pipe transfer IR.
+struct PipeTransferExpansionPlan {
+  SmallVector<CreatePipeOp> createPipes;
+  SmallVector<PipeCopyExpansion> receiveCopies;
+  SmallVector<PipeCopyExpansion> sendCopies;
+  SmallVector<PipeReceiveWaitExpansion> receiveWaits;
+  SmallVector<WaitOp> unreachableReceiveWaits;
+};
+
+/// Collect every replacement before expansion invalidates origin analysis.
+static FailureOr<PipeTransferExpansionPlan>
+buildPipeTransferExpansionPlan(ModuleOp module, ValueOriginAnalysis &analysis) {
+  PipeTransferExpansionPlan plan;
+  module.walk([&](CreatePipeOp op) { plan.createPipes.push_back(op); });
+
+  LogicalResult result = success();
+  module.walk([&](CopyOp op) {
+    if (isPipeReceiveCopy(op)) {
+      FailureOr<PipeTransferContract> contract =
+          getPipeTransferContractForPipeValue(analysis, op.getSrc());
+      if (failed(contract)) {
+        op.emitError()
+            << "requires a consistent transfer contract for all possible "
+               "pipe values";
+        result = failure();
+      } else {
+        FailureOr<int64_t> pipeNetId =
+            getPipeNetIdForPipeValue(op, op.getSrc());
+        if (failed(pipeNetId)) {
+          result = failure();
+        } else {
+          plan.receiveCopies.push_back({op, *contract, *pipeNetId});
+        }
+      }
+      return;
+    }
+    if (isPipeSendCopy(op)) {
+      FailureOr<PipeTransferContract> contract =
+          getPipeTransferContractForPipeValue(analysis, op.getDst());
+      if (failed(contract)) {
+        op.emitError()
+            << "requires a consistent transfer contract for all possible "
+               "pipe values";
+        result = failure();
+      } else {
+        plan.sendCopies.push_back({op, *contract, std::nullopt});
+      }
+    }
+  });
+  if (failed(result)) {
+    return failure();
+  }
+
+  module.walk([&](WaitOp waitOp) {
+    auto handleType =
+        mlir::dyn_cast<TransferHandleType>(waitOp.getXf().getType());
+    if (!handleType || handleType.getKind()) {
+      return;
+    }
+    if (analysis.getOrigins(waitOp.getXf()).empty()) {
+      plan.unreachableReceiveWaits.push_back(waitOp);
+      return;
+    }
+    FailureOr<std::optional<CopyOp>> maybeCopyOp =
+        findUniquePipeReceiveCopy(analysis, waitOp.getXf());
+    if (failed(maybeCopyOp) || !*maybeCopyOp) {
+      waitOp.emitError() << "untyped transfer handle wait requires every "
+                            "possible source to be the same pipe receive "
+                            "ttl.copy";
+      result = failure();
+      return;
+    }
+    CopyOp copyOp = **maybeCopyOp;
+    FailureOr<int64_t> pipeNetId =
+        getPipeNetIdForPipeValue(waitOp, copyOp.getSrc());
+    if (failed(pipeNetId)) {
+      result = failure();
+      return;
+    }
+    plan.receiveWaits.push_back({waitOp, *pipeNetId});
+  });
+  if (failed(result)) {
+    return failure();
+  }
+  return plan;
+}
+
+/// Apply a complete expansion plan without querying invalidated analysis.
+static void
+applyPipeTransferExpansionPlan(ModuleOp module,
+                               const PipeTransferExpansionPlan &plan) {
+  // An unreachable receive handle has no observable completion to wait for.
+  for (WaitOp waitOp : plan.unreachableReceiveWaits) {
+    waitOp.erase();
+  }
+
+  OpBuilder builder(module.getContext());
+  llvm::MapVector<Value, Value> transferByDirectCreatePipe;
+  for (CreatePipeOp createPipe : plan.createPipes) {
+    builder.setInsertionPointAfter(createPipe);
+    auto transferOp =
+        createPipeTransfer(builder, createPipe.getLoc(), createPipe.getResult(),
+                           getPipeTransferContract(createPipe));
+    transferByDirectCreatePipe[createPipe.getResult()] =
+        transferOp.getTransfer();
+  }
+
+  for (const PipeCopyExpansion &expansion : plan.receiveCopies) {
+    CopyOp copyOp = expansion.copy;
+    assert(expansion.pipeNetId && "receiver expansion is missing PipeNet id");
+    builder.setInsertionPoint(copyOp);
+    Value transfer =
+        getOrCreatePipeTransfer(builder, copyOp.getLoc(), copyOp.getSrc(),
+                                expansion.contract, transferByDirectCreatePipe);
+    auto postOp = PipeTransferPostOp::create(
+        builder, copyOp.getLoc(),
+        PipeTokenType::get(builder.getContext(), *expansion.pipeNetId),
+        transfer, copyOp.getDst());
+    auto handleCast = UnrealizedConversionCastOp::create(
+        builder, copyOp.getLoc(), copyOp.getResult().getType(),
+        ValueRange{postOp.getToken()});
+    copyOp.getResult().replaceAllUsesWith(handleCast.getResult(0));
+    copyOp->erase();
+  }
+
+  for (const PipeCopyExpansion &expansion : plan.sendCopies) {
+    CopyOp copyOp = expansion.copy;
+    builder.setInsertionPoint(copyOp);
+    Value transfer =
+        getOrCreatePipeTransfer(builder, copyOp.getLoc(), copyOp.getDst(),
+                                expansion.contract, transferByDirectCreatePipe);
+    auto sendOp = PipeTransferSendOp::create(builder, copyOp.getLoc(),
+                                             copyOp.getResult().getType(),
+                                             transfer, copyOp.getSrc());
+    copyOp.getResult().replaceAllUsesWith(sendOp.getXf());
+    copyOp->erase();
+  }
+
+  for (const PipeReceiveWaitExpansion &wait : plan.receiveWaits) {
+    WaitOp waitOp = wait.wait;
+    builder.setInsertionPoint(waitOp);
+    auto tokenCast = UnrealizedConversionCastOp::create(
+        builder, waitOp.getLoc(),
+        PipeTokenType::get(builder.getContext(), wait.pipeNetId),
+        ValueRange{waitOp.getXf()});
+    PipeTransferWaitOp::create(builder, waitOp.getLoc(),
+                               tokenCast.getResult(0));
+    waitOp->erase();
+  }
+}
+
+} // namespace
+
+LogicalResult expandPipeTransfers(ModuleOp module,
+                                  ValueOriginAnalysis &analysis) {
+  FailureOr<PipeTransferExpansionPlan> maybePlan =
+      buildPipeTransferExpansionPlan(module, analysis);
+  if (failed(maybePlan)) {
+    return failure();
+  }
+  applyPipeTransferExpansionPlan(module, *maybePlan);
+  return success();
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/PipeTransferExpansion.h
+++ b/lib/Dialect/TTL/Transforms/PipeTransferExpansion.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//===----------------------------------------------------------------------===//
+// Pipe Transfer Expansion
+//===----------------------------------------------------------------------===//
+//
+// This file declares conversion from high-level pipe copies to explicit pipe
+// transfer operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_PIPETRANSFEREXPANSION_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_PIPETRANSFEREXPANSION_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt {
+class ValueOriginAnalysis;
+}
+
+namespace mlir::tt::ttl {
+
+/// Replace high-level pipe copies and waits with explicit pipe transfer IR.
+LogicalResult expandPipeTransfers(ModuleOp module,
+                                  ValueOriginAnalysis &analysis);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_PIPETRANSFEREXPANSION_H

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -23,8 +23,8 @@
 #include "ttlang/Dialect/TTL/Passes.h"
 #include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
-#include "ttlang/Dialect/TTL/Transforms/PipeTransferAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h"
+#include "ttlang/Dialect/TTL/Transforms/PipeTransferAnalysis.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
@@ -185,8 +185,7 @@ struct ModuleState {
                                 PipeEventKind kind,
                                 const LaunchNodeDomain &domain,
                                 Operation *unanalyzableOp,
-                                Operation *receivePost,
-                                Operation *foreachOp,
+                                Operation *receivePost, Operation *foreachOp,
                                 SmallVectorImpl<PipeEvent> &events) {
     PipeRole role =
         kind == PipeEventKind::Send ? PipeRole::Source : PipeRole::Destination;
@@ -199,10 +198,9 @@ struct ModuleState {
           role == PipeRole::Source
               ? getPipeRecordSourceLaunchNodeDomain(record)
               : getPipeRecordDestinationLaunchNodeDomain(record);
-      events.push_back(PipeEvent{op, pipeType, kind,
-                                 domain.intersectWith(roleDomain),
-                                 unanalyzableOp, receivePost, foreachOp,
-                                 static_cast<int64_t>(recordIndex)});
+      events.push_back(PipeEvent{
+          op, pipeType, kind, domain.intersectWith(roleDomain), unanalyzableOp,
+          receivePost, foreachOp, static_cast<int64_t>(recordIndex)});
     }
   }
 
@@ -221,19 +219,18 @@ struct ModuleState {
     }
     if (std::optional<SelectedPipeRecords> selected =
             getSelectedPipeRecords(copyOp.getDst())) {
-      appendSelectedPipeEvents(op, selected->records, PipeEventKind::Send,
-                               domain, unanalyzableOp,
-                               /*receivePost=*/nullptr, selected->foreachOp,
-                               events);
+      appendSelectedPipeEvents(
+          op, selected->records, PipeEventKind::Send, domain, unanalyzableOp,
+          /*receivePost=*/nullptr, selected->foreachOp, events);
       return events;
     }
     if (auto pipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
       if (isPipeReceiveCopy(copyOp)) {
-        events.push_back(PipeEvent{
-            op, pipeType, PipeEventKind::ReceivePost,
-            domain.intersectWith(getPipeDestinationLaunchNodeDomain(
-                pipeType, launchDomains.baseDomain)),
-            unanalyzableOp, nullptr, nullptr, -1});
+        events.push_back(
+            PipeEvent{op, pipeType, PipeEventKind::ReceivePost,
+                      domain.intersectWith(getPipeDestinationLaunchNodeDomain(
+                          pipeType, launchDomains.baseDomain)),
+                      unanalyzableOp, nullptr, nullptr, -1});
       }
       return events;
     }
@@ -267,17 +264,16 @@ struct ModuleState {
     SmallVector<PipeEvent> events;
     Operation *op = waitOp.getOperation();
     if (auto pipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
-      events.push_back(PipeEvent{
-          op, pipeType, PipeEventKind::ReceiveWait,
-          domain.intersectWith(getPipeDestinationLaunchNodeDomain(
-              pipeType, launchDomains.baseDomain)),
-          unanalyzableOp, copyOp.getOperation(), nullptr, -1});
+      events.push_back(
+          PipeEvent{op, pipeType, PipeEventKind::ReceiveWait,
+                    domain.intersectWith(getPipeDestinationLaunchNodeDomain(
+                        pipeType, launchDomains.baseDomain)),
+                    unanalyzableOp, copyOp.getOperation(), nullptr, -1});
     } else if (std::optional<SelectedPipeRecords> selected =
                    getSelectedPipeRecords(copyOp.getSrc())) {
-      appendSelectedPipeEvents(op, selected->records,
-                               PipeEventKind::ReceiveWait, domain,
-                               unanalyzableOp, copyOp.getOperation(),
-                               selected->foreachOp, events);
+      appendSelectedPipeEvents(
+          op, selected->records, PipeEventKind::ReceiveWait, domain,
+          unanalyzableOp, copyOp.getOperation(), selected->foreachOp, events);
     }
 
     replacePipeEvents(op, std::move(events));
@@ -1806,9 +1802,9 @@ void verifyPipeScheduleCycles(ModuleOp module, ModuleState &state) {
                         nodes, *matchingNodes, event, function, state))) {
                   return WalkResult::interrupt();
                 }
-                PipeScheduleNodeId nodeId = addPipeScheduleNode(
-                    nodes, event, coord, function, activeCallSites,
-                    executionCountDivisor);
+                PipeScheduleNodeId nodeId =
+                    addPipeScheduleNode(nodes, event, coord, function,
+                                        activeCallSites, executionCountDivisor);
                 ++scheduleNodeCount;
                 matchingNodes->push_back(nodeId);
                 if (event.kind == PipeEventKind::ReceivePost) {
@@ -1984,36 +1980,64 @@ validatePipeNetReferences(ModuleOp module,
   return result;
 }
 
+/// Verify that one declared pipe relation belongs to the module launch grid.
+LogicalResult
+validatePipeRelationEndpoints(Operation *declaration, PipeType pipeType,
+                              const LaunchNodeDomain &launchDomain) {
+  LaunchNodeCoord source{pipeType.getSrcX(), pipeType.getSrcY()};
+  if (!knownLaunchNodeDomainContains(launchDomain, source)) {
+    return declaration->emitOpError()
+           << "declares source core_x=" << source.x << ", core_y=" << source.y
+           << " outside the module `ttl.launch_grid`";
+  }
+  LaunchNodeCoord destinationStart{pipeType.getDstStartX(),
+                                   pipeType.getDstStartY()};
+  LaunchNodeCoord destinationEnd{pipeType.getDstEndX(), pipeType.getDstEndY()};
+  if (!knownLaunchNodeDomainContains(launchDomain, destinationStart) ||
+      !knownLaunchNodeDomainContains(launchDomain, destinationEnd)) {
+    return declaration->emitOpError()
+           << "declares destination range core_x=" << pipeType.getDstStartX()
+           << ".." << pipeType.getDstEndX()
+           << ", core_y=" << pipeType.getDstStartY() << ".."
+           << pipeType.getDstEndY() << " outside the module `ttl.launch_grid`";
+  }
+  return success();
+}
+
 /// Verify that every declared pipe endpoint belongs to the module launch grid.
 LogicalResult
 validatePipeEndpoints(ModuleOp module,
                       const LaunchNodeDomainState &launchDomains) {
   LogicalResult result = success();
-  module.walk([&](CreatePipeOp pipe) {
-    PipeType pipeType = mlir::cast<PipeType>(pipe.getResult().getType());
-    LaunchNodeCoord source{pipeType.getSrcX(), pipeType.getSrcY()};
-    if (!knownLaunchNodeDomainContains(launchDomains.baseDomain, source)) {
-      pipe.emitOpError() << "declares source core_x=" << source.x
-                         << ", core_y=" << source.y
-                         << " outside the module `ttl.launch_grid`";
-      result = failure();
+  llvm::DenseSet<PipeNetRecordsAttr> validatedRecordTables;
+  module.walk([&](Operation *op) {
+    if (auto pipe = mlir::dyn_cast<CreatePipeOp>(op)) {
+      PipeType pipeType = mlir::cast<PipeType>(pipe.getResult().getType());
+      if (failed(validatePipeRelationEndpoints(op, pipeType,
+                                               launchDomains.baseDomain))) {
+        result = failure();
+      }
       return;
     }
-    LaunchNodeCoord destinationStart{pipeType.getDstStartX(),
-                                     pipeType.getDstStartY()};
-    LaunchNodeCoord destinationEnd{pipeType.getDstEndX(),
-                                   pipeType.getDstEndY()};
-    if (!knownLaunchNodeDomainContains(launchDomains.baseDomain,
-                                       destinationStart) ||
-        !knownLaunchNodeDomainContains(launchDomains.baseDomain,
-                                       destinationEnd)) {
-      pipe.emitOpError() << "declares destination range core_x="
-                         << pipeType.getDstStartX() << ".."
-                         << pipeType.getDstEndX()
-                         << ", core_y=" << pipeType.getDstStartY() << ".."
-                         << pipeType.getDstEndY()
-                         << " outside the module `ttl.launch_grid`";
-      result = failure();
+
+    PipeNetRecordsAttr records =
+        llvm::TypeSwitch<Operation *, PipeNetRecordsAttr>(op)
+            .Case<PipeNetForeachSrcOp, PipeNetForeachDstOp, SelectPipeSrcOp,
+                  SelectPipeDstOp>(
+                [](auto recordsOp) { return recordsOp.getRecords(); })
+            .Default(PipeNetRecordsAttr());
+    if (!records || !validatedRecordTables.insert(records).second) {
+      return;
+    }
+    for (PipeRecordAttr record : records.getPipes()) {
+      PipeType pipeType = PipeType::get(
+          records.getContext(), record.getSrcX(), record.getSrcY(),
+          record.getDstStartX(), record.getDstStartY(), record.getDstEndX(),
+          record.getDstEndY(), records.getPipeNetId());
+      if (failed(validatePipeRelationEndpoints(op, pipeType,
+                                               launchDomains.baseDomain))) {
+        result = failure();
+      }
     }
   });
   return result;

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -5,9 +5,10 @@
 //===----------------------------------------------------------------------===//
 // Verify the launch-node domains and synchronization schedules of PipeNet
 // operations. Launch-node dataflow determines where each operation can execute.
-// The guard pass checks those domains against PipeNet roles. The schedule pass
-// uses the same domains to prove event correspondence and reject wait-for
-// cycles.
+// The guard pass checks those domains against PipeNet roles, including
+// table-selected source and destination records. The schedule pass expands
+// direct calls and record callbacks to prove event correspondence and reject
+// wait-for cycles in execution order.
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Analysis/DataFlow/Utils.h"
@@ -90,7 +91,58 @@ struct PipeEvent {
   Operation *unanalyzableOp = nullptr;
   /// Receive post whose token is observed by a receive-wait event.
   Operation *receivePost = nullptr;
+  Operation *selectedForeachOp = nullptr;
+  int64_t selectedRecordIndex = -1;
 };
+
+/// Pipe records and selection context represented by one selected-pipe value.
+struct SelectedPipeRecords {
+  PipeNetRecordsAttr records;
+  PipeRole role = PipeRole::Active;
+  Operation *foreachOp = nullptr;
+};
+
+std::optional<SelectedPipeRecords> getSelectedPipeRecords(Value pipe) {
+  pipe = traceUnrealizedCasts(pipe);
+  if (auto selectedSrc = pipe.getDefiningOp<SelectPipeSrcOp>()) {
+    return SelectedPipeRecords{selectedSrc.getRecords(), PipeRole::Source,
+                               nullptr};
+  }
+  if (auto selectedDst = pipe.getDefiningOp<SelectPipeDstOp>()) {
+    return SelectedPipeRecords{selectedDst.getRecords(), PipeRole::Destination,
+                               nullptr};
+  }
+  auto blockArg = mlir::dyn_cast<BlockArgument>(pipe);
+  if (!blockArg || blockArg.getArgNumber() != 0) {
+    return std::nullopt;
+  }
+  Operation *owner = blockArg.getOwner()->getParentOp();
+  if (auto foreachSrc = mlir::dyn_cast<PipeNetForeachSrcOp>(owner)) {
+    return SelectedPipeRecords{foreachSrc.getRecords(), PipeRole::Source,
+                               owner};
+  }
+  if (auto foreachDst = mlir::dyn_cast<PipeNetForeachDstOp>(owner)) {
+    return SelectedPipeRecords{foreachDst.getRecords(), PipeRole::Destination,
+                               owner};
+  }
+  return std::nullopt;
+}
+
+std::optional<SelectedPipeRecords> getSelectedSourceRecords(Value pipe) {
+  std::optional<SelectedPipeRecords> selected = getSelectedPipeRecords(pipe);
+  if (selected && selected->role == PipeRole::Source) {
+    return selected;
+  }
+  return std::nullopt;
+}
+
+std::optional<SelectedPipeRecords> getSelectedDestinationRecords(Value pipe) {
+  std::optional<SelectedPipeRecords> selected = getSelectedPipeRecords(pipe);
+  if (selected && selected->role == PipeRole::Destination) {
+    return selected;
+  }
+  return std::nullopt;
+}
 
 struct ModuleState;
 void checkKnownSubset(Operation *op, const LaunchNodeDomain &current,
@@ -121,37 +173,106 @@ struct ModuleState {
   llvm::DenseMap<int64_t, LaunchNodeDomain> dfbProducerDomains;
   SmallVector<WaitUse> waitUses;
   SmallVector<PipeEvent> pipeEvents;
-  llvm::DenseMap<Operation *, std::size_t> pipeEventIndices;
+  llvm::DenseMap<Operation *, SmallVector<std::size_t>> pipeEventIndices;
+
+  /// Replace the events for one operation after a dataflow update.
+  void replacePipeEvents(Operation *op, SmallVector<PipeEvent> events) {
+    if (events.empty()) {
+      return;
+    }
+    auto it = pipeEventIndices.find(op);
+    if (it == pipeEventIndices.end()) {
+      SmallVector<std::size_t> indices;
+      indices.reserve(events.size());
+      for (PipeEvent &event : events) {
+        indices.push_back(pipeEvents.size());
+        pipeEvents.push_back(event);
+      }
+      pipeEventIndices.try_emplace(op, std::move(indices));
+      return;
+    }
+
+    assert(it->second.size() == events.size() &&
+           "pipe event count for an op changed during analysis");
+    for (auto [index, event] : llvm::zip_equal(it->second, events)) {
+      pipeEvents[index] = event;
+    }
+  }
+
+  /// Append one event for each selected record represented by `op`.
+  void appendSelectedPipeEvents(Operation *op, PipeNetRecordsAttr records,
+                                PipeEventKind kind,
+                                const LaunchNodeDomain &domain,
+                                Operation *unanalyzableOp,
+                                Operation *receivePost,
+                                Operation *foreachOp,
+                                SmallVectorImpl<PipeEvent> &events) {
+    PipeRole role =
+        kind == PipeEventKind::Send ? PipeRole::Source : PipeRole::Destination;
+    for (auto [recordIndex, record] : llvm::enumerate(records.getPipes())) {
+      PipeType pipeType = PipeType::get(
+          records.getContext(), record.getSrcX(), record.getSrcY(),
+          record.getDstStartX(), record.getDstStartY(), record.getDstEndX(),
+          record.getDstEndY(), records.getPipeNetId());
+      LaunchNodeDomain roleDomain =
+          role == PipeRole::Source
+              ? getPipeRecordSourceLaunchNodeDomain(record)
+              : getPipeRecordDestinationLaunchNodeDomain(record);
+      events.push_back(PipeEvent{op, pipeType, kind,
+                                 domain.intersectWith(roleDomain),
+                                 unanalyzableOp, receivePost, foreachOp,
+                                 static_cast<int64_t>(recordIndex)});
+    }
+  }
+
+  /// Return the direct or selected-record events represented by `copyOp`.
+  SmallVector<PipeEvent> getPipeCopyEvents(CopyOp copyOp,
+                                           const LaunchNodeDomain &domain,
+                                           Operation *unanalyzableOp) {
+    SmallVector<PipeEvent> events;
+    Operation *op = copyOp.getOperation();
+    if (auto pipeType = mlir::dyn_cast<PipeType>(copyOp.getDst().getType())) {
+      events.push_back(PipeEvent{
+          op, pipeType, PipeEventKind::Send,
+          domain.intersectWith(getPipeSourceLaunchNodeDomain(pipeType)),
+          unanalyzableOp, nullptr, nullptr, -1});
+      return events;
+    }
+    if (std::optional<SelectedPipeRecords> selected =
+            getSelectedSourceRecords(copyOp.getDst())) {
+      appendSelectedPipeEvents(op, selected->records, PipeEventKind::Send,
+                               domain, unanalyzableOp,
+                               /*receivePost=*/nullptr, selected->foreachOp,
+                               events);
+      return events;
+    }
+    if (auto pipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
+      if (isPipeReceiveCopy(copyOp)) {
+        events.push_back(PipeEvent{
+            op, pipeType, PipeEventKind::ReceivePost,
+            domain.intersectWith(getPipeDestinationLaunchNodeDomain(
+                pipeType, launchDomains.baseDomain)),
+            unanalyzableOp, nullptr, nullptr, -1});
+      }
+      return events;
+    }
+    if (std::optional<SelectedPipeRecords> selected =
+            getSelectedDestinationRecords(copyOp.getSrc())) {
+      if (isPipeReceiveCopy(copyOp)) {
+        appendSelectedPipeEvents(op, selected->records,
+                                 PipeEventKind::ReceivePost, domain,
+                                 unanalyzableOp, /*receivePost=*/nullptr,
+                                 selected->foreachOp, events);
+      }
+    }
+    return events;
+  }
 
   /// Record pipe sends and receive posts from `ttl.copy` operations.
   void recordPipeEvent(CopyOp copyOp, const LaunchNodeDomain &domain,
                        Operation *unanalyzableOp) {
-    PipeEvent event;
-    event.op = copyOp.getOperation();
-    if (isPipeSendCopy(copyOp)) {
-      auto pipeType = mlir::cast<PipeType>(copyOp.getDst().getType());
-      event.pipeType = pipeType;
-      event.kind = PipeEventKind::Send;
-      event.domain =
-          domain.intersectWith(getPipeSourceLaunchNodeDomain(pipeType));
-    } else if (isPipeReceiveCopy(copyOp)) {
-      auto pipeType = mlir::cast<PipeType>(copyOp.getSrc().getType());
-      event.pipeType = pipeType;
-      event.kind = PipeEventKind::ReceivePost;
-      event.domain = domain.intersectWith(getPipeDestinationLaunchNodeDomain(
-          pipeType, launchDomains.baseDomain));
-    } else {
-      return;
-    }
-    event.unanalyzableOp = unanalyzableOp;
-
-    auto [it, inserted] =
-        pipeEventIndices.try_emplace(copyOp.getOperation(), pipeEvents.size());
-    if (inserted) {
-      pipeEvents.push_back(event);
-      return;
-    }
-    pipeEvents[it->second] = event;
+    replacePipeEvents(copyOp.getOperation(),
+                      getPipeCopyEvents(copyOp, domain, unanalyzableOp));
   }
 
   /// Record a receive completion wait for schedule verification.
@@ -162,24 +283,23 @@ struct ModuleState {
       return;
     }
     CopyOp copyOp = *maybeCopyOp;
-    auto pipeType = mlir::cast<PipeType>(copyOp.getSrc().getType());
-
-    PipeEvent event;
-    event.op = waitOp.getOperation();
-    event.pipeType = pipeType;
-    event.kind = PipeEventKind::ReceiveWait;
-    event.domain = domain.intersectWith(
-        getPipeDestinationLaunchNodeDomain(pipeType, launchDomains.baseDomain));
-    event.unanalyzableOp = unanalyzableOp;
-    event.receivePost = copyOp.getOperation();
-
-    auto [it, inserted] =
-        pipeEventIndices.try_emplace(waitOp.getOperation(), pipeEvents.size());
-    if (inserted) {
-      pipeEvents.push_back(event);
-      return;
+    SmallVector<PipeEvent> events;
+    Operation *op = waitOp.getOperation();
+    if (auto pipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
+      events.push_back(PipeEvent{
+          op, pipeType, PipeEventKind::ReceiveWait,
+          domain.intersectWith(getPipeDestinationLaunchNodeDomain(
+              pipeType, launchDomains.baseDomain)),
+          unanalyzableOp, copyOp.getOperation(), nullptr, -1});
+    } else if (std::optional<SelectedPipeRecords> selected =
+                   getSelectedDestinationRecords(copyOp.getSrc())) {
+      appendSelectedPipeEvents(op, selected->records,
+                               PipeEventKind::ReceiveWait, domain,
+                               unanalyzableOp, copyOp.getOperation(),
+                               selected->foreachOp, events);
     }
-    pipeEvents[it->second] = event;
+
+    replacePipeEvents(op, std::move(events));
   }
 };
 
@@ -389,6 +509,23 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
                      msg, {{netId, PipeRole::Source}}, state);
     return;
   }
+  if (std::optional<SelectedPipeRecords> selected =
+          getSelectedSourceRecords(copyOp.getDst())) {
+    int64_t netId = selected->records.getPipeNetId();
+    std::string name = state.launchDomains.netName(netId);
+    std::string msg;
+    llvm::raw_string_ostream(msg)
+        << "this `ttl.copy(buffer, pipe)` sends data on PipeNet " << name
+        << " from a node that is not a source of any pipe in that net; "
+           "wrap the copy in `"
+        << name << ".if_src(...)` or guard with `if " << name
+        << ".is_src(): ...`";
+    checkKnownSubset(
+        copyOp, current,
+        getPipeRecordsRoleLaunchNodeDomain(selected->records, PipeRole::Source),
+        unanalyzable, msg, {{netId, PipeRole::Source}}, state);
+    return;
+  }
   if (auto srcPipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
     int64_t netId = srcPipeType.getPipeNetId();
     std::string name = state.launchDomains.netName(netId);
@@ -402,6 +539,24 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
     checkKnownSubset(copyOp, current,
                      getPipeDestinationLaunchNodeDomain(
                          srcPipeType, state.launchDomains.baseDomain),
+                     unanalyzable, msg, {{netId, PipeRole::Destination}},
+                     state);
+    return;
+  }
+  if (std::optional<SelectedPipeRecords> selected =
+          getSelectedDestinationRecords(copyOp.getSrc())) {
+    int64_t netId = selected->records.getPipeNetId();
+    std::string name = state.launchDomains.netName(netId);
+    std::string msg;
+    llvm::raw_string_ostream(msg)
+        << "this `ttl.copy(pipe, buffer)` receives data from PipeNet " << name
+        << " on a node that is not a destination of any pipe in that "
+           "net; wrap the copy in `"
+        << name << ".if_dst(...)` or guard with `if " << name
+        << ".is_dst(): ...`";
+    checkKnownSubset(copyOp, current,
+                     getPipeRecordsRoleLaunchNodeDomain(selected->records,
+                                                        PipeRole::Destination),
                      unanalyzable, msg, {{netId, PipeRole::Destination}},
                      state);
   }
@@ -552,6 +707,7 @@ struct PipeScheduleNode {
   Operation *receivePost;
   func::FuncOp kernelFunction;
   SmallVector<PipeCallSite> callSites;
+  std::optional<std::uint64_t> executionCountDivisor;
   SmallVector<PipeScheduleEdge> successors;
 };
 
@@ -590,7 +746,9 @@ PipeScheduleNodeId addPipeScheduleNode(SmallVectorImpl<PipeScheduleNode> &nodes,
                                        const PipeEvent &event,
                                        LaunchNodeCoord coord,
                                        func::FuncOp kernelFunction,
-                                       ArrayRef<PipeCallSite> callSites) {
+                                       ArrayRef<PipeCallSite> callSites,
+                                       std::optional<std::uint64_t>
+                                           executionCountDivisor) {
   PipeScheduleNodeId nodeId = nodes.size();
   nodes.push_back({event.op,
                    event.pipeType,
@@ -599,6 +757,7 @@ PipeScheduleNodeId addPipeScheduleNode(SmallVectorImpl<PipeScheduleNode> &nodes,
                    event.receivePost,
                    kernelFunction,
                    SmallVector<PipeCallSite>(callSites),
+                   executionCountDivisor,
                    {}});
   return nodeId;
 }
@@ -996,6 +1155,16 @@ getPipeExecutionCountExpression(const PipeScheduleNode &node,
   }
   if (failed(collectFactor(node.op))) {
     return std::nullopt;
+  }
+  if (!node.executionCountDivisor) {
+    return std::nullopt;
+  }
+  if (*node.executionCountDivisor != 1) {
+    if (!expression.unresolvedOps.empty() ||
+        expression.constantFactor % *node.executionCountDivisor != 0) {
+      return std::nullopt;
+    }
+    expression.constantFactor /= *node.executionCountDivisor;
   }
   return expression;
 }
@@ -1457,24 +1626,110 @@ LogicalResult verifyPipeEventDomainsKnown(const ModuleState &state) {
   return result;
 }
 
-/// Visit pipe events in the order executed by one kernel thread. Direct helper
-/// calls are expanded at each call site so their events retain caller order and
-/// invocation multiplicity.
+using ActiveForeachRecord = std::pair<Operation *, int64_t>;
+
+std::optional<int64_t>
+getActiveForeachRecordIndex(ArrayRef<ActiveForeachRecord> activeRecords,
+                            Operation *foreachOp) {
+  auto activeIt = llvm::find_if(llvm::reverse(activeRecords),
+                                [&](const ActiveForeachRecord &active) {
+                                  return active.first == foreachOp;
+                                });
+  if (activeIt == activeRecords.rend()) {
+    return std::nullopt;
+  }
+  return activeIt->second;
+}
+
+/// Visit pipe events in the order executed by one kernel thread.
+///
+/// Direct helper calls are expanded at each call site. A PipeNet foreach body
+/// is expanded once per matching record before execution continues after the
+/// foreach operation.
 WalkResult walkPipeEventsInProgramOrder(
     Operation *op, LaunchNodeCoord coord, ModuleState &state,
     const llvm::DenseSet<Operation *> &functionsWithPipeEvents,
     SymbolTableCollection &symbolTables,
     SmallVectorImpl<func::FuncOp> &activeFunctions,
     SmallVectorImpl<PipeCallSite> &callSites,
+    SmallVectorImpl<ActiveForeachRecord> &activeRecords,
+    std::optional<std::uint64_t> executionCountDivisor,
     llvm::DenseSet<Operation *> &diagnosedRecursiveCalls,
-    llvm::function_ref<WalkResult(const PipeEvent &, ArrayRef<PipeCallSite>)>
+    llvm::function_ref<WalkResult(const PipeEvent &, ArrayRef<PipeCallSite>,
+                                  std::optional<std::uint64_t>)>
         visitEvent) {
+  PipeNetRecordsAttr foreachRecords;
+  PipeRole foreachRole = PipeRole::Active;
+  if (auto foreachSrc = mlir::dyn_cast<PipeNetForeachSrcOp>(op)) {
+    foreachRecords = foreachSrc.getRecords();
+    foreachRole = PipeRole::Source;
+  } else if (auto foreachDst = mlir::dyn_cast<PipeNetForeachDstOp>(op)) {
+    foreachRecords = foreachDst.getRecords();
+    foreachRole = PipeRole::Destination;
+  }
+
+  if (foreachRecords) {
+    SmallVector<int64_t> matchingRecordIndices;
+    for (auto [recordIndex, record] :
+         llvm::enumerate(foreachRecords.getPipes())) {
+      LaunchNodeDomain recordDomain =
+          foreachRole == PipeRole::Source
+              ? getPipeRecordSourceLaunchNodeDomain(record)
+              : getPipeRecordDestinationLaunchNodeDomain(record);
+      if (knownLaunchNodeDomainContains(recordDomain, coord)) {
+        matchingRecordIndices.push_back(static_cast<int64_t>(recordIndex));
+      }
+    }
+
+    std::optional<std::uint64_t> nestedExecutionCountDivisor =
+        executionCountDivisor;
+    if (executionCountDivisor && !matchingRecordIndices.empty()) {
+      nestedExecutionCountDivisor = llvm::checkedMulUnsigned(
+          *executionCountDivisor,
+          static_cast<std::uint64_t>(matchingRecordIndices.size()));
+    }
+
+    for (int64_t recordIndex : matchingRecordIndices) {
+      activeRecords.emplace_back(op, recordIndex);
+      llvm::scope_exit restoreActiveRecord(
+          [&] { activeRecords.pop_back(); });
+      for (Region &region : op->getRegions()) {
+        for (Block &block : region) {
+          for (Operation &nestedOp : block) {
+            if (walkPipeEventsInProgramOrder(
+                    &nestedOp, coord, state, functionsWithPipeEvents,
+                    symbolTables, activeFunctions, callSites, activeRecords,
+                    nestedExecutionCountDivisor, diagnosedRecursiveCalls,
+                    visitEvent)
+                    .wasInterrupted()) {
+              return WalkResult::interrupt();
+            }
+          }
+        }
+      }
+    }
+    return WalkResult::advance();
+  }
+
   auto eventIt = state.pipeEventIndices.find(op);
   if (eventIt != state.pipeEventIndices.end()) {
-    const PipeEvent &event = state.pipeEvents[eventIt->second];
-    if (knownLaunchNodeDomainContains(event.domain, coord)) {
+    for (std::size_t eventIndex : eventIt->second) {
+      const PipeEvent &event = state.pipeEvents[eventIndex];
+      if (!knownLaunchNodeDomainContains(event.domain, coord)) {
+        continue;
+      }
+      if (event.selectedForeachOp) {
+        std::optional<int64_t> activeRecordIndex =
+            getActiveForeachRecordIndex(activeRecords, event.selectedForeachOp);
+        assert(activeRecordIndex &&
+               "selected pipe event must be nested in its foreach operation");
+        if (*activeRecordIndex != event.selectedRecordIndex) {
+          continue;
+        }
+      }
       if (!hasZeroExecutionCount(callSites, event.op, coord, state) &&
-          visitEvent(event, callSites).wasInterrupted()) {
+          visitEvent(event, callSites, executionCountDivisor)
+              .wasInterrupted()) {
         return WalkResult::interrupt();
       }
     }
@@ -1508,7 +1763,8 @@ WalkResult walkPipeEventsInProgramOrder(
       for (Operation &nestedOp : block) {
         if (walkPipeEventsInProgramOrder(
                 &nestedOp, coord, state, functionsWithPipeEvents, symbolTables,
-                activeFunctions, callSites, diagnosedRecursiveCalls, visitEvent)
+                activeFunctions, callSites, activeRecords,
+                executionCountDivisor, diagnosedRecursiveCalls, visitEvent)
                 .wasInterrupted()) {
           return WalkResult::interrupt();
         }
@@ -1522,7 +1778,8 @@ WalkResult walkPipeEventsInProgramOrder(
       for (Operation &nestedOp : block) {
         if (walkPipeEventsInProgramOrder(
                 &nestedOp, coord, state, functionsWithPipeEvents, symbolTables,
-                activeFunctions, callSites, diagnosedRecursiveCalls, visitEvent)
+                activeFunctions, callSites, activeRecords,
+                executionCountDivisor, diagnosedRecursiveCalls, visitEvent)
                 .wasInterrupted()) {
           return WalkResult::interrupt();
         }
@@ -1578,14 +1835,17 @@ void verifyPipeScheduleCycles(ModuleOp module, ModuleState &state) {
     for (LaunchNodeCoord coord : scheduleCoords) {
       SmallVector<func::FuncOp> activeFunctions{function};
       SmallVector<PipeCallSite> callSites;
+      SmallVector<ActiveForeachRecord> activeRecords;
       std::optional<PipeScheduleNodeId> lastNode;
       for (Block &block : function.getBody()) {
         for (Operation &op : block) {
           WalkResult walkResult = walkPipeEventsInProgramOrder(
               &op, coord, state, functionsWithPipeEvents, symbolTables,
-              activeFunctions, callSites, diagnosedRecursiveCalls,
+              activeFunctions, callSites, activeRecords,
+              /*executionCountDivisor=*/1, diagnosedRecursiveCalls,
               [&](const PipeEvent &event,
-                  ArrayRef<PipeCallSite> activeCallSites) {
+                  ArrayRef<PipeCallSite> activeCallSites,
+                  std::optional<std::uint64_t> executionCountDivisor) {
                 std::size_t &scheduleNodeCount = scheduleNodeCounts[coord];
                 if (scheduleNodeCount >= kMaxPipeScheduleNodesPerLaunchNode) {
                   event.op->emitOpError()
@@ -1619,7 +1879,8 @@ void verifyPipeScheduleCycles(ModuleOp module, ModuleState &state) {
                   return WalkResult::interrupt();
                 }
                 PipeScheduleNodeId nodeId = addPipeScheduleNode(
-                    nodes, event, coord, function, activeCallSites);
+                    nodes, event, coord, function, activeCallSites,
+                    executionCountDivisor);
                 ++scheduleNodeCount;
                 matchingNodes->push_back(nodeId);
                 if (event.kind == PipeEventKind::ReceivePost) {
@@ -1761,8 +2022,8 @@ void verifyPipeScheduleCycles(ModuleOp module, ModuleState &state) {
   }
 }
 
-// Walk the module and report any `pipenet_scope` or PipeNetPredicate that
-// references a PipeNet id not declared by some `ttl.create_pipe`.
+// Reject predicates and scopes that reference no static or record-table
+// declaration, since an empty role set would otherwise accept any nested work.
 LogicalResult
 validatePipeNetReferences(ModuleOp module,
                           const LaunchNodeDomainState &launchDomains) {
@@ -1771,7 +2032,8 @@ validatePipeNetReferences(ModuleOp module,
     auto report = [&](int64_t netId) {
       op->emitOpError() << "references unknown PipeNet "
                         << launchDomains.netName(netId) << " (id " << netId
-                        << "); no `ttl.create_pipe` declares this net";
+                        << "); no pipe or PipeNet record table declares this "
+                           "net";
       result = failure();
     };
     if (auto pred = mlir::dyn_cast<PipeNetPredicateOpInterface>(op)) {

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -24,6 +24,7 @@
 #include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/PipeTransferAnalysis.h"
+#include "ttlang/Dialect/TTL/Transforms/PipeNetExecutionUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
@@ -98,19 +99,17 @@ struct PipeEvent {
 /// Pipe records and selection context represented by one selected-pipe value.
 struct SelectedPipeRecords {
   PipeNetRecordsAttr records;
-  PipeRole role = PipeRole::Active;
   Operation *foreachOp = nullptr;
 };
 
+/// Return the records and foreach operation referenced by a selected pipe.
 std::optional<SelectedPipeRecords> getSelectedPipeRecords(Value pipe) {
   pipe = traceUnrealizedCasts(pipe);
   if (auto selectedSrc = pipe.getDefiningOp<SelectPipeSrcOp>()) {
-    return SelectedPipeRecords{selectedSrc.getRecords(), PipeRole::Source,
-                               nullptr};
+    return SelectedPipeRecords{selectedSrc.getRecords(), nullptr};
   }
   if (auto selectedDst = pipe.getDefiningOp<SelectPipeDstOp>()) {
-    return SelectedPipeRecords{selectedDst.getRecords(), PipeRole::Destination,
-                               nullptr};
+    return SelectedPipeRecords{selectedDst.getRecords(), nullptr};
   }
   auto blockArg = mlir::dyn_cast<BlockArgument>(pipe);
   if (!blockArg || blockArg.getArgNumber() != 0) {
@@ -118,28 +117,10 @@ std::optional<SelectedPipeRecords> getSelectedPipeRecords(Value pipe) {
   }
   Operation *owner = blockArg.getOwner()->getParentOp();
   if (auto foreachSrc = mlir::dyn_cast<PipeNetForeachSrcOp>(owner)) {
-    return SelectedPipeRecords{foreachSrc.getRecords(), PipeRole::Source,
-                               owner};
+    return SelectedPipeRecords{foreachSrc.getRecords(), owner};
   }
   if (auto foreachDst = mlir::dyn_cast<PipeNetForeachDstOp>(owner)) {
-    return SelectedPipeRecords{foreachDst.getRecords(), PipeRole::Destination,
-                               owner};
-  }
-  return std::nullopt;
-}
-
-std::optional<SelectedPipeRecords> getSelectedSourceRecords(Value pipe) {
-  std::optional<SelectedPipeRecords> selected = getSelectedPipeRecords(pipe);
-  if (selected && selected->role == PipeRole::Source) {
-    return selected;
-  }
-  return std::nullopt;
-}
-
-std::optional<SelectedPipeRecords> getSelectedDestinationRecords(Value pipe) {
-  std::optional<SelectedPipeRecords> selected = getSelectedPipeRecords(pipe);
-  if (selected && selected->role == PipeRole::Destination) {
-    return selected;
+    return SelectedPipeRecords{foreachDst.getRecords(), owner};
   }
   return std::nullopt;
 }
@@ -239,7 +220,7 @@ struct ModuleState {
       return events;
     }
     if (std::optional<SelectedPipeRecords> selected =
-            getSelectedSourceRecords(copyOp.getDst())) {
+            getSelectedPipeRecords(copyOp.getDst())) {
       appendSelectedPipeEvents(op, selected->records, PipeEventKind::Send,
                                domain, unanalyzableOp,
                                /*receivePost=*/nullptr, selected->foreachOp,
@@ -257,7 +238,7 @@ struct ModuleState {
       return events;
     }
     if (std::optional<SelectedPipeRecords> selected =
-            getSelectedDestinationRecords(copyOp.getSrc())) {
+            getSelectedPipeRecords(copyOp.getSrc())) {
       if (isPipeReceiveCopy(copyOp)) {
         appendSelectedPipeEvents(op, selected->records,
                                  PipeEventKind::ReceivePost, domain,
@@ -292,7 +273,7 @@ struct ModuleState {
               pipeType, launchDomains.baseDomain)),
           unanalyzableOp, copyOp.getOperation(), nullptr, -1});
     } else if (std::optional<SelectedPipeRecords> selected =
-                   getSelectedDestinationRecords(copyOp.getSrc())) {
+                   getSelectedPipeRecords(copyOp.getSrc())) {
       appendSelectedPipeEvents(op, selected->records,
                                PipeEventKind::ReceiveWait, domain,
                                unanalyzableOp, copyOp.getOperation(),
@@ -429,8 +410,21 @@ void verifyPipeWaitGuard(WaitOp waitOp, const LaunchNodeDomain &domain,
     return;
   }
 
-  auto pipeType = mlir::cast<PipeType>(maybeCopyOp->getSrc().getType());
-  int64_t netId = pipeType.getPipeNetId();
+  CopyOp copyOp = *maybeCopyOp;
+  int64_t netId;
+  LaunchNodeDomain allowedDomain;
+  if (auto pipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
+    netId = pipeType.getPipeNetId();
+    allowedDomain = getPipeDestinationLaunchNodeDomain(
+        pipeType, state.launchDomains.baseDomain);
+  } else {
+    std::optional<SelectedPipeRecords> selected =
+        getSelectedPipeRecords(copyOp.getSrc());
+    assert(selected && "selected pipe must have a verified direct definition");
+    netId = selected->records.getPipeNetId();
+    allowedDomain = getPipeRecordsRoleLaunchNodeDomain(selected->records,
+                                                       PipeRole::Destination);
+  }
   std::string name = state.launchDomains.netName(netId);
   std::string message;
   llvm::raw_string_ostream(message)
@@ -439,11 +433,8 @@ void verifyPipeWaitGuard(WaitOp waitOp, const LaunchNodeDomain &domain,
       << name << "; keep the wait under the same `if " << name
       << ".is_dst(): ...` or `" << name
       << ".if_dst(...)` guard as the receive copy";
-  checkKnownSubset(waitOp, domain,
-                   getPipeDestinationLaunchNodeDomain(
-                       pipeType, state.launchDomains.baseDomain),
-                   unanalyzableOp, message, {{netId, PipeRole::Destination}},
-                   state);
+  checkKnownSubset(waitOp, domain, allowedDomain, unanalyzableOp, message,
+                   {{netId, PipeRole::Destination}}, state);
 }
 
 // Emit an op error when `current` is not a subset of `allowed`. Attaches an
@@ -510,7 +501,7 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
     return;
   }
   if (std::optional<SelectedPipeRecords> selected =
-          getSelectedSourceRecords(copyOp.getDst())) {
+          getSelectedPipeRecords(copyOp.getDst())) {
     int64_t netId = selected->records.getPipeNetId();
     std::string name = state.launchDomains.netName(netId);
     std::string msg;
@@ -544,7 +535,7 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
     return;
   }
   if (std::optional<SelectedPipeRecords> selected =
-          getSelectedDestinationRecords(copyOp.getSrc())) {
+          getSelectedPipeRecords(copyOp.getSrc())) {
     int64_t netId = selected->records.getPipeNetId();
     std::string name = state.launchDomains.netName(netId);
     std::string msg;
@@ -742,13 +733,12 @@ PipeCoordIdentity getPipeCoordIdentity(PipeType pipeType,
 }
 
 /// Add one graph node for a synchronization event at one call-site occurrence.
-PipeScheduleNodeId addPipeScheduleNode(SmallVectorImpl<PipeScheduleNode> &nodes,
-                                       const PipeEvent &event,
-                                       LaunchNodeCoord coord,
-                                       func::FuncOp kernelFunction,
-                                       ArrayRef<PipeCallSite> callSites,
-                                       std::optional<std::uint64_t>
-                                           executionCountDivisor) {
+PipeScheduleNodeId
+addPipeScheduleNode(SmallVectorImpl<PipeScheduleNode> &nodes,
+                    const PipeEvent &event, LaunchNodeCoord coord,
+                    func::FuncOp kernelFunction,
+                    ArrayRef<PipeCallSite> callSites,
+                    std::optional<std::uint64_t> executionCountDivisor) {
   PipeScheduleNodeId nodeId = nodes.size();
   nodes.push_back({event.op,
                    event.pipeType,
@@ -1626,21 +1616,6 @@ LogicalResult verifyPipeEventDomainsKnown(const ModuleState &state) {
   return result;
 }
 
-using ActiveForeachRecord = std::pair<Operation *, int64_t>;
-
-std::optional<int64_t>
-getActiveForeachRecordIndex(ArrayRef<ActiveForeachRecord> activeRecords,
-                            Operation *foreachOp) {
-  auto activeIt = llvm::find_if(llvm::reverse(activeRecords),
-                                [&](const ActiveForeachRecord &active) {
-                                  return active.first == foreachOp;
-                                });
-  if (activeIt == activeRecords.rend()) {
-    return std::nullopt;
-  }
-  return activeIt->second;
-}
-
 /// Visit pipe events in the order executed by one kernel thread.
 ///
 /// Direct helper calls are expanded at each call site. A PipeNet foreach body
@@ -1652,141 +1627,94 @@ WalkResult walkPipeEventsInProgramOrder(
     SymbolTableCollection &symbolTables,
     SmallVectorImpl<func::FuncOp> &activeFunctions,
     SmallVectorImpl<PipeCallSite> &callSites,
-    SmallVectorImpl<ActiveForeachRecord> &activeRecords,
+    SmallVectorImpl<ActivePipeNetRecord> &activeRecords,
     std::optional<std::uint64_t> executionCountDivisor,
     llvm::DenseSet<Operation *> &diagnosedRecursiveCalls,
     llvm::function_ref<WalkResult(const PipeEvent &, ArrayRef<PipeCallSite>,
                                   std::optional<std::uint64_t>)>
         visitEvent) {
-  PipeNetRecordsAttr foreachRecords;
-  PipeRole foreachRole = PipeRole::Active;
-  if (auto foreachSrc = mlir::dyn_cast<PipeNetForeachSrcOp>(op)) {
-    foreachRecords = foreachSrc.getRecords();
-    foreachRole = PipeRole::Source;
-  } else if (auto foreachDst = mlir::dyn_cast<PipeNetForeachDstOp>(op)) {
-    foreachRecords = foreachDst.getRecords();
-    foreachRole = PipeRole::Destination;
-  }
+  auto resolveGeneratedRecordLoop =
+      [](Operation *) -> std::optional<PipeNetRecordLoop> {
+    return std::nullopt;
+  };
+  auto visitOperation =
+      [&](Operation *currentOp,
+          ArrayRef<ActivePipeNetRecord> currentActiveRecords,
+          std::optional<std::uint64_t> currentExecutionCountDivisor) {
+        auto eventIt = state.pipeEventIndices.find(currentOp);
+        if (eventIt != state.pipeEventIndices.end()) {
+          for (std::size_t eventIndex : eventIt->second) {
+            const PipeEvent &event = state.pipeEvents[eventIndex];
+            if (!knownLaunchNodeDomainContains(event.domain, coord)) {
+              continue;
+            }
+            if (event.selectedForeachOp) {
+              std::optional<std::uint64_t> activeRecordIndex =
+                  getActivePipeNetRecordIndex(currentActiveRecords,
+                                              event.selectedForeachOp);
+              assert(activeRecordIndex &&
+                     "selected pipe event must be nested in its foreach "
+                     "operation");
+              if (*activeRecordIndex !=
+                  static_cast<std::uint64_t>(event.selectedRecordIndex)) {
+                continue;
+              }
+            }
+            if (!hasZeroExecutionCount(callSites, event.op, coord, state) &&
+                visitEvent(event, callSites, currentExecutionCountDivisor)
+                    .wasInterrupted()) {
+              return WalkResult::interrupt();
+            }
+          }
+        }
 
-  if (foreachRecords) {
-    SmallVector<int64_t> matchingRecordIndices;
-    for (auto [recordIndex, record] :
-         llvm::enumerate(foreachRecords.getPipes())) {
-      LaunchNodeDomain recordDomain =
-          foreachRole == PipeRole::Source
-              ? getPipeRecordSourceLaunchNodeDomain(record)
-              : getPipeRecordDestinationLaunchNodeDomain(record);
-      if (knownLaunchNodeDomainContains(recordDomain, coord)) {
-        matchingRecordIndices.push_back(static_cast<int64_t>(recordIndex));
-      }
-    }
+        auto callOp = mlir::dyn_cast<func::CallOp>(currentOp);
+        if (!callOp) {
+          return WalkResult::advance();
+        }
+        func::FuncOp callee =
+            symbolTables.lookupNearestSymbolFrom<func::FuncOp>(
+                callOp, callOp.getCalleeAttr());
+        if (!callee ||
+            !functionsWithPipeEvents.contains(callee.getOperation()) ||
+            hasZeroExecutionCount({}, callOp.getOperation(), coord, state)) {
+          return WalkResult::advance();
+        }
+        if (llvm::is_contained(activeFunctions, callee)) {
+          if (diagnosedRecursiveCalls.insert(callOp.getOperation()).second) {
+            callOp.emitOpError()
+                << "cannot verify PipeNet synchronization through a recursive "
+                   "call to @"
+                << callee.getSymName();
+            state.sawError = true;
+          }
+          return WalkResult::advance();
+        }
 
-    std::optional<std::uint64_t> nestedExecutionCountDivisor =
-        executionCountDivisor;
-    if (executionCountDivisor && !matchingRecordIndices.empty()) {
-      nestedExecutionCountDivisor = llvm::checkedMulUnsigned(
-          *executionCountDivisor,
-          static_cast<std::uint64_t>(matchingRecordIndices.size()));
-    }
-
-    for (int64_t recordIndex : matchingRecordIndices) {
-      activeRecords.emplace_back(op, recordIndex);
-      llvm::scope_exit restoreActiveRecord(
-          [&] { activeRecords.pop_back(); });
-      for (Region &region : op->getRegions()) {
-        for (Block &block : region) {
+        activeFunctions.push_back(callee);
+        callSites.push_back({callOp, callee});
+        llvm::scope_exit restoreCallStack([&] {
+          callSites.pop_back();
+          activeFunctions.pop_back();
+        });
+        for (Block &block : callee.getBody()) {
           for (Operation &nestedOp : block) {
             if (walkPipeEventsInProgramOrder(
                     &nestedOp, coord, state, functionsWithPipeEvents,
                     symbolTables, activeFunctions, callSites, activeRecords,
-                    nestedExecutionCountDivisor, diagnosedRecursiveCalls,
+                    currentExecutionCountDivisor, diagnosedRecursiveCalls,
                     visitEvent)
                     .wasInterrupted()) {
               return WalkResult::interrupt();
             }
           }
         }
-      }
-    }
-    return WalkResult::advance();
-  }
+        return WalkResult::advance();
+      };
 
-  auto eventIt = state.pipeEventIndices.find(op);
-  if (eventIt != state.pipeEventIndices.end()) {
-    for (std::size_t eventIndex : eventIt->second) {
-      const PipeEvent &event = state.pipeEvents[eventIndex];
-      if (!knownLaunchNodeDomainContains(event.domain, coord)) {
-        continue;
-      }
-      if (event.selectedForeachOp) {
-        std::optional<int64_t> activeRecordIndex =
-            getActiveForeachRecordIndex(activeRecords, event.selectedForeachOp);
-        assert(activeRecordIndex &&
-               "selected pipe event must be nested in its foreach operation");
-        if (*activeRecordIndex != event.selectedRecordIndex) {
-          continue;
-        }
-      }
-      if (!hasZeroExecutionCount(callSites, event.op, coord, state) &&
-          visitEvent(event, callSites, executionCountDivisor)
-              .wasInterrupted()) {
-        return WalkResult::interrupt();
-      }
-    }
-  }
-
-  if (auto callOp = mlir::dyn_cast<func::CallOp>(op)) {
-    func::FuncOp callee = symbolTables.lookupNearestSymbolFrom<func::FuncOp>(
-        callOp, callOp.getCalleeAttr());
-    if (!callee || !functionsWithPipeEvents.contains(callee.getOperation()) ||
-        hasZeroExecutionCount({}, callOp.getOperation(), coord, state)) {
-      return WalkResult::advance();
-    }
-    if (llvm::is_contained(activeFunctions, callee)) {
-      if (diagnosedRecursiveCalls.insert(callOp.getOperation()).second) {
-        callOp.emitOpError()
-            << "cannot verify PipeNet synchronization through a recursive "
-               "call to @"
-            << callee.getSymName();
-        state.sawError = true;
-      }
-      return WalkResult::advance();
-    }
-
-    activeFunctions.push_back(callee);
-    callSites.push_back({callOp, callee});
-    llvm::scope_exit restoreCallStack([&] {
-      callSites.pop_back();
-      activeFunctions.pop_back();
-    });
-    for (Block &block : callee.getBody()) {
-      for (Operation &nestedOp : block) {
-        if (walkPipeEventsInProgramOrder(
-                &nestedOp, coord, state, functionsWithPipeEvents, symbolTables,
-                activeFunctions, callSites, activeRecords,
-                executionCountDivisor, diagnosedRecursiveCalls, visitEvent)
-                .wasInterrupted()) {
-          return WalkResult::interrupt();
-        }
-      }
-    }
-    return WalkResult::advance();
-  }
-
-  for (Region &region : op->getRegions()) {
-    for (Block &block : region) {
-      for (Operation &nestedOp : block) {
-        if (walkPipeEventsInProgramOrder(
-                &nestedOp, coord, state, functionsWithPipeEvents, symbolTables,
-                activeFunctions, callSites, activeRecords,
-                executionCountDivisor, diagnosedRecursiveCalls, visitEvent)
-                .wasInterrupted()) {
-          return WalkResult::interrupt();
-        }
-      }
-    }
-  }
-  return WalkResult::advance();
+  return walkPipeNetOpsInProgramOrder(op, coord, resolveGeneratedRecordLoop,
+                                      visitOperation, activeRecords,
+                                      executionCountDivisor);
 }
 
 // Verify synchronization dependencies implied by pipe operations. Receive-side
@@ -1835,7 +1763,7 @@ void verifyPipeScheduleCycles(ModuleOp module, ModuleState &state) {
     for (LaunchNodeCoord coord : scheduleCoords) {
       SmallVector<func::FuncOp> activeFunctions{function};
       SmallVector<PipeCallSite> callSites;
-      SmallVector<ActiveForeachRecord> activeRecords;
+      SmallVector<ActivePipeNetRecord> activeRecords;
       std::optional<PipeScheduleNodeId> lastNode;
       for (Block &block : function.getBody()) {
         for (Operation &op : block) {

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -96,35 +96,6 @@ struct PipeEvent {
   int64_t selectedRecordIndex = -1;
 };
 
-/// Pipe records and selection context represented by one selected-pipe value.
-struct SelectedPipeRecords {
-  PipeNetRecordsAttr records;
-  Operation *foreachOp = nullptr;
-};
-
-/// Return the records and foreach operation referenced by a selected pipe.
-std::optional<SelectedPipeRecords> getSelectedPipeRecords(Value pipe) {
-  pipe = traceUnrealizedCasts(pipe);
-  if (auto selectedSrc = pipe.getDefiningOp<SelectPipeSrcOp>()) {
-    return SelectedPipeRecords{selectedSrc.getRecords(), nullptr};
-  }
-  if (auto selectedDst = pipe.getDefiningOp<SelectPipeDstOp>()) {
-    return SelectedPipeRecords{selectedDst.getRecords(), nullptr};
-  }
-  auto blockArg = mlir::dyn_cast<BlockArgument>(pipe);
-  if (!blockArg || blockArg.getArgNumber() != 0) {
-    return std::nullopt;
-  }
-  Operation *owner = blockArg.getOwner()->getParentOp();
-  if (auto foreachSrc = mlir::dyn_cast<PipeNetForeachSrcOp>(owner)) {
-    return SelectedPipeRecords{foreachSrc.getRecords(), owner};
-  }
-  if (auto foreachDst = mlir::dyn_cast<PipeNetForeachDstOp>(owner)) {
-    return SelectedPipeRecords{foreachDst.getRecords(), owner};
-  }
-  return std::nullopt;
-}
-
 struct ModuleState;
 void checkKnownSubset(Operation *op, const LaunchNodeDomain &current,
                       const LaunchNodeDomain &allowed,
@@ -155,6 +126,15 @@ struct ModuleState {
   SmallVector<WaitUse> waitUses;
   SmallVector<PipeEvent> pipeEvents;
   llvm::DenseMap<Operation *, SmallVector<std::size_t>> pipeEventIndices;
+
+  /// Diagnose malformed selected-pipe IR when this pass runs directly.
+  void reportInvalidSelectedPipeDefinition(CopyOp copyOp) {
+    copyOp.emitOpError()
+        << "selected pipe operand must be defined by ttl.select_pipe_src, "
+           "ttl.select_pipe_dst, ttl.pipenet_foreach_src, or "
+           "ttl.pipenet_foreach_dst";
+    sawError = true;
+  }
 
   /// Replace the events for one operation after a dataflow update.
   void replacePipeEvents(Operation *op, SmallVector<PipeEvent> events) {
@@ -217,11 +197,17 @@ struct ModuleState {
           unanalyzableOp, nullptr, nullptr, -1});
       return events;
     }
-    if (std::optional<SelectedPipeRecords> selected =
-            getSelectedPipeRecords(copyOp.getDst())) {
+    FailureOr<SelectedPipeRecords> selectedDst =
+        getSelectedPipeRecords(copyOp.getDst());
+    if (succeeded(selectedDst)) {
       appendSelectedPipeEvents(
-          op, selected->records, PipeEventKind::Send, domain, unanalyzableOp,
-          /*receivePost=*/nullptr, selected->foreachOp, events);
+          op, selectedDst->records, PipeEventKind::Send, domain, unanalyzableOp,
+          /*receivePost=*/nullptr, selectedDst->maybeForeachOp, events);
+      return events;
+    }
+    if (mlir::isa<SelectedPipeSrcType, SelectedPipeDstType>(
+            copyOp.getDst().getType())) {
+      reportInvalidSelectedPipeDefinition(copyOp);
       return events;
     }
     if (auto pipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
@@ -234,14 +220,18 @@ struct ModuleState {
       }
       return events;
     }
-    if (std::optional<SelectedPipeRecords> selected =
-            getSelectedPipeRecords(copyOp.getSrc())) {
+    FailureOr<SelectedPipeRecords> selectedSrc =
+        getSelectedPipeRecords(copyOp.getSrc());
+    if (succeeded(selectedSrc)) {
       if (isPipeReceiveCopy(copyOp)) {
-        appendSelectedPipeEvents(op, selected->records,
+        appendSelectedPipeEvents(op, selectedSrc->records,
                                  PipeEventKind::ReceivePost, domain,
                                  unanalyzableOp, /*receivePost=*/nullptr,
-                                 selected->foreachOp, events);
+                                 selectedSrc->maybeForeachOp, events);
       }
+    } else if (mlir::isa<SelectedPipeSrcType, SelectedPipeDstType>(
+                   copyOp.getSrc().getType())) {
+      reportInvalidSelectedPipeDefinition(copyOp);
     }
     return events;
   }
@@ -269,11 +259,18 @@ struct ModuleState {
                     domain.intersectWith(getPipeDestinationLaunchNodeDomain(
                         pipeType, launchDomains.baseDomain)),
                     unanalyzableOp, copyOp.getOperation(), nullptr, -1});
-    } else if (std::optional<SelectedPipeRecords> selected =
-                   getSelectedPipeRecords(copyOp.getSrc())) {
-      appendSelectedPipeEvents(
-          op, selected->records, PipeEventKind::ReceiveWait, domain,
-          unanalyzableOp, copyOp.getOperation(), selected->foreachOp, events);
+    } else {
+      FailureOr<SelectedPipeRecords> selected =
+          getSelectedPipeRecords(copyOp.getSrc());
+      if (failed(selected)) {
+        reportInvalidSelectedPipeDefinition(copyOp);
+        replacePipeEvents(op, {});
+        return;
+      }
+      appendSelectedPipeEvents(op, selected->records,
+                               PipeEventKind::ReceiveWait, domain,
+                               unanalyzableOp, copyOp.getOperation(),
+                               selected->maybeForeachOp, events);
     }
 
     replacePipeEvents(op, std::move(events));
@@ -414,9 +411,12 @@ void verifyPipeWaitGuard(WaitOp waitOp, const LaunchNodeDomain &domain,
     allowedDomain = getPipeDestinationLaunchNodeDomain(
         pipeType, state.launchDomains.baseDomain);
   } else {
-    std::optional<SelectedPipeRecords> selected =
+    FailureOr<SelectedPipeRecords> selected =
         getSelectedPipeRecords(copyOp.getSrc());
-    assert(selected && "selected pipe must have a verified direct definition");
+    if (failed(selected)) {
+      state.reportInvalidSelectedPipeDefinition(copyOp);
+      return;
+    }
     netId = selected->records.getPipeNetId();
     allowedDomain = getPipeRecordsRoleLaunchNodeDomain(selected->records,
                                                        PipeRole::Destination);
@@ -496,9 +496,10 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
                      msg, {{netId, PipeRole::Source}}, state);
     return;
   }
-  if (std::optional<SelectedPipeRecords> selected =
-          getSelectedPipeRecords(copyOp.getDst())) {
-    int64_t netId = selected->records.getPipeNetId();
+  FailureOr<SelectedPipeRecords> selectedDst =
+      getSelectedPipeRecords(copyOp.getDst());
+  if (succeeded(selectedDst)) {
+    int64_t netId = selectedDst->records.getPipeNetId();
     std::string name = state.launchDomains.netName(netId);
     std::string msg;
     llvm::raw_string_ostream(msg)
@@ -507,10 +508,10 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
            "wrap the copy in `"
         << name << ".if_src(...)` or guard with `if " << name
         << ".is_src(): ...`";
-    checkKnownSubset(
-        copyOp, current,
-        getPipeRecordsRoleLaunchNodeDomain(selected->records, PipeRole::Source),
-        unanalyzable, msg, {{netId, PipeRole::Source}}, state);
+    checkKnownSubset(copyOp, current,
+                     getPipeRecordsRoleLaunchNodeDomain(selectedDst->records,
+                                                        PipeRole::Source),
+                     unanalyzable, msg, {{netId, PipeRole::Source}}, state);
     return;
   }
   if (auto srcPipeType = mlir::dyn_cast<PipeType>(copyOp.getSrc().getType())) {
@@ -530,9 +531,10 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
                      state);
     return;
   }
-  if (std::optional<SelectedPipeRecords> selected =
-          getSelectedPipeRecords(copyOp.getSrc())) {
-    int64_t netId = selected->records.getPipeNetId();
+  FailureOr<SelectedPipeRecords> selectedSrc =
+      getSelectedPipeRecords(copyOp.getSrc());
+  if (succeeded(selectedSrc)) {
+    int64_t netId = selectedSrc->records.getPipeNetId();
     std::string name = state.launchDomains.netName(netId);
     std::string msg;
     llvm::raw_string_ostream(msg)
@@ -542,7 +544,7 @@ void verifyCopy(CopyOp copyOp, const LaunchNodeDomain &current,
         << name << ".if_dst(...)` or guard with `if " << name
         << ".is_dst(): ...`";
     checkKnownSubset(copyOp, current,
-                     getPipeRecordsRoleLaunchNodeDomain(selected->records,
+                     getPipeRecordsRoleLaunchNodeDomain(selectedSrc->records,
                                                         PipeRole::Destination),
                      unanalyzable, msg, {{netId, PipeRole::Destination}},
                      state);

--- a/lib/Dialect/TTL/Transforms/TransferProvenance.cpp
+++ b/lib/Dialect/TTL/Transforms/TransferProvenance.cpp
@@ -4,6 +4,7 @@
 
 #include "ttlang/Dialect/TTL/Transforms/TransferProvenance.h"
 
+#include "PipeGraph.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
 
@@ -126,9 +127,12 @@ LogicalResult verifyPost(PipeTransferPostOp op, ValueOriginAnalysis &analysis) {
            << "requires every possible transfer value to derive from the "
               "same ttl.pipe_transfer.create";
   }
-  auto pipeType = cast<PipeType>(create->getPipe().getType());
+  FailureOr<PipeReference> pipeRef = getPipeReference(op, create->getPipe());
+  if (failed(pipeRef)) {
+    return failure();
+  }
   auto tokenType = cast<PipeTokenType>(op.getToken().getType());
-  if (tokenType.getPipeNetId() != pipeType.getPipeNetId()) {
+  if (tokenType.getPipeNetId() != pipeRef->getPipeNetId()) {
     return op.emitOpError() << "token pipeNetId must match transfer pipeNetId";
   }
   return success();

--- a/lib/Target/TTKernel/CMakeLists.txt
+++ b/lib/Target/TTKernel/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LLK_HEADERS
   experimental_invoke_sfpi_llks
   experimental_matmul_llks
   experimental_padding_llks
+  experimental_constant_table
   experimental_coord_translation
   experimental_fabric_topology_info
   experimental_fabric_1d_routing

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -28,10 +28,12 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/Cpp/CppEmitter.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -328,6 +330,27 @@ cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
 
   OpBuilder builder(ctx);
 
+  SymbolTableCollection symbolTables;
+  llvm::DenseSet<emitc::GlobalOp> seenGlobals;
+  SmallVector<emitc::GlobalOp> referencedGlobals;
+  bool missingGlobal = false;
+  origEntry.walk([&](emitc::GetGlobalOp getGlobalOp) {
+    emitc::GlobalOp global =
+        symbolTables.lookupNearestSymbolFrom<emitc::GlobalOp>(
+            getGlobalOp, getGlobalOp.getNameAttr());
+    if (!global) {
+      getGlobalOp.emitOpError("does not reference an emitc.global");
+      missingGlobal = true;
+      return;
+    }
+    if (seenGlobals.insert(global).second) {
+      referencedGlobals.push_back(global);
+    }
+  });
+  if (missingGlobal) {
+    return failure();
+  }
+
   // We will wrap everything in a standalone module op so that we can run the
   // translation.
   auto moduleWrapper = builder.create<mlir::ModuleOp>(loc, "module_wrapper");
@@ -336,6 +359,10 @@ cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
   Region *kernelMainRegion;
   {
     ScopedModuleHelper threadConfigHelper(&builder, loc, region, threadType);
+
+    for (emitc::GlobalOp global : referencedGlobals) {
+      builder.clone(*global);
+    }
 
     // Clone 'region' into a new func op nested inside 'moduleWrapper':
     auto kernelMain = builder.create<func::FuncOp>(

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -6,6 +6,7 @@
 
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 
+#include "ttlang/Target/TTKernel/LLKs/experimental_constant_table_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_coord_translation_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_fabric_1d_routing_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_fabric_2d_routing_generated.h"
@@ -128,6 +129,10 @@ public:
           callee == "experimental::convert_logical_y_to_translated") {
         emitLlk(experimental_coord_translation_generated,
                 experimental_coord_translation_generated_len);
+      }
+      if (callee == "experimental::constant_table_lookup") {
+        emitLlk(experimental_constant_table_generated,
+                experimental_constant_table_generated_len);
       }
       if (callee == "experimental::close_fabric_connections" ||
           callee == "experimental::setup_fabric_connections" ||

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -173,9 +173,8 @@ class TTLGenericCompiler(TTCompilerBase):
 
         # Map id(PipeNet object) -> Python variable name the user assigned
         # it to. Populated from captures/globals at function entry and
-        # from body-local PipeNet assignments. Read by `_emit_pipe_from_capture`
-        # to stamp the user's variable name onto each `ttl.create_pipe`
-        # so the verifier can name PipeNets by user-facing identifier.
+        # from body-local PipeNet assignments. The name is stored on emitted
+        # pipe declarations so diagnostics use the user's identifier.
         self._pipe_net_names: dict[int, str] = {}
 
         # Include paths collected from ttl.call_extern_func invocations,

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -450,7 +450,7 @@ class TTLGenericCompiler(TTCompilerBase):
 
     def _handle_pipenet_callback(self, node):
         """Handle pipenet.if_src(callback) or pipenet.if_dst(callback) calls."""
-        from ..pipe import PipeNet, SrcPipeIdentity, DstPipeIdentity
+        from ..pipe import PipeNet
 
         method_name = node.func.attr
         var_name = node.func.value.id
@@ -505,45 +505,51 @@ class TTLGenericCompiler(TTCompilerBase):
         # is always non-empty.
         pipe_net_name = self._resolve_pipe_net_name(pipenet)
 
-        # Iterate over all pipes and emit if_src/if_dst for each
+        pipe_records = [
+            ttl.PipeRecordAttr.get(
+                self.ctx,
+                pipe.src[0],
+                pipe.src[1],
+                pipe.dst_start[0],
+                pipe.dst_start[1],
+                pipe.dst_end[0],
+                pipe.dst_end[1],
+                pipe.is_collective,
+            )
+            for pipe in pipenet.pipes
+        ]
+        records_attr = ttl.PipeNetRecordsAttr.get(
+            self.ctx,
+            pipenet.pipe_net_id,
+            pipe_net_name=pipe_net_name,
+            pipes=pipe_records,
+        )
         decl_file = getattr(pipenet, "_source_file", None)
         decl_line = getattr(pipenet, "_source_line", None)
-        for pipe in pipenet.pipes:
-            # Emit the pipe MLIR value
-            pipe_val = self._emit_pipe_from_capture(
-                pipe,
-                pipe_net_name=pipe_net_name,
-                source_file=decl_file,
-                source_line=decl_line,
-            )
-            pipe._mlir_value = pipe_val
+        loc = None
+        if decl_file and decl_line is not None:
+            loc = Location.file(decl_file, decl_line, 1, self.ctx)
 
-            # Create the appropriate PipeIdentity
-            if method_name == "if_src":
-                pipe_identity = SrcPipeIdentity(pipe)
-                op = ttl.if_src(pipe_val)
+        if method_name == "if_src":
+            op = ttl.pipenet_foreach_src(records_attr, loc=loc)
+            pipe_type = ttl.SelectedPipeSrcType.get(self.ctx)
+        else:
+            op = ttl.pipenet_foreach_dst(records_attr, loc=loc)
+            pipe_type = ttl.SelectedPipeDstType.get(self.ctx)
+
+        block = Block.create_at_start(op.body, [pipe_type])
+        with InsertionPoint(block):
+            self.symbol_tables.append({})
+            self.symbol_tables[-1][pipe_param_name] = block.arguments[0]
+
+            if isinstance(callback_body, list):
+                for stmt in callback_body:
+                    self.visit(stmt)
             else:
-                pipe_identity = DstPipeIdentity(pipe)
-                op = ttl.if_dst(pipe_val)
+                self.visit(callback_body)
 
-            # Create body block and compile callback inside
-            block = Block.create_at_start(op.body)
-            with InsertionPoint(block):
-                # Bind the pipe parameter to the MLIR pipe value.
-                # TODO: bind to PipeIdentity instead so .src/.dst work
-                # on the callback parameter per the spec.
-                self.symbol_tables.append({})
-                self.symbol_tables[-1][pipe_param_name] = pipe_val
-                self.symbol_tables[-1][f"__{pipe_param_name}_identity"] = pipe_identity
-
-                if isinstance(callback_body, list):
-                    for stmt in callback_body:
-                        self.visit(stmt)
-                else:
-                    self.visit(callback_body)
-
-                self.symbol_tables.pop()
-                ttl.yield_([])
+            self.symbol_tables.pop()
+            ttl.yield_([])
 
         return None  # Statement, no return value
 

--- a/python/ttl/dialects/ttl.py
+++ b/python/ttl/dialects/ttl.py
@@ -24,8 +24,12 @@ def ensure_dialects_registered(ctx):
 # Re-export C++-bound attributes/types for convenience.
 SliceAttr = ir.SliceAttr
 TensorBackingAttr = ir.TensorBackingAttr
+PipeRecordAttr = ir.PipeRecordAttr
+PipeNetRecordsAttr = ir.PipeNetRecordsAttr
 CircularBufferType = ir.CircularBufferType
 PipeType = ir.PipeType
+SelectedPipeSrcType = ir.SelectedPipeSrcType
+SelectedPipeDstType = ir.SelectedPipeDstType
 
 __all__ = [  # noqa: F405
     *[name for name in globals().keys() if not name.startswith("_")],

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -472,15 +472,27 @@ def _process_tensor_subscript(subscript_tuple, cb_shape):
 
 
 def _is_pipe(val):
-    """Check if a value is a pipe (either MLIR PipeType or Python Pipe with MLIR value)."""
-    if hasattr(val, "type") and ttl.PipeType.maybe_downcast(val.type):
+    """Check if a value is a pipe reference."""
+    if not hasattr(val, "type"):
+        return isinstance(val, Pipe) and hasattr(val, "_mlir_value")
+    if ttl.PipeType.maybe_downcast(val.type):
+        return True
+    if ttl.SelectedPipeSrcType.maybe_downcast(val.type):
+        return True
+    if ttl.SelectedPipeDstType.maybe_downcast(val.type):
         return True
     return isinstance(val, Pipe) and hasattr(val, "_mlir_value")
 
 
 def _get_pipe_mlir_value(pipe):
-    """Get the MLIR value for a pipe (either MLIR value or Python Pipe object)."""
-    if hasattr(pipe, "type") and ttl.PipeType.maybe_downcast(pipe.type):
+    """Get the MLIR value for a pipe reference."""
+    if not hasattr(pipe, "type"):
+        return pipe._mlir_value
+    if ttl.PipeType.maybe_downcast(pipe.type):
+        return pipe
+    if ttl.SelectedPipeSrcType.maybe_downcast(pipe.type):
+        return pipe
+    if ttl.SelectedPipeDstType.maybe_downcast(pipe.type):
         return pipe
     return pipe._mlir_value
 

--- a/python/ttl/pipe.py
+++ b/python/ttl/pipe.py
@@ -5,8 +5,8 @@
 """Pipe operations for core-to-core data transfer.
 
 This module provides Python classes for the Pipe and PipeNet abstractions
-as defined in the TT-Lang specification. The MLIR ops (ttl.create_pipe,
-ttl.if_src, ttl.if_dst) are implemented and lower to TTKernel.
+as defined in the TT-Lang specification. PipeNet callbacks lower through
+`ttl.pipenet_foreach_src` and `ttl.pipenet_foreach_dst` to TTKernel.
 
 PipeNet supports the spec's callback API:
     net.if_src(lambda pipe: ttl.copy(blk, pipe))
@@ -241,8 +241,8 @@ class PipeNet:
         # before AST emission (see _build_operation_pipenets).
         self.pipe_net_id = 0
         self.pipes = pipes
-        # Capture the user's call site so `ttl.create_pipe` ops can carry
-        # the declaration location.
+        # Preserve the user's call site so diagnostics identify the PipeNet
+        # declaration instead of frontend implementation code.
         self._source_file: Optional[str] = None
         self._source_line: Optional[int] = None
         try:
@@ -256,16 +256,16 @@ class PipeNet:
         """
         Execute callback for each pipe where current core is source.
 
-        This method is compiled specially by the TTL compiler. At compile time,
-        it iterates over all pipes and emits conditional blocks for each pipe
-        where the current core matches the source coordinates.
+        The frontend compiles the callback once into a PipeNet region. The
+        generated kernel executes it once per matching PipeNet record, in
+        construction order.
 
         Args:
             callback: Function taking SrcPipeIdentity, called for matching pipes
 
         Note:
             This method should only be called inside a @ttl.datamovement thread.
-            The callback is invoked at compile time, not runtime.
+            The callback body is compiled once and executes on the device.
         """
         # This is a marker method. The actual implementation is in ttl_ast.py
         # which detects calls to this method and handles them specially.
@@ -278,16 +278,16 @@ class PipeNet:
         """
         Execute callback for each pipe where current core is destination.
 
-        This method is compiled specially by the TTL compiler. At compile time,
-        it iterates over all pipes and emits conditional blocks for each pipe
-        where the current core falls within the destination range.
+        The frontend compiles the callback once into a PipeNet region. The
+        generated kernel executes it once per matching PipeNet record, in
+        construction order.
 
         Args:
             callback: Function taking DstPipeIdentity, called for matching pipes
 
         Note:
             This method should only be called inside a @ttl.datamovement thread.
-            The callback is invoked at compile time, not runtime.
+            The callback body is compiled once and executes on the device.
         """
         # This is a marker method. The actual implementation is in ttl_ast.py
         # which detects calls to this method and handles them specially.

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -2042,7 +2042,7 @@ def _lower_program_to_kernel(
                 "cse",
             ]
         pipeline_passes += [
-            "func.func(convert-ttkernel-to-emitc)",
+            "convert-ttkernel-to-emitc",
             "symbol-dce",
         ]
 

--- a/python/ttlang/TTLModule.cpp
+++ b/python/ttlang/TTLModule.cpp
@@ -11,6 +11,7 @@
 #include "mlir/CAPI/IR.h"
 
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
 namespace nb = nanobind;
@@ -69,6 +70,72 @@ void populateTTLModule(nb::module_ &m) {
       .def_prop_ro("tensor_index", &TensorBackingAttr::getTensorIndex)
       .def_prop_ro("byte_offset", &TensorBackingAttr::getByteOffset)
       .def_prop_ro("byte_size", &TensorBackingAttr::getByteSize);
+
+  //===--------------------------------------------------------------------===//
+  // PipeRecordAttr
+  //===--------------------------------------------------------------------===//
+
+  tt_attribute_class<PipeRecordAttr>(m, "PipeRecordAttr")
+      .def_static(
+          "get",
+          [](MlirContext ctx, int64_t srcX, int64_t srcY, int64_t dstStartX,
+             int64_t dstStartY, int64_t dstEndX, int64_t dstEndY,
+             bool isCollective) {
+            return wrap(PipeRecordAttr::get(unwrap(ctx), srcX, srcY, dstStartX,
+                                            dstStartY, dstEndX, dstEndY,
+                                            isCollective));
+          },
+          nb::arg("context"), nb::arg("src_x"), nb::arg("src_y"),
+          nb::arg("dst_start_x"), nb::arg("dst_start_y"), nb::arg("dst_end_x"),
+          nb::arg("dst_end_y"), nb::arg("is_collective") = false)
+      .def_prop_ro("src_x", &PipeRecordAttr::getSrcX)
+      .def_prop_ro("src_y", &PipeRecordAttr::getSrcY)
+      .def_prop_ro("dst_start_x", &PipeRecordAttr::getDstStartX)
+      .def_prop_ro("dst_start_y", &PipeRecordAttr::getDstStartY)
+      .def_prop_ro("dst_end_x", &PipeRecordAttr::getDstEndX)
+      .def_prop_ro("dst_end_y", &PipeRecordAttr::getDstEndY)
+      .def_prop_ro("is_collective", &PipeRecordAttr::getIsCollective);
+
+  //===--------------------------------------------------------------------===//
+  // PipeNetRecordsAttr
+  //===--------------------------------------------------------------------===//
+
+  tt_attribute_class<PipeNetRecordsAttr>(m, "PipeNetRecordsAttr")
+      .def_static(
+          "get",
+          [](MlirContext ctx, int64_t pipeNetId,
+             std::optional<std::string> pipeNetName,
+             std::vector<MlirAttribute> pipes) {
+            SmallVector<PipeRecordAttr> records;
+            records.reserve(pipes.size());
+            for (MlirAttribute attr : pipes) {
+              records.push_back(mlir::cast<PipeRecordAttr>(unwrap(attr)));
+            }
+            StringAttr nameAttr;
+            if (pipeNetName.has_value()) {
+              nameAttr = StringAttr::get(unwrap(ctx), *pipeNetName);
+            }
+            return wrap(PipeNetRecordsAttr::get(unwrap(ctx), pipeNetId,
+                                                nameAttr, records));
+          },
+          nb::arg("context"), nb::arg("pipe_net_id"),
+          nb::arg("pipe_net_name").none() = nb::none(), nb::arg("pipes"))
+      .def_prop_ro("pipe_net_id", &PipeNetRecordsAttr::getPipeNetId)
+      .def_prop_ro("pipe_net_name",
+                   [](PipeNetRecordsAttr &self) -> std::optional<std::string> {
+                     if (auto nameAttr = self.getPipeNetName()) {
+                       return nameAttr.getValue().str();
+                     }
+                     return std::nullopt;
+                   })
+      .def_prop_ro("pipes", [](PipeNetRecordsAttr &self) {
+        std::vector<MlirAttribute> out;
+        out.reserve(self.getPipes().size());
+        for (PipeRecordAttr record : self.getPipes()) {
+          out.push_back(wrap(record));
+        }
+        return out;
+      });
 
   //===--------------------------------------------------------------------===//
   // CircularBufferType
@@ -184,4 +251,24 @@ void populateTTLModule(nb::module_ &m) {
             return type.hasMultipleReceivers();
           },
           "Deprecated. Use has_multiple_receivers().");
+
+  //===--------------------------------------------------------------------===//
+  // SelectedPipe types
+  //===--------------------------------------------------------------------===//
+
+  tt_type_class<SelectedPipeSrcType>(m, "SelectedPipeSrcType")
+      .def_static(
+          "get",
+          [](MlirContext ctx) {
+            return wrap(SelectedPipeSrcType::get(unwrap(ctx)));
+          },
+          nb::arg("context"));
+
+  tt_type_class<SelectedPipeDstType>(m, "SelectedPipeDstType")
+      .def_static(
+          "get",
+          [](MlirContext ctx) {
+            return wrap(SelectedPipeDstType::get(unwrap(ctx)));
+          },
+          nb::arg("context"));
 }

--- a/test/python/pipe/pipenet_foreach_iteration.py
+++ b/test/python/pipe/pipenet_foreach_iteration.py
@@ -4,17 +4,17 @@
 
 # REQUIRES: ttnn
 # UNSUPPORTED: system-darwin
-# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir TTLANG_EMIT_RUNNER=%t.runner.py %python %s > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-INITIAL < %t.initial.mlir
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
 # RUN: FileCheck %s --check-prefix=CHECK-LOOPS < %t.output
-# RUN: FileCheck %s --check-prefix=CHECK-SIZE < %t.output
+# RUN: %python %s --report-kernel-size %t.output | FileCheck %s --check-prefix=CHECK-SIZE
 # RUN: FileCheck %s --check-prefix=CHECK-NO-DESCRIPTOR-ARRAYS < %t.output
 
 """Compile-only coverage for large table-driven PipeNet callback lowering."""
 
-import os
-import runpy
+import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -112,13 +112,17 @@ def compile_all_to_all():
         ALL_TO_ALL_NET.if_dst(receive)
 
 
-def report_table_driven_kernel_size():
-    runner = runpy.run_path(os.environ["TTLANG_EMIT_RUNNER"])
+def report_table_driven_kernel_size(output_path):
+    output = Path(output_path).read_text()
     pipe_kernel_paths = [
-        Path(kernel_path)
-        for kernel_path, thread_type in runner["KERNEL_PATHS"]
-        if thread_type == "noc"
+        Path(match.group(1))
+        for match in re.finditer(
+            r"^=== (?:send_dm|recv_dm) kernel written to (.+) ===$",
+            output,
+            re.MULTILINE,
+        )
     ]
+    assert len(pipe_kernel_paths) == 4
     largest_kernel_bytes = max(
         kernel_path.stat().st_size for kernel_path in pipe_kernel_paths
     )
@@ -130,13 +134,14 @@ def report_table_driven_kernel_size():
 
 
 if __name__ == "__main__":
-    assert len(ALL_TO_ALL_NET.pipes) == ALL_TO_ALL_EDGE_COUNT
-    print(f"ALL-TO-ALL-EDGE-COUNT: {len(ALL_TO_ALL_NET.pipes)}")
-    compile_single_receiver_collective()
-    # Compile this operation last so the emitted runner identifies the 992-edge
-    # kernels measured by report_table_driven_kernel_size().
-    compile_all_to_all()
-    report_table_driven_kernel_size()
+    if len(sys.argv) == 3 and sys.argv[1] == "--report-kernel-size":
+        report_table_driven_kernel_size(sys.argv[2])
+    else:
+        assert len(sys.argv) == 1
+        assert len(ALL_TO_ALL_NET.pipes) == ALL_TO_ALL_EDGE_COUNT
+        print(f"ALL-TO-ALL-EDGE-COUNT: {len(ALL_TO_ALL_NET.pipes)}")
+        compile_single_receiver_collective()
+        compile_all_to_all()
 
 
 # CHECK-INITIAL-NOT: ttl.if_src
@@ -169,4 +174,4 @@ if __name__ == "__main__":
 # state requires local arrays.
 # CHECK-NO-DESCRIPTOR-ARRAYS: TTNN INTEROP: Compiling kernel
 # CHECK-NO-DESCRIPTOR-ARRAYS-NOT: {{size_t v[0-9]+\[[0-9]+\];}}
-# CHECK-NO-DESCRIPTOR-ARRAYS: TABLE-DRIVEN-PIPE-KERNEL-SOURCE-BYTES:
+# CHECK-NO-DESCRIPTOR-ARRAYS: Compiled kernel ready

--- a/test/python/pipe/pipenet_foreach_iteration.py
+++ b/test/python/pipe/pipenet_foreach_iteration.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir TTLANG_EMIT_RUNNER=%t.runner.py %python %s > %t.output 2>&1
+# RUN: FileCheck %s --check-prefix=CHECK-INITIAL < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
+# RUN: FileCheck %s --check-prefix=CHECK-LOOPS < %t.output
+# RUN: FileCheck %s --check-prefix=CHECK-SIZE < %t.output
+# RUN: FileCheck %s --check-prefix=CHECK-NO-DESCRIPTOR-ARRAYS < %t.output
+
+"""Compile-only coverage for table-driven PipeNet callback lowering."""
+
+import os
+import runpy
+from pathlib import Path
+
+import pytest
+import torch
+import ttl
+
+pytest.importorskip("ttnn", exc_type=ImportError)
+
+PIPE_COUNT = 7
+MAX_PIPE_KERNEL_SOURCE_BYTES = 24 * 1024
+
+
+class BFloat16Tensor:
+    dtype = torch.bfloat16
+
+
+UNICAST_NET = ttl.PipeNet(
+    [ttl.Pipe(src=(node, 0), dst=(node, 1)) for node in range(PIPE_COUNT)]
+)
+
+SINGLETON_MULTICAST_NET = ttl.PipeNet(
+    [
+        ttl.Pipe(src=(node, 0), dst=(slice(node, node + 1), 1))
+        for node in range(PIPE_COUNT)
+    ]
+)
+
+
+@ttl.operation(grid=(PIPE_COUNT, 2))
+def compile_pipenet_foreach_iteration():
+    template = BFloat16Tensor()
+    send_dfb = ttl.make_dataflow_buffer_like(template, shape=(1, 1), block_count=2)
+    recv_dfb = ttl.make_dataflow_buffer_like(template, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        if UNICAST_NET.is_dst():
+            with recv_dfb.wait() as _recv_blk:
+                pass
+
+    @ttl.datamovement()
+    def send_dm():
+        if UNICAST_NET.is_src():
+            with send_dfb.reserve() as send_blk:
+
+                def send(pipe):
+                    ttl.copy(send_blk, pipe).wait()
+
+                UNICAST_NET.if_src(send)
+        if SINGLETON_MULTICAST_NET.is_src():
+            with send_dfb.reserve() as send_blk:
+                SINGLETON_MULTICAST_NET.if_src(
+                    lambda pipe: ttl.copy(send_blk, pipe).wait()
+                )
+
+    @ttl.datamovement()
+    def recv_dm():
+        def recv(pipe):
+            with recv_dfb.reserve() as recv_blk:
+                ttl.copy(pipe, recv_blk).wait()
+
+        UNICAST_NET.if_dst(recv)
+        SINGLETON_MULTICAST_NET.if_dst(recv)
+
+
+def report_table_driven_kernel_size():
+    runner = runpy.run_path(os.environ["TTLANG_EMIT_RUNNER"])
+    pipe_kernel_paths = [
+        Path(kernel_path)
+        for kernel_path, thread_type in runner["KERNEL_PATHS"]
+        if thread_type == "noc"
+    ]
+    largest_kernel_bytes = max(
+        kernel_path.stat().st_size for kernel_path in pipe_kernel_paths
+    )
+    assert largest_kernel_bytes < MAX_PIPE_KERNEL_SOURCE_BYTES
+    print(
+        "TABLE-DRIVEN-PIPE-KERNEL-SOURCE-BYTES: "
+        f"{largest_kernel_bytes} / {MAX_PIPE_KERNEL_SOURCE_BYTES}"
+    )
+
+
+if __name__ == "__main__":
+    compile_pipenet_foreach_iteration()
+    report_table_driven_kernel_size()
+
+
+# CHECK-INITIAL-NOT: ttl.if_src
+# CHECK-INITIAL-NOT: ttl.if_dst
+# CHECK-INITIAL-NOT: ttl.create_pipe
+# CHECK-INITIAL: ttl.pipenet_foreach_src
+# CHECK-INITIAL-SAME: name "UNICAST_NET"
+# CHECK-INITIAL: ^bb0(%{{.*}}: !ttl.selected_pipe_src):
+# CHECK-INITIAL: ttl.copy
+# CHECK-INITIAL: ttl.pipenet_foreach_dst
+# CHECK-INITIAL-SAME: name "UNICAST_NET"
+# CHECK-INITIAL: ^bb0(%{{.*}}: !ttl.selected_pipe_dst):
+# CHECK-INITIAL: ttl.copy
+# CHECK-INITIAL: ttl.pipenet_foreach_dst
+# CHECK-INITIAL-SAME: name "SINGLETON_MULTICAST_NET"
+# CHECK-INITIAL: ^bb0(%{{.*}}: !ttl.selected_pipe_dst):
+# CHECK-INITIAL: ttl.copy
+# CHECK-INITIAL-NOT: ttl.if_src
+# CHECK-INITIAL-NOT: ttl.if_dst
+# CHECK-INITIAL-NOT: ttl.create_pipe
+
+# CHECK-CPP: {{noc[0-9]*\.async_write\(}}
+# CHECK-CPP: {{noc[0-9]*\.async_write_multicast}}
+# CHECK-CPP-COUNT-2: {{noc[0-9]*\.inline_dw_write}}
+# CHECK-CPP: experimental::constant_table_lookup<
+
+# CHECK-LOOPS-COUNT-4: for (
+# CHECK-LOOPS-NOT: for (
+
+# CHECK-SIZE: TABLE-DRIVEN-PIPE-KERNEL-SOURCE-BYTES: {{[0-9]+}} / 24576
+
+# Pipe-record fields must remain compile-time tables; only mutable progress
+# state requires local arrays.
+# CHECK-NO-DESCRIPTOR-ARRAYS: TTNN INTEROP: Compiling kernel
+# CHECK-NO-DESCRIPTOR-ARRAYS-NOT: {{size_t v[0-9]+\[[0-9]+\];}}
+# CHECK-NO-DESCRIPTOR-ARRAYS: TABLE-DRIVEN-PIPE-KERNEL-SOURCE-BYTES:

--- a/test/python/pipe/pipenet_foreach_iteration.py
+++ b/test/python/pipe/pipenet_foreach_iteration.py
@@ -8,14 +8,13 @@
 # RUN: FileCheck %s --check-prefix=CHECK-INITIAL < %t.initial.mlir
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
 # RUN: FileCheck %s --check-prefix=CHECK-LOOPS < %t.output
-# RUN: %python %s --report-kernel-size %t.output | FileCheck %s --check-prefix=CHECK-SIZE
+# RUN: %python %s --report-kernel-size < %t.output | FileCheck %s --check-prefix=CHECK-SIZE
 # RUN: FileCheck %s --check-prefix=CHECK-NO-DESCRIPTOR-ARRAYS < %t.output
 
 """Compile-only coverage for large table-driven PipeNet callback lowering."""
 
 import re
 import sys
-from pathlib import Path
 
 import pytest
 import torch
@@ -112,19 +111,21 @@ def compile_all_to_all():
         ALL_TO_ALL_NET.if_dst(receive)
 
 
-def report_table_driven_kernel_size(output_path):
-    output = Path(output_path).read_text()
-    pipe_kernel_paths = [
-        Path(match.group(1))
+def report_table_driven_kernel_size(output):
+    """Report the largest pipe kernel source section in compiler output."""
+    # Kernel logging appends one newline after the source text.
+    pipe_kernel_sources = [
+        match.group("source").removesuffix("\n")
         for match in re.finditer(
-            r"^=== (?:send_dm|recv_dm) kernel written to (.+) ===$",
+            r"^=== (?:send_dm|recv_dm) kernel written to [^\n]+ ===\n"
+            r"(?P<source>.*?)^={60}$",
             output,
-            re.MULTILINE,
+            re.DOTALL | re.MULTILINE,
         )
     ]
-    assert len(pipe_kernel_paths) == 4
+    assert len(pipe_kernel_sources) == 4
     largest_kernel_bytes = max(
-        kernel_path.stat().st_size for kernel_path in pipe_kernel_paths
+        len(kernel_source.encode()) for kernel_source in pipe_kernel_sources
     )
     assert largest_kernel_bytes < MAX_PIPE_KERNEL_SOURCE_BYTES
     print(
@@ -134,8 +135,8 @@ def report_table_driven_kernel_size(output_path):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 3 and sys.argv[1] == "--report-kernel-size":
-        report_table_driven_kernel_size(sys.argv[2])
+    if len(sys.argv) == 2 and sys.argv[1] == "--report-kernel-size":
+        report_table_driven_kernel_size(sys.stdin.read())
     else:
         assert len(sys.argv) == 1
         assert len(ALL_TO_ALL_NET.pipes) == ALL_TO_ALL_EDGE_COUNT

--- a/test/python/pipe/pipenet_foreach_iteration.py
+++ b/test/python/pipe/pipenet_foreach_iteration.py
@@ -11,7 +11,7 @@
 # RUN: FileCheck %s --check-prefix=CHECK-SIZE < %t.output
 # RUN: FileCheck %s --check-prefix=CHECK-NO-DESCRIPTOR-ARRAYS < %t.output
 
-"""Compile-only coverage for table-driven PipeNet callback lowering."""
+"""Compile-only coverage for large table-driven PipeNet callback lowering."""
 
 import os
 import runpy
@@ -23,7 +23,11 @@ import ttl
 
 pytest.importorskip("ttnn", exc_type=ImportError)
 
-PIPE_COUNT = 7
+NODE_GRID = (4, 8)
+NODE_COUNT = NODE_GRID[0] * NODE_GRID[1]
+PEER_COUNT = NODE_COUNT - 1
+ALL_TO_ALL_EDGE_COUNT = NODE_COUNT * PEER_COUNT
+SINGLE_RECEIVER_COLLECTIVE_COUNT = 7
 MAX_PIPE_KERNEL_SOURCE_BYTES = 24 * 1024
 
 
@@ -31,42 +35,43 @@ class BFloat16Tensor:
     dtype = torch.bfloat16
 
 
-UNICAST_NET = ttl.PipeNet(
-    [ttl.Pipe(src=(node, 0), dst=(node, 1)) for node in range(PIPE_COUNT)]
+NODES = [
+    (node_x, node_y) for node_x in range(NODE_GRID[0]) for node_y in range(NODE_GRID[1])
+]
+ALL_TO_ALL_NET = ttl.PipeNet(
+    [
+        ttl.Pipe(src=source, dst=destination)
+        for source in NODES
+        for destination in NODES
+        if source != destination
+    ]
 )
 
-SINGLETON_MULTICAST_NET = ttl.PipeNet(
+SINGLE_RECEIVER_COLLECTIVE_NET = ttl.PipeNet(
     [
         ttl.Pipe(src=(node, 0), dst=(slice(node, node + 1), 1))
-        for node in range(PIPE_COUNT)
+        for node in range(SINGLE_RECEIVER_COLLECTIVE_COUNT)
     ]
 )
 
 
-@ttl.operation(grid=(PIPE_COUNT, 2))
-def compile_pipenet_foreach_iteration():
+@ttl.operation(grid=(SINGLE_RECEIVER_COLLECTIVE_COUNT, 2))
+def compile_single_receiver_collective():
     template = BFloat16Tensor()
     send_dfb = ttl.make_dataflow_buffer_like(template, shape=(1, 1), block_count=2)
     recv_dfb = ttl.make_dataflow_buffer_like(template, shape=(1, 1), block_count=2)
 
     @ttl.compute()
     def compute():
-        if UNICAST_NET.is_dst():
+        if SINGLE_RECEIVER_COLLECTIVE_NET.is_dst():
             with recv_dfb.wait() as _recv_blk:
                 pass
 
     @ttl.datamovement()
     def send_dm():
-        if UNICAST_NET.is_src():
+        if SINGLE_RECEIVER_COLLECTIVE_NET.is_src():
             with send_dfb.reserve() as send_blk:
-
-                def send(pipe):
-                    ttl.copy(send_blk, pipe).wait()
-
-                UNICAST_NET.if_src(send)
-        if SINGLETON_MULTICAST_NET.is_src():
-            with send_dfb.reserve() as send_blk:
-                SINGLETON_MULTICAST_NET.if_src(
+                SINGLE_RECEIVER_COLLECTIVE_NET.if_src(
                     lambda pipe: ttl.copy(send_blk, pipe).wait()
                 )
 
@@ -76,8 +81,35 @@ def compile_pipenet_foreach_iteration():
             with recv_dfb.reserve() as recv_blk:
                 ttl.copy(pipe, recv_blk).wait()
 
-        UNICAST_NET.if_dst(recv)
-        SINGLETON_MULTICAST_NET.if_dst(recv)
+        SINGLE_RECEIVER_COLLECTIVE_NET.if_dst(recv)
+
+
+@ttl.operation(grid=NODE_GRID)
+def compile_all_to_all():
+    template = BFloat16Tensor()
+    send_dfb = ttl.make_dataflow_buffer_like(template, shape=(1, 1), block_count=2)
+    recv_dfb = ttl.make_dataflow_buffer_like(
+        template, shape=(1, 1), block_count=PEER_COUNT
+    )
+
+    @ttl.compute()
+    def compute():
+        for _peer_index in range(PEER_COUNT):
+            with recv_dfb.wait() as _recv_block:
+                pass
+
+    @ttl.datamovement()
+    def send_dm():
+        with send_dfb.reserve() as send_block:
+            ALL_TO_ALL_NET.if_src(lambda pipe: ttl.copy(send_block, pipe).wait())
+
+    @ttl.datamovement()
+    def recv_dm():
+        def receive(pipe):
+            with recv_dfb.reserve() as recv_block:
+                ttl.copy(pipe, recv_block).wait()
+
+        ALL_TO_ALL_NET.if_dst(receive)
 
 
 def report_table_driven_kernel_size():
@@ -98,7 +130,12 @@ def report_table_driven_kernel_size():
 
 
 if __name__ == "__main__":
-    compile_pipenet_foreach_iteration()
+    assert len(ALL_TO_ALL_NET.pipes) == ALL_TO_ALL_EDGE_COUNT
+    print(f"ALL-TO-ALL-EDGE-COUNT: {len(ALL_TO_ALL_NET.pipes)}")
+    compile_single_receiver_collective()
+    # Compile this operation last so the emitted runner identifies the 992-edge
+    # kernels measured by report_table_driven_kernel_size().
+    compile_all_to_all()
     report_table_driven_kernel_size()
 
 
@@ -106,27 +143,24 @@ if __name__ == "__main__":
 # CHECK-INITIAL-NOT: ttl.if_dst
 # CHECK-INITIAL-NOT: ttl.create_pipe
 # CHECK-INITIAL: ttl.pipenet_foreach_src
-# CHECK-INITIAL-SAME: name "UNICAST_NET"
+# CHECK-INITIAL-SAME: name "ALL_TO_ALL_NET"
 # CHECK-INITIAL: ^bb0(%{{.*}}: !ttl.selected_pipe_src):
 # CHECK-INITIAL: ttl.copy
 # CHECK-INITIAL: ttl.pipenet_foreach_dst
-# CHECK-INITIAL-SAME: name "UNICAST_NET"
-# CHECK-INITIAL: ^bb0(%{{.*}}: !ttl.selected_pipe_dst):
-# CHECK-INITIAL: ttl.copy
-# CHECK-INITIAL: ttl.pipenet_foreach_dst
-# CHECK-INITIAL-SAME: name "SINGLETON_MULTICAST_NET"
+# CHECK-INITIAL-SAME: name "ALL_TO_ALL_NET"
 # CHECK-INITIAL: ^bb0(%{{.*}}: !ttl.selected_pipe_dst):
 # CHECK-INITIAL: ttl.copy
 # CHECK-INITIAL-NOT: ttl.if_src
 # CHECK-INITIAL-NOT: ttl.if_dst
 # CHECK-INITIAL-NOT: ttl.create_pipe
 
+# CHECK-CPP: ALL-TO-ALL-EDGE-COUNT: 992
 # CHECK-CPP: {{noc[0-9]*\.async_write\(}}
 # CHECK-CPP: {{noc[0-9]*\.async_write_multicast}}
 # CHECK-CPP-COUNT-2: {{noc[0-9]*\.inline_dw_write}}
 # CHECK-CPP: experimental::constant_table_lookup<
 
-# CHECK-LOOPS-COUNT-4: for (
+# CHECK-LOOPS-COUNT-5: for (
 # CHECK-LOOPS-NOT: for (
 
 # CHECK-SIZE: TABLE-DRIVEN-PIPE-KERNEL-SOURCE-BYTES: {{[0-9]+}} / 24576

--- a/test/python/pipe/pipenet_resource_allocation.py
+++ b/test/python/pipe/pipenet_resource_allocation.py
@@ -4,7 +4,7 @@
 
 # REQUIRES: ttnn, tt-device
 #
-# RUN: env TTLANG_FINAL_MLIR=%t.final.mlir timeout 180 %python %s > %t.output 2>&1
+# RUN: env TTLANG_FINAL_MLIR=%t.final.mlir timeout 240 %python %s > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=FINAL < %t.final.mlir
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
 # RUN: FileCheck %s --check-prefix=RUNTIME < %t.output
@@ -16,8 +16,8 @@ https://github.com/tenstorrent/tt-lang/issues/625. The report stated that
 either PipeNet delivery route alone completed, while enabling both routes
 deadlocked.
 
-The runtime RUN uses GRID_DIM=2, the original small issue-625 reproducer. It
-keeps the same row/column/helper PipeNet structure, both-route semantics,
+The runtime RUN uses GRID_DIM=7 to cover the issue-628 code-size reproducer.
+It keeps the same row/column/helper PipeNet structure, both-route semantics,
 float32 tensors, and compute-side DFB waits. It fixes the schedule by posting
 loopback receives before sending and by popping send DFB blocks before reusing
 them. Each node writes one result tile per K-pair, which verifies both
@@ -30,10 +30,7 @@ constant:
 
 The output is an OUTPUT_K_PAIRS*GRID_DIM x (GRID_DIM+1) tile grid. Each output
 tile is the sum of the row-route tile and column-route tile received by that
-node. For the runtime GRID_DIM=2 run, the expected output tile values are:
-
-  4 6 2
-  4 8 6
+node. make_expected_output computes the full GRID_DIM=7 expected tensor.
 """
 
 import contextlib  # noqa: E402
@@ -47,9 +44,7 @@ import ttl  # noqa: E402
 from ttlang_test_utils import assert_allclose, to_dram  # noqa: E402
 
 TILE = 32
-# TODO(#628): increase toward 7 after PipeNet data-movement lowering stops
-# duplicating transfer bodies per participating coordinate.
-GRID_DIM = 2
+GRID_DIM = 7
 
 
 def get_transfer_k_tiles(grid_dim):
@@ -323,13 +318,17 @@ def make_ksplit_resource_allocation_kernel(grid_dim):
 # FINAL-SAME: ttl.pipe_computed_address_dfb_indices = array<i32: 0, 2>
 #
 # CHECK-CPP-LABEL: === post_receives_and_send kernel written to {{.*}} ===
-# CHECK-CPP-DAG: {{(size_t|int32_t)}} [[READY:v[0-9]+]] = 6;
-# CHECK-CPP: get_semaphore([[READY]])
+# CHECK-CPP-DAG: {{(size_t|int32_t)}} [[STATIC_READY:v[0-9]+]] = 6;
+# CHECK-CPP: get_semaphore([[STATIC_READY]])
+# CHECK-CPP: noc0.inline_dw_write<NocOptions::INLINE_L1>
 # CHECK-CPP: reinterpret_cast<tt_l1_ptr uint32_t*>
 # CHECK-CPP: experimental::semaphore_wait
+# CHECK-CPP: noc0.async_write_multicast
 # CHECK-CPP: get_common_arg_val<uint32_t>
 # CHECK-CPP: noc0.async_write(
 # CHECK-CPP: noc_semaphore_inc
+# CHECK-CPP: size_t [[SELECTED_READY:v[0-9]+]] = experimental::constant_table_lookup<10,
+# CHECK-CPP-NEXT: int32_t {{v[0-9]+}} = get_semaphore([[SELECTED_READY]]);
 #
 # RUNTIME: PASS: ksplit_resource_allocation result verified
 def make_expected_output(input_torch, grid_dim):

--- a/test/python/pipe/pipenet_resource_allocation.py
+++ b/test/python/pipe/pipenet_resource_allocation.py
@@ -308,27 +308,24 @@ def make_ksplit_resource_allocation_kernel(grid_dim):
 
 # Transfers with disjoint receiver sets reuse completion semaphores. The six
 # completion semaphores are followed by the sender-ready semaphore at index 6.
+# Table-driven transfers publish receiver addresses in one 32-byte SRAM table.
 # FINAL-LABEL: module attributes
-# FINAL-SAME: ttl.pipe_sync_semaphore_count = 7 : i64
-# FINAL-NOT: ttl.pipe_sram_scratch_bytes
+# FINAL-DAG: ttl.pipe_sync_semaphore_count = 7 : i64
+# FINAL-DAG: ttl.pipe_sram_scratch_bytes = 32 : i64
 # FINAL-NOT: ttl.pipe_global_semaphore_count
 # FINAL: func.func @post_receives_and_send
-# The output DFB occupies physical index 1 while both receiver DFBs are live, so
-# computed addressing uses receiver indices 0 and 2.
-# FINAL-SAME: ttl.pipe_computed_address_dfb_indices = array<i32: 0, 2>
+# FINAL-NOT: ttl.pipe_computed_address_dfb_indices
 #
 # CHECK-CPP-LABEL: === post_receives_and_send kernel written to {{.*}} ===
-# CHECK-CPP-DAG: {{(size_t|int32_t)}} [[STATIC_READY:v[0-9]+]] = 6;
-# CHECK-CPP: get_semaphore([[STATIC_READY]])
 # CHECK-CPP: noc0.inline_dw_write<NocOptions::INLINE_L1>
+# CHECK-CPP: noc0.async_write_barrier
+# CHECK-CPP: size_t [[SELECTED_READY:v[0-9]+]] = experimental::constant_table_lookup<
+# CHECK-CPP-NEXT: int32_t {{v[0-9]+}} = get_semaphore([[SELECTED_READY]]);
 # CHECK-CPP: reinterpret_cast<tt_l1_ptr uint32_t*>
 # CHECK-CPP: experimental::semaphore_wait
-# CHECK-CPP: noc0.async_write_multicast
-# CHECK-CPP: get_common_arg_val<uint32_t>
 # CHECK-CPP: noc0.async_write(
+# CHECK-CPP: noc0.async_write_multicast
 # CHECK-CPP: noc_semaphore_inc
-# CHECK-CPP: size_t [[SELECTED_READY:v[0-9]+]] = experimental::constant_table_lookup<10,
-# CHECK-CPP-NEXT: int32_t {{v[0-9]+}} = get_semaphore([[SELECTED_READY]]);
 #
 # RUNTIME: PASS: ksplit_resource_allocation result verified
 def make_expected_output(input_torch, grid_dim):

--- a/test/python/pipe/scatter.py
+++ b/test/python/pipe/scatter.py
@@ -71,13 +71,22 @@ def scatter(inp, out):
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: ttl.kernel_thread = #ttkernel.thread<noc>
 
-# PipeNet emits create_pipe + if_src for each pipe in the net
-# CHECK: ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0)
-# CHECK: ttl.if_src
+# Each callback must retain the selected pipe as its copy operand.
+# CHECK: ttl.pipenet_foreach_src
+# CHECK-SAME: name "scatter_net"
+# CHECK-SAME: <srcX = 0, srcY = 0
+# CHECK-SAME: dstStartX = 1, dstStartY = 0
+# CHECK-SAME: dstEndX = 3, dstEndY = 0, isCollective = true>
+# CHECK: ^bb0(%[[SRC_PIPE:.*]]: !ttl.selected_pipe_src):
+# CHECK: ttl.copy %{{.*}}, %[[SRC_PIPE]]
 
-# if_dst call (receive from pipe)
-# CHECK: ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0)
-# CHECK: ttl.if_dst
+# CHECK: ttl.pipenet_foreach_dst
+# CHECK-SAME: name "scatter_net"
+# CHECK-SAME: <srcX = 0, srcY = 0
+# CHECK-SAME: dstStartX = 1, dstStartY = 0
+# CHECK-SAME: dstEndX = 3, dstEndY = 0, isCollective = true>
+# CHECK: ^bb0(%[[DST_PIPE:.*]]: !ttl.selected_pipe_dst):
+# CHECK: ttl.copy %[[DST_PIPE]], %{{.*}}
 
 # =============================================================================
 # C++ Output Checks (multicast pipe)

--- a/test/python/pipe/test_pipenet_collectives.py
+++ b/test/python/pipe/test_pipenet_collectives.py
@@ -10,6 +10,8 @@ gather, scatter, scatter-gather, and ring forward kernels with launch
 extent equal to work extent. The cases here cover regimes the
 `ttl-verify-pipenet-guards` verifier exercises under `grid="full"`:
 
+* Table-driven single-receiver collectives: five loopback-only collective
+  records verify that one-node ranges use unicast transport.
 * Scatter on a subgrid (`grid="full"`, work = 4 nodes in row 0):
   single PipeNet, single multicast pipe, dst rectangle smaller than the
   launch grid.
@@ -34,6 +36,72 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 from ttlang_test_utils import assert_pcc, to_dram
 
 TILE = 32
+
+
+# Five records use one loop body with record tables. Each range contains one
+# node, so transport lowering must use unicast while preserving collective
+# loopback semantics.
+TABLE_DRIVEN_COLLECTIVE_RECORDS = 5
+
+
+@ttl.operation(grid=(1, TABLE_DRIVEN_COLLECTIVE_RECORDS))
+def table_driven_single_receiver_collective_kernel(inp, out):
+    net = ttl.PipeNet(
+        [
+            ttl.Pipe(src=(0, row_idx), dst=(slice(0, 1), row_idx))
+            for row_idx in range(TABLE_DRIVEN_COLLECTIVE_RECORDS)
+        ]
+    )
+
+    recv_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    send_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        with recv_dfb.wait() as recv_blk, out_dfb.reserve() as out_blk:
+            out_blk.store(recv_blk)
+
+    @ttl.datamovement()
+    def post_and_send():
+        _, node_y = ttl.node(dims=2)
+        with send_dfb.reserve() as send_blk:
+            ttl.copy(inp[node_y : node_y + 1, 0:1], send_blk).wait()
+
+        with send_dfb.wait() as send_blk, recv_dfb.reserve() as recv_blk:
+
+            def receive_then_send(recv_pipe):
+                recv_tx = ttl.copy(recv_pipe, recv_blk)
+
+                def send(send_pipe):
+                    ttl.copy(send_blk, send_pipe).wait()
+
+                net.if_src(send)
+                recv_tx.wait()
+
+            net.if_dst(receive_then_send)
+
+    @ttl.datamovement()
+    def write_output():
+        _, node_y = ttl.node(dims=2)
+        with out_dfb.wait() as out_blk:
+            ttl.copy(out_blk, out[node_y : node_y + 1, 0:1]).wait()
+
+
+@pytest.mark.parametrize(
+    "torch_dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"]
+)
+def test_table_driven_single_receiver_collective(device, torch_dtype):
+    input_torch = torch.randn(
+        TABLE_DRIVEN_COLLECTIVE_RECORDS * TILE, TILE, dtype=torch_dtype
+    )
+    input_tensor = to_dram(input_torch, device)
+    output_tensor = to_dram(torch.zeros_like(input_torch), device)
+
+    table_driven_single_receiver_collective_kernel(input_tensor, output_tensor)
+
+    result = ttnn.to_torch(output_tensor).float()
+    assert_pcc(input_torch.float(), result)
 
 
 # ---------------------------------------------------------------------------

--- a/test/python/pipe/test_unicast_forward_chains.py
+++ b/test/python/pipe/test_unicast_forward_chains.py
@@ -10,6 +10,10 @@ blocks across several loop iterations, so the test also exercises pipe
 write/read pointer tracking beyond the DFB depth.
 """
 
+import re
+import runpy
+from pathlib import Path
+
 import pytest
 import torch
 import ttl
@@ -123,7 +127,10 @@ def row_column_unicast_chains(row_in, col_in, out):
                 ).wait()
 
 
-def test_row_column_unicast_forward_chains(device):
+def test_row_column_unicast_forward_chains(device, monkeypatch, tmp_path):
+    runner_path = tmp_path / "row_column_unicast_chains_runner.py"
+    monkeypatch.setenv("TTLANG_EMIT_RUNNER", str(runner_path))
+
     row_in_torch = torch.randn(
         CHAIN_Y * CHAIN_ITERS * TILE, BLOCK_TILES * TILE, dtype=torch.bfloat16
     )
@@ -142,6 +149,22 @@ def test_row_column_unicast_forward_chains(device):
 
     row_column_unicast_chains(row_in, col_in, out)
     ttnn.synchronize_device(device)
+
+    runner = runpy.run_path(str(runner_path))
+    assert runner["NUM_PIPE_SYNC_SEMAPHORES"] == 4
+    assert runner["PIPE_SRAM_SCRATCH_BYTES"] == 32
+    assert runner["NUM_PIPE_GLOBAL_SEMAPHORES"] == 0
+
+    data_movement_kernel = next(
+        Path(kernel_path)
+        for kernel_path, _thread_type in runner["KERNEL_PATHS"]
+        if "read_forward_rows_then_columns" in kernel_path
+    )
+    kernel_source = data_movement_kernel.read_text()
+    assert len(kernel_source.encode()) < 24 * 1024
+    assert kernel_source.count("noc0.async_write(") == 2
+    assert "experimental::constant_table_lookup<" in kernel_source
+    assert re.search(r"^\s+size_t v\d+\[", kernel_source, re.MULTILINE) is None
 
     result = ttnn.to_torch(out)
     expected = torch.zeros_like(out_torch)

--- a/test/python/pipe/unicast.py
+++ b/test/python/pipe/unicast.py
@@ -71,11 +71,19 @@ def unicast_pipe(inp, out):
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: ttl.kernel_thread = #ttkernel.thread<noc>
 
-# CHECK: ttl.create_pipe src(1, 0) dst(0, 0) to(0, 0)
-# CHECK: ttl.if_src
+# CHECK: ttl.pipenet_foreach_src
+# CHECK-SAME: name "net"
+# CHECK-SAME: <srcX = 1, srcY = 0
+# CHECK-SAME: dstEndX = 0, dstEndY = 0>
+# CHECK: ^bb0(%[[SRC_PIPE:.*]]: !ttl.selected_pipe_src):
+# CHECK: ttl.copy %{{.*}}, %[[SRC_PIPE]]
 
-# CHECK: ttl.create_pipe src(1, 0) dst(0, 0) to(0, 0)
-# CHECK: ttl.if_dst
+# CHECK: ttl.pipenet_foreach_dst
+# CHECK-SAME: name "net"
+# CHECK-SAME: <srcX = 1, srcY = 0
+# CHECK-SAME: dstEndX = 0, dstEndY = 0>
+# CHECK: ^bb0(%[[DST_PIPE:.*]]: !ttl.selected_pipe_dst):
+# CHECK: ttl.copy %[[DST_PIPE]], %{{.*}}
 
 # =============================================================================
 # C++ Output Checks (unicast pipe)

--- a/test/python/sdpa_operation_statistics.py
+++ b/test/python/sdpa_operation_statistics.py
@@ -236,15 +236,16 @@ def sdpa_fused(query, key, value, output):
 
 # Launch-coordinate predicates are deliberately unknown to this toy client.
 # Their nested data-movement operations therefore have unknown aggregate
-# dynamic counts, while surrounding static loops remain exact.
+# dynamic counts, while surrounding static loops remain exact. PipeNet foreach
+# callbacks remain one static region and count selected records dynamically.
 # CHECK-LABEL: func @dm_brisc
 # CHECK:       scf.yield static_occurrences=2 dynamic_instances=8
-# CHECK:       ttl.copy static_occurrences=40 dynamic_instances=unknown
-# CHECK:       ttl.create_pipe static_occurrences=28 dynamic_instances=64
+# CHECK:       ttl.copy static_occurrences=7 dynamic_instances=unknown
+# CHECK:       ttl.pipenet_foreach_src static_occurrences=4 dynamic_instances=13
 # CHECK-LABEL: func @dm_ncrisc
 # CHECK:       scf.yield static_occurrences=2 dynamic_instances=8
-# CHECK:       ttl.copy static_occurrences=29 dynamic_instances=unknown
-# CHECK:       ttl.create_pipe static_occurrences=28 dynamic_instances=64
+# CHECK:       ttl.copy static_occurrences=5 dynamic_instances=unknown
+# CHECK:       ttl.pipenet_foreach_dst static_occurrences=4 dynamic_instances=13
 
 
 def to_dram(device, tensor):

--- a/test/ttlang/Dialect/TTKernel/IR/verifier_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/verifier_invalid.mlir
@@ -10,3 +10,21 @@
 %count = arith.constant 1 : i32
 // expected-error @below {{'ttkernel.cb_push_back' op CBPushBackOp must be inside a kernel function}}
 ttkernel.cb_push_back(%cb, %count) : (!ttkernel.cb<2, !ttcore.tile<32x32, bf16>>, i32) -> ()
+
+// -----
+
+// Test: constant lookup tables must contain at least one value.
+func.func @empty_constant_table(%index: index) -> index {
+  // expected-error @below {{'ttkernel.experimental.constant_table_lookup' op requires at least one table value}}
+  %value = ttkernel.experimental.constant_table_lookup %index, [] : index
+  return %value : index
+}
+
+// -----
+
+// Test: constant lookup tables contain only non-negative values.
+func.func @negative_constant_table_value(%index: index) -> index {
+  // expected-error @below {{'ttkernel.experimental.constant_table_lookup' op requires non-negative table values}}
+  %value = ttkernel.experimental.constant_table_lookup %index, [0, -1] : index
+  return %value : index
+}

--- a/test/ttlang/Dialect/TTKernel/IR/verifier_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/verifier_invalid.mlir
@@ -28,3 +28,13 @@ func.func @negative_constant_table_value(%index: index) -> index {
   %value = ttkernel.experimental.constant_table_lookup %index, [0, -1] : index
   return %value : index
 }
+
+// -----
+
+// Test: a constant lookup index must identify an element in the table.
+func.func @constant_table_index_out_of_bounds() -> index {
+  %index = arith.constant 2 : index
+  // expected-error @below {{'ttkernel.experimental.constant_table_lookup' op constant index 2 is outside the table bounds [0, 2)}}
+  %value = ttkernel.experimental.constant_table_lookup %index, [10, 20] : index
+  return %value : index
+}

--- a/test/ttlang/Dialect/TTL/IR/pipenet_foreach.mlir
+++ b/test/ttlang/Dialect/TTL/IR/pipenet_foreach.mlir
@@ -1,0 +1,83 @@
+// RUN: ttlang-opt %s --split-input-file | FileCheck %s
+
+// Summary: Verifies PipeNet foreach ops and selected-pipe representations.
+
+// A source foreach body sends from a DFB through the selected source pipe.
+
+// CHECK-LABEL: func.func @foreach_src_send
+func.func @foreach_src_send() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  // CHECK: ttl.pipenet_foreach_src
+  // CHECK-SAME: records = #ttl.pipenet_records<net 0 name "row_net" pipes
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    // CHECK: ^bb0(%[[PIPE:.*]]: !ttl.selected_pipe_src)
+    // CHECK: ttl.copy %{{.*}}, %[[PIPE]]
+    %xf = ttl.copy %cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %xf : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// A destination foreach body receives into a reserved DFB slot through the
+// selected destination pipe.
+
+// CHECK-LABEL: func.func @foreach_dst_receive
+func.func @foreach_dst_receive() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // CHECK: ^bb0(%[[PIPE:.*]]: !ttl.selected_pipe_dst)
+    // CHECK: ttl.copy %[[PIPE]], %{{.*}}
+    %xf = ttl.copy %pipe, %recv
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+        -> !ttl.transfer_handle
+    ttl.wait %xf : !ttl.transfer_handle
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// Selected-pipe ops store the record index separately from coordinates.
+
+// CHECK-LABEL: func.func @select_pipe_ops
+func.func @select_pipe_ops() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %false = arith.constant false
+  // CHECK: ttl.select_pipe_src record(%{{.*}})
+  %src = ttl.select_pipe_src record(%c0) src (%c0, %c0) dst (%c1, %c0) to (%c1, %c0)
+      num_dests (%c1) src_in_dst (%false)
+      {records = #ttl.pipenet_records<net 0 pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>
+      ]>} : !ttl.selected_pipe_src
+  // CHECK: ttl.select_pipe_dst record(%{{.*}})
+  %dst = ttl.select_pipe_dst record(%c0) src (%c0, %c0) dst (%c1, %c0) to (%c1, %c0)
+      num_dests (%c1) src_in_dst (%false)
+      {records = #ttl.pipenet_records<net 0 pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>
+      ]>} : !ttl.selected_pipe_dst
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/IR/pipenet_foreach.mlir
+++ b/test/ttlang/Dialect/TTL/IR/pipenet_foreach.mlir
@@ -60,6 +60,70 @@ func.func @foreach_dst_receive() attributes {ttl.kernel_thread = #ttkernel.threa
 
 // -----
 
+// Selection identifies why a callback executes, not its copy direction. A
+// loopback source-selected record can therefore receive on the same node.
+
+// CHECK-LABEL: func.func @source_selected_loopback_receive
+func.func @source_selected_loopback_receive()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  // CHECK: %[[CB:.*]] = ttl.bind_cb
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  // CHECK: ttl.pipenet_foreach_src
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    // CHECK: ^bb0(%[[PIPE:.*]]: !ttl.selected_pipe_src)
+    // CHECK-NEXT: %[[RESERVE:.*]] = ttl.cb_reserve %[[CB]]
+    %reserve = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // CHECK-NEXT: %[[COPY:.*]] = ttl.copy %[[PIPE]], %[[RESERVE]]
+    %copy = ttl.copy %pipe, %reserve
+        : (!ttl.selected_pipe_src,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+        -> !ttl.transfer_handle
+    // CHECK-NEXT: ttl.wait %[[COPY]]
+    ttl.wait %copy : !ttl.transfer_handle
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// A loopback destination-selected record can send because its destination node
+// is also the record source.
+
+// CHECK-LABEL: func.func @destination_selected_loopback_send
+func.func @destination_selected_loopback_send()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  // CHECK: %[[CB:.*]] = ttl.bind_cb
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  // CHECK: ttl.pipenet_foreach_dst
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    // CHECK: ^bb0(%[[PIPE:.*]]: !ttl.selected_pipe_dst)
+    // CHECK-NEXT: %[[COPY:.*]] = ttl.copy %[[CB]], %[[PIPE]]
+    %copy = ttl.copy %cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+           !ttl.selected_pipe_dst)
+        -> !ttl.transfer_handle<write>
+    // CHECK-NEXT: ttl.wait %[[COPY]]
+    ttl.wait %copy : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
 // Selected-pipe ops store the record index separately from coordinates.
 
 // CHECK-LABEL: func.func @select_pipe_ops

--- a/test/ttlang/Dialect/TTL/IR/pipenet_foreach_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/pipenet_foreach_invalid.mlir
@@ -18,10 +18,24 @@ func.func @point_to_point_record_receiver_count() {
 
 // -----
 
+// PipeNet record tables must not be empty.
+func.func @empty_record_table() {
+  ttl.pipenet_foreach_src attributes {
+      // expected-error @+2 {{expected '<'}}
+      // expected-error @below {{failed to parse TTL_PipeNetRecordsAttr parameter 'pipes'}}
+      records = #ttl.pipenet_records<net 0 pipes []>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
 // Foreach records must have a uniform pipe kind.
 func.func @foreach_mixed_record_kind() {
-  // expected-error @+1 {{'ttl.pipenet_foreach_src' op all pipe records must be either point-to-point or collective}}
   ttl.pipenet_foreach_src attributes {
+      // expected-error @below {{all pipe records must be either point-to-point or collective}}
       records = #ttl.pipenet_records<net 0 pipes [
         #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
         #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1, isCollective = true>
@@ -36,7 +50,7 @@ func.func @foreach_mixed_record_kind() {
 
 // Selected transfer creation requires a direct select_pipe definition.
 func.func @selected_transfer_requires_direct_def(%pipe: !ttl.selected_pipe_src) {
-  // expected-error @+1 {{'ttl.pipe_transfer.create' op selected pipe operand must be a direct result of ttl.select_pipe_src or ttl.select_pipe_dst}}
+  // expected-error @below {{'ttl.pipe_transfer.create' op selected pipe operand must be a direct result of ttl.select_pipe_src or ttl.select_pipe_dst}}
   %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.selected_pipe_src -> !ttl.pipe_transfer
   func.return
@@ -54,7 +68,7 @@ func.func @selected_transfer_kind_mismatch() {
       {records = #ttl.pipenet_records<net 0 pipes [
         #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0, isCollective = true>
       ]>} : !ttl.selected_pipe_src
-  // expected-error @+1 {{'ttl.pipe_transfer.create' op selected pipe transfer kind must match the records kind}}
+  // expected-error @below {{'ttl.pipe_transfer.create' op selected pipe transfer kind must match the records kind}}
   %transfer = ttl.pipe_transfer.create %src {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.selected_pipe_src -> !ttl.pipe_transfer
   func.return

--- a/test/ttlang/Dialect/TTL/IR/pipenet_foreach_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/pipenet_foreach_invalid.mlir
@@ -58,6 +58,25 @@ func.func @selected_transfer_requires_direct_def(%pipe: !ttl.selected_pipe_src) 
 
 // -----
 
+// Selected-pipe copy operands require a select operation or foreach block
+// argument that supplies their record table.
+func.func @selected_copy_requires_record_definition(
+    %pipe: !ttl.selected_pipe_dst) {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %reserve = ttl.cb_reserve %cb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.copy' op selected pipe operand must be defined by ttl.select_pipe_src, ttl.select_pipe_dst, ttl.pipenet_foreach_src, or ttl.pipenet_foreach_dst}}
+  %copy = ttl.copy %pipe, %reserve
+      : (!ttl.selected_pipe_dst,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle
+  func.return
+}
+
+// -----
+
 // Selected transfer kind must match the selected records kind.
 func.func @selected_transfer_kind_mismatch() {
   %c0 = arith.constant 0 : index

--- a/test/ttlang/Dialect/TTL/IR/pipenet_foreach_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/pipenet_foreach_invalid.mlir
@@ -1,0 +1,61 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics
+
+// Summary: Negative tests for PipeNet foreach and selected-pipe IR.
+
+// Point-to-point records must have exactly one receiver.
+func.func @point_to_point_record_receiver_count() {
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 pipes [
+        // expected-error @below {{point-to-point pipe record must have exactly one receiver}}
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 2, dstEndY = 0>
+        // expected-error @below {{failed to parse TTL_PipeNetRecordsAttr parameter 'pipes'}}
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// Foreach records must have a uniform pipe kind.
+func.func @foreach_mixed_record_kind() {
+  // expected-error @+1 {{'ttl.pipenet_foreach_src' op all pipe records must be either point-to-point or collective}}
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1, isCollective = true>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// Selected transfer creation requires a direct select_pipe definition.
+func.func @selected_transfer_requires_direct_def(%pipe: !ttl.selected_pipe_src) {
+  // expected-error @+1 {{'ttl.pipe_transfer.create' op selected pipe operand must be a direct result of ttl.select_pipe_src or ttl.select_pipe_dst}}
+  %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
+      : !ttl.selected_pipe_src -> !ttl.pipe_transfer
+  func.return
+}
+
+// -----
+
+// Selected transfer kind must match the selected records kind.
+func.func @selected_transfer_kind_mismatch() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %false = arith.constant false
+  %src = ttl.select_pipe_src record(%c0) src (%c0, %c0) dst (%c1, %c0) to (%c1, %c0)
+      num_dests (%c1) src_in_dst (%false)
+      {records = #ttl.pipenet_records<net 0 pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0, isCollective = true>
+      ]>} : !ttl.selected_pipe_src
+  // expected-error @+1 {{'ttl.pipe_transfer.create' op selected pipe transfer kind must match the records kind}}
+  %transfer = ttl.pipe_transfer.create %src {kind = #ttl.pipe_transfer_kind<point_to_point>}
+      : !ttl.selected_pipe_src -> !ttl.pipe_transfer
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/IR/pipes.mlir
+++ b/test/ttlang/Dialect/TTL/IR/pipes.mlir
@@ -116,7 +116,6 @@ func.func @copy_pipe_to_cb() {
 // CHECK-LABEL: func.func @pipe_transfer_ir
 // CHECK: %[[P:.*]] = ttl.create_pipe
 // CHECK: %[[TRANSFER:.*]] = ttl.pipe_transfer.create %[[P]]
-// CHECK-SAME: expectedReceivers = 1 : i64
 // CHECK-SAME: kind = #ttl.pipe_transfer_kind<point_to_point>
 // CHECK: %[[TOKEN:.*]] = ttl.pipe_transfer.post %[[TRANSFER]]
 // CHECK: %[[XF:.*]] = ttl.pipe_transfer.send %[[TRANSFER]]
@@ -125,7 +124,7 @@ func.func @copy_pipe_to_cb() {
 func.func @pipe_transfer_ir() {
   %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], f32, 2>
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %recv = ttl.cb_reserve %cb : <[1, 1], f32, 2> -> tensor<1x1xf32>
   %token = ttl.pipe_transfer.post %transfer, %recv
@@ -149,7 +148,7 @@ func.func @pipe_transfer_loop_carried_token() {
   %one = arith.constant 1 : index
   %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], f32, 2>
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %recv = ttl.cb_reserve %cb : <[1, 1], f32, 2> -> tensor<1x1xf32>
   %token_init = ttl.pipe_transfer.post %transfer, %recv
@@ -200,21 +199,19 @@ func.func @pipe_transfer_one_iteration_selects_yield() {
 // CHECK-LABEL: func.func @pipe_transfer_kind_printing
 // CHECK: %[[PTP_PIPE:.*]] = ttl.create_pipe
 // CHECK: ttl.pipe_transfer.create %[[PTP_PIPE]]
-// CHECK-SAME: expectedReceivers = 1 : i64
 // CHECK-SAME: kind = #ttl.pipe_transfer_kind<point_to_point>
 // CHECK: %[[COLLECTIVE_PIPE:.*]] = ttl.create_pipe
 // CHECK: ttl.pipe_transfer.create %[[COLLECTIVE_PIPE]]
-// CHECK-SAME: expectedReceivers = 2 : i64
 // CHECK-SAME: kind = #ttl.pipe_transfer_kind<collective>
 func.func @pipe_transfer_kind_printing() {
   %ptp_pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %ptp_transfer = ttl.pipe_transfer.create %ptp_pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %ptp_transfer = ttl.pipe_transfer.create %ptp_pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
 
   %collective_pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0
       : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
-  %collective_transfer = ttl.pipe_transfer.create %collective_pipe {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<collective>}
+  %collective_transfer = ttl.pipe_transfer.create %collective_pipe {kind = #ttl.pipe_transfer_kind<collective>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
 
   func.return

--- a/test/ttlang/Dialect/TTL/IR/pipes_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/pipes_invalid.mlir
@@ -23,33 +23,11 @@ func.func @pipe_receive_without_reserve(%t: tensor<32x32xf32>) {
 
 // -----
 
-// Test: internal pipe transfer expected receiver count must be positive.
-func.func @pipe_transfer_expected_receiver_count_positive() {
-  %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  // expected-error @+1 {{'ttl.pipe_transfer.create' op requires positive expectedReceivers}}
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 0 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
-      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
-  func.return
-}
-
-// -----
-
-// Test: internal pipe transfer expected receiver count must match the pipe.
-func.func @pipe_transfer_expected_receiver_count_mismatch() {
-  %p = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
-  // expected-error @+1 {{'ttl.pipe_transfer.create' op expectedReceivers must match the pipe receiver count}}
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<collective>}
-      : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
-  func.return
-}
-
-// -----
-
 // Test: point-to-point pipe transfer cannot target multiple receivers.
 func.func @pipe_transfer_point_to_point_multi_receiver() {
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
   // expected-error @+1 {{'ttl.pipe_transfer.create' op point_to_point transfer requires one receiver}}
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
   func.return
 }
@@ -59,7 +37,7 @@ func.func @pipe_transfer_point_to_point_multi_receiver() {
 // Test: pipe transfer send result is a write handle.
 func.func @pipe_transfer_send_requires_write_handle() {
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops.mlir
@@ -253,7 +253,7 @@ func.func @explicit_pipe_transfer_ir() attributes { "ttl.kernel_thread" = #ttker
   %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %transfer_init = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer_init = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %transfer = scf.for %iter = %zero to %one step %one iter_args(%transfer_arg = %transfer_init)
       -> (!ttl.pipe_transfer) {
@@ -312,7 +312,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %p : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -364,9 +364,9 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
     %ready_pipe = ttl.create_pipe src(0, 0) dst(2, 0) to(2, 0) net 1
         : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 1>
-    %capacity_transfer = ttl.pipe_transfer.create %capacity_pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %capacity_transfer = ttl.pipe_transfer.create %capacity_pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
-    %ready_transfer = ttl.pipe_transfer.create %ready_pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %ready_transfer = ttl.pipe_transfer.create %ready_pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 1> -> !ttl.pipe_transfer
     ttl.if_dst %capacity_pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %capacity_dst : <[1, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -418,7 +418,7 @@ func.func @static_subview_pipe_transfer_computed_address() attributes { "ttl.ker
   %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[2, 1], !ttcore.tile<32x32, f32>, 1>
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %recv_full = ttl.cb_reserve %dst_cb : <[2, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<2x1x!ttcore.tile<32x32, f32>>
   %recv = tensor.extract_slice %recv_full[1, 0] [1, 1] [1, 1]
@@ -461,9 +461,9 @@ func.func @two_incoming_edges_one_dfb_compute_addresses() attributes { "ttl.kern
   %dst_cb = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   %pA = ttl.create_pipe src(0, 0) dst(2, 0) to(2, 0) net 0 : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0>
   %pB = ttl.create_pipe src(1, 0) dst(2, 0) to(2, 0) net 1 : !ttl.pipe<src(1, 0) dst(2, 0) to(2, 0) net 1>
-  %tA = ttl.pipe_transfer.create %pA {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %tA = ttl.pipe_transfer.create %pA {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
-  %tB = ttl.pipe_transfer.create %pB {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %tB = ttl.pipe_transfer.create %pB {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(1, 0) dst(2, 0) to(2, 0) net 1> -> !ttl.pipe_transfer
   ttl.if_dst %pA : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0> {
     %recvA = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -517,11 +517,11 @@ func.func @receiver_published_address_slots_ignore_computed_colors(%dynamic_idx:
       : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 1>
   %published_b_pipe = ttl.create_pipe src(0, 0) dst(3, 0) to(3, 0) net 2
       : !ttl.pipe<src(0, 0) dst(3, 0) to(3, 0) net 2>
-  %published_a_transfer = ttl.pipe_transfer.create %published_a_pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %published_a_transfer = ttl.pipe_transfer.create %published_a_pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
-  %computed_transfer = ttl.pipe_transfer.create %computed_pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %computed_transfer = ttl.pipe_transfer.create %computed_pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 1> -> !ttl.pipe_transfer
-  %published_b_transfer = ttl.pipe_transfer.create %published_b_pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %published_b_transfer = ttl.pipe_transfer.create %published_b_pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(3, 0) to(3, 0) net 2> -> !ttl.pipe_transfer
   %published_a_full = ttl.cb_reserve %published_a_dst
       : <[2, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<2x1x!ttcore.tile<32x32, f32>>
@@ -585,9 +585,9 @@ func.func @two_multicast_edges_one_dfb_compute_addresses() attributes { "ttl.ker
   %dst_cb = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   %p0 = ttl.create_pipe src(0, 0) dst(0, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(0, 0) to(1, 0) net 0>
   %p1 = ttl.create_pipe src(1, 0) dst(0, 0) to(1, 0) net 0 : !ttl.pipe<src(1, 0) dst(0, 0) to(1, 0) net 0>
-  %t0 = ttl.pipe_transfer.create %p0 {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<collective>}
+  %t0 = ttl.pipe_transfer.create %p0 {kind = #ttl.pipe_transfer_kind<collective>}
       : !ttl.pipe<src(0, 0) dst(0, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
-  %t1 = ttl.pipe_transfer.create %p1 {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<collective>}
+  %t1 = ttl.pipe_transfer.create %p1 {kind = #ttl.pipe_transfer_kind<collective>}
       : !ttl.pipe<src(1, 0) dst(0, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   ttl.if_dst %p0 : !ttl.pipe<src(0, 0) dst(0, 0) to(1, 0) net 0> {
     %recv0 = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -637,9 +637,9 @@ func.func @independent_receivers_same_dfb_compute_addresses() attributes { "ttl.
   %dst_cb = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
   %pipe0 = ttl.create_pipe src(0, 0) dst(2, 0) to(2, 0) net 0 : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0>
   %pipe1 = ttl.create_pipe src(1, 0) dst(3, 0) to(3, 0) net 1 : !ttl.pipe<src(1, 0) dst(3, 0) to(3, 0) net 1>
-  %transfer0 = ttl.pipe_transfer.create %pipe0 {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer0 = ttl.pipe_transfer.create %pipe0 {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
-  %transfer1 = ttl.pipe_transfer.create %pipe1 {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer1 = ttl.pipe_transfer.create %pipe1 {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(1, 0) dst(3, 0) to(3, 0) net 1> -> !ttl.pipe_transfer
   ttl.if_dst %pipe0 : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0> {
     %recv0 = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -681,7 +681,7 @@ func.func @independent_receivers_same_dfb_compute_addresses() attributes { "ttl.
 func.func @explicit_pipe_transfer_receive_only() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
   %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   // Preserve receiver-published lowering while testing an unused post token.
   %local = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -697,7 +697,7 @@ func.func @explicit_pipe_transfer_receive_only() attributes { "ttl.kernel_thread
 func.func @explicit_pipe_transfer_receive_only_sender() attributes { "ttl.kernel_thread" = #ttkernel.thread<noc> } {
   %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-  %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %send = ttl.pipe_transfer.send %transfer, %src_cb
       : (!ttl.pipe_transfer, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
@@ -945,7 +945,7 @@ func.func @same_source_control_flow_interval_uses_distinct_sync_state() attribut
   %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 1], !ttcore.tile<32x32, f32>, 2>
   %p0 = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
   %p1 = ttl.create_pipe src(0, 0) dst(2, 0) to(2, 0) net 0 : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0>
-  %transfer0 = ttl.pipe_transfer.create %p0 {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer0 = ttl.pipe_transfer.create %p0 {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %recv0_full = ttl.cb_reserve %dst_cb : <[2, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<2x1x!ttcore.tile<32x32, f32>>
   %recv0 = tensor.extract_slice %recv0_full[1, 0] [1, 1] [1, 1]
@@ -960,7 +960,7 @@ func.func @same_source_control_flow_interval_uses_distinct_sync_state() attribut
   %send0 = ttl.pipe_transfer.send %transfer0, %src_cb
       : (!ttl.pipe_transfer, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> !ttl.transfer_handle<write>
   ttl.wait %send0 : !ttl.transfer_handle<write>
-  %transfer1 = ttl.pipe_transfer.create %p1 {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer1 = ttl.pipe_transfer.create %p1 {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
   %recv1_full = ttl.cb_reserve %dst_cb : <[2, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<2x1x!ttcore.tile<32x32, f32>>
   %recv1 = tensor.extract_slice %recv1_full[1, 0] [1, 1] [1, 1]
@@ -998,7 +998,7 @@ func.func @same_source_control_flow_send_interval_uses_distinct_sync_state() att
   %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 1], !ttcore.tile<32x32, f32>, 2>
   %p0 = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
   %p1 = ttl.create_pipe src(0, 0) dst(2, 0) to(2, 0) net 0 : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0>
-  %transfer0 = ttl.pipe_transfer.create %p0 {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer0 = ttl.pipe_transfer.create %p0 {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
   %recv0_full = ttl.cb_reserve %dst_cb : <[2, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<2x1x!ttcore.tile<32x32, f32>>
   %recv0 = tensor.extract_slice %recv0_full[1, 0] [1, 1] [1, 1]
@@ -1015,7 +1015,7 @@ func.func @same_source_control_flow_send_interval_uses_distinct_sync_state() att
     ttl.wait %else_send : !ttl.transfer_handle<write>
   }
   ttl.pipe_transfer.wait %token0 : !ttl.pipe_token<net 0>
-  %transfer1 = ttl.pipe_transfer.create %p1 {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+  %transfer1 = ttl.pipe_transfer.create %p1 {kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
   %recv1_full = ttl.cb_reserve %dst_cb : <[2, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<2x1x!ttcore.tile<32x32, f32>>
   %recv1 = tensor.extract_slice %recv1_full[1, 0] [1, 1] [1, 1]

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_invalid.mlir
@@ -412,7 +412,7 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
     %receiver_one = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 1
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 1>
     %transfer = ttl.pipe_transfer.create %collective
-        {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<collective>}
+        {kind = #ttl.pipe_transfer_kind<collective>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %receiver_one
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 1> {
@@ -472,10 +472,10 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
     %receiver_one = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 1
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 1>
     %collective_transfer = ttl.pipe_transfer.create %collective
-        {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<collective>}
+        {kind = #ttl.pipe_transfer_kind<collective>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
     %receiver_one_transfer = ttl.pipe_transfer.create %receiver_one
-        {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+        {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 1> -> !ttl.pipe_transfer
     %lower = arith.constant 0 : index
     %upper = arith.constant 2 : index

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_receive_ahead.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_receive_ahead.mlir
@@ -28,7 +28,6 @@ func.func @same_pipe_receive_ahead_across_blocks_allocates_two_slots()
   %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
   %transfer = ttl.pipe_transfer.create %p {
-      expectedReceivers = 1 : i64,
       kind = #ttl.pipe_transfer_kind<point_to_point>}
       : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
       -> !ttl.pipe_transfer

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_capacity_analysis.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_capacity_analysis.mlir
@@ -14,7 +14,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -162,7 +162,7 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
     %dst_cb = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0 {isCollective = true}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<collective>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<collective>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -196,7 +196,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -236,9 +236,9 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
     %dst_cb = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pA = ttl.create_pipe src(0, 0) dst(2, 0) to(2, 0) net 0 : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0>
     %pB = ttl.create_pipe src(1, 0) dst(2, 0) to(2, 0) net 1 : !ttl.pipe<src(1, 0) dst(2, 0) to(2, 0) net 1>
-    %tA = ttl.pipe_transfer.create %pA {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %tA = ttl.pipe_transfer.create %pA {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(2, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
-    %tB = ttl.pipe_transfer.create %pB {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %tB = ttl.pipe_transfer.create %pB {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(1, 0) dst(2, 0) to(2, 0) net 1> -> !ttl.pipe_transfer
     %recvA = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
     %tokA = ttl.pipe_transfer.post %tA, %recvA
@@ -284,7 +284,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb {num_tiles = 2 : i64}

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_computed_address_option.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_computed_address_option.mlir
@@ -283,7 +283,7 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
     %transfer = ttl.pipe_transfer.create %pipe
-        {expectedReceivers = 2 : i64, kind = #ttl.pipe_transfer_kind<collective>}
+        {kind = #ttl.pipe_transfer_kind<collective>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb
@@ -396,7 +396,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
     %p = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %p {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %p {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %p : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<1x1x!ttcore.tile<32x32, f32>>

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_only_receiver_streams.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_only_receiver_streams.mlir
@@ -20,7 +20,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -50,7 +50,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     %is_dst = ttl.is_dst {pipe_net_id = 0 : i64}
     scf.if %is_dst {
@@ -81,7 +81,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -113,7 +113,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -143,7 +143,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -173,7 +173,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -200,7 +200,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %recv = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -232,7 +232,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     %src_cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0 : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %transfer = ttl.pipe_transfer.create %pipe {expectedReceivers = 1 : i64, kind = #ttl.pipe_transfer_kind<point_to_point>}
+    %transfer = ttl.pipe_transfer.create %pipe {kind = #ttl.pipe_transfer_kind<point_to_point>}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> -> !ttl.pipe_transfer
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %unused = ttl.cb_reserve %dst_cb : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach.mlir
@@ -116,6 +116,72 @@ func.func @foreach_dst_receive_direct()
 
 // -----
 
+// Direct record conditions use TTKernel logical coordinates. Pipe analysis
+// must restrict each receive to its matching row before proving the shared
+// outer reservation has one receive and wait.
+
+module attributes {ttl.launch_grid = array<i64: 3, 2>} {
+
+func.func @foreach_dst_outer_reserve_direct_sender()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %is_src = ttl.is_src {pipe_net_id = 0 : i64}
+  scf.if %is_src {
+    ttl.pipenet_foreach_src attributes {
+        records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 2, dstEndY = 0, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 2, dstEndY = 1, isCollective = true>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_src):
+      %xf = ttl.copy %cb, %pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+             !ttl.selected_pipe_src)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %xf : !ttl.transfer_handle<write>
+      ttl.yield
+    }
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @foreach_dst_outer_reserve_direct
+// CHECK-NOT: scf.for
+// CHECK-COUNT-2: ttkernel.experimental.semaphore_wait_min
+// CHECK: ttkernel.cb_push_back
+// CHECK-NOT: scf.for
+// CHECK: return
+func.func @foreach_dst_outer_reserve_direct()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %is_dst = ttl.is_dst {pipe_net_id = 0 : i64}
+  scf.if %is_dst {
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.pipenet_foreach_dst attributes {
+        records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 2, dstEndY = 0, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 2, dstEndY = 1, isCollective = true>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_dst):
+      %xf = ttl.copy %pipe, %recv
+          : (!ttl.selected_pipe_dst,
+             tensor<1x1x!ttcore.tile<32x32, f32>>)
+          -> !ttl.transfer_handle
+      ttl.wait %xf : !ttl.transfer_handle
+      ttl.yield
+    }
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+  }
+  func.return
+}
+
+}
+
+// -----
+
 // Five-record source foreach lowering emits one loop and one send protocol
 // body.
 
@@ -238,4 +304,301 @@ func.func @foreach_dst_receive_table_driven()
     ttl.yield
   }
   func.return
+}
+
+// -----
+
+// A selected receive wait completes before a push after the record loop. The
+// graph already represents the one matching iteration for each receiver.
+
+module attributes {ttl.launch_grid = array<i64: 3, 5>} {
+
+func.func @foreach_dst_outer_reserve_sender()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %is_src = ttl.is_src {pipe_net_id = 0 : i64}
+  scf.if %is_src {
+    ttl.pipenet_foreach_src attributes {
+        records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 2, dstEndY = 0, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 2, dstEndY = 1, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 2, dstEndY = 2, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 2, dstEndY = 3, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 4, dstEndX = 2, dstEndY = 4, isCollective = true>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_src):
+      %xf = ttl.copy %cb, %pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+             !ttl.selected_pipe_src)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %xf : !ttl.transfer_handle<write>
+      ttl.yield
+    }
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @foreach_dst_outer_reserve
+// CHECK: scf.for
+// CHECK: ttkernel.experimental.semaphore_wait_min
+// CHECK: ttkernel.cb_push_back
+// CHECK: return
+func.func @foreach_dst_outer_reserve()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %is_dst = ttl.is_dst {pipe_net_id = 0 : i64}
+  scf.if %is_dst {
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.pipenet_foreach_dst attributes {
+        records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 2, dstEndY = 0, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 2, dstEndY = 1, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 2, dstEndY = 2, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 2, dstEndY = 3, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 4, dstEndX = 2, dstEndY = 4, isCollective = true>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_dst):
+      %xf = ttl.copy %pipe, %recv
+          : (!ttl.selected_pipe_dst,
+             tensor<1x1x!ttcore.tile<32x32, f32>>)
+          -> !ttl.transfer_handle
+      ttl.wait %xf : !ttl.transfer_handle
+      ttl.yield
+    }
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+  }
+  func.return
+}
+
+}
+
+// -----
+
+// Lowering an outer direct callback clones its nested table-driven callback.
+// Both generated record-selection regions must remain visible to pipe analysis.
+
+module attributes {ttl.launch_grid = array<i64: 2, 5>} {
+
+// CHECK-LABEL: func.func @nested_foreach_sender
+// CHECK: scf.if
+// CHECK: scf.for
+// CHECK: ttkernel.noc_async_write
+// CHECK-NOT: ttl.pipenet_foreach
+// CHECK: return
+func.func @nested_foreach_sender()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %send_cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 1 name "outer" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 4, isCollective = true>
+      ]>} {
+  ^bb0(%outer_pipe: !ttl.selected_pipe_src):
+    ttl.pipenet_foreach_src attributes {
+        records = #ttl.pipenet_records<net 0 name "inner" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 4, dstEndX = 1, dstEndY = 4>
+        ]>} {
+    ^bb0(%inner_pipe: !ttl.selected_pipe_src):
+      %send = ttl.copy %send_cb, %inner_pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+             !ttl.selected_pipe_src)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+      ttl.yield
+    }
+    ttl.yield
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @nested_foreach_receiver
+// CHECK: scf.if
+// CHECK: scf.for
+// CHECK: ttkernel.experimental.semaphore_wait_min
+// CHECK-NOT: ttl.pipenet_foreach
+// CHECK: return
+func.func @nested_foreach_receiver()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %recv_cb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 1 name "outer" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 4, isCollective = true>
+      ]>} {
+  ^bb0(%outer_pipe: !ttl.selected_pipe_dst):
+    ttl.pipenet_foreach_dst attributes {
+        records = #ttl.pipenet_records<net 0 name "inner" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 4, dstEndX = 1, dstEndY = 4>
+        ]>} {
+    ^bb0(%inner_pipe: !ttl.selected_pipe_dst):
+      %reserve = ttl.cb_reserve %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %receive = ttl.copy %inner_pipe, %reserve
+          : (!ttl.selected_pipe_dst,
+             tensor<1x1x!ttcore.tile<32x32, f32>>)
+          -> !ttl.transfer_handle
+      ttl.wait %receive : !ttl.transfer_handle
+      ttl.cb_push %recv_cb : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+      ttl.yield
+    }
+    ttl.yield
+  }
+  func.return
+}
+
+}
+
+// -----
+
+// A loopback collective publishes the source receiver address with a direct
+// L1 store and publishes the remote receiver address with a NoC write.
+
+module attributes {ttl.launch_grid = array<i64: 5, 1>} {
+
+func.func @loopback_collective_sender()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %send_cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "loopback" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0, dstEndX = 2, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0, dstEndX = 3, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 4, dstStartY = 0, dstEndX = 4, dstEndY = 0, isCollective = true>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %send = ttl.copy %send_cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %send : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @loopback_collective_receiver
+// CHECK-DAG: ttkernel.store_to_l1
+// CHECK-DAG: ttkernel.noc_inline_dw_write
+// CHECK: return
+func.func @loopback_collective_receiver()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %recv_cb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "loopback" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0, dstEndX = 2, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0, dstEndX = 3, dstEndY = 0, isCollective = true>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 4, dstStartY = 0, dstEndX = 4, dstEndY = 0, isCollective = true>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %reserve = ttl.cb_reserve %recv_cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %receive = ttl.copy %pipe, %reserve
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %receive : !ttl.transfer_handle
+    ttl.cb_push %recv_cb : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+    ttl.yield
+  }
+  func.return
+}
+
+}
+
+// -----
+
+// Static and selected transfers can coexist in one module. Both contribute
+// protocol operations and synchronization resources to the shared plan.
+
+module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+
+// CHECK-LABEL: func.func @mixed_static_and_selected_sender
+// CHECK-COUNT-2: ttkernel.noc_async_write
+// CHECK-NOT: ttl.pipenet_foreach
+// CHECK: return
+func.func @mixed_static_and_selected_sender()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %send_cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %static_pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  ttl.if_src %static_pipe
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+    %send = ttl.copy %send_cb, %static_pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+           !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %send : !ttl.transfer_handle<write>
+  }
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 1 name "selected" pipes [
+        #ttl.pipe_record<srcX = 2, srcY = 0, dstStartX = 3, dstStartY = 0, dstEndX = 3, dstEndY = 0>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %send = ttl.copy %send_cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %send : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+func.func @mixed_static_and_selected_receiver()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %recv_cb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %static_pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  ttl.if_dst %static_pipe
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+    %reserve = ttl.cb_reserve %recv_cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %receive = ttl.copy %static_pipe, %reserve
+        : (!ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %receive : !ttl.transfer_handle
+    ttl.cb_push %recv_cb : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+  }
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 1 name "selected" pipes [
+        #ttl.pipe_record<srcX = 2, srcY = 0, dstStartX = 3, dstStartY = 0, dstEndX = 3, dstEndY = 0>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %reserve = ttl.cb_reserve %recv_cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %receive = ttl.copy %pipe, %reserve
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %receive : !ttl.transfer_handle
+    ttl.cb_push %recv_cb : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+    ttl.yield
+  }
+  func.return
+}
+
 }

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach.mlir
@@ -3,7 +3,8 @@
 // Summary: Verifies direct and table-driven PipeNet callback lowering through
 // pipe-transfer IR.
 
-// Small source foreach lowering emits direct static guards.
+// Four source records exercise the inclusive direct-lowering boundary. Each
+// record emits one static guard and one payload write without a record loop.
 
 func.func private @foreach_src_send_direct_receiver()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -12,7 +13,9 @@ func.func private @foreach_src_send_direct_receiver()
   ttl.pipenet_foreach_dst attributes {
       records = #ttl.pipenet_records<net 0 name "row_net" pipes [
         #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>
       ]>} {
   ^bb0(%pipe: !ttl.selected_pipe_dst):
     %recv = ttl.cb_reserve %cb
@@ -31,10 +34,11 @@ func.func private @foreach_src_send_direct_receiver()
 
 // CHECK-LABEL: func.func @foreach_src_send_direct
 // CHECK-NOT: scf.for
-// CHECK-COUNT-2: ttkernel.noc_async_write %
+// CHECK-COUNT-4: ttkernel.noc_async_write %
 // CHECK-NOT: scf.for
 // CHECK-NOT: ttl.pipenet_foreach_src
 // CHECK-NOT: ttl.select_pipe_src
+// CHECK-NOT: ttkernel.noc_async_write %
 // CHECK: return
 func.func @foreach_src_send_direct()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -43,7 +47,9 @@ func.func @foreach_src_send_direct()
   ttl.pipenet_foreach_src attributes {
       records = #ttl.pipenet_records<net 0 name "row_net" pipes [
         #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>
       ]>} {
   ^bb0(%pipe: !ttl.selected_pipe_src):
     %xf = ttl.copy %cb, %pipe
@@ -58,7 +64,8 @@ func.func @foreach_src_send_direct()
 
 // -----
 
-// Small destination foreach lowering emits direct static guards.
+// Four destination records exercise the inclusive direct-lowering boundary.
+// Each record emits one address publication and one completion wait.
 
 func.func private @foreach_dst_receive_direct_sender()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -67,7 +74,9 @@ func.func private @foreach_dst_receive_direct_sender()
   ttl.pipenet_foreach_src attributes {
       records = #ttl.pipenet_records<net 0 name "row_net" pipes [
         #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>
       ]>} {
   ^bb0(%pipe: !ttl.selected_pipe_src):
     %xf = ttl.copy %cb, %pipe
@@ -86,9 +95,15 @@ func.func private @foreach_dst_receive_direct_sender()
 // CHECK: ttkernel.experimental.semaphore_wait_min(
 // CHECK: ttkernel.noc_inline_dw_write(
 // CHECK: ttkernel.experimental.semaphore_wait_min(
+// CHECK: ttkernel.noc_inline_dw_write(
+// CHECK: ttkernel.experimental.semaphore_wait_min(
+// CHECK: ttkernel.noc_inline_dw_write(
+// CHECK: ttkernel.experimental.semaphore_wait_min(
 // CHECK-NOT: scf.for
 // CHECK-NOT: ttl.pipenet_foreach_dst
 // CHECK-NOT: ttl.select_pipe_dst
+// CHECK-NOT: ttkernel.noc_inline_dw_write
+// CHECK-NOT: ttkernel.experimental.semaphore_wait_min
 // CHECK: return
 func.func @foreach_dst_receive_direct()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -97,7 +112,9 @@ func.func @foreach_dst_receive_direct()
   ttl.pipenet_foreach_dst attributes {
       records = #ttl.pipenet_records<net 0 name "row_net" pipes [
         #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>
       ]>} {
   ^bb0(%pipe: !ttl.selected_pipe_dst):
     %recv = ttl.cb_reserve %cb

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach.mlir
@@ -1,0 +1,241 @@
+// RUN: ttlang-opt %s --split-input-file -convert-ttl-to-ttkernel | FileCheck %s
+
+// Summary: Verifies direct and table-driven PipeNet callback lowering through
+// pipe-transfer IR.
+
+// Small source foreach lowering emits direct static guards.
+
+func.func private @foreach_src_send_direct_receiver()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %xf = ttl.copy %pipe, %recv
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %xf : !ttl.transfer_handle
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    ttl.yield
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @foreach_src_send_direct
+// CHECK-NOT: scf.for
+// CHECK-COUNT-2: ttkernel.noc_async_write %
+// CHECK-NOT: scf.for
+// CHECK-NOT: ttl.pipenet_foreach_src
+// CHECK-NOT: ttl.select_pipe_src
+// CHECK: return
+func.func @foreach_src_send_direct()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %xf = ttl.copy %cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %xf : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// Small destination foreach lowering emits direct static guards.
+
+func.func private @foreach_dst_receive_direct_sender()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %xf = ttl.copy %cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %xf : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @foreach_dst_receive_direct
+// CHECK-NOT: scf.for
+// CHECK: ttkernel.noc_inline_dw_write(
+// CHECK: ttkernel.experimental.semaphore_wait_min(
+// CHECK: ttkernel.noc_inline_dw_write(
+// CHECK: ttkernel.experimental.semaphore_wait_min(
+// CHECK-NOT: scf.for
+// CHECK-NOT: ttl.pipenet_foreach_dst
+// CHECK-NOT: ttl.select_pipe_dst
+// CHECK: return
+func.func @foreach_dst_receive_direct()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %xf = ttl.copy %pipe, %recv
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %xf : !ttl.transfer_handle
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// Five-record source foreach lowering emits one loop and one send protocol
+// body.
+
+func.func private @foreach_src_send_table_driven_receiver()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 5}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 5>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>,
+        #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 4, dstEndX = 1, dstEndY = 4>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 5>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %xf = ttl.copy %pipe, %recv
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %xf : !ttl.transfer_handle
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, f32>, 5>
+    ttl.yield
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @foreach_src_send_table_driven
+// CHECK: scf.for
+// CHECK: ttkernel.experimental.constant_table_lookup
+// CHECK: ttkernel.experimental.semaphore_wait(
+// CHECK-COUNT-1: ttkernel.noc_async_write %
+// CHECK-NOT: ttl.pipenet_foreach_src
+// CHECK-NOT: ttl.select_pipe_src
+// CHECK: return
+func.func @foreach_src_send_table_driven()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>,
+        #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 4, dstEndX = 1, dstEndY = 4>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %xf = ttl.copy %cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %xf : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+// -----
+
+// Five-record destination foreach lowering emits one loop and one receive
+// protocol body.
+
+func.func private @foreach_dst_receive_table_driven_sender()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>,
+        #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 4, dstEndX = 1, dstEndY = 4>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %xf = ttl.copy %cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %xf : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @foreach_dst_receive_table_driven
+// CHECK: memref.alloca
+// CHECK: scf.for
+// CHECK-COUNT-1: ttkernel.noc_inline_dw_write(
+// CHECK-COUNT-1: ttkernel.experimental.semaphore_wait_min(
+// CHECK-NOT: ttl.pipenet_foreach_dst
+// CHECK-NOT: ttl.select_pipe_dst
+// CHECK: return
+func.func @foreach_dst_receive_table_driven()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "row_net" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 1, dstEndX = 1, dstEndY = 1>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 2, dstEndX = 1, dstEndY = 2>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 3, dstEndX = 1, dstEndY = 3>,
+        #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 4, dstEndX = 1, dstEndY = 4>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %xf = ttl.copy %pipe, %recv
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %xf : !ttl.transfer_handle
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    ttl.yield
+  }
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_mixed_counter_storage.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_mixed_counter_storage.mlir
@@ -1,0 +1,96 @@
+// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+
+// Verifies that table-driven receiver lowering selects the correct completion
+// address when its records use both local and global semaphore storage.
+
+// CHECK: module attributes
+// CHECK-SAME: ttl.pipe_global_semaphore_count = 2 : i64
+// CHECK-SAME: ttl.pipe_sync_semaphore_count = 16 : i64
+
+module attributes {ttl.launch_grid = array<i64: 18, 1>} {
+
+// CHECK-LABEL: func.func @mixed_completion_counter_receiver
+// CHECK: memref.alloca() : memref<17xi32>
+// CHECK: scf.for
+// CHECK: %[[LOCAL_ADDRESS:.*]] = ttkernel.get_semaphore
+// CHECK: %[[TYPED_LOCAL_ADDRESS:.*]] = ttkernel.cast_to_l1_addr %[[LOCAL_ADDRESS]]
+// CHECK: %[[GLOBAL_ADDRESS:.*]] = ttkernel.get_common_arg_val
+// CHECK: %[[TYPED_GLOBAL_ADDRESS:.*]] = ttkernel.cast_to_l1_addr %[[GLOBAL_ADDRESS]]
+// CHECK: %[[COMPLETION_ADDRESS:.*]] = arith.select %{{.*}}, %[[TYPED_GLOBAL_ADDRESS]], %[[TYPED_LOCAL_ADDRESS]]
+// CHECK: %[[COMPLETION_POINTER:.*]] = ttkernel.reinterpret_cast{{.*}}(%[[COMPLETION_ADDRESS]])
+// CHECK: ttkernel.experimental.semaphore_wait_min(%[[COMPLETION_POINTER]]
+func.func @mixed_completion_counter_receiver()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %recv_dfb = ttl.bind_cb {cb_index = 1, block_count = 17}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 17>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "mixed_completion" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 1, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 2, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 3, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 4, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 5, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 6, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 7, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 8, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 9, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 10, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 11, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 12, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 13, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 14, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 15, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 16, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %recv = ttl.cb_reserve %recv_dfb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 17>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %transfer = ttl.copy %pipe, %recv
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %transfer : !ttl.transfer_handle
+    ttl.cb_push %recv_dfb : <[1, 1], !ttcore.tile<32x32, f32>, 17>
+    ttl.yield
+  }
+  func.return
+}
+
+func.func @mixed_completion_counter_senders()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %send_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "mixed_completion" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 1, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 2, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 3, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 4, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 5, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 6, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 7, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 8, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 9, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 10, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 11, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 12, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 13, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 14, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 15, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 16, srcY = 0, dstStartX = 17, dstStartY = 0, dstEndX = 17, dstEndY = 0>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %transfer = ttl.copy %send_dfb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %transfer : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_multiple_matches.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_multiple_matches.mlir
@@ -1,0 +1,79 @@
+// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+// RUN: ttlang-opt %s -ttl-verify-pipenet-guards
+
+// Verifies that one table-driven protocol operation receives distinct
+// resources for every matching record, including identical records. A record
+// outside the launch grid retains table alignment without allocating state.
+
+// CHECK: module attributes {ttl.launch_grid = array<i64: 2, 5>, ttl.pipe_sram_scratch_bytes = 32 : i64, ttl.pipe_sync_semaphore_count = 8 : i64}
+
+module attributes {ttl.launch_grid = array<i64: 2, 5>} {
+
+// CHECK-LABEL: func.func @gather_receiver
+// Six distinct completion counters are sufficient because the inactive record
+// reuses an existing resource while retaining its table entry.
+// CHECK: %[[COUNTERS:.*]] = memref.alloca() : memref<6xi32>
+// CHECK: scf.for %[[INDEX:.*]] =
+// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [6, 6, 6, 6, 6, 7, 6] : index
+// CHECK: %[[PROGRESS_INDEX:.*]] = ttkernel.experimental.constant_table_lookup %[[INDEX]], [0, 2, 3, 4, 5, 1, 0] : index
+// CHECK: memref.load %[[COUNTERS]][%[[PROGRESS_INDEX]]] : memref<6xi32>
+// CHECK: ttkernel.experimental.semaphore_wait_min
+func.func @gather_receiver()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 6}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 6>
+  ttl.pipenet_foreach_dst attributes {
+      records = #ttl.pipenet_records<net 0 name "gather" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 9, srcY = 9, dstStartX = 10, dstStartY = 10, dstEndX = 10, dstEndY = 10>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_dst):
+    %recv = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 6>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %xf = ttl.copy %pipe, %recv
+        : (!ttl.selected_pipe_dst,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    ttl.wait %xf : !ttl.transfer_handle
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, f32>, 6>
+    ttl.yield
+  }
+  func.return
+}
+
+// CHECK-LABEL: func.func @gather_senders
+// CHECK: scf.for %[[INDEX:.*]] =
+// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [6, 6, 6, 6, 6, 7, 6] : index
+// CHECK: ttkernel.noc_async_write %
+// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [0, 2, 3, 4, 5, 1, 0] : index
+func.func @gather_senders()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  ttl.pipenet_foreach_src attributes {
+      records = #ttl.pipenet_records<net 0 name "gather" pipes [
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
+        #ttl.pipe_record<srcX = 9, srcY = 9, dstStartX = 10, dstStartY = 10, dstEndX = 10, dstEndY = 10>
+      ]>} {
+  ^bb0(%pipe: !ttl.selected_pipe_src):
+    %xf = ttl.copy %cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+           !ttl.selected_pipe_src)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %xf : !ttl.transfer_handle<write>
+    ttl.yield
+  }
+  func.return
+}
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_multiple_matches.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_multiple_matches.mlir
@@ -2,20 +2,18 @@
 // RUN: ttlang-opt %s -ttl-verify-pipenet-guards
 
 // Verifies that one table-driven protocol operation receives distinct
-// resources for every matching record, including identical records. A record
-// outside the launch grid retains table alignment without allocating state.
+// resources for every matching record, including identical records.
 
 // CHECK: module attributes {ttl.launch_grid = array<i64: 2, 5>, ttl.pipe_sram_scratch_bytes = 32 : i64, ttl.pipe_sync_semaphore_count = 8 : i64}
 
 module attributes {ttl.launch_grid = array<i64: 2, 5>} {
 
 // CHECK-LABEL: func.func @gather_receiver
-// Six distinct completion counters are sufficient because the inactive record
-// reuses an existing resource while retaining its table entry.
+// Six distinct completion counters cover the six matching records.
 // CHECK: %[[COUNTERS:.*]] = memref.alloca() : memref<6xi32>
 // CHECK: scf.for %[[INDEX:.*]] =
-// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [6, 6, 6, 6, 6, 7, 6] : index
-// CHECK: %[[PROGRESS_INDEX:.*]] = ttkernel.experimental.constant_table_lookup %[[INDEX]], [0, 2, 3, 4, 5, 1, 0] : index
+// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [6, 6, 6, 6, 6, 7] : index
+// CHECK: %[[PROGRESS_INDEX:.*]] = ttkernel.experimental.constant_table_lookup %[[INDEX]], [0, 2, 3, 4, 5, 1] : index
 // CHECK: memref.load %[[COUNTERS]][%[[PROGRESS_INDEX]]] : memref<6xi32>
 // CHECK: ttkernel.experimental.semaphore_wait_min
 func.func @gather_receiver()
@@ -29,8 +27,7 @@ func.func @gather_receiver()
         #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
         #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
         #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 9, srcY = 9, dstStartX = 10, dstStartY = 10, dstEndX = 10, dstEndY = 10>
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>
       ]>} {
   ^bb0(%pipe: !ttl.selected_pipe_dst):
     %recv = ttl.cb_reserve %cb
@@ -49,9 +46,9 @@ func.func @gather_receiver()
 
 // CHECK-LABEL: func.func @gather_senders
 // CHECK: scf.for %[[INDEX:.*]] =
-// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [6, 6, 6, 6, 6, 7, 6] : index
+// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [6, 6, 6, 6, 6, 7] : index
 // CHECK: ttkernel.noc_async_write %
-// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [0, 2, 3, 4, 5, 1, 0] : index
+// CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [0, 2, 3, 4, 5, 1] : index
 func.func @gather_senders()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
@@ -63,8 +60,7 @@ func.func @gather_senders()
         #ttl.pipe_record<srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
         #ttl.pipe_record<srcX = 0, srcY = 3, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
         #ttl.pipe_record<srcX = 0, srcY = 4, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>,
-        #ttl.pipe_record<srcX = 9, srcY = 9, dstStartX = 10, dstStartY = 10, dstEndX = 10, dstEndY = 10>
+        #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>
       ]>} {
   ^bb0(%pipe: !ttl.selected_pipe_src):
     %xf = ttl.copy %cb, %pipe

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_multiple_matches.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_multiple_matches.mlir
@@ -18,7 +18,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 5>} {
 // CHECK: ttkernel.experimental.semaphore_wait_min
 func.func @gather_receiver()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-  %cb = ttl.bind_cb {cb_index = 1, block_count = 6}
+  %cb = ttl.bind_cb {cb_index = 1, block_count = 6} {dfb_id = 1 : index}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 6>
   ttl.pipenet_foreach_dst attributes {
       records = #ttl.pipenet_records<net 0 name "gather" pipes [
@@ -51,7 +51,7 @@ func.func @gather_receiver()
 // CHECK: ttkernel.experimental.constant_table_lookup %[[INDEX]], [0, 2, 3, 4, 5, 1] : index
 func.func @gather_senders()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-  %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   ttl.pipenet_foreach_src attributes {
       records = #ttl.pipenet_records<net 0 name "gather" pipes [

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_record_order.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_record_order.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s --implicit-check-not=ttl.pipenet_foreach
 
 // Verifies that table-driven callbacks execute in record order and that one
 // selected loopback record can provide both receive and send endpoints.
@@ -6,13 +6,28 @@
 // Each callback releases the single receiver DFB slot before the next
 // identical record executes.
 // CHECK-LABEL: func.func @record_order_loopback
-// CHECK: scf.for
+// CHECK-DAG: %[[ONE_I32:.*]] = arith.constant 1 : i32
+// CHECK-DAG: %[[FIVE:.*]] = arith.constant 5 : index
+// CHECK-DAG: %[[ONE:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[SEND_DFB:.*]] = ttkernel.get_compile_time_arg_val(0)
+// CHECK-DAG: %[[RECEIVER_DFB:.*]] = ttkernel.get_compile_time_arg_val(1)
+// CHECK: scf.for %[[RECORD:.*]] = %[[ZERO]] to %[[FIVE]] step %[[ONE]] {
+// CHECK: ttkernel.experimental.constant_table_lookup %[[RECORD]], [0, 0, 0, 0, 0]
 // CHECK: scf.if
-// CHECK: ttkernel.cb_reserve_back
-// CHECK: ttkernel.noc_async_write
-// CHECK: ttkernel.cb_push_back
-// CHECK: ttkernel.cb_wait_front
-// CHECK: ttkernel.cb_pop_front
+// CHECK: ttkernel.cb_reserve_back(%[[RECEIVER_DFB]], %[[ONE_I32]])
+// CHECK: %[[RECEIVER_WRITE_PTR:.*]] = ttkernel.get_write_ptr(%[[RECEIVER_DFB]])
+// CHECK: ttkernel.store_to_l1(%[[RECEIVER_WRITE_PTR]],
+// CHECK: ttkernel.noc_semaphore_inc
+// CHECK: ttkernel.experimental.semaphore_wait
+// CHECK: %[[SEND_WRITE_PTR:.*]] = ttkernel.get_write_ptr(%[[SEND_DFB]])
+// CHECK: ttkernel.noc_async_write %[[SEND_WRITE_PTR]], core[{{.*}}]
+// CHECK: ttkernel.noc_async_write_barrier
+// CHECK: ttkernel.noc_semaphore_inc
+// CHECK: ttkernel.experimental.semaphore_wait_min
+// CHECK: ttkernel.cb_push_back(%[[RECEIVER_DFB]], %[[ONE_I32]])
+// CHECK-NEXT: ttkernel.cb_wait_front(%[[RECEIVER_DFB]], %[[ONE_I32]])
+// CHECK-NEXT: ttkernel.cb_pop_front(%[[RECEIVER_DFB]], %[[ONE_I32]])
 module attributes {ttl.launch_grid = array<i64: 1, 1>} {
   func.func @record_order_loopback()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_record_order.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_foreach_record_order.mlir
@@ -1,0 +1,56 @@
+// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+
+// Verifies that table-driven callbacks execute in record order and that one
+// selected loopback record can provide both receive and send endpoints.
+
+// Each callback releases the single receiver DFB slot before the next
+// identical record executes.
+// CHECK-LABEL: func.func @record_order_loopback
+// CHECK: scf.for
+// CHECK: scf.if
+// CHECK: ttkernel.cb_reserve_back
+// CHECK: ttkernel.noc_async_write
+// CHECK: ttkernel.cb_push_back
+// CHECK: ttkernel.cb_wait_front
+// CHECK: ttkernel.cb_pop_front
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
+  func.func @record_order_loopback()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %send_cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+    %recv_cb = ttl.bind_cb {cb_index = 1, block_count = 1}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+    ttl.pipenet_foreach_dst attributes {
+        records = #ttl.pipenet_records<net 0 name "loopback" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0, dstEndX = 0, dstEndY = 0>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_dst):
+      %reserve = ttl.cb_reserve %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %receive = ttl.copy %pipe, %reserve
+          : (!ttl.selected_pipe_dst,
+             tensor<1x1x!ttcore.tile<32x32, f32>>)
+          -> !ttl.transfer_handle
+      %send = ttl.copy %send_cb, %pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+             !ttl.selected_pipe_dst)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+      ttl.wait %receive : !ttl.transfer_handle
+      ttl.cb_push %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+      %ready = ttl.cb_wait %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      ttl.cb_pop %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+      ttl.yield
+    }
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
@@ -533,9 +533,9 @@ module attributes {ttl.launch_grid = [8 : i64, 1 : i64]} {
 
 // -----
 
-// `is_src` referencing a PipeNet id that no `ttl.create_pipe` declares is
-// rejected. Without this check, the empty role domain would silently accept
-// any pipe-coupled op nested under the bogus guard.
+// `is_src` referencing a PipeNet id with no pipe or record-table declaration is
+// rejected. Otherwise the empty role domain would accept any pipe-coupled op
+// nested under the invalid guard.
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unknown_pipenet_id() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
@@ -44,7 +44,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @destination_selected_non_loopback_send()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
     // expected-note @below {{PipeNet non_loopback declared here}}
     ttl.pipenet_foreach_dst attributes {
@@ -71,7 +71,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @source_selected_non_loopback_receive()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
     // expected-note @below {{PipeNet non_loopback declared here}}
     ttl.pipenet_foreach_src attributes {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
@@ -39,6 +39,63 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 
 // -----
 
+// Destination iteration does not authorize a send from a non-source node.
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @destination_selected_non_loopback_send()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+    // expected-note @below {{PipeNet non_loopback declared here}}
+    ttl.pipenet_foreach_dst attributes {
+        records = #ttl.pipenet_records<net 0 name "non_loopback" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_dst):
+      // expected-error @below {{this `ttl.copy(buffer, pipe)` sends data on PipeNet non_loopback from a node that is not a source}}
+      // expected-note @below {{example node where the guard does not hold: core_x=1}}
+      %send = ttl.copy %cb, %pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+             !ttl.selected_pipe_dst)
+          -> !ttl.transfer_handle<write>
+      ttl.yield
+    }
+    func.return
+  }
+}
+
+// -----
+
+// Source iteration does not authorize a receive on a non-destination node.
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @source_selected_non_loopback_receive()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+    // expected-note @below {{PipeNet non_loopback declared here}}
+    ttl.pipenet_foreach_src attributes {
+        records = #ttl.pipenet_records<net 0 name "non_loopback" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_src):
+      %reserve = ttl.cb_reserve %cb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      // expected-error @below {{this `ttl.copy(pipe, buffer)` receives data from PipeNet non_loopback on a node that is not a destination}}
+      // expected-note @below {{example node where the guard does not hold: core_x=0}}
+      %receive = ttl.copy %pipe, %reserve
+          : (!ttl.selected_pipe_src,
+             tensor<1x1x!ttcore.tile<32x32, f32>>)
+          -> !ttl.transfer_handle
+      ttl.yield
+    }
+    func.return
+  }
+}
+
+// -----
+
 // A wait that can observe two receive copies has no unique completion event for
 // the wait-for graph.
 

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_invalid.mlir
@@ -47,6 +47,46 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 
 // -----
 
+// Record-backed PipeNet sources must refer to cores instantiated by the module
+// launch grid.
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @record_source_outside_launch_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-error @below {{declares source core_x=2, core_y=0 outside the module `ttl.launch_grid`}}
+    ttl.pipenet_foreach_src attributes {
+        records = #ttl.pipenet_records<net 0 name "invalid_source" pipes [
+          #ttl.pipe_record<srcX = 2, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_src):
+      ttl.yield
+    }
+    func.return
+  }
+}
+
+// -----
+
+// Record-backed PipeNet destination ranges must remain inside the module
+// launch grid.
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @record_destination_outside_launch_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-error @below {{declares destination range core_x=1..2, core_y=0..0 outside the module `ttl.launch_grid`}}
+    ttl.pipenet_foreach_dst attributes {
+        records = #ttl.pipenet_records<net 0 name "invalid_destination" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 2, dstEndY = 0, isCollective = true>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_dst):
+      ttl.yield
+    }
+    func.return
+  }
+}
+
+// -----
+
 // A collective send missing every receiver post produces one primary error.
 // Notes identify the additional receiver coordinates with the same mismatch.
 

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_invalid.mlir
@@ -771,6 +771,64 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // -----
 
+// Each foreach callback completes before the next matching record begins.
+// Reversing the sender records creates a cycle between the first receiver wait
+// and the sender's first selected record.
+
+module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
+  func.func @receiver_record_order()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %recv_cb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.pipenet_foreach_dst attributes {
+        records = #ttl.pipenet_records<net 0 name "ordered" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 1, isCollective = true>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_dst):
+      %recv_reserve = ttl.cb_reserve %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      // expected-note @below {{program order requires receiver post at core_x=1, core_y=0 after receive completion at core_x=1, core_y=0}}
+      %recv = ttl.copy %pipe, %recv_reserve
+          : (!ttl.selected_pipe_dst,
+             tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> !ttl.transfer_handle
+      // expected-error @below {{pipe schedule contains a wait-for cycle on PipeNet ordered}}
+      // expected-note @below {{receive completion at core_x=1, core_y=0 waits for send at core_x=0, core_y=0 to transfer data}}
+      ttl.wait %recv : !ttl.transfer_handle
+      ttl.cb_push %recv_cb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      ttl.yield
+    }
+    func.return
+  }
+
+  func.func @sender_reversed_record_order()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %send_cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.pipenet_foreach_src attributes {
+        records = #ttl.pipenet_records<net 0 name "ordered" pipes [
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 1, isCollective = true>,
+          #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 0, isCollective = true>
+        ]>} {
+    ^bb0(%pipe: !ttl.selected_pipe_src):
+      // expected-note @below {{sender waits for receiver post at core_x=1, core_y=0 before send at core_x=0, core_y=0}}
+      // expected-note @below {{program order requires send at core_x=0, core_y=0 after send at core_x=0, core_y=0}}
+      %send = ttl.copy %send_cb, %pipe
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+             !ttl.selected_pipe_src)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+      ttl.yield
+    }
+    func.return
+  }
+}
+
+// -----
+
 // Straight-line post and send counts must agree for one logical pipe.
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_schedule_invalid.mlir
@@ -773,7 +773,8 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // Each foreach callback completes before the next matching record begins.
 // Reversing the sender records creates a cycle between the first receiver wait
-// and the sender's first selected record.
+// and the sender's first selected record. The sender callback is in a helper to
+// verify that call expansion preserves the enclosing record order.
 
 module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
   func.func @receiver_record_order()
@@ -804,10 +805,8 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
     func.return
   }
 
-  func.func @sender_reversed_record_order()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %send_cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  func.func private @send_records_reversed(
+      %send_cb: !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) {
     ttl.pipenet_foreach_src attributes {
         records = #ttl.pipenet_records<net 0 name "ordered" pipes [
           #ttl.pipe_record<srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0, dstEndX = 1, dstEndY = 1, isCollective = true>,
@@ -823,6 +822,15 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
       ttl.wait %send : !ttl.transfer_handle<write>
       ttl.yield
     }
+    func.return
+  }
+
+  func.func @sender_reversed_record_order()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %send_cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.call @send_records_reversed(%send_cb)
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
     func.return
   }
 }

--- a/test/ttlang/Translate/TTLToCpp/cast_to_l1_addr.mlir
+++ b/test/ttlang/Translate/TTLToCpp/cast_to_l1_addr.mlir
@@ -1,0 +1,37 @@
+// RUN: ttlang-opt --convert-ttkernel-to-emitc %s -o %t.emitc.mlir
+// RUN: FileCheck %s --input-file=%t.emitc.mlir --check-prefix=EMITC
+// RUN: ttlang-translate --ttkernel-to-cpp %t.emitc.mlir 2>&1 | FileCheck %s --check-prefix=CPP
+
+// Verifies that local and runtime-provided semaphore addresses can share one
+// SSA address without introducing a C++ conversion.
+
+// EMITC-LABEL: func.func @kernel_main
+// EMITC-NOT: cast_to_l1_addr
+// EMITC: emitc.conditional
+
+// CPP-LABEL: void kernel_main()
+// CPP: get_semaphore
+// CPP: get_common_arg_val
+// CPP: ? {{.*}} : {{.*}}
+func.func @kernel_main() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+  %semaphore_index = arith.constant 0 : index
+  %common_arg_index = arith.constant 1 : index
+  %logical_x = "ttkernel.my_logical_x_"() : () -> index
+  %condition = arith.cmpi ne, %logical_x, %semaphore_index : index
+  %local_address = ttkernel.get_semaphore(%semaphore_index)
+      : (index) -> !ttkernel.local_semaphore
+  %global_address = ttkernel.get_common_arg_val(%common_arg_index)
+      : (index) -> i32
+  %typed_local_address = ttkernel.cast_to_l1_addr %local_address
+      : !ttkernel.local_semaphore to !ttkernel.l1_addr
+  %typed_global_address = ttkernel.cast_to_l1_addr %global_address
+      : i32 to !ttkernel.l1_addr
+  %selected_address = arith.select %condition, %typed_global_address,
+      %typed_local_address : !ttkernel.l1_addr
+  %selected_pointer = ttkernel.reinterpret_cast(%selected_address)
+      : (!ttkernel.l1_addr) -> !ttkernel.l1_addr_ptr
+  %sequence = arith.constant 1 : i32
+  ttkernel.experimental.semaphore_wait_min(%selected_pointer, %sequence)
+      : (!ttkernel.l1_addr_ptr, i32) -> ()
+  return
+}

--- a/test/ttlang/Translate/TTLToCpp/constant_table_lookup.mlir
+++ b/test/ttlang/Translate/TTLToCpp/constant_table_lookup.mlir
@@ -1,24 +1,40 @@
 // RUN: ttlang-opt --convert-ttkernel-to-emitc %s -o %t.emitc.mlir
 // RUN: FileCheck %s --input-file=%t.emitc.mlir --check-prefix=EMITC
-// RUN: ttlang-translate --ttkernel-to-cpp %t.emitc.mlir 2>&1 | FileCheck %s --check-prefix=CPP
+// RUN: ttlang-translate --ttkernel-to-cpp %t.emitc.mlir > %t.cpp
+// RUN: FileCheck %s --input-file=%t.cpp --check-prefix=CPP
+// RUN: FileCheck %s --input-file=%t.cpp --check-prefix=NUM
 
-// Verify that immutable TTKernel tables become bit-packed compile-time C++
-// storage rather than arrays allocated in kernel_main.
+// Verify that immutable TTKernel tables become bit-packed static C++ storage
+// without variadic template arguments or arrays allocated in kernel_main.
 
+// EMITC: emitc.global static const @__ttlang_constant_table_{{[A-F0-9]+}} : !emitc.array<2xui64> = #emitc.opaque<"{0xC5A928398A418820ULL, 0x107B9AULL}">
+// EMITC-NEXT: emitc.global static const @__ttlang_constant_table_{{[A-F0-9]+}} : !emitc.array<1xui64> = #emitc.opaque<"{0x853ULL}">
 // EMITC-LABEL: func.func @kernel_main
+// EMITC: emitc.get_global @[[NARROW:__ttlang_constant_table_[A-F0-9]+]]
+// EMITC: emitc.call_opaque "experimental::constant_table_lookup"
+// EMITC: emitc.get_global @__ttlang_constant_table_{{[A-F0-9]+}}
+// EMITC: emitc.call_opaque "experimental::constant_table_lookup"
+// EMITC: emitc.get_global @[[NARROW]]
 // EMITC: emitc.call_opaque "experimental::constant_table_lookup"
 
-// CPP: static constexpr std::uint64_t packed_table[] = {PackedWords...};
+// NUM-COUNT-2: static const uint64_t __ttlang_constant_table_
+// CPP: #include <cstdint>
+// CPP: static const uint64_t __ttlang_constant_table_{{[A-F0-9]+}}[1] = {0x853ULL};
+// CPP-NEXT: static const uint64_t __ttlang_constant_table_{{[A-F0-9]+}}[2] = {0xC5A928398A418820ULL, 0x107B9AULL};
 // CPP-LABEL: void kernel_main()
 // CPP-NOT: size_t v{{[0-9]+}}[3];
 // Values [3, 5, 8] require four bits each and pack into 0x853.
-// CPP: experimental::constant_table_lookup<4, 0x853ULL>
+// CPP: experimental::constant_table_lookup<4>({{.*}}, [[NARROW_CPP:__ttlang_constant_table_[A-F0-9]+]])
 // Seventeen five-bit values cross a 64-bit boundary.
-// CPP: experimental::constant_table_lookup<5, 0xC5A928398A418820ULL, 0x107B9AULL>
+// CPP: experimental::constant_table_lookup<5>({{.*}}, __ttlang_constant_table_{{[A-F0-9]+}})
+// Repeated values reuse the same static table.
+// CPP: experimental::constant_table_lookup<4>({{.*}}, [[NARROW_CPP]])
 func.func @kernel_main() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
   %index = arith.constant 1 : index
   %value = ttkernel.experimental.constant_table_lookup %index, [3, 5, 8] : index
   %wide = ttkernel.experimental.constant_table_lookup %index,
       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] : index
+  %duplicate = ttkernel.experimental.constant_table_lookup %index,
+      [3, 5, 8] : index
   return
 }

--- a/test/ttlang/Translate/TTLToCpp/constant_table_lookup.mlir
+++ b/test/ttlang/Translate/TTLToCpp/constant_table_lookup.mlir
@@ -1,0 +1,19 @@
+// RUN: ttlang-opt --convert-ttkernel-to-emitc %s -o %t.emitc.mlir
+// RUN: FileCheck %s --input-file=%t.emitc.mlir --check-prefix=EMITC
+// RUN: ttlang-translate --ttkernel-to-cpp %t.emitc.mlir 2>&1 | FileCheck %s --check-prefix=CPP
+
+// Verify that immutable TTKernel tables become compile-time C++ storage rather
+// than arrays allocated in kernel_main.
+
+// EMITC-LABEL: func.func @kernel_main
+// EMITC: emitc.call_opaque "experimental::constant_table_lookup"
+
+// CPP: static constexpr std::size_t table[] = {Values...};
+// CPP-LABEL: void kernel_main()
+// CPP-NOT: size_t v{{[0-9]+}}[3];
+// CPP: experimental::constant_table_lookup<3, 5, 8>
+func.func @kernel_main() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+  %index = arith.constant 1 : index
+  %value = ttkernel.experimental.constant_table_lookup %index, [3, 5, 8] : index
+  return
+}

--- a/test/ttlang/Translate/TTLToCpp/constant_table_lookup.mlir
+++ b/test/ttlang/Translate/TTLToCpp/constant_table_lookup.mlir
@@ -2,18 +2,23 @@
 // RUN: FileCheck %s --input-file=%t.emitc.mlir --check-prefix=EMITC
 // RUN: ttlang-translate --ttkernel-to-cpp %t.emitc.mlir 2>&1 | FileCheck %s --check-prefix=CPP
 
-// Verify that immutable TTKernel tables become compile-time C++ storage rather
-// than arrays allocated in kernel_main.
+// Verify that immutable TTKernel tables become bit-packed compile-time C++
+// storage rather than arrays allocated in kernel_main.
 
 // EMITC-LABEL: func.func @kernel_main
 // EMITC: emitc.call_opaque "experimental::constant_table_lookup"
 
-// CPP: static constexpr std::size_t table[] = {Values...};
+// CPP: static constexpr std::uint64_t packed_table[] = {PackedWords...};
 // CPP-LABEL: void kernel_main()
 // CPP-NOT: size_t v{{[0-9]+}}[3];
-// CPP: experimental::constant_table_lookup<3, 5, 8>
+// Values [3, 5, 8] require four bits each and pack into 0x853.
+// CPP: experimental::constant_table_lookup<4, 0x853ULL>
+// Seventeen five-bit values cross a 64-bit boundary.
+// CPP: experimental::constant_table_lookup<5, 0xC5A928398A418820ULL, 0x107B9AULL>
 func.func @kernel_main() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
   %index = arith.constant 1 : index
   %value = ttkernel.experimental.constant_table_lookup %index, [3, 5, 8] : index
+  %wide = ttkernel.experimental.constant_table_lookup %index,
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] : index
   return
 }


### PR DESCRIPTION
PipeNet PR tree:

```text
main (includes #756, #768, #704, #782, #778, #775, #783, #765, #700,
               and [pipes-8] #754 (this PR))
  |-> [pipes-7] #780
  `-> [pipes-fabric] #734 (restack pending)
```

### Problem description

Large PipeNets clone each source and destination callback for every transfer record. Generated data-movement code therefore grows with the number of participating nodes and can exceed NCRISC instruction memory or the TT-Metal kernel configuration buffer before execution. This PR addresses the expansion mechanism described in #628.

### What's changed

- Add verified PipeNet record-table, selected-pipe, and table-lookup IR.
- Lower PipeNets with at most four records directly. Lower larger PipeNets through one runtime loop over immutable coordinate and resource tables.
- Represent selected-record resources and protocols in the immutable module plan before TTKernel IR emission.
- Reuse the existing PipeTransport emitters for static and selected transfers, including unicast, multicast, loopback, sender-ready, address-publication, and completion behavior.
- Store packed constant tables in generated C++ metadata instead of kernel stack arrays.
- Extract reusable PipeTransfer expansion and payload geometry for downstream transport optimization.

The table-driven form uses receiver-published addresses and receiver-post synchronization. Computed addresses and capacity counters remain available for transfers represented by individual static pipe operations.

### Validation

New regressions cover record-table and selected-pipe verification, direct and table-driven lowering, exact record-order execution, nested callbacks, mixed static and selected transfers, local and GlobalSemaphore resources, single-receiver collectives, BF16 and FP32 execution, exact outputs, and generated source-size limits.

### Checklist

- [x] New and existing tests provide coverage for the changes.
