### PR TITLE
[build] Package tt-metal triage tool

### DIFF
--- a/.github/containers/CONTAINER_README.md
+++ b/.github/containers/CONTAINER_README.md
@@ -18,7 +18,7 @@ python $TTLANG_TOOLCHAIN_DIR/examples/elementwise-tutorial/step_4_multinode_grid
 
 ## Available Tools
 
-`vim`, `nano`, `python` (3.12), `pytest`, `tt-smi`, `capture-release`, `csvexport-release` (Tracy profiler)
+`vim`, `nano`, `python` (3.12), `pytest`, `tt-smi`, `tt-triage`, `capture-release`, `csvexport-release` (Tracy profiler)
 
 ## Documentation
 

--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -21,6 +21,17 @@ ARG BASE_IMAGE
 FROM scratch AS ird-toolchain
 FROM scratch AS dist-toolchain
 
+# Keep triage's debugger stack separate from the main toolchain venv. tt-smi
+# and tt-exalens can require different tt-umd versions.
+FROM ${BASE_IMAGE} AS tt-triage-python
+ENV TT_TRIAGE_VENV=/opt/ttlang-toolchain/tt-triage-venv
+COPY third-party/tt-metal/tools/triage/requirements.txt /tmp/tt-triage-requirements.txt
+RUN python3.12 -m venv "$TT_TRIAGE_VENV" && \
+    "$TT_TRIAGE_VENV/bin/python" -m pip install \
+        --no-cache-dir -r /tmp/tt-triage-requirements.txt && \
+    "$TT_TRIAGE_VENV/bin/python" -m pip check && \
+    rm /tmp/tt-triage-requirements.txt
+
 # =============================================================================
 # IRD (for developers who will clone and build their own tt-lang)
 # =============================================================================
@@ -29,6 +40,8 @@ SHELL ["/bin/bash", "-c"]
 
 ENV TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain
 ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --from=tt-triage-python /opt/ttlang-toolchain/tt-triage-venv $TTLANG_TOOLCHAIN_DIR/tt-triage-venv/
 
 # Split toolchain into multiple layers for parallel pulls.
 # Largest directories get their own layer; the rest go in one layer.
@@ -76,6 +89,8 @@ FROM ${BASE_IMAGE} AS dist
 SHELL ["/bin/bash", "-c"]
 
 ENV TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain
+
+COPY --from=tt-triage-python /opt/ttlang-toolchain/tt-triage-venv $TTLANG_TOOLCHAIN_DIR/tt-triage-venv/
 
 # Split toolchain into multiple layers for parallel pulls.
 COPY --from=dist-toolchain --chmod=777 /bin $TTLANG_TOOLCHAIN_DIR/bin/

--- a/.github/containers/IRD_README.md
+++ b/.github/containers/IRD_README.md
@@ -31,7 +31,7 @@ ninja -C build check-ttlang-pytest   # Python pytest tests
 
 ## Available Tools
 
-`vim`, `nano`, `tmux`, `ssh`, `sudo`, `git`, `ccache`, `tt-smi`, `capture-release`, `csvexport-release` (Tracy profiler)
+`vim`, `nano`, `tmux`, `ssh`, `sudo`, `git`, `ccache`, `tt-smi`, `tt-triage`, `capture-release`, `csvexport-release` (Tracy profiler)
 
 ## Documentation
 

--- a/.github/containers/cleanup-toolchain.sh
+++ b/.github/containers/cleanup-toolchain.sh
@@ -45,6 +45,7 @@ KEEP_BINS=(
     mlir-tblgen
     mlir-translate
     tt-lang-sim
+    tt-triage
 )
 
 if [ -d "$TOOLCHAIN_DIR/bin" ]; then

