### PR TITLE
[ci] Prevent unavailable hardware runners from blocking CI

### DIFF
--- a/.github/scripts/check-hardware-job-results.py
+++ b/.github/scripts/check-hardware-job-results.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check aggregate hardware results without treating runner setup as a test failure."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from enum import Enum
+from typing import Any
+
+HARDWARE_JOB_NAME_MARKER = "Hardware Tests ("
+RUNNER_SETUP_STEP_NAME = "Set up runner"
+TESTS_COMPLETE_STEP_NAME = "Mark hardware tests complete"
+FAILED_STEP_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "stale",
+    "timed_out",
+}
+
+
+class HardwareJobResult(Enum):
+    SUCCESS = "success"
+    RUNNER_SETUP_FAILURE = "runner_setup_failure"
+    POST_SETUP_FAILURE = "post_setup_failure"
+
+
+def _load_jobs(jobs_json: str) -> list[dict[str, Any]]:
+    decoder = json.JSONDecoder()
+    payloads: list[Any] = []
+    position = 0
+    while position < len(jobs_json):
+        while position < len(jobs_json) and jobs_json[position].isspace():
+            position += 1
+        if position == len(jobs_json):
+            break
+        payload, position = decoder.raw_decode(jobs_json, position)
+        payloads.append(payload)
+
+    if len(payloads) == 1 and isinstance(payloads[0], list):
+        pages = payloads[0]
+    else:
+        pages = payloads
+
+    jobs: list[dict[str, Any]] = []
+
+    for page in pages:
+        if not isinstance(page, dict) or not isinstance(page.get("jobs"), list):
+            raise ValueError("expected an Actions jobs response or a list of responses")
+        jobs.extend(page["jobs"])
+
+    return jobs
+
+
+def _find_step(job: dict[str, Any], step_name: str) -> dict[str, Any] | None:
+    return next(
+        (step for step in job.get("steps", []) if step.get("name") == step_name),
+        None,
+    )
+
+
+def _classify_job(job: dict[str, Any]) -> tuple[HardwareJobResult, str]:
+    setup_step = _find_step(job, RUNNER_SETUP_STEP_NAME)
+    if setup_step is None:
+        return HardwareJobResult.POST_SETUP_FAILURE, "has no runner setup result"
+
+    setup_conclusion = setup_step.get("conclusion")
+    if setup_conclusion != "success":
+        return (
+            HardwareJobResult.RUNNER_SETUP_FAILURE,
+            f"runner setup concluded {setup_conclusion or 'without a result'}",
+        )
+
+    failed_steps = [
+        step
+        for step in job.get("steps", [])
+        if step.get("conclusion") in FAILED_STEP_CONCLUSIONS
+        and step.get("name") != RUNNER_SETUP_STEP_NAME
+    ]
+    if failed_steps:
+        failed_step = failed_steps[0]
+        return (
+            HardwareJobResult.POST_SETUP_FAILURE,
+            f"{failed_step.get('name')} concluded {failed_step.get('conclusion')}",
+        )
+
+    completion_step = _find_step(job, TESTS_COMPLETE_STEP_NAME)
+    if completion_step is not None and completion_step.get("conclusion") == "success":
+        return HardwareJobResult.SUCCESS, "completed all hardware tests"
+
+    return (
+        HardwareJobResult.POST_SETUP_FAILURE,
+        f"did not complete {TESTS_COMPLETE_STEP_NAME}",
+    )
+
+
+def _hardware_jobs(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [job for job in jobs if HARDWARE_JOB_NAME_MARKER in str(job.get("name", ""))]
+
+
+def check_hardware_jobs(jobs: list[dict[str, Any]], expected_job_count: int) -> bool:
+    hardware_jobs = _hardware_jobs(jobs)
+    if len(hardware_jobs) != expected_job_count:
+        print(
+            "::error::Expected "
+            f"{expected_job_count} hardware jobs, found {len(hardware_jobs)}."
+        )
+        return False
+
+    successful_jobs = 0
+    post_setup_failures = 0
+    for job in sorted(hardware_jobs, key=lambda hardware_job: hardware_job["name"]):
+        job_name = job["name"]
+        result, description = _classify_job(job)
+        if result is HardwareJobResult.SUCCESS:
+            successful_jobs += 1
+            print(f"{job_name}: {description}.")
+        elif result is HardwareJobResult.RUNNER_SETUP_FAILURE:
+            print(f"::warning::{job_name}: {description}; hardware tests did not run.")
+        else:
+            post_setup_failures += 1
+            print(f"::error::{job_name}: {description}.")
+
+    if post_setup_failures:
+        return False
+    if successful_jobs == 0:
+        print("::error::No hardware runner completed the test suite.")
+        return False
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check aggregate GitHub Actions hardware job results from stdin."
+    )
+    parser.add_argument(
+        "--expected-job-count",
+        type=int,
+        required=True,
+        help="Number of hardware matrix jobs expected in the workflow run.",
+    )
+    arguments = parser.parse_args()
+
+    try:
+        jobs = _load_jobs(sys.stdin.read())
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+
+    return 0 if check_hardware_jobs(jobs, arguments.expected_job_count) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -7,6 +7,10 @@ on:
                 description: "Build and deploy documentation."
                 type: boolean
                 default: false
