### PR TITLE
[ci][build] Consolidate manylinux wheel builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,7 @@ build/env/
 
 # Git
 .git/
+.wheel-workflow-src/.git/
 .gitignore
 
 # Docker temp

--- a/.github/actions/setup-wheel-image-build/action.yml
+++ b/.github/actions/setup-wheel-image-build/action.yml
@@ -1,0 +1,31 @@
+name: Set up wheel image build
+description: Prepare a checked-out repository for a manylinux BuildKit build.
+
+inputs:
+  registry-owner:
+    description: GitHub Container Registry owner.
+    required: true
+  registry-token:
+    description: GitHub token used to access the container registry.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Free runner space
+      shell: bash
+      run: ${{ github.action_path }}/../../scripts/cleanup-ci-space.sh
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.registry-owner }}
+        password: ${{ inputs.registry-token }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Allow submodule Git operations
+      shell: bash
+      run: git config --global --add safe.directory '*'

--- a/.github/containers/CMakeLists.wheel-toolchain
+++ b/.github/containers/CMakeLists.wheel-toolchain
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.28.0)
+
+if(NOT DEFINED CMAKE_C_COMPILER)
+  set(CMAKE_C_COMPILER clang CACHE STRING "C Compiler" FORCE)
+endif()
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+  set(CMAKE_CXX_COMPILER clang++ CACHE STRING "C++ Compiler" FORCE)
+endif()
+
+project(ttlang-wheel-toolchain LANGUAGES CXX C)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+include(TTLangUtils)
+include(TTLangCompilerSetup)
+include(TTLangToolchainOptions)
+set(TTLANG_INSTALL_RUNTIME_REQUIREMENTS OFF CACHE BOOL
+  "Install runtime requirements outside the component cache" FORCE)
+
+if(TTLANG_TOOLCHAIN_COMPONENT STREQUAL "all")
+  message(FATAL_ERROR
+    "The wheel toolchain project requires llvm or tt-metal")
+endif()
+
+include(TTLangPython)
+include(TTLangToolchainComponent)
+if(NOT TTLANG_TOOLCHAIN_COMPONENT_CONFIGURED)
+  message(FATAL_ERROR
+    "Failed to configure toolchain component ${TTLANG_TOOLCHAIN_COMPONENT}")
+endif()

--- a/.github/containers/Dockerfile.wheel-manylinux-2-34
+++ b/.github/containers/Dockerfile.wheel-manylinux-2-34
@@ -1,17 +1,17 @@
+# syntax=docker/dockerfile:1
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
 # SPDX-License-Identifier: Apache-2.0
 #
-# Build a tt-lang wheel-builder image for S3 light wheels. The toolchain is
-# built inside manylinux_2_34 base (matching tt-metal's base image) so the
-# toolchain and the wheel are compiled against the same glibc version.
+# Build the manylinux_2_34 wheel-builder images used by the public PyPI and S3
+# light-wheel workflows. LLVM and tt-metal are independent stages so BuildKit
+# can persist and restore their caches separately.
 
-FROM quay.io/pypa/manylinux_2_34_x86_64
+ARG WORKFLOW_SOURCE=.
+
+FROM quay.io/pypa/manylinux_2_34_x86_64 AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG PYTHON_TAG=cp312
-ARG TT_METAL_TAG
-ARG TT_METAL_SHORT_SHA
-ARG TTLANG_BUILD_PARALLEL_LEVEL=""
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain
 
@@ -63,22 +63,73 @@ RUN dnf install -y \
 #
 # LLVM_ENABLE_ZSTD=OFF drops LLVM's libzstd dependency, which the
 # tt-lang -> ttkernel -> emitc pipeline never uses. With zstd enabled the
-# MLIR/tt-lang .so files link the system libzstd, so `auditwheel repair`
-# bundles a renamed copy of libzstd into the wheel and runs
-# `patchelf --replace-needed` on every library to repoint it at that copy.
-# patchelf corrupts the very large MLIR/tt-lang libraries (hundreds of MB)
-# during that rewrite, producing a broken ELF that segfaults on `import ttl`.
-# Dropping the dependency leaves auditwheel nothing to vendor or patch.
+# MLIR/tt-lang .so files link the system libzstd, so auditwheel repair bundles
+# and rewrites libzstd references in the very large MLIR libraries. Disabling
+# the unused dependency avoids that rewrite.
 ENV TTLANG_LLVM_EXTRA_CMAKE_ARGS="-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON;-DCMAKE_C_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gcc;-DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++;-DCMAKE_CXX_FLAGS=-fno-gnu-unique;-DLLVM_ENABLE_ZSTD=OFF"
 
-COPY . /workspace
+FROM base AS llvm-toolchain
+
+ARG PYTHON_TAG=cp312
+ARG TTLANG_BUILD_PARALLEL_LEVEL=""
+ARG WORKFLOW_SOURCE
+
 WORKDIR /workspace
+COPY ${WORKFLOW_SOURCE}/.github/containers/CMakeLists.wheel-toolchain CMakeLists.txt
+COPY ${WORKFLOW_SOURCE}/cmake/modules/BuildLLVM.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangCompilerSetup.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangPython.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangToolchainComponent.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangToolchainOptions.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangUtils.cmake \
+     cmake/modules/
+COPY ${WORKFLOW_SOURCE}/scripts/build-and-install.sh scripts/
+COPY ${WORKFLOW_SOURCE}/.github/containers/cleanup-toolchain.sh .github/containers/
+COPY ${WORKFLOW_SOURCE}/.github/scripts/normalize-toolchain-install.sh .github/scripts/
+COPY third-party/llvm-project third-party/llvm-project
 
-RUN git config --global --add safe.directory '*'
+RUN python_dir="/opt/python/${PYTHON_TAG}-${PYTHON_TAG}" && \
+    test -x "${python_dir}/bin/python" && \
+    "${python_dir}/bin/python" -m pip install --no-cache-dir cmake==3.28.4 && \
+    if [ -n "${TTLANG_BUILD_PARALLEL_LEVEL}" ]; then \
+      export CMAKE_BUILD_PARALLEL_LEVEL="${TTLANG_BUILD_PARALLEL_LEVEL}"; \
+    fi && \
+    export PATH="${python_dir}/bin:${PATH}" && \
+    scripts/build-and-install.sh \
+      --llvm-toolchain-only \
+      --force-rebuild \
+      --python "${python_dir}/bin/python" \
+      --python-venv "${TTLANG_TOOLCHAIN_DIR}/venv" \
+      --remove-build-dir
 
-# Docker build contexts intentionally exclude .git. tt-metal's version.cmake is
-# marked export-subst, so reproduce the git-archive substitutions in the copied
-# source tree before configuring tt-metal.
+FROM base AS ttmetal-toolchain
+
+ARG TTMETAL_PYTHON_TAG=cp312
+ARG TT_METAL_TAG
+ARG TT_METAL_SHORT_SHA
+ARG TTLANG_BUILD_PARALLEL_LEVEL=""
+ARG WORKFLOW_SOURCE
+
+WORKDIR /workspace
+COPY ${WORKFLOW_SOURCE}/.github/containers/CMakeLists.wheel-toolchain CMakeLists.txt
+COPY ${WORKFLOW_SOURCE}/cmake/modules/BuildTTMetal.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangCompilerSetup.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangPython.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangToolchainComponent.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangToolchainOptions.cmake \
+     ${WORKFLOW_SOURCE}/cmake/modules/TTLangUtils.cmake \
+     cmake/modules/
+COPY ${WORKFLOW_SOURCE}/scripts/build-and-install.sh \
+     ${WORKFLOW_SOURCE}/scripts/copy-ttmetal-runtime-artifacts.sh \
+     ${WORKFLOW_SOURCE}/scripts/install-ttmetal.sh \
+     scripts/
+COPY ${WORKFLOW_SOURCE}/.github/containers/cleanup-toolchain.sh .github/containers/
+COPY ${WORKFLOW_SOURCE}/.github/scripts/normalize-toolchain-install.sh .github/scripts/
+COPY third-party/patches third-party/patches
+COPY third-party/tt-metal third-party/tt-metal
+
+# Docker build contexts exclude git metadata. Reproduce tt-metal's
+# git-archive substitutions before configuring it.
 RUN test -n "${TT_METAL_TAG}" && \
     test -n "${TT_METAL_SHORT_SHA}" && \
     sed -i \
@@ -86,29 +137,39 @@ RUN test -n "${TT_METAL_TAG}" && \
       -e "s|\\\$Format:%h\\\$|${TT_METAL_SHORT_SHA}|g" \
       third-party/tt-metal/cmake/version.cmake
 
-RUN python_dir="/opt/python/${PYTHON_TAG}-${PYTHON_TAG}" && \
+RUN python_dir="/opt/python/${TTMETAL_PYTHON_TAG}-${TTMETAL_PYTHON_TAG}" && \
     test -x "${python_dir}/bin/python" && \
-    "${python_dir}/bin/python" -m pip install --no-cache-dir \
-      auditwheel \
-      cmake==3.28.4 \
-      packaging \
-      patchelf \
-      wheel && \
+    "${python_dir}/bin/python" -m pip install --no-cache-dir cmake==3.28.4 && \
     if [ -n "${TTLANG_BUILD_PARALLEL_LEVEL}" ]; then \
       export CMAKE_BUILD_PARALLEL_LEVEL="${TTLANG_BUILD_PARALLEL_LEVEL}"; \
     fi && \
     export PATH="${python_dir}/bin:${PATH}" && \
     scripts/build-and-install.sh \
-      --toolchain-only \
+      --ttmetal-toolchain-only \
       --force-rebuild \
       --python "${python_dir}/bin/python" \
       --python-venv "${TTLANG_TOOLCHAIN_DIR}/venv" \
-      --remove-build-dir && \
+      --remove-build-dir
+
+FROM base AS wheel-builder
+
+ARG PYTHON_TAG=cp312
+ARG TTLANG_BUILD_PARALLEL_LEVEL=""
+
+COPY --from=llvm-toolchain /opt/ttlang-toolchain/ /opt/ttlang-toolchain/
+COPY --from=ttmetal-toolchain /opt/ttlang-toolchain/tt-metal/ /opt/ttlang-toolchain/tt-metal/
+COPY requirements.txt requirements-runtime.txt /tmp/ttlang-requirements/
+
+RUN python_dir="/opt/python/${PYTHON_TAG}-${PYTHON_TAG}" && \
+    test -x "${python_dir}/bin/python" && \
     "${TTLANG_TOOLCHAIN_DIR}/venv/bin/python" -m pip install --no-cache-dir \
+      -r /tmp/ttlang-requirements/requirements.txt \
       auditwheel \
+      cmake==3.28.4 \
       packaging \
       patchelf \
-      wheel
+      wheel && \
+    rm -rf /tmp/ttlang-requirements
 
 ENV PATH="/opt/ttlang-toolchain/venv/bin:/opt/ttlang-toolchain/bin:${PATH}"
 ENV CMAKE_BUILD_PARALLEL_LEVEL="${TTLANG_BUILD_PARALLEL_LEVEL}"

--- a/.github/containers/Dockerfile.wheel-manylinux-2-34
+++ b/.github/containers/Dockerfile.wheel-manylinux-2-34
@@ -137,6 +137,9 @@ RUN test -n "${TT_METAL_TAG}" && \
       -e "s|\\\$Format:%h\\\$|${TT_METAL_SHORT_SHA}|g" \
       third-party/tt-metal/cmake/version.cmake
 
+# tt-metal requires a venv while configuring its cp312 Python bindings. The
+# final builder uses the ABI-specific LLVM venv, so only the tt-metal install
+# directory is shared between cp310 and cp312 images.
 RUN python_dir="/opt/python/${TTMETAL_PYTHON_TAG}-${TTMETAL_PYTHON_TAG}" && \
     test -x "${python_dir}/bin/python" && \
     "${python_dir}/bin/python" -m pip install --no-cache-dir cmake==3.28.4 && \
@@ -157,6 +160,10 @@ ARG PYTHON_TAG=cp312
 ARG TTLANG_BUILD_PARALLEL_LEVEL=""
 
 COPY --from=llvm-toolchain /opt/ttlang-toolchain/ /opt/ttlang-toolchain/
+# The shared install contains cp312 extension modules because CMake uses
+# _ttnn.so to identify the install layout. Core wheel builds consume its C++
+# headers and libraries but do not import ttnn; the wheel dependency mode
+# supplies the runtime ttnn package.
 COPY --from=ttmetal-toolchain /opt/ttlang-toolchain/tt-metal/ /opt/ttlang-toolchain/tt-metal/
 COPY requirements.txt requirements-runtime.txt /tmp/ttlang-requirements/
 

--- a/.github/containers/build-wheel-manylinux-images.sh
+++ b/.github/containers/build-wheel-manylinux-images.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Build and optionally push manylinux_2_34 wheel-builder images for S3 light
-# wheels.
+# Build and optionally push the manylinux_2_34 wheel-builder images shared by
+# public PyPI and S3 wheel workflows.
 
 set -eu
 
@@ -11,10 +11,14 @@ NO_PUSH=false
 PYTHON_TAGS=cp310,cp312
 DOCKER_TAG=""
 BUILD_PARALLEL_LEVEL=""
+LLVM_CACHE_REF=""
+TTMETAL_CACHE_REF=""
+WORKFLOW_SOURCE="."
+PUBLISH_LATEST=""
 
 usage() {
     cat >&2 <<'EOF'
-Usage: build-wheel-manylinux-images.sh [--no-push] [--image-tag <tag>] [--python-tags cp310,cp312] [--build-parallel-level <jobs>]
+Usage: build-wheel-manylinux-images.sh [--no-push] [--image-tag <tag>] [--python-tags cp310,cp312] [--build-parallel-level <jobs>] [--llvm-cache-ref <ref> --ttmetal-cache-ref <ref>] [--workflow-source <dir>] [--publish-latest true|false]
 EOF
     exit 2
 }
@@ -46,17 +50,66 @@ while [ "$#" -gt 0 ]; do
             BUILD_PARALLEL_LEVEL="$2"
             shift 2
             ;;
+        --llvm-cache-ref)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            LLVM_CACHE_REF="$2"
+            shift 2
+            ;;
+        --ttmetal-cache-ref)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            TTMETAL_CACHE_REF="$2"
+            shift 2
+            ;;
+        --workflow-source)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            WORKFLOW_SOURCE="$2"
+            shift 2
+            ;;
+        --publish-latest)
+            if [ "$#" -lt 2 ]; then
+                usage
+            fi
+            PUBLISH_LATEST="$2"
+            shift 2
+            ;;
         *)
             usage
             ;;
     esac
 done
 
-repo=tenstorrent/tt-lang
+repo="${GITHUB_REPOSITORY:-tenstorrent/tt-lang}"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(git rev-parse --show-toplevel)"
 docker_tag="${DOCKER_TAG:-$("$script_dir/get-version-tag.sh")}"
 dockerfile="$script_dir/Dockerfile.wheel-manylinux-2-34"
+case "$WORKFLOW_SOURCE" in
+    /* | *../* | */.. | ..)
+        echo "--workflow-source must stay within the build context" >&2
+        exit 2
+        ;;
+esac
+[ -f "$repo_root/$WORKFLOW_SOURCE/.github/containers/CMakeLists.wheel-toolchain" ] || {
+    echo "Workflow source not found: $WORKFLOW_SOURCE" >&2
+    exit 2
+}
+if [ -z "$PUBLISH_LATEST" ]; then
+    if [ "${GITHUB_REF:-}" = refs/heads/main ]; then
+        PUBLISH_LATEST=true
+    else
+        PUBLISH_LATEST=false
+    fi
+fi
+case "$PUBLISH_LATEST" in
+    true | false) ;;
+    *) usage ;;
+esac
 
 # shellcheck source=/dev/null
 . "$repo_root/third-party/tt-metal-version"
@@ -77,27 +130,25 @@ case "$BUILD_PARALLEL_LEVEL" in
         ;;
 esac
 
-docker_build() {
-    if [ -n "$BUILD_PARALLEL_LEVEL" ]; then
-        ${DOCKER:-docker} build \
-            --progress=plain \
-            --build-arg "PYTHON_TAG=$python_tag" \
-            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
-            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
-            --build-arg "TTLANG_BUILD_PARALLEL_LEVEL=$BUILD_PARALLEL_LEVEL" \
-            "$@" \
-            -f "$dockerfile" \
-            "$repo_root"
-    else
-        ${DOCKER:-docker} build \
-            --progress=plain \
-            --build-arg "PYTHON_TAG=$python_tag" \
-            --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
-            --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha" \
-            "$@" \
-            -f "$dockerfile" \
-            "$repo_root"
+if [ -n "$LLVM_CACHE_REF" ] || [ -n "$TTMETAL_CACHE_REF" ]; then
+    if [ -z "$LLVM_CACHE_REF" ] || [ -z "$TTMETAL_CACHE_REF" ]; then
+        echo "--llvm-cache-ref and --ttmetal-cache-ref must be provided together" >&2
+        exit 2
     fi
+fi
+
+docker_build_args() {
+    set -- \
+        --progress=plain \
+        --target wheel-builder \
+        --build-arg "WORKFLOW_SOURCE=$WORKFLOW_SOURCE" \
+        --build-arg "PYTHON_TAG=$python_tag" \
+        --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
+        --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha"
+    if [ -n "$BUILD_PARALLEL_LEVEL" ]; then
+        set -- "$@" --build-arg "TTLANG_BUILD_PARALLEL_LEVEL=$BUILD_PARALLEL_LEVEL"
+    fi
+    printf '%s\n' "$@"
 }
 
 for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
@@ -113,17 +164,54 @@ for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
     local_image="${image_name}:${docker_tag}"
     registry_image="ghcr.io/${repo}/${image_name}:${docker_tag}"
 
+    if [ "$NO_PUSH" != true ] && ${DOCKER:-docker} manifest inspect "$registry_image" >/dev/null 2>&1; then
+        echo "Image already exists, skipping build: $registry_image"
+        if [ "$PUBLISH_LATEST" = true ]; then
+            latest="${registry_image%:*}:latest"
+            if ! ${DOCKER:-docker} buildx imagetools create -t "$latest" "$registry_image"; then
+                echo "WARNING: could not retag $registry_image as $latest" >&2
+            fi
+        fi
+        continue
+    fi
+
+    set --
+    while IFS= read -r build_arg; do
+        set -- "$@" "$build_arg"
+    done <<EOF
+$(docker_build_args)
+EOF
+
+    if [ -n "$LLVM_CACHE_REF" ]; then
+        set -- "$@" \
+            --cache-from "type=registry,ref=$LLVM_CACHE_REF" \
+            --cache-from "type=registry,ref=$TTMETAL_CACHE_REF"
+        if [ "$NO_PUSH" = true ]; then
+            echo "Building local image from component caches: $local_image"
+            ${DOCKER:-docker} buildx build "$@" --load -t "$local_image" -f "$dockerfile" "$repo_root"
+        else
+            echo "Building registry image from component caches: $registry_image"
+            set -- "$@" --push -t "$registry_image"
+            if [ "$PUBLISH_LATEST" = true ]; then
+                latest="${registry_image%:*}:latest"
+                set -- "$@" -t "$latest"
+            fi
+            ${DOCKER:-docker} buildx build "$@" -f "$dockerfile" "$repo_root"
+        fi
+        continue
+    fi
+
     if [ "$NO_PUSH" = true ]; then
         echo "Building local image: $local_image"
-        docker_build -t "$local_image"
+        ${DOCKER:-docker} build "$@" -t "$local_image" -f "$dockerfile" "$repo_root"
     else
         echo "Building registry image: $registry_image"
-        docker_build -t "$registry_image" -t "$local_image"
+        ${DOCKER:-docker} build "$@" -t "$registry_image" -t "$local_image" -f "$dockerfile" "$repo_root"
     fi
 
     if [ "$NO_PUSH" != true ]; then
         ${DOCKER:-docker} push "$registry_image"
-        if [ "${GITHUB_REF:-}" = "refs/heads/main" ]; then
+        if [ "$PUBLISH_LATEST" = true ]; then
             latest="${registry_image%:*}:latest"
             ${DOCKER:-docker} tag "$registry_image" "$latest"
             ${DOCKER:-docker} push "$latest"

--- a/.github/containers/build-wheel-manylinux-images.sh
+++ b/.github/containers/build-wheel-manylinux-images.sh
@@ -14,11 +14,10 @@ BUILD_PARALLEL_LEVEL=""
 LLVM_CACHE_REF=""
 TTMETAL_CACHE_REF=""
 WORKFLOW_SOURCE="."
-PUBLISH_LATEST=""
 
 usage() {
     cat >&2 <<'EOF'
-Usage: build-wheel-manylinux-images.sh [--no-push] [--image-tag <tag>] [--python-tags cp310,cp312] [--build-parallel-level <jobs>] [--llvm-cache-ref <ref> --ttmetal-cache-ref <ref>] [--workflow-source <dir>] [--publish-latest true|false]
+Usage: build-wheel-manylinux-images.sh [--no-push] [--image-tag <tag>] [--python-tags cp310,cp312] [--build-parallel-level <jobs>] [--llvm-cache-ref <ref> --ttmetal-cache-ref <ref>] [--workflow-source <dir>]
 EOF
     exit 2
 }
@@ -71,13 +70,6 @@ while [ "$#" -gt 0 ]; do
             WORKFLOW_SOURCE="$2"
             shift 2
             ;;
-        --publish-latest)
-            if [ "$#" -lt 2 ]; then
-                usage
-            fi
-            PUBLISH_LATEST="$2"
-            shift 2
-            ;;
         *)
             usage
             ;;
@@ -99,17 +91,8 @@ esac
     echo "Workflow source not found: $WORKFLOW_SOURCE" >&2
     exit 2
 }
-if [ -z "$PUBLISH_LATEST" ]; then
-    if [ "${GITHUB_REF:-}" = refs/heads/main ]; then
-        PUBLISH_LATEST=true
-    else
-        PUBLISH_LATEST=false
-    fi
-fi
-case "$PUBLISH_LATEST" in
-    true | false) ;;
-    *) usage ;;
-esac
+# shellcheck source=../scripts/lib/docker-image-utils.sh
+. "$script_dir/../scripts/lib/docker-image-utils.sh"
 
 # shellcheck source=/dev/null
 . "$repo_root/third-party/tt-metal-version"
@@ -137,7 +120,17 @@ if [ -n "$LLVM_CACHE_REF" ] || [ -n "$TTMETAL_CACHE_REF" ]; then
     fi
 fi
 
-docker_build_args() {
+for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
+    image_name="$(ttlang_wheel_builder_image_name "$python_tag")"
+    local_image="${image_name}:${docker_tag}"
+    registry_image="$(ttlang_wheel_builder_registry_image \
+        "$python_tag" "$docker_tag" "ghcr.io/${repo}")"
+
+    if [ "$NO_PUSH" != true ] && ${DOCKER:-docker} manifest inspect "$registry_image" >/dev/null 2>&1; then
+        echo "Image already exists, skipping build: $registry_image"
+        continue
+    fi
+
     set -- \
         --progress=plain \
         --target wheel-builder \
@@ -148,39 +141,6 @@ docker_build_args() {
     if [ -n "$BUILD_PARALLEL_LEVEL" ]; then
         set -- "$@" --build-arg "TTLANG_BUILD_PARALLEL_LEVEL=$BUILD_PARALLEL_LEVEL"
     fi
-    printf '%s\n' "$@"
-}
-
-for python_tag in $(printf '%s\n' "$PYTHON_TAGS" | tr ',' ' '); do
-    case "$python_tag" in
-        cp310 | cp312) ;;
-        *)
-            echo "Unsupported Python tag: $python_tag" >&2
-            exit 2
-            ;;
-    esac
-
-    image_name="tt-lang-wheel-manylinux-2-34-${python_tag}"
-    local_image="${image_name}:${docker_tag}"
-    registry_image="ghcr.io/${repo}/${image_name}:${docker_tag}"
-
-    if [ "$NO_PUSH" != true ] && ${DOCKER:-docker} manifest inspect "$registry_image" >/dev/null 2>&1; then
-        echo "Image already exists, skipping build: $registry_image"
-        if [ "$PUBLISH_LATEST" = true ]; then
-            latest="${registry_image%:*}:latest"
-            if ! ${DOCKER:-docker} buildx imagetools create -t "$latest" "$registry_image"; then
-                echo "WARNING: could not retag $registry_image as $latest" >&2
-            fi
-        fi
-        continue
-    fi
-
-    set --
-    while IFS= read -r build_arg; do
-        set -- "$@" "$build_arg"
-    done <<EOF
-$(docker_build_args)
-EOF
 
     if [ -n "$LLVM_CACHE_REF" ]; then
         set -- "$@" \
@@ -192,10 +152,6 @@ EOF
         else
             echo "Building registry image from component caches: $registry_image"
             set -- "$@" --push -t "$registry_image"
-            if [ "$PUBLISH_LATEST" = true ]; then
-                latest="${registry_image%:*}:latest"
-                set -- "$@" -t "$latest"
-            fi
             ${DOCKER:-docker} buildx build "$@" -f "$dockerfile" "$repo_root"
         fi
         continue
@@ -211,10 +167,5 @@ EOF
 
     if [ "$NO_PUSH" != true ]; then
         ${DOCKER:-docker} push "$registry_image"
-        if [ "$PUBLISH_LATEST" = true ]; then
-            latest="${registry_image%:*}:latest"
-            ${DOCKER:-docker} tag "$registry_image" "$latest"
-            ${DOCKER:-docker} push "$latest"
-        fi
     fi
 done

--- a/.github/containers/cache-wheel-manylinux-component.sh
+++ b/.github/containers/cache-wheel-manylinux-component.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build one manylinux wheel-toolchain component and export its BuildKit cache
+# to GHCR. The LLVM and tt-metal cache references are intentionally distinct.
+
+set -eu
+
+component=""
+python_tag=""
+cache_ref=""
+build_parallel_level=""
+workflow_source="."
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: cache-wheel-manylinux-component.sh --component llvm|ttmetal --cache-ref <registry-ref> [options]
+
+Options:
+  --python-tag cp310|cp312       Required for LLVM; tt-metal always uses cp312.
+  --build-parallel-level <jobs>  CMake build parallelism.
+  --workflow-source <dir>        Workflow implementation within the build context.
+EOF
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --component)
+            [ "$#" -ge 2 ] || usage
+            component="$2"
+            shift 2
+            ;;
+        --python-tag)
+            [ "$#" -ge 2 ] || usage
+            python_tag="$2"
+            shift 2
+            ;;
+        --cache-ref)
+            [ "$#" -ge 2 ] || usage
+            cache_ref="$2"
+            shift 2
+            ;;
+        --build-parallel-level)
+            [ "$#" -ge 2 ] || usage
+            build_parallel_level="$2"
+            shift 2
+            ;;
+        --workflow-source)
+            [ "$#" -ge 2 ] || usage
+            workflow_source="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+case "$component" in
+    llvm)
+        case "$python_tag" in
+            cp310 | cp312) ;;
+            *) echo "LLVM requires --python-tag cp310 or cp312" >&2; exit 2 ;;
+        esac
+        target=llvm-toolchain
+        ;;
+    ttmetal)
+        if [ -n "$python_tag" ]; then
+            echo "--python-tag is not valid for ttmetal; it uses cp312" >&2
+            exit 2
+        fi
+        target=ttmetal-toolchain
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+case "$build_parallel_level" in
+    "" | *[!0-9]* | 0)
+        if [ -n "$build_parallel_level" ]; then
+            echo "Build parallel level must be a positive integer: $build_parallel_level" >&2
+            exit 2
+        fi
+        ;;
+esac
+
+[ -n "$cache_ref" ] || usage
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(git rev-parse --show-toplevel)"
+dockerfile="$script_dir/Dockerfile.wheel-manylinux-2-34"
+case "$workflow_source" in
+    /* | *../* | */.. | ..)
+        echo "--workflow-source must stay within the build context" >&2
+        exit 2
+        ;;
+esac
+[ -f "$repo_root/$workflow_source/.github/containers/CMakeLists.wheel-toolchain" ] || {
+    echo "Workflow source not found: $workflow_source" >&2
+    exit 2
+}
+
+set -- \
+    buildx build \
+    --progress=plain \
+    --target "$target" \
+    --build-arg "WORKFLOW_SOURCE=$workflow_source" \
+    --cache-from "type=registry,ref=$cache_ref" \
+    --cache-to "type=registry,ref=$cache_ref,mode=max" \
+    --output type=cacheonly
+
+if [ -n "$python_tag" ]; then
+    set -- "$@" --build-arg "PYTHON_TAG=$python_tag"
+else
+    # shellcheck source=/dev/null
+    . "$repo_root/third-party/tt-metal-version"
+    : "${TT_METAL_TAG:?third-party/tt-metal-version: TT_METAL_TAG not set}"
+    tt_metal_short_sha="$(git -C "$repo_root/third-party/tt-metal" rev-parse --short=10 HEAD)"
+    set -- "$@" \
+        --build-arg "TT_METAL_TAG=$TT_METAL_TAG" \
+        --build-arg "TT_METAL_SHORT_SHA=$tt_metal_short_sha"
+fi
+if [ -n "$build_parallel_level" ]; then
+    set -- "$@" --build-arg "TTLANG_BUILD_PARALLEL_LEVEL=$build_parallel_level"
+fi
+
+echo "Updating $component cache: $cache_ref"
+${DOCKER:-docker} "$@" -f "$dockerfile" "$repo_root"

--- a/.github/scripts/build-manylinux-core-wheel.sh
+++ b/.github/scripts/build-manylinux-core-wheel.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build one tt-lang core wheel inside a manylinux_2_34 builder image. PyPI mode
+# records a dependency on published ttnn; external mode produces the core wheel
+# consumed by the tt-lang-light metapackage.
+
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+
+PYTHON_TAG=""
+VERSION=""
+TTNN_DEP_MODE=""
+BUILD_DIR=""
+RAW_DIR=""
+DIST_DIR=dist
+ALLOW_FINAL_INTERNAL_VERSION="${TTLANG_ALLOW_FINAL_INTERNAL_VERSION:-false}"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: build-manylinux-core-wheel.sh --python-tag cp310|cp312 --version <version> --ttnn-dep-mode pypi|external [options]
+
+Options:
+  --build-dir <dir>               CMake build directory. Default: build-<python-tag>.
+  --raw-dir <dir>                 Unrepaired wheel directory. Default: dist-raw-<python-tag>.
+  --dist-dir <dir>                Final wheel directory. Default: dist.
+  --allow-final-internal-version  Allow final release versions for S3 light wheels.
+EOF
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --python-tag)
+            if [ "$#" -lt 2 ]; then usage; fi
+            PYTHON_TAG="$2"
+            shift 2
+            ;;
+        --version)
+            if [ "$#" -lt 2 ]; then usage; fi
+            VERSION="$2"
+            shift 2
+            ;;
+        --ttnn-dep-mode)
+            if [ "$#" -lt 2 ]; then usage; fi
+            TTNN_DEP_MODE="$2"
+            shift 2
+            ;;
+        --build-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            BUILD_DIR="$2"
+            shift 2
+            ;;
+        --raw-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            RAW_DIR="$2"
+            shift 2
+            ;;
+        --dist-dir)
+            if [ "$#" -lt 2 ]; then usage; fi
+            DIST_DIR="$2"
+            shift 2
+            ;;
+        --allow-final-internal-version)
+            ALLOW_FINAL_INTERNAL_VERSION=true
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+case "$PYTHON_TAG" in
+    cp310 | cp312) ;;
+    *) echo "Unsupported Python tag: $PYTHON_TAG" >&2; exit 2 ;;
+esac
+
+if [ -z "$VERSION" ]; then
+    echo "--version is required" >&2
+    exit 2
+fi
+case "$TTNN_DEP_MODE" in
+    pypi | external) ;;
+    *) echo "--ttnn-dep-mode must be pypi or external" >&2; exit 2 ;;
+esac
+
+BUILD_DIR="${BUILD_DIR:-build-${PYTHON_TAG}}"
+RAW_DIR="${RAW_DIR:-dist-raw-${PYTHON_TAG}}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+TTLANG_GIT_COMMIT="${TTLANG_GIT_COMMIT:-$(git rev-parse HEAD)}"
+TT_METAL_COMMIT="${TT_METAL_COMMIT:-$(git rev-parse HEAD:third-party/tt-metal)}"
+export TTLANG_GIT_COMMIT TT_METAL_COMMIT
+version_output="$(mktemp)"
+trap 'rm -f "$version_output"' EXIT
+TTNN_DEP_MODE="$TTNN_DEP_MODE" \
+VERSION_OVERRIDE="$VERSION" \
+GITHUB_OUTPUT="$version_output" \
+    "$script_dir/resolve-wheel-versions.sh"
+core_version="$(sed -n 's/^core_version=//p' "$version_output")"
+
+. /opt/ttlang-toolchain/venv/bin/activate
+
+rm -rf "$BUILD_DIR" "$RAW_DIR"
+mkdir -p "$DIST_DIR"
+rm -f "$DIST_DIR"/tt_lang-*-"${PYTHON_TAG}"-"${PYTHON_TAG}"-manylinux_2_34_x86_64.whl
+
+export CMAKE_BINARY_DIR="$BUILD_DIR"
+export TTLANG_TTNN_DEP_MODE="$TTNN_DEP_MODE"
+export TTLANG_VERSION_OVERRIDE="$core_version"
+export TTLANG_EXTERNAL_TT_METAL_DIR="${TTLANG_EXTERNAL_TT_METAL_DIR:-/opt/ttlang-toolchain/tt-metal}"
+export TTLANG_PYTHON_VENV="${TTLANG_PYTHON_VENV:-/opt/ttlang-toolchain/venv}"
+export TTLANG_ALLOW_FINAL_INTERNAL_VERSION="$ALLOW_FINAL_INTERNAL_VERSION"
+
+"$script_dir/configure-ttlang-build.sh" "$BUILD_DIR"
+python -m pip wheel . --wheel-dir="$RAW_DIR" --no-deps --no-build-isolation
+auditwheel repair \
+    --plat manylinux_2_34_x86_64 \
+    "$RAW_DIR"/tt_lang-*.whl \
+    --wheel-dir="$DIST_DIR"
+
+expected_wheel="$DIST_DIR/tt_lang-${core_version}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_34_x86_64.whl"
+if [ ! -f "$expected_wheel" ]; then
+    echo "Expected wheel was not produced: $expected_wheel" >&2
+    ls -lh "$DIST_DIR" >&2 || true
+    exit 1
+fi
+
+auditwheel show "$expected_wheel"
+set -- \
+    --mode "$TTNN_DEP_MODE" \
+    --dist-dir "$DIST_DIR" \
+    --expect-tt-metal-commit "$TT_METAL_COMMIT"
+if [ "$TTNN_DEP_MODE" = pypi ]; then
+    # shellcheck source=/dev/null
+    . "$repo_root/third-party/tt-metal-version"
+    : "${TTNN_PYPI:?third-party/tt-metal-version: TTNN_PYPI not set}"
+    set -- "$@" --expect-ttnn-version "$TTNN_PYPI"
+fi
+python "$script_dir/check-wheel-ttnn-metadata.py" "$@"
+"$script_dir/assert-no-gnu-unique.sh" "$expected_wheel"

--- a/.github/scripts/build-manylinux-wheel-set-member.sh
+++ b/.github/scripts/build-manylinux-wheel-set-member.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build one ABI member of a manylinux wheel set. The cp312 member also produces
+# the ABI-independent simulator wheel and, in external mode, the light
+# metapackage.
+
+set -eu
+
+python_tag=""
+version=""
+ttnn_dep_mode=""
+build_sim=true
+dist_dir=dist
+
+usage() {
+    echo "Usage: $0 --python-tag cp310|cp312 --version <version> --ttnn-dep-mode pypi|external [--build-sim true|false] [--dist-dir <dir>]" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --python-tag)
+            [ "$#" -ge 2 ] || usage
+            python_tag="$2"
+            shift 2
+            ;;
+        --version)
+            [ "$#" -ge 2 ] || usage
+            version="$2"
+            shift 2
+            ;;
+        --ttnn-dep-mode)
+            [ "$#" -ge 2 ] || usage
+            ttnn_dep_mode="$2"
+            shift 2
+            ;;
+        --build-sim)
+            [ "$#" -ge 2 ] || usage
+            build_sim="$2"
+            shift 2
+            ;;
+        --dist-dir)
+            [ "$#" -ge 2 ] || usage
+            dist_dir="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+case "$python_tag" in
+    cp310 | cp312) ;;
+    *) usage ;;
+esac
+case "$ttnn_dep_mode" in
+    pypi | external) ;;
+    *) usage ;;
+esac
+case "$build_sim" in
+    true | false) ;;
+    *) usage ;;
+esac
+[ -n "$version" ] || usage
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+"$script_dir/build-manylinux-core-wheel.sh" \
+    --python-tag "$python_tag" \
+    --version "$version" \
+    --ttnn-dep-mode "$ttnn_dep_mode" \
+    --dist-dir "$dist_dir"
+
+if [ "$python_tag" != cp312 ]; then
+    exit 0
+fi
+
+if [ "$build_sim" = true ]; then
+    . /opt/ttlang-toolchain/venv/bin/activate
+    TTLANG_VERSION_OVERRIDE="$version" \
+        python -m pip wheel packaging/sim \
+            --wheel-dir="$dist_dir" \
+            --no-deps \
+            --no-build-isolation
+
+    test_venv="$(mktemp -d /tmp/ttlang-sim-wheel-test.XXXXXX)"
+    trap 'rm -rf "$test_venv"' EXIT
+    /opt/python/cp312-cp312/bin/python -m venv "$test_venv"
+    # shellcheck disable=SC1090
+    . "$test_venv/bin/activate"
+    pip install \
+        --no-cache-dir \
+        --extra-index-url https://download.pytorch.org/whl/cpu \
+        "$dist_dir"/tt_lang_sim-*.whl
+    python "$script_dir/smoke-test-wheel.py"
+fi
+
+if [ "$ttnn_dep_mode" = external ]; then
+    "$script_dir/build-s3-light-metapackage-wheel.sh" \
+        --version "$version" \
+        --dist-dir "$dist_dir"
+fi

--- a/.github/scripts/build-s3-light-core-wheel.sh
+++ b/.github/scripts/build-s3-light-core-wheel.sh
@@ -1,126 +1,13 @@
 #!/bin/sh
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
 # SPDX-License-Identifier: Apache-2.0
 #
-# Build one S3 tt-lang-light core wheel inside a manylinux_2_34 builder image.
+# Compatibility entry point for S3 and per-tt-metal light-wheel workflows.
 
 set -eu
 
-PYTHON_TAG=""
-VERSION=""
-BUILD_DIR=""
-RAW_DIR=""
-DIST_DIR=dist
-ALLOW_FINAL_INTERNAL_VERSION="${TTLANG_ALLOW_FINAL_INTERNAL_VERSION:-false}"
-
-usage() {
-    cat >&2 <<'EOF'
-Usage: build-s3-light-core-wheel.sh --python-tag cp310|cp312 --version <version> [options]
-
-Options:
-  --build-dir <dir>               CMake build directory. Default: build-<python-tag>.
-  --raw-dir <dir>                 Unrepaired wheel directory. Default: dist-raw-<python-tag>.
-  --dist-dir <dir>                Final wheel directory. Default: dist.
-  --allow-final-internal-version  Allow final release versions for S3 light wheels.
-EOF
-    exit 2
-}
-
-while [ "$#" -gt 0 ]; do
-    case "$1" in
-        --python-tag)
-            if [ "$#" -lt 2 ]; then usage; fi
-            PYTHON_TAG="$2"
-            shift 2
-            ;;
-        --version)
-            if [ "$#" -lt 2 ]; then usage; fi
-            VERSION="$2"
-            shift 2
-            ;;
-        --build-dir)
-            if [ "$#" -lt 2 ]; then usage; fi
-            BUILD_DIR="$2"
-            shift 2
-            ;;
-        --raw-dir)
-            if [ "$#" -lt 2 ]; then usage; fi
-            RAW_DIR="$2"
-            shift 2
-            ;;
-        --dist-dir)
-            if [ "$#" -lt 2 ]; then usage; fi
-            DIST_DIR="$2"
-            shift 2
-            ;;
-        --allow-final-internal-version)
-            ALLOW_FINAL_INTERNAL_VERSION=true
-            shift
-            ;;
-        *)
-            usage
-            ;;
-    esac
-done
-
-case "$PYTHON_TAG" in
-    cp310 | cp312) ;;
-    *) echo "Unsupported Python tag: $PYTHON_TAG" >&2; exit 2 ;;
-esac
-
-if [ -z "$VERSION" ]; then
-    echo "--version is required" >&2
-    exit 2
-fi
-
-BUILD_DIR="${BUILD_DIR:-build-${PYTHON_TAG}}"
-RAW_DIR="${RAW_DIR:-dist-raw-${PYTHON_TAG}}"
-
-repo_root="$(git rev-parse --show-toplevel)"
-version_output="$(mktemp)"
-trap 'rm -f "$version_output"' EXIT
-TTNN_DEP_MODE=external \
-VERSION_OVERRIDE="$VERSION" \
-GITHUB_OUTPUT="$version_output" \
-    "$repo_root/.github/scripts/resolve-wheel-versions.sh"
-core_version="$(sed -n 's/^core_version=//p' "$version_output")"
-
-. /opt/ttlang-toolchain/venv/bin/activate
-
-rm -rf "$BUILD_DIR" "$RAW_DIR"
-mkdir -p "$DIST_DIR"
-rm -f "$DIST_DIR"/tt_lang-*-"${PYTHON_TAG}"-"${PYTHON_TAG}"-manylinux_2_34_x86_64.whl
-
-export CMAKE_BINARY_DIR="$BUILD_DIR"
-export TTLANG_TTNN_DEP_MODE=external
-export TTLANG_VERSION_OVERRIDE="$core_version"
-export TTLANG_EXTERNAL_TT_METAL_DIR="${TTLANG_EXTERNAL_TT_METAL_DIR:-/opt/ttlang-toolchain/tt-metal}"
-export TTLANG_PYTHON_VENV="${TTLANG_PYTHON_VENV:-/opt/ttlang-toolchain/venv}"
-export TTLANG_ALLOW_FINAL_INTERNAL_VERSION="$ALLOW_FINAL_INTERNAL_VERSION"
-
-"$repo_root/.github/scripts/configure-ttlang-build.sh" "$BUILD_DIR"
-python -m pip wheel . --wheel-dir="$RAW_DIR" --no-deps --no-build-isolation
-auditwheel repair \
-    --plat manylinux_2_34_x86_64 \
-    "$RAW_DIR"/tt_lang-*.whl \
-    --wheel-dir="$DIST_DIR"
-
-expected_wheel="$DIST_DIR/tt_lang-${core_version}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_34_x86_64.whl"
-if [ ! -f "$expected_wheel" ]; then
-    echo "Expected wheel was not produced: $expected_wheel" >&2
-    ls -lh "$DIST_DIR" >&2 || true
-    exit 1
-fi
-
-auditwheel show "$expected_wheel"
-if [ -n "${TT_METAL_COMMIT:-}" ]; then
-    python "$repo_root/.github/scripts/check-wheel-ttnn-metadata.py" \
-        --mode external \
-        --dist-dir "$DIST_DIR" \
-        --expect-tt-metal-commit "$TT_METAL_COMMIT"
-else
-    python "$repo_root/.github/scripts/check-wheel-ttnn-metadata.py" \
-        --mode external \
-        --dist-dir "$DIST_DIR"
-fi
-"$repo_root/.github/scripts/assert-no-gnu-unique.sh" "$expected_wheel"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+exec "$script_dir/build-manylinux-core-wheel.sh" \
+    --ttnn-dep-mode external \
+    "$@"

--- a/.github/scripts/build-s3-light-metapackage-wheel.sh
+++ b/.github/scripts/build-s3-light-metapackage-wheel.sh
@@ -48,13 +48,13 @@ if [ -z "$VERSION" ]; then
     exit 2
 fi
 
-repo_root="$(git rev-parse --show-toplevel)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 version_output="$(mktemp)"
 trap 'rm -f "$version_output"' EXIT
 TTNN_DEP_MODE=external \
 VERSION_OVERRIDE="$VERSION" \
 GITHUB_OUTPUT="$version_output" \
-    "$repo_root/.github/scripts/resolve-wheel-versions.sh"
+    "$script_dir/resolve-wheel-versions.sh"
 light_version="$(sed -n 's/^light_version=//p' "$version_output")"
 
 . /opt/ttlang-toolchain/venv/bin/activate
@@ -77,6 +77,6 @@ if [ ! -f "$expected_wheel" ]; then
     exit 1
 fi
 
-python "$repo_root/.github/scripts/check-light-metapackage.py" \
+python "$script_dir/check-light-metapackage.py" \
     --dist-dir "$DIST_DIR" \
     --expect-ttlang-version "$light_version"

--- a/.github/scripts/check-installed-ttnn.py
+++ b/.github/scripts/check-installed-ttnn.py
@@ -5,7 +5,7 @@
 
   --mode external  -> ttnn must NOT be importable.
   --mode bundled   -> ttnn must be importable and bundled native libs present.
-  --mode pypi      -> no check; exit 0.
+  --mode pypi      -> ttnn must be installed.
 
 Run inside the test venv so importlib resolves the installed tt-lang.
 
@@ -35,6 +35,13 @@ _LDD_COMMAND_ENV = "TTLANG_LDD_COMMAND"
 def check_external() -> int:
     if importlib.util.find_spec("ttnn") is not None:
         print("external wheel unexpectedly installed ttnn", file=sys.stderr)
+        return 1
+    return 0
+
+
+def check_pypi() -> int:
+    if importlib.util.find_spec("ttnn") is None:
+        print("pypi wheel did not install its ttnn dependency", file=sys.stderr)
         return 1
     return 0
 
@@ -123,7 +130,7 @@ def main() -> int:
         return check_external()
     if args.mode == "bundled":
         return check_bundled()
-    return 0
+    return check_pypi()
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check-wheel-ttnn-metadata.py
+++ b/.github/scripts/check-wheel-ttnn-metadata.py
@@ -51,7 +51,7 @@ def _tt_metal_commit(wheel_path: str) -> str:
     return match.group(1)
 
 
-def _requires_ttnn(metadata: str) -> bool:
+def _ttnn_requirement(metadata: str) -> Requirement | None:
     for line in metadata.splitlines():
         if not line.startswith("Requires-Dist:"):
             continue
@@ -60,8 +60,8 @@ def _requires_ttnn(metadata: str) -> bool:
         except InvalidRequirement as error:
             raise ValueError(f"invalid Requires-Dist line: {line}: {error}") from error
         if requirement.name.lower() == "ttnn":
-            return True
-    return False
+            return requirement
+    return None
 
 
 def main() -> int:
@@ -69,6 +69,7 @@ def main() -> int:
     parser.add_argument("--mode", required=True, choices=MODES)
     parser.add_argument("--dist-dir", required=True)
     parser.add_argument("--expect-tt-metal-commit")
+    parser.add_argument("--expect-ttnn-version")
     args = parser.parse_args()
 
     wheels = glob.glob(f"{args.dist_dir}/tt_lang-*.whl")
@@ -80,11 +81,12 @@ def main() -> int:
         return 1
 
     try:
-        has_ttnn = _requires_ttnn(_read_metadata(wheels[0]))
+        ttnn_requirement = _ttnn_requirement(_read_metadata(wheels[0]))
     except ValueError as error:
         print(str(error), file=sys.stderr)
         return 1
 
+    has_ttnn = ttnn_requirement is not None
     if args.mode in ("external", "bundled") and has_ttnn:
         print(f"{args.mode} wheel metadata must not require ttnn", file=sys.stderr)
         return 1
@@ -94,6 +96,21 @@ def main() -> int:
     if args.mode == "pypi" and not has_ttnn:
         print("default wheel metadata must require ttnn", file=sys.stderr)
         return 1
+    if args.expect_ttnn_version is not None:
+        if args.mode != "pypi":
+            print(
+                "--expect-ttnn-version is valid only in pypi mode",
+                file=sys.stderr,
+            )
+            return 1
+        expected_specifier = f"=={args.expect_ttnn_version}"
+        if str(ttnn_requirement.specifier) != expected_specifier:
+            print(
+                "tt-lang wheel ttnn dependency mismatch: "
+                f"expected {expected_specifier}, got {ttnn_requirement.specifier}",
+                file=sys.stderr,
+            )
+            return 1
     if args.expect_tt_metal_commit is not None:
         try:
             tt_metal_commit = _tt_metal_commit(wheels[0])

--- a/.github/scripts/inject-s3-index-readme.sh
+++ b/.github/scripts/inject-s3-index-readme.sh
@@ -83,7 +83,8 @@ if ! aws s3api get-object --bucket "$bucket" --key "$key" "$index_html" >/dev/nu
     fi
 fi
 
-python3 .github/scripts/inject_s3_index_readme.py \
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$script_dir/inject_s3_index_readme.py" \
     --create-from-dist "$dist_dir" \
     "$readme" \
     "$index_html"

--- a/.github/scripts/inject-s3-publish-readme.sh
+++ b/.github/scripts/inject-s3-publish-readme.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+[ "$#" -eq 2 ] || {
+    echo "Usage: $0 <publish-prefix> <dist-dir>" >&2
+    exit 2
+}
+
+prefix="$1"
+dist_dir="$2"
+case "$prefix" in
+    tt-lang/releases | tt-lang/[0-9][0-9][0-9][0-9]-[0-9][0-9]) ;;
+    *)
+        echo "Invalid S3 publish prefix: $prefix" >&2
+        exit 2
+        ;;
+esac
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+workflow_root="$(cd "$script_dir/../.." && pwd)"
+parent="$(dirname "$prefix")"
+"$script_dir/inject-s3-index-readme.sh" \
+    --key "$parent/" \
+    --readme "$workflow_root/packaging/s3-index/README.md" \
+    --require-existing \
+    --dist-dir "$dist_dir"

--- a/.github/scripts/inject-s3-publish-readme.sh
+++ b/.github/scripts/inject-s3-publish-readme.sh
@@ -12,15 +12,15 @@ set -eu
 
 prefix="$1"
 dist_dir="$2"
-case "$prefix" in
-    tt-lang/releases | tt-lang/[0-9][0-9][0-9][0-9]-[0-9][0-9]) ;;
-    *)
-        echo "Invalid S3 publish prefix: $prefix" >&2
-        exit 2
-        ;;
-esac
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/s3-publish-prefix.sh
+. "$script_dir/lib/s3-publish-prefix.sh"
+if ! ttlang_s3_valid_publish_prefix "$prefix"; then
+    echo "Invalid S3 publish prefix: $prefix" >&2
+    exit 2
+fi
+
 workflow_root="$(cd "$script_dir/../.." && pwd)"
 parent="$(dirname "$prefix")"
 "$script_dir/inject-s3-index-readme.sh" \

--- a/.github/scripts/lib/docker-image-utils.sh
+++ b/.github/scripts/lib/docker-image-utils.sh
@@ -8,6 +8,23 @@ ttlang_docker() {
     ${DOCKER:-docker} "$@"
 }
 
+ttlang_validate_docker_tag() {
+    if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+        return 1
+    fi
+    ttlang_docker_tag="$1"
+    if [ "${#ttlang_docker_tag}" -gt 128 ]; then
+        return 1
+    fi
+    case "$ttlang_docker_tag" in
+        *[!A-Za-z0-9_.-]*) return 1 ;;
+    esac
+    case "$ttlang_docker_tag" in
+        [A-Za-z0-9_]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 ttlang_image_for_tag() {
     if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
         echo "Usage: ttlang_image_for_tag <image-name> <tag> [registry]" >&2

--- a/.github/scripts/lib/docker-image-utils.sh
+++ b/.github/scripts/lib/docker-image-utils.sh
@@ -43,12 +43,38 @@ ttlang_image_for_tag() {
     fi
 }
 
+ttlang_wheel_builder_image_name() {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: ttlang_wheel_builder_image_name <python-tag>" >&2
+        return 2
+    fi
+    case "$1" in
+        cp310 | cp312) ;;
+        *)
+            echo "Unsupported Python tag: $1" >&2
+            return 2
+            ;;
+    esac
+    printf "tt-lang-wheel-manylinux-2-34-%s\n" "$1"
+}
+
+ttlang_wheel_builder_registry_image() {
+    if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+        echo "Usage: ttlang_wheel_builder_registry_image <python-tag> <docker-tag> [registry]" >&2
+        return 2
+    fi
+    ttlang_wbri_name="$(ttlang_wheel_builder_image_name "$1")" || return
+    ttlang_wbri_registry="${3:-ghcr.io/tenstorrent/tt-lang}"
+    printf "%s/%s:%s\n" "$ttlang_wbri_registry" "$ttlang_wbri_name" "$2"
+}
+
 ttlang_wheel_builder_image() {
     if [ "$#" -ne 2 ]; then
         echo "Usage: ttlang_wheel_builder_image <python-tag> <docker-tag>" >&2
         return 2
     fi
-    ttlang_image_for_tag "tt-lang-wheel-manylinux-2-34-$1" "$2"
+    ttlang_wbi_name="$(ttlang_wheel_builder_image_name "$1")" || return
+    ttlang_image_for_tag "$ttlang_wbi_name" "$2"
 }
 
 # Validate a comma-separated list of supported Python ABI tags and print them

--- a/.github/scripts/lib/s3-publish-prefix.sh
+++ b/.github/scripts/lib/s3-publish-prefix.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ttlang_s3_valid_year_month() {
+    case "$1" in
+        [0-9][0-9][0-9][0-9]-0[1-9] | [0-9][0-9][0-9][0-9]-1[0-2])
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+ttlang_s3_valid_publish_prefix() {
+    if [ "$1" = "tt-lang/releases" ]; then
+        return 0
+    fi
+    case "$1" in
+        tt-lang/*)
+            ttlang_s3_valid_year_month "${1#tt-lang/}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/.github/scripts/normalize-pep440-version.py
+++ b/.github/scripts/normalize-pep440-version.py
@@ -13,12 +13,12 @@ from packaging.version import InvalidVersion, Version
 
 def main() -> int:
     if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+        print("Usage: normalize-pep440-version.py <version>", file=sys.stderr)
         return 2
     try:
         version = Version(sys.argv[1])
     except InvalidVersion:
-        print(f"Invalid PEP 440 version: {sys.argv[1]!r}", file=sys.stderr)
+        print("Invalid PEP 440 version", file=sys.stderr)
         return 1
     print(version)
     return 0

--- a/.github/scripts/normalize-pep440-version.py
+++ b/.github/scripts/normalize-pep440-version.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Validate one PEP 440 version and print its canonical form."""
+
+from __future__ import annotations
+
+import sys
+
+from packaging.version import InvalidVersion, Version
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+        return 2
+    try:
+        version = Version(sys.argv[1])
+    except InvalidVersion:
+        print(f"Invalid PEP 440 version: {sys.argv[1]!r}", file=sys.stderr)
+        return 1
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/prepare-selected-s3-publish-dist.sh
+++ b/.github/scripts/prepare-selected-s3-publish-dist.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+[ "$#" -eq 3 ] || {
+    echo "Usage: $0 <version> <artifact-root> <publish-dir>" >&2
+    exit 2
+}
+
+version="$1"
+artifact_root="$2"
+publish_dir="$3"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+set --
+if [ -d "$artifact_root/bundled" ]; then
+    set -- "$@" "bundled=$artifact_root/bundled"
+fi
+if [ -d "$artifact_root/light" ]; then
+    set -- "$@" "light:no-sim=$artifact_root/light"
+fi
+if [ -d "$artifact_root/pypi" ]; then
+    set -- "$@" "pypi=$artifact_root/pypi"
+fi
+if [ "$#" -eq 0 ]; then
+    echo "No selected wheel artifacts found under $artifact_root" >&2
+    exit 1
+fi
+
+"$script_dir/prepare-s3-publish-dist.sh" "$version" "$publish_dir" "$@"

--- a/.github/scripts/publish-s3-summary.sh
+++ b/.github/scripts/publish-s3-summary.sh
@@ -10,12 +10,12 @@
 # With no $GITHUB_STEP_SUMMARY set, output goes to stdout for local
 # invocations/tests.
 #
-# Usage: publish-s3-summary.sh [--dry-run] [--index-subdir <subdir>] [--find-links-subdir <subdir>] <wheel_variant> <version_override>
+# Usage: publish-s3-summary.sh [--dry-run] [--dry-run-if true|false] [--index-subdir <subdir>] [--find-links-subdir <subdir>] <wheel_variant> <version_override>
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 [--dry-run] [--index-subdir <subdir>] [--find-links-subdir <subdir>] <wheel_variant> <version_override>" >&2
+    echo "Usage: $0 [--dry-run] [--dry-run-if true|false] [--index-subdir <subdir>] [--find-links-subdir <subdir>] <wheel_variant> <version_override>" >&2
     exit 2
 }
 
@@ -27,6 +27,15 @@ while [[ $# -gt 0 ]]; do
         --dry-run)
             dry_run=1
             shift
+            ;;
+        --dry-run-if)
+            [[ $# -ge 2 ]] || usage
+            case "$2" in
+                true) dry_run=1 ;;
+                false) dry_run=0 ;;
+                *) usage ;;
+            esac
+            shift 2
             ;;
         --index-subdir)
             [[ $# -ge 2 ]] || usage

--- a/.github/scripts/publish-s3-wheels.sh
+++ b/.github/scripts/publish-s3-wheels.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/s3-index.sh
 . "$script_dir/lib/s3-index.sh"
+# shellcheck source=lib/s3-publish-prefix.sh
+. "$script_dir/lib/s3-publish-prefix.sh"
 
 usage() {
     echo "Usage: $0 [--overwrite] [--overwrite-if true|false] --prefix <tt-lang/YYYY-MM|tt-lang/releases> <dist_dir>" >&2
@@ -55,7 +57,7 @@ done
 if [[ $# -ne 1 || -z "$prefix" ]]; then
     usage
 fi
-if [[ ! "$prefix" =~ ^tt-lang/[0-9]{4}-[0-9]{2}$ && "$prefix" != "tt-lang/releases" ]]; then
+if ! ttlang_s3_valid_publish_prefix "$prefix"; then
     echo "Publish prefix must be tt-lang/<YYYY-MM> or tt-lang/releases: $prefix" >&2
     exit 2
 fi

--- a/.github/scripts/publish-s3-wheels.sh
+++ b/.github/scripts/publish-s3-wheels.sh
@@ -7,7 +7,7 @@
 # those top-level wheel objects, not physical copies. With --overwrite, replace
 # existing direct wheel objects.
 #
-# Usage: publish-s3-wheels.sh [--overwrite] --prefix <tt-lang/YYYY-MM|tt-lang/releases> <dist_dir>
+# Usage: publish-s3-wheels.sh [--overwrite] [--overwrite-if true|false] --prefix <tt-lang/YYYY-MM|tt-lang/releases> <dist_dir>
 
 set -euo pipefail
 
@@ -16,7 +16,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$script_dir/lib/s3-index.sh"
 
 usage() {
-    echo "Usage: $0 [--overwrite] --prefix <tt-lang/YYYY-MM|tt-lang/releases> <dist_dir>" >&2
+    echo "Usage: $0 [--overwrite] [--overwrite-if true|false] --prefix <tt-lang/YYYY-MM|tt-lang/releases> <dist_dir>" >&2
     exit 2
 }
 
@@ -27,6 +27,15 @@ while [[ $# -gt 0 ]]; do
         --overwrite)
             overwrite=1
             shift
+            ;;
+        --overwrite-if)
+            [[ $# -ge 2 ]] || usage
+            case "$2" in
+                true) overwrite=1 ;;
+                false) overwrite=0 ;;
+                *) usage ;;
+            esac
+            shift 2
             ;;
         --prefix)
             [[ $# -ge 2 ]] || usage

--- a/.github/scripts/publish-wheel-builder-latest.sh
+++ b/.github/scripts/publish-wheel-builder-latest.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Publish :latest manifests for a complete pair of content-tagged manylinux
+# wheel-builder images.
+
+set -eu
+
+repository="${GITHUB_REPOSITORY:-tenstorrent/tt-lang}"
+docker_tag=""
+
+usage() {
+    echo "Usage: $0 [--repository <owner/repo>] --docker-tag <tag>" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repository)
+            [ "$#" -ge 2 ] || usage
+            repository="$2"
+            shift 2
+            ;;
+        --docker-tag)
+            [ "$#" -ge 2 ] || usage
+            docker_tag="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+case "$repository" in
+    */*) ;;
+    *) usage ;;
+esac
+[ -n "$docker_tag" ] || usage
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/docker-image-utils.sh
+. "$script_dir/lib/docker-image-utils.sh"
+
+for python_tag in cp310 cp312; do
+    image="$(ttlang_wheel_builder_registry_image \
+        "$python_tag" "$docker_tag" "ghcr.io/${repository}")"
+    if ! ${DOCKER:-docker} manifest inspect "$image" >/dev/null 2>&1; then
+        echo "Required image does not exist: $image" >&2
+        exit 1
+    fi
+done
+
+for python_tag in cp310 cp312; do
+    image="$(ttlang_wheel_builder_registry_image \
+        "$python_tag" "$docker_tag" "ghcr.io/${repository}")"
+    latest="${image%:*}:latest"
+    ${DOCKER:-docker} buildx imagetools create -t "$latest" "$image"
+    echo "Published: $latest -> $image"
+done

--- a/.github/scripts/record-ttmetal-miss.sh
+++ b/.github/scripts/record-ttmetal-miss.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Record that no compatible tt-lang was found for a tt-metal SHA, so the nightly
-# detector skips re-attempting it until tt-lang HEAD advances. Writes a small
+# Record that no compatible tt-lang was found for a tt-metal SHA, so scheduled
+# runs skip re-attempting it until tt-lang HEAD advances. Writes a small
 # attempt.json marker under the tt-lang/ttmetal/<ttmetal7> S3 prefix.
 #
 # Usage:

--- a/.github/scripts/refresh-s3-wheel-views.sh
+++ b/.github/scripts/refresh-s3-wheel-views.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --months YYYY-MM[,YYYY-MM...]" >&2
+    exit 2
+}
+
+months=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --months)
+            [[ $# -ge 2 ]] || usage
+            months="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+[[ -n "$months" ]] || usage
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/s3-index.sh
+. "$script_dir/lib/s3-index.sh"
+bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
+
+IFS=, read -r -a month_values <<< "$months"
+for month in "${month_values[@]}"; do
+    [[ "$month" =~ ^[0-9]{4}-[0-9]{2}$ ]] || {
+        echo "Invalid year-month: $month" >&2
+        exit 2
+    }
+    prefix="tt-lang/$month"
+    anchors="$(s3_month_view_anchors "$bucket" "$month")"
+    if [[ -n "$anchors" ]]; then
+        s3_regenerate_month_view "$bucket" "$prefix"
+    else
+        aws s3api delete-object --bucket "$bucket" --key "$prefix" >/dev/null
+        aws s3api delete-object --bucket "$bucket" --key "$prefix/" >/dev/null
+    fi
+done
+
+s3_regenerate_index \
+    --directories-only \
+    --hidden-stable-wheels \
+    "$bucket" \
+    tt-lang
+
+"${INJECT_S3_INDEX_README:-$script_dir/inject-s3-index-readme.sh}" \
+    --bucket "$bucket" \
+    --key tt-lang/ \
+    --require-existing

--- a/.github/scripts/refresh-s3-wheel-views.sh
+++ b/.github/scripts/refresh-s3-wheel-views.sh
@@ -28,11 +28,13 @@ done
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/s3-index.sh
 . "$script_dir/lib/s3-index.sh"
+# shellcheck source=lib/s3-publish-prefix.sh
+. "$script_dir/lib/s3-publish-prefix.sh"
 bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
 
 IFS=, read -r -a month_values <<< "$months"
 for month in "${month_values[@]}"; do
-    [[ "$month" =~ ^[0-9]{4}-[0-9]{2}$ ]] || {
+    ttlang_s3_valid_year_month "$month" || {
         echo "Invalid year-month: $month" >&2
         exit 2
     }

--- a/.github/scripts/report-docker-disk-usage.sh
+++ b/.github/scripts/report-docker-disk-usage.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -u
+
+df -h
+${DOCKER:-docker} system df || true

--- a/.github/scripts/resolve-pypi-publish-inputs.sh
+++ b/.github/scripts/resolve-pypi-publish-inputs.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate the public PyPI publish target and emit the wheel version used by
+# the shared manylinux build.
+
+set -euo pipefail
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${RELEASE_SOURCE:?RELEASE_SOURCE is required}"
+
+dry_run="${DRY_RUN:-false}"
+docker_tag="${DOCKER_TAG:-}"
+ttlang_sha="${TTLANG_SHA:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/docker-image-utils.sh
+. "$script_dir/lib/docker-image-utils.sh"
+output_file="${GITHUB_OUTPUT:-/dev/stdout}"
+
+case "$EVENT_NAME" in
+    push | workflow_dispatch) ;;
+    *)
+        echo "Unsupported public PyPI event: $EVENT_NAME" >&2
+        exit 1
+        ;;
+esac
+case "$dry_run" in
+    true | false) ;;
+    *)
+        echo "DRY_RUN must be true or false" >&2
+        exit 2
+        ;;
+esac
+if [[ -n "$docker_tag" ]] && ! ttlang_validate_docker_tag "$docker_tag"; then
+    echo "DOCKER_TAG is not a valid Docker tag" >&2
+    exit 2
+fi
+
+if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+    echo "dry_run=$dry_run"
+    echo "docker_tag=$docker_tag"
+    echo "ttlang_sha=$ttlang_sha"
+
+    if [[ ! "$ttlang_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+        echo "ttlang_sha must be a full 40-character commit SHA." >&2
+        exit 1
+    fi
+    checked_out_sha="$(git -C "$RELEASE_SOURCE" rev-parse HEAD)"
+    if [[ "$checked_out_sha" != "${ttlang_sha,,}" ]]; then
+        echo "Checked-out commit does not match ttlang_sha." >&2
+        exit 1
+    fi
+fi
+
+if [[ "$EVENT_NAME" == "workflow_dispatch" && "$dry_run" != true ]]; then
+    if [[ "${GITHUB_REF:-}" != refs/heads/main ]]; then
+        echo "Public PyPI publishing is restricted to workflow dispatches from refs/heads/main." >&2
+        exit 1
+    fi
+    if ! git -C "$RELEASE_SOURCE" merge-base --is-ancestor "$ttlang_sha" "${GITHUB_SHA:?GITHUB_SHA is required}"; then
+        echo "ttlang_sha must be an ancestor of the dispatching main commit." >&2
+        exit 1
+    fi
+fi
+
+tag_version=""
+if [[ "$EVENT_NAME" == push || "$dry_run" != true ]]; then
+    release_ref="${GITHUB_REF:-}"
+    if [[ -n "$ttlang_sha" ]]; then
+        mapfile -t release_tags < <(
+            git -C "$RELEASE_SOURCE" tag --list 'v[0-9]*' --points-at "$ttlang_sha"
+        )
+        if [[ "${#release_tags[@]}" -ne 1 ]]; then
+            echo "ttlang_sha must have exactly one v* release tag; found ${#release_tags[@]}." >&2
+            exit 1
+        fi
+        release_ref="refs/tags/${release_tags[0]}"
+    fi
+    tag_version="$(GITHUB_OUTPUT='' "$script_dir/require-release-tag.sh" "$release_ref")"
+    wheel_version="$tag_version"
+else
+    wheel_version="$(
+        cd "$RELEASE_SOURCE"
+        python3 "$script_dir/compute-nightly-version.py"
+    )"
+fi
+
+{
+    echo "tag_version=$tag_version"
+    echo "wheel_version=$wheel_version"
+} >> "$output_file"
+
+echo "Resolved public PyPI wheel version: $wheel_version"

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -19,14 +19,16 @@
 #
 # Outputs (written to $GITHUB_OUTPUT):
 #   docker_tag, dry_run, overwrite_releases, version_override, wheel_variant,
-#   wheel_variants, wheel_matrix, standard_wheel_matrix,
-#   allow_final_internal_version
+#   wheel_variants, bundled_selected, manylinux_selected,
+#   manylinux_wheel_matrix, allow_final_internal_version
 
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/tt-metal-version-utils.sh
 . "$script_dir/lib/tt-metal-version-utils.sh"
+# shellcheck source=lib/docker-image-utils.sh
+. "$script_dir/lib/docker-image-utils.sh"
 
 is_stable_version() {
     [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
@@ -50,6 +52,25 @@ overwrite_releases="$DISPATCH_OVERWRITE_RELEASES"
 version_override="${DISPATCH_VERSION_OVERRIDE:-}"
 wheel_variant="${DISPATCH_WHEEL_VARIANT:-}"
 
+case "$dry_run" in
+    true | false) ;;
+    *)
+        echo "DISPATCH_DRY_RUN must be true or false" >&2
+        exit 2
+        ;;
+esac
+case "$overwrite_releases" in
+    true | false) ;;
+    *)
+        echo "DISPATCH_OVERWRITE_RELEASES must be true or false" >&2
+        exit 2
+        ;;
+esac
+if [[ -n "$docker_tag" ]] && ! ttlang_validate_docker_tag "$docker_tag"; then
+    echo "DISPATCH_DOCKER_TAG is not a valid Docker tag" >&2
+    exit 2
+fi
+
 case "$EVENT_NAME" in
     workflow_dispatch | schedule)
         ;;
@@ -66,6 +87,7 @@ esac
 if [[ -z "$version_override" ]]; then
     version_override=$(python3 "$script_dir/compute-nightly-version.py")
 fi
+version_override=$(python3 "$script_dir/normalize-pep440-version.py" "$version_override")
 
 if [[ -z "$wheel_variant" ]]; then
     case "$EVENT_NAME" in
@@ -82,23 +104,27 @@ fi
 case "$wheel_variant" in
     bundled)
         wheel_variants='["bundled"]'
-        wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
-        standard_wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
+        bundled_selected=true
+        manylinux_selected=false
+        manylinux_wheel_matrix='{"include":[]}'
         ;;
     light)
         wheel_variants='["light"]'
-        wheel_matrix='{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
-        standard_wheel_matrix='{"include":[]}'
+        bundled_selected=false
+        manylinux_selected=true
+        manylinux_wheel_matrix='{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external","build_sim_wheel":false}]}'
         ;;
     bundled-and-light)
         wheel_variants='["bundled","light"]'
-        wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"},{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
-        standard_wheel_matrix='{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
+        bundled_selected=true
+        manylinux_selected=true
+        manylinux_wheel_matrix='{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external","build_sim_wheel":false}]}'
         ;;
     pypi)
         wheel_variants='["pypi"]'
-        wheel_matrix='{"include":[{"wheel_variant":"pypi","ttnn_dep_mode":"pypi"}]}'
-        standard_wheel_matrix='{"include":[{"wheel_variant":"pypi","ttnn_dep_mode":"pypi"}]}'
+        bundled_selected=false
+        manylinux_selected=true
+        manylinux_wheel_matrix='{"include":[{"wheel_variant":"pypi","ttnn_dep_mode":"pypi","build_sim_wheel":true}]}'
         ;;
     *)
         echo "Unknown S3 wheel variant: $wheel_variant" >&2
@@ -121,6 +147,12 @@ if [[ "$EVENT_NAME" == "schedule" ]]; then
     overwrite_releases=true
 fi
 
+if [[ "${GITHUB_REF:-}" != refs/heads/main &&
+      ("$dry_run" != true || -z "$docker_tag") ]]; then
+    echo "Publishing is restricted to refs/heads/main (got ${GITHUB_REF:-unset}). Non-main dry runs must provide docker_tag." >&2
+    exit 1
+fi
+
 output_file="${GITHUB_OUTPUT:-/dev/stdout}"
 {
     echo "docker_tag=$docker_tag"
@@ -129,14 +161,17 @@ output_file="${GITHUB_OUTPUT:-/dev/stdout}"
     echo "version_override=$version_override"
     echo "wheel_variant=$wheel_variant"
     echo "wheel_variants=$wheel_variants"
-    echo "wheel_matrix=$wheel_matrix"
-    echo "standard_wheel_matrix=$standard_wheel_matrix"
+    echo "bundled_selected=$bundled_selected"
+    echo "manylinux_selected=$manylinux_selected"
+    echo "manylinux_wheel_matrix=$manylinux_wheel_matrix"
     echo "allow_final_internal_version=$allow_final_internal_version"
 } >> "$output_file"
 
 echo "Resolved wheel_variant=$wheel_variant"
 echo "Resolved wheel_variants=$wheel_variants"
-echo "Resolved standard_wheel_matrix=$standard_wheel_matrix"
+echo "Resolved bundled_selected=$bundled_selected"
+echo "Resolved manylinux_selected=$manylinux_selected"
+echo "Resolved manylinux_wheel_matrix=$manylinux_wheel_matrix"
 echo "Resolved version_override=$version_override"
 echo "Resolved allow_final_internal_version=$allow_final_internal_version"
 echo "Resolved dry_run=$dry_run"
@@ -144,5 +179,5 @@ echo "Resolved overwrite_releases=$overwrite_releases"
 if [[ -n "$docker_tag" ]]; then
     echo "Using existing docker_tag=$docker_tag"
 else
-    echo "No docker_tag provided; build-docker will create one"
+    echo "No docker_tag provided; required builder workflows will create it"
 fi

--- a/.github/scripts/resolve-s3-publish-inputs.sh
+++ b/.github/scripts/resolve-s3-publish-inputs.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Resolve the inputs of the S3 PyPI publish workflow into a single set of
-# step outputs. Scheduled runs compute a nightly version and force
-# `overwrite_releases=true`; workflow_dispatch runs use their explicit inputs.
+# step outputs. Scheduled runs compute a date-based development version and
+# force `overwrite_releases=true`; workflow_dispatch runs use explicit inputs.
 #
 # Required env:
 #   DISPATCH_DOCKER_TAG          May be empty (workflow_dispatch input).

--- a/.github/scripts/resolve-s3-publish-prefix.sh
+++ b/.github/scripts/resolve-s3-publish-prefix.sh
@@ -15,13 +15,22 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$script_dir/lib/s3-publish-prefix.sh"
 
 version="$1"
+public_version="${version%%+*}"
 prefix=tt-lang/releases
-if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.dev([0-9]{4})([0-9]{2})[0-9]{2} ]]; then
+if [[ "$public_version" =~ \.dev([0-9]+)$ ]]; then
+    dev_number="${BASH_REMATCH[1]}"
+    if [[ ! "$dev_number" =~ ^([0-9]{4})([0-9]{2})[0-9]{2}$ ]]; then
+        echo "S3 dev versions must use an 8-digit YYYYMMDD dev number: $version" >&2
+        exit 2
+    fi
     prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
     if ! ttlang_s3_valid_publish_prefix "$prefix"; then
         echo "Invalid calendar month in dev version: $version" >&2
         exit 2
     fi
+elif [[ "$public_version" == *".dev"* ]]; then
+    echo "Invalid dev version: $version" >&2
+    exit 2
 fi
 
 echo "prefix=$prefix" >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/resolve-s3-publish-prefix.sh
+++ b/.github/scripts/resolve-s3-publish-prefix.sh
@@ -10,10 +10,18 @@ set -euo pipefail
     exit 2
 }
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/s3-publish-prefix.sh
+. "$script_dir/lib/s3-publish-prefix.sh"
+
 version="$1"
 prefix=tt-lang/releases
 if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.dev([0-9]{4})([0-9]{2})[0-9]{2} ]]; then
     prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+    if ! ttlang_s3_valid_publish_prefix "$prefix"; then
+        echo "Invalid calendar month in dev version: $version" >&2
+        exit 2
+    fi
 fi
 
 echo "prefix=$prefix" >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/resolve-s3-publish-prefix.sh
+++ b/.github/scripts/resolve-s3-publish-prefix.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+[[ $# -eq 1 ]] || {
+    echo "Usage: $0 <version>" >&2
+    exit 2
+}
+
+version="$1"
+prefix=tt-lang/releases
+if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.dev([0-9]{4})([0-9]{2})[0-9]{2} ]]; then
+    prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+fi
+
+echo "prefix=$prefix" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "Publish prefix: $prefix"

--- a/.github/scripts/resolve-wheel-builder-images.sh
+++ b/.github/scripts/resolve-wheel-builder-images.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Resolve the content-derived manylinux builder tag and report whether all
+# required ABI images already exist.
+
+set -eu
+
+repository="${GITHUB_REPOSITORY:-tenstorrent/tt-lang}"
+docker_tag=""
+workflow_source=""
+
+usage() {
+    echo "Usage: $0 [--repository <owner/repo>] [--docker-tag <tag>] [--workflow-source <git-checkout>]" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repository)
+            [ "$#" -ge 2 ] || usage
+            repository="$2"
+            shift 2
+            ;;
+        --docker-tag)
+            [ "$#" -ge 2 ] || usage
+            docker_tag="$2"
+            shift 2
+            ;;
+        --workflow-source)
+            [ "$#" -ge 2 ] || usage
+            workflow_source="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+case "$repository" in
+    */*) ;;
+    *) usage ;;
+esac
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+if [ -z "$docker_tag" ]; then
+    docker_tag="$("$script_dir/../containers/get-version-tag.sh")"
+    if [ -n "$workflow_source" ]; then
+        workflow_sha="$(git -C "$workflow_source" rev-parse HEAD)"
+        target_sha="$(git rev-parse HEAD)"
+        if [ "$workflow_sha" != "$target_sha" ]; then
+            docker_tag="${docker_tag}-wf$(printf '%s' "$workflow_sha" | cut -c1-8)"
+        fi
+    fi
+fi
+update_latest=false
+if [ "${GITHUB_REF:-}" = refs/heads/main ]; then
+    update_latest=true
+    if [ -n "$workflow_source" ] &&
+        [ "$(git -C "$workflow_source" rev-parse HEAD)" != "$(git rev-parse HEAD)" ]; then
+        update_latest=false
+    fi
+fi
+all_images_exist=true
+
+for python_tag in cp310 cp312; do
+    image="ghcr.io/${repository}/tt-lang-wheel-manylinux-2-34-${python_tag}:${docker_tag}"
+    if ${DOCKER:-docker} manifest inspect "$image" >/dev/null 2>&1; then
+        echo "Image exists: $image"
+        if [ "$update_latest" = true ]; then
+            latest="${image%:*}:latest"
+            ${DOCKER:-docker} buildx imagetools create -t "$latest" "$image"
+        fi
+    else
+        echo "Image missing: $image"
+        all_images_exist=false
+    fi
+done
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "docker-tag=$docker_tag"
+        echo "all-images-exist=$all_images_exist"
+        echo "update-latest=$update_latest"
+    } >> "$GITHUB_OUTPUT"
+else
+    echo "docker-tag=$docker_tag"
+    echo "all-images-exist=$all_images_exist"
+    echo "update-latest=$update_latest"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+        echo "### manylinux wheel-builder images"
+        echo
+        echo "- Docker tag: \`$docker_tag\`"
+        echo "- All images exist: \`$all_images_exist\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/scripts/resolve-wheel-builder-images.sh
+++ b/.github/scripts/resolve-wheel-builder-images.sh
@@ -46,6 +46,8 @@ case "$repository" in
 esac
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/docker-image-utils.sh
+. "$script_dir/lib/docker-image-utils.sh"
 if [ -z "$docker_tag" ]; then
     docker_tag="$("$script_dir/../containers/get-version-tag.sh")"
     if [ -n "$workflow_source" ]; then
@@ -67,13 +69,10 @@ fi
 all_images_exist=true
 
 for python_tag in cp310 cp312; do
-    image="ghcr.io/${repository}/tt-lang-wheel-manylinux-2-34-${python_tag}:${docker_tag}"
+    image="$(ttlang_wheel_builder_registry_image \
+        "$python_tag" "$docker_tag" "ghcr.io/${repository}")"
     if ${DOCKER:-docker} manifest inspect "$image" >/dev/null 2>&1; then
         echo "Image exists: $image"
-        if [ "$update_latest" = true ]; then
-            latest="${image%:*}:latest"
-            ${DOCKER:-docker} buildx imagetools create -t "$latest" "$image"
-        fi
     else
         echo "Image missing: $image"
         all_images_exist=false

--- a/.github/scripts/s3-nightly-state.py
+++ b/.github/scripts/s3-nightly-state.py
@@ -18,6 +18,9 @@ from pathlib import Path
 DEFAULT_BUCKET = "tenstorrent-pypi"
 DEFAULT_KEY = "tt-lang/nightly-state.json"
 SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+HEAD_OBJECT_ERROR_RE = re.compile(
+    r"An error occurred \((?P<code>[^)]+)\) " r"when calling the HeadObject operation"
+)
 
 
 def _sha(value: str | None) -> str:
@@ -53,6 +56,26 @@ def _aws(*args: str, input_text: str | None = None) -> subprocess.CompletedProce
 
 
 def _read_marker(bucket: str, key: str) -> dict[str, object] | None:
+    head_result = _aws(
+        "s3api",
+        "head-object",
+        "--bucket",
+        bucket,
+        "--key",
+        key,
+    )
+    if head_result.returncode != 0:
+        error_match = HEAD_OBJECT_ERROR_RE.search(head_result.stderr)
+        if error_match and error_match.group("code") in {
+            "404",
+            "NoSuchKey",
+            "NotFound",
+        }:
+            return None
+        raise RuntimeError(
+            f"failed to inspect s3://{bucket}/{key}: {head_result.stderr.strip()}"
+        )
+
     result = _aws(
         "s3",
         "cp",
@@ -60,22 +83,17 @@ def _read_marker(bucket: str, key: str) -> dict[str, object] | None:
         "-",
         "--only-show-errors",
     )
-    if result.returncode == 0:
-        try:
-            marker = json.loads(result.stdout)
-        except json.JSONDecodeError as error:
-            raise RuntimeError(f"invalid nightly marker JSON: {error}") from error
-        if not isinstance(marker, dict):
-            raise RuntimeError("invalid nightly marker JSON: expected an object")
-        return marker
-
-    error_text = result.stderr
-    if any(
-        missing_text in error_text
-        for missing_text in ("NoSuchKey", "Not Found", "404", "does not exist")
-    ):
-        return None
-    raise RuntimeError(f"failed to read s3://{bucket}/{key}: {error_text.strip()}")
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to read s3://{bucket}/{key}: {result.stderr.strip()}"
+        )
+    try:
+        marker = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"invalid nightly marker JSON: {error}") from error
+    if not isinstance(marker, dict):
+        raise RuntimeError("invalid nightly marker JSON: expected an object")
+    return marker
 
 
 def check(args: argparse.Namespace) -> int:

--- a/.github/scripts/s3-nightly-state.py
+++ b/.github/scripts/s3-nightly-state.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Read and update the successful scheduled S3 wheel publish marker."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_BUCKET = "tenstorrent-pypi"
+DEFAULT_KEY = "tt-lang/nightly-state.json"
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _sha(value: str | None) -> str:
+    resolved = (
+        value
+        if value
+        else subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    )
+    if not SHA_RE.fullmatch(resolved):
+        raise RuntimeError(f"expected a full 40-character commit SHA, got {resolved!r}")
+    return resolved.lower()
+
+
+def _write_outputs(values: dict[str, str]) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    stream = Path(output_path).open("a") if output_path else sys.stdout
+    try:
+        for name, value in values.items():
+            print(f"{name}={value}", file=stream)
+    finally:
+        if output_path:
+            stream.close()
+
+
+def _aws(*args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [os.environ.get("AWS", "aws"), *args],
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _read_marker(bucket: str, key: str) -> dict[str, object] | None:
+    result = _aws(
+        "s3",
+        "cp",
+        f"s3://{bucket}/{key}",
+        "-",
+        "--only-show-errors",
+    )
+    if result.returncode == 0:
+        try:
+            marker = json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(f"invalid nightly marker JSON: {error}") from error
+        if not isinstance(marker, dict):
+            raise RuntimeError("invalid nightly marker JSON: expected an object")
+        return marker
+
+    error_text = result.stderr
+    if any(
+        missing_text in error_text
+        for missing_text in ("NoSuchKey", "Not Found", "404", "does not exist")
+    ):
+        return None
+    raise RuntimeError(f"failed to read s3://{bucket}/{key}: {error_text.strip()}")
+
+
+def check(args: argparse.Namespace) -> int:
+    ttlang_sha = _sha(args.sha)
+    if args.event != "schedule":
+        _write_outputs(
+            {
+                "publish-needed": "true",
+                "ttlang-sha": ttlang_sha,
+                "previous-sha": "",
+            }
+        )
+        print("Non-scheduled publish: source-state skip is disabled.")
+        return 0
+
+    marker = _read_marker(args.bucket, args.key)
+    previous_sha = "" if marker is None else str(marker.get("ttlang_sha", ""))
+    if previous_sha and not SHA_RE.fullmatch(previous_sha):
+        raise RuntimeError("invalid nightly marker JSON: ttlang_sha is not a full SHA")
+    previous_sha = previous_sha.lower()
+    publish_needed = previous_sha != ttlang_sha
+    _write_outputs(
+        {
+            "publish-needed": str(publish_needed).lower(),
+            "ttlang-sha": ttlang_sha,
+            "previous-sha": previous_sha,
+        }
+    )
+    if publish_needed:
+        print(
+            f"Scheduled publish required: previous={previous_sha or 'none'} current={ttlang_sha}"
+        )
+    else:
+        print(f"Scheduled publish skipped: {ttlang_sha} was already published.")
+    return 0
+
+
+def record(args: argparse.Namespace) -> int:
+    if args.event != "schedule":
+        raise RuntimeError("nightly state is recorded only for schedule events")
+    marker = {
+        "ttlang_sha": _sha(args.sha),
+        "version": args.version,
+        "run_id": args.run_id or os.environ.get("GITHUB_RUN_ID", ""),
+        "published_at": datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat(),
+    }
+    payload = json.dumps(marker, sort_keys=True) + "\n"
+    result = _aws(
+        "s3",
+        "cp",
+        "-",
+        f"s3://{args.bucket}/{args.key}",
+        "--content-type",
+        "application/json",
+        "--only-show-errors",
+        input_text=payload,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to write s3://{args.bucket}/{args.key}: {result.stderr.strip()}"
+        )
+    print(f"Recorded scheduled publish state for {marker['ttlang_sha']}.")
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("check", "record"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument(
+            "--event", default=os.environ.get("GITHUB_EVENT_NAME", "")
+        )
+        subparser.add_argument("--sha")
+        subparser.add_argument(
+            "--bucket", default=os.environ.get("TTLANG_S3_BUCKET", DEFAULT_BUCKET)
+        )
+        subparser.add_argument("--key", default=DEFAULT_KEY)
+    record_parser = subparsers.choices["record"]
+    record_parser.add_argument("--version", required=True)
+    record_parser.add_argument("--run-id")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        return check(args) if args.command == "check" else record(args)
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/s3-pypi-ops.sh
+++ b/.github/scripts/s3-pypi-ops.sh
@@ -17,6 +17,8 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/s3-index.sh
 . "$script_dir/lib/s3-index.sh"
+# shellcheck source=lib/s3-publish-prefix.sh
+. "$script_dir/lib/s3-publish-prefix.sh"
 
 bucket="${TTLANG_S3_BUCKET:-tenstorrent-pypi}"
 ALLOWED_PREFIXES=(tt-lang/)
@@ -174,7 +176,8 @@ case "$operation" in
                     --require-existing
             elif [[ "$prefix" == "tt-lang/releases" ]]; then
                 s3_regenerate_release_view "$bucket"
-            elif [[ "$prefix" =~ ^tt-lang/[0-9]{4}-[0-9]{2}$ ]]; then
+            elif [[ "$prefix" == tt-lang/* ]] &&
+                ttlang_s3_valid_year_month "${prefix#tt-lang/}"; then
                 s3_regenerate_month_view "$bucket" "$prefix"
             else
                 s3_regenerate_index "$bucket" "$prefix"

--- a/.github/scripts/s3-wheel-maintenance.py
+++ b/.github/scripts/s3-wheel-maintenance.py
@@ -21,6 +21,8 @@ from typing import Iterable
 BUCKET = "tenstorrent-pypi"
 PREFIX = "tt-lang/"
 DEV_DATE_RE = re.compile(r"\.dev(?P<date>[0-9]{8})(?:\+[^-]+)?-")
+MONTH_RE = re.compile(r"^[0-9]{4}-(?:0[1-9]|1[0-2])$")
+REFRESH_SCRIPT = Path(__file__).with_name("refresh-s3-wheel-views.sh").resolve()
 CONFIRMATIONS = {
     "deduplicate": "delete-duplicate-versions",
     "remove-dev-range": "delete-dev-versions",
@@ -304,11 +306,13 @@ def _write_summary(
     print("\n".join(lines))
 
 
-def _refresh_views(months: list[str], script: str) -> None:
+def _refresh_views(months: list[str]) -> None:
     if not months:
         return
+    if any(MONTH_RE.fullmatch(month) is None for month in months):
+        raise RuntimeError("invalid month passed to S3 wheel view refresh")
     subprocess.run(
-        [script, "--months", ",".join(months)],
+        [str(REFRESH_SCRIPT), "--months", ",".join(months)],
         check=True,
     )
 
@@ -343,10 +347,6 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--confirm", default="")
     parser.add_argument("--github-ref", default=os.environ.get("GITHUB_REF", ""))
     parser.add_argument("--bucket", default=os.environ.get("TTLANG_S3_BUCKET", BUCKET))
-    parser.add_argument(
-        "--refresh-script",
-        default=str(Path(__file__).with_name("refresh-s3-wheel-views.sh")),
-    )
     return parser
 
 
@@ -379,7 +379,7 @@ def main() -> int:
             if deletions:
                 delete_versions(deletions, args.bucket)
             if args.operation == "remove-dev-range":
-                _refresh_views(months, args.refresh_script)
+                _refresh_views(months)
         _write_summary(args.operation, args.dry_run, deletions, months)
         return 0
     except (RuntimeError, subprocess.CalledProcessError) as error:

--- a/.github/scripts/s3-wheel-maintenance.py
+++ b/.github/scripts/s3-wheel-maintenance.py
@@ -21,8 +21,6 @@ from typing import Iterable
 BUCKET = "tenstorrent-pypi"
 PREFIX = "tt-lang/"
 DEV_DATE_RE = re.compile(r"\.dev(?P<date>[0-9]{8})(?:\+[^-]+)?-")
-MONTH_RE = re.compile(r"^[0-9]{4}-(?:0[1-9]|1[0-2])$")
-REFRESH_SCRIPT = Path(__file__).with_name("refresh-s3-wheel-views.sh").resolve()
 CONFIRMATIONS = {
     "deduplicate": "delete-duplicate-versions",
     "remove-dev-range": "delete-dev-versions",
@@ -306,15 +304,11 @@ def _write_summary(
     print("\n".join(lines))
 
 
-def _refresh_views(months: list[str]) -> None:
-    if not months:
-        return
-    if any(MONTH_RE.fullmatch(month) is None for month in months):
-        raise RuntimeError("invalid month passed to S3 wheel view refresh")
-    subprocess.run(
-        [str(REFRESH_SCRIPT), "--months", ",".join(months)],
-        check=True,
-    )
+def _write_outputs(refresh_months: list[str]) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with Path(output_path).open("a") as output:
+            print(f"refresh-months={','.join(refresh_months)}", file=output)
 
 
 def _validate(args: argparse.Namespace) -> None:
@@ -378,11 +372,13 @@ def main() -> int:
         if not args.dry_run:
             if deletions:
                 delete_versions(deletions, args.bucket)
-            if args.operation == "remove-dev-range":
-                _refresh_views(months)
+        refresh_months = (
+            months if args.operation == "remove-dev-range" and not args.dry_run else []
+        )
+        _write_outputs(refresh_months)
         _write_summary(args.operation, args.dry_run, deletions, months)
         return 0
-    except (RuntimeError, subprocess.CalledProcessError) as error:
+    except RuntimeError as error:
         print(error, file=sys.stderr)
         return 1
 

--- a/.github/scripts/s3-wheel-maintenance.py
+++ b/.github/scripts/s3-wheel-maintenance.py
@@ -200,7 +200,12 @@ def _dev_date(key: str) -> datetime.date | None:
     match = DEV_DATE_RE.search(key_path.name)
     if match is None:
         return None
-    return datetime.datetime.strptime(match.group("date"), "%Y%m%d").date()
+    try:
+        return datetime.datetime.strptime(match.group("date"), "%Y%m%d").date()
+    except ValueError:
+        # PEP 440 dev releases are arbitrary integers, even when they contain
+        # eight digits. Only calendar-date dev releases belong to month views.
+        return None
 
 
 def date_range_deletions(
@@ -296,7 +301,12 @@ def _write_summary(
         f"- Selected bytes: `{total_bytes}`",
     ]
     if months:
-        lines.append(f"- Affected month views: `{','.join(months)}`")
+        month_label = (
+            "Affected month views"
+            if operation == "remove-dev-range"
+            else "Duplicate wheel months"
+        )
+        lines.append(f"- {month_label}: `{','.join(months)}`")
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
         with Path(summary_path).open("a") as summary:
@@ -378,7 +388,7 @@ def main() -> int:
         _write_outputs(refresh_months)
         _write_summary(args.operation, args.dry_run, deletions, months)
         return 0
-    except RuntimeError as error:
+    except (RuntimeError, ValueError) as error:
         print(error, file=sys.stderr)
         return 1
 

--- a/.github/scripts/s3-wheel-maintenance.py
+++ b/.github/scripts/s3-wheel-maintenance.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Plan or delete redundant and date-selected S3 wheel object versions."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+BUCKET = "tenstorrent-pypi"
+PREFIX = "tt-lang/"
+DEV_DATE_RE = re.compile(r"\.dev(?P<date>[0-9]{8})(?:\+[^-]+)?-")
+CONFIRMATIONS = {
+    "deduplicate": "delete-duplicate-versions",
+    "remove-dev-range": "delete-dev-versions",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class ObjectVersion:
+    key: str
+    version_id: str
+    last_modified: str
+    size: int | None
+    etag: str | None
+    is_latest: bool
+    is_delete_marker: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class Deletion:
+    version: ObjectVersion
+    reason: str
+    retained_version_id: str | None = None
+
+
+def _bool(value: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
+def _date(value: str) -> datetime.date | None:
+    if value == "":
+        return None
+    try:
+        return datetime.date.fromisoformat(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            f"expected YYYY-MM-DD, got {value!r}"
+        ) from error
+
+
+def _aws(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [os.environ.get("AWS", "aws"), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_aws_json(*args: str) -> dict[str, object]:
+    result = _aws(*args, "--output", "json")
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "AWS CLI command failed")
+    try:
+        value = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"AWS CLI returned invalid JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError("AWS CLI returned non-object JSON")
+    return value
+
+
+def list_object_versions(bucket: str = BUCKET) -> list[ObjectVersion]:
+    versions: list[ObjectVersion] = []
+    key_marker: str | None = None
+    version_id_marker: str | None = None
+
+    while True:
+        arguments = [
+            "s3api",
+            "list-object-versions",
+            "--bucket",
+            bucket,
+            "--prefix",
+            PREFIX,
+        ]
+        if key_marker is not None:
+            arguments.extend(["--key-marker", key_marker])
+        if version_id_marker is not None:
+            arguments.extend(["--version-id-marker", version_id_marker])
+        response = _run_aws_json(*arguments)
+
+        for raw_version in response.get("Versions", []):
+            if not isinstance(raw_version, dict):
+                raise RuntimeError("invalid Versions entry from AWS")
+            versions.append(
+                ObjectVersion(
+                    key=str(raw_version["Key"]),
+                    version_id=str(raw_version["VersionId"]),
+                    last_modified=str(raw_version["LastModified"]),
+                    size=int(raw_version["Size"]),
+                    etag=str(raw_version["ETag"]),
+                    is_latest=bool(raw_version.get("IsLatest", False)),
+                )
+            )
+        for raw_marker in response.get("DeleteMarkers", []):
+            if not isinstance(raw_marker, dict):
+                raise RuntimeError("invalid DeleteMarkers entry from AWS")
+            versions.append(
+                ObjectVersion(
+                    key=str(raw_marker["Key"]),
+                    version_id=str(raw_marker["VersionId"]),
+                    last_modified=str(raw_marker["LastModified"]),
+                    size=None,
+                    etag=None,
+                    is_latest=bool(raw_marker.get("IsLatest", False)),
+                    is_delete_marker=True,
+                )
+            )
+
+        if not response.get("IsTruncated", False):
+            return versions
+        key_marker_value = response.get("NextKeyMarker")
+        version_marker_value = response.get("NextVersionIdMarker")
+        if not key_marker_value or not version_marker_value:
+            raise RuntimeError("truncated AWS response omitted continuation markers")
+        key_marker = str(key_marker_value)
+        version_id_marker = str(version_marker_value)
+
+
+def _newest(versions: Iterable[ObjectVersion]) -> ObjectVersion:
+    return max(
+        versions,
+        key=lambda version: (
+            version.last_modified,
+            version.is_latest,
+            version.version_id,
+        ),
+    )
+
+
+def duplicate_deletions(versions: Iterable[ObjectVersion]) -> list[Deletion]:
+    groups: dict[tuple[str, int, str], list[ObjectVersion]] = collections.defaultdict(
+        list
+    )
+    for version in versions:
+        if (
+            version.is_delete_marker
+            or not version.key.endswith(".whl")
+            or version.size is None
+            or version.etag is None
+        ):
+            continue
+        groups[(version.key, version.size, version.etag)].append(version)
+
+    deletions: list[Deletion] = []
+    for matching_versions in groups.values():
+        if len(matching_versions) < 2:
+            continue
+        retained = _newest(matching_versions)
+        for version in matching_versions:
+            if version.version_id != retained.version_id:
+                deletions.append(
+                    Deletion(
+                        version=version,
+                        reason="duplicate",
+                        retained_version_id=retained.version_id,
+                    )
+                )
+    return sorted(
+        deletions,
+        key=lambda deletion: (
+            deletion.version.key,
+            deletion.version.last_modified,
+            deletion.version.version_id,
+        ),
+    )
+
+
+def _dev_date(key: str) -> datetime.date | None:
+    key_path = PurePosixPath(key)
+    if key_path.parent != PurePosixPath("tt-lang") or key_path.suffix != ".whl":
+        return None
+    match = DEV_DATE_RE.search(key_path.name)
+    if match is None:
+        return None
+    return datetime.datetime.strptime(match.group("date"), "%Y%m%d").date()
+
+
+def date_range_deletions(
+    versions: Iterable[ObjectVersion],
+    start_date: datetime.date,
+    end_date: datetime.date,
+) -> list[Deletion]:
+    deletions = []
+    for version in versions:
+        dev_date = _dev_date(version.key)
+        if dev_date is not None and start_date <= dev_date <= end_date:
+            deletions.append(
+                Deletion(version=version, reason=f"dev-date={dev_date.isoformat()}")
+            )
+    return sorted(
+        deletions,
+        key=lambda deletion: (
+            deletion.version.key,
+            deletion.version.last_modified,
+            deletion.version.version_id,
+        ),
+    )
+
+
+def delete_versions(
+    deletions: list[Deletion],
+    bucket: str = BUCKET,
+) -> None:
+    for offset in range(0, len(deletions), 1000):
+        batch = deletions[offset : offset + 1000]
+        request = {
+            "Objects": [
+                {
+                    "Key": deletion.version.key,
+                    "VersionId": deletion.version.version_id,
+                }
+                for deletion in batch
+            ],
+            "Quiet": True,
+        }
+        response = _run_aws_json(
+            "s3api",
+            "delete-objects",
+            "--bucket",
+            bucket,
+            "--delete",
+            json.dumps(request, separators=(",", ":")),
+        )
+        errors = response.get("Errors", [])
+        if errors:
+            raise RuntimeError(f"S3 version deletion failed: {json.dumps(errors)}")
+
+
+def _affected_months(deletions: Iterable[Deletion]) -> list[str]:
+    months = set()
+    for deletion in deletions:
+        dev_date = _dev_date(deletion.version.key)
+        if dev_date is not None:
+            months.add(dev_date.strftime("%Y-%m"))
+    return sorted(months)
+
+
+def _months_in_range(
+    start_date: datetime.date,
+    end_date: datetime.date,
+) -> list[str]:
+    months = []
+    current_year = start_date.year
+    current_month = start_date.month
+    while (current_year, current_month) <= (end_date.year, end_date.month):
+        months.append(f"{current_year:04d}-{current_month:02d}")
+        if current_month == 12:
+            current_year += 1
+            current_month = 1
+        else:
+            current_month += 1
+    return months
+
+
+def _write_summary(
+    operation: str,
+    dry_run: bool,
+    deletions: list[Deletion],
+    months: list[str],
+) -> None:
+    total_bytes = sum(deletion.version.size or 0 for deletion in deletions)
+    lines = [
+        "### S3 wheel maintenance",
+        "",
+        f"- Operation: `{operation}`",
+        f"- Dry run: `{str(dry_run).lower()}`",
+        f"- Object versions selected: `{len(deletions)}`",
+        f"- Selected bytes: `{total_bytes}`",
+    ]
+    if months:
+        lines.append(f"- Affected month views: `{','.join(months)}`")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with Path(summary_path).open("a") as summary:
+            print("\n".join(lines), file=summary)
+    print("\n".join(lines))
+
+
+def _refresh_views(months: list[str], script: str) -> None:
+    if not months:
+        return
+    subprocess.run(
+        [script, "--months", ",".join(months)],
+        check=True,
+    )
+
+
+def _validate(args: argparse.Namespace) -> None:
+    if args.github_ref != "refs/heads/main":
+        raise RuntimeError(
+            f"S3 wheel maintenance is restricted to refs/heads/main (got {args.github_ref or 'unset'})"
+        )
+    if args.operation == "remove-dev-range":
+        if args.start_date is None or args.end_date is None:
+            raise RuntimeError("remove-dev-range requires --start-date and --end-date")
+        if args.start_date > args.end_date:
+            raise RuntimeError("start date must not be after end date")
+    elif args.start_date is not None or args.end_date is not None:
+        raise RuntimeError("date arguments are valid only for remove-dev-range")
+
+    if not args.dry_run:
+        required_confirmation = CONFIRMATIONS[args.operation]
+        if args.confirm != required_confirmation:
+            raise RuntimeError(
+                f"live {args.operation} requires --confirm {required_confirmation}"
+            )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("operation", choices=("deduplicate", "remove-dev-range"))
+    parser.add_argument("--dry-run", type=_bool, default=True)
+    parser.add_argument("--start-date", type=_date)
+    parser.add_argument("--end-date", type=_date)
+    parser.add_argument("--confirm", default="")
+    parser.add_argument("--github-ref", default=os.environ.get("GITHUB_REF", ""))
+    parser.add_argument("--bucket", default=os.environ.get("TTLANG_S3_BUCKET", BUCKET))
+    parser.add_argument(
+        "--refresh-script",
+        default=str(Path(__file__).with_name("refresh-s3-wheel-views.sh")),
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        _validate(args)
+        versions = list_object_versions(args.bucket)
+        if args.operation == "deduplicate":
+            deletions = duplicate_deletions(versions)
+            months = _affected_months(deletions)
+        else:
+            deletions = date_range_deletions(versions, args.start_date, args.end_date)
+            months = _months_in_range(args.start_date, args.end_date)
+
+        for deletion in deletions:
+            retained = (
+                f" retain={deletion.retained_version_id}"
+                if deletion.retained_version_id
+                else ""
+            )
+            print(
+                f"{'WOULD DELETE' if args.dry_run else 'DELETE'} "
+                f"s3://{args.bucket}/{deletion.version.key}"
+                f"?versionId={deletion.version.version_id} "
+                f"reason={deletion.reason}{retained}"
+            )
+
+        if not args.dry_run:
+            if deletions:
+                delete_versions(deletions, args.bucket)
+            if args.operation == "remove-dev-range":
+                _refresh_views(months, args.refresh_script)
+        _write_summary(args.operation, args.dry_run, deletions, months)
+        return 0
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/summarize-wheel-artifact.sh
+++ b/.github/scripts/summarize-wheel-artifact.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+dry_run=false
+if [ "${1:-}" = --dry-run ]; then
+    dry_run=true
+    shift
+fi
+[ "$#" -eq 1 ] || {
+    echo "Usage: $0 [--dry-run] <dist-dir>" >&2
+    exit 2
+}
+
+dist_dir="$1"
+if [ "$dry_run" = true ]; then
+    echo "Dry run complete; no upload performed."
+fi
+echo "Wheel artifact:"
+ls -lh "$dist_dir"

--- a/.github/scripts/test-manylinux-wheel.sh
+++ b/.github/scripts/test-manylinux-wheel.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install and hardware-test the cp312 core wheel from a shared manylinux wheel
+# artifact.
+
+set -eu
+
+dist_dir=dist
+ttnn_dep_mode=""
+python_bin=/opt/python/cp312-cp312/bin/python
+repo_root="$(git rev-parse --show-toplevel)"
+tutorial_script=""
+
+usage() {
+    echo "Usage: $0 --ttnn-dep-mode pypi|external [--dist-dir <dir>] [--python <path>] [--repo-root <dir>] [--tutorial-script <path>]" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dist-dir)
+            [ "$#" -ge 2 ] || usage
+            dist_dir="$2"
+            shift 2
+            ;;
+        --ttnn-dep-mode)
+            [ "$#" -ge 2 ] || usage
+            ttnn_dep_mode="$2"
+            shift 2
+            ;;
+        --python)
+            [ "$#" -ge 2 ] || usage
+            python_bin="$2"
+            shift 2
+            ;;
+        --repo-root)
+            [ "$#" -ge 2 ] || usage
+            repo_root="$2"
+            shift 2
+            ;;
+        --tutorial-script)
+            [ "$#" -ge 2 ] || usage
+            tutorial_script="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+case "$ttnn_dep_mode" in
+    pypi | external) ;;
+    *) usage ;;
+esac
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+tutorial_script="${tutorial_script:-$script_dir/run-tutorials.sh}"
+core_wheel="$(find "$dist_dir" -maxdepth 1 -type f \
+    -name 'tt_lang-*-cp312-cp312-manylinux_2_34_x86_64.whl' \
+    -print -quit)"
+if [ -z "$core_wheel" ]; then
+    echo "cp312 manylinux_2_34 tt-lang wheel not found in $dist_dir" >&2
+    exit 1
+fi
+
+test_venv="$(mktemp -d /tmp/test-manylinux-wheel.XXXXXX)"
+trap 'rm -rf "$test_venv"' EXIT
+"$python_bin" -m venv "$test_venv"
+test_python="$test_venv/bin/python"
+
+"$test_python" -m pip install \
+    --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/cpu \
+    "$core_wheel"
+"$test_python" "$script_dir/check-installed-ttnn.py" --mode "$ttnn_dep_mode"
+"$test_python" "$script_dir/smoke-test-wheel.py"
+
+if [ ! -x "$test_venv/bin/tt-triage" ]; then
+    echo "tt-triage was not installed by $core_wheel" >&2
+    exit 1
+fi
+
+PATH="$test_venv/bin:$PATH" "$tutorial_script" "$repo_root"

--- a/.github/scripts/test-manylinux-wheel.sh
+++ b/.github/scripts/test-manylinux-wheel.sh
@@ -11,7 +11,7 @@ set -eu
 dist_dir=dist
 ttnn_dep_mode=""
 python_bin=/opt/python/cp312-cp312/bin/python
-repo_root="$(git rev-parse --show-toplevel)"
+repo_root=""
 tutorial_script=""
 
 usage() {
@@ -58,6 +58,7 @@ case "$ttnn_dep_mode" in
 esac
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="${repo_root:-$(git rev-parse --show-toplevel)}"
 tutorial_script="${tutorial_script:-$script_dir/run-tutorials.sh}"
 core_wheel="$(find "$dist_dir" -maxdepth 1 -type f \
     -name 'tt_lang-*-cp312-cp312-manylinux_2_34_x86_64.whl' \

--- a/.github/scripts/test-manylinux-wheel.sh
+++ b/.github/scripts/test-manylinux-wheel.sh
@@ -58,7 +58,13 @@ case "$ttnn_dep_mode" in
 esac
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-repo_root="${repo_root:-$(git rev-parse --show-toplevel)}"
+if [ -z "$repo_root" ]; then
+    if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+        repo_root="$GITHUB_WORKSPACE"
+    else
+        repo_root="$(git rev-parse --show-toplevel)"
+    fi
+fi
 tutorial_script="${tutorial_script:-$script_dir/run-tutorials.sh}"
 core_wheel="$(find "$dist_dir" -maxdepth 1 -type f \
     -name 'tt_lang-*-cp312-cp312-manylinux_2_34_x86_64.whl' \

--- a/.github/scripts/test-manylinux-wheel.sh
+++ b/.github/scripts/test-manylinux-wheel.sh
@@ -84,6 +84,9 @@ test_python="$test_venv/bin/python"
     --extra-index-url https://download.pytorch.org/whl/cpu \
     "$core_wheel"
 "$test_python" "$script_dir/check-installed-ttnn.py" --mode "$ttnn_dep_mode"
+if [ "$ttnn_dep_mode" = pypi ]; then
+    "$test_venv/bin/tt-lang-setup-sfpi"
+fi
 "$test_python" "$script_dir/smoke-test-wheel.py"
 
 if [ ! -x "$test_venv/bin/tt-triage" ]; then

--- a/.github/scripts/test-s3-light-wheels.sh
+++ b/.github/scripts/test-s3-light-wheels.sh
@@ -57,8 +57,9 @@ if [ -z "$VERSION" ]; then
 fi
 
 repo_root="$(git rev-parse --show-toplevel)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/docker-image-utils.sh
-. "$repo_root/.github/scripts/lib/docker-image-utils.sh"
+. "$script_dir/lib/docker-image-utils.sh"
 docker_tag="${DOCKER_TAG:-$("$repo_root/.github/containers/get-version-tag.sh")}"
 dist_dir="$(cd "$DIST_DIR" && pwd)"
 
@@ -72,6 +73,7 @@ for python_tag in $python_tags; do
     ttlang_docker run --rm \
         -v "$repo_root:/workspace" \
         -v "$dist_dir:/dist" \
+        -v "$script_dir:/workflow-scripts:ro" \
         -w /workspace \
         -e "PYTHON_TAG=$python_tag" \
         -e "TTLANG_VERSION=$VERSION" \
@@ -88,7 +90,7 @@ for python_tag in $python_tags; do
             --find-links=/dist \
             --extra-index-url https://download.pytorch.org/whl/cpu \
             "tt-lang-light==${TTLANG_VERSION}"
-          python .github/scripts/check-installed-ttnn.py --mode external
-          python .github/scripts/smoke-test-wheel.py
+          python /workflow-scripts/check-installed-ttnn.py --mode external
+          python /workflow-scripts/smoke-test-wheel.py
         '
 done

--- a/.github/scripts/tests/test_build_and_install.bats
+++ b/.github/scripts/tests/test_build_and_install.bats
@@ -79,8 +79,10 @@ run_script_default_build_dir() {
     : > "$(cmake_log)"
     : > "$(bash_log)"
     setup_stubs
-    create_build_env build-toolchain
-    create_build_env build
+    if [ "${CREATE_BUILD_ENV:-true}" = true ]; then
+        create_build_env build-toolchain
+        create_build_env build
+    fi
     mkdir -p "$BATS_TEST_TMPDIR/toolchain"
     mkdir -p "$BATS_TEST_TMPDIR/home"
 
@@ -216,26 +218,31 @@ setup() {
     [[ ! -s "$(cmake_log)" ]]
 }
 
-@test "llvm-toolchain-only requires external tt-metal directory" {
-    run run_script_default_build_dir --llvm-toolchain-only
-    assert_failure
-    assert_output --partial "ERROR: --llvm-toolchain-only requires --external-tt-metal-dir"
-    [[ ! -s "$(cmake_log)" ]]
-}
-
 @test "llvm-toolchain-only configures LLVM without installing tt-metal" {
-    run run_script_default_build_dir \
+    CREATE_BUILD_ENV=false run run_script_default_build_dir \
         --llvm-toolchain-only \
-        --force-rebuild \
-        --external-tt-metal-dir "$BATS_TEST_TMPDIR/external-metal"
+        --force-rebuild
     assert_success
     grep -q '^-B$' "$(cmake_log)"
     grep -q '^build-toolchain$' "$(cmake_log)"
     grep -q '^-DTTLANG_FORCE_TOOLCHAIN_REBUILD=ON$' "$(cmake_log)"
-    grep -q '^-DTTLANG_BUILD_TOOLCHAIN=OFF$' "$(cmake_log)"
-    grep -q "^-DTTLANG_EXTERNAL_TT_METAL_DIR=$BATS_TEST_TMPDIR/external-metal$" "$(cmake_log)"
+    grep -q '^-DTTLANG_BUILD_TOOLCHAIN=ON$' "$(cmake_log)"
+    grep -q '^-DTTLANG_TOOLCHAIN_COMPONENT=llvm$' "$(cmake_log)"
     ! grep -q 'scripts/install-ttmetal.sh' "$(bash_log)"
     assert_output --partial "=== LLVM toolchain build complete ==="
+}
+
+@test "ttmetal-toolchain-only configures tt-metal without installing it twice" {
+    CREATE_BUILD_ENV=false run run_script_default_build_dir \
+        --ttmetal-toolchain-only \
+        --force-rebuild
+    assert_success
+    grep -q '^-B$' "$(cmake_log)"
+    grep -q '^build-toolchain$' "$(cmake_log)"
+    grep -q '^-DTTLANG_BUILD_TOOLCHAIN=ON$' "$(cmake_log)"
+    grep -q '^-DTTLANG_TOOLCHAIN_COMPONENT=tt-metal$' "$(cmake_log)"
+    ! grep -q 'scripts/install-ttmetal.sh' "$(bash_log)"
+    assert_output --partial "=== tt-metal toolchain build complete ==="
 }
 
 @test "unknown flag aborts with a non-zero exit" {

--- a/.github/scripts/tests/test_docker_image_utils.bats
+++ b/.github/scripts/tests/test_docker_image_utils.bats
@@ -101,6 +101,20 @@ EOF
     assert_output --partial "Usage: ttlang_wheel_builder_image"
 }
 
+@test "ttlang_wheel_builder_registry_image uses an explicit registry" {
+    run bash -c "source '$LIB'; ttlang_wheel_builder_registry_image cp312 some-tag ghcr.io/example/project"
+
+    assert_success
+    assert_output "ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp312:some-tag"
+}
+
+@test "ttlang_wheel_builder_registry_image rejects unsupported Python tags" {
+    run bash -c "source '$LIB'; ttlang_wheel_builder_registry_image cp311 some-tag"
+
+    assert_failure
+    assert_output --partial "Unsupported Python tag: cp311"
+}
+
 @test "ttlang_python_tags validates and lists every requested tag" {
     run bash -c "source '$LIB'; ttlang_python_tags cp310,cp312"
 

--- a/.github/scripts/tests/test_docker_image_utils.bats
+++ b/.github/scripts/tests/test_docker_image_utils.bats
@@ -22,6 +22,24 @@ EOF
     export DOCKER="$MOCK_DOCKER"
 }
 
+@test "ttlang_validate_docker_tag accepts the registry tag grammar" {
+    run bash -c "source '$LIB'; ttlang_validate_docker_tag 'v1.2.3_rc1-build'"
+
+    assert_success
+}
+
+@test "ttlang_validate_docker_tag rejects unsafe and oversized values" {
+    run bash -c "source '$LIB'; ttlang_validate_docker_tag 'bad/tag'"
+    assert_failure
+
+    run bash -c "source '$LIB'; ttlang_validate_docker_tag '-bad'"
+    assert_failure
+
+    long_tag="$(printf 'a%.0s' {1..129})"
+    run bash -c "source '$LIB'; ttlang_validate_docker_tag '$long_tag'"
+    assert_failure
+}
+
 @test "ttlang_image_for_tag prefers a local image when it exists" {
     write_mock_docker 0
 

--- a/.github/scripts/tests/test_get_version_tag.bats
+++ b/.github/scripts/tests/test_get_version_tag.bats
@@ -69,6 +69,10 @@ container_input_one_path() {
     container_input_one_path "third-party/tt-metal-version"
 }
 
+@test "container input change in CMakeLists.txt -> -<hash> form" {
+    container_input_one_path "CMakeLists.txt"
+}
+
 @test "container input change in third-party/llvm-project/sentinel -> -<hash> form" {
     container_input_one_path "third-party/llvm-project/sentinel"
 }
@@ -256,14 +260,32 @@ container_input_one_path() {
     cat > "$REPO/.github/scripts/uplift-paths.sh" <<'EOF'
 #!/bin/bash
 UPLIFT_PATHS=(
+    scripts/install-ttmetal.sh
+    scripts/copy-ttmetal-runtime-artifacts.sh
+    scripts/build-and-install.sh
     requirements-runtime.txt
+    requirements.txt
     bin/tt-triage
+    .github/scripts/normalize-toolchain-install.sh
+    .github/containers/cleanup-toolchain.sh
     .github/containers/Dockerfile
     .github/containers/Dockerfile.base
     .github/containers/Dockerfile.wheel-manylinux-2-34
+    .github/containers/CMakeLists.wheel-toolchain
+    third-party/patches
     third-party/tt-metal
     third-party/llvm-project
     third-party/tt-metal-version
+    cmake/modules/TTLangUtils.cmake
+    cmake/modules/TTLangPython.cmake
+    cmake/modules/TTLangCompilerSetup.cmake
+    cmake/modules/TTLangToolchainOptions.cmake
+    cmake/modules/TTLangToolchainComponent.cmake
+    cmake/modules/GetVersionFromGit.cmake
+    cmake/modules/BuildTTMetal.cmake
+    cmake/modules/BuildLLVM.cmake
+    CMakeLists.txt
+    .dockerignore
 )
 EOF
     tag_reversed=$(get_tag "$REPO")

--- a/.github/scripts/tests/test_helper.bash
+++ b/.github/scripts/tests/test_helper.bash
@@ -89,11 +89,17 @@ mkrepo() {
             "$TEST_TT_METAL_TAG"
         echo "llvm-content-v1" > third-party/llvm-project/sentinel
         echo "tt-metal-content-v1" > third-party/tt-metal/sentinel
+        echo "cmake_minimum_required(VERSION 3.28)" > CMakeLists.txt
         cat > .github/containers/Dockerfile.base <<'EOF'
 FROM ubuntu:24.04
 RUN echo "base v1"
 EOF
+        cat > .github/containers/CMakeLists.wheel-toolchain <<'EOF'
+cmake_minimum_required(VERSION 3.28)
+project(test-wheel-toolchain)
+EOF
         echo "tt-triage launcher" > bin/tt-triage
+        echo "-r requirements-runtime.txt" > requirements.txt
         echo "greenlet>=3.0.0" > requirements-runtime.txt
         echo "// kernel placeholder" > python/sim/example.py
         git add -A

--- a/.github/scripts/tests/test_manylinux_workflow_scripts.bats
+++ b/.github/scripts/tests/test_manylinux_workflow_scripts.bats
@@ -33,8 +33,15 @@ if [ "$1 $2" = "-m venv" ]; then
     venv_dir="$3"
     mkdir -p "$venv_dir/bin"
     cp "$0" "$venv_dir/bin/python"
+    cat > "$venv_dir/bin/tt-lang-setup-sfpi" <<'MOCK'
+#!/bin/sh
+echo called >> "$FAKE_SFPI_CALLS"
+MOCK
     : > "$venv_dir/bin/tt-triage"
-    chmod +x "$venv_dir/bin/python" "$venv_dir/bin/tt-triage"
+    chmod +x \
+        "$venv_dir/bin/python" \
+        "$venv_dir/bin/tt-lang-setup-sfpi" \
+        "$venv_dir/bin/tt-triage"
 fi
 exit 0
 EOF
@@ -53,8 +60,10 @@ printf '%s\n' "$*" >> "$FAKE_TUTORIAL_CALLS"
 EOF
     chmod +x "$hardware_tutorial_mock"
     export FAKE_PYTHON_CALLS="$BATS_TEST_TMPDIR/python.calls"
+    export FAKE_SFPI_CALLS="$BATS_TEST_TMPDIR/sfpi.calls"
     export FAKE_TUTORIAL_CALLS="$BATS_TEST_TMPDIR/tutorial.calls"
     : > "$FAKE_PYTHON_CALLS"
+    : > "$FAKE_SFPI_CALLS"
     : > "$FAKE_TUTORIAL_CALLS"
     hardware_outside_repo="$BATS_TEST_TMPDIR/outside-repo"
     mkdir -p "$hardware_outside_repo"
@@ -63,6 +72,7 @@ EOF
 
 run_hardware_wheel_test() {
     local resolution_mode="$1"
+    local ttnn_dep_mode="${2:-pypi}"
     local github_workspace=""
     local -a repo_root_args=()
     case "$resolution_mode" in
@@ -73,11 +83,12 @@ run_hardware_wheel_test() {
 
     run env \
         FAKE_PYTHON_CALLS="$FAKE_PYTHON_CALLS" \
+        FAKE_SFPI_CALLS="$FAKE_SFPI_CALLS" \
         FAKE_TUTORIAL_CALLS="$FAKE_TUTORIAL_CALLS" \
         GITHUB_WORKSPACE="$github_workspace" \
         "$SCRIPTS_DIR/test-manylinux-wheel.sh" \
             --dist-dir "$hardware_wheel_dir" \
-            --ttnn-dep-mode pypi \
+            --ttnn-dep-mode "$ttnn_dep_mode" \
             --python "$hardware_python_mock" \
             --tutorial-script "$hardware_tutorial_mock" \
             "${repo_root_args[@]}"
@@ -416,8 +427,18 @@ EOF
     assert_success
     grep -q -- "-m pip install .*tt_lang-1.2.3-cp312" "$FAKE_PYTHON_CALLS"
     grep -q -- "check-installed-ttnn.py --mode pypi" "$FAKE_PYTHON_CALLS"
+    grep -qx called "$FAKE_SFPI_CALLS"
     grep -q -- "smoke-test-wheel.py" "$FAKE_PYTHON_CALLS"
     grep -qx "$TTLANG_REPO_ROOT" "$FAKE_TUTORIAL_CALLS"
+}
+
+@test "hardware wheel test skips sfpi setup for external ttnn" {
+    setup_hardware_wheel_test
+    run_hardware_wheel_test explicit external
+
+    assert_success
+    grep -q -- "check-installed-ttnn.py --mode external" "$FAKE_PYTHON_CALLS"
+    test ! -s "$FAKE_SFPI_CALLS"
 }
 
 @test "hardware wheel test script uses GitHub workspace outside a Git checkout" {

--- a/.github/scripts/tests/test_manylinux_workflow_scripts.bats
+++ b/.github/scripts/tests/test_manylinux_workflow_scripts.bats
@@ -70,7 +70,7 @@ setup() {
     grep -q 'All images exist: `false`' "$summary_file"
 }
 
-@test "builder resolver updates both latest tags on main" {
+@test "builder resolver reports latest publication policy without mutation" {
     output_file="$BATS_TEST_TMPDIR/output"
 
     run env \
@@ -83,9 +83,40 @@ setup() {
 
     assert_success
     grep -qx 'all-images-exist=true' "$output_file"
+    grep -qx 'update-latest=true' "$output_file"
+    ! grep -q '^buildx imagetools create' "$FAKE_DOCKER_CALLS"
+}
+
+@test "latest publisher updates both ABI manifests" {
+    run env DOCKER="$DOCKER_MOCK" \
+        "$SCRIPTS_DIR/publish-wheel-builder-latest.sh" \
+            --repository example/project \
+            --docker-tag test-tag
+
+    assert_success
     run grep -c '^buildx imagetools create -t .*:latest .*:test-tag$' "$FAKE_DOCKER_CALLS"
     assert_success
     assert_output "2"
+    grep -qx \
+        'buildx imagetools create -t ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp310:latest ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp310:test-tag' \
+        "$FAKE_DOCKER_CALLS"
+    grep -qx \
+        'buildx imagetools create -t ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp312:latest ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp312:test-tag' \
+        "$FAKE_DOCKER_CALLS"
+}
+
+@test "latest publisher makes no changes when an ABI image is missing" {
+    run env \
+        DOCKER="$DOCKER_MOCK" \
+        FAKE_MISSING_IMAGE=cp312 \
+        "$SCRIPTS_DIR/publish-wheel-builder-latest.sh" \
+            --repository example/project \
+            --docker-tag test-tag
+
+    assert_failure
+    assert_output --partial \
+        "Required image does not exist: ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp312:test-tag"
+    ! grep -q '^buildx imagetools create' "$FAKE_DOCKER_CALLS"
 }
 
 @test "builder resolver distinguishes an older target from workflow source" {
@@ -253,6 +284,37 @@ EOF
     assert_output --partial "Unexpected manylinux wheel: unrelated-1.0-py3-none-any.whl"
 }
 
+@test "wheel-set verification rejects an incomplete ABI set" {
+    wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3-cp312-cp312-manylinux_2_34_x86_64.whl)"
+
+    run "$SCRIPTS_DIR/verify-manylinux-wheel-set.sh" \
+        --ttnn-dep-mode pypi \
+        --build-sim false \
+        1.2.3 \
+        "$wheel_dir"
+
+    assert_failure
+    assert_output --partial \
+        "Expected manylinux wheel was not produced: tt_lang-1.2.3-cp310-cp310-manylinux_2_34_x86_64.whl"
+}
+
+@test "wheel-set verification requires the light metapackage in external mode" {
+    wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3.dev20260726+light-cp310-cp310-manylinux_2_34_x86_64.whl \
+        tt_lang-1.2.3.dev20260726+light-cp312-cp312-manylinux_2_34_x86_64.whl)"
+
+    run "$SCRIPTS_DIR/verify-manylinux-wheel-set.sh" \
+        --ttnn-dep-mode external \
+        --build-sim false \
+        1.2.3.dev20260726 \
+        "$wheel_dir"
+
+    assert_failure
+    assert_output --partial \
+        "Expected manylinux wheel was not produced: tt_lang_light-1.2.3.dev20260726-py3-none-any.whl"
+}
+
 @test "component cache exporter keeps LLVM and tt-metal cache references separate" {
     repo="$(mkrepo)"
     cd "$repo"
@@ -320,6 +382,9 @@ EOF
     export FAKE_TUTORIAL_CALLS="$BATS_TEST_TMPDIR/tutorial.calls"
     : > "$FAKE_PYTHON_CALLS"
     : > "$FAKE_TUTORIAL_CALLS"
+    outside_repo="$BATS_TEST_TMPDIR/outside-repo"
+    mkdir -p "$outside_repo"
+    cd "$outside_repo"
 
     run env \
         FAKE_PYTHON_CALLS="$FAKE_PYTHON_CALLS" \

--- a/.github/scripts/tests/test_manylinux_workflow_scripts.bats
+++ b/.github/scripts/tests/test_manylinux_workflow_scripts.bats
@@ -42,6 +42,47 @@ EOF
     echo "$mock"
 }
 
+setup_hardware_wheel_test() {
+    hardware_wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3-cp312-cp312-manylinux_2_34_x86_64.whl)"
+    hardware_python_mock="$(make_python_mock)"
+    hardware_tutorial_mock="$BATS_TEST_TMPDIR/tutorial"
+    cat > "$hardware_tutorial_mock" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_TUTORIAL_CALLS"
+EOF
+    chmod +x "$hardware_tutorial_mock"
+    export FAKE_PYTHON_CALLS="$BATS_TEST_TMPDIR/python.calls"
+    export FAKE_TUTORIAL_CALLS="$BATS_TEST_TMPDIR/tutorial.calls"
+    : > "$FAKE_PYTHON_CALLS"
+    : > "$FAKE_TUTORIAL_CALLS"
+    hardware_outside_repo="$BATS_TEST_TMPDIR/outside-repo"
+    mkdir -p "$hardware_outside_repo"
+    cd "$hardware_outside_repo"
+}
+
+run_hardware_wheel_test() {
+    local resolution_mode="$1"
+    local github_workspace=""
+    local -a repo_root_args=()
+    case "$resolution_mode" in
+        explicit) repo_root_args=(--repo-root "$TTLANG_REPO_ROOT") ;;
+        github-workspace) github_workspace="$TTLANG_REPO_ROOT" ;;
+        *) return 2 ;;
+    esac
+
+    run env \
+        FAKE_PYTHON_CALLS="$FAKE_PYTHON_CALLS" \
+        FAKE_TUTORIAL_CALLS="$FAKE_TUTORIAL_CALLS" \
+        GITHUB_WORKSPACE="$github_workspace" \
+        "$SCRIPTS_DIR/test-manylinux-wheel.sh" \
+            --dist-dir "$hardware_wheel_dir" \
+            --ttnn-dep-mode pypi \
+            --python "$hardware_python_mock" \
+            --tutorial-script "$hardware_tutorial_mock" \
+            "${repo_root_args[@]}"
+}
+
 setup() {
     export FAKE_DOCKER_CALLS="$BATS_TEST_TMPDIR/docker.calls"
     : > "$FAKE_DOCKER_CALLS"
@@ -369,37 +410,21 @@ EOF
 }
 
 @test "hardware wheel test script orchestrates install and tutorials" {
-    wheel_dir="$(make_wheel_dir \
-        tt_lang-1.2.3-cp312-cp312-manylinux_2_34_x86_64.whl)"
-    python_mock="$(make_python_mock)"
-    tutorial_mock="$BATS_TEST_TMPDIR/tutorial"
-    cat > "$tutorial_mock" <<'EOF'
-#!/bin/sh
-printf '%s\n' "$*" >> "$FAKE_TUTORIAL_CALLS"
-EOF
-    chmod +x "$tutorial_mock"
-    export FAKE_PYTHON_CALLS="$BATS_TEST_TMPDIR/python.calls"
-    export FAKE_TUTORIAL_CALLS="$BATS_TEST_TMPDIR/tutorial.calls"
-    : > "$FAKE_PYTHON_CALLS"
-    : > "$FAKE_TUTORIAL_CALLS"
-    outside_repo="$BATS_TEST_TMPDIR/outside-repo"
-    mkdir -p "$outside_repo"
-    cd "$outside_repo"
-
-    run env \
-        FAKE_PYTHON_CALLS="$FAKE_PYTHON_CALLS" \
-        FAKE_TUTORIAL_CALLS="$FAKE_TUTORIAL_CALLS" \
-        "$SCRIPTS_DIR/test-manylinux-wheel.sh" \
-            --dist-dir "$wheel_dir" \
-            --ttnn-dep-mode pypi \
-            --python "$python_mock" \
-            --repo-root "$TTLANG_REPO_ROOT" \
-            --tutorial-script "$tutorial_mock"
+    setup_hardware_wheel_test
+    run_hardware_wheel_test explicit
 
     assert_success
     grep -q -- "-m pip install .*tt_lang-1.2.3-cp312" "$FAKE_PYTHON_CALLS"
     grep -q -- "check-installed-ttnn.py --mode pypi" "$FAKE_PYTHON_CALLS"
     grep -q -- "smoke-test-wheel.py" "$FAKE_PYTHON_CALLS"
+    grep -qx "$TTLANG_REPO_ROOT" "$FAKE_TUTORIAL_CALLS"
+}
+
+@test "hardware wheel test script uses GitHub workspace outside a Git checkout" {
+    setup_hardware_wheel_test
+    run_hardware_wheel_test github-workspace
+
+    assert_success
     grep -qx "$TTLANG_REPO_ROOT" "$FAKE_TUTORIAL_CALLS"
 }
 

--- a/.github/scripts/tests/test_manylinux_workflow_scripts.bats
+++ b/.github/scripts/tests/test_manylinux_workflow_scripts.bats
@@ -1,0 +1,352 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for the scripts that implement the shared manylinux wheel workflows.
+
+load test_helper
+
+make_docker_mock() {
+    local mock="$BATS_TEST_TMPDIR/fake-docker"
+    cat > "$mock" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_DOCKER_CALLS"
+if [ "$1 $2" = "manifest inspect" ]; then
+    case "$*" in
+        *"${FAKE_MISSING_IMAGE:-__none__}"*) exit 1 ;;
+        *) exit 0 ;;
+    esac
+fi
+exit 0
+EOF
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+make_python_mock() {
+    local mock="$BATS_TEST_TMPDIR/fake-python"
+    cat > "$mock" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_PYTHON_CALLS"
+if [ "$1 $2" = "-m venv" ]; then
+    venv_dir="$3"
+    mkdir -p "$venv_dir/bin"
+    cp "$0" "$venv_dir/bin/python"
+    : > "$venv_dir/bin/tt-triage"
+    chmod +x "$venv_dir/bin/python" "$venv_dir/bin/tt-triage"
+fi
+exit 0
+EOF
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+setup() {
+    export FAKE_DOCKER_CALLS="$BATS_TEST_TMPDIR/docker.calls"
+    : > "$FAKE_DOCKER_CALLS"
+    DOCKER_MOCK="$(make_docker_mock)"
+}
+
+@test "builder resolver reports a missing ABI image" {
+    output_file="$BATS_TEST_TMPDIR/output"
+    summary_file="$BATS_TEST_TMPDIR/summary"
+
+    run env \
+        DOCKER="$DOCKER_MOCK" \
+        FAKE_MISSING_IMAGE=cp312 \
+        GITHUB_OUTPUT="$output_file" \
+        GITHUB_STEP_SUMMARY="$summary_file" \
+        GITHUB_REF=refs/heads/feature \
+        "$SCRIPTS_DIR/resolve-wheel-builder-images.sh" \
+            --repository example/project \
+            --docker-tag test-tag
+
+    assert_success
+    assert_output --partial "Image exists: ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp310:test-tag"
+    assert_output --partial "Image missing: ghcr.io/example/project/tt-lang-wheel-manylinux-2-34-cp312:test-tag"
+    grep -qx 'docker-tag=test-tag' "$output_file"
+    grep -qx 'all-images-exist=false' "$output_file"
+    grep -q 'All images exist: `false`' "$summary_file"
+}
+
+@test "builder resolver updates both latest tags on main" {
+    output_file="$BATS_TEST_TMPDIR/output"
+
+    run env \
+        DOCKER="$DOCKER_MOCK" \
+        GITHUB_OUTPUT="$output_file" \
+        GITHUB_REF=refs/heads/main \
+        "$SCRIPTS_DIR/resolve-wheel-builder-images.sh" \
+            --repository example/project \
+            --docker-tag test-tag
+
+    assert_success
+    grep -qx 'all-images-exist=true' "$output_file"
+    run grep -c '^buildx imagetools create -t .*:latest .*:test-tag$' "$FAKE_DOCKER_CALLS"
+    assert_success
+    assert_output "2"
+}
+
+@test "builder resolver distinguishes an older target from workflow source" {
+    target_repo="$(mkrepo)"
+    install_scripts_in_repo "$target_repo"
+    (cd "$target_repo" && git tag v99.99.99)
+    workflow_repo="$(mkrepo)"
+    echo "workflow change" >> "$workflow_repo/CMakeLists.txt"
+    commit_all "$workflow_repo" "workflow change"
+    workflow_sha="$(git -C "$workflow_repo" rev-parse --short=8 HEAD)"
+    output_file="$BATS_TEST_TMPDIR/output"
+
+    cd "$target_repo"
+    run env \
+        DOCKER="$DOCKER_MOCK" \
+        GITHUB_OUTPUT="$output_file" \
+        GITHUB_REF=refs/heads/main \
+        "$SCRIPTS_DIR/resolve-wheel-builder-images.sh" \
+            --repository example/project \
+            --workflow-source "$workflow_repo"
+
+    assert_success
+    grep -Eq "^docker-tag=v99\\.99\\.99-wf${workflow_sha}$" "$output_file"
+    grep -qx 'update-latest=false' "$output_file"
+    ! grep -q '^buildx imagetools create' "$FAKE_DOCKER_CALLS"
+}
+
+@test "manylinux input validation accepts supported dependency modes" {
+    run "$SCRIPTS_DIR/validate-manylinux-wheel-inputs.sh" pypi 1.2.3
+    assert_success
+
+    run "$SCRIPTS_DIR/validate-manylinux-wheel-inputs.sh" \
+        external \
+        1.2.3.dev20260726
+    assert_success
+}
+
+@test "manylinux input validation rejects unknown dependency modes" {
+    run "$SCRIPTS_DIR/validate-manylinux-wheel-inputs.sh" bundled 1.2.3
+    assert_failure 2
+    assert_output --partial "ttnn_dep_mode must be pypi or external"
+}
+
+@test "S3 light compatibility entry point selects external-ttnn mode" {
+    shadow_dir="$BATS_TEST_TMPDIR/shadow"
+    mkdir -p "$shadow_dir"
+    cp "$SCRIPTS_DIR/build-s3-light-core-wheel.sh" "$shadow_dir/"
+    cat > "$shadow_dir/build-manylinux-core-wheel.sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" > "$BUILD_MEMBER_CALLS"
+EOF
+    chmod +x "$shadow_dir"/*.sh
+    export BUILD_MEMBER_CALLS="$BATS_TEST_TMPDIR/member.calls"
+
+    run "$shadow_dir/build-s3-light-core-wheel.sh" \
+        --python-tag cp312 \
+        --version 1.2.3 \
+        --dist-dir dist
+
+    assert_success
+    run cat "$BUILD_MEMBER_CALLS"
+    assert_output "--ttnn-dep-mode external --python-tag cp312 --version 1.2.3 --dist-dir dist"
+}
+
+@test "wheel-set member builds only the core wheel for cp310" {
+    shadow_dir="$BATS_TEST_TMPDIR/shadow"
+    mkdir -p "$shadow_dir"
+    cp "$SCRIPTS_DIR/build-manylinux-wheel-set-member.sh" "$shadow_dir/"
+    cat > "$shadow_dir/build-manylinux-core-wheel.sh" <<'EOF'
+#!/bin/sh
+printf 'core %s\n' "$*" >> "$BUILD_MEMBER_CALLS"
+EOF
+    cat > "$shadow_dir/build-s3-light-metapackage-wheel.sh" <<'EOF'
+#!/bin/sh
+printf 'meta %s\n' "$*" >> "$BUILD_MEMBER_CALLS"
+EOF
+    chmod +x "$shadow_dir"/*.sh
+    export BUILD_MEMBER_CALLS="$BATS_TEST_TMPDIR/member.calls"
+
+    run "$shadow_dir/build-manylinux-wheel-set-member.sh" \
+        --python-tag cp310 \
+        --version 1.2.3 \
+        --ttnn-dep-mode pypi \
+        --build-sim true \
+        --dist-dir dist
+
+    assert_success
+    run cat "$BUILD_MEMBER_CALLS"
+    assert_line "core --python-tag cp310 --version 1.2.3 --ttnn-dep-mode pypi --dist-dir dist"
+    refute_output --partial "meta"
+}
+
+@test "external cp312 wheel-set member adds only the light metapackage when sim is disabled" {
+    shadow_dir="$BATS_TEST_TMPDIR/shadow"
+    mkdir -p "$shadow_dir"
+    cp "$SCRIPTS_DIR/build-manylinux-wheel-set-member.sh" "$shadow_dir/"
+    cat > "$shadow_dir/build-manylinux-core-wheel.sh" <<'EOF'
+#!/bin/sh
+printf 'core %s\n' "$*" >> "$BUILD_MEMBER_CALLS"
+EOF
+    cat > "$shadow_dir/build-s3-light-metapackage-wheel.sh" <<'EOF'
+#!/bin/sh
+printf 'meta %s\n' "$*" >> "$BUILD_MEMBER_CALLS"
+EOF
+    chmod +x "$shadow_dir"/*.sh
+    export BUILD_MEMBER_CALLS="$BATS_TEST_TMPDIR/member.calls"
+
+    run "$shadow_dir/build-manylinux-wheel-set-member.sh" \
+        --python-tag cp312 \
+        --version 1.2.3.dev20260726 \
+        --ttnn-dep-mode external \
+        --build-sim false \
+        --dist-dir dist
+
+    assert_success
+    run cat "$BUILD_MEMBER_CALLS"
+    assert_line "core --python-tag cp312 --version 1.2.3.dev20260726 --ttnn-dep-mode external --dist-dir dist"
+    assert_line "meta --version 1.2.3.dev20260726 --dist-dir dist"
+}
+
+@test "wheel-set verification accepts a complete public PyPI set" {
+    wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3-cp310-cp310-manylinux_2_34_x86_64.whl \
+        tt_lang-1.2.3-cp312-cp312-manylinux_2_34_x86_64.whl \
+        tt_lang_sim-1.2.3-py3-none-any.whl)"
+
+    run "$SCRIPTS_DIR/verify-manylinux-wheel-set.sh" \
+        --ttnn-dep-mode pypi \
+        --build-sim true \
+        1.2.3 \
+        "$wheel_dir"
+
+    assert_success
+}
+
+@test "wheel-set verification accepts a complete external-ttnn set without sim" {
+    wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3.dev20260726+light-cp310-cp310-manylinux_2_34_x86_64.whl \
+        tt_lang-1.2.3.dev20260726+light-cp312-cp312-manylinux_2_34_x86_64.whl \
+        tt_lang_light-1.2.3.dev20260726-py3-none-any.whl)"
+
+    run "$SCRIPTS_DIR/verify-manylinux-wheel-set.sh" \
+        --ttnn-dep-mode external \
+        --build-sim false \
+        1.2.3.dev20260726 \
+        "$wheel_dir"
+
+    assert_success
+}
+
+@test "wheel-set verification rejects unexpected files" {
+    wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3-cp310-cp310-manylinux_2_34_x86_64.whl \
+        tt_lang-1.2.3-cp312-cp312-manylinux_2_34_x86_64.whl \
+        tt_lang_sim-1.2.3-py3-none-any.whl \
+        unrelated-1.0-py3-none-any.whl)"
+
+    run "$SCRIPTS_DIR/verify-manylinux-wheel-set.sh" \
+        --ttnn-dep-mode pypi \
+        --build-sim true \
+        1.2.3 \
+        "$wheel_dir"
+
+    assert_failure
+    assert_output --partial "Unexpected manylinux wheel: unrelated-1.0-py3-none-any.whl"
+}
+
+@test "component cache exporter keeps LLVM and tt-metal cache references separate" {
+    repo="$(mkrepo)"
+    cd "$repo"
+
+    run env DOCKER="$DOCKER_MOCK" \
+        "$CONTAINERS_DIR/cache-wheel-manylinux-component.sh" \
+            --component llvm \
+            --python-tag cp310 \
+            --cache-ref ghcr.io/example/cache:llvm-cp310 \
+            --build-parallel-level 2
+    assert_success
+
+    run env DOCKER="$DOCKER_MOCK" \
+        "$CONTAINERS_DIR/cache-wheel-manylinux-component.sh" \
+            --component ttmetal \
+            --python-tag "" \
+            --cache-ref ghcr.io/example/cache:ttmetal-cp312 \
+            --build-parallel-level 2
+    assert_success
+
+    run cat "$FAKE_DOCKER_CALLS"
+    assert_line --partial "--target llvm-toolchain"
+    assert_line --partial "--cache-to type=registry,ref=ghcr.io/example/cache:llvm-cp310,mode=max"
+    assert_line --partial "--build-arg PYTHON_TAG=cp310"
+    assert_line --partial "--build-arg WORKFLOW_SOURCE=."
+    refute_line --regexp 'llvm-toolchain.*TT_METAL_TAG'
+    assert_line --partial "--target ttmetal-toolchain"
+    assert_line --partial "--cache-to type=registry,ref=ghcr.io/example/cache:ttmetal-cp312,mode=max"
+}
+
+@test "builder image consumes both component caches" {
+    repo="$(mkrepo)"
+    cd "$repo"
+
+    run env \
+        DOCKER="$DOCKER_MOCK" \
+        FAKE_MISSING_IMAGE=cp312 \
+        GITHUB_REF=refs/heads/feature \
+        "$CONTAINERS_DIR/build-wheel-manylinux-images.sh" \
+            --python-tags cp312 \
+            --image-tag test-tag \
+            --llvm-cache-ref ghcr.io/example/cache:llvm-cp312 \
+            --ttmetal-cache-ref ghcr.io/example/cache:ttmetal-cp312
+
+    assert_success
+    run cat "$FAKE_DOCKER_CALLS"
+    assert_line --partial "buildx build"
+    assert_line --partial "--cache-from type=registry,ref=ghcr.io/example/cache:llvm-cp312"
+    assert_line --partial "--cache-from type=registry,ref=ghcr.io/example/cache:ttmetal-cp312"
+    assert_line --partial "--build-arg WORKFLOW_SOURCE=."
+    assert_line --partial "--push -t ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp312:test-tag"
+}
+
+@test "hardware wheel test script orchestrates install and tutorials" {
+    wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3-cp312-cp312-manylinux_2_34_x86_64.whl)"
+    python_mock="$(make_python_mock)"
+    tutorial_mock="$BATS_TEST_TMPDIR/tutorial"
+    cat > "$tutorial_mock" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_TUTORIAL_CALLS"
+EOF
+    chmod +x "$tutorial_mock"
+    export FAKE_PYTHON_CALLS="$BATS_TEST_TMPDIR/python.calls"
+    export FAKE_TUTORIAL_CALLS="$BATS_TEST_TMPDIR/tutorial.calls"
+    : > "$FAKE_PYTHON_CALLS"
+    : > "$FAKE_TUTORIAL_CALLS"
+
+    run env \
+        FAKE_PYTHON_CALLS="$FAKE_PYTHON_CALLS" \
+        FAKE_TUTORIAL_CALLS="$FAKE_TUTORIAL_CALLS" \
+        "$SCRIPTS_DIR/test-manylinux-wheel.sh" \
+            --dist-dir "$wheel_dir" \
+            --ttnn-dep-mode pypi \
+            --python "$python_mock" \
+            --repo-root "$TTLANG_REPO_ROOT" \
+            --tutorial-script "$tutorial_mock"
+
+    assert_success
+    grep -q -- "-m pip install .*tt_lang-1.2.3-cp312" "$FAKE_PYTHON_CALLS"
+    grep -q -- "check-installed-ttnn.py --mode pypi" "$FAKE_PYTHON_CALLS"
+    grep -q -- "smoke-test-wheel.py" "$FAKE_PYTHON_CALLS"
+    grep -qx "$TTLANG_REPO_ROOT" "$FAKE_TUTORIAL_CALLS"
+}
+
+@test "hardware wheel test script rejects a missing cp312 wheel" {
+    wheel_dir="$(make_wheel_dir \
+        tt_lang-1.2.3-cp310-cp310-manylinux_2_34_x86_64.whl)"
+
+    run "$SCRIPTS_DIR/test-manylinux-wheel.sh" \
+        --dist-dir "$wheel_dir" \
+        --ttnn-dep-mode pypi \
+        --python /does/not/matter
+
+    assert_failure
+    assert_output --partial "cp312 manylinux_2_34 tt-lang wheel not found"
+}

--- a/.github/scripts/tests/test_publish_s3_summary.bats
+++ b/.github/scripts/tests/test_publish_s3_summary.bats
@@ -70,6 +70,19 @@ setup() {
     refute_output --partial "### Published wheels"
 }
 
+@test "--dry-run-if selects dry-run output from a boolean value" {
+    run -0 "$SCRIPT" --dry-run-if true bundled "$VER"
+    assert_output --partial "### Wheel publish dry run"
+
+    run -0 "$SCRIPT" --dry-run-if false bundled "$VER"
+    assert_output --partial "### Published wheels"
+    refute_output --partial "### Wheel publish dry run"
+}
+
+@test "--dry-run-if rejects non-boolean values" {
+    run -2 "$SCRIPT" --dry-run-if yes bundled "$VER"
+}
+
 @test "--index-subdir points install commands at the subdir index" {
     run -0 "$SCRIPT" --index-subdir 2026-06 light "$VER"
     assert_output --partial "https://pypi.eng.aws.tenstorrent.com/2026-06/"

--- a/.github/scripts/tests/test_publish_s3_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_wheels.bats
@@ -184,6 +184,36 @@ EOF
     assert_output --partial "s3://tenstorrent-pypi/tt-lang/tt_lang-1.0-py3-none-any.whl"
 }
 
+@test "--overwrite-if true skips object-existence checks" {
+    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
+    HEAD_OBJECT_EXISTS=true run -0 "$SCRIPT" \
+        --overwrite-if true \
+        --prefix tt-lang/2026-07 \
+        "$dir"
+
+    run cat "$FAKE_AWS_ARGS"
+    refute_output --partial "s3api head-object"
+    assert_output --partial "s3 cp $dir/tt_lang-1.0-py3-none-any.whl"
+}
+
+@test "--overwrite-if false preserves object-existence checks" {
+    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
+    HEAD_OBJECT_EXISTS=true run -1 "$SCRIPT" \
+        --overwrite-if false \
+        --prefix tt-lang/2026-07 \
+        "$dir"
+
+    assert_output --partial "S3 object already exists"
+}
+
+@test "--overwrite-if rejects non-boolean values" {
+    dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
+    run -2 "$SCRIPT" \
+        --overwrite-if yes \
+        --prefix tt-lang/2026-07 \
+        "$dir"
+}
+
 @test "--prefix without --overwrite rejects an existing wheel object" {
     dir=$(make_dist_dir "tt_lang-1.0-py3-none-any.whl")
     HEAD_OBJECT_EXISTS=true run -1 "$SCRIPT" --prefix tt-lang/2026-07 "$dir"

--- a/.github/scripts/tests/test_publish_s3_wheels.bats
+++ b/.github/scripts/tests/test_publish_s3_wheels.bats
@@ -99,6 +99,8 @@ EOF
     assert_output --partial "Publish prefix must be tt-lang/<YYYY-MM> or tt-lang/releases"
     run -2 "$SCRIPT" --prefix tt-lang/ttmetal "$dir"
     assert_output --partial "Publish prefix must be tt-lang/<YYYY-MM> or tt-lang/releases"
+    run -2 "$SCRIPT" --prefix tt-lang/2026-13 "$dir"
+    assert_output --partial "Publish prefix must be tt-lang/<YYYY-MM> or tt-lang/releases"
 }
 
 @test "--prefix publishes top-level wheels and regenerates a month view" {

--- a/.github/scripts/tests/test_refresh_s3_wheel_views.bats
+++ b/.github/scripts/tests/test_refresh_s3_wheel_views.bats
@@ -66,3 +66,11 @@ EOF
     assert_output --partial "Invalid year-month"
     [[ ! -s "$CALLS" ]]
 }
+
+@test "refresh rejects out-of-range months before writing" {
+    run "$SCRIPT" --months 2026-13
+
+    assert_failure 2
+    assert_output --partial "Invalid year-month"
+    [[ ! -s "$CALLS" ]]
+}

--- a/.github/scripts/tests/test_refresh_s3_wheel_views.bats
+++ b/.github/scripts/tests/test_refresh_s3_wheel_views.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/refresh-s3-wheel-views.sh"
+    CALLS="$BATS_TEST_TMPDIR/calls"
+    LISTING="$BATS_TEST_TMPDIR/listing"
+    bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/aws" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$CALLS"
+if [ "$1 $2" = "s3 ls" ]; then
+    cat "$LISTING"
+fi
+exit 0
+EOF
+    cat > "$bindir/inject" <<'EOF'
+#!/bin/sh
+printf 'inject %s\n' "$*" >> "$CALLS"
+EOF
+    chmod +x "$bindir/aws" "$bindir/inject"
+    export PATH="$bindir:$PATH"
+    export CALLS LISTING
+    export INJECT_S3_INDEX_README="$bindir/inject"
+    : > "$CALLS"
+}
+
+@test "refresh regenerates a month that still has wheels" {
+    cat > "$LISTING" <<'EOF'
+                           PRE releases/
+2026-07-01 00:00:00       100 tt_lang-1.2.3.dev20260701-py3-none-any.whl
+EOF
+
+    run "$SCRIPT" --months 2026-07
+
+    assert_success
+    run cat "$CALLS"
+    assert_output --partial "s3api put-object --bucket tenstorrent-pypi --key tt-lang/2026-07/"
+    refute_output --partial "delete-object --bucket tenstorrent-pypi --key tt-lang/2026-07"
+    assert_output --partial "inject --bucket tenstorrent-pypi --key tt-lang/ --require-existing"
+}
+
+@test "refresh removes an empty month view" {
+    cat > "$LISTING" <<'EOF'
+                           PRE releases/
+EOF
+
+    run "$SCRIPT" --months 2026-07
+
+    assert_success
+    run cat "$CALLS"
+    assert_output --partial "delete-object --bucket tenstorrent-pypi --key tt-lang/2026-07"
+    assert_output --partial "delete-object --bucket tenstorrent-pypi --key tt-lang/2026-07/"
+    assert_output --partial "inject --bucket tenstorrent-pypi --key tt-lang/ --require-existing"
+}
+
+@test "refresh rejects malformed months before writing" {
+    run "$SCRIPT" --months 202607
+
+    assert_failure 2
+    assert_output --partial "Invalid year-month"
+    [[ ! -s "$CALLS" ]]
+}

--- a/.github/scripts/tests/test_resolve_pypi_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_pypi_publish_inputs.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load test_helper
+
+setup() {
+    REPO="$(mkrepo)"
+    install_scripts_in_repo "$REPO"
+    (
+        cd "$REPO"
+        git tag v1.2.3
+    )
+    SHA="$(git -C "$REPO" rev-parse HEAD)"
+    SCRIPT="$SCRIPTS_DIR/resolve-pypi-publish-inputs.sh"
+    OUTPUT_FILE="$BATS_TEST_TMPDIR/output"
+    : > "$OUTPUT_FILE"
+
+    export DRY_RUN=false
+    export EVENT_NAME=workflow_dispatch
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    export GITHUB_REF=refs/heads/main
+    export GITHUB_SHA="$SHA"
+    export RELEASE_SOURCE="$REPO"
+    export TTLANG_SHA="$SHA"
+}
+
+output_value() {
+    local key="$1"
+    sed -n "s/^${key}=//p" "$OUTPUT_FILE"
+}
+
+@test "non-dry dispatch resolves the unique release tag" {
+    run "$SCRIPT"
+
+    assert_success
+    assert_equal "$(output_value tag_version)" "1.2.3"
+    assert_equal "$(output_value wheel_version)" "1.2.3"
+}
+
+@test "tag push resolves the triggering tag" {
+    EVENT_NAME=push \
+    GITHUB_REF=refs/tags/v1.2.3 \
+    TTLANG_SHA="" \
+        run "$SCRIPT"
+
+    assert_success
+    assert_equal "$(output_value tag_version)" "1.2.3"
+    assert_equal "$(output_value wheel_version)" "1.2.3"
+}
+
+@test "dry dispatch uses a nightly version without requiring a release tag" {
+    git -C "$REPO" tag -d v1.2.3 >/dev/null
+    git -C "$REPO" tag v1.1.0
+
+    DRY_RUN=true run "$SCRIPT"
+
+    assert_success
+    assert_equal "$(output_value tag_version)" ""
+    [[ "$(output_value wheel_version)" =~ ^1\.1\.0\.dev[0-9]{8}$ ]]
+}
+
+@test "dispatch requires a full SHA" {
+    TTLANG_SHA=main run "$SCRIPT"
+
+    assert_failure
+    assert_output --partial "ttlang_sha must be a full 40-character commit SHA"
+}
+
+@test "dispatch rejects an invalid Docker tag" {
+    DOCKER_TAG='bad tag' run "$SCRIPT"
+
+    assert_failure 2
+    assert_output --partial "DOCKER_TAG is not a valid Docker tag"
+}
+
+@test "dispatch rejects a checkout that differs from the requested SHA" {
+    TTLANG_SHA=0000000000000000000000000000000000000000 run "$SCRIPT"
+
+    assert_failure
+    assert_output --partial "Checked-out commit does not match ttlang_sha"
+}
+
+@test "non-dry dispatch requires main" {
+    GITHUB_REF=refs/heads/feature run "$SCRIPT"
+
+    assert_failure
+    assert_output --partial "restricted to workflow dispatches from refs/heads/main"
+}
+
+@test "non-dry dispatch rejects multiple release tags" {
+    git -C "$REPO" tag v1.2.4
+
+    run "$SCRIPT"
+
+    assert_failure
+    assert_output --partial "must have exactly one v* release tag; found 2"
+}
+
+@test "unsupported event is rejected" {
+    EVENT_NAME=pull_request run "$SCRIPT"
+
+    assert_failure
+    assert_output --partial "Unsupported public PyPI event"
+}

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -55,8 +55,10 @@ output_value() {
 }
 
 @test "version input is validated and normalized" {
-    DISPATCH_VERSION_OVERRIDE="not a version" run -1 "$SCRIPT"
+    malicious_version='<script>alert(1)</script>'
+    DISPATCH_VERSION_OVERRIDE="$malicious_version" run -1 "$SCRIPT"
     assert_output --partial "Invalid PEP 440 version"
+    refute_output --partial "$malicious_version"
 
     DISPATCH_VERSION_OVERRIDE=1.2.3-rc1 run -0 "$SCRIPT"
     assert_equal "$(output_value version_override)" "1.2.3rc1"

--- a/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
+++ b/.github/scripts/tests/test_resolve_s3_publish_inputs.bats
@@ -40,6 +40,28 @@ output_value() {
     assert_output --partial "EVENT_NAME is required"
 }
 
+@test "boolean inputs must be canonical" {
+    DISPATCH_DRY_RUN=yes run -2 "$SCRIPT"
+    assert_output --partial "DISPATCH_DRY_RUN must be true or false"
+
+    DISPATCH_OVERWRITE_RELEASES=yes run -2 "$SCRIPT"
+    assert_output --partial "DISPATCH_OVERWRITE_RELEASES must be true or false"
+}
+
+@test "docker tag rejects GitHub output injection" {
+    DISPATCH_DOCKER_TAG=$'valid\npublish_needed=false' run -2 "$SCRIPT"
+    assert_output --partial "DISPATCH_DOCKER_TAG is not a valid Docker tag"
+    [[ ! -s "$GITHUB_OUTPUT_FILE" ]]
+}
+
+@test "version input is validated and normalized" {
+    DISPATCH_VERSION_OVERRIDE="not a version" run -1 "$SCRIPT"
+    assert_output --partial "Invalid PEP 440 version"
+
+    DISPATCH_VERSION_OVERRIDE=1.2.3-rc1 run -0 "$SCRIPT"
+    assert_equal "$(output_value version_override)" "1.2.3rc1"
+}
+
 @test "workflow_dispatch with explicit inputs -> pass-through" {
     DISPATCH_DOCKER_TAG=mytag \
     DISPATCH_DRY_RUN=true \
@@ -55,8 +77,9 @@ output_value() {
     assert_equal "$(output_value version_override)" "1.2.3.dev20260101"
     assert_equal "$(output_value wheel_variant)" "light"
     assert_equal "$(output_value wheel_variants)" '["light"]'
-    assert_equal "$(output_value wheel_matrix)" '{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
-    assert_equal "$(output_value standard_wheel_matrix)" '{"include":[]}'
+    assert_equal "$(output_value bundled_selected)" "false"
+    assert_equal "$(output_value manylinux_selected)" "true"
+    assert_equal "$(output_value manylinux_wheel_matrix)" '{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external","build_sim_wheel":false}]}'
     assert_output --partial "Using existing docker_tag=mytag"
 }
 
@@ -65,8 +88,9 @@ output_value() {
 
     assert_equal "$(output_value wheel_variant)" "bundled-and-light"
     assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
-    assert_equal "$(output_value wheel_matrix)" '{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"},{"wheel_variant":"light","ttnn_dep_mode":"external"}]}'
-    assert_equal "$(output_value standard_wheel_matrix)" '{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
+    assert_equal "$(output_value bundled_selected)" "true"
+    assert_equal "$(output_value manylinux_selected)" "true"
+    assert_equal "$(output_value manylinux_wheel_matrix)" '{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external","build_sim_wheel":false}]}'
     assert_output --partial 'Resolved wheel_variants=["bundled","light"]'
 }
 
@@ -75,9 +99,9 @@ output_value() {
     assert_output --partial "Unknown S3 wheel variant: garbage"
 }
 
-@test "empty docker_tag -> hint about build-docker" {
+@test "empty docker_tag -> hint about builder workflows" {
     DISPATCH_DOCKER_TAG="" run -0 "$SCRIPT"
-    assert_output --partial "No docker_tag provided; build-docker will create one"
+    assert_output --partial "No docker_tag provided; required builder workflows will create it"
 }
 
 @test "schedule event forces overwrite_releases=true even if dispatch said false" {
@@ -89,7 +113,9 @@ output_value() {
     DISPATCH_WHEEL_VARIANT="" EVENT_NAME=schedule run -0 "$SCRIPT"
     assert_equal "$(output_value wheel_variant)" "bundled-and-light"
     assert_equal "$(output_value wheel_variants)" '["bundled","light"]'
-    assert_equal "$(output_value standard_wheel_matrix)" '{"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
+    assert_equal "$(output_value bundled_selected)" "true"
+    assert_equal "$(output_value manylinux_selected)" "true"
+    assert_equal "$(output_value manylinux_wheel_matrix)" '{"include":[{"wheel_variant":"light","ttnn_dep_mode":"external","build_sim_wheel":false}]}'
 }
 
 @test "schedule event keeps overwrite_releases=true if already set" {
@@ -100,6 +126,28 @@ output_value() {
 @test "non-schedule event does not force overwrite_releases" {
     DISPATCH_OVERWRITE_RELEASES=false EVENT_NAME=workflow_dispatch run -0 "$SCRIPT"
     assert_equal "$(output_value overwrite_releases)" "false"
+}
+
+@test "pypi uses the shared manylinux build and includes sim" {
+    DISPATCH_WHEEL_VARIANT=pypi run -0 "$SCRIPT"
+    assert_equal "$(output_value bundled_selected)" "false"
+    assert_equal "$(output_value manylinux_selected)" "true"
+    assert_equal "$(output_value manylinux_wheel_matrix)" '{"include":[{"wheel_variant":"pypi","ttnn_dep_mode":"pypi","build_sim_wheel":true}]}'
+}
+
+@test "non-main dry run requires an existing docker tag" {
+    GITHUB_REF=refs/heads/feature \
+    DISPATCH_DRY_RUN=true \
+    DISPATCH_DOCKER_TAG="" \
+        run -1 "$SCRIPT"
+    assert_output --partial "Non-main dry runs must provide docker_tag"
+}
+
+@test "non-main dry run with an existing docker tag is allowed" {
+    GITHUB_REF=refs/heads/feature \
+    DISPATCH_DRY_RUN=true \
+    DISPATCH_DOCKER_TAG=existing \
+        run -0 "$SCRIPT"
 }
 
 @test "push event is rejected" {
@@ -127,16 +175,13 @@ output_value() {
 }
 
 @test "empty version_override invokes compute-nightly-version.py" {
-    # Mock compute-nightly-version.py on PATH so we don't need git history.
-    mock_bin="$BATS_TEST_TMPDIR/mock-bin"
-    mkdir -p "$mock_bin"
-    # The script invokes the compute-nightly script by absolute path
-    # ($script_dir/compute-nightly-version.py), so shadow that file specifically.
+    # Shadow the helper next to a copied resolver so git history is not needed.
     shadow_dir="$BATS_TEST_TMPDIR/shadow-scripts"
     mkdir -p "$shadow_dir/tests"
     # Copy real script and its sibling lib (so the sourced helper resolves),
     # then override compute-nightly.
     cp "$SCRIPT" "$shadow_dir/"
+    cp "$SCRIPTS_DIR/normalize-pep440-version.py" "$shadow_dir/"
     cp -r "$SCRIPTS_DIR/lib" "$shadow_dir/"
     cat > "$shadow_dir/compute-nightly-version.py" <<'EOF'
 #!/usr/bin/env python3
@@ -155,7 +200,9 @@ EOF
     assert_output --partial "version_override=42.42.42.dev20260527"
     assert_output --partial "wheel_variant=bundled"
     assert_output --partial 'wheel_variants=["bundled"]'
-    assert_output --partial 'standard_wheel_matrix={"include":[{"wheel_variant":"bundled","ttnn_dep_mode":"bundled"}]}'
+    assert_output --partial "bundled_selected=true"
+    assert_output --partial "manylinux_selected=false"
+    assert_output --partial 'manylinux_wheel_matrix={"include":[]}'
     assert_output --partial "allow_final_internal_version=false"
 }
 

--- a/.github/scripts/tests/test_s3_nightly_state.bats
+++ b/.github/scripts/tests/test_s3_nightly_state.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load test_helper
+
+make_aws_mock() {
+    local mock="$BATS_TEST_TMPDIR/aws"
+    cat > "$mock" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_AWS_CALLS"
+if [ "$1 $2 $3" = "s3 cp s3://test-bucket/state.json" ]; then
+    case "${FAKE_AWS_MODE:-existing}" in
+        existing)
+            printf '{"ttlang_sha":"%s","version":"1.2.3.dev20260725"}\n' "$FAKE_MARKER_SHA"
+            ;;
+        missing)
+            echo "fatal error: An error occurred (NoSuchKey)" >&2
+            exit 1
+            ;;
+        invalid)
+            echo "not-json"
+            ;;
+        error)
+            echo "fatal error: AccessDenied" >&2
+            exit 1
+            ;;
+    esac
+    exit 0
+fi
+if [ "$1 $2 $3" = "s3 cp -" ]; then
+    cat > "$FAKE_AWS_PAYLOAD"
+    exit 0
+fi
+exit 2
+EOF
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/s3-nightly-state.py"
+    AWS_MOCK="$(make_aws_mock)"
+    OUTPUT_FILE="$BATS_TEST_TMPDIR/output"
+    CURRENT_SHA=1111111111111111111111111111111111111111
+    PREVIOUS_SHA=2222222222222222222222222222222222222222
+    export FAKE_AWS_CALLS="$BATS_TEST_TMPDIR/aws.calls"
+    export FAKE_AWS_PAYLOAD="$BATS_TEST_TMPDIR/aws.payload"
+    : > "$OUTPUT_FILE"
+    : > "$FAKE_AWS_CALLS"
+    export AWS="$AWS_MOCK"
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+}
+
+output_value() {
+    local key="$1"
+    sed -n "s/^${key}=//p" "$OUTPUT_FILE"
+}
+
+@test "scheduled check skips an already-published SHA" {
+    FAKE_MARKER_SHA="$CURRENT_SHA" run "$SCRIPT" check \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_success
+    assert_equal "$(output_value publish-needed)" "false"
+    assert_equal "$(output_value previous-sha)" "$CURRENT_SHA"
+}
+
+@test "scheduled check publishes a changed SHA" {
+    FAKE_MARKER_SHA="$PREVIOUS_SHA" run "$SCRIPT" check \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_success
+    assert_equal "$(output_value publish-needed)" "true"
+    assert_equal "$(output_value previous-sha)" "$PREVIOUS_SHA"
+}
+
+@test "missing marker bootstraps the scheduled publish" {
+    FAKE_AWS_MODE=missing run "$SCRIPT" check \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_success
+    assert_equal "$(output_value publish-needed)" "true"
+    assert_equal "$(output_value previous-sha)" ""
+}
+
+@test "manual check never reads S3 and always publishes" {
+    FAKE_AWS_MODE=error run "$SCRIPT" check \
+        --event workflow_dispatch \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_success
+    assert_equal "$(output_value publish-needed)" "true"
+    [[ ! -s "$FAKE_AWS_CALLS" ]]
+}
+
+@test "unexpected S3 read error fails" {
+    FAKE_AWS_MODE=error run "$SCRIPT" check \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_failure
+    assert_output --partial "AccessDenied"
+}
+
+@test "invalid marker JSON fails" {
+    FAKE_AWS_MODE=invalid run "$SCRIPT" check \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_failure
+    assert_output --partial "invalid nightly marker JSON"
+}
+
+@test "record writes source SHA and version as JSON" {
+    run "$SCRIPT" record \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --version 1.2.3.dev20260726 \
+        --run-id 123 \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_success
+    run python3 -c 'import json,sys; data=json.load(open(sys.argv[1])); print(data["ttlang_sha"], data["version"], data["run_id"])' "$FAKE_AWS_PAYLOAD"
+    assert_success
+    assert_output "$CURRENT_SHA 1.2.3.dev20260726 123"
+    grep -q '^s3 cp - s3://test-bucket/state.json --content-type application/json' "$FAKE_AWS_CALLS"
+}
+
+@test "record rejects non-schedule events" {
+    run "$SCRIPT" record \
+        --event workflow_dispatch \
+        --sha "$CURRENT_SHA" \
+        --version 1.2.3.dev20260726 \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_failure
+    assert_output --partial "recorded only for schedule events"
+}
+
+@test "scheduled check rejects an invalid marker SHA" {
+    FAKE_MARKER_SHA='invalid\npublish-needed=false' run "$SCRIPT" check \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_failure
+    assert_output --partial "ttlang_sha is not a full SHA"
+}

--- a/.github/scripts/tests/test_s3_nightly_state.bats
+++ b/.github/scripts/tests/test_s3_nightly_state.bats
@@ -10,14 +10,23 @@ make_aws_mock() {
     cat > "$mock" <<'EOF'
 #!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_AWS_CALLS"
+if [ "$1 $2" = "s3api head-object" ]; then
+    case "${FAKE_AWS_MODE:-existing}" in
+        missing)
+            echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
+            exit 1
+            ;;
+        misleading-404)
+            echo "An error occurred (AccessDenied) when calling the HeadObject operation: request ID 404-example" >&2
+            exit 1
+            ;;
+    esac
+    exit 0
+fi
 if [ "$1 $2 $3" = "s3 cp s3://test-bucket/state.json" ]; then
     case "${FAKE_AWS_MODE:-existing}" in
         existing)
             printf '{"ttlang_sha":"%s","version":"1.2.3.dev20260725"}\n' "$FAKE_MARKER_SHA"
-            ;;
-        missing)
-            echo "fatal error: An error occurred (NoSuchKey)" >&2
-            exit 1
             ;;
         invalid)
             echo "not-json"
@@ -115,6 +124,18 @@ output_value() {
 
     assert_failure
     assert_output --partial "AccessDenied"
+}
+
+@test "unrelated 404 text is not treated as a missing marker" {
+    FAKE_AWS_MODE=misleading-404 run "$SCRIPT" check \
+        --event schedule \
+        --sha "$CURRENT_SHA" \
+        --bucket test-bucket \
+        --key state.json
+
+    assert_failure
+    assert_output --partial "AccessDenied"
+    assert_output --partial "404-example"
 }
 
 @test "invalid marker JSON fails" {

--- a/.github/scripts/tests/test_s3_publish_orchestration.bats
+++ b/.github/scripts/tests/test_s3_publish_orchestration.bats
@@ -25,6 +25,17 @@ load test_helper
     grep -qx 'prefix=tt-lang/releases' "$output_file"
 }
 
+@test "dev version rejects an out-of-range month" {
+    output_file="$BATS_TEST_TMPDIR/output"
+    run env GITHUB_OUTPUT="$output_file" \
+        "$SCRIPTS_DIR/resolve-s3-publish-prefix.sh" \
+        1.2.3.dev20261332
+
+    assert_failure 2
+    assert_output --partial "Invalid calendar month in dev version"
+    [[ ! -e "$output_file" ]]
+}
+
 @test "selected publish preparation rejects an empty artifact root" {
     artifact_root="$BATS_TEST_TMPDIR/artifacts"
     mkdir -p "$artifact_root"

--- a/.github/scripts/tests/test_s3_publish_orchestration.bats
+++ b/.github/scripts/tests/test_s3_publish_orchestration.bats
@@ -25,6 +25,16 @@ load test_helper
     grep -qx 'prefix=tt-lang/releases' "$output_file"
 }
 
+@test "local label text does not classify a final version as dev" {
+    output_file="$BATS_TEST_TMPDIR/output"
+    run env GITHUB_OUTPUT="$output_file" \
+        "$SCRIPTS_DIR/resolve-s3-publish-prefix.sh" \
+        1.2.3+foo.dev1
+
+    assert_success
+    grep -qx 'prefix=tt-lang/releases' "$output_file"
+}
+
 @test "dev version rejects an out-of-range month" {
     output_file="$BATS_TEST_TMPDIR/output"
     run env GITHUB_OUTPUT="$output_file" \
@@ -33,6 +43,18 @@ load test_helper
 
     assert_failure 2
     assert_output --partial "Invalid calendar month in dev version"
+    [[ ! -e "$output_file" ]]
+}
+
+@test "dev version rejects a non-date dev number" {
+    output_file="$BATS_TEST_TMPDIR/output"
+    run env GITHUB_OUTPUT="$output_file" \
+        "$SCRIPTS_DIR/resolve-s3-publish-prefix.sh" \
+        1.2.3.dev1
+
+    assert_failure 2
+    assert_output --partial \
+        "S3 dev versions must use an 8-digit YYYYMMDD dev number"
     [[ ! -e "$output_file" ]]
 }
 

--- a/.github/scripts/tests/test_s3_publish_orchestration.bats
+++ b/.github/scripts/tests/test_s3_publish_orchestration.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load test_helper
+
+@test "dev version resolves to its year-month view" {
+    output_file="$BATS_TEST_TMPDIR/output"
+    run env GITHUB_OUTPUT="$output_file" \
+        "$SCRIPTS_DIR/resolve-s3-publish-prefix.sh" \
+        1.2.3.dev20260726
+
+    assert_success
+    grep -qx 'prefix=tt-lang/2026-07' "$output_file"
+}
+
+@test "final version resolves to the releases view" {
+    output_file="$BATS_TEST_TMPDIR/output"
+    run env GITHUB_OUTPUT="$output_file" \
+        "$SCRIPTS_DIR/resolve-s3-publish-prefix.sh" \
+        1.2.3
+
+    assert_success
+    grep -qx 'prefix=tt-lang/releases' "$output_file"
+}
+
+@test "selected publish preparation rejects an empty artifact root" {
+    artifact_root="$BATS_TEST_TMPDIR/artifacts"
+    mkdir -p "$artifact_root"
+
+    run "$SCRIPTS_DIR/prepare-selected-s3-publish-dist.sh" \
+        1.2.3.dev20260726 \
+        "$artifact_root" \
+        "$BATS_TEST_TMPDIR/dist"
+
+    assert_failure
+    assert_output --partial "No selected wheel artifacts found"
+}
+
+@test "selected publish preparation combines bundled and light artifacts" {
+    artifact_root="$BATS_TEST_TMPDIR/artifacts"
+    publish_dir="$BATS_TEST_TMPDIR/dist"
+    mkdir -p "$artifact_root/bundled" "$artifact_root/light"
+    touch \
+        "$artifact_root/bundled/$(whl 1.2.3.dev20260726)" \
+        "$artifact_root/bundled/$(whl_sim 1.2.3.dev20260726)" \
+        "$artifact_root/light/$(whl_light_core_cp310 1.2.3.dev20260726)" \
+        "$artifact_root/light/$(whl_light_core_cp312 1.2.3.dev20260726)" \
+        "$artifact_root/light/$(whl_light 1.2.3.dev20260726)"
+
+    run "$SCRIPTS_DIR/prepare-selected-s3-publish-dist.sh" \
+        1.2.3.dev20260726 \
+        "$artifact_root" \
+        "$publish_dir"
+
+    assert_success
+    run find "$publish_dir" -maxdepth 1 -name '*.whl' -print
+    assert_success
+    assert_line --partial "tt_lang-1.2.3.dev20260726"
+    assert_line --partial "tt_lang-1.2.3.dev20260726+light"
+    assert_line --partial "tt_lang_light-1.2.3.dev20260726"
+}

--- a/.github/scripts/tests/test_wheel_or_container_changed.bats
+++ b/.github/scripts/tests/test_wheel_or_container_changed.bats
@@ -118,11 +118,11 @@ setup() {
     assert_equal "$(run_changed "$BASE" "$head")" "false"
 }
 
-@test "diff only in third-party uplift path -> false (covered by detect-uplift, not this script)" {
+@test "diff in a shared container input -> true" {
     printf '%s\n' "$TEST_TT_METAL_RC1_TAG" > "$REPO/third-party/tt-metal-version"
     commit_all "$REPO" "uplift only"
     head=$(cd "$REPO" && git rev-parse HEAD)
-    assert_equal "$(run_changed "$BASE" "$head")" "false"
+    assert_equal "$(run_changed "$BASE" "$head")" "true"
 }
 
 @test "no diff (same base and head) -> false" {

--- a/.github/scripts/uplift-paths.sh
+++ b/.github/scripts/uplift-paths.sh
@@ -11,17 +11,35 @@
 #   - System packages + SFPI/firmware (driven by tt-metal-version)
 #   - Pre-built LLVM artifacts        (driven by third-party/llvm-project)
 #   - Pre-built tt-metal artifacts    (driven by third-party/tt-metal)
-#   - Python runtime deps             (requirements-runtime.txt)
+#   - Toolchain build logic and deps  (CMake modules, scripts, requirements)
 # tt-lang is built fresh by call-build.yml against the pre-built LLVM inside
 # the container, so ordinary source changes are NOT in this list.
 
 UPLIFT_PATHS=(
+    .dockerignore
+    CMakeLists.txt
+    cmake/modules/BuildLLVM.cmake
+    cmake/modules/BuildTTMetal.cmake
+    cmake/modules/GetVersionFromGit.cmake
+    cmake/modules/TTLangCompilerSetup.cmake
+    cmake/modules/TTLangPython.cmake
+    cmake/modules/TTLangToolchainComponent.cmake
+    cmake/modules/TTLangToolchainOptions.cmake
+    cmake/modules/TTLangUtils.cmake
     third-party/tt-metal-version
     third-party/llvm-project
     third-party/tt-metal
+    third-party/patches
     .github/containers/Dockerfile
     .github/containers/Dockerfile.base
     .github/containers/Dockerfile.wheel-manylinux-2-34
+    .github/containers/CMakeLists.wheel-toolchain
+    .github/containers/cleanup-toolchain.sh
+    .github/scripts/normalize-toolchain-install.sh
     bin/tt-triage
+    requirements.txt
     requirements-runtime.txt
+    scripts/build-and-install.sh
+    scripts/copy-ttmetal-runtime-artifacts.sh
+    scripts/install-ttmetal.sh
 )

--- a/.github/scripts/validate-manylinux-wheel-inputs.sh
+++ b/.github/scripts/validate-manylinux-wheel-inputs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+[ "$#" -eq 2 ] || {
+    echo "Usage: $0 <pypi|external> <version>" >&2
+    exit 2
+}
+
+ttnn_dep_mode="$1"
+version="$2"
+[ -n "$version" ] || {
+    echo "version_override is required" >&2
+    exit 2
+}
+
+case "$ttnn_dep_mode" in
+    pypi | external) ;;
+    *)
+        echo "ttnn_dep_mode must be pypi or external" >&2
+        exit 2
+        ;;
+esac

--- a/.github/scripts/verify-manylinux-wheel-set.sh
+++ b/.github/scripts/verify-manylinux-wheel-set.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify the complete cp310/cp312 manylinux_2_34 wheel set produced by the
+# shared PyPI/light build workflow.
+
+set -eu
+
+build_sim=true
+ttnn_dep_mode=""
+
+usage() {
+    echo "Usage: $0 --ttnn-dep-mode pypi|external [--build-sim true|false] <version> <dist-dir>" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --ttnn-dep-mode)
+            [ "$#" -ge 2 ] || usage
+            ttnn_dep_mode="$2"
+            shift 2
+            ;;
+        --build-sim)
+            [ "$#" -ge 2 ] || usage
+            build_sim="$2"
+            shift 2
+            ;;
+        --*)
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+[ "$#" -eq 2 ] || usage
+case "$ttnn_dep_mode" in
+    pypi | external) ;;
+    *) usage ;;
+esac
+case "$build_sim" in
+    true | false) ;;
+    *) usage ;;
+esac
+
+version="$1"
+dist_dir="$2"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+version_output="$(mktemp)"
+trap 'rm -f "$version_output"' EXIT
+TTNN_DEP_MODE="$ttnn_dep_mode" \
+VERSION_OVERRIDE="$version" \
+GITHUB_OUTPUT="$version_output" \
+    "$script_dir/resolve-wheel-versions.sh"
+core_version="$(sed -n 's/^core_version=//p' "$version_output")"
+
+expected_files="
+tt_lang-${core_version}-cp310-cp310-manylinux_2_34_x86_64.whl
+tt_lang-${core_version}-cp312-cp312-manylinux_2_34_x86_64.whl
+"
+if [ "$ttnn_dep_mode" = external ]; then
+    expected_files="${expected_files}tt_lang_light-${version}-py3-none-any.whl
+"
+fi
+if [ "$build_sim" = true ]; then
+    expected_files="${expected_files}tt_lang_sim-${version}-py3-none-any.whl
+"
+fi
+
+failed=0
+seen=0
+for wheel in "$dist_dir"/*.whl; do
+    if [ ! -e "$wheel" ]; then
+        continue
+    fi
+    seen=$((seen + 1))
+    wheel_name="$(basename "$wheel")"
+    if ! printf '%s' "$expected_files" | grep -Fxq "$wheel_name"; then
+        echo "Unexpected manylinux wheel: $wheel_name" >&2
+        failed=1
+    fi
+done
+
+if [ "$seen" -eq 0 ]; then
+    echo "No wheels found in $dist_dir" >&2
+    exit 1
+fi
+
+printf '%s' "$expected_files" | while IFS= read -r expected_file; do
+    [ -n "$expected_file" ] || continue
+    if [ ! -f "$dist_dir/$expected_file" ]; then
+        echo "Expected manylinux wheel was not produced: $expected_file" >&2
+        exit 1
+    fi
+done || failed=1
+
+exit "$failed"

--- a/.github/scripts/wheel-or-container-paths.sh
+++ b/.github/scripts/wheel-or-container-paths.sh
@@ -3,26 +3,42 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Paths whose change should trigger PR-time wheel build + dist-container
-# tutorial coverage. Sourced by wheel-or-container-changed.sh. Disjoint
-# purpose from UPLIFT_PATHS (which decides whether to rebuild the image).
+# tutorial coverage. Every container input requires that coverage, with
+# additional wheel-only inputs appended here.
+
+wheel_path_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=uplift-paths.sh
+source "$wheel_path_script_dir/uplift-paths.sh"
 
 WHEEL_OR_CONTAINER_PATHS=(
-    .github/containers/Dockerfile
-    .github/containers/Dockerfile.base
-    .github/containers/Dockerfile.wheel-manylinux-2-34
+    "${UPLIFT_PATHS[@]}"
+    .github/actions/setup-wheel-image-build
     .github/containers/build-wheel-manylinux-images.sh
+    .github/containers/cache-wheel-manylinux-component.sh
+    .github/scripts/build-manylinux-core-wheel.sh
+    .github/scripts/build-manylinux-wheel-set-member.sh
     .github/scripts/build-s3-light-core-wheel.sh
     .github/scripts/build-s3-light-metapackage-wheel.sh
+    .github/scripts/check-installed-ttnn.py
+    .github/scripts/check-wheel-ttnn-metadata.py
     .github/scripts/lib/docker-image-utils.sh
+    .github/scripts/resolve-wheel-builder-images.sh
+    .github/scripts/resolve-wheel-versions.sh
     .github/scripts/run-tutorials.sh
     .github/scripts/smoke-test-wheel.py
+    .github/scripts/test-manylinux-wheel.sh
     .github/scripts/test-s3-light-wheels.sh
+    .github/scripts/validate-manylinux-wheel-inputs.sh
+    .github/scripts/verify-manylinux-wheel-set.sh
+    .github/workflows/call-build-manylinux-wheels.yml
+    .github/workflows/call-build-wheel-images.yml
+    .github/workflows/call-test-manylinux-wheels.yml
     scripts/build-s3-light-wheels-local.sh
     bin
-    CMakeLists.txt
     examples
     packaging
     pyproject.toml
+    setup.py
     python/CMakeLists.txt
     python/setup.py
 )

--- a/.github/workflows/call-build-manylinux-wheels.yml
+++ b/.github/workflows/call-build-manylinux-wheels.yml
@@ -1,0 +1,174 @@
+name: Build Manylinux Wheels
+
+on:
+  workflow_call:
+    inputs:
+      docker_tag:
+        description: "Tag for the cp310 and cp312 manylinux wheel-builder images."
+        required: true
+        type: string
+      version_override:
+        description: "PEP 440 version for the generated wheels."
+        required: true
+        type: string
+      ttnn_dep_mode:
+        description: "ttnn dependency mode: pypi or external."
+        required: true
+        type: string
+      build_sim_wheel:
+        description: "Build and test the pure-Python tt-lang-sim wheel."
+        required: false
+        type: boolean
+        default: true
+      allow_final_internal_version:
+        description: "Allow final versions for external-ttnn S3 wheels."
+        required: false
+        type: boolean
+        default: false
+      artifact_name:
+        description: "Name of the combined wheel artifact."
+        required: false
+        type: string
+        default: tt-lang-manylinux-wheels
+      ttlang_sha_override:
+        description: "tt-lang SHA/tag to build. Empty uses the caller ref."
+        required: false
+        type: string
+        default: ""
+      apply_patches:
+        description: "Apply wheel patches from the caller workflow commit."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  validate:
+    name: "Validate manylinux wheel inputs"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate inputs
+        env:
+          TTLANG_TTNN_DEP_MODE: ${{ inputs.ttnn_dep_mode }}
+          TTLANG_WHEEL_VERSION: ${{ inputs.version_override }}
+        run: .github/scripts/validate-manylinux-wheel-inputs.sh "$TTLANG_TTNN_DEP_MODE" "$TTLANG_WHEEL_VERSION"
+
+  build-core:
+    name: "Build ${{ inputs.ttnn_dep_mode }} core wheel (${{ matrix.python_tag }})"
+    needs: validate
+    runs-on: mlir-large-runner-lang
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        python_tag: [cp310, cp312]
+    container:
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${{ inputs.docker_tag }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout workflow wheel helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: |
+            .github/scripts
+            .github/wheel-patches
+          sparse-checkout-cone-mode: false
+
+      - name: Fix git safe directory
+        run: git config --global --add safe.directory '*'
+
+      - name: Apply wheel patches
+        if: ${{ inputs.apply_patches }}
+        run: .wheel-workflow-src/.github/scripts/apply-wheel-patches.sh --target-dir "$GITHUB_WORKSPACE"
+
+      - name: Build core wheel
+        env:
+          BUILD_SIM_WHEEL: ${{ inputs.build_sim_wheel }}
+          PYTHON_TAG: ${{ matrix.python_tag }}
+          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ inputs.allow_final_internal_version }}
+          TTLANG_TTNN_DEP_MODE: ${{ inputs.ttnn_dep_mode }}
+          TTLANG_WHEEL_VERSION: ${{ inputs.version_override }}
+        run: .wheel-workflow-src/.github/scripts/build-manylinux-wheel-set-member.sh --python-tag "$PYTHON_TAG" --version "$TTLANG_WHEEL_VERSION" --ttnn-dep-mode "$TTLANG_TTNN_DEP_MODE" --build-sim "$BUILD_SIM_WHEEL" --dist-dir dist
+
+      - name: Upload per-ABI wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact_name }}-${{ matrix.python_tag }}
+          path: dist/*.whl
+          retention-days: 14
+
+  collect:
+    name: "Verify manylinux wheel set"
+    needs: [validate, build-core]
+    if: ${{ always() && needs.validate.result == 'success' && needs.build-core.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
+
+      - name: Checkout workflow wheel helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Download wheel set
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ inputs.artifact_name }}-*
+          path: dist
+          merge-multiple: true
+
+      - name: Verify wheel filenames and versions
+        env:
+          BUILD_SIM_WHEEL: ${{ inputs.build_sim_wheel }}
+          TTLANG_TTNN_DEP_MODE: ${{ inputs.ttnn_dep_mode }}
+          TTLANG_WHEEL_VERSION: ${{ inputs.version_override }}
+        run: .wheel-workflow-src/.github/scripts/verify-manylinux-wheel-set.sh --ttnn-dep-mode "$TTLANG_TTNN_DEP_MODE" --build-sim "$BUILD_SIM_WHEEL" "$TTLANG_WHEEL_VERSION" dist
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ inputs.ttnn_dep_mode == 'external' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Install-test external-ttnn wheels
+        if: ${{ inputs.ttnn_dep_mode == 'external' }}
+        env:
+          DOCKER_TAG: ${{ inputs.docker_tag }}
+          TTLANG_WHEEL_VERSION: ${{ inputs.version_override }}
+        run: .wheel-workflow-src/.github/scripts/test-s3-light-wheels.sh --version "$TTLANG_WHEEL_VERSION" --docker-tag "$DOCKER_TAG" --dist-dir dist
+
+      - name: Upload combined wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist/*.whl
+          retention-days: 14

--- a/.github/workflows/call-build-manylinux-wheels.yml
+++ b/.github/workflows/call-build-manylinux-wheels.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         python_tag: [cp310, cp312]
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${{ inputs.docker_tag }}
+      image: ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${{ inputs.docker_tag }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/call-build-wheel-images.yml
+++ b/.github/workflows/call-build-wheel-images.yml
@@ -1,10 +1,5 @@
 name: Build Wheel-Builder Images
 
-# Builds and pushes the manylinux_2_34 wheel-builder images used to build the S3
-# light wheels. Kept separate from call-build-docker.yml so that hardware tests
-# and standard wheels (which depend on the ird image, not these) do not wait on
-# this build. Callers decide when to invoke it.
-
 on:
   workflow_dispatch:
     inputs:
@@ -18,34 +13,43 @@ on:
         description: "tt-lang SHA/branch override (optional, defaults to current commit)"
         type: string
         required: false
+    outputs:
+      docker-tag:
+        description: "Tag shared by the cp310 and cp312 manylinux builders"
+        value: ${{ jobs.resolve.outputs.docker-tag }}
 
 permissions:
   contents: read
   packages: write
 
+env:
+  WHEEL_CACHE_IMAGE: ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-build-cache
+
 jobs:
-  build-manylinux-wheel-images:
-    runs-on: mlir-large-runner-lang
-    timeout-minutes: 360
-    strategy:
-      fail-fast: false
-      matrix:
-        python_tag: [cp310, cp312]
-
-    defaults:
-      run:
-        shell: bash
-
+  resolve:
+    name: "Resolve manylinux builder state"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      docker-tag: ${{ steps.resolve.outputs.docker-tag }}
+      all-images-exist: ${{ steps.resolve.outputs.all-images-exist }}
+      update-latest: ${{ steps.resolve.outputs.update-latest }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ttlang_sha_override || github.sha }}
-          submodules: recursive
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Free up runner space
-        run: .github/scripts/cleanup-ci-space.sh
+      - name: Checkout wheel image workflow source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: |
+            .github/containers
+            .github/scripts
+          sparse-checkout-cone-mode: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -54,33 +58,114 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
-      - name: Fix git safe directory for submodules
-        run: git config --global --add safe.directory '*'
+      - name: Resolve Docker tag and existing images
+        id: resolve
+        run: .wheel-workflow-src/.github/scripts/resolve-wheel-builder-images.sh --repository "${{ github.repository }}" --workflow-source .wheel-workflow-src
 
-      - name: Resolve Docker tag
-        id: docker-tag
-        run: |
-          docker_tag=$(.github/containers/get-version-tag.sh)
-          registry_image="ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${docker_tag}"
-          echo "docker-tag=${docker_tag}" >> "$GITHUB_OUTPUT"
-          echo "registry-image=${registry_image}" >> "$GITHUB_OUTPUT"
-          echo "Docker tag: ${docker_tag}"
-          echo "Registry image: ${registry_image}"
-          {
-            echo "### manylinux wheel-builder image"
-            echo ""
-            echo "- Docker tag: \`${docker_tag}\`"
-            echo "- Image: \`${registry_image}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+  cache-components:
+    name: "Cache ${{ matrix.name }}"
+    needs: resolve
+    if: ${{ needs.resolve.outputs.all-images-exist != 'true' }}
+    runs-on: mlir-large-runner-lang
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "tt-metal"
+            component: ttmetal
+            python_tag: ""
+            cache_tag: linux-amd64-ttmetal-cp312
+          - name: "LLVM (cp310)"
+            component: llvm
+            python_tag: cp310
+            cache_tag: linux-amd64-llvm-cp310
+          - name: "LLVM (cp312)"
+            component: llvm
+            python_tag: cp312
+            cache_tag: linux-amd64-llvm-cp312
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
 
-      - name: Build and push manylinux wheel-builder image
+      - name: Checkout wheel image workflow source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: |
+            .github/actions/setup-wheel-image-build
+            .github/containers
+            .github/scripts
+            cmake/modules
+            scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Set up wheel image build
+        uses: ./.wheel-workflow-src/.github/actions/setup-wheel-image-build
+        with:
+          registry-owner: ${{ github.repository_owner }}
+          registry-token: ${{ github.token }}
+
+      - name: Update component build cache
         env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_STEP_LOG_MAX_SIZE: -1
-        run: .github/containers/build-wheel-manylinux-images.sh --python-tags "${{ matrix.python_tag }}" --image-tag "${{ steps.docker-tag.outputs.docker-tag }}" --build-parallel-level 2
+          CACHE_COMPONENT: ${{ matrix.component }}
+          CACHE_REF: ${{ format('{0}:{1}', env.WHEEL_CACHE_IMAGE, matrix.cache_tag) }}
+          PYTHON_TAG: ${{ matrix.python_tag }}
+        run: .wheel-workflow-src/.github/containers/cache-wheel-manylinux-component.sh --component "$CACHE_COMPONENT" --python-tag "$PYTHON_TAG" --cache-ref "$CACHE_REF" --build-parallel-level 2 --workflow-source .wheel-workflow-src
 
       - name: Show disk usage on failure
         if: failure()
-        run: |
-          df -h
-          docker system df || true
+        run: .wheel-workflow-src/.github/scripts/report-docker-disk-usage.sh
+
+  build-manylinux-wheel-images:
+    name: "Build manylinux wheel image (${{ matrix.python_tag }})"
+    needs: [resolve, cache-components]
+    if: ${{ always() && needs.resolve.result == 'success' && (needs.cache-components.result == 'success' || needs.cache-components.result == 'skipped') && needs.resolve.outputs.all-images-exist != 'true' }}
+    runs-on: mlir-large-runner-lang
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        python_tag: [cp310, cp312]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout wheel image workflow source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: |
+            .github/actions/setup-wheel-image-build
+            .github/containers
+            .github/scripts
+            cmake/modules
+            scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Set up wheel image build
+        uses: ./.wheel-workflow-src/.github/actions/setup-wheel-image-build
+        with:
+          registry-owner: ${{ github.repository_owner }}
+          registry-token: ${{ github.token }}
+
+      - name: Assemble and push manylinux wheel-builder image
+        env:
+          DOCKER_TAG: ${{ needs.resolve.outputs.docker-tag }}
+          PUBLISH_LATEST: ${{ needs.resolve.outputs.update-latest }}
+          PYTHON_TAG: ${{ matrix.python_tag }}
+        run: .wheel-workflow-src/.github/containers/build-wheel-manylinux-images.sh --python-tags "$PYTHON_TAG" --image-tag "$DOCKER_TAG" --llvm-cache-ref "${WHEEL_CACHE_IMAGE}:linux-amd64-llvm-${PYTHON_TAG}" --ttmetal-cache-ref "${WHEEL_CACHE_IMAGE}:linux-amd64-ttmetal-cp312" --build-parallel-level 2 --workflow-source .wheel-workflow-src --publish-latest "$PUBLISH_LATEST"
+
+      - name: Show disk usage on failure
+        if: failure()
+        run: .wheel-workflow-src/.github/scripts/report-docker-disk-usage.sh

--- a/.github/workflows/call-build-wheel-images.yml
+++ b/.github/workflows/call-build-wheel-images.yml
@@ -162,10 +162,40 @@ jobs:
       - name: Assemble and push manylinux wheel-builder image
         env:
           DOCKER_TAG: ${{ needs.resolve.outputs.docker-tag }}
-          PUBLISH_LATEST: ${{ needs.resolve.outputs.update-latest }}
           PYTHON_TAG: ${{ matrix.python_tag }}
-        run: .wheel-workflow-src/.github/containers/build-wheel-manylinux-images.sh --python-tags "$PYTHON_TAG" --image-tag "$DOCKER_TAG" --llvm-cache-ref "${WHEEL_CACHE_IMAGE}:linux-amd64-llvm-${PYTHON_TAG}" --ttmetal-cache-ref "${WHEEL_CACHE_IMAGE}:linux-amd64-ttmetal-cp312" --build-parallel-level 2 --workflow-source .wheel-workflow-src --publish-latest "$PUBLISH_LATEST"
+        run: .wheel-workflow-src/.github/containers/build-wheel-manylinux-images.sh --python-tags "$PYTHON_TAG" --image-tag "$DOCKER_TAG" --llvm-cache-ref "${WHEEL_CACHE_IMAGE}:linux-amd64-llvm-${PYTHON_TAG}" --ttmetal-cache-ref "${WHEEL_CACHE_IMAGE}:linux-amd64-ttmetal-cp312" --build-parallel-level 2 --workflow-source .wheel-workflow-src
 
       - name: Show disk usage on failure
         if: failure()
         run: .wheel-workflow-src/.github/scripts/report-docker-disk-usage.sh
+
+  publish-latest:
+    name: "Publish latest manylinux wheel images"
+    needs: [resolve, build-manylinux-wheel-images]
+    if: ${{ always() && needs.resolve.result == 'success' && needs.resolve.outputs.update-latest == 'true' && (needs.resolve.outputs.all-images-exist == 'true' || needs.build-manylinux-wheel-images.result == 'success') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout wheel image workflow source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Publish latest manifests
+        env:
+          DOCKER_TAG: ${{ needs.resolve.outputs.docker-tag }}
+          REPOSITORY: ${{ github.repository }}
+        run: .github/scripts/publish-wheel-builder-latest.sh --repository "$REPOSITORY" --docker-tag "$DOCKER_TAG"

--- a/.github/workflows/call-test-manylinux-wheels.yml
+++ b/.github/workflows/call-test-manylinux-wheels.yml
@@ -1,0 +1,82 @@
+name: Test Manylinux Wheels
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Hardware type to run on."
+        required: false
+        type: string
+        default: n150
+      timeout:
+        description: "Job timeout in minutes."
+        required: false
+        type: number
+        default: 90
+      docker_tag:
+        description: "Tag for the cp312 manylinux wheel-builder image."
+        required: true
+        type: string
+      artifact_name:
+        description: "Combined wheel artifact to install."
+        required: true
+        type: string
+      ttnn_dep_mode:
+        description: "Expected installed ttnn dependency mode."
+        required: true
+        type: string
+      ttlang_sha_override:
+        description: "tt-lang SHA/tag to test. Empty uses the caller ref."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  checks: write
+  contents: read
+  packages: read
+
+jobs:
+  test-manylinux-wheels:
+    name: "Manylinux wheel tutorials (${{ inputs.runs-on }})"
+    runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runs-on) }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
+    container:
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
+      options: --device /dev/tenstorrent
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+    defaults:
+      run:
+        shell: bash
+    env:
+      PYTHONDONTWRITEBYTECODE: 1
+      TTLANG_TEST_SEED: 42
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ttlang_sha_override || github.sha }}
+          fetch-depth: 1
+
+      - name: Checkout workflow wheel helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Download wheels
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist
+
+      - name: Install and test cp312 wheel
+        env:
+          TTLANG_TTNN_DEP_MODE: ${{ inputs.ttnn_dep_mode }}
+        run: .wheel-workflow-src/.github/scripts/test-manylinux-wheel.sh --dist-dir dist --ttnn-dep-mode "$TTLANG_TTNN_DEP_MODE"

--- a/.github/workflows/call-test-manylinux-wheels.yml
+++ b/.github/workflows/call-test-manylinux-wheels.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runs-on) }}
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
+      image: ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
       options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -101,7 +101,7 @@ jobs:
     # Built once in the oldest glibc (manylinux_2_34, forward-compatible to the
     # ird runners) at cp312 to match the device jobs' ttnn import ABI.
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
+      image: ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
     defaults:
       run:
         shell: bash
@@ -266,7 +266,7 @@ jobs:
       matrix:
         python_tag: [cp310, cp312]
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${{ inputs.docker_tag }}
+      image: ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${{ inputs.docker_tag }}
     defaults:
       run:
         shell: bash
@@ -337,7 +337,7 @@ jobs:
     runs-on: mlir-large-runner-lang
     timeout-minutes: 30
     container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
+      image: ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux-2-34-cp312:${{ inputs.docker_tag }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/call-ttmetal-light-wheel.yml
+++ b/.github/workflows/call-ttmetal-light-wheel.yml
@@ -319,11 +319,7 @@ jobs:
           TTLANG_EXTERNAL_TT_METAL_DIR: /tmp/ttmetal-install
           TTLANG_GIT_COMMIT: ${{ needs.find-compatible.outputs.winner_sha }}
           TT_METAL_COMMIT: ${{ needs.find-compatible.outputs.ttmetal_sha }}
-        run: |
-          .github/scripts/build-s3-light-core-wheel.sh \
-            --python-tag "${{ matrix.python_tag }}" \
-            --version "${{ needs.find-compatible.outputs.winner_version }}" \
-            --dist-dir dist
+        run: .github/scripts/build-s3-light-core-wheel.sh --python-tag "${{ matrix.python_tag }}" --version "${{ needs.find-compatible.outputs.winner_version }}" --dist-dir dist
 
       - name: Upload per-ABI wheels
         if: ${{ steps.gate.outputs.build == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,8 @@ jobs:
     with:
       push: true
 
-  # Wheel-builder images are only consumed by the S3 light-wheel publish, never
-  # by hardware tests or standard wheels. Build them alongside build-docker so
-  # the `build` job (hardware tests) does not wait on this 360-min build.
+  # Manylinux wheel-builder images are independent of the IRD image. Build them
+  # alongside build-docker so hardware tests do not wait for toolchain caches.
   build-wheel-images:
     needs: resolve-docker-tag
     if: ${{ needs.resolve-docker-tag.outputs.needs_rebuild == 'true' }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,8 +7,7 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      # Public PyPI rejects PEP 440 local-version labels (e.g. +light), so the
-      # internal-wheel tags are intentionally excluded here.
+      # Public PyPI rejects PEP 440 local-version labels such as +light.
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
@@ -18,11 +17,12 @@ on:
         type: string
         required: true
       docker_tag:
-        description: "Docker image tag for the ird container."
+        description: "Existing manylinux_2_34 wheel-builder tag. Empty builds the images."
         type: string
-        required: true
+        default: ""
+        required: false
       dry_run:
-        description: "Skip tag enforcement and the PyPI upload (for pipeline testing). build-wheels and test-dist-tutorials still run; pass an existing docker_tag so build-docker is skipped."
+        description: "Build and test a nightly-versioned wheel without enforcing a release tag or uploading to PyPI."
         type: boolean
         default: false
 
@@ -31,11 +31,12 @@ permissions:
 
 jobs:
   preflight:
-    name: "Verify release tag"
-    runs-on: ubuntu-latest
+    name: "Verify release target"
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
-      tag_version: ${{ steps.parse.outputs.tag_version }}
+      tag_version: ${{ steps.resolve.outputs.tag_version }}
+      wheel_version: ${{ steps.resolve.outputs.wheel_version }}
     steps:
       - name: Checkout workflow source
         uses: actions/checkout@v6
@@ -48,68 +49,19 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Echo dispatch inputs
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          DISPATCH_DOCKER_TAG: ${{ inputs.docker_tag }}
-          DISPATCH_DRY_RUN: ${{ inputs.dry_run }}
-          TTLANG_SHA: ${{ inputs.ttlang_sha }}
-        run: |
-          echo "dry_run=$DISPATCH_DRY_RUN"
-          echo "docker_tag=$DISPATCH_DOCKER_TAG"
-          echo "ttlang_sha=$TTLANG_SHA"
-
-      - name: Validate tt-lang SHA
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          TTLANG_SHA: ${{ inputs.ttlang_sha }}
-        run: |
-          release_source="$GITHUB_WORKSPACE/release-source"
-          if [[ ! "$TTLANG_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "::error::ttlang_sha must be a full 40-character commit SHA."
-            exit 1
-          fi
-          if [[ "$(git -C "$release_source" rev-parse HEAD)" != "${TTLANG_SHA,,}" ]]; then
-            echo "::error::Checked-out commit does not match ttlang_sha."
-            exit 1
-          fi
-
-      - name: Require publish target from main
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != true }}
-        env:
-          TTLANG_SHA: ${{ inputs.ttlang_sha }}
-        run: |
-          release_source="$GITHUB_WORKSPACE/release-source"
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "::error::Public PyPI publishing is restricted to workflow dispatches from refs/heads/main."
-            exit 1
-          fi
-          if ! git -C "$release_source" merge-base --is-ancestor "$TTLANG_SHA" "$GITHUB_SHA"; then
-            echo "::error::ttlang_sha must be an ancestor of the dispatching main commit."
-            exit 1
-          fi
-
-      - name: Install packaging (for PEP 440 normalization in require-release-tag.sh)
+      - name: Install packaging
         if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
         run: python3 -m pip install --user packaging
 
-      - name: Require release tag
-        id: parse
-        if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
+      - name: Resolve publish inputs
+        id: resolve
         env:
+          DOCKER_TAG: ${{ inputs.docker_tag }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.dry_run) || 'false' }}
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_SOURCE: ${{ github.workspace }}/release-source
           TTLANG_SHA: ${{ inputs.ttlang_sha }}
-        run: |
-          release_ref="$GITHUB_REF"
-          if [[ -n "$TTLANG_SHA" ]]; then
-            mapfile -t release_tags < <(git -C "$RELEASE_SOURCE" tag --list 'v[0-9]*' --points-at "$TTLANG_SHA")
-            if [[ ${#release_tags[@]} -ne 1 ]]; then
-              echo "::error::ttlang_sha must have exactly one v* release tag; found ${#release_tags[@]}."
-              exit 1
-            fi
-            release_ref="refs/tags/${release_tags[0]}"
-          fi
-          .github/scripts/require-release-tag.sh "$release_ref"
+        run: .github/scripts/resolve-pypi-publish-inputs.sh
 
       - name: Require PyPI ttnn alignment
         if: ${{ github.event_name == 'push' || inputs.dry_run != true }}
@@ -117,55 +69,56 @@ jobs:
           TTLANG_TT_METAL_VERSION_FILE: ${{ github.workspace }}/release-source/third-party/tt-metal-version
         run: .github/scripts/require-pypi-ttnn-alignment.sh
 
-  build-docker:
+  build-wheel-images:
     needs: preflight
     if: ${{ github.event_name == 'push' || inputs.docker_tag == '' }}
     permissions:
       contents: read
       packages: write
-      checks: write
-    uses: ./.github/workflows/call-build-docker.yml
+    uses: ./.github/workflows/call-build-wheel-images.yml
     secrets: inherit
     with:
-      push: true
       ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
   build-wheels:
-    needs: [preflight, build-docker]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') }}
+    needs: [preflight, build-wheel-images]
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-wheel-images.result == 'success' || needs.build-wheel-images.result == 'skipped') }}
     permissions:
       contents: read
       packages: read
-    uses: ./.github/workflows/call-build-wheels.yml
+    uses: ./.github/workflows/call-build-manylinux-wheels.yml
     with:
-      docker_tag: ${{ (github.event_name == 'workflow_dispatch' && inputs.docker_tag != '' && inputs.docker_tag) || needs.build-docker.outputs.docker-tag }}
+      docker_tag: ${{ inputs.docker_tag != '' && inputs.docker_tag || needs.build-wheel-images.outputs.docker-tag }}
+      version_override: ${{ needs.preflight.outputs.wheel_version }}
+      ttnn_dep_mode: pypi
+      build_sim_wheel: true
+      artifact_name: tt-lang-wheels
       ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
-  test-dist-tutorials:
-    needs: [preflight, build-docker, build-wheels]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && needs.build-wheels.result == 'success' }}
+  test-wheels:
+    needs: [preflight, build-wheel-images, build-wheels]
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-wheel-images.result == 'success' || needs.build-wheel-images.result == 'skipped') && needs.build-wheels.result == 'success' }}
     permissions:
+      checks: write
       contents: read
       packages: read
-      checks: write
-    uses: ./.github/workflows/call-test-dist-tutorials.yml
-    secrets: inherit
+    uses: ./.github/workflows/call-test-manylinux-wheels.yml
     with:
       runs-on: n150
-      dist_docker_tag: ${{ (github.event_name == 'workflow_dispatch' && inputs.docker_tag != '' && inputs.docker_tag) || needs.build-docker.outputs.docker-tag }}
+      docker_tag: ${{ inputs.docker_tag != '' && inputs.docker_tag || needs.build-wheel-images.outputs.docker-tag }}
+      artifact_name: tt-lang-wheels
+      ttnn_dep_mode: pypi
       ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
   publish:
     name: "Publish to PyPI"
-    needs: [preflight, build-wheels, test-dist-tutorials]
-    # Existing Docker tags skip build-docker, so override transitive skip propagation.
-    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && inputs.dry_run != true && needs.preflight.result == 'success' && needs.build-wheels.result == 'success' && needs.test-dist-tutorials.result == 'success' }}
-    runs-on: ubuntu-latest
+    needs: [preflight, build-wheels, test-wheels]
+    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && inputs.dry_run != true && needs.preflight.result == 'success' && needs.build-wheels.result == 'success' && needs.test-wheels.result == 'success' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment: pypi
     permissions:
       id-token: write
-
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
@@ -174,33 +127,34 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: tt-lang-wheels
-          path: dist/
+          path: dist
 
       - name: List wheels
-        run: ls -lh dist/
+        run: .github/scripts/summarize-wheel-artifact.sh dist
 
       - name: Verify wheel version matches tag
-        run: .github/scripts/verify-wheel-version.sh "${{ needs.preflight.outputs.tag_version }}" dist
+        env:
+          TAG_VERSION: ${{ needs.preflight.outputs.tag_version }}
+        run: .github/scripts/verify-wheel-version.sh "$TAG_VERSION" dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
   dry-run-summary:
     name: "Dry-run summary"
-    needs: [preflight, build-wheels]
-    # Existing Docker tags skip build-docker, so override transitive skip propagation.
-    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && inputs.dry_run == true && needs.preflight.result == 'success' && needs.build-wheels.result == 'success' }}
-    runs-on: ubuntu-latest
+    needs: [preflight, build-wheels, test-wheels]
+    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && inputs.dry_run == true && needs.preflight.result == 'success' && needs.build-wheels.result == 'success' && needs.test-wheels.result == 'success' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
           name: tt-lang-wheels
-          path: dist/
+          path: dist
 
       - name: Summarize
-        run: |
-          echo "::notice::Dry run complete; no upload performed."
-          echo "Wheels that would have been published:"
-          ls -lh dist/
+        run: .github/scripts/summarize-wheel-artifact.sh --dry-run dist

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -6,8 +6,8 @@ name: Publish S3 PyPI Wheels
 
 on:
   schedule:
-    # Nightly S3-only wheel publish. GitHub cron uses UTC.
-    - cron: "0 8 * * *"
+    # Weekly S3-only publish: 08:00 UTC Monday (00:00 PST / 01:00 PDT).
+    - cron: "0 8 * * 1"
   workflow_dispatch:
     inputs:
       docker_tag:
@@ -16,7 +16,7 @@ on:
         default: ""
         required: false
       version_override:
-        description: "PEP 440 wheel version. Empty computes a nightly dev version."
+        description: "PEP 440 wheel version. Empty computes a date-based dev version."
         type: string
         default: ""
         required: false
@@ -76,6 +76,7 @@ jobs:
       manylinux_wheel_matrix: ${{ steps.resolve.outputs.manylinux_wheel_matrix }}
       overwrite_releases: ${{ steps.resolve.outputs.overwrite_releases }}
       publish_needed: ${{ steps.nightly.outputs.publish-needed }}
+      publish_prefix: ${{ steps.publish-prefix.outputs.prefix }}
       ttlang_sha: ${{ steps.nightly.outputs.ttlang-sha }}
       version_override: ${{ steps.resolve.outputs.version_override }}
       wheel_variant: ${{ steps.resolve.outputs.wheel_variant }}
@@ -111,6 +112,12 @@ jobs:
           DISPATCH_WHEEL_VARIANT: ${{ github.event_name == 'workflow_dispatch' && inputs.wheel_variant || '' }}
           EVENT_NAME: ${{ github.event_name }}
         run: .wheel-workflow-src/.github/scripts/resolve-s3-publish-inputs.sh
+
+      - name: Resolve publish prefix
+        id: publish-prefix
+        env:
+          TTLANG_WHEEL_VERSION: ${{ steps.resolve.outputs.version_override }}
+        run: .wheel-workflow-src/.github/scripts/resolve-s3-publish-prefix.sh "$TTLANG_WHEEL_VERSION"
 
       - name: Configure AWS Credentials
         if: ${{ github.event_name == 'schedule' }}
@@ -236,12 +243,6 @@ jobs:
           TTLANG_WHEEL_VERSION: ${{ needs.preflight.outputs.version_override }}
         run: .wheel-workflow-src/.github/scripts/prepare-selected-s3-publish-dist.sh "$TTLANG_WHEEL_VERSION" wheel-artifacts dist
 
-      - name: Resolve publish prefix
-        id: publish-prefix
-        env:
-          TTLANG_WHEEL_VERSION: ${{ needs.preflight.outputs.version_override }}
-        run: .wheel-workflow-src/.github/scripts/resolve-s3-publish-prefix.sh "$TTLANG_WHEEL_VERSION"
-
       - name: Configure AWS Credentials
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
         uses: ./.wheel-workflow-src/.github/actions/configure-tt-s3-credentials
@@ -250,7 +251,7 @@ jobs:
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
         env:
           OVERWRITE_RELEASES: ${{ needs.preflight.outputs.overwrite_releases }}
-          PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}
+          PUBLISH_PREFIX: ${{ needs.preflight.outputs.publish_prefix }}
         run: .wheel-workflow-src/.github/scripts/publish-s3-wheels.sh --overwrite-if "$OVERWRITE_RELEASES" --prefix "$PUBLISH_PREFIX" dist
 
       - name: Install Markdown renderer
@@ -260,7 +261,7 @@ jobs:
       - name: Restore S3 index README
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
         env:
-          PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}
+          PUBLISH_PREFIX: ${{ needs.preflight.outputs.publish_prefix }}
         run: .wheel-workflow-src/.github/scripts/inject-s3-publish-readme.sh "$PUBLISH_PREFIX" dist
 
       - name: Record scheduled publish state
@@ -273,7 +274,7 @@ jobs:
       - name: Report install command
         env:
           DRY_RUN: ${{ needs.preflight.outputs.dry_run }}
-          PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}
+          PUBLISH_PREFIX: ${{ needs.preflight.outputs.publish_prefix }}
           TTLANG_WHEEL_VERSION: ${{ needs.preflight.outputs.version_override }}
           WHEEL_VARIANT: ${{ needs.preflight.outputs.wheel_variant }}
         run: .wheel-workflow-src/.github/scripts/publish-s3-summary.sh --dry-run-if "$DRY_RUN" --find-links-subdir "$PUBLISH_PREFIX" "$WHEEL_VARIANT" "$TTLANG_WHEEL_VERSION"

--- a/.github/workflows/publish-s3-pypi.yml
+++ b/.github/workflows/publish-s3-pypi.yml
@@ -11,12 +11,12 @@ on:
   workflow_dispatch:
     inputs:
       docker_tag:
-        description: "Docker image tag for required builder containers. Leave empty to build and push them first."
+        description: "Existing tag for all required builder images. Empty builds the images."
         type: string
         default: ""
         required: false
       version_override:
-        description: "PEP 440 version for the S3 wheel. Leave empty to compute a nightly dev version."
+        description: "PEP 440 wheel version. Empty computes a nightly dev version."
         type: string
         default: ""
         required: false
@@ -41,12 +41,12 @@ on:
         default: true
         required: true
       ttlang_ref:
-        description: "tt-lang SHA or tag to build the wheels from. Leave empty to use the triggering commit."
+        description: "tt-lang SHA or tag to build. Empty uses the triggering commit."
         type: string
         default: ""
         required: false
       apply_patches:
-        description: "Apply wheel patches from .github/wheel-patches/ before building (e.g., correct the numpy version constraints when rebuilding an older ref)."
+        description: "Apply .github/wheel-patches from the workflow commit before building."
         type: boolean
         default: false
         required: false
@@ -63,18 +63,23 @@ jobs:
   preflight:
     name: "Resolve S3 publish inputs"
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     outputs:
+      allow_final_internal_version: ${{ steps.resolve.outputs.allow_final_internal_version }}
+      bundled_selected: ${{ steps.resolve.outputs.bundled_selected }}
       docker_tag: ${{ steps.resolve.outputs.docker_tag }}
       dry_run: ${{ steps.resolve.outputs.dry_run }}
+      manylinux_selected: ${{ steps.resolve.outputs.manylinux_selected }}
+      manylinux_wheel_matrix: ${{ steps.resolve.outputs.manylinux_wheel_matrix }}
       overwrite_releases: ${{ steps.resolve.outputs.overwrite_releases }}
+      publish_needed: ${{ steps.nightly.outputs.publish-needed }}
+      ttlang_sha: ${{ steps.nightly.outputs.ttlang-sha }}
       version_override: ${{ steps.resolve.outputs.version_override }}
       wheel_variant: ${{ steps.resolve.outputs.wheel_variant }}
       wheel_variants: ${{ steps.resolve.outputs.wheel_variants }}
-      wheel_matrix: ${{ steps.resolve.outputs.wheel_matrix }}
-      standard_wheel_matrix: ${{ steps.resolve.outputs.standard_wheel_matrix }}
-      allow_final_internal_version: ${{ steps.resolve.outputs.allow_final_internal_version }}
-
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
@@ -82,6 +87,19 @@ jobs:
           ref: ${{ inputs.ttlang_ref || github.sha }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Checkout workflow wheel helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: |
+            .github/actions/configure-tt-s3-credentials
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Install packaging
+        run: python3 -m pip install --user packaging
 
       - name: Resolve publish inputs
         id: resolve
@@ -92,21 +110,23 @@ jobs:
           DISPATCH_VERSION_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.version_override || '' }}
           DISPATCH_WHEEL_VARIANT: ${{ github.event_name == 'workflow_dispatch' && inputs.wheel_variant || '' }}
           EVENT_NAME: ${{ github.event_name }}
-        run: .github/scripts/resolve-s3-publish-inputs.sh
+        run: .wheel-workflow-src/.github/scripts/resolve-s3-publish-inputs.sh
 
-      - name: Require main ref for publishing
-        if: ${{ github.ref != 'refs/heads/main' && (steps.resolve.outputs.dry_run != 'true' || steps.resolve.outputs.docker_tag == '') }}
-        run: |
-          echo "Publishing is restricted to refs/heads/main (got ${GITHUB_REF}). Non-main dry runs must provide docker_tag." >&2
-          exit 1
+      - name: Configure AWS Credentials
+        if: ${{ github.event_name == 'schedule' }}
+        uses: ./.wheel-workflow-src/.github/actions/configure-tt-s3-credentials
+
+      - name: Check scheduled publish state
+        id: nightly
+        run: .wheel-workflow-src/.github/scripts/s3-nightly-state.py check --event "${{ github.event_name }}"
 
   build-docker:
     needs: preflight
-    if: ${{ needs.preflight.outputs.docker_tag == '' }}
+    if: ${{ needs.preflight.outputs.publish_needed == 'true' && needs.preflight.outputs.docker_tag == '' && needs.preflight.outputs.bundled_selected == 'true' }}
     permissions:
+      checks: write
       contents: read
       packages: write
-      checks: write
     uses: ./.github/workflows/call-build-docker.yml
     secrets: inherit
     with:
@@ -115,7 +135,7 @@ jobs:
 
   build-wheel-images:
     needs: preflight
-    if: ${{ needs.preflight.outputs.docker_tag == '' && contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light') }}
+    if: ${{ needs.preflight.outputs.publish_needed == 'true' && needs.preflight.outputs.docker_tag == '' && needs.preflight.outputs.manylinux_selected == 'true' }}
     permissions:
       contents: read
       packages: write
@@ -124,172 +144,71 @@ jobs:
     with:
       ttlang_sha_override: ${{ inputs.ttlang_ref }}
 
-  build-standard-wheels:
+  build-bundled-wheels:
     needs: [preflight, build-docker]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (contains(fromJSON(needs.preflight.outputs.wheel_variants), 'bundled') || contains(fromJSON(needs.preflight.outputs.wheel_variants), 'pypi')) }}
-    name: "Build ${{ matrix.wheel_variant }} wheels"
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.preflight.outputs.standard_wheel_matrix) }}
+    if: ${{ always() && needs.preflight.result == 'success' && needs.preflight.outputs.publish_needed == 'true' && needs.preflight.outputs.bundled_selected == 'true' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') }}
+    name: "Build bundled wheels"
     permissions:
       contents: read
       packages: read
     uses: ./.github/workflows/call-build-wheels.yml
     with:
       docker_tag: ${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}
-      ttnn_dep_mode: ${{ matrix.ttnn_dep_mode }}
+      ttnn_dep_mode: bundled
       version_override: ${{ needs.preflight.outputs.version_override }}
-      external_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/tt-metal' || '' }}
-      external_python_venv: ${{ matrix.ttnn_dep_mode == 'external' && '/opt/ttlang-toolchain/venv' || '' }}
-      bundled_tt_metal_dir: ${{ matrix.ttnn_dep_mode == 'bundled' && '/opt/ttlang-toolchain/tt-metal' || '' }}
+      bundled_tt_metal_dir: /opt/ttlang-toolchain/tt-metal
       build_sim_wheel: true
+      allow_final_internal_version: ${{ needs.preflight.outputs.allow_final_internal_version == 'true' }}
+      artifact_name: tt-lang-wheels-bundled
+      ttlang_sha_override: ${{ inputs.ttlang_ref }}
+      apply_patches: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_patches }}
+
+  build-manylinux-wheels:
+    needs: [preflight, build-wheel-images]
+    if: ${{ always() && needs.preflight.result == 'success' && needs.preflight.outputs.publish_needed == 'true' && needs.preflight.outputs.manylinux_selected == 'true' && (needs.build-wheel-images.result == 'success' || needs.build-wheel-images.result == 'skipped') }}
+    name: "Build ${{ matrix.wheel_variant }} wheels"
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.preflight.outputs.manylinux_wheel_matrix) }}
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/call-build-manylinux-wheels.yml
+    with:
+      docker_tag: ${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-wheel-images.outputs.docker-tag }}
+      version_override: ${{ needs.preflight.outputs.version_override }}
+      ttnn_dep_mode: ${{ matrix.ttnn_dep_mode }}
+      build_sim_wheel: ${{ matrix.build_sim_wheel }}
       allow_final_internal_version: ${{ needs.preflight.outputs.allow_final_internal_version == 'true' }}
       artifact_name: tt-lang-wheels-${{ matrix.wheel_variant }}
       ttlang_sha_override: ${{ inputs.ttlang_ref }}
       apply_patches: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_patches }}
 
-  build-light-wheels:
-    needs: [preflight, build-docker, build-wheel-images]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (needs.build-wheel-images.result == 'success' || needs.build-wheel-images.result == 'skipped') && contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light') }}
-    name: "Build light wheel (${{ matrix.python_tag }})"
-    runs-on: mlir-large-runner-lang
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        python_tag: [cp310, cp312]
-    container:
-      image: ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}:${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}
-
-    defaults:
-      run:
-        shell: bash
-
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Checkout tt-lang
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ttlang_ref || github.sha }}
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Fix git safe directory
-        run: git config --global --add safe.directory '*'
-
-      # The patch runner and patches come from the workflow commit, not the
-      # (possibly older) target ref being rebuilt, which may predate them.
-      - name: Check out wheel patches from the workflow commit
-        if: ${{ inputs.apply_patches }}
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.sha }}
-          path: .wheel-patch-src
-          sparse-checkout: |
-            .github/scripts/apply-wheel-patches.sh
-            .github/wheel-patches
-          sparse-checkout-cone-mode: false
-
-      - name: Apply wheel patches
-        if: ${{ inputs.apply_patches }}
-        run: .wheel-patch-src/.github/scripts/apply-wheel-patches.sh --target-dir "$GITHUB_WORKSPACE"
-
-      - name: Build light core wheel
-        env:
-          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ needs.preflight.outputs.allow_final_internal_version }}
-        run: |
-          # inputs.ttlang_ref may be a tag or branch; record the resolved commit.
-          TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"
-          export TTLANG_GIT_COMMIT
-          # Submodules aren't checked out here; read tt-metal's commit from the gitlink.
-          TT_METAL_COMMIT="$(git rev-parse HEAD:third-party/tt-metal)"
-          export TT_METAL_COMMIT
-          .github/scripts/build-s3-light-core-wheel.sh --python-tag "${{ matrix.python_tag }}" --version "${{ needs.preflight.outputs.version_override }}" --dist-dir dist
-
-      - name: Build tt-lang-light metapackage
-        if: ${{ matrix.python_tag == 'cp312' }}
-        env:
-          TTLANG_ALLOW_FINAL_INTERNAL_VERSION: ${{ needs.preflight.outputs.allow_final_internal_version }}
-        run: .github/scripts/build-s3-light-metapackage-wheel.sh --version "${{ needs.preflight.outputs.version_override }}" --dist-dir dist
-
-      - name: Upload per-ABI wheels
-        uses: actions/upload-artifact@v7
-        with:
-          name: tt-lang-s3-light-${{ matrix.python_tag }}
-          path: dist/*.whl
-          retention-days: 14
-
-  collect-light-wheels:
-    name: "Verify S3 light wheel set"
-    needs: [preflight, build-docker, build-light-wheels]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && needs.build-light-wheels.result == 'success' && contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light') }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-
-    defaults:
-      run:
-        shell: bash
-
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Checkout tt-lang
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ttlang_ref || github.sha }}
-
-      - name: Download per-ABI wheels
-        uses: actions/download-artifact@v8
-        with:
-          pattern: tt-lang-s3-light-*
-          path: dist
-          merge-multiple: true
-
-      - name: Verify wheel filenames and versions
-        run: .github/scripts/verify-s3-wheel-versions.sh --no-sim light "${{ needs.preflight.outputs.version_override }}" dist
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
-
-      - name: Install-test light wheels
-        run: .github/scripts/test-s3-light-wheels.sh --version "${{ needs.preflight.outputs.version_override }}" --docker-tag "${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}" --dist-dir dist
-
-      - name: Upload combined wheels
-        uses: actions/upload-artifact@v7
-        with:
-          name: tt-lang-wheels-light
-          path: dist/*.whl
-          retention-days: 14
-
   publish:
     name: "Publish wheels to S3 PyPI"
-    needs: [preflight, build-standard-wheels, collect-light-wheels]
-    if: ${{ always() && needs.preflight.result == 'success' && (needs.build-standard-wheels.result == 'success' || needs.build-standard-wheels.result == 'skipped') && (needs.collect-light-wheels.result == 'success' || needs.collect-light-wheels.result == 'skipped') && (needs.preflight.outputs.dry_run == 'true' || github.ref == 'refs/heads/main') }}
+    needs: [preflight, build-bundled-wheels, build-manylinux-wheels]
+    if: ${{ always() && needs.preflight.result == 'success' && needs.preflight.outputs.publish_needed == 'true' && (needs.preflight.outputs.bundled_selected != 'true' || needs.build-bundled-wheels.result == 'success') && (needs.preflight.outputs.manylinux_selected != 'true' || needs.build-manylinux-wheels.result == 'success') && (needs.preflight.outputs.dry_run == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-
-    defaults:
-      run:
-        shell: bash
-
     permissions:
       contents: read
       id-token: write
-
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ttlang_ref || github.sha }}
+
+      - name: Checkout workflow wheel helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .wheel-workflow-src
+          sparse-checkout: |
+            .github/actions/configure-tt-s3-credentials
+            .github/scripts
+            packaging/s3-index/README.md
+          sparse-checkout-cone-mode: false
 
       - name: Download bundled wheels
         if: ${{ contains(fromJSON(needs.preflight.outputs.wheel_variants), 'bundled') }}
@@ -313,93 +232,59 @@ jobs:
           path: wheel-artifacts/pypi
 
       - name: Prepare publish dist
-        run: |
-          set -euo pipefail
-          prepare_args=()
-          if [ -d wheel-artifacts/bundled ]; then
-            prepare_args+=(bundled=wheel-artifacts/bundled)
-          fi
-          if [ -d wheel-artifacts/light ]; then
-            prepare_args+=(light:no-sim=wheel-artifacts/light)
-          fi
-          if [ -d wheel-artifacts/pypi ]; then
-            prepare_args+=(pypi=wheel-artifacts/pypi)
-          fi
-          .github/scripts/prepare-s3-publish-dist.sh \
-            "${{ needs.preflight.outputs.version_override }}" \
-            dist \
-            "${prepare_args[@]}"
+        env:
+          TTLANG_WHEEL_VERSION: ${{ needs.preflight.outputs.version_override }}
+        run: .wheel-workflow-src/.github/scripts/prepare-selected-s3-publish-dist.sh "$TTLANG_WHEEL_VERSION" wheel-artifacts dist
 
-      # Regular S3 publishes upload wheel objects under tt-lang/. Dev versions
-      # use a generated year-month view; final versions use the releases view.
-      - name: Derive publish prefix
-        id: publish_prefix
-        run: |
-          set -euo pipefail
-          version="${{ needs.preflight.outputs.version_override }}"
-          prefix="tt-lang/releases"
-          if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.dev([0-9]{4})([0-9]{2})[0-9]{2} ]]; then
-            prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
-          fi
-          echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
-          echo "Publish prefix: $prefix"
+      - name: Resolve publish prefix
+        id: publish-prefix
+        env:
+          TTLANG_WHEEL_VERSION: ${{ needs.preflight.outputs.version_override }}
+        run: .wheel-workflow-src/.github/scripts/resolve-s3-publish-prefix.sh "$TTLANG_WHEEL_VERSION"
 
       - name: Configure AWS Credentials
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
-        uses: ./.github/actions/configure-tt-s3-credentials
+        uses: ./.wheel-workflow-src/.github/actions/configure-tt-s3-credentials
 
       - name: Publish wheels
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
-        run: |
-          set -euo pipefail
-          publish_args=()
-          if [ "${{ needs.preflight.outputs.overwrite_releases }}" = "true" ]; then
-            publish_args+=(--overwrite)
-          fi
-          publish_args+=(--prefix "${{ steps.publish_prefix.outputs.prefix }}")
-          .github/scripts/publish-s3-wheels.sh "${publish_args[@]}" dist
+        env:
+          OVERWRITE_RELEASES: ${{ needs.preflight.outputs.overwrite_releases }}
+          PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}
+        run: .wheel-workflow-src/.github/scripts/publish-s3-wheels.sh --overwrite-if "$OVERWRITE_RELEASES" --prefix "$PUBLISH_PREFIX" dist
 
-      # Direct monthly publishes regenerate the tt-lang/ slash-key listing.
-      # Restore the README afterward.
-      - name: Inject S3 index README
+      - name: Install Markdown renderer
         if: ${{ needs.preflight.outputs.dry_run != 'true' }}
-        run: |
-          set -euo pipefail
-          python3 -m pip install markdown
-          prefix="${{ steps.publish_prefix.outputs.prefix }}"
-          parent="$(dirname "$prefix")"
-          key="$parent/"
-          .github/scripts/inject-s3-index-readme.sh \
-            --key "$key" \
-            --require-existing \
-            --dist-dir dist
+        run: python3 -m pip install markdown
+
+      - name: Restore S3 index README
+        if: ${{ needs.preflight.outputs.dry_run != 'true' }}
+        env:
+          PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}
+        run: .wheel-workflow-src/.github/scripts/inject-s3-publish-readme.sh "$PUBLISH_PREFIX" dist
+
+      - name: Record scheduled publish state
+        if: ${{ github.event_name == 'schedule' && needs.preflight.outputs.dry_run != 'true' }}
+        env:
+          TTLANG_SHA: ${{ needs.preflight.outputs.ttlang_sha }}
+          TTLANG_WHEEL_VERSION: ${{ needs.preflight.outputs.version_override }}
+        run: .wheel-workflow-src/.github/scripts/s3-nightly-state.py record --event schedule --sha "$TTLANG_SHA" --version "$TTLANG_WHEEL_VERSION"
 
       - name: Report install command
-        run: |
-          set -euo pipefail
-          summary_args=()
-          if [ "${{ needs.preflight.outputs.dry_run }}" = "true" ]; then
-            summary_args+=(--dry-run)
-          fi
-          summary_args+=(--find-links-subdir "${{ steps.publish_prefix.outputs.prefix }}")
-          .github/scripts/publish-s3-summary.sh \
-            "${summary_args[@]}" \
-            "${{ needs.preflight.outputs.wheel_variant }}" \
-            "${{ needs.preflight.outputs.version_override }}"
+        env:
+          DRY_RUN: ${{ needs.preflight.outputs.dry_run }}
+          PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}
+          TTLANG_WHEEL_VERSION: ${{ needs.preflight.outputs.version_override }}
+          WHEEL_VARIANT: ${{ needs.preflight.outputs.wheel_variant }}
+        run: .wheel-workflow-src/.github/scripts/publish-s3-summary.sh --dry-run-if "$DRY_RUN" --find-links-subdir "$PUBLISH_PREFIX" "$WHEEL_VARIANT" "$TTLANG_WHEEL_VERSION"
 
-  # Reuse this run's freshly pushed ird and manylinux images. Best-effort:
-  # continue-on-error here and soft_fail on the reusable build below keep a
-  # failure in this extra wheel from failing the nightly publish.
   ttmetal-light-detect:
     name: "Detect tt-lang-light per-tt-metal-SHA build"
     needs: preflight
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' && needs.preflight.outputs.publish_needed == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    defaults:
-      run:
-        shell: bash
     permissions:
       contents: read
       id-token: write
@@ -409,9 +294,6 @@ jobs:
     steps:
       - name: Checkout tt-lang
         uses: actions/checkout@v6
-
-      - name: Git safe directory
-        run: git config --global --add safe.directory "$(pwd)"
 
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure-tt-s3-credentials
@@ -423,15 +305,15 @@ jobs:
   ttmetal-light-build:
     name: "Build tt-lang-light per-tt-metal-SHA wheel"
     needs: [preflight, build-docker, build-wheel-images, ttmetal-light-detect]
-    if: ${{ github.event_name == 'schedule' && needs.ttmetal-light-detect.outputs.uplift == 'true' }}
+    if: ${{ github.event_name == 'schedule' && needs.preflight.outputs.publish_needed == 'true' && needs.ttmetal-light-detect.outputs.uplift == 'true' }}
     permissions:
       contents: read
-      packages: read
       id-token: write
+      packages: read
     uses: ./.github/workflows/call-ttmetal-light-wheel.yml
     secrets: inherit
     with:
       tt_metal_sha: ${{ needs.ttmetal-light-detect.outputs.tt_metal_sha }}
-      docker_tag: ${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-docker.outputs.docker-tag }}
+      docker_tag: ${{ needs.preflight.outputs.docker_tag != '' && needs.preflight.outputs.docker_tag || needs.build-wheel-images.outputs.docker-tag }}
       dry_run: false
       soft_fail: true

--- a/.github/workflows/s3-wheel-maintenance.yml
+++ b/.github/workflows/s3-wheel-maintenance.yml
@@ -63,6 +63,7 @@ jobs:
         run: python3 -m pip install markdown
 
       - name: Plan or apply maintenance
+        id: maintenance
         env:
           CONFIRM: ${{ inputs.confirm }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -70,3 +71,9 @@ jobs:
           OPERATION: ${{ inputs.operation }}
           START_DATE: ${{ inputs.start_date }}
         run: .github/scripts/s3-wheel-maintenance.py "$OPERATION" --dry-run "$DRY_RUN" --start-date "$START_DATE" --end-date "$END_DATE" --confirm "$CONFIRM" --github-ref "$GITHUB_REF"
+
+      - name: Refresh S3 wheel views
+        if: ${{ inputs.operation == 'remove-dev-range' && inputs.dry_run != true }}
+        env:
+          AFFECTED_MONTHS: ${{ steps.maintenance.outputs.refresh-months }}
+        run: .github/scripts/refresh-s3-wheel-views.sh --months "$AFFECTED_MONTHS"

--- a/.github/workflows/s3-wheel-maintenance.yml
+++ b/.github/workflows/s3-wheel-maintenance.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: S3 Wheel Maintenance
+
+run-name: "S3 wheels: ${{ inputs.operation }} (dry_run=${{ inputs.dry_run }})"
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Storage maintenance operation."
+        type: choice
+        options:
+          - deduplicate
+          - remove-dev-range
+        required: true
+      start_date:
+        description: "Inclusive start date (YYYY-MM-DD) for remove-dev-range."
+        type: string
+        default: ""
+        required: false
+      end_date:
+        description: "Inclusive end date (YYYY-MM-DD) for remove-dev-range."
+        type: string
+        default: ""
+        required: false
+      dry_run:
+        description: "List selected object versions without deleting them."
+        type: boolean
+        default: true
+        required: true
+      confirm:
+        description: "Live token: delete-duplicate-versions or delete-dev-versions."
+        type: string
+        default: ""
+        required: false
+
+concurrency:
+  group: publish-s3-pypi-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  maintain:
+    name: "Plan or apply S3 wheel maintenance"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: ./.github/actions/configure-tt-s3-credentials
+
+      - name: Install Markdown renderer
+        if: ${{ inputs.operation == 'remove-dev-range' && inputs.dry_run != true }}
+        run: python3 -m pip install markdown
+
+      - name: Plan or apply maintenance
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          END_DATE: ${{ inputs.end_date }}
+          OPERATION: ${{ inputs.operation }}
+          START_DATE: ${{ inputs.start_date }}
+        run: .github/scripts/s3-wheel-maintenance.py "$OPERATION" --dry-run "$DRY_RUN" --start-date "$START_DATE" --end-date "$END_DATE" --confirm "$CONFIRM" --github-ref "$GITHUB_REF"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,38 +55,20 @@ include(TTLangCompilerSetup)
 # ---------------------------------------------------------------------------
 # Toolchain options (declared early because TTLangPython needs them).
 # ---------------------------------------------------------------------------
-option(TTLANG_USE_TOOLCHAIN "Use pre-built LLVM from ttlang toolchain" OFF)
-option(TTLANG_BUILD_TOOLCHAIN
-  "Build LLVM and tt-metal into a reusable toolchain directory" OFF)
-
-# Per-component toolchain overrides. By default they follow TTLANG_USE_TOOLCHAIN
-# but can be set independently, e.g. to rebuild tt-metal from submodule while
-# still consuming LLVM from a pre-built toolchain.
-option(TTLANG_USE_TOOLCHAIN_TTMETAL
-  "Use pre-built tt-metal from ttlang toolchain (defaults to TTLANG_USE_TOOLCHAIN)"
-  ${TTLANG_USE_TOOLCHAIN})
-
-# External tt-metal override: point at an existing tt-metal installation
-# (install-ttmetal.sh output layout) instead of the toolchain copy or the
-# submodule. Takes precedence over TTLANG_USE_TOOLCHAIN_TTMETAL. See
-# BuildTTMetal.cmake for the required directory layout.
-set(TTLANG_EXTERNAL_TT_METAL_DIR "" CACHE PATH
-  "Path to an existing tt-metal installation; overrides the toolchain or submodule build.")
-if(NOT DEFINED TTLANG_TOOLCHAIN_DIR)
-  if(DEFINED ENV{TTLANG_TOOLCHAIN_DIR})
-    set(TTLANG_TOOLCHAIN_DIR "$ENV{TTLANG_TOOLCHAIN_DIR}" CACHE PATH
-      "tt-lang toolchain directory")
-  elseif(TTLANG_USE_TOOLCHAIN)
-    set(TTLANG_TOOLCHAIN_DIR "/opt/ttlang-toolchain" CACHE PATH
-      "tt-lang toolchain directory" FORCE)
-  endif()
-endif()
+include(TTLangToolchainOptions)
 
 # ---------------------------------------------------------------------------
 # Python venv setup (must run before BuildLLVM so that find_package(Python3)
 # resolves against the venv, not a system Python).
 # ---------------------------------------------------------------------------
 include(TTLangPython)
+
+# Component builds produce independent cache artifacts without configuring
+# tt-lang targets.
+include(TTLangToolchainComponent)
+if(TTLANG_TOOLCHAIN_COMPONENT_CONFIGURED)
+  return()
+endif()
 
 # ---------------------------------------------------------------------------
 # Simulator-only mode: create venv, install requirements, generate activate

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ TT-Lang bridges this gap through progressive disclosure: simple kernels require 
 We provide two tt-lang packages: the [tt-lang](https://pypi.org/project/tt-lang/) package includes the tt-lang compiler, Tenstorrent hardware support and depends on the `ttnn`, `pytorch` and several smaller python packages, while [tt-lang-sim](https://pypi.org/project/tt-lang-sim/) includes only the functional simulator (no compiler or hardware support) and does not depend on `ttnn`.
 
 First, create an isolated Python environment (venv, conda, etc.) with Python
-matching the selected wheel. Public PyPI hardware wheels currently use Python
-3.12; S3 light wheels are built for Python 3.10 and Python 3.12. For example:
+matching the selected wheel. Public PyPI and S3 light hardware wheels are built
+for Python 3.10 and Python 3.12. For example:
 
 ```bash
 python3 -m venv --prompt ttlang ttlang-venv

--- a/cmake/modules/BuildLLVM.cmake
+++ b/cmake/modules/BuildLLVM.cmake
@@ -155,11 +155,12 @@ if(NOT _VENV_PYTHON)
   )
 endif()
 
-# Install/update tt-lang Python requirements on every configure (pip is a
-# no-op when packages are already satisfied).  requirements.txt includes all
-# runtime dependencies: MLIR bindings, tt-metal/ttnn, and tt-lang itself.
-ttlang_pip_install_requirements("${_VENV_PYTHON}"
-  "${CMAKE_SOURCE_DIR}/requirements.txt" FATAL)
+# Component-only wheel builds install runtime requirements in a later Docker
+# layer so requirement changes do not invalidate the LLVM compilation cache.
+if(TTLANG_INSTALL_RUNTIME_REQUIREMENTS)
+  ttlang_pip_install_requirements("${_VENV_PYTHON}"
+    "${CMAKE_SOURCE_DIR}/requirements.txt" FATAL)
+endif()
 
 set(Python3_EXECUTABLE "${_VENV_PYTHON}")
 message(STATUS "Python venv: ${TTLANG_PYTHON_VENV}")

--- a/cmake/modules/BuildTTMetal.cmake
+++ b/cmake/modules/BuildTTMetal.cmake
@@ -354,7 +354,8 @@ if(DEFINED TTLANG_TOOLCHAIN_DIR AND NOT TTLANG_USE_TOOLCHAIN_TTMETAL)
     RESULT_VARIABLE _TTMETAL_INSTALL_RESULT
   )
   if(NOT _TTMETAL_INSTALL_RESULT EQUAL 0)
-    message(WARNING "tt-metal install into toolchain failed (exit ${_TTMETAL_INSTALL_RESULT})")
+    message(FATAL_ERROR
+      "tt-metal install into toolchain failed (exit ${_TTMETAL_INSTALL_RESULT})")
   endif()
 endif()
 

--- a/cmake/modules/TTLangToolchainComponent.cmake
+++ b/cmake/modules/TTLangToolchainComponent.cmake
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+set(TTLANG_TOOLCHAIN_COMPONENT_CONFIGURED OFF)
+if(TTLANG_TOOLCHAIN_COMPONENT STREQUAL "llvm")
+  include(BuildLLVM)
+  set(TTLANG_TOOLCHAIN_COMPONENT_CONFIGURED ON)
+elseif(TTLANG_TOOLCHAIN_COMPONENT STREQUAL "tt-metal")
+  include(BuildTTMetal)
+  set(TTLANG_TOOLCHAIN_COMPONENT_CONFIGURED ON)
+endif()

--- a/cmake/modules/TTLangToolchainOptions.cmake
+++ b/cmake/modules/TTLangToolchainOptions.cmake
@@ -18,12 +18,15 @@ if(NOT TTLANG_TOOLCHAIN_COMPONENT IN_LIST _TTLANG_TOOLCHAIN_COMPONENTS)
     "TTLANG_TOOLCHAIN_COMPONENT must be one of: all, llvm, tt-metal")
 endif()
 
-# This override permits rebuilding tt-metal while consuming LLVM from a
-# pre-built toolchain.
+# Per-component toolchain overrides follow TTLANG_USE_TOOLCHAIN by default but
+# can be set independently to rebuild tt-metal while consuming pre-built LLVM.
 option(TTLANG_USE_TOOLCHAIN_TTMETAL
   "Use pre-built tt-metal from ttlang toolchain (defaults to TTLANG_USE_TOOLCHAIN)"
   ${TTLANG_USE_TOOLCHAIN})
 
+# An external tt-metal install uses the install-ttmetal.sh layout and takes
+# precedence over TTLANG_USE_TOOLCHAIN_TTMETAL. BuildTTMetal.cmake documents
+# the required directory structure.
 set(TTLANG_EXTERNAL_TT_METAL_DIR "" CACHE PATH
   "Path to an existing tt-metal installation; overrides the toolchain or submodule build.")
 if(NOT DEFINED TTLANG_TOOLCHAIN_DIR)

--- a/cmake/modules/TTLangToolchainOptions.cmake
+++ b/cmake/modules/TTLangToolchainOptions.cmake
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+option(TTLANG_USE_TOOLCHAIN "Use pre-built LLVM from ttlang toolchain" OFF)
+option(TTLANG_BUILD_TOOLCHAIN
+  "Build LLVM and tt-metal into a reusable toolchain directory" OFF)
+option(TTLANG_INSTALL_RUNTIME_REQUIREMENTS
+  "Install tt-lang runtime requirements while configuring LLVM" ON)
+set(TTLANG_TOOLCHAIN_COMPONENT "all" CACHE STRING
+  "Toolchain component to configure: all, llvm, or tt-metal")
+set_property(CACHE TTLANG_TOOLCHAIN_COMPONENT PROPERTY STRINGS all llvm tt-metal)
+set(_TTLANG_TOOLCHAIN_COMPONENTS all llvm tt-metal)
+if(NOT TTLANG_TOOLCHAIN_COMPONENT IN_LIST _TTLANG_TOOLCHAIN_COMPONENTS)
+  message(FATAL_ERROR
+    "TTLANG_TOOLCHAIN_COMPONENT must be one of: all, llvm, tt-metal")
+endif()
+
+# This override permits rebuilding tt-metal while consuming LLVM from a
+# pre-built toolchain.
+option(TTLANG_USE_TOOLCHAIN_TTMETAL
+  "Use pre-built tt-metal from ttlang toolchain (defaults to TTLANG_USE_TOOLCHAIN)"
+  ${TTLANG_USE_TOOLCHAIN})
+
+set(TTLANG_EXTERNAL_TT_METAL_DIR "" CACHE PATH
+  "Path to an existing tt-metal installation; overrides the toolchain or submodule build.")
+if(NOT DEFINED TTLANG_TOOLCHAIN_DIR)
+  if(DEFINED ENV{TTLANG_TOOLCHAIN_DIR})
+    set(TTLANG_TOOLCHAIN_DIR "$ENV{TTLANG_TOOLCHAIN_DIR}" CACHE PATH
+      "tt-lang toolchain directory")
+  elseif(TTLANG_USE_TOOLCHAIN)
+    set(TTLANG_TOOLCHAIN_DIR "/opt/ttlang-toolchain" CACHE PATH
+      "tt-lang toolchain directory" FORCE)
+  endif()
+endif()

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -282,7 +282,7 @@ first:
 2. **Latest phase.** On top of the first, bump `TT_METAL_TAG` to the latest
    tt-metal tag and leave `TTNN_PYPI`/`TTNN_PYPI_TT_METAL_TAG` unchanged. The tags
    now diverge on `vX.Y.Z`, so the wheel is S3-only until a matching public
-   `ttnn` ships (S3 publishing runs from the nightly schedule or a manual
+   `ttnn` ships (S3 publishing runs from the weekly schedule or a manual
    dispatch on `main`, never a tag push).
 
 Build, validate, and commit each phase separately (see [Rebuilding and
@@ -626,8 +626,9 @@ and `<DOCKER_TAG>` an existing manylinux wheel-builder tag):
 #### Publishing to S3 PyPI
 
 `publish-s3-pypi.yml` publishes S3-hosted wheels to the Tenstorrent S3 PyPI
-index at `https://pypi.eng.aws.tenstorrent.com/`. It runs nightly on a GitHub
-schedule and can also be dispatched manually. Publishing is restricted to
+index at `https://pypi.eng.aws.tenstorrent.com/`. It runs weekly at 08:00 UTC
+on Monday (00:00 PST / 01:00 PDT) and can also be dispatched manually.
+Publishing is restricted to
 workflow runs on `refs/heads/main` because the AWS OIDC role is limited to
 main-branch refs; a manual dispatch from another ref can only perform a dry run.
 The workflow uses GitHub OIDC for AWS access. Regular publishes upload wheel
@@ -661,7 +662,7 @@ S3 publishing uses this policy:
 - Do not mix public PyPI and S3 indexes for a `tt-lang` version whose artifacts
   have different dependency semantics. Use the S3 install command emitted by the
   workflow summary for S3 release wheels.
-- Nightly builds do not create Git tags. The scheduled workflow computes a
+- Scheduled builds do not create Git tags. The workflow computes a
   PEP 440 development version of the form `<MAJOR.MINOR.PATCH>.dev<YYYYMMDD>`,
   where the base version matches the latest stable tag reachable from `HEAD`,
   and the numeric suffix is a UTC date.
@@ -762,7 +763,7 @@ because auto-detection reads the dispatch ref's `third-party/tt-metal-version`
 rather than the pinned ref's. With `dry_run: true` the workflow builds and
 validates without publishing and needs no S3 credentials, so it can run from a
 feature branch; the scheduled per-tt-metal-SHA build in `publish-s3-pypi.yml`
-is best-effort and does not fail the nightly publish.
+is best-effort and does not fail the scheduled publish.
 
 Successful per-SHA publishes place the wheel files (both tt-lang and
 tt-lang-light) under `https://pypi.eng.aws.tenstorrent.com/tt-lang/ttmetal/<ttmetal7>/`

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -535,10 +535,11 @@ they cannot be distinguished by `pip install`. Prefer `-dev<YYYYMMDD>` or
 
 `publish-pypi.yml` prepares release images and wheels on release-tag pushes,
 but PyPI upload requires a manual dispatch from `refs/heads/main`. Manual
-dispatch takes the full SHA of the release-tagged commit and an existing IRD
-Docker tag. The selected commit must be an ancestor of the dispatching main
-commit and must have exactly one supported public release tag (`vX.Y.Z` or
-`vX.Y.Z-<prerelease>`). Local-version tags containing `+` are rejected.
+dispatch takes the full SHA of the release-tagged commit and an optional
+manylinux wheel-builder tag. The selected commit must be an ancestor of the
+dispatching main commit and must have exactly one supported public release tag
+(`vX.Y.Z` or `vX.Y.Z-<prerelease>`). Local-version tags containing `+` are
+rejected.
 
 ```text
    push release tag
@@ -550,21 +551,21 @@ commit and must have exactly one supported public release tag (`vX.Y.Z` or
    +--------------+   (release checks skipped if dry_run=true)
           |
           v
-   +--------------+
-   | build-docker |   call-build-docker.yml
-   +--------------+   (skipped if docker_tag input is set;
-          |            smoke-tests image before push to GHCR)
+   +--------------------+
+   | build-wheel-images |   call-build-wheel-images.yml
+   +--------------------+   (skipped if docker_tag input is set;
+          |                  reuses separate LLVM and tt-metal caches)
           v
    +--------------+
-   | build-wheels |   call-build-wheels.yml
-   +--------------+   (builds + smoke-tests wheel inside ird container,
+   | build-wheels |   call-build-manylinux-wheels.yml
+   +--------------+   (builds cp310/cp312 public wheels and tt-lang-sim,
           |            uploads tt-lang-wheels artifact)
           |
           +-----------------------+
           v                       |
-   +---------------------+        |
-   | test-dist-tutorials |        |  (also runs for dry runs)
-   +---------------------+        |
+   +-------------+                |
+   | test-wheels |                |  (also runs for dry runs)
+   +-------------+                |
           | workflow_dispatch     |
           | with dry_run=false    |
           +-----------------------+
@@ -577,7 +578,7 @@ commit and must have exactly one supported public release tag (`vX.Y.Z` or
    dry_run=false
    (uploads to PyPI)        (lists artifacts only)
 
-   Release-tag pushes complete after test-dist-tutorials.
+   Release-tag pushes complete after test-wheels.
 ```
 
 Job-by-job:
@@ -588,22 +589,22 @@ Job-by-job:
    release tag. Current workflow scripts validate that tag and the selected
    source's `third-party/tt-metal-version`. Release checks are skipped under
    `dry_run: true`. Exposes `tag_version` for the wheel-version check.
-2. **`build-docker`** — calls `call-build-docker.yml` on tag pushes and emits
-   the release Docker tag. Manual dispatch requires an existing `docker_tag`,
-   so this job is skipped.
-3. **`build-wheels`** — calls `call-build-wheels.yml` against either the
-   `docker_tag` input (manual dispatch) or the `build-docker` output (tag
-   push). Builds the wheel inside the ird container, runs
-   `smoke-test-wheel.py` in an isolated venv (imports + `tt-lang-sim --help`
-   + `tt-lang-sim-stats --help`), and runs the CMake-install regression test
-   (`cmake --install` + `bin/tt-lang-sim --help` against the parallel-install
-   layout). Uploads the result as the `tt-lang-wheels` artifact.
-4. **`test-dist-tutorials`**: checks out the selected source and calls
-   `call-test-dist-tutorials.yml` against the matching dist image on the
-   `n150` hardware runner. It runs during dry runs and must pass before
+2. **`build-wheel-images`** — calls `call-build-wheel-images.yml` when no
+   `docker_tag` is supplied. The multi-stage `manylinux_2_34` build stores LLVM
+   caches separately for Python 3.10 and 3.12 and stores tt-metal in a third
+   cache. Unchanged component inputs restore from GHCR instead of recompiling.
+3. **`build-wheels`** — calls `call-build-manylinux-wheels.yml` against either
+   the `docker_tag` input or the image-build output. It builds Python 3.10 and
+   3.12 `tt-lang` wheels with an exact public `ttnn` dependency and builds the
+   ABI-independent `tt-lang-sim` wheel. The workflow verifies wheel names,
+   versions, dependency metadata, and the `manylinux_2_34` platform tag before
+   uploading the `tt-lang-wheels` artifact.
+4. **`test-wheels`**: installs the Python 3.12 public wheel and its PyPI `ttnn`
+   dependency in an isolated environment on an `n150` runner, then runs the
+   smoke test and tutorials. It runs during dry runs and must pass before
    `publish`.
 5. **`publish`**: runs only for a manual dispatch from `main` when `dry_run` is
-   false and `test-dist-tutorials` succeeded. Downloads the artifact, verifies
+   false and `test-wheels` succeeded. Downloads the artifact, verifies
    every wheel filename's version field matches `preflight.outputs.tag_version`,
    and uploads via `pypa/gh-action-pypi-publish` using OIDC trusted publishing
    (`environment: pypi`, `id-token: write`).
@@ -612,14 +613,14 @@ Job-by-job:
    uploaded. No `environment`, no PyPI credentials.
 
 Common scenarios (`<TAG>` denotes a release tag, `<SHA>` its full commit SHA,
-and `<DOCKER_TAG>` an existing ird image tag):
+and `<DOCKER_TAG>` an existing manylinux wheel-builder tag):
 
-| Trigger                                                          | docker_tag input | Result                                                              |
-| ---------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
-| `git push origin <TAG>`                                          | (n/a)            | Build and test the release images and wheels; do not upload to PyPI |
-| Dispatch from `main` with `ttlang_sha: <SHA>`                     | required         | Build the tagged commit and publish its version to PyPI             |
-| Dispatch with `ttlang_sha: <SHA>` and `dry_run: true`             | required         | Build and test the selected commit; skip PyPI upload                |
-| Non-main dispatch with `ttlang_sha: <SHA>` and `dry_run: false`   | required         | Fail at `preflight`                                                 |
+| Trigger                                                        | docker_tag input | Result                                                              |
+| -------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
+| `git push origin <TAG>`                                        | (n/a)            | Build and test the release images and wheels; do not upload to PyPI |
+| Dispatch from `main` with `ttlang_sha: <SHA>`                   | optional         | Build the tagged commit and publish its version to PyPI             |
+| Dispatch with `ttlang_sha: <SHA>` and `dry_run: true`           | optional         | Build and test the selected commit; skip PyPI upload                |
+| Non-main dispatch with `ttlang_sha: <SHA>` and `dry_run: false` | optional         | Fail at `preflight`                                                 |
 
 (publishing-to-s3-pypi)=
 #### Publishing to S3 PyPI
@@ -638,8 +639,9 @@ browser, but it keeps hidden anchors for final-release root wheels so
 `pip --find-links https://pypi.eng.aws.tenstorrent.com/tt-lang` remains
 backward-compatible for `X.Y.Z` S3 releases.
 Non-main dry runs must provide an existing `docker_tag`. If `docker_tag` is
-empty, the workflow builds and pushes GHCR IRD and manylinux wheel-builder images
-before the wheel build; that image publication is also restricted to
+empty, the workflow builds only the builder images required by the selected
+variants: the IRD image for bundled wheels and the shared manylinux images for
+light or PyPI-style wheels. Image publication is also restricted to
 `refs/heads/main`.
 
 The workflow prevents publishing a bundled S3 `tt-lang` wheel with the
@@ -663,20 +665,25 @@ S3 publishing uses this policy:
   PEP 440 development version of the form `<MAJOR.MINOR.PATCH>.dev<YYYYMMDD>`,
   where the base version matches the latest stable tag reachable from `HEAD`,
   and the numeric suffix is a UTC date.
-- Scheduled reruns overwrite the same date-based version in the S3 index. This
-  keeps nightly versions readable, but existing local pip caches may still hold
-  the older wheel for that version.
+- Before building, a scheduled run compares the selected source SHA with the
+  marker written by the last successful scheduled publish. An equal SHA skips
+  all image, wheel, publish, and per-tt-metal work. A changed SHA publishes and
+  updates the marker only after the wheel objects and index are complete.
+- Scheduled reruns after a source update overwrite the same date-based version
+  in the S3 index. Existing local pip caches may still hold an older wheel for
+  that version.
 
-Manual stable-version publishes set `version_override` explicitly, build and
-push the matching IRD image when `docker_tag` is empty, build the selected wheel
-variants from that image, verify the wheel versions, and publish the result to
-S3 PyPI.
+Manual stable-version publishes set `version_override` explicitly, build any
+missing selected builder images when `docker_tag` is empty, verify each wheel
+set, and publish the result to S3 PyPI.
 
 The scheduled workflow defaults to `wheel_variant: bundled-and-light`. It keeps
 building the complete bundled wheel from the IRD image, and also builds and
 pushes the matching manylinux_2_34 wheel-builder images for Python 3.10 and
-Python 3.12 light wheels. The workflow verifies all wheel versions before
-publishing the combined result to S3 PyPI.
+Python 3.12 light wheels. The manylinux images use separate BuildKit registry
+caches for the two LLVM/Python combinations and for tt-metal, so unchanged
+components are restored instead of rebuilt. The workflow verifies all wheel
+versions before publishing the combined result to S3 PyPI.
 
 For a manual bundled S3 wheel with an existing IRD image, dispatch the
 workflow with:
@@ -708,6 +715,11 @@ wheels. Those wheels omit `Requires-Dist: ttnn`; the normal PyPI build keeps
 that requirement. The same build also emits
 `tt-lang-light==<version_override>`, a metapackage that depends on
 `tt-lang==<version_override>+light`.
+
+The `pypi` selection uses the same manylinux_2_34 base and build process but
+retains public package semantics: `tt-lang==<version_override>` has no `+light`
+label, requires the exact `ttnn` version from `third-party/tt-metal-version`,
+and includes `tt-lang-sim`. It does not emit the `tt-lang-light` metapackage.
 
 To publish bundled and light wheels from the same workflow run, dispatch with:
 
@@ -814,6 +826,19 @@ Writes require `refs/heads/main`; `dry_run` defaults to true. Operations are
 restricted to the `tt-lang/` prefix and cannot touch other teams' packages
 (including the sibling `tt-lang-light/` and `tt-lang-sim/` package indexes) or
 the bucket root. `delete` requires a `confirm` token equal to the prefix.
+
+`s3-wheel-maintenance.yml` provides wheel-specific storage maintenance.
+`deduplicate` removes older object versions only when the key, size, and ETag
+match a newer retained version. It never deletes the logical wheel key.
+`remove-dev-range` permanently removes every object version and delete marker
+for top-level `tt-lang` wheels whose `.devYYYYMMDD` version date is within the
+inclusive `start_date` and `end_date`; per-tt-metal wheel directories are
+excluded. A live date removal regenerates affected month views and the root
+index.
+
+Both operations require `refs/heads/main` and default to `dry_run: true`. Live
+deduplication requires `confirm: delete-duplicate-versions`; live date removal
+requires `confirm: delete-dev-versions`.
 
 #### Local S3 wheel testing
 

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -600,9 +600,9 @@ Job-by-job:
    versions, dependency metadata, and the `manylinux_2_34` platform tag before
    uploading the `tt-lang-wheels` artifact.
 4. **`test-wheels`**: installs the Python 3.12 public wheel and its PyPI `ttnn`
-   dependency in an isolated environment on an `n150` runner, then runs the
-   smoke test and tutorials. It runs during dry runs and must pass before
-   `publish`.
+   dependency in an isolated environment on an `n150` runner, installs the sfpi
+   release recorded by `ttnn`, then runs the smoke test and tutorials. It runs
+   during dry runs and must pass before `publish`.
 5. **`publish`**: runs only for a manual dispatch from `main` when `dry_run` is
    false and `test-wheels` succeeded. Downloads the artifact, verifies
    every wheel filename's version field matches `preflight.outputs.tag_version`,

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -15,18 +15,17 @@ functional simulator (no compiler or hardware support) and does not depend on
 `ttnn`.
 
 First, create an isolated Python environment (venv, conda, etc.) with Python
-matching the selected wheel. Public PyPI hardware wheels currently use Python
-3.12; S3 light wheels are built for Python 3.10 and Python 3.12. The wheel
-targets a specific CPython ABI, so the venv's Python must match. Invoke
-`python3.12` (or `python3.10` for a light wheel) explicitly rather than the
-system default `python3`:
+matching the selected wheel. Public PyPI and S3 light hardware wheels are built
+for Python 3.10 and Python 3.12. The wheel targets a specific CPython ABI, so
+the venv's Python must match. Invoke `python3.12` or `python3.10` explicitly
+rather than the system default `python3`:
 
 ```bash
 python3.12 -m venv --prompt ttlang ttlang-venv
 source ttlang-venv/bin/activate
 ```
 
-On Linux machines with Tenstorrent hardware (Linux x86_64 / aarch64):
+On Linux x86_64 machines with Tenstorrent hardware:
 
 ```bash
 pip install tt-lang

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -69,7 +69,7 @@ Tenstorrent S3 wheels use browsable wheel views (`--find-links`):
 - Light wheels built and device-tested against a specific tt-metal commit are
   under `tt-lang/ttmetal/<ttmetal7>/`, that commit's 7-character prefix.
 
-The bundled-wheel example below installs a nightly development wheel. Stable
+The bundled-wheel example below installs a scheduled development wheel. Stable
 S3 releases use `TTLANG_VERSION=X.Y.Z` and
 `https://pypi.eng.aws.tenstorrent.com/tt-lang/releases/`.
 
@@ -94,7 +94,7 @@ metapackage: `tt-lang-light==X` depends on the matching no-ttnn core wheel
 environment, not both.
 
 A per-tt-metal-SHA light wheel resolves from that commit's directory with
-`--find-links`; a nightly light wheel resolves from its `tt-lang/<YYYY-MM>/`
+`--find-links`; a scheduled light wheel resolves from its `tt-lang/<YYYY-MM>/`
 directory with `--find-links` as well:
 
 ```bash

--- a/scripts/build-and-install.sh
+++ b/scripts/build-and-install.sh
@@ -10,7 +10,9 @@
 # Modes (mutually exclusive):
 #   (default)              Full pipeline: configure + install tt-metal + build + install + finalize
 #   --toolchain-only       Configure only (LLVM + tt-metal) + finalize; no tt-lang build
-#   --llvm-toolchain-only  Configure only (LLVM) + finalize using an external tt-metal; no tt-lang build
+#   --llvm-toolchain-only  Configure and finalize LLVM only; no tt-lang build
+#   --ttmetal-toolchain-only
+#                          Configure and finalize tt-metal only; no tt-lang build
 #   --configure-only       Configure only; keep build dirs for downstream steps
 #   --install-ttmetal      Install tt-metal artifacts from build dir into toolchain
 #   --build-and-install    Build tt-lang + install (assumes configure already ran)
@@ -34,11 +36,10 @@
 #                                 (pypi, external, or bundled)
 #
 # Typical multi-stage usage (build outside Docker, copy results in):
-#   1. build-and-install.sh --configure-only               # Build LLVM + tt-metal
-#   2. build-and-install.sh --install-ttmetal              # Install tt-metal into toolchain
-#   3. cp -a toolchain/ ird-toolchain/                     # Save ird toolchain
-#   4. build-and-install.sh --build-and-install            # Build + install tt-lang
-#   5. build-and-install.sh --finalize --remove-build-dir  # Normalize + cleanup
+#   1. build-and-install.sh --configure-only               # Build and install toolchain components
+#   2. cp -a toolchain/ ird-toolchain/                     # Save ird toolchain
+#   3. build-and-install.sh --build-and-install            # Build + install tt-lang
+#   4. build-and-install.sh --finalize --remove-build-dir  # Normalize + cleanup
 
 set -Eeo pipefail
 
@@ -74,6 +75,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --llvm-toolchain-only)
             MODE="llvm-toolchain-only"
+            shift
+            ;;
+        --ttmetal-toolchain-only)
+            MODE="ttmetal-toolchain-only"
             shift
             ;;
         --configure-only)
@@ -160,11 +165,6 @@ if [ -n "$EXTERNAL_TT_METAL_BUILD_DIR" ] && [ -z "$EXTERNAL_TT_METAL_DIR" ]; the
     exit 1
 fi
 
-if [ "$MODE" = "llvm-toolchain-only" ] && [ -z "$EXTERNAL_TT_METAL_DIR" ]; then
-    echo "ERROR: --llvm-toolchain-only requires --external-tt-metal-dir" >&2
-    exit 1
-fi
-
 if [ -n "$TTNN_DEP_MODE" ]; then
     case "$TTNN_DEP_MODE" in
         pypi | external | bundled)
@@ -178,7 +178,9 @@ if [ -n "$TTNN_DEP_MODE" ]; then
 fi
 
 TTLANG_TOOLCHAIN_DIR="${TTLANG_TOOLCHAIN_DIR:-/opt/ttlang-toolchain}"
-if [ "$MODE" = "toolchain-only" ] || [ "$MODE" = "llvm-toolchain-only" ]; then
+if [ "$MODE" = "toolchain-only" ] ||
+    [ "$MODE" = "llvm-toolchain-only" ] ||
+    [ "$MODE" = "ttmetal-toolchain-only" ]; then
     CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR:-build-toolchain}"
 else
     CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR:-build}"
@@ -199,10 +201,6 @@ do_configure() {
         _force_rebuild=ON
         _build_toolchain=ON
         _use_toolchain=OFF
-    fi
-
-    if [ "$MODE" = "llvm-toolchain-only" ]; then
-        _build_toolchain=OFF
     fi
 
     # Per-component override: rebuild tt-metal from submodule while still
@@ -229,20 +227,33 @@ do_configure() {
         _external_ttmetal_args+=("-DTTLANG_EXTERNAL_TT_METAL_BUILD_DIR=$EXTERNAL_TT_METAL_BUILD_DIR")
     fi
 
+    local _toolchain_component=all
+    if [ "$MODE" = "llvm-toolchain-only" ]; then
+        _toolchain_component=llvm
+    elif [ "$MODE" = "ttmetal-toolchain-only" ]; then
+        _toolchain_component=tt-metal
+    fi
+
     cmake -G Ninja -B "$CMAKE_BINARY_DIR" \
         -DCMAKE_BUILD_TYPE=Release \
         -DTTLANG_USE_TOOLCHAIN=$_use_toolchain \
         -DTTLANG_USE_TOOLCHAIN_TTMETAL=$_use_toolchain_ttmetal \
-        -DTTLANG_TOOLCHAIN_DIR=$TTLANG_TOOLCHAIN_DIR \
-        -DTTLANG_PYTHON_VENV=$TTLANG_TOOLCHAIN_DIR/venv \
+        "-DTTLANG_TOOLCHAIN_DIR=$TTLANG_TOOLCHAIN_DIR" \
+        "-DTTLANG_PYTHON_VENV=$TTLANG_TOOLCHAIN_DIR/venv" \
         -DTTLANG_ENABLE_PERF_TRACE=ON \
         -DTTLANG_FORCE_TOOLCHAIN_REBUILD=$_force_rebuild \
         -DTTLANG_BUILD_TOOLCHAIN=$_build_toolchain \
+        -DTTLANG_TOOLCHAIN_COMPONENT=$_toolchain_component \
         "${_external_ttmetal_args[@]}" \
         "${_python_args[@]}"
 
     echo "=== Disk space after configure ==="
     df -h
+
+    if [ "$MODE" = "llvm-toolchain-only" ] ||
+        [ "$MODE" = "ttmetal-toolchain-only" ]; then
+        return
+    fi
 
     source "$CMAKE_BINARY_DIR/env/activate"
 
@@ -341,24 +352,12 @@ do_test_toolchain() {
 case "$MODE" in
     full)
         do_configure
-        # Only install tt-metal into the toolchain when we actually built it
-        # from submodule. With TTLANG_USE_TOOLCHAIN_TTMETAL=ON (the default
-        # when a toolchain copy exists), BuildTTMetal.cmake skips the build
-        # and there is nothing in $CMAKE_BINARY_DIR/tt-metal to install.
-        if [ "$REBUILD_TTMETAL" = true ] || [ "$FORCE_REBUILD" = true ]; then
-            do_install_ttmetal
-        fi
         do_build_and_install
         do_finalize
         echo "=== Build complete ==="
         ;;
     toolchain-only)
         do_configure
-        if [ "$REBUILD_TTMETAL" = true ] || [ "$FORCE_REBUILD" = true ]; then
-            do_install_ttmetal
-        else
-            echo "=== Skipping tt-metal install: not rebuilt (pass --rebuild-ttmetal or --force-rebuild to install) ==="
-        fi
         do_finalize
         echo "=== Toolchain build complete ==="
         ;;
@@ -366,6 +365,11 @@ case "$MODE" in
         do_configure
         do_finalize
         echo "=== LLVM toolchain build complete ==="
+        ;;
+    ttmetal-toolchain-only)
+        do_configure
+        do_finalize
+        echo "=== tt-metal toolchain build complete ==="
         ;;
     configure-only)
         do_configure

--- a/test/packaging/test_s3_wheel_maintenance.py
+++ b/test/packaging/test_s3_wheel_maintenance.py
@@ -11,6 +11,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from conftest import REPO_ROOT
 
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "s3-wheel-maintenance.py"
@@ -118,6 +120,43 @@ def test_date_range_is_inclusive_and_limited_to_top_level_dev_wheels() -> None:
     assert maintenance._affected_months(deletions) == ["2026-07"]
 
 
+def test_unparsable_dev_date_is_not_selected() -> None:
+    versions = [
+        _version(
+            "tt-lang/tt_lang-1.2.3.dev20261332-py3-none-any.whl",
+            "impossible-date",
+            modified="2026-07-01T00:00:00Z",
+        ),
+        _version(
+            "tt-lang/tt_lang-1.2.3.dev20260715-py3-none-any.whl",
+            "real-date",
+            modified="2026-07-15T00:00:00Z",
+        ),
+    ]
+
+    deletions = maintenance.date_range_deletions(
+        versions,
+        maintenance._date("2026-07-01"),
+        maintenance._date("2026-07-31"),
+    )
+
+    assert [deletion.version.version_id for deletion in deletions] == ["real-date"]
+    assert maintenance._affected_months(deletions) == ["2026-07"]
+
+
+def test_unparsable_dev_date_does_not_break_deduplicate() -> None:
+    key = "tt-lang/tt_lang-1.2.3.dev12345678-py3-none-any.whl"
+    versions = [
+        _version(key, "old", modified="2026-07-01T00:00:00Z"),
+        _version(key, "new", modified="2026-07-02T00:00:00Z", latest=True),
+    ]
+
+    deletions = maintenance.duplicate_deletions(versions)
+
+    assert [deletion.version.version_id for deletion in deletions] == ["old"]
+    assert maintenance._affected_months(deletions) == []
+
+
 def test_month_range_includes_every_month_across_year_boundary() -> None:
     assert maintenance._months_in_range(
         maintenance._date("2026-12-31"),
@@ -196,6 +235,47 @@ def test_delete_versions_batches_at_s3_limit(monkeypatch) -> None:
     second_request = json.loads(calls[1][calls[1].index("--delete") + 1])
     assert len(first_request["Objects"]) == 1000
     assert len(second_request["Objects"]) == 1
+
+
+def test_delete_versions_rejects_partial_s3_failures(monkeypatch) -> None:
+    monkeypatch.setattr(
+        maintenance,
+        "_run_aws_json",
+        lambda *_: {
+            "Errors": [
+                {
+                    "Key": "tt-lang/wheel.whl",
+                    "VersionId": "version",
+                    "Code": "AccessDenied",
+                }
+            ]
+        },
+    )
+    deletions = [
+        maintenance.Deletion(
+            _version(
+                "tt-lang/wheel.whl",
+                "version",
+                modified="2026-07-01T00:00:00Z",
+            ),
+            "test",
+        )
+    ]
+
+    with pytest.raises(RuntimeError, match="S3 version deletion failed"):
+        maintenance.delete_versions(deletions, "bucket")
+
+
+def test_deduplicate_summary_does_not_imply_month_view_refresh(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    maintenance._write_summary("deduplicate", True, [], ["2026-07"])
+
+    output = capsys.readouterr().out
+    assert "Duplicate wheel months: `2026-07`" in output
+    assert "Affected month views" not in output
 
 
 def test_dry_run_does_not_delete_or_refresh(monkeypatch) -> None:

--- a/test/packaging/test_s3_wheel_maintenance.py
+++ b/test/packaging/test_s3_wheel_maintenance.py
@@ -11,8 +11,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 from conftest import REPO_ROOT
 
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "s3-wheel-maintenance.py"
@@ -213,11 +211,6 @@ def test_dry_run_does_not_delete_or_refresh(monkeypatch) -> None:
         lambda *_: (_ for _ in ()).throw(AssertionError("delete called")),
     )
     monkeypatch.setattr(
-        maintenance,
-        "_refresh_views",
-        lambda *_: (_ for _ in ()).throw(AssertionError("refresh called")),
-    )
-    monkeypatch.setattr(
         sys,
         "argv",
         [
@@ -231,41 +224,6 @@ def test_dry_run_does_not_delete_or_refresh(monkeypatch) -> None:
     )
 
     assert maintenance.main() == 0
-
-
-def test_refresh_views_uses_repository_owned_script(monkeypatch) -> None:
-    calls = []
-    monkeypatch.setattr(
-        maintenance.subprocess,
-        "run",
-        lambda command, check: calls.append((command, check)),
-    )
-
-    maintenance._refresh_views(["2026-07", "2026-08"])
-
-    assert calls == [
-        (
-            [
-                str(SCRIPT.with_name("refresh-s3-wheel-views.sh").resolve()),
-                "--months",
-                "2026-07,2026-08",
-            ],
-            True,
-        )
-    ]
-
-
-def test_refresh_views_rejects_invalid_month_before_running(monkeypatch) -> None:
-    monkeypatch.setattr(
-        maintenance.subprocess,
-        "run",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("subprocess called")
-        ),
-    )
-
-    with pytest.raises(RuntimeError, match="invalid month"):
-        maintenance._refresh_views(["2026-07;echo unexpected"])
 
 
 def test_live_date_removal_requires_confirmation_before_listing(
@@ -298,6 +256,7 @@ def test_live_date_removal_requires_confirmation_before_listing(
 
 def test_live_date_removal_deletes_and_refreshes_affected_month(
     monkeypatch,
+    tmp_path: Path,
 ) -> None:
     versions = [
         _version(
@@ -307,18 +266,14 @@ def test_live_date_removal_deletes_and_refreshes_affected_month(
         )
     ]
     deleted = []
-    refreshed = []
+    output_path = tmp_path / "output"
     monkeypatch.setattr(maintenance, "list_object_versions", lambda _: versions)
     monkeypatch.setattr(
         maintenance,
         "delete_versions",
         lambda deletions, bucket: deleted.extend(deletions),
     )
-    monkeypatch.setattr(
-        maintenance,
-        "_refresh_views",
-        lambda months: refreshed.extend(months),
-    )
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
     monkeypatch.setattr(
         sys,
         "argv",
@@ -340,24 +295,21 @@ def test_live_date_removal_deletes_and_refreshes_affected_month(
 
     assert maintenance.main() == 0
     assert [deletion.version.version_id for deletion in deleted] == ["version"]
-    assert refreshed == ["2026-07"]
+    assert output_path.read_text() == "refresh-months=2026-07\n"
 
 
 def test_live_date_removal_refreshes_range_after_prior_deletion(
     monkeypatch,
+    tmp_path: Path,
 ) -> None:
-    refreshed = []
+    output_path = tmp_path / "output"
     monkeypatch.setattr(maintenance, "list_object_versions", lambda _: [])
     monkeypatch.setattr(
         maintenance,
         "delete_versions",
         lambda *_: (_ for _ in ()).throw(AssertionError("delete called")),
     )
-    monkeypatch.setattr(
-        maintenance,
-        "_refresh_views",
-        lambda months: refreshed.extend(months),
-    )
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
     monkeypatch.setattr(
         sys,
         "argv",
@@ -378,7 +330,7 @@ def test_live_date_removal_refreshes_range_after_prior_deletion(
     )
 
     assert maintenance.main() == 0
-    assert refreshed == ["2026-07", "2026-08"]
+    assert output_path.read_text() == "refresh-months=2026-07,2026-08\n"
 
 
 def test_maintenance_workflow_is_dry_by_default_and_has_no_inline_shell() -> None:
@@ -391,3 +343,8 @@ def test_maintenance_workflow_is_dry_by_default_and_has_no_inline_shell() -> Non
             assert "${{ inputs." not in line
     assert "delete-duplicate-versions or delete-dev-versions" in workflow
     assert ".github/scripts/s3-wheel-maintenance.py" in workflow
+    assert "id: maintenance" in workflow
+    assert (
+        "AFFECTED_MONTHS: ${{ steps.maintenance.outputs.refresh-months }}" in workflow
+    )
+    assert 'refresh-s3-wheel-views.sh --months "$AFFECTED_MONTHS"' in workflow

--- a/test/packaging/test_s3_wheel_maintenance.py
+++ b/test/packaging/test_s3_wheel_maintenance.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for S3 wheel object-version maintenance."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from conftest import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "s3-wheel-maintenance.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "s3-wheel-maintenance.yml"
+
+spec = importlib.util.spec_from_file_location("s3_wheel_maintenance", SCRIPT)
+assert spec is not None and spec.loader is not None
+maintenance = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = maintenance
+spec.loader.exec_module(maintenance)
+
+
+def _version(
+    key: str,
+    version_id: str,
+    *,
+    modified: str,
+    size: int = 100,
+    etag: str = '"etag"',
+    latest: bool = False,
+    marker: bool = False,
+):
+    return maintenance.ObjectVersion(
+        key=key,
+        version_id=version_id,
+        last_modified=modified,
+        size=None if marker else size,
+        etag=None if marker else etag,
+        is_latest=latest,
+        is_delete_marker=marker,
+    )
+
+
+def test_deduplicate_keeps_newest_identical_version_per_key() -> None:
+    key = "tt-lang/tt_lang-1.2.3-py3-none-any.whl"
+    versions = [
+        _version(key, "old", modified="2026-07-01T00:00:00Z"),
+        _version(key, "new", modified="2026-07-02T00:00:00Z", latest=True),
+        _version(
+            key,
+            "different",
+            modified="2026-07-03T00:00:00Z",
+            etag='"different"',
+        ),
+        _version(
+            key,
+            "marker",
+            modified="2026-07-04T00:00:00Z",
+            marker=True,
+        ),
+        _version(
+            "tt-lang/other-1.2.3-py3-none-any.whl",
+            "other",
+            modified="2026-07-01T00:00:00Z",
+        ),
+    ]
+
+    deletions = maintenance.duplicate_deletions(versions)
+
+    assert [deletion.version.version_id for deletion in deletions] == ["old"]
+    assert deletions[0].retained_version_id == "new"
+
+
+def test_date_range_is_inclusive_and_limited_to_top_level_dev_wheels() -> None:
+    versions = [
+        _version(
+            "tt-lang/tt_lang-1.2.3.dev20260701-py3-none-any.whl",
+            "start",
+            modified="2026-07-01T00:00:00Z",
+        ),
+        _version(
+            "tt-lang/tt_lang-1.2.3.dev20260731+light-py3-none-any.whl",
+            "end",
+            modified="2026-07-31T00:00:00Z",
+        ),
+        _version(
+            "tt-lang/tt_lang-1.2.3.dev20260801-py3-none-any.whl",
+            "outside",
+            modified="2026-08-01T00:00:00Z",
+        ),
+        _version(
+            "tt-lang/ttmetal/abc/tt_lang-1.2.3.dev20260715-py3-none-any.whl",
+            "per-sha",
+            modified="2026-07-15T00:00:00Z",
+        ),
+        _version(
+            "tt-lang/tt_lang-1.2.3.dev20260701-py3-none-any.whl",
+            "marker",
+            modified="2026-07-02T00:00:00Z",
+            marker=True,
+        ),
+    ]
+
+    deletions = maintenance.date_range_deletions(
+        versions,
+        maintenance._date("2026-07-01"),
+        maintenance._date("2026-07-31"),
+    )
+
+    assert [deletion.version.version_id for deletion in deletions] == [
+        "start",
+        "marker",
+        "end",
+    ]
+    assert maintenance._affected_months(deletions) == ["2026-07"]
+
+
+def test_month_range_includes_every_month_across_year_boundary() -> None:
+    assert maintenance._months_in_range(
+        maintenance._date("2026-12-31"),
+        maintenance._date("2027-02-01"),
+    ) == ["2026-12", "2027-01", "2027-02"]
+
+
+def test_list_object_versions_follows_version_markers(monkeypatch) -> None:
+    responses = [
+        {
+            "Versions": [
+                {
+                    "Key": "tt-lang/a.whl",
+                    "VersionId": "one",
+                    "LastModified": "2026-07-01T00:00:00Z",
+                    "Size": 1,
+                    "ETag": '"one"',
+                }
+            ],
+            "IsTruncated": True,
+            "NextKeyMarker": "tt-lang/a.whl",
+            "NextVersionIdMarker": "one",
+        },
+        {
+            "Versions": [
+                {
+                    "Key": "tt-lang/b.whl",
+                    "VersionId": "two",
+                    "LastModified": "2026-07-02T00:00:00Z",
+                    "Size": 2,
+                    "ETag": '"two"',
+                }
+            ],
+            "IsTruncated": False,
+        },
+    ]
+    calls = []
+
+    def fake_aws_json(*args):
+        calls.append(args)
+        return responses.pop(0)
+
+    monkeypatch.setattr(maintenance, "_run_aws_json", fake_aws_json)
+
+    versions = maintenance.list_object_versions("bucket")
+
+    assert [version.version_id for version in versions] == ["one", "two"]
+    assert "--key-marker" in calls[1]
+    assert "--version-id-marker" in calls[1]
+
+
+def test_delete_versions_batches_at_s3_limit(monkeypatch) -> None:
+    calls = []
+
+    def fake_aws_json(*args):
+        calls.append(args)
+        return {}
+
+    monkeypatch.setattr(maintenance, "_run_aws_json", fake_aws_json)
+    deletions = [
+        maintenance.Deletion(
+            _version(
+                f"tt-lang/wheel-{index}.whl",
+                str(index),
+                modified="2026-07-01T00:00:00Z",
+            ),
+            "test",
+        )
+        for index in range(1001)
+    ]
+
+    maintenance.delete_versions(deletions, "bucket")
+
+    assert len(calls) == 2
+    first_request = json.loads(calls[0][calls[0].index("--delete") + 1])
+    second_request = json.loads(calls[1][calls[1].index("--delete") + 1])
+    assert len(first_request["Objects"]) == 1000
+    assert len(second_request["Objects"]) == 1
+
+
+def test_dry_run_does_not_delete_or_refresh(monkeypatch) -> None:
+    key = "tt-lang/tt_lang-1.2.3.dev20260701-py3-none-any.whl"
+    versions = [
+        _version(key, "old", modified="2026-07-01T00:00:00Z"),
+        _version(key, "new", modified="2026-07-02T00:00:00Z"),
+    ]
+    monkeypatch.setattr(maintenance, "list_object_versions", lambda _: versions)
+    monkeypatch.setattr(
+        maintenance,
+        "delete_versions",
+        lambda *_: (_ for _ in ()).throw(AssertionError("delete called")),
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_refresh_views",
+        lambda *_: (_ for _ in ()).throw(AssertionError("refresh called")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "deduplicate",
+            "--dry-run",
+            "true",
+            "--github-ref",
+            "refs/heads/main",
+        ],
+    )
+
+    assert maintenance.main() == 0
+
+
+def test_live_date_removal_requires_confirmation_before_listing(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        maintenance,
+        "list_object_versions",
+        lambda _: (_ for _ in ()).throw(AssertionError("listing called")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "remove-dev-range",
+            "--dry-run",
+            "false",
+            "--start-date",
+            "2026-07-01",
+            "--end-date",
+            "2026-07-31",
+            "--github-ref",
+            "refs/heads/main",
+        ],
+    )
+
+    assert maintenance.main() == 1
+
+
+def test_live_date_removal_deletes_and_refreshes_affected_month(
+    monkeypatch,
+) -> None:
+    versions = [
+        _version(
+            "tt-lang/tt_lang-1.2.3.dev20260701-py3-none-any.whl",
+            "version",
+            modified="2026-07-01T00:00:00Z",
+        )
+    ]
+    deleted = []
+    refreshed = []
+    monkeypatch.setattr(maintenance, "list_object_versions", lambda _: versions)
+    monkeypatch.setattr(
+        maintenance,
+        "delete_versions",
+        lambda deletions, bucket: deleted.extend(deletions),
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_refresh_views",
+        lambda months, script: refreshed.extend(months),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "remove-dev-range",
+            "--dry-run",
+            "false",
+            "--start-date",
+            "2026-07-01",
+            "--end-date",
+            "2026-07-31",
+            "--confirm",
+            "delete-dev-versions",
+            "--github-ref",
+            "refs/heads/main",
+        ],
+    )
+
+    assert maintenance.main() == 0
+    assert [deletion.version.version_id for deletion in deleted] == ["version"]
+    assert refreshed == ["2026-07"]
+
+
+def test_live_date_removal_refreshes_range_after_prior_deletion(
+    monkeypatch,
+) -> None:
+    refreshed = []
+    monkeypatch.setattr(maintenance, "list_object_versions", lambda _: [])
+    monkeypatch.setattr(
+        maintenance,
+        "delete_versions",
+        lambda *_: (_ for _ in ()).throw(AssertionError("delete called")),
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "_refresh_views",
+        lambda months, script: refreshed.extend(months),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "remove-dev-range",
+            "--dry-run",
+            "false",
+            "--start-date",
+            "2026-07-01",
+            "--end-date",
+            "2026-08-31",
+            "--confirm",
+            "delete-dev-versions",
+            "--github-ref",
+            "refs/heads/main",
+        ],
+    )
+
+    assert maintenance.main() == 0
+    assert refreshed == ["2026-07", "2026-08"]
+
+
+def test_maintenance_workflow_is_dry_by_default_and_has_no_inline_shell() -> None:
+    workflow = WORKFLOW.read_text()
+    dry_run_input = workflow.split("      dry_run:", 1)[1].split("      confirm:", 1)[0]
+    assert "default: true" in dry_run_input
+    assert "run: |" not in workflow
+    for line in workflow.splitlines():
+        if line.lstrip().startswith("run:"):
+            assert "${{ inputs." not in line
+    assert "delete-duplicate-versions or delete-dev-versions" in workflow
+    assert ".github/scripts/s3-wheel-maintenance.py" in workflow

--- a/test/packaging/test_s3_wheel_maintenance.py
+++ b/test/packaging/test_s3_wheel_maintenance.py
@@ -11,6 +11,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from conftest import REPO_ROOT
 
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "s3-wheel-maintenance.py"
@@ -231,6 +233,41 @@ def test_dry_run_does_not_delete_or_refresh(monkeypatch) -> None:
     assert maintenance.main() == 0
 
 
+def test_refresh_views_uses_repository_owned_script(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        maintenance.subprocess,
+        "run",
+        lambda command, check: calls.append((command, check)),
+    )
+
+    maintenance._refresh_views(["2026-07", "2026-08"])
+
+    assert calls == [
+        (
+            [
+                str(SCRIPT.with_name("refresh-s3-wheel-views.sh").resolve()),
+                "--months",
+                "2026-07,2026-08",
+            ],
+            True,
+        )
+    ]
+
+
+def test_refresh_views_rejects_invalid_month_before_running(monkeypatch) -> None:
+    monkeypatch.setattr(
+        maintenance.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("subprocess called")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid month"):
+        maintenance._refresh_views(["2026-07;echo unexpected"])
+
+
 def test_live_date_removal_requires_confirmation_before_listing(
     monkeypatch,
 ) -> None:
@@ -280,7 +317,7 @@ def test_live_date_removal_deletes_and_refreshes_affected_month(
     monkeypatch.setattr(
         maintenance,
         "_refresh_views",
-        lambda months, script: refreshed.extend(months),
+        lambda months: refreshed.extend(months),
     )
     monkeypatch.setattr(
         sys,
@@ -319,7 +356,7 @@ def test_live_date_removal_refreshes_range_after_prior_deletion(
     monkeypatch.setattr(
         maintenance,
         "_refresh_views",
-        lambda months, script: refreshed.extend(months),
+        lambda months: refreshed.extend(months),
     )
     monkeypatch.setattr(
         sys,

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -133,7 +133,7 @@ def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     assert ".github/scripts/test-s3-light-wheels.sh" in shared_build
     assert ".github/scripts/inject-s3-index-readme.sh" not in workflow
     assert ".github/scripts/inject-s3-publish-readme.sh" in workflow
-    assert "PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}" in workflow
+    assert "PUBLISH_PREFIX: ${{ needs.preflight.outputs.publish_prefix }}" in workflow
     assert '--find-links-subdir "$PUBLISH_PREFIX"' in workflow
     assert "python3 -m pip install s3pypi" not in workflow
     assert "manylinux_wheel_matrix" in workflow
@@ -380,6 +380,12 @@ def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
 def test_scheduled_s3_publish_skips_unchanged_source_sha() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
 
+    assert (
+        "# Weekly S3-only publish: 08:00 UTC Monday (00:00 PST / 01:00 PDT)."
+        in workflow
+    )
+    assert '- cron: "0 8 * * 1"' in workflow
+    assert '- cron: "0 8 * * *"' not in workflow
     assert "publish_needed: ${{ steps.nightly.outputs.publish-needed }}" in workflow
     assert "s3-nightly-state.py check" in workflow
     for job_name in (
@@ -396,6 +402,23 @@ def test_scheduled_s3_publish_skips_unchanged_source_sha() -> None:
     assert workflow.index("Record scheduled publish state") > workflow.index(
         "Restore S3 index README"
     )
+
+
+def test_s3_publish_resolves_prefix_before_building() -> None:
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    preflight_job = workflow.split("\n  preflight:", 1)[1].split(
+        "\n  build-docker:", 1
+    )[0]
+    publish_job = workflow.split("\n  publish:", 1)[1].split(
+        "\n  ttmetal-light-detect:", 1
+    )[0]
+
+    assert preflight_job.count("resolve-s3-publish-prefix.sh") == 1
+    assert "publish_prefix: ${{ steps.publish-prefix.outputs.prefix }}" in (
+        preflight_job
+    )
+    assert "resolve-s3-publish-prefix.sh" not in publish_job
+    assert publish_job.count("needs.preflight.outputs.publish_prefix") == 3
 
 
 def test_s3_publish_requires_every_selected_wheel_build_to_succeed() -> None:
@@ -490,7 +513,7 @@ def test_on_demand_requires_tt_metal_sha_when_ttlang_ref_pinned() -> None:
     assert "TTLANG_REF: ${{ inputs.ttlang_ref }}" in workflow
 
 
-def test_nightly_light_wheel_soft_fails_without_failing_publish() -> None:
+def test_scheduled_light_wheel_soft_fails_without_failing_publish() -> None:
     publish = PUBLISH_S3_PYPI_WORKFLOW.read_text()
     reusable = CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW.read_text()
     # The scheduled detect job tolerates its own failure, and the reusable

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -637,6 +637,22 @@ def test_shared_manylinux_workflows_have_no_multiline_shell(
             assert "${{ inputs." not in line
 
 
+@pytest.mark.parametrize(
+    "workflow",
+    [
+        CALL_BUILD_MANYLINUX_WHEELS_WORKFLOW,
+        CALL_TEST_MANYLINUX_WHEELS_WORKFLOW,
+        CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW,
+    ],
+)
+def test_manylinux_consumers_use_the_current_repository_namespace(
+    workflow: Path,
+) -> None:
+    workflow_text = workflow.read_text()
+    assert "ghcr.io/${{ github.repository }}/tt-lang-wheel-manylinux" in workflow_text
+    assert "ghcr.io/tenstorrent/tt-lang/tt-lang-wheel-manylinux" not in workflow_text
+
+
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
     build_docker_workflow = CALL_BUILD_DOCKER_WORKFLOW.read_text()
     wheel_images_workflow = CALL_BUILD_WHEEL_IMAGES_WORKFLOW.read_text()
@@ -673,7 +689,9 @@ def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
         'build-wheel-manylinux-images.sh --python-tags "$PYTHON_TAG"'
         ' --image-tag "$DOCKER_TAG"'
     ) in wheel_images_workflow
-    assert '--publish-latest "$PUBLISH_LATEST"' in wheel_images_workflow
+    assert "publish-latest:" in wheel_images_workflow
+    assert ".github/scripts/publish-wheel-builder-latest.sh" in wheel_images_workflow
+    assert "--publish-latest" not in wheel_images_workflow
     assert "--build-parallel-level 2" in wheel_images_workflow
     assert "ARG WORKFLOW_SOURCE=." in manylinux_dockerfile
     assert (

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -21,7 +21,11 @@ from conftest import REPO_ROOT  # noqa: E402
 SCRIPTS_DIR = REPO_ROOT / ".github" / "scripts"
 CHECK_WHEEL_TTNN_METADATA = SCRIPTS_DIR / "check-wheel-ttnn-metadata.py"
 CHECK_LIGHT_METAPACKAGE = SCRIPTS_DIR / "check-light-metapackage.py"
-BUILD_S3_LIGHT_CORE_WHEEL = SCRIPTS_DIR / "build-s3-light-core-wheel.sh"
+BUILD_MANYLINUX_CORE_WHEEL = SCRIPTS_DIR / "build-manylinux-core-wheel.sh"
+RESOLVE_PYPI_PUBLISH_INPUTS = SCRIPTS_DIR / "resolve-pypi-publish-inputs.sh"
+RESOLVE_S3_PUBLISH_INPUTS = SCRIPTS_DIR / "resolve-s3-publish-inputs.sh"
+RESOLVE_S3_PUBLISH_PREFIX = SCRIPTS_DIR / "resolve-s3-publish-prefix.sh"
+INJECT_S3_PUBLISH_README = SCRIPTS_DIR / "inject-s3-publish-readme.sh"
 COMPUTE_NIGHTLY_VERSION = SCRIPTS_DIR / "compute-nightly-version.py"
 CHECK_INSTALLED_TTNN = SCRIPTS_DIR / "check-installed-ttnn.py"
 CHECK_BUNDLED_PAYLOAD = SCRIPTS_DIR / "check-wheel-bundled-payload.py"
@@ -33,6 +37,15 @@ CALL_BUILD_DOCKER_WORKFLOW = (
 )
 CALL_BUILD_WHEEL_IMAGES_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-build-wheel-images.yml"
+)
+CALL_BUILD_MANYLINUX_WHEELS_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "call-build-manylinux-wheels.yml"
+)
+CALL_TEST_MANYLINUX_WHEELS_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "call-test-manylinux-wheels.yml"
+)
+SETUP_WHEEL_IMAGE_BUILD_ACTION = (
+    REPO_ROOT / ".github" / "actions" / "setup-wheel-image-build" / "action.yml"
 )
 CALL_TTMETAL_LIGHT_WHEEL_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "call-ttmetal-light-wheel.yml"
@@ -54,6 +67,15 @@ TTMETAL_LIGHT_XLA_ON_DEMAND_WORKFLOW = (
 S3_PYPI_OPS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "s3-pypi-ops.yml"
 MANYLINUX_WHEEL_DOCKERFILE = (
     REPO_ROOT / ".github" / "containers" / "Dockerfile.wheel-manylinux-2-34"
+)
+WHEEL_TOOLCHAIN_CMAKELISTS = (
+    REPO_ROOT / ".github" / "containers" / "CMakeLists.wheel-toolchain"
+)
+TOOLCHAIN_COMPONENT_MODULE = (
+    REPO_ROOT / "cmake" / "modules" / "TTLangToolchainComponent.cmake"
+)
+TOOLCHAIN_OPTIONS_MODULE = (
+    REPO_ROOT / "cmake" / "modules" / "TTLangToolchainOptions.cmake"
 )
 SETUP_PY = REPO_ROOT / "setup.py"
 
@@ -87,46 +109,55 @@ def _add_config_py(wheel_path: Path, *, tt_metal_commit: str) -> None:
         wheel.writestr("ttl/config.py", f'TT_METAL_COMMIT = "{tt_metal_commit}"\n')
 
 
+def test_manylinux_core_helper_resolves_sibling_scripts_from_its_directory() -> None:
+    helper = BUILD_MANYLINUX_CORE_WHEEL.read_text()
+
+    assert 'script_dir=$(CDPATH=\'\' cd -- "$(dirname -- "$0")" && pwd)' in helper
+    assert '"$script_dir/resolve-wheel-versions.sh"' in helper
+    assert '"$script_dir/configure-ttlang-build.sh"' in helper
+
+
 def test_s3_workflow_routes_light_wheels_to_manylinux_builder() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    shared_build = CALL_BUILD_MANYLINUX_WHEELS_WORKFLOW.read_text()
 
     assert (
         "github.event_name == 'workflow_dispatch' && inputs.wheel_variant || ''"
     ) in workflow
     assert "EVENT_NAME: ${{ github.event_name }}" in workflow
-    assert "tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}" in workflow
-    assert "python_tag: [cp310, cp312]" in workflow
-    assert ".github/scripts/build-s3-light-core-wheel.sh" in workflow
-    assert ".github/scripts/build-s3-light-metapackage-wheel.sh" in workflow
-    assert ".github/scripts/test-s3-light-wheels.sh" in workflow
-    assert ".github/scripts/inject-s3-index-readme.sh" in workflow
-    assert '--key "$key"' in workflow
-    assert "--require-existing" in workflow
-    assert (
-        '--find-links-subdir "${{ steps.publish_prefix.outputs.prefix }}"' in workflow
-    )
+    assert "uses: ./.github/workflows/call-build-manylinux-wheels.yml" in workflow
+    assert "ttnn_dep_mode: ${{ matrix.ttnn_dep_mode }}" in workflow
+    assert "tt-lang-wheel-manylinux-2-34-${{ matrix.python_tag }}" in shared_build
+    assert "python_tag: [cp310, cp312]" in shared_build
+    assert ".github/scripts/build-manylinux-wheel-set-member.sh" in shared_build
+    assert ".github/scripts/test-s3-light-wheels.sh" in shared_build
+    assert ".github/scripts/inject-s3-index-readme.sh" not in workflow
+    assert ".github/scripts/inject-s3-publish-readme.sh" in workflow
+    assert "PUBLISH_PREFIX: ${{ steps.publish-prefix.outputs.prefix }}" in workflow
+    assert '--find-links-subdir "$PUBLISH_PREFIX"' in workflow
     assert "python3 -m pip install s3pypi" not in workflow
-    assert "standard_wheel_matrix" in workflow
+    assert "manylinux_wheel_matrix" in workflow
 
 
 def test_regular_s3_publish_prefix_routes_dev_to_month_and_final_to_releases() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
-    assert 'prefix="tt-lang/releases"' in workflow
-    assert 'prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"' in workflow
-    assert (
-        'publish_args+=(--prefix "${{ steps.publish_prefix.outputs.prefix }}")'
-        in workflow
-    )
+    resolver = RESOLVE_S3_PUBLISH_PREFIX.read_text()
+    assert "resolve-s3-publish-prefix.sh" in workflow
+    assert "prefix=tt-lang/releases" in resolver
+    assert 'prefix="tt-lang/${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"' in resolver
+    assert '--prefix "$PUBLISH_PREFIX"' in workflow
 
 
 def test_regular_s3_index_injection_targets_parent_slash_key() -> None:
     # Regular direct publishing regenerates the top tt-lang/ slash-key listing;
     # the README injection must target that parent listing, not the month dir.
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
-    assert 'parent="$(dirname "$prefix")"' in workflow
-    assert 'key="$parent/"' in workflow
-    assert 'key="$prefix/index.html"' not in workflow
-    assert 'key="$prefix/"' not in workflow
+    injector = INJECT_S3_PUBLISH_README.read_text()
+    assert "inject-s3-publish-readme.sh" in workflow
+    assert 'parent="$(dirname "$prefix")"' in injector
+    assert '--key "$parent/"' in injector
+    assert 'key="$prefix/index.html"' not in injector
+    assert 'key="$prefix/"' not in injector
 
 
 def test_ttmetal_light_workflow_builds_and_validates_metapackage() -> None:
@@ -316,6 +347,8 @@ def test_pinned_ttlang_ref_skips_search_and_tt_metal_build() -> None:
 
 def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    bundled_build = CALL_BUILD_WHEELS_WORKFLOW.read_text()
+    manylinux_build = CALL_BUILD_MANYLINUX_WHEELS_WORKFLOW.read_text()
     # Dispatch inputs to rebuild from a pinned ref and optionally patch it.
     assert "ttlang_ref:" in workflow
     assert "apply_patches:" in workflow
@@ -325,16 +358,18 @@ def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
     assert "ttlang_sha_override: ${{ inputs.ttlang_ref }}" in workflow
     # Patches come from the workflow commit (a checkout of github.sha), not the
     # target ref -- an older ref that needs a patch predates the patch files.
-    assert "ref: ${{ github.sha }}" in workflow
-    assert "path: .wheel-patch-src" in workflow
+    assert "ref: ${{ github.sha }}" in bundled_build
+    assert "path: .wheel-patch-src" in bundled_build
     assert (
         ".wheel-patch-src/.github/scripts/apply-wheel-patches.sh"
         ' --target-dir "$GITHUB_WORKSPACE"'
-    ) in workflow
-    # TTLANG_GIT_COMMIT records the resolved commit, not a tag/branch name.
-    assert 'TTLANG_GIT_COMMIT="$(git rev-parse HEAD)"' in workflow
-    assert "export TTLANG_GIT_COMMIT" in workflow
-    assert "TTLANG_GIT_COMMIT: ${{ inputs.ttlang_ref" not in workflow
+    ) in bundled_build
+    assert "ref: ${{ github.sha }}" in manylinux_build
+    assert "path: .wheel-workflow-src" in manylinux_build
+    assert (
+        ".wheel-workflow-src/.github/scripts/apply-wheel-patches.sh"
+        ' --target-dir "$GITHUB_WORKSPACE"'
+    ) in manylinux_build
     # apply_patches stays a valid boolean on push/schedule (no dispatch inputs).
     assert (
         "apply_patches: ${{ github.event_name == 'workflow_dispatch'"
@@ -342,10 +377,48 @@ def test_publish_s3_supports_pinned_ref_and_wheel_patches() -> None:
     ) in workflow
 
 
+def test_scheduled_s3_publish_skips_unchanged_source_sha() -> None:
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+
+    assert "publish_needed: ${{ steps.nightly.outputs.publish-needed }}" in workflow
+    assert "s3-nightly-state.py check" in workflow
+    for job_name in (
+        "build-docker",
+        "build-wheel-images",
+        "build-bundled-wheels",
+        "build-manylinux-wheels",
+        "publish",
+        "ttmetal-light-detect",
+        "ttmetal-light-build",
+    ):
+        job_prefix = workflow.split(f"\n  {job_name}:", 1)[1][:1000]
+        assert "needs.preflight.outputs.publish_needed == 'true'" in job_prefix
+    assert workflow.index("Record scheduled publish state") > workflow.index(
+        "Restore S3 index README"
+    )
+
+
+def test_s3_publish_requires_every_selected_wheel_build_to_succeed() -> None:
+    workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    publish_job = workflow.split("\n  publish:", 1)[1].split(
+        "\n  ttmetal-light-detect:", 1
+    )[0]
+
+    assert (
+        "needs.preflight.outputs.bundled_selected != 'true' || "
+        "needs.build-bundled-wheels.result == 'success'"
+    ) in publish_job
+    assert (
+        "needs.preflight.outputs.manylinux_selected != 'true' || "
+        "needs.build-manylinux-wheels.result == 'success'"
+    ) in publish_job
+
+
 def test_publish_pypi_supports_release_sha_from_main() -> None:
     workflow = PUBLISH_PYPI_WORKFLOW.read_text()
+    resolver = RESOLVE_PYPI_PUBLISH_INPUTS.read_text()
     preflight_job = workflow.split("\n  preflight:", 1)[1].split(
-        "\n  build-docker:", 1
+        "\n  build-wheel-images:", 1
     )[0]
     publish_job = workflow.split("\n  publish:", 1)[1].split("\n  dry-run-summary:", 1)[
         0
@@ -354,15 +427,15 @@ def test_publish_pypi_supports_release_sha_from_main() -> None:
     assert "ttlang_sha:" in workflow
     assert "ref: ${{ inputs.ttlang_sha || github.sha }}" in workflow
     assert "path: release-source" in preflight_job
-    assert 'git -C "$release_source" rev-parse HEAD' in preflight_job
+    assert 'git -C "$RELEASE_SOURCE" rev-parse HEAD' in resolver
     assert "TTLANG_TT_METAL_VERSION_FILE:" in preflight_job
-    assert "ttlang_sha must be a full 40-character commit SHA" in workflow
+    assert "ttlang_sha must be a full 40-character commit SHA" in resolver
     assert (
-        'git -C "$release_source" merge-base --is-ancestor'
-        ' "$TTLANG_SHA" "$GITHUB_SHA"'
-    ) in workflow
-    assert "git -C \"$RELEASE_SOURCE\" tag --list 'v[0-9]*' --points-at" in workflow
-    assert '.github/scripts/require-release-tag.sh "$release_ref"' in workflow
+        'git -C "$RELEASE_SOURCE" merge-base --is-ancestor'
+        ' "$ttlang_sha" "${GITHUB_SHA:?GITHUB_SHA is required}"'
+    ) in resolver
+    assert "git -C \"$RELEASE_SOURCE\" tag --list 'v[0-9]*' --points-at" in resolver
+    assert '"$script_dir/require-release-tag.sh" "$release_ref"' in resolver
     assert workflow.count("ttlang_sha_override: ${{ inputs.ttlang_sha }}") == 3
     assert 'echo "dry_run=${{ inputs.dry_run }}"' not in workflow
     assert 'echo "docker_tag=${{ inputs.docker_tag }}"' not in workflow
@@ -386,7 +459,7 @@ def test_publish_pypi_terminal_jobs_override_skipped_docker_build_status() -> No
         assert "!cancelled()" in terminal_job
         assert "needs.preflight.result == 'success'" in terminal_job
         assert "needs.build-wheels.result == 'success'" in terminal_job
-    assert "needs.test-dist-tutorials.result == 'success'" in publish_job
+    assert "needs.test-wheels.result == 'success'" in publish_job
 
 
 def test_dist_tutorial_workflow_supports_pinned_ref() -> None:
@@ -533,10 +606,35 @@ def test_s3_pypi_ops_workflow_is_main_gated_and_dry_run_by_default() -> None:
 
 
 def test_light_core_builder_checks_tt_metal_provenance_when_exported() -> None:
-    script = BUILD_S3_LIGHT_CORE_WHEEL.read_text()
+    script = BUILD_MANYLINUX_CORE_WHEEL.read_text()
 
-    assert 'if [ -n "${TT_METAL_COMMIT:-}" ]; then' in script
+    assert (
+        'TT_METAL_COMMIT="${TT_METAL_COMMIT:-$(git rev-parse HEAD:third-party/tt-metal)}"'
+        in script
+    )
     assert '--expect-tt-metal-commit "$TT_METAL_COMMIT"' in script
+    assert '--expect-ttnn-version "$TTNN_PYPI"' in script
+
+
+@pytest.mark.parametrize(
+    "workflow",
+    [
+        CALL_BUILD_WHEEL_IMAGES_WORKFLOW,
+        CALL_BUILD_MANYLINUX_WHEELS_WORKFLOW,
+        CALL_TEST_MANYLINUX_WHEELS_WORKFLOW,
+        PUBLISH_PYPI_WORKFLOW,
+        PUBLISH_S3_PYPI_WORKFLOW,
+        SETUP_WHEEL_IMAGE_BUILD_ACTION,
+    ],
+)
+def test_shared_manylinux_workflows_have_no_multiline_shell(
+    workflow: Path,
+) -> None:
+    workflow_text = workflow.read_text()
+    assert "run: |" not in workflow_text
+    for line in workflow_text.splitlines():
+        if line.lstrip().startswith("run:"):
+            assert "${{ inputs." not in line
 
 
 def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
@@ -556,31 +654,151 @@ def test_manylinux_builder_images_are_opt_in_for_docker_workflows() -> None:
     # The wheel-builder images live in their own opt-in workflow.
     assert "build-manylinux-wheel-images:" in wheel_images_workflow
     assert "python_tag: [cp310, cp312]" in wheel_images_workflow
-    assert "id: docker-tag" in wheel_images_workflow
-    assert "registry-image=${registry_image}" in wheel_images_workflow
-    assert r"Image: \`${registry_image}\`" in wheel_images_workflow
+    assert "id: resolve" in wheel_images_workflow
+    assert ".github/scripts/resolve-wheel-builder-images.sh" in wheel_images_workflow
+    assert "cache-components:" in wheel_images_workflow
+    assert "component: ttmetal" in wheel_images_workflow
+    assert wheel_images_workflow.count("component: llvm") == 2
+    assert "linux-amd64-ttmetal-cp312" in wheel_images_workflow
+    assert "cache_tag: linux-amd64-llvm-cp310" in wheel_images_workflow
+    assert "cache_tag: linux-amd64-llvm-cp312" in wheel_images_workflow
+    assert "CACHE_REF: ${{ format(" in wheel_images_workflow
+    assert "path: .wheel-workflow-src" in wheel_images_workflow
+    assert "--workflow-source .wheel-workflow-src" in wheel_images_workflow
+    assert "PYTHON_TAG: ${{ matrix.python_tag }}" in wheel_images_workflow
+    assert "DOCKER_TAG: ${{ needs.resolve.outputs.docker-tag }}" in (
+        wheel_images_workflow
+    )
     assert (
-        "build-wheel-manylinux-images.sh --python-tags"
-        ' "${{ matrix.python_tag }}" --image-tag'
+        'build-wheel-manylinux-images.sh --python-tags "$PYTHON_TAG"'
+        ' --image-tag "$DOCKER_TAG"'
     ) in wheel_images_workflow
-    assert '"${{ steps.docker-tag.outputs.docker-tag }}"' in wheel_images_workflow
+    assert '--publish-latest "$PUBLISH_LATEST"' in wheel_images_workflow
     assert "--build-parallel-level 2" in wheel_images_workflow
+    assert "ARG WORKFLOW_SOURCE=." in manylinux_dockerfile
+    assert (
+        "COPY ${WORKFLOW_SOURCE}/.github/containers/"
+        "CMakeLists.wheel-toolchain CMakeLists.txt"
+    ) in manylinux_dockerfile
+    assert "COPY ${WORKFLOW_SOURCE}/CMakeLists.txt" not in manylinux_dockerfile
+    llvm_stage = manylinux_dockerfile.split("FROM base AS llvm-toolchain", 1)[1].split(
+        "FROM base AS ttmetal-toolchain", 1
+    )[0]
+    ttmetal_stage = manylinux_dockerfile.split("FROM base AS ttmetal-toolchain", 1)[
+        1
+    ].split("FROM base AS wheel-builder", 1)[0]
+    final_stage = manylinux_dockerfile.split("FROM base AS wheel-builder", 1)[1]
+    assert "COPY requirements.txt requirements-runtime.txt" not in llvm_stage
+    assert "COPY requirements.txt requirements-runtime.txt" not in ttmetal_stage
+    assert (
+        "COPY requirements.txt requirements-runtime.txt " "/tmp/ttlang-requirements/"
+    ) in final_stage
+    assert "-r /tmp/ttlang-requirements/requirements.txt" in final_stage
+    assert "TTLANG_INSTALL_RUNTIME_REQUIREMENTS OFF" in (
+        WHEEL_TOOLCHAIN_CMAKELISTS.read_text()
+    )
+    assert (
+        "if(TTLANG_INSTALL_RUNTIME_REQUIREMENTS)"
+        in (REPO_ROOT / "cmake" / "modules" / "BuildLLVM.cmake").read_text()
+    )
     assert "ARG TTLANG_BUILD_PARALLEL_LEVEL" in manylinux_dockerfile
     assert (
         'ENV CMAKE_BUILD_PARALLEL_LEVEL="${TTLANG_BUILD_PARALLEL_LEVEL}"'
         in manylinux_dockerfile
     )
 
-    # CI opts in on image rebuild; the S3 publish opts in only for the light
-    # wheel variant; the PyPI publish never builds them.
+    # CI, S3 manylinux variants, and public PyPI all use the same builder.
     assert "uses: ./.github/workflows/call-build-wheel-images.yml" in ci_workflow
     assert "uses: ./.github/workflows/call-build-wheel-images.yml" in s3_workflow
-    assert (
-        "contains(fromJSON(needs.preflight.outputs.wheel_variants), 'light')"
-        in s3_workflow
+    assert "needs.preflight.outputs.manylinux_selected == 'true'" in s3_workflow
+    assert "uses: ./.github/workflows/call-build-wheel-images.yml" in pypi_workflow
+    assert "uses: ./.github/workflows/call-build-manylinux-wheels.yml" in pypi_workflow
+    assert "ttnn_dep_mode: pypi" in pypi_workflow
+
+
+@pytest.mark.parametrize(
+    ("component", "expected_marker"),
+    [("llvm", "llvm"), ("tt-metal", "tt-metal")],
+)
+def test_wheel_toolchain_cmake_configures_only_selected_component(
+    tmp_path: Path,
+    component: str,
+    expected_marker: str,
+) -> None:
+    source_dir = tmp_path / "source"
+    module_dir = source_dir / "cmake" / "modules"
+    module_dir.mkdir(parents=True)
+    (source_dir / "CMakeLists.txt").write_text(WHEEL_TOOLCHAIN_CMAKELISTS.read_text())
+    (module_dir / "TTLangToolchainComponent.cmake").write_text(
+        TOOLCHAIN_COMPONENT_MODULE.read_text()
     )
-    assert "call-build-wheel-images" not in pypi_workflow
-    assert "build_manylinux_wheel_images" not in pypi_workflow
+    (module_dir / "TTLangToolchainOptions.cmake").write_text(
+        TOOLCHAIN_OPTIONS_MODULE.read_text()
+    )
+    (module_dir / "TTLangUtils.cmake").write_text(
+        "function(ttlang_pip_install_requirements)\nendfunction()\n"
+    )
+    for module_name in ("TTLangCompilerSetup", "TTLangPython"):
+        (module_dir / f"{module_name}.cmake").write_text("")
+    (module_dir / "BuildLLVM.cmake").write_text(
+        'file(WRITE "${CMAKE_BINARY_DIR}/configured-component" "llvm")\n'
+    )
+    (module_dir / "BuildTTMetal.cmake").write_text(
+        'file(WRITE "${CMAKE_BINARY_DIR}/configured-component" "tt-metal")\n'
+    )
+
+    build_dir = tmp_path / "build"
+    result = subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(source_dir),
+            "-B",
+            str(build_dir),
+            "-DCMAKE_C_COMPILER=cc",
+            "-DCMAKE_CXX_COMPILER=c++",
+            f"-DTTLANG_TOOLCHAIN_COMPONENT={component}",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (build_dir / "configured-component").read_text() == expected_marker
+
+
+def test_wheel_toolchain_cmake_rejects_full_project_configuration(
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "source"
+    module_dir = source_dir / "cmake" / "modules"
+    module_dir.mkdir(parents=True)
+    (source_dir / "CMakeLists.txt").write_text(WHEEL_TOOLCHAIN_CMAKELISTS.read_text())
+    for module in (
+        TOOLCHAIN_OPTIONS_MODULE,
+        REPO_ROOT / "cmake" / "modules" / "TTLangUtils.cmake",
+        REPO_ROOT / "cmake" / "modules" / "TTLangCompilerSetup.cmake",
+    ):
+        (module_dir / module.name).write_text(module.read_text())
+
+    result = subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(source_dir),
+            "-B",
+            str(tmp_path / "build"),
+            "-DCMAKE_C_COMPILER=cc",
+            "-DCMAKE_CXX_COMPILER=c++",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "requires llvm or tt-metal" in result.stdout + result.stderr
 
 
 def test_setup_py_removes_stale_native_payloads_before_wheel_install() -> None:
@@ -595,15 +813,15 @@ def test_setup_py_removes_stale_native_payloads_before_wheel_install() -> None:
 
 def test_s3_workflow_publishes_only_from_main_ref() -> None:
     workflow = PUBLISH_S3_PYPI_WORKFLOW.read_text()
+    resolver = RESOLVE_S3_PUBLISH_INPUTS.read_text()
     trigger_block = workflow.split("\nconcurrency:", maxsplit=1)[0]
 
     assert "push:" not in trigger_block
     assert "tags:" not in trigger_block
     assert "- 'v[0-9]+.[0-9]+.[0-9]+'" not in trigger_block
-    assert "github.ref != 'refs/heads/main'" in workflow
-    assert "steps.resolve.outputs.docker_tag == ''" in workflow
-    assert "Publishing is restricted to refs/heads/main" in workflow
-    assert "Non-main dry runs must provide docker_tag" in workflow
+    assert '"${GITHUB_REF:-}" != refs/heads/main' in resolver
+    assert "Publishing is restricted to refs/heads/main" in resolver
+    assert "Non-main dry runs must provide docker_tag" in resolver
     assert (
         "needs.preflight.outputs.dry_run == 'true' || github.ref == 'refs/heads/main'"
         in workflow
@@ -625,6 +843,55 @@ def test_check_wheel_ttnn_metadata_matches_requirement_name(tmp_path: Path) -> N
 
     assert result.returncode != 0
     assert "default wheel metadata must require ttnn" in result.stderr
+
+
+def test_check_wheel_ttnn_metadata_requires_exact_pypi_version(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    _write_wheel(
+        dist_dir,
+        "tt_lang-0.71.0.dev20260525-py3-none-any.whl",
+        "Metadata-Version: 2.1\nRequires-Dist: ttnn == 1.2.3\n",
+    )
+
+    result = _run_script(
+        CHECK_WHEEL_TTNN_METADATA,
+        "--mode",
+        "pypi",
+        "--dist-dir",
+        str(dist_dir),
+        "--expect-ttnn-version",
+        "1.2.4",
+    )
+
+    assert result.returncode != 0
+    assert "ttnn dependency mismatch: expected ==1.2.4, got ==1.2.3" in result.stderr
+
+
+def test_check_wheel_ttnn_metadata_accepts_exact_pypi_version(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    _write_wheel(
+        dist_dir,
+        "tt_lang-0.71.0.dev20260525-py3-none-any.whl",
+        "Metadata-Version: 2.1\nRequires-Dist: ttnn == 1.2.3\n",
+    )
+
+    result = _run_script(
+        CHECK_WHEEL_TTNN_METADATA,
+        "--mode",
+        "pypi",
+        "--dist-dir",
+        str(dist_dir),
+        "--expect-ttnn-version",
+        "1.2.3",
+    )
+
+    assert result.returncode == 0
 
 
 def test_check_wheel_ttnn_metadata_rejects_external_payload(tmp_path: Path) -> None:
@@ -803,8 +1070,28 @@ def _env_with_pythonpath_and_ldd(path: Path) -> dict[str, str]:
     )
 
 
-def test_check_installed_ttnn_pypi_mode_is_noop() -> None:
-    result = _run_script(CHECK_INSTALLED_TTNN, "--mode", "pypi")
+def test_check_installed_ttnn_pypi_fails_when_ttnn_absent(tmp_path: Path) -> None:
+    result = _run_script(
+        CHECK_INSTALLED_TTNN,
+        "--mode",
+        "pypi",
+        env=_env_with_pythonpath(tmp_path),
+    )
+    assert result.returncode != 0
+    assert "did not install its ttnn dependency" in result.stderr
+
+
+def test_check_installed_ttnn_pypi_passes_when_ttnn_present(
+    tmp_path: Path,
+) -> None:
+    _write_fake_ttnn(tmp_path, with_native_libs=False)
+
+    result = _run_script(
+        CHECK_INSTALLED_TTNN,
+        "--mode",
+        "pypi",
+        env=_env_with_pythonpath(tmp_path),
+    )
     assert result.returncode == 0, result.stderr
 
 


### PR DESCRIPTION
### Problem description
PyPI and S3 wheels used separate build pipelines, while scheduled S3 builds rebuilt unchanged source and toolchains.

### What's changed
- Share the `manylinux_2_34` build for public PyPI and S3 light/PyPI wheels while preserving the exact public `ttnn` dependency.
- Cache LLVM and tt-metal separately and skip scheduled S3 publishes when the source SHA is unchanged.
- Add dry-run-first S3 object-version deduplication and dev-version date-range removal.
- Fail configuration when a requested tt-metal toolchain installation fails.
- Keep workflow shell logic in tested repository scripts.

Validation: 511 Bats tests, 161 packaging tests, actionlint, shellcheck, and pre-commit.

### Checklist
- [x] New/Existing tests provide coverage for changes
