### PR TITLE
[ci] Harden hardware pytest, parallelize tutorials, fix runner selection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /test/ bnorris@tenstorrent.com zcarver@tenstorrent.com kfragkiadakis@tenstorrent.com
 /test/sim/ kfragkiadakis@tenstorrent.com phizalev@tenstorrent.com
 /test/packaging/ @tenstorrent/tt-lang-maintainers @brnorris03 @phizalev-TT
+/test/tutorial/ @brnorris03 @phizalev-TT
 /examples/ phizalev@tenstorrent.com kfragkiadakis@tenstorrent.com arichins@tenstorrent.com
 /examples/metal_examples/ arichins@tenstorrent.com
 /examples/matmul-tutorial/ phizalev@tenstorrent.com

--- a/.github/scripts/run-hardware-pytests.sh
+++ b/.github/scripts/run-hardware-pytests.sh
@@ -29,7 +29,10 @@ chips="$(resolve_tt_chip_count "${HW_PYTEST_CHIPS:-}")" || {
 }
 
 # The thread timeout method interrupts C-level device deadlocks; SIGALRM cannot.
-common=(-v --tb=long --timeout=300 --timeout-method=thread)
+# --reruns retries a flaky test up to 3 times (pytest-rerunfailures) before
+# reporting failure. A worker segfault is a crash, not a rerunnable failure, so
+# it is unaffected.
+common=(-v --tb=long --timeout=300 --timeout-method=thread --reruns 3)
 
 selected_phase_count=0
 run_pytest_phase() {
@@ -48,10 +51,15 @@ if [ "$chips" -gt 1 ]; then
     unset TT_VISIBLE_DEVICES
     cache_root="$(absolute_path "${TT_METAL_CACHE:-${REPORT_PREFIX}-tt-metal-cache}")"
     rc=0
+    # Workers are pinned 1:1 to chips by index (see pin_xdist_worker_to_device).
+    # Disable xdist's crash-restart: a replacement worker gets the next index
+    # (e.g. gw8 on an 8-chip host), which maps to a nonexistent device and turns
+    # one crash into a flood of "Invalid device ID" errors.
     TTLANG_PIN_XDIST_WORKERS_TO_DEVICES=1 \
         TTLANG_XDIST_TT_METAL_CACHE_ROOT="$cache_root" \
         run_pytest_phase "$TEST_DIR" -m "not multi_device" -n "$chips" \
-        "${common[@]}" --junitxml="${REPORT_PREFIX}-parallel.xml" || rc=1
+        --max-worker-restart=0 "${common[@]}" \
+        --junitxml="${REPORT_PREFIX}-parallel.xml" || rc=1
     run_pytest_phase "$TEST_DIR" -m multi_device \
         "${common[@]}" --junitxml="${REPORT_PREFIX}-multidevice.xml" || rc=1
     if [ "$selected_phase_count" -eq 0 ]; then

--- a/.github/scripts/tests/test_run_hardware_pytests.bats
+++ b/.github/scripts/tests/test_run_hardware_pytests.bats
@@ -60,6 +60,9 @@ EOF
     run cat "$CALLS"
     assert_line --partial "env:1 cache-root:$PWD/build/test/pytest-report-tt-metal-cache args:-m pytest"
     assert_line --partial "pytest test/python -m not multi_device -n 4"
+    # Crash-restart disabled and flaky-retry enabled on the parallel phase.
+    assert_line --partial "-n 4 --max-worker-restart=0"
+    assert_line --partial "--reruns 3"
     assert_line --partial "pytest-report-parallel.xml"
     assert_line --partial "env: cache-root: args:-m pytest test/python -m multi_device"
     assert_line --partial "pytest-report-multidevice.xml"
@@ -88,6 +91,9 @@ EOF
     refute_output --partial "env:1"
     refute_output --partial "cache-root:build"
     refute_output --partial " -n "
+    # Flaky-retry applies to the serial run too; the xdist-only restart flag does not.
+    assert_output --partial "--reruns 3"
+    refute_output --partial "max-worker-restart"
     refute_output --partial "multi_device"
     assert_output --partial "pytest-report.xml"
     [ "${#lines[@]}" -eq 1 ]

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -121,7 +121,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                runner: [n150, bh-loudbox-viommu]
+                include:
+                    - runner: n150
+                      labels: '["tt-ubuntu-2204-n150-stable"]'
+                    - runner: galaxy-bh
+                      labels: '["in-service", "galaxy-bh"]'
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -130,5 +130,6 @@ jobs:
         secrets: inherit
         with:
             runs-on: ${{ matrix.runner }}
+            runner_labels: ${{ matrix.labels }}
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Tutorial examples
         run: |
           source build/env/activate
-          bash .github/scripts/run-tutorials.sh .
+          .github/scripts/run-hardware-pytests.sh test/tutorial build/test/tutorial-report
 
       - name: Upload test reports
         uses: actions/upload-artifact@v7
@@ -145,4 +145,5 @@ jobs:
             build/test/python-lit-report*.xml
             build/test/pytest-report*.xml
             build/test/sim-report.xml
+            build/test/tutorial-report*.xml
           retention-days: 7

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: 'n150'
+      runner_labels:
+        description: 'JSON array of runner labels, e.g. ["in-service","qb2-blackhole"]'
+        required: false
+        type: string
+        default: '["tt-ubuntu-2204-n150-stable"]'
       timeout:
         description: 'Job timeout in minutes'
         required: false
@@ -24,6 +29,11 @@ on:
         required: false
         type: string
         default: 'n150'
+      runner_labels:
+        description: 'JSON array of runner labels, e.g. ["in-service","qb2-blackhole"]'
+        required: false
+        type: string
+        default: '["tt-ubuntu-2204-n150-stable"]'
       timeout:
         description: 'Job timeout in minutes'
         required: false
@@ -41,7 +51,7 @@ permissions:
 jobs:
   test-n150:
     name: "Hardware Tests (${{ inputs.runs-on }})"
-    runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runs-on) }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
 
     container:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,5 +7,6 @@ packaging
 pre-commit
 pyright
 pytest-order>=1.0.0
