### PR TITLE
[ttl] Add data movement subtile support 

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -108,6 +108,34 @@ inline std::optional<mlir::Type> getTileElementType(mlir::Type type) {
   return std::nullopt;
 }
 
+/// Check tilization consistency between two element types.
+/// - Both non-tile: success (no tilization to compare).
+/// - Exactly one side tiled: error (mixed tile/scalar is invalid).
+/// - Both tiled with differing HxW: error.
+/// - Both tiled with matching HxW: success.
+inline LogicalResult emitIfTileShapeMismatch(Operation *op, Type lhs, Type rhs,
+                                             StringRef lhsName,
+                                             StringRef rhsName) {
+  auto lhsTile = dyn_cast<ttcore::TileType>(lhs);
+  auto rhsTile = dyn_cast<ttcore::TileType>(rhs);
+  if (!lhsTile && !rhsTile) {
+    return success();
+  }
+  if (!lhsTile || !rhsTile) {
+    return op->emitOpError()
+           << "cannot mix tiled and non-tiled element types; got " << lhsName
+           << "=" << lhs << ", " << rhsName << "=" << rhs;
+  }
+  if (lhsTile.getHeight() == rhsTile.getHeight() &&
+      lhsTile.getWidth() == rhsTile.getWidth()) {
+    return success();
+  }
+  return op->emitOpError() << lhsName << " tile shape (" << lhsTile.getHeight()
+                           << "x" << lhsTile.getWidth() << ") must match "
+                           << rhsName << " tile shape (" << rhsTile.getHeight()
+                           << "x" << rhsTile.getWidth() << ")";
+}
+
 /// Return true when `tensor` was acquired from a CB via ttl.cb_wait or
 /// ttl.cb_reserve (the only two ViewLikeOpInterface implementations whose
 /// view source is a CircularBufferType). Traces through

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -249,6 +249,21 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
     }
   }
 