+            run_galaxy_tests:
+                description: "Run hardware tests on the Galaxy Blackhole runner."
+                type: boolean
+                default: false
             docker_tag:
                 description: "Docker image tag for the ird container."
                 type: string
@@ -18,12 +22,18 @@ on:
                 type: boolean
                 required: false
                 default: false
+            run_galaxy_tests:
+                description: "Run hardware tests on the Galaxy Blackhole runner."
+                type: boolean
+                required: false
+                default: false
             docker_tag:
                 description: "Docker image tag for the ird container."
                 type: string
                 required: true
 
 permissions:
+    actions: read
     checks: write
     contents: read
     packages: read
@@ -121,15 +131,46 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                include:
-                    - runner: n150
-                      labels: '["tt-ubuntu-2204-n150-stable"]'
-                    - runner: galaxy-bh
-                      labels: '["in-service", "galaxy-bh"]'
+                runner: ${{ inputs.run_galaxy_tests && fromJSON('["n150","galaxy-bh"]') || fromJSON('["n150"]') }}
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:
+            defer_result_check: true
             runs-on: ${{ matrix.runner }}
-            runner_labels: ${{ matrix.labels }}
+            runner_labels: ${{ matrix.runner == 'galaxy-bh' && '["in-service", "galaxy-bh"]' || '["tt-ubuntu-2204-n150-stable"]' }}
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}
+
+    report-skipped-galaxy:
+        name: "Report skipped Galaxy hardware tests"
+        if: ${{ !inputs.run_galaxy_tests }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+
+        steps:
+            - name: Report unavailable runner
+              run: echo "::warning::Galaxy hardware tests are disabled for this workflow run."
+
+    check-hardware:
+        name: "Check aggregate hardware result"
+        needs: test-hardware
+        if: ${{ !cancelled() }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+
+        steps:
+            - name: Checkout tt-lang
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+                  submodules: false
+
+            - name: Check hardware job results
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -o pipefail
+                  gh api --paginate \
+                      "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" |
+                      python3 .github/scripts/check-hardware-job-results.py \
+                          --expected-job-count "${{ inputs.run_galaxy_tests && 2 || 1 }}"

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -24,6 +24,11 @@ on:
         type: string
   workflow_call:
     inputs:
+      defer_result_check:
+        description: 'Allow the calling workflow to check the aggregate hardware result.'
+        required: false
+        type: boolean
+        default: false
       runs-on:
         description: 'Hardware type to run on'
         required: false
@@ -53,6 +58,7 @@ jobs:
     name: "Hardware Tests (${{ inputs.runs-on }})"
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
+    continue-on-error: ${{ inputs.defer_result_check }}
 
     container:
       image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${{ inputs.docker_tag }}
@@ -158,3 +164,6 @@ jobs:
             build/test/sim-report.xml
             build/test/tutorial-report*.xml
           retention-days: 7
+
+      - name: Mark hardware tests complete
+        run: echo "Hardware tests completed successfully."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   checks: write
   contents: read
   packages: read

--- a/test/packaging/test_hardware_job_results.py
+++ b/test/packaging/test_hardware_job_results.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for aggregate hardware job result handling."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from conftest import REPO_ROOT
+
+CHECK_HARDWARE_JOB_RESULTS = (
+    REPO_ROOT / ".github" / "scripts" / "check-hardware-job-results.py"
+)
+
+
+def _hardware_job(
+    runner_name: str,
+    *,
+    setup_conclusion: str = "success",
+    tests_complete: bool = True,
+    failed_step_name: str | None = None,
+    complete_runner_conclusion: str = "success",
+) -> dict[str, object]:
+    steps: list[dict[str, str]] = [
+        {"name": "Set up job", "conclusion": "success"},
+        {"name": "Set up runner", "conclusion": setup_conclusion},
+    ]
+    if setup_conclusion == "success":
+        steps.append({"name": "Initialize containers", "conclusion": "success"})
+        if failed_step_name is not None:
+            steps.append({"name": failed_step_name, "conclusion": "failure"})
+        steps.append(
+            {
+                "name": "Mark hardware tests complete",
+                "conclusion": "success" if tests_complete else "skipped",
+            }
+        )
+        steps.append(
+            {
+                "name": "Complete runner",
+                "conclusion": complete_runner_conclusion,
+            }
+        )
+
+    return {
+        "name": f'build / test-hardware ({runner_name}, ["label"]) / '
+        f"Hardware Tests ({runner_name})",
+        "steps": steps,
+    }
+
+
+def _run_check(
+    jobs: list[dict[str, object]],
+    *,
+    expected_job_count: int = 2,
+    separate_pages: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    if separate_pages:
+        jobs_json = "\n".join(
+            json.dumps({"total_count": len(jobs), "jobs": [job]}) for job in jobs
+        )
+    else:
+        jobs_json = json.dumps([{"total_count": len(jobs), "jobs": jobs}])
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECK_HARDWARE_JOB_RESULTS),
+            "--expected-job-count",
+            str(expected_job_count),
+        ],
+        input=jobs_json,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_both_hardware_jobs_succeed() -> None:
+    result = _run_check(
+        [_hardware_job("n150"), _hardware_job("galaxy-bh")],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.count("completed all hardware tests") == 2
+
+
+def test_single_expected_hardware_job_succeeds() -> None:
+    result = _run_check(
+        [_hardware_job("n150")],
+        expected_job_count=1,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "completed all hardware tests" in result.stdout
+
+
+def test_paginated_hardware_jobs_succeed() -> None:
+    result = _run_check(
+        [_hardware_job("n150"), _hardware_job("galaxy-bh")],
+        separate_pages=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_one_setup_failure_and_one_success_succeeds() -> None:
+    result = _run_check(
+        [
+            _hardware_job("n150", setup_conclusion="cancelled", tests_complete=False),
+            _hardware_job("galaxy-bh"),
+        ],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "::warning::" in result.stdout
+    assert "hardware tests did not run" in result.stdout
+
+
+def test_both_setup_failures_fail() -> None:
+    result = _run_check(
+        [
+            _hardware_job("n150", setup_conclusion="failure", tests_complete=False),
+            _hardware_job(
+                "galaxy-bh", setup_conclusion="cancelled", tests_complete=False
+            ),
+        ],
+    )
+
+    assert result.returncode == 1
+    assert "No hardware runner completed the test suite" in result.stdout
+
+
+@pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh"])
+def test_post_setup_failure_fails(failed_runner: str) -> None:
+    other_runner = "galaxy-bh" if failed_runner == "n150" else "n150"
+    result = _run_check(
+        [
+            _hardware_job(
+                failed_runner,
+                tests_complete=False,
+                failed_step_name="Build tt-lang",
+            ),
+            _hardware_job(other_runner),
+        ],
+    )
+
+    assert result.returncode == 1
+    assert "Build tt-lang concluded failure" in result.stdout
+
+
+def test_incomplete_job_after_successful_setup_fails() -> None:
+    result = _run_check(
+        [
+            _hardware_job("n150", tests_complete=False),
+            _hardware_job("galaxy-bh"),
+        ],
+    )
+
+    assert result.returncode == 1
+    assert "did not complete Mark hardware tests complete" in result.stdout
+
+
+def test_runner_completion_failure_fails() -> None:
+    result = _run_check(
+        [
+            _hardware_job("n150", complete_runner_conclusion="failure"),
+            _hardware_job("galaxy-bh"),
+        ],
+    )
+
+    assert result.returncode == 1
+    assert "Complete runner concluded failure" in result.stdout
+
+
+def test_missing_hardware_job_fails() -> None:
+    result = _run_check(
+        [_hardware_job("n150")],
+    )
+
+    assert result.returncode == 1
+    assert "Expected 2 hardware jobs, found 1" in result.stdout


### PR DESCRIPTION
### Problem description

An unavailable Galaxy runner leaves CI jobs queued for up to 24 hours. Runner setup failures should not mask failures after setup completes.

### What changed

Galaxy hardware tests are disabled by default and produce a warning without creating a Galaxy runner job. run_galaxy_tests enables Galaxy validation when the runner is available.

When both runners are enabled, one setup-only failure is accepted only if the other runner completes. Any post-setup failure, or no complete hardware run, fails CI.

Validated with actionlint, pre-commit, 129 packaging tests, and live run 30276040537.

### Checklist

- [x] New/Existing tests provide coverage for changes