--- a/.github/scripts/check-wheel-bundled-payload.py
+++ b/.github/scripts/check-wheel-bundled-payload.py
@@ -12,6 +12,9 @@ import sys
 import zipfile
 
 REQUIRED_PATHS = (
+    "triage/inspector.capnp",
+    "triage/requirements.txt",
+    "triage/triage.py",
     "ttnn/__init__.py",
     "ttnn/_ttnn.so",
     "ttnn/build/lib/_ttnncpp.so",

--- a/.github/scripts/tests/test_detect_uplift.bats
+++ b/.github/scripts/tests/test_detect_uplift.bats
@@ -74,6 +74,13 @@ setup() {
     assert_equal "$(run_detect "$BASE" "$head")" "true"
 }
 
+@test "diff in bin/tt-triage marks uplift=true" {
+    echo "modified" >> "$REPO/bin/tt-triage"
+    commit_all "$REPO" "uplift"
+    head=$(cd "$REPO" && git rev-parse HEAD)
+    assert_equal "$(run_detect "$BASE" "$head")" "true"
+}
+
 # --- No-diff case ---
 
 @test "same base and head -> uplift=false" {

--- a/.github/scripts/tests/test_detect_uplift.bats
+++ b/.github/scripts/tests/test_detect_uplift.bats
@@ -60,6 +60,13 @@ setup() {
     assert_equal "$(run_detect "$BASE" "$head")" "true"
 }
 
+@test "diff in .github/containers/Dockerfile marks uplift=true" {
+    echo "modified" >> "$REPO/.github/containers/Dockerfile"
+    commit_all "$REPO" "uplift"
+    head=$(cd "$REPO" && git rev-parse HEAD)
+    assert_equal "$(run_detect "$BASE" "$head")" "true"
+}
+
 @test "diff in .github/containers/Dockerfile.wheel-manylinux-2-34 marks uplift=true" {
     echo "modified" >> "$REPO/.github/containers/Dockerfile.wheel-manylinux-2-34"
     commit_all "$REPO" "uplift"

--- a/.github/scripts/tests/test_get_version_tag.bats
+++ b/.github/scripts/tests/test_get_version_tag.bats
@@ -81,6 +81,10 @@ container_input_one_path() {
     container_input_one_path ".github/containers/Dockerfile.base"
 }
 
+@test "container input change in .github/containers/Dockerfile -> -<hash> form" {
+    container_input_one_path ".github/containers/Dockerfile"
+}
+
 @test "container input change in .github/containers/Dockerfile.wheel-manylinux-2-34 -> -<hash> form" {
     container_input_one_path ".github/containers/Dockerfile.wheel-manylinux-2-34"
 }
@@ -254,6 +258,7 @@ container_input_one_path() {
 UPLIFT_PATHS=(
     requirements-runtime.txt
     bin/tt-triage
+    .github/containers/Dockerfile
     .github/containers/Dockerfile.base
     .github/containers/Dockerfile.wheel-manylinux-2-34
     third-party/tt-metal

--- a/.github/scripts/tests/test_get_version_tag.bats
+++ b/.github/scripts/tests/test_get_version_tag.bats
@@ -89,6 +89,10 @@ container_input_one_path() {
     container_input_one_path "requirements-runtime.txt"
 }
 
+@test "container input change in bin/tt-triage -> -<hash> form" {
+    container_input_one_path "bin/tt-triage"
+}
+
 # --- Hash determinism: same content yields same tag ---
 
 @test "hash determinism across independent repos with same content" {
@@ -249,6 +253,7 @@ container_input_one_path() {
 #!/bin/bash
 UPLIFT_PATHS=(
     requirements-runtime.txt
+    bin/tt-triage
     .github/containers/Dockerfile.base
     .github/containers/Dockerfile.wheel-manylinux-2-34
     third-party/tt-metal

--- a/.github/scripts/tests/test_helper.bash
+++ b/.github/scripts/tests/test_helper.bash
@@ -80,7 +80,7 @@ mkrepo() {
         git init -q -b main
         git config user.email t@t
         git config user.name t
-        mkdir -p third-party/llvm-project third-party/tt-metal .github/containers python/sim
+        mkdir -p third-party/llvm-project third-party/tt-metal .github/containers bin python/sim
         # Sourceable shell snippet matching the real third-party/tt-metal-version
         # schema.
         write_tt_metal_version_file third-party/tt-metal-version \
@@ -93,6 +93,7 @@ mkrepo() {
 FROM ubuntu:24.04
 RUN echo "base v1"
 EOF
+        echo "tt-triage launcher" > bin/tt-triage
         echo "greenlet>=3.0.0" > requirements-runtime.txt
         echo "// kernel placeholder" > python/sim/example.py
         git add -A

--- a/.github/scripts/tests/test_install_ttmetal.bats
+++ b/.github/scripts/tests/test_install_ttmetal.bats
@@ -22,13 +22,16 @@ mkfake_ttmetal() {
     dir=$(mktemp -d "${BATS_TEST_TMPDIR:-/tmp}/ttmetal.XXXXXX")
 
     mkdir -p "$dir/src/ttnn/ttnn" "$dir/src/ttnn/cpp" "$dir/src/tt_metal/api" \
-        "$dir/src/tools/tracy" "$dir/src/tt_metal/pre-compiled/stale"
+        "$dir/src/tools/tracy" "$dir/src/tools/triage" \
+        "$dir/src/tt_metal/pre-compiled/stale"
     echo "from . import _ttnn" > "$dir/src/ttnn/ttnn/__init__.py"
     echo "version = '0.x'" > "$dir/src/ttnn/ttnn/version.py"
     echo "// cpp header" > "$dir/src/ttnn/cpp/placeholder.h"
     echo "// header" > "$dir/src/tt_metal/api/sample.h"
     echo "stale firmware" > "$dir/src/tt_metal/pre-compiled/stale/fw.elf"
     echo "tracy_module" > "$dir/src/tools/tracy/__init__.py"
+    echo "triage_module" > "$dir/src/tools/triage/triage.py"
+    echo "tt-exalens==0.3.21" > "$dir/src/tools/triage/requirements.txt"
 
     if [[ "$has_stale_so" == "stale" ]]; then
         printf '\x7fELF stale ttnn' > "$dir/src/ttnn/ttnn/_ttnn.so"
@@ -82,6 +85,16 @@ run_install() {
     assert_success
     [ -f "$install/python_packages/ttnn/ttnn/__init__.py" ]
     [ -f "$install/python_packages/ttnn/ttnn/version.py" ]
+}
+
+@test "install copies tt-triage from \$SRC" {
+    local d
+    d=$(mkfake_ttmetal "with-so" "fresh")
+    local install="$BATS_TEST_TMPDIR/install"
+    run run_install "$d/src" "$d/build" "$install"
+    assert_success
+    [ -f "$install/tools/triage/triage.py" ]
+    [ -f "$install/tools/triage/requirements.txt" ]
 }
 
 @test "install fails when neither stale .so nor fresh .so exist" {

--- a/.github/scripts/uplift-paths.sh
+++ b/.github/scripts/uplift-paths.sh
@@ -21,5 +21,6 @@ UPLIFT_PATHS=(
     third-party/tt-metal
     .github/containers/Dockerfile.base
     .github/containers/Dockerfile.wheel-manylinux-2-34
+    bin/tt-triage
     requirements-runtime.txt
 )

--- a/.github/scripts/uplift-paths.sh
+++ b/.github/scripts/uplift-paths.sh
@@ -19,6 +19,7 @@ UPLIFT_PATHS=(
     third-party/tt-metal-version
     third-party/llvm-project
     third-party/tt-metal
+    .github/containers/Dockerfile
     .github/containers/Dockerfile.base
     .github/containers/Dockerfile.wheel-manylinux-2-34
     bin/tt-triage

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -265,8 +265,7 @@ jobs:
             export PATH=/opt/ttlang-toolchain/venv/bin:/opt/ttlang-toolchain/bin:$PATH
             tt-lang-sim --help
             tt-lang-sim-stats --help
-            test -s /opt/ttlang-toolchain/bin/tt-triage
-            test -f /opt/ttlang-toolchain/tt-metal/tools/triage/triage.py
+            tt-triage --help
           '
 
       - name: Push dist image to GHCR
@@ -326,8 +325,7 @@ jobs:
             mlir-opt --version
             FileCheck --version
             python3 --version
-            test -s /opt/ttlang-toolchain/bin/tt-triage
-            test -f /opt/ttlang-toolchain/tt-metal/tools/triage/triage.py
+            tt-triage --help
           '
 
       - name: Push ird image to GHCR

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -149,8 +149,13 @@ jobs:
           key: ${{ needs.configure-deps.outputs.cache-key }}
           fail-on-cache-miss: true
 
-      - name: Patch missing runtime artifacts into cached toolchain
-        run: bash scripts/copy-ttmetal-runtime-artifacts.sh third-party/tt-metal /opt/ttlang-toolchain
+      - name: Patch missing runtime artifacts and tt-triage into cached toolchain
+        run: |
+          bash scripts/copy-ttmetal-runtime-artifacts.sh third-party/tt-metal /opt/ttlang-toolchain
+          rm -rf /opt/ttlang-toolchain/tt-metal/tools/triage
+          install -d /opt/ttlang-toolchain/tt-metal/tools
+          cp -a third-party/tt-metal/tools/triage /opt/ttlang-toolchain/tt-metal/tools/
+          install -m 755 bin/tt-triage /opt/ttlang-toolchain/bin/tt-triage
 
       - name: Pull base image
         run: |
@@ -260,6 +265,8 @@ jobs:
             export PATH=/opt/ttlang-toolchain/venv/bin:/opt/ttlang-toolchain/bin:$PATH
             tt-lang-sim --help
             tt-lang-sim-stats --help
+            test -s /opt/ttlang-toolchain/bin/tt-triage
+            test -f /opt/ttlang-toolchain/tt-metal/tools/triage/triage.py
           '
 
       - name: Push dist image to GHCR
@@ -319,6 +326,8 @@ jobs:
             mlir-opt --version
             FileCheck --version
             python3 --version
+            test -s /opt/ttlang-toolchain/bin/tt-triage
+            test -f /opt/ttlang-toolchain/tt-metal/tools/triage/triage.py
           '
 
       - name: Push ird image to GHCR

--- a/.github/workflows/call-build-wheels.yml
+++ b/.github/workflows/call-build-wheels.yml
@@ -191,6 +191,7 @@ jobs:
             dist/tt_lang-*.whl
           python .github/scripts/check-installed-ttnn.py --mode "${{ inputs.ttnn_dep_mode }}"
           python .github/scripts/smoke-test-wheel.py
+          command -v tt-triage
 
       - name: Free disk space before remaining wheel tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,9 +260,10 @@ install(DIRECTORY python/sim_stats DESTINATION python_packages
         FILES_MATCHING PATTERN "*.py"
         PATTERN "__pycache__" EXCLUDE)
 
-# Install tt-lang-sim script to bin directory
+# Install command-line scripts to the bin directory.
 install(PROGRAMS "${CMAKE_SOURCE_DIR}/bin/tt-lang-sim" DESTINATION bin)
 install(PROGRAMS "${CMAKE_SOURCE_DIR}/bin/tt-lang-sim-stats" DESTINATION bin)
+install(PROGRAMS "${CMAKE_SOURCE_DIR}/bin/tt-triage" DESTINATION bin)
 
 # ---------------------------------------------------------------------------
 # Configuration summary

--- a/bin/tt-triage
+++ b/bin/tt-triage
@@ -50,6 +50,12 @@ def _find_triage_directory() -> Path:
         if (triage_directory / "triage.py").is_file():
             return triage_directory
 
+    toolchain_directory = os.environ.get("TTLANG_TOOLCHAIN_DIR", "").strip()
+    if toolchain_directory:
+        triage_directory = Path(toolchain_directory) / "tt-metal" / "tools" / "triage"
+        if (triage_directory / "triage.py").is_file():
+            return triage_directory
+
     triage_spec = find_spec("triage")
     if triage_spec is not None and triage_spec.submodule_search_locations:
         for package_directory in triage_spec.submodule_search_locations:

--- a/bin/tt-triage
+++ b/bin/tt-triage
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run tt-metal's triage utility from a source or wheel installation."""
+
+from importlib.util import find_spec
+import os
+from pathlib import Path
+import runpy
+import sys
+
+
+def _find_triage_directory() -> Path:
+    runtime_root = (
+        os.environ.get("TT_METAL_RUNTIME_ROOT", "").strip()
+        or os.environ.get("TT_METAL_HOME", "").strip()
+    )
+    if runtime_root:
+        triage_directory = Path(runtime_root) / "tools" / "triage"
+        if (triage_directory / "triage.py").is_file():
+            return triage_directory
+
+    triage_spec = find_spec("triage")
+    if triage_spec is not None and triage_spec.submodule_search_locations:
+        for package_directory in triage_spec.submodule_search_locations:
+            triage_directory = Path(package_directory)
+            if (triage_directory / "triage.py").is_file():
+                return triage_directory
+
+    raise SystemExit(
+        "tt-triage could not find tools/triage in the installed tt-metal runtime"
+    )
+
+
+def main() -> None:
+    triage_directory = _find_triage_directory()
+    sys.path.insert(0, str(triage_directory))
+    runpy.run_path(str(triage_directory / "triage.py"), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/tt-triage
+++ b/bin/tt-triage
@@ -12,6 +12,34 @@ import runpy
 import sys
 
 
+def _reexec_in_container_triage_environment() -> None:
+    toolchain_directory = os.environ.get("TTLANG_TOOLCHAIN_DIR", "").strip()
+    if not toolchain_directory:
+        return
+
+    triage_environment = Path(toolchain_directory) / "tt-triage-venv"
+    if Path(sys.prefix).resolve() == triage_environment.resolve():
+        return
+
+    triage_python = triage_environment / "bin" / "python"
+    if not triage_python.is_file():
+        return
+
+    # Device-management packages in the container have independent version
+    # constraints, so triage runs with its isolated dependencies.
+    environment = os.environ.copy()
+    environment["VIRTUAL_ENV"] = str(triage_environment)
+    existing_path = environment.get("PATH", "")
+    environment["PATH"] = str(triage_environment / "bin") + (
+        f"{os.pathsep}{existing_path}" if existing_path else ""
+    )
+    os.execve(
+        str(triage_python),
+        [str(triage_python), str(Path(__file__).resolve()), *sys.argv[1:]],
+        environment,
+    )
+
+
 def _find_triage_directory() -> Path:
     runtime_root = (
         os.environ.get("TT_METAL_RUNTIME_ROOT", "").strip()
@@ -35,6 +63,7 @@ def _find_triage_directory() -> Path:
 
 
 def main() -> None:
+    _reexec_in_container_triage_environment()
     triage_directory = _find_triage_directory()
     sys.path.insert(0, str(triage_directory))
     runpy.run_path(str(triage_directory / "triage.py"), run_name="__main__")

--- a/packaging/bundled_ttnn.py
+++ b/packaging/bundled_ttnn.py
@@ -129,6 +129,10 @@ def stage_bundled_ttnn_python_packages(
         stage_root / "tracy",
         required=False,
     )
+    _copy_python_package(
+        tt_metal_root / "tools" / "triage",
+        stage_root / "triage",
+    )
 
     packages = find_packages(
         where=str(stage_root), exclude=("ttnn.examples", "ttnn.examples.*")
@@ -138,6 +142,7 @@ def stage_bundled_ttnn_python_packages(
     }
     if (stage_root / "tracy" / "__init__.py").is_file():
         package_dir["tracy"] = os.path.relpath(stage_root / "tracy", repo_root)
+    package_dir["triage"] = os.path.relpath(stage_root / "triage", repo_root)
 
     return BundledTTNNMetadata(packages=packages, package_dir=package_dir)
 
@@ -179,6 +184,10 @@ def copy_bundled_ttnn(tt_metal_root: Path, build_lib: Path) -> None:
         tt_metal_root / "python_packages" / "tools" / "tracy",
         build_lib / "tracy",
         required=False,
+    )
+    _copy_python_package(
+        tt_metal_root / "tools" / "triage",
+        build_lib / "triage",
     )
 
     lib_dir = ttnn_package / "build" / "lib"

--- a/scripts/install-ttmetal.sh
+++ b/scripts/install-ttmetal.sh
@@ -94,6 +94,15 @@ if [ -d "$SRC/tools/tracy" ]; then
     echo "Installed Tracy Python module"
 fi
 
+# --- tt-triage ---
+# Preserve this layout because triage modules import sibling files directly.
+if [ -d "$SRC/tools/triage" ]; then
+    rm -rf "$INSTALL/tools/triage"
+    mkdir -p "$INSTALL/tools"
+    cp -a "$SRC/tools/triage" "$INSTALL/tools/"
+    echo "Installed tt-triage"
+fi
+
 # --- Runtime artifacts (linker scripts, LLK headers, SoC/core descriptors, sfpi) ---
 # Some artifacts are build-generated (runtime/hw), others live only in the
 # source tree (runtime/sfpi).  Copy from the build dir first for

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,7 @@ class CMakeBuild(build_ext):
 
     def _remove_bundled_ttnn(self, install_dir):
         """Remove stale bundled payloads left by earlier wheel builds."""
-        for package_name in ("ttnn", "tracy"):
+        for package_name in ("ttnn", "tracy", "triage"):
             package_dir = install_dir / package_name
             if package_dir.exists():
                 shutil.rmtree(package_dir)
@@ -500,6 +500,8 @@ setup(
         "sim_stats": "python/sim_stats",
     }
     | _bundled_package_dir,
+    package_data={"triage": ["inspector.capnp", "requirements.txt"]},
+    scripts=["bin/tt-triage"],
     ext_modules=[ttlang_c],
     cmdclass={"build_ext": CMakeBuild, "sdist": NoSdist},
     zip_safe=False,

--- a/test/packaging/conftest.py
+++ b/test/packaging/conftest.py
@@ -83,6 +83,14 @@ def make_fake_tt_metal_install(tmp_path: Path) -> Callable[..., Path]:
         tracy_package = tt_metal / "python_packages" / "tools" / "tracy"
         tracy_package.mkdir(parents=True)
         (tracy_package / "__init__.py").write_text("")
+        triage_package = tt_metal / "tools" / "triage"
+        triage_package.mkdir(parents=True)
+        (triage_package / "__init__.py").write_text("")
+        (triage_package / "inspector.capnp").write_text("")
+        (triage_package / "requirements.txt").write_text(
+            "pycapnp==2.0.0\ntt-umd==0.9.6\ntt-exalens==0.3.21\n"
+        )
+        (triage_package / "triage.py").write_text("")
         (tt_metal / "lib").mkdir()
         (tt_metal / "runtime").mkdir()
         (tt_metal / "tt_metal").mkdir()

--- a/test/packaging/test_bundled_ttnn.py
+++ b/test/packaging/test_bundled_ttnn.py
@@ -23,7 +23,7 @@ from bundled_ttnn import (  # noqa: E402
 )
 
 
-def test_staged_metadata_discovers_ttnn_and_tracy_packages(
+def test_staged_metadata_discovers_ttnn_tracy_and_triage_packages(
     tmp_path: Path,
     make_fake_tt_metal_install: Callable[..., Path],
 ) -> None:
@@ -37,8 +37,11 @@ def test_staged_metadata_discovers_ttnn_and_tracy_packages(
     assert "ttnn.operations" in metadata.packages
     assert "ttnn.examples" not in metadata.packages
     assert "tracy" in metadata.packages
+    assert "triage" in metadata.packages
     assert metadata.package_dir["ttnn"] == "stage/ttnn"
+    assert metadata.package_dir["triage"] == "stage/triage"
     assert (tmp_path / "stage" / "ttnn" / "__init__.py").is_file()
+    assert (tmp_path / "stage" / "triage" / "requirements.txt").is_file()
     assert not (tmp_path / "stage" / "ttnn" / "_ttnn.so").exists()
 
 
@@ -95,3 +98,6 @@ def test_copy_bundled_ttnn_uses_pip_wheel_layout(
     ).is_file()
     assert (build_lib / "ttnn" / "tt_metal" / "hw" / "kernel.cpp").is_file()
     assert (build_lib / "tracy" / "__init__.py").is_file()
+    assert (build_lib / "triage" / "triage.py").is_file()
+    assert (build_lib / "triage" / "inspector.capnp").is_file()
+    assert (build_lib / "triage" / "requirements.txt").is_file()

--- a/test/packaging/test_triage_launcher.py
+++ b/test/packaging/test_triage_launcher.py
@@ -31,6 +31,7 @@ def test_launcher_runs_triage(tmp_path: Path, wheel_package: bool) -> None:
         "import sys\n" "import utils\n" "print(utils.VALUE, sys.argv[1])\n"
     )
     environment = os.environ.copy()
+    environment.pop("TTLANG_TOOLCHAIN_DIR", None)
     if runtime_root is not None:
         environment["TT_METAL_RUNTIME_ROOT"] = str(runtime_root)
     else:
@@ -48,3 +49,29 @@ def test_launcher_runs_triage(tmp_path: Path, wheel_package: bool) -> None:
 
     assert result.returncode == 0, result.stderr
     assert result.stdout == "loaded argument\n"
+
+
+def test_launcher_uses_isolated_container_python(tmp_path: Path) -> None:
+    toolchain_directory = tmp_path / "toolchain"
+    triage_environment = toolchain_directory / "tt-triage-venv"
+    triage_python = triage_environment / "bin" / "python"
+    triage_python.parent.mkdir(parents=True)
+    triage_python.write_text("#!/bin/sh\n" 'printf "%s %s\\n" "$VIRTUAL_ENV" "$2"\n')
+    triage_python.chmod(0o755)
+
+    environment = os.environ.copy()
+    environment["TTLANG_TOOLCHAIN_DIR"] = str(toolchain_directory)
+    environment.pop("TT_METAL_RUNTIME_ROOT", None)
+    environment.pop("TT_METAL_HOME", None)
+    environment.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "bin" / "tt-triage"), "argument"],
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"{triage_environment} argument\n"

--- a/test/packaging/test_triage_launcher.py
+++ b/test/packaging/test_triage_launcher.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import venv
 
 import pytest
 
@@ -57,7 +58,7 @@ def test_launcher_uses_isolated_container_python(tmp_path: Path) -> None:
     triage_python = triage_environment / "bin" / "python"
     triage_python.parent.mkdir(parents=True)
     triage_python.write_text("#!/bin/sh\n" 'printf "%s %s\\n" "$VIRTUAL_ENV" "$2"\n')
-    triage_python.chmod(0o755)
+    triage_python.chmod(0o700)
 
     environment = os.environ.copy()
     environment["TTLANG_TOOLCHAIN_DIR"] = str(toolchain_directory)
@@ -75,3 +76,33 @@ def test_launcher_uses_isolated_container_python(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert result.stdout == f"{triage_environment} argument\n"
+
+
+def test_launcher_runs_triage_from_container_toolchain(tmp_path: Path) -> None:
+    toolchain_directory = tmp_path / "toolchain"
+    triage_environment = toolchain_directory / "tt-triage-venv"
+    venv.EnvBuilder(with_pip=False).create(triage_environment)
+
+    triage_directory = toolchain_directory / "tt-metal" / "tools" / "triage"
+    triage_directory.mkdir(parents=True)
+    (triage_directory / "utils.py").write_text("VALUE = 'loaded'\n")
+    (triage_directory / "triage.py").write_text(
+        "import sys\n" "import utils\n" "print(utils.VALUE, sys.argv[1])\n"
+    )
+
+    environment = os.environ.copy()
+    environment["TTLANG_TOOLCHAIN_DIR"] = str(toolchain_directory)
+    environment.pop("TT_METAL_RUNTIME_ROOT", None)
+    environment.pop("TT_METAL_HOME", None)
+    environment.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "bin" / "tt-triage"), "argument"],
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "loaded argument\n"

--- a/test/packaging/test_triage_launcher.py
+++ b/test/packaging/test_triage_launcher.py
@@ -52,32 +52,6 @@ def test_launcher_runs_triage(tmp_path: Path, wheel_package: bool) -> None:
     assert result.stdout == "loaded argument\n"
 
 
-def test_launcher_uses_isolated_container_python(tmp_path: Path) -> None:
-    toolchain_directory = tmp_path / "toolchain"
-    triage_environment = toolchain_directory / "tt-triage-venv"
-    triage_python = triage_environment / "bin" / "python"
-    triage_python.parent.mkdir(parents=True)
-    triage_python.write_text("#!/bin/sh\n" 'printf "%s %s\\n" "$VIRTUAL_ENV" "$2"\n')
-    triage_python.chmod(0o700)
-
-    environment = os.environ.copy()
-    environment["TTLANG_TOOLCHAIN_DIR"] = str(toolchain_directory)
-    environment.pop("TT_METAL_RUNTIME_ROOT", None)
-    environment.pop("TT_METAL_HOME", None)
-    environment.pop("PYTHONPATH", None)
-
-    result = subprocess.run(
-        [sys.executable, str(REPO_ROOT / "bin" / "tt-triage"), "argument"],
-        env=environment,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert result.stdout == f"{triage_environment} argument\n"
-
-
 def test_launcher_runs_triage_from_container_toolchain(tmp_path: Path) -> None:
     toolchain_directory = tmp_path / "toolchain"
     triage_environment = toolchain_directory / "tt-triage-venv"
@@ -87,7 +61,10 @@ def test_launcher_runs_triage_from_container_toolchain(tmp_path: Path) -> None:
     triage_directory.mkdir(parents=True)
     (triage_directory / "utils.py").write_text("VALUE = 'loaded'\n")
     (triage_directory / "triage.py").write_text(
-        "import sys\n" "import utils\n" "print(utils.VALUE, sys.argv[1])\n"
+        "import os\n"
+        "import sys\n"
+        "import utils\n"
+        "print(utils.VALUE, os.environ['VIRTUAL_ENV'], sys.argv[1])\n"
     )
 
     environment = os.environ.copy()
@@ -105,4 +82,4 @@ def test_launcher_runs_triage_from_container_toolchain(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout == "loaded argument\n"
+    assert result.stdout == f"loaded {triage_environment} argument\n"

--- a/test/packaging/test_triage_launcher.py
+++ b/test/packaging/test_triage_launcher.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the tt-triage launcher."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from conftest import REPO_ROOT
+
+
+@pytest.mark.parametrize("wheel_package", [False, True], ids=["runtime", "wheel"])
+def test_launcher_runs_triage(tmp_path: Path, wheel_package: bool) -> None:
+    if wheel_package:
+        triage_directory = tmp_path / "triage"
+        runtime_root = None
+    else:
+        runtime_root = tmp_path / "tt-metal"
+        triage_directory = runtime_root / "tools" / "triage"
+    triage_directory.mkdir(parents=True)
+    (triage_directory / "__init__.py").write_text("")
+    (triage_directory / "utils.py").write_text("VALUE = 'loaded'\n")
+    (triage_directory / "triage.py").write_text(
+        "import sys\n" "import utils\n" "print(utils.VALUE, sys.argv[1])\n"
+    )
+    environment = os.environ.copy()
+    if runtime_root is not None:
+        environment["TT_METAL_RUNTIME_ROOT"] = str(runtime_root)
+    else:
+        environment.pop("TT_METAL_RUNTIME_ROOT", None)
+        environment.pop("TT_METAL_HOME", None)
+        environment["PYTHONPATH"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "bin" / "tt-triage"), "argument"],
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "loaded argument\n"

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -925,6 +925,9 @@ def _write_bundled_wheel(dist_dir: Path, *, complete: bool) -> Path:
         wheel.writestr("ttnn/__init__.py", "")
         wheel.writestr("ttnn/_ttnn.so", b"")
         if complete:
+            wheel.writestr("triage/inspector.capnp", "")
+            wheel.writestr("triage/requirements.txt", "")
+            wheel.writestr("triage/triage.py", "")
             wheel.writestr("ttnn/build/lib/_ttnncpp.so", b"")
             wheel.writestr("ttnn/build/lib/libtt_metal.so", b"")
     return wheel_path


### PR DESCRIPTION
### Problem description

tt-lang does not install tt-metal through tt-metal's Python packaging. Its toolchain and bundled-wheel builds select specific tt-metal artifacts instead. Those selections include ttnn and Tracy, but not `tools/triage`, so tt-metal's triage utility is unavailable in tt-lang containers and bundled wheels.

The container also installs `tt-smi` in the main toolchain environment. Current `tt-smi` and the `tt-exalens` version pinned by triage require different `tt-umd` versions, so installing triage's dependencies into that environment would make it inconsistent.

### What's changed

The tt-metal triage sources and runtime data are now included in toolchain and bundled-wheel payloads. A `tt-triage` launcher supports both layouts while preserving the sibling imports used by the upstream scripts. Container cleanup and image tagging retain and rebuild the added payload.

Containers install triage's pinned debugger dependencies in an isolated environment. The launcher selects that environment in containers without changing the main toolchain environment used by `tt-smi`. Wheels retain the upstream optional-dependency behavior and report the packaged requirements file when those dependencies are absent.

### Checklist

- [x] New/Existing tests provide coverage for changes

Validation:
- `python3 -m pytest test/packaging -q` (119 passed)
- Uplift-detection and image-tag Bats tests (40 passed)
- Python 3.12 isolated environment: `pip check` and upstream `tt-triage --help`