+  // Reject mismatched tilization before the generic element-type check so the
+  // diagnostic names tile shapes rather than opaque TileType spellings.
+  if (failed(emitIfTileShapeMismatch(getOperation(),
+                                     transferTensorTy.getElementType(),
+                                     cbTy.getElementType(), "tensor", "CB"))) {
+    return failure();
+  }
+
+  auto layoutAttr = mlir::cast<LayoutAttr>(enc);
+  if (failed(emitIfTileShapeMismatch(getOperation(),
+                                     layoutAttr.getElementType(),
+                                     cbTy.getElementType(), "layout", "CB"))) {
+    return failure();
+  }
+
   if (transferTensorTy.getElementType() != cbTy.getElementType()) {
     return emitOpError() << "tensor element type ("
                          << transferTensorTy.getElementType()
@@ -1369,6 +1384,14 @@ mlir::LogicalResult mlir::tt::ttl::CBPopOp::verify() {
 mlir::LogicalResult mlir::tt::ttl::StoreOp::verify() {
   auto tensorTy = mlir::cast<RankedTensorType>(getTensor().getType());
   auto viewTy = mlir::cast<RankedTensorType>(getView().getType());
+
+  // CB->CB identity stores (dst.reserve().store(src.wait())) must use the same
+  // tile shape; mismatched tilization is not a supported retile.
+  if (failed(emitIfTileShapeMismatch(getOperation(), tensorTy.getElementType(),
+                                     viewTy.getElementType(), "source",
+                                     "destination CB"))) {
+    return failure();
+  }
 
   if (tensorTy.getElementType() != viewTy.getElementType()) {
     return emitOpError() << "tensor element type (" << tensorTy.getElementType()

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -92,6 +92,10 @@ def _build_tensor_type(ctx, tensor, grid, tiled, memory_space):
     if is_ttnn_tensor(tensor):
         mem_layout = detect_memory_layout(tensor)
 
+    tile = (DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE)
+    if is_ttnn_tensor(tensor) and hasattr(tensor, "get_tile"):
+        tile = tuple(tensor.get_tile().tile_shape)
+
     layout = create_layout(
         ctx,
         LayoutConfig(
@@ -99,19 +103,18 @@ def _build_tensor_type(ctx, tensor, grid, tiled, memory_space):
             grid=grid,
             dtype=tensor.dtype,
             memory_layout=mem_layout,
+            tile=tile,
         ),
     )
 
     ttcore_dtype = tensor_dtype_to_ttcore_datatype(tensor.dtype)
-    element_type = ttcore.ir.TileType.get(
-        ctx, DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE, ttcore_dtype
-    )
+    element_type = ttcore.ir.TileType.get(ctx, tile[0], tile[1], ttcore_dtype)
 
     # Device shape: batch dims preserved, last 2 dims converted to tile counts
     batch_dims = shape[:-2]
     tensor_rows, tensor_cols = shape[-2], shape[-1]
-    total_row_tiles = _ceil_div(tensor_rows, DEFAULT_TILE_SIZE)
-    total_col_tiles = _ceil_div(tensor_cols, DEFAULT_TILE_SIZE)
+    total_row_tiles = _ceil_div(tensor_rows, tile[0])
+    total_col_tiles = _ceil_div(tensor_cols, tile[1])
     device_shape = batch_dims + [total_row_tiles, total_col_tiles]
 
     return RankedTensorType.get(device_shape, element_type, layout)
@@ -846,7 +849,7 @@ class TTLGenericCompiler(TTCompilerBase):
         """Emit ttl.bind_cb for a captured DataflowBuffer instance."""
         ttcore_dtype = tensor_dtype_to_ttcore_datatype(cb.dtype)
         element_type = ttcore.ir.TileType.get(
-            self.ctx, DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE, ttcore_dtype
+            self.ctx, cb.tile[0], cb.tile[1], ttcore_dtype
         )
         cb_type = ttl.CircularBufferType.get(
             self.ctx,

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -61,6 +61,7 @@ class DataflowBuffer:
         shape: Tuple[int, ...],
         block_count: int,
         dtype: Any = None,
+        tile: Tuple[int, int] = (32, 32),
     ):
         if len(shape) < 2:
             raise ValueError(f"DFB shape must have at least 2 dimensions, got {shape}")
@@ -79,6 +80,7 @@ class DataflowBuffer:
         self.shape = shape
         self.block_count = block_count
         self._dtype = dtype
+        self.tile = tuple(tile)
         self._cb_index = _next_cb_index()
 
     @property
@@ -168,7 +170,10 @@ def make_dataflow_buffer_like(
     Returns:
         DataflowBuffer for use in thread function closures
     """
-    return DataflowBuffer(tensor, shape, block_count)
+    tile = (32, 32)
+    if hasattr(tensor, "get_tile"):
+        tile = tuple(tensor.get_tile().tile_shape)
+    return DataflowBuffer(tensor, shape, block_count, tile=tile)
 
 
 def _resolve_dfb_dtype(dtype: Any):
@@ -190,6 +195,7 @@ def make_dfb(
     dtype: Any,
     shape: Tuple[int, ...],
     block_count: int = 2,
+    tile: Tuple[int, int] = (32, 32),
 ) -> DataflowBuffer:
     """
     Create a dataflow buffer from an explicit dtype, with no backing tensor.
@@ -210,4 +216,5 @@ def make_dfb(
         shape=shape,
         block_count=block_count,
         dtype=_resolve_dfb_dtype(dtype),
+        tile=tile,
     )

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -421,14 +421,16 @@ def build_cb_descriptors(
                     data_format,
                     page_size,
                     total_size,
+                    None,
                     f"  CB[{i}]: compiler-allocated num_tiles={cb.num_tiles} "
                     f"block_count={cb.block_count} format={cb.data_format} -> {total_size} bytes",
                 )
             )
         else:
             data_format = _cb_data_format(cb)
-
-            page_size = tile_bytes_from_dtype(data_format)
+            tile = ttnn.Tile(cb.tile)
+            tile_descriptor = ttnn.TileDescriptor(tile)
+            page_size = tile.get_tile_size(data_format)
             num_tiles = cb.shape[0] * cb.shape[1] * cb.block_count
             total_size = num_tiles * page_size
             rows.append(
@@ -436,6 +438,7 @@ def build_cb_descriptors(
                     data_format,
                     page_size,
                     total_size,
+                    tile_descriptor,
                     f"  CB[{i}]: shape={cb.shape} block_count={cb.block_count} -> {total_size} bytes",
                 )
             )
@@ -454,7 +457,7 @@ def build_cb_descriptors(
     # Must stay aligned with MLIR ttl-validate-cb-budget (TileType::getSizeBytes) and
     # tile_bytes_from_dtype; see issue #511.
     if total_cb_bytes > remaining_bytes:
-        breakdown = "\n".join(r[3] for r in rows)
+        breakdown = "\n".join(r[-1] for r in rows)
         raise ValueError(
             "Total circular buffer allocation ("
             f"{total_cb_bytes} bytes) exceeds L1 budget ({remaining_bytes} bytes). "
@@ -464,11 +467,14 @@ def build_cb_descriptors(
         )
 
     cb_descriptors = []
-    for i, (data_format, page_size, total_size, _) in enumerate(rows):
+    for i, row in enumerate(rows):
+        data_format, page_size, total_size = row[:3]
+        tile_descriptor = row[3]
         cb_format = ttnn.CBFormatDescriptor(
             buffer_index=i,
             data_format=data_format,
             page_size=page_size,
+            **({"tile": tile_descriptor} if tile_descriptor is not None else {}),
         )
         cb_desc = ttnn.CBDescriptor(
             total_size=total_size,

--- a/python/ttl/layouts.py
+++ b/python/ttl/layouts.py
@@ -5,7 +5,7 @@
 """Layout creation utilities for tensor distribution across cores."""
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Tuple
 
 from ttl.dialects import ttcore
 
@@ -21,6 +21,7 @@ class LayoutConfig:
     grid: List[int]
     dtype: str
     memory_layout: int = 0  # Default: TENSOR_MEMORY_LAYOUT_INTERLEAVED
+    tile: Tuple[int, int] = (DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE)
 
 
 # BufferType enum values (match TTLOpsEnums.td)
@@ -81,9 +82,7 @@ def create_layout(ctx, config: LayoutConfig):
     mlir_grid = [grid_rows, grid_cols]
 
     ttcore_dtype = tensor_dtype_to_ttcore_datatype(config.dtype)
-    element_type = ttcore.ir.TileType.get(
-        ctx, DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE, ttcore_dtype
-    )
+    element_type = ttcore.ir.TileType.get(ctx, config.tile[0], config.tile[1], ttcore_dtype)
 
     # Import ttl.ir from our _ttlang extension module
     from ttl._mlir_libs._ttlang import ttl_ir

--- a/python/ttl/layouts.py
+++ b/python/ttl/layouts.py
@@ -82,7 +82,9 @@ def create_layout(ctx, config: LayoutConfig):
     mlir_grid = [grid_rows, grid_cols]
 
     ttcore_dtype = tensor_dtype_to_ttcore_datatype(config.dtype)
-    element_type = ttcore.ir.TileType.get(ctx, config.tile[0], config.tile[1], ttcore_dtype)
+    element_type = ttcore.ir.TileType.get(
+        ctx, config.tile[0], config.tile[1], ttcore_dtype
+    )
 
     # Import ttl.ir from our _ttlang extension module
     from ttl._mlir_libs._ttlang import ttl_ir

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -98,6 +98,17 @@ def _get_constant_float(val) -> float:
     return v
 
 
+def _tile_hw(elem_type) -> Optional[Tuple[int, int]]:
+    """Return (H, W) when ``elem_type`` is a TileType, else None."""
+    from ttl.dialects import ttcore
+
+    tile = ttcore.ir.TileType.maybe_downcast(elem_type)
+    if tile is None:
+        return None
+    shape = list(tile.shape)
+    return (int(shape[0]), int(shape[1]))
+
+
 # Type aliases for common patterns
 CoreCoordinate = Tuple[int, int]
 IndexedTensor = Union["TensorBlock", Tuple["TensorBlock", Tuple[int, ...]]]
@@ -211,6 +222,12 @@ class TensorBlock:
                 "store() must be called on a block acquired from reserve(), not a regular tensor"
             )
         reserve = _get_reserve_from_block(ast_self)
+        _require_matching_tile_shapes(
+            rhs.type.element_type,
+            reserve.type.element_type,
+            "source",
+            "destination CB",
+        )
         ttl.store(rhs, reserve)
 
     def __iadd__(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
@@ -378,6 +395,28 @@ def _get_cb_shape(cb_val):
     return list(cb_type.shape)
 
 
+def _require_matching_tile_shapes(lhs_elem, rhs_elem, lhs_name: str, rhs_name: str):
+    """Reject copies/stores with inconsistent tilization.
+
+    Both non-tile is allowed. Mixing tile and non-tile, or two different
+    tile shapes, is an error.
+    """
+    lhs = _tile_hw(lhs_elem)
+    rhs = _tile_hw(rhs_elem)
+    if lhs is None and rhs is None:
+        return
+    if lhs is None or rhs is None:
+        raise ValueError(
+            f"cannot mix tiled and non-tiled element types; got "
+            f"{lhs_name}={lhs_elem}, {rhs_name}={rhs_elem}"
+        )
+    if lhs != rhs:
+        raise ValueError(
+            f"{lhs_name} tile shape {lhs[0]}x{lhs[1]} must match "
+            f"{rhs_name} tile shape {rhs[0]}x{rhs[1]}"
+        )
+
+
 def _process_tensor_subscript(subscript_tuple, cb_shape):
     """Process tensor subscript and create tensor slice.
 
@@ -533,10 +572,22 @@ def copy(src, dst) -> CopyTransferHandler:
 
     if dst_is_block and not src_is_block:
         # Read: device tensor/slice -> block (CB)
+        dst_cb_ty = ttl.CircularBufferType.maybe_downcast(dst_cb.type)
+        if dst_cb_ty is None:
+            raise ValueError(f"Expected CircularBufferType, got {dst_cb.type}")
+        _require_matching_tile_shapes(
+            src.type.element_type, dst_cb_ty.element_type, "tensor", "CB"
+        )
         xf_type = Type.parse("!ttl.transfer_handle<read>", ctx)
         return ttl.copy(xf_type, src, dst_cb)
     elif src_is_block and not dst_is_block:
         # Write: block (CB) -> device tensor/slice
+        src_cb_ty = ttl.CircularBufferType.maybe_downcast(src_cb.type)
+        if src_cb_ty is None:
+            raise ValueError(f"Expected CircularBufferType, got {src_cb.type}")
+        _require_matching_tile_shapes(
+            dst.type.element_type, src_cb_ty.element_type, "tensor", "CB"
+        )
         xf_type = Type.parse("!ttl.transfer_handle<write>", ctx)
         return ttl.copy(xf_type, src_cb, dst)
     else:

--- a/test/python/test_subtile_tensor_dm.py
+++ b/test/python/test_subtile_tensor_dm.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Sub-tile data-movement coverage.
+
+1. Tiny-page tensor->CB->tensor copies: when ``page < aligned_page_size``,
+   confirm the NOC transfer uses logical tile bytes (not the aligned size)
+   so padding/neighbor tiles are not pulled into the destination.
+
+2. Tilization mismatch rejection: ``ttl.copy`` (tensor<->CB) and
+   ``block.store`` (CB->CB) must error when tile HxW differs.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttl
+from ttl.diagnostics import TTLangCompileError
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+
+@ttl.operation(grid=(1, 1))
+def subtile_tensor_copy(src, dst):
+    """Copy one tile tensor->CB->tensor with an empty compute thread."""
+    cb = ttl.make_dataflow_buffer_like(src, shape=(1, 1), block_count=2)
+    blk_in = cb.reserve()
+    ttl.copy(src[0:1, 0:1], blk_in)
+    blk_out = cb.wait()
+    ttl.copy(blk_out, dst[0:1, 0:1])
+
+
+@ttl.operation(grid=(1, 1))
+def _copy_tensor_32_into_cb_16(src, dst):
+    """INVALID: copy a 32x32 tensor tile into a 16x16 CB."""
+    cb = ttl.make_dfb(ttnn.bfloat16, shape=(1, 1), block_count=2, tile=(16, 16))
+    blk = cb.reserve()
+    ttl.copy(src[0:1, 0:1], blk)
+    out_blk = cb.wait()
+    ttl.copy(out_blk, dst[0:1, 0:1])
+
+
+@ttl.operation(grid=(1, 1))
+def _store_cb_16_into_cb_32(out):
+    """INVALID: store a 16x16 CB block into a 32x32 CB reserve."""
+    src_dfb = ttl.make_dfb(ttnn.bfloat16, shape=(1, 1), block_count=2, tile=(16, 16))
+    dst_dfb = ttl.make_dfb(ttnn.bfloat16, shape=(1, 1), block_count=2, tile=(32, 32))
+
+    @ttl.compute()
+    def compute():
+        o = dst_dfb.reserve()
+        o.store(src_dfb.wait())
+
+
+def _to_device(torch_tensor, device, tile_hw, dtype, memory_config):
+    return ttnn.from_torch(
+        torch_tensor,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        tile=ttnn.Tile(tile_hw),
+        memory_config=memory_config,
+    )
+
+
+def _torch_dtype(tt_dtype):
+    if tt_dtype == ttnn.bfloat16:
+        return torch.bfloat16
+    if tt_dtype == ttnn.uint8:
+        return torch.uint8
+    raise ValueError(f"unsupported dtype {tt_dtype}")
+
+
+# (tile_hw, tt_dtype, memory_config, label)
+TINY_COPY_CASES = [
+    ((1, 16), ttnn.bfloat16, ttnn.DRAM_MEMORY_CONFIG, "dram_bf16_1x16"),
+    ((1, 16), ttnn.bfloat16, ttnn.L1_MEMORY_CONFIG, "l1_bf16_1x16"),
+    ((1, 16), ttnn.uint8, ttnn.DRAM_MEMORY_CONFIG, "dram_u8_1x16"),
+    ((1, 16), ttnn.uint8, ttnn.L1_MEMORY_CONFIG, "l1_u8_1x16"),
+    ((1, 32), ttnn.uint8, ttnn.DRAM_MEMORY_CONFIG, "dram_u8_1x32"),
+]
+
+
+@pytest.mark.parametrize(
+    "tile_hw, tt_dtype, memory_config, label",
+    TINY_COPY_CASES,
+    ids=[c[-1] for c in TINY_COPY_CASES],
+)
+def test_subtile_tensor_copy_single_tile(
+    device, tile_hw, tt_dtype, memory_config, label
+):
+    """Round-trip one tiny tile and report page vs aligned sizes."""
+    h, w = tile_hw
+    torch_dtype = _torch_dtype(tt_dtype)
+    tile = ttnn.Tile(tile_hw)
+    src_t = (
+        (torch.arange(h * w, dtype=torch.int64) % 200 + 1).to(torch_dtype).reshape(h, w)
+    )
+
+    src = _to_device(src_t, device, tile_hw, tt_dtype, memory_config)
+    dst = _to_device(
+        torch.zeros(h, w, dtype=torch_dtype), device, tile_hw, tt_dtype, memory_config
+    )
+
+    tile_bytes = tile.get_tile_size(tt_dtype)
+    page = src.buffer_page_size()
+    aligned = src.buffer_aligned_page_size()
+    print(
+        f"[{label}] tile_bytes={tile_bytes} page={page} aligned={aligned} "
+        f"(aligned-page gap={aligned - page})"
+    )
+
+    subtile_tensor_copy(src, dst)
+
+    got = ttnn.to_torch(dst).reshape(h, w)
+    if torch_dtype == torch.bfloat16:
+        got = got.to(torch.bfloat16)
+        assert torch.equal(got, src_t), f"[{label}] mismatch got={got} exp={src_t}"
+    else:
+        assert torch.equal(
+            got.to(torch.int64), src_t.to(torch.int64)
+        ), f"[{label}] mismatch got={got} exp={src_t}"
+
+    ttnn.deallocate(src)
+    ttnn.deallocate(dst)
+
+
+@pytest.mark.parametrize(
+    "tile_hw, tt_dtype, memory_config, label",
+    [
+        ((1, 16), ttnn.uint8, ttnn.DRAM_MEMORY_CONFIG, "dram_u8_1x16"),
+        ((1, 16), ttnn.uint8, ttnn.L1_MEMORY_CONFIG, "l1_u8_1x16"),
+        ((1, 16), ttnn.bfloat16, ttnn.DRAM_MEMORY_CONFIG, "dram_bf16_1x16"),
+    ],
+    ids=["dram_u8_1x16", "l1_u8_1x16", "dram_bf16_1x16"],
+)
+def test_subtile_tensor_copy_neighbor_untouched(
+    device, tile_hw, tt_dtype, memory_config, label
+):
+    """Copy tile 0 of a 2-tile tensor; tile 1 must stay at its sentinel.
+
+    If the NOC transfer uses ``aligned_page_size`` (> logical tile bytes),
+    writing tile 0 can spill into the padding/next page and corrupt tile 1.
+    """
+    h, w = tile_hw
+    torch_dtype = _torch_dtype(tt_dtype)
+    # Two tiles side-by-side along W.
+    shape = (h, 2 * w)
+    src_t = torch.zeros(shape, dtype=torch_dtype)
+    dst_t = torch.zeros(shape, dtype=torch_dtype)
+    # Tile 0: 1..N, tile 1: 200+i (distinct sentinel).
+    src_t[:, :w] = (
+        (torch.arange(h * w, dtype=torch.int64) % 100 + 1).to(torch_dtype).reshape(h, w)
+    )
+    src_t[:, w:] = (
+        (torch.arange(h * w, dtype=torch.int64) % 100 + 200)
+        .to(torch_dtype)
+        .reshape(h, w)
+    )
+    dst_t[:, :w] = 0
+    dst_t[:, w:] = 77  # sentinel that must survive a tile-0-only copy
+
+    src = _to_device(src_t, device, tile_hw, tt_dtype, memory_config)
+    dst = _to_device(dst_t, device, tile_hw, tt_dtype, memory_config)
+
+    tile = ttnn.Tile(tile_hw)
+    print(
+        f"[{label} neighbor] tile_bytes={tile.get_tile_size(tt_dtype)} "
+        f"page={src.buffer_page_size()} aligned={src.buffer_aligned_page_size()}"
+    )
+
+    # Kernel always copies src[0:1,0:1] -> dst[0:1,0:1] (first tile only).
+    subtile_tensor_copy(src, dst)
+
+    got = ttnn.to_torch(dst).reshape(shape)
+    if torch_dtype == torch.bfloat16:
+        got = got.to(torch.bfloat16)
+
+    got0, got1 = got[:, :w], got[:, w:]
+    exp0, exp1 = src_t[:, :w], dst_t[:, w:]
+
+    if torch_dtype == torch.uint8:
+        assert torch.equal(
+            got0.to(torch.int64), exp0.to(torch.int64)
+        ), f"[{label}] tile0 mismatch got={got0} exp={exp0}"
+        assert torch.equal(got1.to(torch.int64), exp1.to(torch.int64)), (
+            f"[{label}] tile1 corrupted (possible aligned-page oversize write): "
+            f"got={got1} exp={exp1}"
+        )
+    else:
+        assert torch.equal(
+            got0, exp0
+        ), f"[{label}] tile0 mismatch got={got0} exp={exp0}"
+        assert torch.equal(got1, exp1), (
+            f"[{label}] tile1 corrupted (possible aligned-page oversize write): "
+            f"got={got1} exp={exp1}"
+        )
+
+    ttnn.deallocate(src)
+    ttnn.deallocate(dst)
+
+
+def test_copy_rejects_mismatched_tile_shape(device):
+    """ttl.copy must reject tensor tile HxW that differs from the CB tile."""
+    src = _to_device(
+        torch.ones((32, 32), dtype=torch.bfloat16),
+        device,
+        (32, 32),
+        ttnn.bfloat16,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    dst = _to_device(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        device,
+        (32, 32),
+        ttnn.bfloat16,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with pytest.raises(
+        TTLangCompileError,
+        match=r"tensor tile shape 32x32 must match CB tile shape 16x16",
+    ):
+        _copy_tensor_32_into_cb_16(src, dst)
+    ttnn.deallocate(src)
+    ttnn.deallocate(dst)
+
+
+def test_store_rejects_mismatched_tile_shape(device):
+    """CB->CB store must reject source/destination tile HxW mismatch."""
+    out = _to_device(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        device,
+        (32, 32),
+        ttnn.bfloat16,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with pytest.raises(
+        TTLangCompileError,
+        match=r"source tile shape 16x16 must match destination CB tile shape 32x32",
+    ):
+        _store_cb_16_into_cb_32(out)
+    ttnn.deallocate(out)

--- a/test/ttlang/Dialect/TTL/IR/dma_single_core_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/dma_single_core_invalid.mlir
@@ -75,6 +75,54 @@ module {
 
 // -----
 
+// Tensor and CB must both be tiled (reject tile vs scalar element type).
+#layout_tiled = #ttl.layout<shape = [1, 1], element_type = !ttcore.tile<32x32, f32>,
+                            buffer = dram, grid = [1, 1], memory = interleaved>
+
+module {
+  func.func @copy_tile_vs_scalar_invalid(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #layout_tiled>) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], f32, 2>
+    // expected-error @below {{cannot mix tiled and non-tiled element types}}
+    %xf = ttl.copy %arg0, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>, #layout_tiled>, !ttl.cb<[1, 1], f32, 2>) -> !ttl.transfer_handle<read>
+    ttl.wait %xf : !ttl.transfer_handle<read>
+    func.return
+  }
+}
+
+// -----
+
+// Tensor tile shape must match the CB tile shape (tensor -> CB).
+#layout_32 = #ttl.layout<shape = [1, 1], element_type = !ttcore.tile<32x32, f32>,
+                         buffer = dram, grid = [1, 1], memory = interleaved>
+
+module {
+  func.func @copy_tile_shape_mismatch_tensor_to_cb(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #layout_32>) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<16x16, f32>, 2>
+    // expected-error @below {{tensor tile shape (32x32) must match CB tile shape (16x16)}}
+    %xf = ttl.copy %arg0, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>, #layout_32>, !ttl.cb<[1, 1], !ttcore.tile<16x16, f32>, 2>) -> !ttl.transfer_handle<read>
+    ttl.wait %xf : !ttl.transfer_handle<read>
+    func.return
+  }
+}
+
+// -----
+
+// Tensor tile shape must match the CB tile shape (CB -> tensor).
+#layout_16 = #ttl.layout<shape = [1, 1], element_type = !ttcore.tile<16x16, f32>,
+                         buffer = dram, grid = [1, 1], memory = interleaved>
+
+module {
+  func.func @copy_tile_shape_mismatch_cb_to_tensor(%arg0: tensor<1x1x!ttcore.tile<16x16, f32>, #layout_16>) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    // expected-error @below {{tensor tile shape (16x16) must match CB tile shape (32x32)}}
+    %xf = ttl.copy %cb, %arg0 : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, tensor<1x1x!ttcore.tile<16x16, f32>, #layout_16>) -> !ttl.transfer_handle<write>
+    ttl.wait %xf : !ttl.transfer_handle<write>
+    func.return
+  }
+}
+
+// -----
+
 // Tensor block shape must match the CB shape.
 #layout_2x1 = #ttl.layout<shape = [2, 1], element_type = !ttcore.tile<32x32, f32>,
                           buffer = dram, grid = [1, 1], memory = interleaved>

--- a/test/ttlang/Dialect/TTL/IR/store_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/store_invalid.mlir
@@ -3,6 +3,18 @@
 
 // -----
 
+// Tile shape mismatch between source block and destination CB reserve view.
+func.func @store_tile_shape_mismatch(
+    %tensor: tensor<2x2x!ttcore.tile<16x16, f32>>) {
+  %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+  %view = ttl.cb_reserve %cb : <[2, 2], !ttcore.tile<32x32, f32>, 2> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{source tile shape (16x16) must match destination CB tile shape (32x32)}}
+  ttl.store %tensor, %view : tensor<2x2x!ttcore.tile<16x16, f32>>, tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return
+}
+
+// -----
+
 // Element type mismatch between tensor and view.
 func.func @store_element_type_mismatch(
     %tensor: tensor<2x2x!ttcore.tile<32x32, f32>>) {


### PR DESCRIPTION
### Problem description
TT-Lang assumed a default 32x32 tile in the Python frontend when building tensor types, dataflow buffers, and CB descriptors. Sub-tile shapes from tensor.get_tile() (e.g. 16x32, 1x16) were dropped, so DFBs and CB page sizing did not match the real tile bytes. 

### What's changed
Threaded tile shape through the Python frontend so DFBs, tensor/layout typing, and CB page sizing honor tensor.get_tile(). Added DM-only pytest coverage for page tensor to CB to tensor round trip copies. Including single-tile round-trips and a neighbor-tile check when page < aligned, to confirm the NOC transfer uses logical tile size rather than oversizing to the aligned page.

### Ticket
[Issue](https://github.com/tenstorrent/tt-lang-ops-and-models/issues/9) 

### Checklist
- [ ] New/Existing tests provide coverage for changes