+pytest-rerunfailures>=12.0
 pytest-timeout>=2.0
 pytest-xdist>=3.0

--- a/examples/matmul-tutorial/step_5_multidevice_shard_m.py
+++ b/examples/matmul-tutorial/step_5_multidevice_shard_m.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# TTLANG_TUTORIAL_CI: multi-device
 
 #
 # Tutorial Step 5: Multi-Device, Shard M

--- a/examples/matmul-tutorial/step_6_multidevice_shard_k.py
+++ b/examples/matmul-tutorial/step_6_multidevice_shard_k.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# TTLANG_TUTORIAL_CI: multi-device
 
 #
 # Tutorial Step 6: Multi-Device, Shard K

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -223,17 +223,37 @@ pytest test/python/
 
 ### Pytest timeouts in CI
 
-`call-test-hardware.yml` and `call-test-dist-tutorials.yml` pass
-`--timeout=60 --timeout-method=signal` to every pytest invocation so a hung
-test exits within ~60 seconds instead of holding the single `n150` runner
-until the 90-minute job timeout. Tests that legitimately need longer should
-set their own `@pytest.mark.timeout(...)` override. Local runs use the
-default (no timeout) unless you pass `--timeout` yourself.
+`call-test-hardware.yml` bounds every pytest run so a hung test cannot hold the
+hardware runner until the job timeout. The simulator step passes
+`--timeout=60 --timeout-method=signal`; the device suites (`test/python`,
+`test/me2e`, `test/tutorial`) run through
+`.github/scripts/run-hardware-pytests.sh`, which passes
+`--timeout=300 --timeout-method=thread` — the thread method interrupts C-level
+device deadlocks that `SIGALRM` cannot. Tests that legitimately need longer set
+their own `@pytest.mark.timeout(...)` override; the tutorial suite raises its
+backstop above the per-script subprocess timeout for this reason. Local runs use
+the default (no timeout) unless you pass `--timeout` yourself.
 
 Middle end-to-end tests (requires ttnn and a TT device or simulator):
 ```bash
 pytest -v test/me2e/
 ```
