### PR TITLE
[ci] Swap bh-loudbox-viommu for p150b in hardware CI

### DIFF
--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -121,7 +121,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                runner: [n150, bh-loudbox-viommu]
+                # TODO: restore bh-loudbox-viommu (multi-device runner) when it is back online.
+                runner: [n150, p150b]
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:


### PR DESCRIPTION
The bh-loudbox-viommu runner is rarely available, so its test-hardware jobs queue indefinitely and block the merge queue. This temporarily swaps it for p150b (`tt-ubuntu-2204-p150b-stable`) in the `test-hardware` matrix in `call-build.yml`, keeping n150 alongside it.