+
+Tutorial examples on hardware (requires ttnn and a TT device):
+```bash
+pytest test/tutorial/
+```
+
+Each script under `examples/{elementwise-tutorial,matmul-tutorial,tutorial}/`
+runs as one parametrized case that executes it in a fresh subprocess, so a crash
+or device wedge in one tutorial cannot poison the others. On the hardware CI job
+`.github/scripts/run-hardware-pytests.sh` shards single-device tutorials across
+chips and runs mesh tutorials serially with every chip visible. A tutorial that
+opens a device mesh must declare it with a header tag in its first 80 lines:
+`# TTLANG_TUTORIAL_CI: multi-device`, or `# TTLANG_TUTORIAL_CI: requires-multi-device`
+to additionally skip it below two chips. The same tags drive
+`.github/scripts/run-tutorials.sh`, which runs the tutorials serially on the
+single-device dist-container and wheel jobs.
 
 Simulations (software simulation of runtime behavior):
 ```bash

--- a/test/tutorial/conftest.py
+++ b/test/tutorial/conftest.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pytest configuration for the tutorial example suite.
+
+This suite lives in its own directory, a sibling of test/python and test/me2e,
+so those end-to-end suites do not autocollect these device-heavy example
+scripts. Worker-to-chip pinning matches them so the tutorials participate in the
+run-hardware-pytests.sh parallel (per-chip) and serial (multi_device) phases.
+"""
+
+import os
+import sys
+
+# Shared test utilities live at the test/ root, one level up.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ttlang_test_utils import pin_xdist_worker_to_device
+
+pin_xdist_worker_to_device()
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "multi_device: opens a device mesh; excluded from the per-chip parallel "
+        "run and executed serially with every chip visible",
+    )

--- a/test/tutorial/test_tutorials.py
+++ b/test/tutorial/test_tutorials.py
@@ -40,10 +40,17 @@ REQUIRES_MESH_TAG = "requires-multi-device"
 # single, partially harvested chip (see run-tutorials.sh); multi-device hosts
 # finish each in 20-30s. TUTORIAL_TIMEOUT_SECONDS overrides it.
 SUBPROCESS_TIMEOUT_SECONDS = int(os.environ.get("TUTORIAL_TIMEOUT_SECONDS", "300"))
-# pytest-timeout backstop, kept above the subprocess budget so subprocess.run
-# terminates a hung child first. The thread-method pytest timeout hard-crashes
-# the worker, which would turn the step_7 xfail into a worker crash.
-PYTEST_TIMEOUT_BACKSTOP_SECONDS = SUBPROCESS_TIMEOUT_SECONDS + 60
+# Grace window between SIGTERM and SIGKILL when a tutorial exceeds its budget,
+# matching the retired run-tutorials.sh (`timeout --signal=TERM --kill-after=10`)
+# so tt-metal can close the device instead of being hard-killed mid-operation.
+SIGTERM_GRACE_SECONDS = 10
+# pytest-timeout backstop, kept above the worst-case child lifetime (budget plus
+# the SIGTERM grace) so the child is always terminated first. The thread-method
+# pytest timeout hard-crashes the worker, which would turn the step_7 xfail into
+# a worker crash.
+PYTEST_TIMEOUT_BACKSTOP_SECONDS = (
+    SUBPROCESS_TIMEOUT_SECONDS + SIGTERM_GRACE_SECONDS + 60
+)
 
 # step_7's all_reduce over a Galaxy-scale mesh hangs on a known upstream fabric
 # bug (tt-lang#585, tt-metal#43749 / #41794); the killed process leaves the
@@ -134,12 +141,18 @@ if not TUTORIALS:
 @pytest.mark.parametrize("script", TUTORIALS)
 def test_tutorial(script: Path):
     """Run a tutorial to completion and require a zero exit status."""
-    completed = subprocess.run(
-        [sys.executable, str(script)],
-        cwd=REPO_ROOT,
-        timeout=SUBPROCESS_TIMEOUT_SECONDS,
-        check=False,
-    )
-    assert (
-        completed.returncode == 0
-    ), f"{script.relative_to(REPO_ROOT)} exited with {completed.returncode}"
+    process = subprocess.Popen([sys.executable, str(script)], cwd=REPO_ROOT)
+    try:
+        returncode = process.wait(timeout=SUBPROCESS_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        # SIGTERM first so tt-metal can close the device, then SIGKILL only if
+        # the child ignores the grace window. subprocess.run(timeout=) would
+        # SIGKILL immediately, leaving the chip more likely wedged.
+        process.terminate()
+        try:
+            process.wait(timeout=SIGTERM_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        raise
+    assert returncode == 0, f"{script.relative_to(REPO_ROOT)} exited with {returncode}"

--- a/test/tutorial/test_tutorials.py
+++ b/test/tutorial/test_tutorials.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execute each tutorial example script as an isolated subprocess.
+
+One parametrized test per script under examples/{elementwise-tutorial,
+matmul-tutorial,tutorial}/. Each script is run in a fresh process rather than
+imported: the scripts open and close a device at module top level, so a crash or
+a device wedge in one must not poison the long-lived xdist worker or the next
+tutorial. A subprocess inherits the worker's TT_VISIBLE_DEVICES and
+TT_METAL_CACHE (set by pin_xdist_worker_to_device), so open_device(0) binds to
+that worker's pinned chip during the per-chip parallel phase.
+
+Scheduling reuses .github/scripts/run-hardware-pytests.sh. Single-device
+tutorials run sharded across chips; tutorials that open a device mesh carry the
+multi_device marker and run serially with every chip visible. Classification
+comes from the same "# TTLANG_TUTORIAL_CI:" file tags that
+.github/scripts/run-tutorials.sh reads, keeping the two runners consistent.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES_DIR = REPO_ROOT / "examples"
+TUTORIAL_SUBDIRS = ("elementwise-tutorial", "matmul-tutorial", "tutorial")
+
+CI_TAG_PREFIX = "# TTLANG_TUTORIAL_CI:"
+# Opens a device mesh over every visible chip; belongs in the serial phase.
+MESH_TAG = "multi-device"
+# A mesh tutorial that is meaningless on a single chip; also skipped there.
+REQUIRES_MESH_TAG = "requires-multi-device"
+
+# Per-script subprocess budget. 300s covers a cold-cache 8192x8192 matmul on a
+# single, partially harvested chip (see run-tutorials.sh); multi-device hosts
+# finish each in 20-30s. TUTORIAL_TIMEOUT_SECONDS overrides it.
+SUBPROCESS_TIMEOUT_SECONDS = int(os.environ.get("TUTORIAL_TIMEOUT_SECONDS", "300"))
+# pytest-timeout backstop, kept above the subprocess budget so subprocess.run
+# terminates a hung child first. The thread-method pytest timeout hard-crashes
+# the worker, which would turn the step_7 xfail into a worker crash.
+PYTEST_TIMEOUT_BACKSTOP_SECONDS = SUBPROCESS_TIMEOUT_SECONDS + 60
+
+# step_7's all_reduce over a Galaxy-scale mesh hangs on a known upstream fabric
+# bug (tt-lang#585, tt-metal#43749 / #41794); the killed process leaves the
+# board's ethernet dispatch firmware wedged. It sorts last within its directory,
+# so nothing runs after it in the serial phase, and it is xfailed on Galaxy.
+ALL_REDUCE_TUTORIAL = "step_7_multidevice_shard_k_all_reduce.py"
+
+
+def _host_chip_count() -> int:
+    """Physical Tenstorrent chips on the host.
+
+    Counts digit-named nodes under /dev/tenstorrent, matching count_tt_chips in
+    .github/scripts/hardware-test-common.sh and test/lit.cfg.py. This reflects the
+    physical host rather than TT_VISIBLE_DEVICES, so the requires-mesh gate is not
+    fooled by a pinned worker's single visible chip. TTLANG_TUTORIAL_NUM_DEVICES
+    overrides it for host-independent testing.
+    """
+    override = os.environ.get("TTLANG_TUTORIAL_NUM_DEVICES")
+    if override is not None:
+        return int(override)
+    dev_root = Path("/dev/tenstorrent")
+    if not dev_root.is_dir():
+        return 0
+    return sum(1 for node in dev_root.iterdir() if node.name.isdigit())
+
+
+def _on_galaxy() -> bool:
+    """True on a Galaxy runner, detected from the CI-provided RUNS_ON label."""
+    return "galaxy" in os.environ.get("RUNS_ON", "").lower()
+
+
+def _ci_tags(script: Path) -> set:
+    """TTLANG_TUTORIAL_CI tag values declared in the script's first 80 lines."""
+    tags = set()
+    with script.open(encoding="utf-8") as handle:
+        for _, line in zip(range(80), handle):
+            stripped = line.strip()
+            if stripped.startswith(CI_TAG_PREFIX):
+                tags.add(stripped[len(CI_TAG_PREFIX) :].strip())
+    return tags
+
+
+def _discover_tutorials() -> list:
+    scripts = []
+    for subdir in TUTORIAL_SUBDIRS:
+        directory = EXAMPLES_DIR / subdir
+        if directory.is_dir():
+            scripts.extend(
+                sorted(p for p in directory.glob("*.py") if p.name != "__init__.py")
+            )
+    return scripts
+
+
+def _tutorial_param(script: Path) -> "pytest.ParameterSet":
+    tags = _ci_tags(script)
+    opens_mesh = MESH_TAG in tags or REQUIRES_MESH_TAG in tags
+
+    marks = [pytest.mark.timeout(PYTEST_TIMEOUT_BACKSTOP_SECONDS)]
+    if opens_mesh:
+        marks.append(pytest.mark.multi_device)
+    if REQUIRES_MESH_TAG in tags:
+        marks.append(
+            pytest.mark.skipif(_host_chip_count() < 2, reason="requires >= 2 devices")
+        )
+    if script.name == ALL_REDUCE_TUTORIAL and _on_galaxy():
+        marks.append(
+            pytest.mark.xfail(
+                reason=(
+                    "Galaxy all_reduce/reduce_scatter fabric hang: tt-lang#585, "
+                    "tt-metal#43749 / #41794; the killed run wedges ethernet "
+                    "dispatch firmware"
+                ),
+                strict=True,
+            )
+        )
+
+    return pytest.param(
+        script, id=script.relative_to(EXAMPLES_DIR).as_posix(), marks=marks
+    )
+
+
+TUTORIALS = [_tutorial_param(script) for script in _discover_tutorials()]
+
+if not TUTORIALS:
+    raise RuntimeError(f"no tutorial scripts discovered under {EXAMPLES_DIR}")
+
+
+@pytest.mark.parametrize("script", TUTORIALS)
+def test_tutorial(script: Path):
+    """Run a tutorial to completion and require a zero exit status."""
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=REPO_ROOT,
+        timeout=SUBPROCESS_TIMEOUT_SECONDS,
+        check=False,
+    )
+    assert (
+        completed.returncode == 0
+    ), f"{script.relative_to(REPO_ROOT)} exited with {completed.returncode}"

--- a/test/tutorial/test_tutorials.py
+++ b/test/tutorial/test_tutorials.py
@@ -40,14 +40,10 @@ REQUIRES_MESH_TAG = "requires-multi-device"
 # single, partially harvested chip (see run-tutorials.sh); multi-device hosts
 # finish each in 20-30s. TUTORIAL_TIMEOUT_SECONDS overrides it.
 SUBPROCESS_TIMEOUT_SECONDS = int(os.environ.get("TUTORIAL_TIMEOUT_SECONDS", "300"))
-# Grace window between SIGTERM and SIGKILL when a tutorial exceeds its budget,
-# matching the retired run-tutorials.sh (`timeout --signal=TERM --kill-after=10`)
-# so tt-metal can close the device instead of being hard-killed mid-operation.
+# SIGTERM-to-SIGKILL grace on timeout, so tt-metal can close the device.
 SIGTERM_GRACE_SECONDS = 10
-# pytest-timeout backstop, kept above the worst-case child lifetime (budget plus
-# the SIGTERM grace) so the child is always terminated first. The thread-method
-# pytest timeout hard-crashes the worker, which would turn the step_7 xfail into
-# a worker crash.
+# Above the worst-case child lifetime (budget + grace) so the subprocess handles
+# the timeout; pytest-timeout's thread method aborts the whole worker.
 PYTEST_TIMEOUT_BACKSTOP_SECONDS = (
     SUBPROCESS_TIMEOUT_SECONDS + SIGTERM_GRACE_SECONDS + 60
 )
@@ -145,9 +141,8 @@ def test_tutorial(script: Path):
     try:
         returncode = process.wait(timeout=SUBPROCESS_TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:
-        # SIGTERM first so tt-metal can close the device, then SIGKILL only if
-        # the child ignores the grace window. subprocess.run(timeout=) would
-        # SIGKILL immediately, leaving the chip more likely wedged.
+        # SIGTERM first so tt-metal can close the device; SIGKILL only if it
+        # outlasts the grace window.
         process.terminate()
         try:
             process.wait(timeout=SIGTERM_GRACE_SECONDS)


### PR DESCRIPTION
Three related hardware-CI changes, verified green on the `galaxy-bh` runner:

- Crash-safe pytest: workers pin 1:1 to chips by index, so a crashed xdist worker used to be replaced by a higher-index one that mapped to a nonexistent device — the hundreds-of-`Invalid device ID` cascade. Add `--max-worker-restart=0` (no replacement) and `--reruns 3` for genuinely flaky tests, plus `pytest-rerunfailures` in `dev-requirements.txt` and bats coverage for both flags.
- Parallelized tutorials: the serial `run-tutorials.sh` loop left every chip but one idle and let one killed multi-device tutorial wedge the board and abort the tutorials after it. They now run as a `test/tutorial/` pytest suite under `run-hardware-pytests.sh` — single-device tutorials sharded across chips, mesh tutorials serial with every chip visible, each script in a fresh subprocess. `step_7`'s `all_reduce` is xfailed on Galaxy pending the upstream fabric hang (tt-lang#585, tt-metal#43749 / #41794). `run-tutorials.sh` still serves the single-device dist and wheel jobs.
- Runner selection by label: `format('tt-ubuntu-2204-{0}-stable', inputs.runs-on)` produced the nonexistent label `tt-ubuntu-2204-galaxy-bh-stable` for `galaxy-bh`. It now takes a `runner_labels` JSON input with `runs-on: fromJSON(...)`, `call-build.yml` passes the matrix labels through, and the Blackhole slot moves to `galaxy-bh`.
