### PR TITLE
[ttl] Reuse physical DFB indices for non-overlapping user DFBs [dfb-reuse-2]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1312,9 +1312,9 @@ processors.
 Repeated DFB protocols may produce periodic or disconnected lifetimes. Cyclic
 register-allocation work models software-pipelined lifetimes with
 [circular-arc graphs](https://www.sciencedirect.com/science/article/pii/S0166218X99001055).
-SSA chordality or interval-coloring results apply only after the compiler proves
-that each physical DFB version has the required connected lifetime. A separate
-exact constraint model, following
+Allocation algorithms that require one connected lifetime per value apply only
+after the compiler proves that property for each physical DFB version. A
+separate exact constraint model, following
 [Unison](https://arxiv.org/abs/1804.02452), can validate small cases that
 combine index assignment, per-node specialization, lifetime splitting,
 scheduling, and spilling without requiring the production allocator to use a
@@ -1327,8 +1327,8 @@ general solver.
 The liveness analysis consumes the cached logical-identity result and exposes
 logical lifecycles, lifetime frontiers, boundedness, and pairwise lifetime
 order. Its operation events and program-order and protocol edges remain an
-internal proof representation. It does not construct an interference graph or
-select physical indices.
+internal proof representation. It does not construct the physical-index
+conflict relation or select indices.
 
 ```text
 resolveLogicalIdentities(module):
@@ -1377,6 +1377,23 @@ following reasons: descriptor mismatch, unknown launch-node domain, unproven
 quiescence, transaction mismatch, pointer-owner mismatch, or concurrent
 lifetime.
 
+The allocation graph uses one vertex per logical DFB and one edge per pair
+that cannot share. Assigning a graph color means assigning a physical DFB
+index; vertices joined by an edge must receive different indices. A clique is
+a set of vertices in which every pair has an edge. Every DFB in a clique needs a
+different physical index, so the clique size is a proved lower bound on the
+number of required indices. The allocator finds a clique greedily. It may miss
+a larger clique, but the one it finds still proves its lower bound.
+
+First-fit processes DFBs in immutable declaration order and assigns the lowest
+index not used by a conflict. This produces a valid assignment quickly, but a
+different order can use fewer indices. Exact search uses deterministic DSATUR
+ordering: it next selects the unassigned DFB constrained by the most different
+indices among already assigned conflicts, then tries legal indices in numeric
+order. Resolving the most constrained DFB first reduces failed alternatives.
+DSATUR changes search order only; feasibility and infeasibility results come
+from exhaustive backtracking within the configured state limit.
+
 ```text
 buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
   reject if a derived DFB-index attribute exists
@@ -1403,23 +1420,23 @@ buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
 
   conflicts = typed conflict graph induced by candidates
   assignment = deterministicFirstFit(conflicts)
-  lowerBound = greedyClique(conflicts)
+  pairwiseConflictLowerBound = findCliqueLowerBound(conflicts)
   if assignment exceeds the physical-index limit:
-    fitResult = fixedLimitDSATUR(conflicts, physicalIndexLimit,
-                                 searchStateLimit)
+    fitResult = exactFixedLimitSearch(conflicts, physicalIndexLimit,
+                                      searchStateLimit)
     if fitResult is SearchLimitReached:
       reject with an inconclusive-search diagnostic
     if fitResult is Infeasible:
       reject with a proved capacity diagnostic
     assignment = fitResult.assignment
-  reject a capacity result only after exact infeasibility or a sound lower
-      bound proves that the applicable limit cannot be met
+  reject a capacity result only after exact infeasibility or the
+      pairwise-conflict lower bound exceeds the applicable limit
   verify every pair assigned one index against the typed conflict model
 
   aggregate L1 bytes once per unique physical index
   if assignment exceeds the L1 limit and is not known minimum:
-    minimumResult = minimumColorDSATUR(conflicts, lowerBound,
-                                      searchStateLimit)
+    minimumResult = exactMinimumIndexSearch(
+        conflicts, pairwiseConflictLowerBound, searchStateLimit)
     if minimumResult is SearchLimitReached:
       reject with an inconclusive-search diagnostic
     assignment = minimumResult.assignment
@@ -1442,15 +1459,17 @@ applyPhysicalAllocationPlan(module, plan):
   write ttl.dfb_allocations from plan.runtimeDescriptors
 ```
 
-Each color is one physical index. First-fit is the default assignment mechanism.
-When first-fit exceeds the physical-index limit, one fixed-limit exact query
-tests that limit directly. Minimum-color search runs only when a valid index
-assignment exceeds the L1 budget. Any deterministic assignment that satisfies
-both hardware limits is valid. Each exact query examines at most
-`exact-coloring-search-limit` deterministic states, which defaults to 1,000,000.
-Reaching the limit reports that feasibility was not proved and identifies the
-option that increases the limit; it never reports a proved capacity failure.
-The planner completes every
+First-fit is accepted whenever its valid assignment satisfies the physical
+index and L1 limits; proving a smaller assignment would not change compilation.
+Backtracking can grow exponentially, so exact search is reserved for cases
+where first-fit prevents acceptance. A physical-index failure asks one direct
+question at the available index count instead of proving the minimum. A valid
+assignment that exceeds L1 requires a minimum physical-index-count search
+because a different sharing assignment may use less physical storage. Each
+exact query examines at most `exact-coloring-search-limit` deterministic states,
+which defaults to 1,000,000, to bound compile time. Reaching the limit reports
+that feasibility was not proved and identifies the option that increases the
+limit; it never reports a proved capacity failure. The planner completes every
 diagnostic-producing validation before `TTLFinalizeDFBIndices` changes any
 `dfb_id`, `cb_index`, kernel attribute, or module attribute. The finalizer only
 materializes the validated plan.
@@ -1489,16 +1508,16 @@ consumer can begin B. An early B wait cannot consume A's data because its entry
 is at or after one of B's earliest use events. The physical allocation is
 sufficient for both logical DFBs.
 
-Coloring places two DFBs in one color only when this relation holds in one
-direction on every shared node. The final pairwise verification independently
-checks the typed conflict model for every shared color. If a lifetime or
+Allocation places two DFBs at one physical index only when this relation holds
+in one direction on every shared node. The final pairwise verification checks
+the typed conflict model again for every shared index. If a lifetime or
 ordering proof is missing, the DFB conflicts with every candidate that may
 execute on the same node; this can increase the physical count but cannot
 create unsafe reuse.
 
 Two DFBs consumed by the same operation necessarily overlap: both acquires
-precede the consumer and both pops follow it. Coloring therefore assigns them
-different physical indices.
+precede the consumer and both pops follow it. Allocation therefore assigns
+them different physical indices.
 
 #### Representative example
 
@@ -1509,12 +1528,12 @@ kernels. Proven non-overlapping lifetimes reduce the allocation to 29 physical
 indices, below the hardware limit of 32. The device test compares the final
 result with PyTorch scaled dot-product attention.
 
-`test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir` isolates
-the cross-kernel ordering rules. The independent allocation-oracle test joins a
-30-vertex clique with the confirmed four-vertex bad-order graph: first-fit uses
-33 indices and the fixed-limit exact check finds a 32-index assignment. The
-invalid liveness test confirms that 33 mutually conflicting lifetimes are
-rejected.
+`test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir`
+isolates the cross-kernel ordering rules. The independent allocation-oracle
+test joins 30 DFBs that all conflict pairwise with the confirmed four-DFB
+order-sensitive case. First-fit uses 33 indices and the fixed-limit exact check
+finds a 32-index assignment. The invalid liveness test confirms that 33
+mutually conflicting lifetimes are rejected.
 
 `test/python/test_user_dfb_reuse.py` recursively composes copy atoms into an
 operation with 33 logical DFBs. The operation compiles and executes only when
@@ -1525,7 +1544,7 @@ reuse reduces the physical allocation below the hardware limit.
 The pass compacts distinct provisional user indices before placing
 compiler-created DFBs after them. This removes gaps caused by DFBs that the
 frontend created but no kernel captured, without changing logical identity or
-existing physical-index sharing. Lifetime-based coloring may further reuse
+existing physical-index sharing. Lifetime-based assignment may further reuse
 physical indices when enabled. The planned physical DFB count is one greater
 than the greatest assigned index, and the pass verifies this does not exceed
 `kMaxCircularBuffers` (32).
@@ -1572,11 +1591,11 @@ the same physical configuration as direct execution.
 
 Setting `reuse-user-dfbs=false` retains physical sharing already expressed by
 equal provisional user indices but does not introduce new sharing between user
-DFBs. It compacts the distinct provisional values, then colors only
+DFBs. It compacts the distinct provisional values, then assigns only
 compiler-created DFBs. Both allocation modes use the same concurrent lifetime
-proof and interference graph for every DFB they color. Both modes emit the
-complete `ttl.dfb_allocations` table and assign identities to compiler-created
-declarations.
+proof and conflict relation for every DFB whose index they select. Both modes
+emit the complete `ttl.dfb_allocations` table and assign identities to
+compiler-created declarations.
 
 ```text
 allocateWithoutUserReuse(module, lifetimes):
@@ -1676,18 +1695,20 @@ with releases before finalization.
   must also prove compatible transaction counts and address calculations.
 
 - **Pressure above the unspilled limits.** Deterministic first-fit is accepted
-  when it fits. One fixed-limit DSATUR query runs when first-fit exceeds the
-  physical-index limit. Minimum-color DSATUR runs only when a valid assignment
-  exceeds the L1 budget. Each query is limited to 1,000,000 deterministic states
-  by default. Limit exhaustion reports an inconclusive allocation; proven
-  infeasibility reports a capacity failure. DRAM spilling is tracked by
+  when it fits because a smaller assignment would not change acceptance. One
+  fixed-limit exhaustive query runs when first-fit exceeds the physical-index
+  limit. Minimum physical-index-count search runs only when a valid assignment
+  exceeds the L1 budget. Each query is limited to 1,000,000 deterministic
+  states by default so difficult graphs cannot make compile time unbounded.
+  Limit exhaustion reports an inconclusive allocation; proven infeasibility
+  reports a capacity failure. DRAM spilling is tracked by
   [#809](https://github.com/tenstorrent/tt-lang/issues/809).
 
-- **Reachability cost.** The bit-vector transitive closure is cubic in the
-  number of top-level DFB-accessing operations across all kernel sequences.
-  Unrelated operations are excluded. An SCC condensation followed by
-  topological bit-set propagation would scale better for programs with many
-  DFB lifecycle operations.
+- **Reachability cost.** Each launch node runs one graph traversal from every
+  top-level DFB-accessing operation. For `V` operation events and `E` ordering
+  edges, this costs `O(V * (V + E))`; unrelated operations are excluded. Launch
+  nodes with identical active operations currently recompute the same ordering
+  relation. Grouping those nodes could reduce analysis time for large grids.
 
 ## Scalar Element Access to DFBs
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -4,7 +4,7 @@ This document describes how the tt-lang compiler manages dataflow buffers (DFBs)
 
 ## Overview
 
-DFBs originate from two sources. User-declared DFBs are created explicitly in the DSL via `make_dataflow_buffer_like` and correspond to the programmer's data movement plan. Compiler-allocated DFBs are inserted automatically when the compiler needs concrete storage for a tensor SSA value: a tensor-level operation requires a CB-attached operand, a fused expression must be preserved before a source DFB release, or a computed value is stored from multiple blocks.
+DFBs originate from two sources. User-declared DFBs are created explicitly in the DSL via `make_dataflow_buffer_like` and correspond to the programmer's data movement plan. Compiler-allocated DFBs are inserted automatically when the compiler needs concrete storage for a tensor SSA value: a tensor-level operation requires a CB-attached operand, a fused expression must be preserved before a source DFB release, or a computed value is stored by operations in multiple MLIR basic blocks.
 
 The hardware supports at most 32 DFBs per node (indices 0--31). User and
 compiler-allocated DFBs share this index space. Passes operating on individual
@@ -13,11 +13,11 @@ finalization pass assigns module-wide physical indices after the last
 user-declared DFB and applies lifetime-based index reuse.
 
 `ttl.bind_cb` separates logical and physical identity. `dfb_id` identifies one
-logical DFB across kernel functions, while `cb_index` identifies its assigned
+logical DFB across kernel functions, while `cb_index` names its assigned
 hardware slot. Keeping both identities allows non-overlapping logical DFBs to
-share one physical index without merging their producer and consumer
-protocols. Every user declaration carries `dfb_id`. Compiler-created
-declarations may omit it until module finalization assigns a unique ID.
+share one physical index without merging their producer/consumer protocols.
+Every user declaration carries `dfb_id`. Compiler-created declarations may
+omit it until module finalization assigns a unique identity.
 
 ## Pipeline
 
@@ -132,20 +132,22 @@ traces the same occupancy transition and makes the attach dominate all original
 users dominated by the producer result.
 
 Producer `ComputeOp` creation replaces a tensor-level producer and its output
-stores with one `ttl.compute`. It follows the same publication rule for user
-DFBs.
+stores with one `ttl.compute`. It preserves the same write-before-push order for
+user DFBs.
 When `ttl-create-producer-compute` or `convert-ttl-to-compute` absorbs a
-block-level `ttl.store` into a `ttl.compute`, any publication that would
-otherwise precede the new compute is relocated after the compute. This keeps
+`ttl.store` into a `ttl.compute`, any `ttl.cb_push` that would otherwise precede
+the new compute is relocated after the compute. This keeps
 the generated DFB lifecycle in write-then-publish order: `cb_reserve`,
 `ttl.compute` with `tile_store`, then `cb_push`. Both passes use the shared,
 read-only compute-op-creation analysis described below before modifying IR.
 
 After `cb_pop`, the producer may overwrite the released slot because its prior
-contents are no longer live. The DFB's L1 backing storage remains statically
-allocated. Compiler DFB index reuse uses the final pop as the end of the
-contents' live interval, allowing non-overlapping DFBs of the same type to use
-the same backing storage.
+contents are no longer live. The DFB's backing storage remains statically
+allocated. Index reuse uses this release to prove that non-overlapping logical
+DFBs can use the same storage. Two logical DFBs may share a physical index only
+when their read- and write-pointer effects execute on the same hardware
+processors on every shared launched node. A happens-before relation proves zero
+occupancy but does not transfer ring-pointer state between processors.
 
 ## Single-producer Single-consumer Semantics
 
@@ -282,7 +284,7 @@ consumers that now receive DFB-attached operands. The following
 
 This section defines the DFB ownership, availability, and materialization facts
 used by `ComputeOp` creation. [ComputeOpCreation.md](ComputeOpCreation.md) is the
-authoritative design for candidate planning, fusion, output publication,
+authoritative design for candidate planning, fusion, output-store placement,
 kernel-wide selection, and mechanical application.
 
 `ttl-create-producer-compute`, `ttl-insert-intermediate-dfbs`, and
@@ -377,14 +379,14 @@ vacuously because the consumer cannot execute.
 
 #### `ComputeOp` Creation
 
-The creation planner consumes the availability result at the planned
-`ComputeOp` insertion point. A direct or fused candidate is legal only when
-every lifetime root is definitely available there. Planned materializations remain compute roots
-but are excluded from lifetime roots because their replacement DFB supplies
-new storage. If another unmaterialized occurrence reads the same SSA value, it
-remains a lifetime root.
+The creation planner consumes the availability result at the program location
+where it proposes to create the `ComputeOp`. A direct or fused candidate is
+legal only when every lifetime root is definitely available there. Planned
+materializations remain compute roots but are excluded from lifetime roots
+because their replacement DFB supplies new storage. If another unmaterialized
+occurrence reads the same SSA value, it remains a lifetime root.
 
-Output publication planning groups stores by their `cb_reserve` operations and
+Output-store planning groups stores by their `cb_reserve` operations and
 prevents one compute from combining several reserve transactions of the same
 DFB. This preserves producer-pointer order when a push moves after the created
 `ttl.compute`. Kernel-wide selection and application ordering are described in
@@ -477,7 +479,7 @@ cannot reorder but the created `ttl.compute` would follow it, the query records
 tensor SSA uses from producers before that operation to consumers after it.
 Materialization replaces those uses, and the next fixed-point iteration creates
 an independent `ttl.compute` on each side. Uninstrumented pure tensor recomputation remains
-legal. Output reserves are part of the recorded publication transaction and
+legal. Output reserves are part of the recorded output transaction and
 are not ordering boundaries; the created `ttl.compute` necessarily executes after
 them.
 
@@ -485,7 +487,7 @@ them.
 data only through `ttl.tile_store`; `ttl.yield` does not carry tile values. If
 one surviving use requires a compiler DFB, every surviving use of that result
 must read the same pushed and waited materialization. The original user-DFB
-publication remains a `ttl.tile_store` in the compute body and is not a
+store remains a `ttl.tile_store` in the compute body and is not a
 surviving result use. This rule prevents a later creation from treating the
 compute result as readable storage without a DFB acquisition.
 
@@ -522,7 +524,7 @@ Requirements may rewrite some original output stores before final creation.
 The standalone plan therefore selects the last output store that will remain,
 not the last store in the analyzed IR. That store must dominate every rewritten
 consumer, preserve every unrewritten use, and precede each recorded
-instrumentation-order boundary. If no publication satisfies those conditions,
+instrumentation-order boundary. If no output store satisfies those conditions,
 definition-site materialization is legal only when every original use is
 rewritten. These checks ensure the inserted compiler DFB store remains before
 its wait and before the operation whose order must be preserved.
@@ -554,14 +556,14 @@ program analysis and structured operation semantics:
 The upstream One-Shot Bufferize implementation supplies the analysis-first
 methodology but not the required DFB semantics. Bufferization reasons about
 tensor and memory aliases; it does not model DFB FIFO acquisitions,
-reserve/push and wait/pop ownership, publication transactions, or TTL tile
+reserve/push and wait/pop ownership, DFB output transactions, or TTL tile
 recipes. The TTL-specific implementation therefore adds:
 
 - exact acquisition identities and conservative release-owner sets;
 - static FIFO tile-count matching for entry-block transactions;
 - three-state planner results that distinguish a valid plan, a legal candidate
   that must remain unchanged, and malformed IR;
-- complete `ComputeOp` creation and output-publication records;
+- complete `ComputeOp` creation and output-store records;
 - a monotone set of required consumer operands and one grouped
   materialization plan.
 
@@ -638,9 +640,9 @@ The helper chooses a provisional index by scanning only the enclosing kernel,
 so passes operating on individual kernels do not inspect sibling kernels while
 MLIR executes them concurrently.
 
-Non-compute producers use standalone tensor materialization. The helper emits
-the reserve/store and wait/attach after an insertion operation recorded by the
-plan, while `ttl-insert-cb-sync` inserts the missing releases:
+Non-compute producers use standalone tensor materialization. The plan records
+the MLIR operation after which the helper creates the reserve/store and
+wait/attach; `ttl-insert-cb-sync` inserts the missing releases:
 
 ```
 bind_cb {ttl.compiler_allocated}
@@ -653,21 +655,23 @@ attach_cb
 cb_pop
 ```
 
-When the source already has a valid output-publication plan, its final output
-store is the insertion operation if it properly dominates every rewritten
-consumer. Final `ComputeOp` creation may relocate source evaluation to that store;
-placing the compiler reserve/store/wait afterward therefore keeps evaluation
-before the wait. A source without an applicable output-publication plan remains
-at its definition. If a valid publication store does not dominate every
+When the source already has a valid output-store plan, the compute is created
+immediately before its final output store if that store properly dominates
+every rewritten consumer. Final `ComputeOp` creation may relocate source
+evaluation to that program location; placing the compiler reserve/store/wait
+afterward therefore keeps evaluation before the wait. A source without an
+applicable output-store plan remains at its definition. If a valid output store
+does not dominate every
 consumer, the fixed point must require every source use. Rewriting all uses
-removes the original publications, so the compiler DFB store inserted after
+removes the original output stores, so the compiler DFB store inserted after
 the definition becomes the source's only output store and therefore its compute
-insertion position. The planner verifies these conditions before modifying IR.
+creation location. The planner verifies these conditions before modifying IR.
 
 When multiple `DFBInputOpInterface` operations consume the same non-compute
-value, they share one materialization. The selected insertion operation
-properly dominates every rewritten consumer, so the attached replacement is
-valid for consumers in nested or incomparable regions.
+value, they share one materialization. The operation after which the compiler
+creates the materialization properly dominates every rewritten consumer, so
+the attached replacement is valid for consumers in nested or incomparable
+regions.
 
 When one computed value has direct `ttl.store` users in multiple MLIR basic
 blocks, one `ttl.compute` cannot absorb all of them. A compute operation is
@@ -686,7 +690,13 @@ producer push, so consumers originally dominated by the compute result remain
 dominated by the materialized value. This includes branch-local consumers when
 the producer is outside the branch. General occupancy-balance proofs for
 placing compiler-created waits and pops inside arbitrary structured control
-flow are future work ([#724](https://github.com/tenstorrent/tt-lang/issues/724)).
+flow remain tracked by
+[#724](https://github.com/tenstorrent/tt-lang/issues/724).
+`insideMutuallyExclusiveRegions` proves branch-exclusive store fanout, but does
+not prove that DFB lifecycle operations balance within each branch.
+`ExecutionCountAnalysis`, which PipeNet schedule verification uses for
+structured protocol occurrences, is applicable to the remaining occupancy
+proof.
 
 Compiler-allocated intermediate DFBs are created with `blockCount=1`. A
 compute kernel's Unpack, Math, and Pack stages are separate RISC-V cores that
@@ -751,11 +761,13 @@ Two disjoint criteria establish ownership:
   bound: a use of `cb_wait t1`'s tile is owned by `t1` regardless of where it
   appears, even past later acquires on the same DFB.
 
-- **Direct-DFB ownership** -- `U` references the DFB directly as a `ttl.copy`
-  operand on the side matching the acquire's sync class (the DM-thread case,
-  e.g. `ttl.copy %cb, %slice` for a writer). With no SSA tile handle,
-  ownership is positional: `U` belongs to the latest acquire on
-  `(cb, sync class)` that precedes it in op order. Equivalently, `U` is
+- **Direct-DFB ownership** -- `U` references the DFB directly and may access
+  its physical storage. A `ttl.copy` is owned only on the operand side matching
+  the acquire's sync class. An opaque external call is a possible read and
+  write, so it can extend either class. Identity-only `ttl.attach_cb` and
+  `ttl.get_dfb_id` operations do not consume an acquired slot. With no SSA tile
+  handle, ownership is positional: `U` belongs to the latest acquire on
+  `(cb, sync class)` that precedes it in operation order. Equivalently, `U` is
   bounded between `acquire` and the next acquire on the same sync class
   (`interval.syncClassBoundary` in the pass).
 
@@ -768,12 +780,12 @@ The criteria are disjoint. DM-thread `ttl.copy` does not flow through
 Compute threads work through SSA tile handles
 (`cb_wait` result -> `attach_cb` -> `ttl.store` / compute ops), so tile-SSA
 ownership applies and the next-acquire boundary is irrelevant -- SSA already
-distinguishes which slot the use refers to. Data-movement kernels use direct DFB
-references (`ttl.copy %cb, %slice`) where no tile handle exists, so direct-DFB
+distinguishes which slot the use refers to. Data-movement kernels and external
+calls can use direct DFB references where no tile handle exists, so direct-DFB
 ownership uses the operation interval and its boundary to disambiguate
-consecutive direct uses on the same DFB. Unifying would require changing
-`ttl.copy` to take the attached tensor instead of the DFB, a dialect change
-tracked as future work.
+consecutive direct uses on the same DFB. Unifying would require changing every
+direct storage-accessing operation to take the attached tensor instead of the
+DFB.
 
 ### Invariants on the inserted release
 
@@ -1045,203 +1057,484 @@ ttl-coalesce-dfb-acquires))'`) verifies this.
   does not span control flow within an `scf.if` or `scf.for` (loop-body
   coalescing still works because the body is its own block).
 
+`ExecutionCountAnalysis` supplies structured execution counts for PipeNet
+schedules, including reducible block-CFG loops. Counts alone do not justify
+acquire coalescing, which also requires proof that every grouped acquire
+executes in one contiguous DFB interval.
+
 ## Index Reuse
 
 `TTLFinalizeDFBIndices` reduces the physical DFB count by assigning the same
-index to compiler-allocated DFBs whose lifetimes do not overlap. The algorithm
-runs per kernel. It ignores the kernel-local provisional indices and
-assigns each kernel a disjoint physical index range after the highest
-user-declared index in the module.
+index to logical DFBs whose lifetimes cannot overlap. The default analysis
+considers all kernel functions concurrently, including user-declared DFBs
+shared across data-movement and compute kernels.
 
 Two DFBs may share an index only if they have identical `CircularBufferType`
-(shape, element type, block count). Since `CircularBufferType` is an MLIR
-uniqued type, this is a pointer comparison. The algorithm partitions DFBs by
-type and applies deterministic first-fit interval coloring within each
-partition.
+(shape, element type, block count), equal transaction tile counts, and a
+transaction count that divides the physical capacity. These conditions ensure
+one physical allocation has one page size, capacity, data format, and legal
+ring-pointer progression. `CircularBufferType` is an MLIR-uniqued type, so
+exact type equality is a pointer comparison.
 
 ### Logical identity
 
 The frontend assigns each user-declared DFB a module-wide logical `dfb_id` and
 copies that ID to the declaration in every participating kernel.
-Compiler-created declarations receive distinct logical IDs after the largest
-explicit ID. A user declaration without `dfb_id` is rejected before physical
-allocation.
+Compiler-created declarations receive distinct logical identities after the
+largest explicit ID. A user declaration without `dfb_id` is rejected before
+physical allocation.
 
-Declarations with one `dfb_id` must have the same `CircularBufferType`.
-Compiler-created DFBs are currently kernel-local and receive distinct logical
-IDs.
+Compiler-created DFBs are currently kernel-local. A module transformation
+that distributes one compiler-created DFB across multiple kernels
+must assign the same explicit `dfb_id` to every declaration.
+The allocation planner rejects any used compiler-created DFB without a
+complete reserve, push, wait, and pop lifecycle. It does not infer a relation
+between declarations when the IR provides no shared identity.
 
-Logical identity resolution is a read-only analysis. The finalizer
-materializes its complete assignment on `ttl.bind_cb` only after the identity
-and capacity checks succeed. Rewriting `cb_index` therefore does not merge
-the SPSC or PipeNet protocol state of distinct logical DFBs.
+The finalizer records every resolved logical identity on `ttl.bind_cb` before
+rewriting `cb_index`. Repeated finalization therefore cannot merge logical
+DFBs that already share a physical slot. Allocation visits DFBs in immutable
+declaration order. Changing logical ID values therefore does not affect
+acceptance.
 
+### Concurrent-kernel lifetime analysis
+
+`DFBConcurrentKernelLivenessAnalysis` models the concurrently executing kernel
+functions separately on each launched physical node. It uses
+`LaunchNodeDomainAnalysis` to associate every DFB access with the nodes where
+that access may execute. DFBs with disjoint known launch-node domains require
+no global lifetime order. An unknown domain remains conservative.
+
+Each top-level operation in a single-block kernel function receives an entry
+event and a completion event:
+
+```text
+op.entry -> op.completion -> next.entry
 ```
-resolveLogicalDFBIdentities(module):
-  maxExplicitId = max(dfb_id for declarations that have dfb_id, default=-1)
+
+Program-order edges connect consecutive operations within each kernel. When a
+logical DFB has exactly one `cb_push` and one `cb_wait`, the blocking protocol
+adds this cross-kernel edge:
+
+```text
+producer kernel:  ... -> cb_push.completion -----------------+
+                                                             |
+consumer kernel:  cb_wait.entry -> (blocked) -> cb_wait.completion -> ...
+```
+
+The edge targets wait completion, not wait entry. A consumer may enter
+`cb_wait` before the producer publishes data, but it cannot complete that wait
+before the matching push completes. Treating the push as preceding wait entry
+would permit a later logical DFB to reuse the physical slot while its consumer
+is already waiting and could consume the earlier DFB's data.
+
+After adding all sound program-order and protocol edges, the analysis computes
+transitive reachability. Cyclic events are not considered ordered:
+`strictlyPrecedes(A, B)` requires reachability from A to B and no reachability
+from B to A.
+
+This construction follows Lamport's
+[happened-before relation](https://lamport.azurewebsites.net/pubs/time-clocks.pdf):
+per-process order and communication order generate a partial order over events.
+The [LLVM concurrent memory model](https://llvm.org/docs/LangRef.html#memory-model-for-concurrent-operations)
+uses the analogous construction from per-sequence program order and
+`synchronizes-with` edges. DFB push-to-wait completion is the protocol-specific
+communication edge in this analysis.
+
+Every kernel function forms a separate event sequence. A logical `dfb_id` is
+only an equivalence key attached to `ttl.bind_cb` declarations; it does not
+encode hardware state ownership. The analysis associates each lifecycle
+operation with the ID of the declaration reached from its DFB operand.
+Protocol edges from all logical DFBs share one module graph, so transitive
+order can pass through any number of intermediate kernels.
+
+#### Lifetimes with one reserve/push and wait/pop pair
+
+A logical DFB is bounded only when all of these conditions hold:
+
+- exactly one `cb_reserve`, `cb_push`, `cb_wait`, and `cb_pop` reference it;
+- static execution analysis proves that each operation executes exactly once
+  on the applicable launched node;
+- reserve precedes push, and wait precedes pop;
+- push follows all uses owned by the reserve;
+- pop follows all uses owned by the wait;
+- reserve, push, wait, and pop transfer the same tile count (`num_tiles`);
+- the transaction tile count divides the physical DFB capacity;
+- reserve and push have one known write-pointer owner, and wait and pop have
+  one known read-pointer owner.
+
+Lifecycle operations inside a statically selected `scf.if`, `affine.if`,
+`ttl.if_src`, or `ttl.if_dst` region may satisfy these conditions. Repeated or
+unknown execution remains unproven.
+
+The pass runs after `ttl-insert-copy-wait`. A transfer into or out of a DFB
+completes at its `ttl.wait`, whose transfer-handle operand does not identify the
+DFB. Inserting that wait before the corresponding push or pop ensures the
+lifecycle release follows transfer completion.
+
+The acquire/release ownership analysis described in
+[DFB Sync Insertion](#dfb-sync-insertion) supplies the owned-use checks.
+Failure to prove any condition leaves the DFB unbounded.
+
+#### External calls
+
+Every DFB accessed by a custom function or transitive helper must appear as a
+direct DFB operand of `ttl.opaque_call`. When a direct `ttl.get_dfb_id` result
+is passed as an ordinary or template argument, the finalizer verifies that its
+source DFB is also present as a dependency operand and rejects the call before
+mutation otherwise. The compiler cannot inspect custom C++ for hidden
+constants or global state, so validity of the remaining declared access set is
+an external-code assumption.
+
+Every direct DFB operand is a possible read or write from call entry through
+call completion. The liveness proof does not need a read/write distinction:
+either access requires the same physical allocation to remain available. The
+callee must complete every synchronous and asynchronous DFB access before
+returning. An external call before the terminal `cb_pop` can therefore remain
+within a bounded lifetime; the same call after the pop makes the DFB unbounded.
+
+Some external functions implement their reserve, push, wait, and pop operations
+inside C++. Direct operands make their DFB access sets explicit, but the hidden
+protocol cannot supply the exact visible lifecycle required by the reuse proof.
+Those DFBs remain unbounded and conflict with every other allocation candidate.
+The external call does not disable reuse among other DFBs whose visible
+lifecycles remain bounded.
+
+The current DSL cannot declare a dependency-only DFB, summarize hidden
+protocol effects, or represent an unknown DFB access set. An external callee
+with an unknown set is outside the valid-program assumption. A future explicit
+unknown form must disable user DFB reuse for the complete module because an
+unresolved raw index may name any physical allocation. Issue
+[#806](https://github.com/tenstorrent/tt-lang/issues/806) tracks the required
+DFB dependency and protocol-effect representation.
+
+`num_tiles` counts tiles of the DFB's `TileType`. TT-Lang configures each
+tiled CB page from the byte size of that tile. Two 16x32 bf16 tiles therefore
+consume the same bytes as one 32x32 bf16 tile. Tile dimensions remain part of
+the `CircularBufferType`, so DFBs with different tile dimensions cannot share
+a physical index.
+
+TT-Metal advances each ring pointer by
+[`num_pages * fifo_page_size`](https://github.com/tenstorrent/tt-metal/blob/e908c31332b60860ed0d4186452dc880cdd5a81d/tt_metal/hw/inc/api/dataflow/dataflow_api.h#L208-L214).
+The pointer wraps only when it reaches the end of the physical DFB. Logical
+DFBs sharing one physical index therefore use the same transaction tile count,
+and that count divides `block_count * elements_per_block`. This keeps every
+reserve, push, wait, and pop within the allocation and places each pointer on a
+legal wrap boundary.
+
+For a bounded DFB, every storage-accessing operation with a direct DFB operand
+is projected to a top-level function operation. `attach_cb` and `get_dfb_id`
+carry DFB identity without accessing physical storage and are excluded. The
+owned-use check still rejects an attachment whose tensor use extends beyond
+release. Unrelated operations are contracted from each kernel sequence because
+this preserves reachability among all events queried by the lifetime proof. The
+analysis records:
+
+- `earliestEvents`: the minimal use-entry events under happens-before;
+- `terminalEvents`: the `cb_pop` completion event.
+
+`earliestEvents` can contain operations from several kernels. It is an
+antichain: no recorded event strictly precedes another. Requiring the terminal
+event of DFB A to precede every earliest event of DFB B proves that A is dead
+before any kernel can begin using B.
+
+```text
+isOrderedBefore(A, B):
+  return A is bounded
+     and B is bounded
+     and every A.terminalEvent strictly precedes
+         every B.earliestEvent
+```
+
+For example, a second data movement function can relay completion from the
+compute function back to the first data movement function:
+
+```text
+DM0 producer:  push A --------------------------- wait ack2 -> reserve B
+                  |                                   ^
+Compute:       wait A -> pop A -> push ack1           |        wait B
+                                      |               |
+DM1 relay:                       wait ack1 -> push ack2
+```
+
+Program order and the two acknowledgment DFBs establish:
+
+```text
+A.pop[Compute]
+  -> ack1.push[Compute]
+  -> ack1.wait.completion[DM1]
+  -> ack2.push[DM1]
+  -> ack2.wait.completion[DM0]
+  -> B.reserve.entry[DM0]
+```
+
+Compute program order separately establishes
+`A.pop[Compute] -> B.wait.entry[Compute]`. Therefore A's terminal pop precedes
+both producer-side and consumer-side events in B's earliest-event frontier. An
+unrelated third kernel adds no cross-kernel edge. A `B.wait` entered before
+`A.pop` also remains unordered and prevents reuse.
+
+The write- and read-pointer owners are also part of the allocation state. The
+owner is the launched node plus NOC0, NOC1, Pack, or Unpack and the pointer
+direction. Distinct kernel function symbols may share when they execute on the
+same hardware pointer processors. A quiescent handoff does not transfer pointer
+state between different processors.
+
+#### Relation to prior allocation models
+
+The concurrent lifetime model is closest to Suhendra, Roychoudhury, and
+Mitra's
+[scratchpad allocation for concurrent embedded software](https://www.comp.nus.edu.sg/~abhik/pdf/codes08-spm.pdf).
+Their message-sequence model forms a partial order from process-local order and
+inter-process communication, then overlays scratchpad allocations at proven
+boundaries. DFB reuse requires additional proofs: FIFO occupancy must be zero,
+all protocol accesses must be complete, and the physical index must retain
+compatible kernel-local pointer and counter state.
+
+Bhattacharyya and Lee's
+[dataflow memory-management model](https://ptolemy.berkeley.edu/publications/papers/94/buffering/)
+and Murthy and Bhattacharyya's
+[shared-memory implementation model](https://citeseerx.ist.psu.edu/document?doi=6d061c87abf14b211d1f7c64c3527d14bc6b984b&repid=rep1&type=pdf)
+combine static schedules, buffer lifetimes, storage sharing, and external-memory
+tradeoffs for synchronous dataflow. These models apply to matched DFB protocol
+occurrences and future DRAM spilling. Their static-rate assumptions do not
+cover tt-lang structured control flow, external effects, or node-dependent
+execution without further analysis.
+
+Goens, Castrillon, Odendahl, and Leupers
+[model logical-buffer placement on complex multicore systems](https://www.sciencedirect.com/science/article/pii/S1383762116300352)
+using task access intervals, physical memories, topology, and bandwidth. This
+is relevant when allocation differs by launched node or creates specialized
+kernels. Interval non-overlap alone is insufficient for DFBs because one
+physical index also contains protocol state owned by specific hardware
+processors.
+
+Repeated DFB protocols may produce periodic or disconnected lifetimes. Cyclic
+register-allocation work models software-pipelined lifetimes with
+[circular-arc graphs](https://www.sciencedirect.com/science/article/pii/S0166218X99001055).
+SSA chordality or interval-coloring results apply only after the compiler proves
+that each physical DFB version has the required connected lifetime. A separate
+exact constraint model, following
+[Unison](https://arxiv.org/abs/1804.02452), can validate small cases that
+combine index assignment, per-node specialization, lifetime splitting,
+scheduling, and spilling without requiring the production allocator to use a
+general solver.
+
+#### Analysis and allocation algorithms
+
+`DFBLogicalIdentityAnalysis` and
+`DFBConcurrentKernelLivenessAnalysis` are read-only pass-manager analyses.
+The liveness analysis consumes the cached logical-identity result and exposes
+logical lifecycles, lifetime frontiers, boundedness, and pairwise lifetime
+order. Its operation events and program-order and protocol edges remain an
+internal proof representation. It does not construct an interference graph or
+select physical indices.
+
+```text
+resolveLogicalIdentities(module):
+  maxExplicitId = maximum dfb_id on all declarations
   reject any user declaration without dfb_id
-  compilerCount = count(compiler-created declarations without dfb_id)
-  reject if maxExplicitId + compilerCount exceeds the index domain
-  nextCompilerId = maxExplicitId + 1 if compilerCount > 0 else 0
+  assign each compiler-created declaration a unique ID after maxExplicitId
+  reject one logical ID with inconsistent CircularBufferType values
+  return declaration -> logical dfb_id
 
-  for declaration in module traversal order:
-    logicalId = declaration.dfb_id
-    if declaration has no dfb_id:
-      logicalId = nextCompilerId++
-    reject logicalId if another declaration with that ID has a different type
-    assignments.append({declaration, logicalId})
+analyzeConcurrentLifetimes(module, logicalIdentities):
+  logicalDFBs = group bind_cb declarations by logical dfb_id
+  collect every lifecycle operation and direct runtime use
+  compute the launch-node domain of every access
 
-  return assignments
+  for each launched physical node:
+    graph = empty happens-before graph
+    for each single-block kernel function:
+      for each top-level operation active on the node in program order:
+        add operation entry and completion events
+        add entry -> completion
+        add previous completion -> entry
+
+    for each logical DFB active on the node:
+      if exactly one reserve, push, wait, and pop form a matched lifecycle:
+        DFB.nodeLifetime.transactionTileCount = transactionTileCount
+        DFB.nodeLifetime.pointerOwners = read and write hardware processors
+        add DFB.push.completion -> DFB.wait.completion
+
+    compute transitive graph reachability
+
+    for each logical DFB with a matched lifecycle on the node:
+      uses = project every active runtime use to a top-level operation
+      if every use completion precedes DFB.pop.completion:
+        DFB.nodeLifetime.earliestEvents = minimal entry events in uses
+        DFB.nodeLifetime.terminalEvents = {DFB.pop.completion}
+        DFB.nodeLifetime.quiescence = proven
+
+  return logical DFB lifecycles, per-node quiescence, pointer owners,
+         source evidence, and pairwise per-node lifetime order
 ```
 
-Generated IDs are strictly greater than every explicit ID, and each
-compiler-created declaration consumes the next ID exactly once. Generated and
-explicit identities therefore cannot collide. Equal types for repeated
-explicit IDs ensure that one logical identity denotes one DFB representation.
+`DFBPhysicalAllocationPlanner` consumes those immutable facts and constructs a
+typed conflict model before selecting any assignment. Every edge retains the
+logical DFB pair, optional launched node, source operations, and one of the
+following reasons: descriptor mismatch, unknown launch-node domain, unproven
+quiescence, transaction mismatch, pointer-owner mismatch, or concurrent
+lifetime.
 
-### Algorithm
+```text
+buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
+  reject if a derived DFB-index attribute exists
 
-```
-identityAssignments = resolveLogicalDFBIdentities(module)
-reject if logical identity validation fails
+  validate each used compiler-created logical DFB after aggregating all
+      declarations and identity-preserving casts
 
-if any compiler-created DFB exists and a derived DFB-index attribute exists:
-  reject the invalid pass order
+  for each logical DFB pair A, B:
+    add descriptor mismatch if A.type != B.type
+    add unknown-domain conflict if either launch-node domain is unknown
+    for each node where A and B both execute:
+      add unproven-quiescence conflict unless both node lifetimes are proven
+      add transaction conflict unless their transaction sizes match
+      add pointer-owner conflict unless read and write owners match
+      add concurrent-lifetime conflict unless A precedes B or B precedes A
 
-for bindOp in compilerAllocatedBindCBOps:
-  lifecycleOps = reserveOrWaitOrPushOrPopUsers(bindOp)
-  if lifecycleOps is not empty and any operation kind is missing:
-    reject the partial lifecycle
+  if reuseUserDFBs:
+    candidates = all logical DFBs in immutable declaration order
+  else:
+    compactedUserIndices = compactDistinctUserIndices(module)
+    reject every conflicting user pair assigned the same provisional index
+    compilerDFBs = logicalDFBs containing only compiler-created declarations
+    candidates = compilerDFBs
 
-compact distinct user physical indices into a dense zero-based range
-record the compacted index for every user declaration
+  conflicts = typed conflict graph induced by candidates
+  assignment = deterministicFirstFit(conflicts)
+  lowerBound = greedyClique(conflicts)
+  if assignment exceeds the physical-index or L1 limit:
+    exactResult = exactDSATUR(conflicts, lowerBound, searchStateLimit)
+    if exactResult is SearchLimitReached:
+      reject with an inconclusive-search diagnostic
+    assignment = exactResult.optimalAssignment
+  reject a capacity result only after exact infeasibility or a sound lower
+      bound proves that the applicable limit cannot be met
+  verify every pair assigned one index against the typed conflict model
 
-nextCompilerIndex = number of distinct user physical indices
-for kernel in module:
-  slots = planPhysicalDFBIndices(
-      kernel, compilerAllocatedBindCBOps[kernel], nextCompilerIndex, plan)
-  nextCompilerIndex += slots
+  aggregate L1 bytes once per unique physical index
+  reject if the assignment exceeds the physical-index or L1 limit
+  build one runtime descriptor for every physical index
+  reject conflicting descriptors at one physical index
+  assert that the internal assignment is a dense zero-based range
+  record every existing kernel base-index attribute
+  return immutable {
+    logical-to-physical assignments,
+    runtime descriptors,
+    physical DFB count,
+    kernel base indices
+  }
 
-if nextCompilerIndex > 32:
-  reject the allocation
-
-for declaration in module:
-  physicalIndex = planned user or compiler index
-  reject if logicalId previously mapped to a different physicalIndex
-  reject if another declaration at physicalIndex has a different exact type
-
-apply every planned cb_index and dfb_id assignment
-apply ttl.base_cta_index and ttl.dfb_allocations
-
-planPhysicalDFBIndices(
-    kernel, compilerAllocatedBindCBOps, firstPhysicalIndex, plan):
-  // Assign sequential indices to kernel-body operations.
-  for op in kernel.entryBlock:
-    opIndex[op] = nextIdx++
-
-  kernelEndIndex = nextIdx
-
-  // Build half-open intervals from reserve/push/wait/pop operations.
-  // Nested acquires and pops are projected to their kernel-body ancestor.
-  for bindOp in compilerAllocatedBindCBOps:
-    if bindOp has no lifecycle operations:
-      intervals[bindOp.type].append(
-          {opIndex[bindOp], kernelEndIndex, bindOp.result})
-      continue
-    start = min(getBodyIndex(acq) for acq in reserveOrWaitUsers(bindOp))
-    end = max(getBodyIndex(pop) + 1 for pop in cbPopUsers(bindOp))
-    intervals[bindOp.type].append({start, end, bindOp.result})
-
-  // First-fit coloring per type partition. Each partition gets a contiguous
-  // block of indices starting at firstPhysicalIndex + offset.
-  offset = 0
-  for (type, typeIntervals) in intervals:
-    sort typeIntervals by start
-    colors = []
-    for interval in typeIntervals:
-      color = first color in colors where
-          interval overlaps no interval already assigned to color
-      if no such color exists:
-        color = append new color to colors
-      colors[color].append(interval)
-
-    // Record assignments without modifying IR.
-    for (color, assignedIntervals) in colors:
-      for interval in assignedIntervals:
-        plan.append(bindOp[interval.value],
-                    firstPhysicalIndex + offset + color)
-    offset += colors.size()
-
-  return offset
+applyPhysicalAllocationPlan(module, plan):
+  write dfb_id and cb_index from plan.assignments
+  write ttl.base_cta_index from plan.kernelBaseIndices
+  write ttl.dfb_allocations from plan.runtimeDescriptors
 ```
 
-Compiler-created DFBs emitted by the production pipeline have reserve, push,
-wait, and pop operations. The check requires the presence of all four operation
-kinds but does not restrict the number of transactions. Auto-sync is assumed to
-have balanced each acquire with its corresponding release before finalization.
-A declaration with no lifecycle operations is legal but conservatively remains
-live through the end of its kernel.
+Each color is one physical index. Exact search is an acceptance escalation, not
+the default assignment mechanism. Any deterministic assignment that satisfies
+both hardware limits is valid. Exact search examines at most
+`exact-coloring-search-limit` deterministic states, which defaults to
+1,000,000. Reaching the limit reports that feasibility was not proved and
+identifies the option that increases the limit; it never reports a proved
+capacity failure. The planner completes every
+diagnostic-producing validation before `TTLFinalizeDFBIndices` changes any
+`dfb_id`, `cb_index`, kernel attribute, or module attribute. The finalizer only
+materializes the validated plan.
 
-Planning separates all fallible work from mutation. Pass-order, lifecycle,
-logical-identity, capacity, and metadata validation complete before any
-`cb_index`, `dfb_id`, `ttl.base_cta_index`, or `ttl.dfb_allocations` update. A
-failed pass therefore leaves the input IR unchanged. Type-partitioned allocation
-guarantees that compiler-created DFBs sharing a planned index have one exact
-type. Metadata validation applies the same requirement to every declaration at
-each physical index.
+Finalization is idempotent on unchanged finalized IR. Reanalysis reconstructs
+the same logical identities, typed conflicts, physical indices, descriptors,
+and kernel base indices before reapplying the same values.
 
-Intervals are half-open. A pop at kernel-body ordinal `N` produces endpoint
-`N + 1`, so the interval includes the release operation. A reserve in the next
-kernel-body operation may reuse the index because it starts at `N + 1`. If a
-nested pop and reserve project to the same enclosing operation, the pop ends at
-`N + 1` while the reserve starts at `N`, so their intervals overlap. This
-preserves correctness after nested-region ordering is discarded.
+#### Correctness sketch
 
-### Correctness with control flow
+Every happens-before edge is a required execution order:
 
-The algorithm assigns sequential indices to kernel-body operations only.
-Structured operations (`scf.for`, `scf.if`, `ttl.compute`) occupy a single
-index in this sequence; their contents are not individually numbered. Any
-nested acquire or `cb_pop` is projected to its enclosing kernel-body
-operation with `Block::findAncestorOpInBlock`.
+- program order within each kernel is preserved;
+- the matched push must complete before the matched blocking wait can complete.
 
-Projection overestimates liveness because an interval covers the enclosing
-structured operation rather than the exact nested operation. This can miss
-reuse opportunities across loop bodies or mutually exclusive branches, but it
-cannot assign one physical DFB index to lifetimes that may overlap at runtime.
+For a bounded DFB, matching lifecycle tile counts and one push/pop pair imply
+zero occupancy at `cb_pop` completion. The owned-use checks prove that neither
+the producer nor the consumer accesses the slot after its corresponding
+release. Every runtime use is reachable from at least one event in the
+earliest-event antichain and completes no later than the terminal pop.
 
-Two DFBs consumed simultaneously by the same operation (e.g., both operands of
-a matmul) necessarily have overlapping intervals because their acquires
-precede the consumer and their pops follow it. First-fit coloring assigns them
-different slots.
+Suppose A and B receive the same physical index, with A ordered before B.
+The conflict predicate proves:
+
+1. A and B have the same page shape, data format, and block count.
+2. They use the same transaction tile count, and that count divides their
+   physical capacity. Their ring pointers therefore advance by equal increments
+   and wrap only at the allocation boundary.
+3. On every shared launched node, their write effects have the same hardware
+   pointer owner and their read effects have the same hardware pointer owner.
+4. On every shared launched node, A's terminal pop completes before every
+   earliest use of B. Disjoint launch-node domains need no temporal relation.
+
+Therefore A has zero occupancy and no remaining access before any producer or
+consumer can begin B. An early B wait cannot consume A's data because its entry
+is at or after one of B's earliest use events. The physical allocation is
+sufficient for both logical DFBs.
+
+Coloring places two DFBs in one color only when this relation holds in one
+direction on every shared node. The final pairwise verification independently
+checks the typed conflict model for every shared color. If a lifetime or
+ordering proof is missing, the DFB conflicts with every candidate that may
+execute on the same node; this can increase the physical count but cannot
+create unsafe reuse.
+
+Two DFBs consumed by the same operation necessarily overlap: both acquires
+precede the consumer and both pops follow it. Coloring therefore assigns them
+different physical indices.
+
+#### Representative example
+
+`test/python/test_flash_chain_8node.py` composes a per-node flash-attention
+atom with a three-level tree-reduction atom over eight nodes. The composed
+operation contains 36 logical DFBs across the compute and data movement
+kernels. Proven non-overlapping lifetimes reduce the allocation to 29 physical
+indices, below the hardware limit of 32. The device test compares the final
+result with PyTorch scaled dot-product attention.
+
+`test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir` isolates
+the cross-kernel ordering rules. The independent allocation-oracle test joins a
+30-vertex clique with the confirmed four-vertex bad-order graph: first-fit uses
+33 indices and exact escalation proves that 32 suffice. The invalid liveness
+test confirms that 33 mutually conflicting lifetimes are rejected.
+
+`test/python/test_user_dfb_reuse.py` recursively composes copy atoms into an
+operation with 33 logical DFBs. The operation compiles and executes only when
+reuse reduces the physical allocation below the hardware limit.
 
 ### Module attribute and runtime integration
 
-The pass compacts distinct user physical indices before placing
-compiler-created DFBs after them. This removes gaps caused by declarations that
-the frontend created but no kernel captured, without changing logical identity
-or existing physical-index sharing. The planned physical DFB count is one
-greater than the greatest assigned index, and the pass verifies this does not
-exceed `kMaxCircularBuffers` (32).
+The pass compacts distinct provisional user indices before placing
+compiler-created DFBs after them. This removes gaps caused by DFBs that the
+frontend created but no kernel captured, without changing logical identity or
+existing physical-index sharing. Lifetime-based coloring may further reuse
+physical indices when enabled. The planned physical DFB count is one greater
+than the greatest assigned index, and the pass verifies this does not exceed
+`kMaxCircularBuffers` (32).
 
-The pass then sets `ttl.base_cta_index` on every kernel function. Compile-time
-arguments (CTAs) to each kernel are laid out as `[CB indices..., other args...]`.
-`base_cta_index` is the starting index of the non-CB arguments -- equivalently,
-one past the last CB index. CB indices occupy `[0, base_cta_index)`.
+The allocation planner records the final `ttl.base_cta_index` for every kernel
+that has the attribute. Compile-time arguments to each kernel reserve
+`[0, base_cta_index)` for physical DFB indices; `base_cta_index` is the first
+non-DFB argument index.
 
-Finally, the pass builds the `ttl.dfb_allocations` module attribute with one
-descriptor per physical index. Each descriptor contains `dfb_index`,
-`num_tiles`, `element_type`, `page_size`, and `block_count`. The finalizer
-computes `page_size` with `ttcore::getElementSizeBytes()` on the finalized
-element type, so subtile dimensions affect the allocation without requiring
-runtime device initialization.
+The plan contains one `ttl.dfb_allocations` descriptor per physical index.
+Each descriptor contains `dfb_index`, `num_tiles`, `element_type`, `page_size`,
+and `block_count`. The planner computes `page_size` with
+`ttcore::getElementSizeBytes()` on the finalized element type, so subtile
+dimensions affect the physical allocation without requiring runtime device
+initialization.
 
-```
-emitDFBAllocations(declarations, plannedIndices):
-  for declaration in declarations:
-    index = plannedIndices[declaration]
-    reject index if another declaration at that index has a different type
-    allocationByIndex.insert(index, declaration.type)
+```text
+buildRuntimeDescriptors(assignments):
+  for assignment in assignments:
+    reject assignment.physicalIndex if another assignment at that index
+        has a different exact type
+    allocationByIndex.insert(assignment.physicalIndex, assignment.type)
 
   for (index, type) in allocationByIndex sorted by index:
     emit {dfb_index = index,
@@ -1264,69 +1557,123 @@ Scalar element types omit the optional TTNN tile descriptor, so their page
 size is not paired with an invented 32x32 tile. Standalone runner emission uses
 the same physical configuration as direct execution.
 
+Setting `reuse-user-dfbs=false` retains physical sharing already expressed by
+equal provisional user indices but does not introduce new sharing between user
+DFBs. It compacts the distinct provisional values, then colors only
+compiler-created DFBs. Both allocation modes use the same concurrent lifetime
+proof and interference graph for every DFB they color. Both modes emit the
+complete `ttl.dfb_allocations` table and assign identities to compiler-created
+declarations.
+
+```text
+allocateWithoutUserReuse(module, lifetimes):
+  compactedUserIndices = compactDistinctUserIndices(module)
+  assign every user logical DFB its compacted provisional index
+
+  compilerDFBs = logicalDFBs containing only compiler-created declarations
+  compilerColors = colorConcurrentLifetimes(compilerDFBs)
+  assign compiler color C to compactedUserIndices.size + C
+```
+
+The production pipeline emits reserve, push, wait, and pop operations for every
+used compiler-created DFB. Both allocation strategies reject a DFB with only
+part of that lifecycle because its bounded interval is not proven. A
+declaration with no lifecycle operations is legal and conservatively remains
+live through the end of its kernel. The presence check does not restrict the
+number of transactions; `ttl-insert-cb-sync` is assumed to balance acquires
+with releases before finalization.
+
 ## Limitations and Future Work
 
-`ComputeOp` creation requires one block containing all stores of a tensor
-result. Stores in different blocks have different execution conditions and
-cannot be represented by one unconditional compute publication.
-`ttl-insert-intermediate-dfbs` handles this by materializing the tensor result
-before final compute creation, so each control-flow block stores from the same
-attached compiler DFB value. A future region-aware creation plan could avoid
-that intermediate when it proves per-region DFB occupancy balance; this is
-tracked by [#724](https://github.com/tenstorrent/tt-lang/issues/724).
+- **Compute stores in different MLIR basic blocks.** A `ttl.compute` operation
+  is located in one MLIR basic block, and all output stores in its body execute
+  whenever the operation executes. Moving stores from different MLIR basic
+  blocks into one compute could change their conditional execution or violate
+  SSA dominance. `ttl-insert-intermediate-dfbs` instead materializes the tensor
+  result once so each original store remains in its original MLIR basic block.
+  Avoiding that intermediate requires a per-region DFB occupancy proof; this is
+  tracked by [#724](https://github.com/tenstorrent/tt-lang/issues/724).
 
-Cross-region fusion recomputes only side-effect-free producers. When the
-producer's block contains relocatable signposts or tile-observing debug prints,
-the planner rejects the creation because it has no cross-block placement
-relation that proves the observation order is preserved. Representing profiling
-scopes as structured region operations would permit a more precise containment
-proof without weakening this correctness condition.
+- **Cross-region instrumentation.** Cross-region creation recomputes only
+  side-effect-free producers. Relocatable signposts or tile-observing debug
+  prints prevent creation when their observation order cannot be preserved.
+  Structured profiling regions could permit a more precise containment proof.
 
-The availability lattice is not tile-range-sensitive. Releasing any part of an
-acquisition invalidates its complete tensor result. Tracking remaining tile
-ranges could prove more values available after partial `cb_push` or `cb_pop`
-operations without changing creation semantics.
+- **Tile-range availability.** Releasing any part of an acquisition invalidates
+  its complete tensor result. Tracking remaining tile ranges could prove more
+  values available after partial `cb_push` or `cb_pop` operations.
 
-Exact FIFO matching is restricted to the kernel entry block and is disabled
-for a DFB when nested lifecycle operations make that queue
-control-flow-dependent. Interval ownership and dense dataflow propagation
-remain conservative in these cases. A future range-aware transaction lattice
-could propagate FIFO tile counts across `RegionBranchOpInterface` edges and
-recover additional exact owners.
+- **Control-flow-dependent FIFO ownership.** Exact FIFO matching is restricted
+  to the kernel entry block and is disabled when nested lifecycle operations
+  make the queue control-flow-dependent. A range-aware transaction lattice
+  could propagate tile counts across `RegionBranchOpInterface` edges.
 
-Exact tensor identity tracing accepts conversion casts, DFB associations,
-slices, and extracts. An unrecognized aliasing operation produces an unknown
-identity and therefore cannot prove availability. Extending the recognized
-view interface can improve precision only when the operation guarantees that
-its result aliases the same acquired storage.
+- **Tensor identity.** Identity tracing accepts conversion casts, DFB
+  associations, slices, and extracts. An unrecognized aliasing operation
+  produces an unknown identity. Additional view operations require a semantic
+  guarantee that their results alias the same acquired storage.
 
-`ComputeOp` creation plans recognize only tile recipes and instrumentation
-whose relocation semantics are defined. An unrecognized operation prevents fusion rather than
-assuming purity or moving an effect. Adding a recipe requires defining its
-input roles, iteration maps, instrumentation order, and output publication
-semantics together.
+- **Compute recipes.** `ComputeOp` creation plans recognize only tile recipes
+  and instrumentation with defined relocation semantics. An unrecognized
+  operation prevents creation. Adding a recipe requires defining its input
+  roles, iteration maps, instrumentation order, and output-store placement and
+  execution semantics together.
 
-The interval model operates on a linear sequence of kernel-body operations. It
-cannot distinguish between branches of an `scf.if`, so DFBs used in mutually
-exclusive branches are treated as overlapping. This is conservative for
-physical index reuse. More precise reuse across mutually exclusive regions
-would need branch-sensitive liveness.
+- **Structured control flow and index reuse.** Lifecycle operations inside
+  `scf.if`, `affine.if`, `ttl.if_src`, and `ttl.if_dst` can be bounded when
+  launch-node and execution-count analysis prove one execution on the
+  applicable node. Nested operations project to the enclosing kernel-body
+  operation for inter-kernel ordering. Repeated regions and multi-block
+  functions remain conservative. More precise region-local ordering requires
+  occurrence-level entry and completion events.
+  MLIR's
+  [One-Shot Bufferize](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp)
+  applies the same conservative restriction when repeated regions invalidate a
+  dominance-based `happensBefore` result.
 
-Index reuse is restricted to compiler-allocated DFBs. User-declared DFBs retain
-their original indices because the same CB index is referenced by multiple
-kernels (reader, compute, writer) to implement cross-kernel data flow. Reusing
-a user index in one kernel would invalidate references in the others.
+- **Repeated protocols.** The analysis accepts one reserve/push/wait/pop
+  occurrence per logical DFB. Loops and multi-acquire protocols require
+  symbolic occurrence matching so a push, wait, and pop from the same
+  iteration are related without conflating different iterations. PipeNet
+  schedule verification already pairs static protocol occurrences and uses
+  `ExecutionCountAnalysis` to prove equal dynamic counts. DFB reuse requires
+  the corresponding reserve/push/wait/pop occurrence matching.
 
-Liveness is computed at kernel-body granularity. If an acquire or `CBPopOp`
-is inside a structured op, it is projected to its enclosing kernel-body
-operation. This is used by loop-state materialization and by later lowering
-passes that can place lifecycle ops in nested regions. The projection is safe
-but may keep a physical DFB index live longer than necessary.
+- **Credit-return ordering.** Only push-to-wait completion is modeled across
+  kernels. Proving additional pop-to-reserve ordering could shorten later
+  producer frontiers, but requires exact protocol and occurrence matching.
+  PipeNet schedule verification proves receiver post/send/wait correspondence,
+  but does not establish a DFB pop-to-reserve credit-return edge.
 
-The type compatibility constraint prevents reuse across DFBs with different
-shapes or element types, even when L1 footprints happen to match. A size-based
-rather than type-based compatibility check could recover some reuse
-opportunities.
+- **Assignment granularity.** Allocation currently selects one physical index
+  per logical DFB over its complete launch-node domain. Per-node or hybrid
+  assignments can reduce the maximum index count but require kernel
+  specialization and per-node-range allocation metadata.
+
+- **Pointer-owner changes.** Proving zero occupancy does not transfer ring
+  pointer state between NOC0, NOC1, Pack, and Unpack. Reuse across different
+  hardware pointer owners requires an explicit state transfer or reset.
+
+- **Storage compatibility.** Exact `CircularBufferType` equality forbids reuse
+  across different block shapes, tile dimensions, element types, or block
+  counts. A broader compatibility relation would need one physical descriptor
+  that satisfies every logical DFB assigned to it, including page size,
+  capacity, and data format.
+  A max-capacity descriptor could support some unequal logical types, but it
+  must also prove compatible transaction counts and address calculations.
+
+- **Pressure above the unspilled limits.** Deterministic first-fit is accepted
+  when it fits. Exact DSATUR search runs when the upper bound prevents physical
+  index or L1 acceptance. Exact search is limited to 1,000,000 deterministic
+  states by default. Limit exhaustion reports an inconclusive allocation;
+  proven infeasibility reports a capacity failure. DRAM spilling is tracked by
+  [#809](https://github.com/tenstorrent/tt-lang/issues/809).
+
+- **Reachability cost.** The bit-vector transitive closure is cubic in the
+  number of top-level DFB-accessing operations across all kernel sequences.
+  Unrelated operations are excluded. An SCC condensation followed by
+  topological bit-set propagation would scale better for programs with many
+  DFB lifecycle operations.
 
 ## Scalar Element Access to DFBs
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1404,20 +1404,30 @@ buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
   conflicts = typed conflict graph induced by candidates
   assignment = deterministicFirstFit(conflicts)
   lowerBound = greedyClique(conflicts)
-  if assignment exceeds the physical-index or L1 limit:
-    exactResult = exactDSATUR(conflicts, lowerBound, searchStateLimit)
-    if exactResult is SearchLimitReached:
+  if assignment exceeds the physical-index limit:
+    fitResult = fixedLimitDSATUR(conflicts, physicalIndexLimit,
+                                 searchStateLimit)
+    if fitResult is SearchLimitReached:
       reject with an inconclusive-search diagnostic
-    assignment = exactResult.optimalAssignment
+    if fitResult is Infeasible:
+      reject with a proved capacity diagnostic
+    assignment = fitResult.assignment
   reject a capacity result only after exact infeasibility or a sound lower
       bound proves that the applicable limit cannot be met
   verify every pair assigned one index against the typed conflict model
 
   aggregate L1 bytes once per unique physical index
-  reject if the assignment exceeds the physical-index or L1 limit
+  if assignment exceeds the L1 limit and is not known minimum:
+    minimumResult = minimumColorDSATUR(conflicts, lowerBound,
+                                      searchStateLimit)
+    if minimumResult is SearchLimitReached:
+      reject with an inconclusive-search diagnostic
+    assignment = minimumResult.assignment
+    aggregate L1 bytes once per unique physical index
+  reject if the assignment exceeds the L1 limit
   build one runtime descriptor for every physical index
   reject conflicting descriptors at one physical index
-  assert that the internal assignment is a dense zero-based range
+  reject if the internal assignment is not a dense zero-based range
   record every existing kernel base-index attribute
   return immutable {
     logical-to-physical assignments,
@@ -1432,13 +1442,15 @@ applyPhysicalAllocationPlan(module, plan):
   write ttl.dfb_allocations from plan.runtimeDescriptors
 ```
 
-Each color is one physical index. Exact search is an acceptance escalation, not
-the default assignment mechanism. Any deterministic assignment that satisfies
-both hardware limits is valid. Exact search examines at most
-`exact-coloring-search-limit` deterministic states, which defaults to
-1,000,000. Reaching the limit reports that feasibility was not proved and
-identifies the option that increases the limit; it never reports a proved
-capacity failure. The planner completes every
+Each color is one physical index. First-fit is the default assignment mechanism.
+When first-fit exceeds the physical-index limit, one fixed-limit exact query
+tests that limit directly. Minimum-color search runs only when a valid index
+assignment exceeds the L1 budget. Any deterministic assignment that satisfies
+both hardware limits is valid. Each exact query examines at most
+`exact-coloring-search-limit` deterministic states, which defaults to 1,000,000.
+Reaching the limit reports that feasibility was not proved and identifies the
+option that increases the limit; it never reports a proved capacity failure.
+The planner completes every
 diagnostic-producing validation before `TTLFinalizeDFBIndices` changes any
 `dfb_id`, `cb_index`, kernel attribute, or module attribute. The finalizer only
 materializes the validated plan.
@@ -1500,8 +1512,9 @@ result with PyTorch scaled dot-product attention.
 `test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir` isolates
 the cross-kernel ordering rules. The independent allocation-oracle test joins a
 30-vertex clique with the confirmed four-vertex bad-order graph: first-fit uses
-33 indices and exact escalation proves that 32 suffice. The invalid liveness
-test confirms that 33 mutually conflicting lifetimes are rejected.
+33 indices and the fixed-limit exact check finds a 32-index assignment. The
+invalid liveness test confirms that 33 mutually conflicting lifetimes are
+rejected.
 
 `test/python/test_user_dfb_reuse.py` recursively composes copy atoms into an
 operation with 33 logical DFBs. The operation compiles and executes only when
@@ -1663,10 +1676,11 @@ with releases before finalization.
   must also prove compatible transaction counts and address calculations.
 
 - **Pressure above the unspilled limits.** Deterministic first-fit is accepted
-  when it fits. Exact DSATUR search runs when the upper bound prevents physical
-  index or L1 acceptance. Exact search is limited to 1,000,000 deterministic
-  states by default. Limit exhaustion reports an inconclusive allocation;
-  proven infeasibility reports a capacity failure. DRAM spilling is tracked by
+  when it fits. One fixed-limit DSATUR query runs when first-fit exceeds the
+  physical-index limit. Minimum-color DSATUR runs only when a valid assignment
+  exceeds the L1 budget. Each query is limited to 1,000,000 deterministic states
+  by default. Limit exhaustion reports an inconclusive allocation; proven
+  infeasibility reports a capacity failure. DRAM spilling is tracked by
   [#809](https://github.com/tenstorrent/tt-lang/issues/809).
 
 - **Reachability cost.** The bit-vector transitive closure is cubic in the

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -20,7 +20,7 @@ python my_kernel.py --no-ttl-maximize-dst
 | `--ttl-strict-f32-acc` / `--no-ttl-strict-f32-acc` | disabled | Error at compile time if a `+=` accumulation loop's output block exceeds f32 DST capacity (4 tiles with double-buffering). When enabled, guarantees each accumulation step fits in a single DST section without subblocking. |
 | `--ttl-compiler-dfbs` / `--no-ttl-compiler-dfbs` | enabled | Insert compiler-allocated intermediate DFBs when an operation requires DFB-attached inputs, fusion would read a source after its DFB is released, or a computed value is stored by operations in multiple MLIR basic blocks. When disabled, the compiler emits an error if materialization is required. |
 | `--ttl-reuse-user-dfbs` / `--no-ttl-reuse-user-dfbs` | enabled | Reuse physical DFB indices when concurrent-kernel liveness proves that compatible logical DFB lifetimes do not overlap. Disabling compacts provisional user indices without introducing new user-DFB sharing. |
-| `--ttl-dfb-exact-coloring-search-limit N` | `1000000` | Examine at most `N` deterministic exact-coloring search states when first-fit does not satisfy a DFB index or L1 limit. Reaching the limit reports an inconclusive allocation result, not a capacity proof. |
+| `--ttl-dfb-exact-coloring-search-limit N` | `1000000` | Examine at most `N` states during deterministic exact DFB allocation when order-dependent first-fit does not satisfy a DFB index or L1 limit. This bounds compile time; reaching the limit reports an inconclusive result, not a capacity proof. |
 | `--ttl-specialize-cores` / `--no-ttl-specialize-cores` | disabled | Clone each TTKernel function whose control flow branches on a core coordinate once per launch coordinate (`ttkernel-specialize-cores`), replacing `my_logical_x_` / `my_logical_y_` with constants and tagging clones with `ttl.core_coord` for per-core dispatch. Opt-in. |
 
 ### Other Ways to Set These
@@ -119,7 +119,7 @@ ttlang-opt input.mlir -p 'ttl-to-ttkernel-pipeline{maximize-dst=true lower-to-em
 | `strict-f32-acc` | bool | `false` | Error if a `+=` accumulation loop's output block exceeds f32 DST capacity. |
 | `compiler-dfbs` | bool | `true` | Insert compiler-allocated intermediate DFBs for DFB-only operands, source-lifetime preservation, and computed values stored by operations in multiple MLIR basic blocks. Error if disabled and any operation requires one. |
 | `reuse-user-dfbs` | bool | `true` | Reuse physical DFB indices for compatible logical DFBs with proven non-overlapping concurrent lifetimes. |
-| `exact-coloring-search-limit` | uint64 | `1000000` | Maximum deterministic exact-coloring search states before reporting an inconclusive allocation result. |
+| `exact-coloring-search-limit` | uint64 | `1000000` | Maximum states examined during deterministic exact DFB allocation before reporting an inconclusive result. |
 | `specialize-cores` | bool | `false` | Clone TTKernel functions that branch on a core coordinate once per launch coordinate (`ttkernel-specialize-cores`), then run `canonicalize` / `cse`. Maps from `--ttl-specialize-cores`. |
 | `lower-to-emitc` | bool | `false` | Run the TTKernel-to-EmitC backend (produces C++ source). |
 
@@ -134,7 +134,7 @@ The pipeline runs these passes in order:
 - `ttl-insert-cb-sync` -- insert missing DFB synchronization
 - `ttl-verify-pipenet-guards`, then `ttl-verify-pipenet-schedule` -- verify PipeNet launch domains and event ordering before DFB allocation
 - `ttl-coalesce-dfb-acquires` -- coalesce compatible DFB acquires
-- `ttl-finalize-dfb-indices` -- assign logical DFBs to physical indices, validate capacity, and emit runtime metadata; `reuse-user-dfbs` controls user-DFB reuse and `exact-coloring-search-limit` bounds fixed-limit and minimum-color exact queries
+- `ttl-finalize-dfb-indices` -- assign logical DFBs to physical indices, validate capacity, and emit runtime metadata; `reuse-user-dfbs` controls user-DFB reuse and `exact-coloring-search-limit` bounds exhaustive fixed-limit and minimum physical-index-count queries
 - `ttl-set-compute-kernel-config` -- set `fp32_dest_acc_en` / `dst_full_sync_en` defaults
 - `ttl-assign-dst` -- DST register allocation (linear scan with copy insertion)
 - `ttl-subblock-compute-for-dst` -- tile `ttl.compute` into DST-sized subblocks *(only if `maximize-dst=true`)*; optionally refine reserve/push to per-subblock granularity *(only if `subblock-sync=true`)*
@@ -178,7 +178,7 @@ allocation table.
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `reuse-user-dfbs` | bool | `true` | Reuse a physical index when concurrent-kernel liveness proves that two compatible logical DFB lifetimes cannot overlap. When false, compact provisional user indices without introducing new user-DFB sharing and apply the same lifetime proof only to compiler-created DFBs. |
-| `exact-coloring-search-limit` | uint64 | `1000000` | Examine at most this many deterministic exact-coloring states. If first-fit exceeds an index or L1 limit and search reaches this limit, compilation fails with an inconclusive-search diagnostic rather than a capacity diagnostic. |
+| `exact-coloring-search-limit` | uint64 | `1000000` | Examine at most this many states during deterministic exact DFB allocation. Exhaustive search is used only when order-dependent first-fit prevents acceptance. Reaching the limit fails with an inconclusive-search diagnostic rather than a false capacity diagnostic. |
 
 ```bash
 ttlang-opt input.mlir -p 'builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false exact-coloring-search-limit=1000000})'

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -134,7 +134,7 @@ The pipeline runs these passes in order:
 - `ttl-insert-cb-sync` -- insert missing DFB synchronization
 - `ttl-verify-pipenet-guards`, then `ttl-verify-pipenet-schedule` -- verify PipeNet launch domains and event ordering before DFB allocation
 - `ttl-coalesce-dfb-acquires` -- coalesce compatible DFB acquires
-- `ttl-finalize-dfb-indices` -- assign logical DFBs to physical indices, validate capacity, and emit runtime metadata; `reuse-user-dfbs` controls user-DFB reuse and `exact-coloring-search-limit` bounds exact escalation
+- `ttl-finalize-dfb-indices` -- assign logical DFBs to physical indices, validate capacity, and emit runtime metadata; `reuse-user-dfbs` controls user-DFB reuse and `exact-coloring-search-limit` bounds fixed-limit and minimum-color exact queries
 - `ttl-set-compute-kernel-config` -- set `fp32_dest_acc_en` / `dst_full_sync_en` defaults
 - `ttl-assign-dst` -- DST register allocation (linear scan with copy insertion)
 - `ttl-subblock-compute-for-dst` -- tile `ttl.compute` into DST-sized subblocks *(only if `maximize-dst=true`)*; optionally refine reserve/push to per-subblock granularity *(only if `subblock-sync=true`)*

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -18,7 +18,9 @@ python my_kernel.py --no-ttl-maximize-dst
 | `--ttl-subblock-sync` / `--no-ttl-subblock-sync` | disabled | Refine DFB reserve/push to per-subblock granularity, enabling `pack_tile_block` for contiguous subblocks. When disabled, user-placed reserve/push is preserved as written. |
 | `--ttl-combine-pack-tiles` / `--no-ttl-combine-pack-tiles` | enabled | Combine consecutive `pack_tile` ops on the same DFB with contiguous DST and DFB indices into a single `pack_tile_block` call. |
 | `--ttl-strict-f32-acc` / `--no-ttl-strict-f32-acc` | disabled | Error at compile time if a `+=` accumulation loop's output block exceeds f32 DST capacity (4 tiles with double-buffering). When enabled, guarantees each accumulation step fits in a single DST section without subblocking. |
-| `--ttl-compiler-dfbs` / `--no-ttl-compiler-dfbs` | enabled | Insert compiler-allocated intermediate DFBs when an operation requires DFB-attached inputs, fusion would read a source after its DFB is released, or a computed value is stored from multiple blocks. When disabled, the compiler emits an error if materialization is required. |
+| `--ttl-compiler-dfbs` / `--no-ttl-compiler-dfbs` | enabled | Insert compiler-allocated intermediate DFBs when an operation requires DFB-attached inputs, fusion would read a source after its DFB is released, or a computed value is stored by operations in multiple MLIR basic blocks. When disabled, the compiler emits an error if materialization is required. |
+| `--ttl-reuse-user-dfbs` / `--no-ttl-reuse-user-dfbs` | enabled | Reuse physical DFB indices when concurrent-kernel liveness proves that compatible logical DFB lifetimes do not overlap. Disabling compacts provisional user indices without introducing new user-DFB sharing. |
+| `--ttl-dfb-exact-coloring-search-limit N` | `1000000` | Examine at most `N` deterministic exact-coloring search states when first-fit does not satisfy a DFB index or L1 limit. Reaching the limit reports an inconclusive allocation result, not a capacity proof. |
 | `--ttl-specialize-cores` / `--no-ttl-specialize-cores` | disabled | Clone each TTKernel function whose control flow branches on a core coordinate once per launch coordinate (`ttkernel-specialize-cores`), replacing `my_logical_x_` / `my_logical_y_` with constants and tagging clones with `ttl.core_coord` for per-core dispatch. Opt-in. |
 
 ### Other Ways to Set These
@@ -115,7 +117,9 @@ ttlang-opt input.mlir -p 'ttl-to-ttkernel-pipeline{maximize-dst=true lower-to-em
 | `subblock-sync` | bool | `false` | Refine DFB reserve/push to per-subblock granularity. |
 | `combine-pack-tiles` | bool | `true` | Combine consecutive `pack_tile` ops into `pack_tile_block`. |
 | `strict-f32-acc` | bool | `false` | Error if a `+=` accumulation loop's output block exceeds f32 DST capacity. |
-| `compiler-dfbs` | bool | `true` | Insert compiler-allocated intermediate DFBs for DFB-only operands, source-lifetime preservation, and computed values stored from multiple blocks. Error if disabled and any operation requires one. |
+| `compiler-dfbs` | bool | `true` | Insert compiler-allocated intermediate DFBs for DFB-only operands, source-lifetime preservation, and computed values stored by operations in multiple MLIR basic blocks. Error if disabled and any operation requires one. |
+| `reuse-user-dfbs` | bool | `true` | Reuse physical DFB indices for compatible logical DFBs with proven non-overlapping concurrent lifetimes. |
+| `exact-coloring-search-limit` | uint64 | `1000000` | Maximum deterministic exact-coloring search states before reporting an inconclusive allocation result. |
 | `specialize-cores` | bool | `false` | Clone TTKernel functions that branch on a core coordinate once per launch coordinate (`ttkernel-specialize-cores`), then run `canonicalize` / `cse`. Maps from `--ttl-specialize-cores`. |
 | `lower-to-emitc` | bool | `false` | Run the TTKernel-to-EmitC backend (produces C++ source). |
 
@@ -125,17 +129,19 @@ The pipeline runs these passes in order:
 - `ttl-insert-copy-wait` -- insert missing `ttl.wait` after `ttl.copy` ops whose transfer handle has no wait user
 - `ttl-annotate-l1-acc-loops` -- detect `+=` accumulation loops and annotate for L1 packer accumulation
 - `ttl-create-producer-compute` -- create producer `ttl.compute` operations before intermediate materialization
-- `ttl-insert-intermediate-dfbs` -- materialize DFB-only operands, values that must be preserved before source release, and computed values stored from multiple blocks; verify and error when `compiler-dfbs=false`
+- `ttl-insert-intermediate-dfbs` -- materialize DFB-only operands, values that must be preserved before source release, and computed values stored by operations in multiple MLIR basic blocks; verify and error when `compiler-dfbs=false`
 - `convert-ttl-to-compute` -- lower TTL elementwise tensor ops to `ttl.compute` with tile ops
-- `ttl-insert-cb-sync`, then `ttl-coalesce-dfb-acquires` -- insert missing releases and coalesce compatible DFB acquires
-- `ttl-finalize-dfb-indices` -- allocate physical compiler DFB indices, validate capacity, and emit runtime metadata
+- `ttl-insert-cb-sync` -- insert missing DFB synchronization
+- `ttl-verify-pipenet-guards`, then `ttl-verify-pipenet-schedule` -- verify PipeNet launch domains and event ordering before DFB allocation
+- `ttl-coalesce-dfb-acquires` -- coalesce compatible DFB acquires
+- `ttl-finalize-dfb-indices` -- assign logical DFBs to physical indices, validate capacity, and emit runtime metadata; `reuse-user-dfbs` controls user-DFB reuse and `exact-coloring-search-limit` bounds exact escalation
 - `ttl-set-compute-kernel-config` -- set `fp32_dest_acc_en` / `dst_full_sync_en` defaults
 - `ttl-assign-dst` -- DST register allocation (linear scan with copy insertion)
 - `ttl-subblock-compute-for-dst` -- tile `ttl.compute` into DST-sized subblocks *(only if `maximize-dst=true`)*; optionally refine reserve/push to per-subblock granularity *(only if `subblock-sync=true`)*
 - `ttl-lower-to-loops` -- lower `ttl.compute` to `scf.for` loops; matmul computes are expanded inline via `generateMatmulCompute`
 - `ttl-schedule-operations` -- reorder tile ops by dependency depth and kind *(only if `maximize-dst=true`)*
 - `ttl-annotate-cb-associations` -- annotate block args with DFB indices
-- `ttl-verify-pipenet-guards`, then `ttl-verify-dfb-spsc` -- verify PipeNet synchronization and per-node DFB producer/consumer uniqueness
+- `ttl-verify-dfb-spsc` -- verify per-node DFB producer/consumer uniqueness after finalization
 - `ttl-erase-pipenet-scopes` -- remove verified PipeNet structural markers
 - `ttl-validate-cb-budget` -- verify static DFB storage fits the per-core L1 budget
 - `convert-ttl-to-ttkernel` -- lower TTL DMA ops to TTKernel
@@ -162,6 +168,20 @@ concrete DFB storage.
 
 ```bash
 ttlang-opt input.mlir -p 'func.func(ttl-insert-intermediate-dfbs{enable=false})'
+```
+
+#### `ttl-finalize-dfb-indices`
+
+Assign physical indices to logical DFBs and emit the complete runtime
+allocation table.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `reuse-user-dfbs` | bool | `true` | Reuse a physical index when concurrent-kernel liveness proves that two compatible logical DFB lifetimes cannot overlap. When false, compact provisional user indices without introducing new user-DFB sharing and apply the same lifetime proof only to compiler-created DFBs. |
+| `exact-coloring-search-limit` | uint64 | `1000000` | Examine at most this many deterministic exact-coloring states. If first-fit exceeds an index or L1 limit and search reaches this limit, compilation fails with an inconclusive-search diagnostic rather than a capacity diagnostic. |
+
+```bash
+ttlang-opt input.mlir -p 'builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false exact-coloring-search-limit=1000000})'
 ```
 
 #### `ttl-set-compute-kernel-config`

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -22,6 +22,7 @@ namespace mlir::tt::ttl {
 /// Default tile dimensions used for TTL tensors.
 inline constexpr int32_t kDefaultTileHeight = 32;
 inline constexpr int32_t kDefaultTileWidth = 32;
+/// Physical DFB indices supported by TT kernel hardware.
 inline constexpr int32_t kMaxCircularBuffers = 32;
 /// TT kernel hardware semaphore id capacity. Mirrored by
 /// python/ttl/constants.py for simulator-side resource checks.

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1658,9 +1658,20 @@ def TTL_OpaqueCallOp : TTL_Op<"opaque_call",
     template arguments on the emitted call. They are resolved to integer
     literals at EmitC lowering time, e.g. `my_func<1, 2>(a, b)`.
 
-    The `arg_operands` are forwarded as function arguments to the callee.
-    Results are optional; when absent the call is treated as a void
-    function invocation.
+    The `arg_operands` are forwarded as function arguments to the callee. A
+    DFB operand declares that the callee may access that logical DFB from call
+    entry through call completion; storage liveness does not distinguish reads
+    from writes. Every DFB accessed by the callee or a transitive helper must
+    appear as a DFB operand, and all synchronous and asynchronous accesses must
+    complete before the call returns. This external-code contract is assumed
+    because the compiler does not inspect the C++ body.
+
+    An integer produced by `ttl.get_dfb_id`, including a template argument,
+    does not declare a call-level DFB access. If the callee uses that index to
+    access the DFB, the same DFB must also appear in `arg_operands`.
+
+    Results are optional; when absent the call is treated as a void function
+    invocation.
 
     Example:
     ```mlir
@@ -1694,9 +1705,10 @@ def TTL_GetDfbIdOp : TTL_Op<"get_dfb_id", [Pure]> {
   let summary = "Get the integer index for a dataflow buffer";
   let description = [{
     Returns the integer DFB index for the given dataflow buffer as an
-    i32 SSA value. Typically consumed by `ttl.opaque_call` template
-    args, which keeps the DFB live through SSA dataflow. At EmitC time
-    this resolves to a raw integer literal.
+    i32 SSA value. At EmitC time this resolves to a raw integer literal.
+    Integer SSA dataflow does not preserve a call-level DFB access; an
+    external callee that accesses the DFB must also receive it as a DFB
+    operand.
   }];
   let arguments = (ins TTL_CircularBuffer:$dfb);
   let results = (outs I32:$result);

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -102,6 +102,16 @@ inline BindCBOp getDFBDeclaration(mlir::Value dfb) {
   return traceUnrealizedCasts(dfb).getDefiningOp<BindCBOp>();
 }
 
+/// Returns true when a direct DFB operand may access physical storage.
+///
+/// Callers first identify a DFB operand. Unknown operations conservatively
+/// access storage; only operations with defined identity-only semantics are
+/// excluded.
+inline bool mayAccessDFBStorage(mlir::Operation *operation) {
+  return !mlir::isa<AttachCBOp, GetDfbIdOp, mlir::UnrealizedConversionCastOp>(
+      operation);
+}
+
 /// Resolve the CB index attached to `cb`, accepting either the pre-conversion
 /// BindCBOp or the post-conversion GetCompileArgValOp.
 inline std::optional<int64_t> getCBIndex(mlir::Value cb) {

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -818,24 +818,58 @@ def TTLFinalizeDFBIndices
     The logical identity remains independent of the physical `cb_index`, so
     later analyses can distinguish DFBs that share one hardware slot.
 
-    Compiler-created DFBs enter this pass with kernel-local provisional
-    indices. The pass assigns each kernel a disjoint module-wide index range,
-    then applies deterministic first-fit interval coloring, partitioned by
-    CircularBufferType. A half-open lifetime starts at the first `cb_reserve` or
-    `cb_wait` and ends immediately after the last `cb_pop`. DFBs whose lifetimes
-    do not overlap are assigned the same physical index. See
-    docs/development/DFBManagement.md.
+    With `reuse-user-dfbs` enabled, the pass analyzes all logical DFBs,
+    including declarations shared across kernels. Reuse requires exact
+    `CircularBufferType` equality, equal transaction tile counts that divide
+    the DFB capacity, and identical read- and write-pointer processors on each
+    launch node. These requirements preserve hardware counter and ring-pointer
+    state. A logical DFB without an exact single lifecycle or a proven lifetime
+    order conflicts with every other DFB. Unsupported or unknown control flow
+    can reduce reuse but cannot produce an unsafe physical assignment.
+
+    Allocation first applies deterministic first-fit. Exact coloring runs only
+    when first-fit exceeds an index or L1 limit and the available bounds do not
+    already prove acceptance or rejection. Exact search examines at most
+    `exact-coloring-search-limit` deterministic states. Reaching that limit
+    reports an inconclusive allocation diagnostic; it does not report that the
+    hardware capacity was proved insufficient.
+
+    Every storage-accessing operation with a direct DFB operand is treated as a
+    runtime access from operation entry through completion. Every direct DFB
+    operand of `ttl.opaque_call` is a possible read or write; both require the
+    same storage-liveness interval. Identity-only `ttl.attach_cb` and
+    `ttl.get_dfb_id` operations do not access storage. An external call whose
+    C++ body implements the DFB protocol does not provide the visible reserve,
+    push, wait, and pop operations required to prove a bounded lifecycle.
+
+    Disabling `reuse-user-dfbs` compacts distinct provisional user indices
+    without introducing new sharing between user DFBs, then colors only
+    compiler-created DFBs. Both modes use the same concurrent lifetime proof
+    and interference graph for every DFB they color.
+
+    Every used compiler-created DFB must contain `ttl.cb_reserve`,
+    `ttl.cb_push`, `ttl.cb_wait`, and `ttl.cb_pop`. An unused declaration is
+    legal and remains live through the end of its kernel.
 
     The pass rejects copied DFB-index attributes from later passes. It computes
-    all physical assignments and runtime metadata and validates capacity before
-    modifying the IR, so a capacity error leaves provisional
-    indices and existing kernel attributes unchanged. After validation, it
-    applies the physical assignments and logical identities, updates
-    `ttl.base_cta_index`, and builds the `ttl.dfb_allocations` module attribute
-    for the Python runtime. The attribute contains one descriptor per physical
-    index, including user-declared and compiler-created DFBs, and records the
-    page size computed from the finalized element type.
+    all physical assignments and runtime metadata and validates the 32-index
+    hardware limit before modifying the IR. Applying the validated plan updates
+    physical indices and `ttl.base_cta_index`, assigns missing compiler-created
+    logical IDs, and builds `ttl.dfb_allocations` for the Python runtime. The
+    attribute contains one descriptor per physical index, including
+    user-declared and compiler-created DFBs, and records the page size computed
+    from the finalized element type. See docs/development/DFBManagement.md.
   }];
+
+  let options = [
+    Option<"reuseUserDFBs", "reuse-user-dfbs", "bool", "true",
+           "Reuse physical DFB indices for logical DFBs with proven "
+           "non-overlapping lifetimes across concurrent kernels.">,
+    Option<"exactColoringSearchStateLimit", "exact-coloring-search-limit",
+           "uint64_t", "1000000",
+           "Maximum exact-coloring search states before reporting an "
+           "inconclusive allocation result.">
+  ];
 }
 
 def TTLValidateCBBudget

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -827,12 +827,22 @@ def TTLFinalizeDFBIndices
     order conflicts with every other DFB. Unsupported or unknown control flow
     can reduce reuse but cannot produce an unsafe physical assignment.
 
-    Allocation first applies deterministic first-fit. Exact coloring runs only
-    when first-fit exceeds an index or L1 limit and the available bounds do not
-    already prove acceptance or rejection. Exact search examines at most
-    `exact-coloring-search-limit` deterministic states. Reaching that limit
-    reports an inconclusive allocation diagnostic; it does not report that the
-    hardware capacity was proved insufficient.
+    The allocator represents each logical DFB as a vertex, each pair that
+    cannot share as an edge, and each physical index as a color. First-fit
+    quickly produces a valid assignment by giving each DFB the lowest index
+    not used by one of its conflicts, but its result depends on DFB order and
+    may use more indices than necessary. A found set of pairwise-conflicting
+    DFBs proves that at least that many indices are required.
+
+    Exhaustive assignment search can grow exponentially, so it runs only when
+    first-fit prevents acceptance and the pairwise-conflict lower bound does
+    not already prove failure. The physical-index check asks directly whether
+    an assignment fits the available indices. Minimum physical-index-count
+    search runs only when an otherwise valid assignment exceeds the L1 budget.
+    Each search examines at most `exact-coloring-search-limit` deterministic
+    states to bound compile time. Reaching that limit reports an inconclusive
+    allocation diagnostic; it does not report that hardware capacity was
+    proved insufficient.
 
     Every storage-accessing operation with a direct DFB operand is treated as a
     runtime access from operation entry through completion. Every direct DFB
@@ -843,9 +853,9 @@ def TTLFinalizeDFBIndices
     push, wait, and pop operations required to prove a bounded lifecycle.
 
     Disabling `reuse-user-dfbs` compacts distinct provisional user indices
-    without introducing new sharing between user DFBs, then colors only
-    compiler-created DFBs. Both modes use the same concurrent lifetime proof
-    and interference graph for every DFB they color.
+    without introducing new sharing between user DFBs, then assigns only
+    compiler-created DFBs. Both modes use the same lifetime proof and conflict
+    relation for every DFB whose index they select.
 
     Every used compiler-created DFB must contain `ttl.cb_reserve`,
     `ttl.cb_push`, `ttl.cb_wait`, and `ttl.cb_pop`. An unused declaration is
@@ -867,8 +877,8 @@ def TTLFinalizeDFBIndices
            "non-overlapping lifetimes across concurrent kernels.">,
     Option<"exactColoringSearchStateLimit", "exact-coloring-search-limit",
            "uint64_t", "1000000",
-           "Maximum exact-coloring search states before reporting an "
-           "inconclusive allocation result.">
+           "Maximum states examined by exact DFB allocation before reporting "
+           "an inconclusive result.">
   ];
 }
 

--- a/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
+++ b/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
@@ -64,8 +64,8 @@ struct TTLToTTKernelPipelineOptions
       llvm::cl::init(true)};
   Option<std::uint64_t> exactColoringSearchStateLimit{
       *this, "exact-coloring-search-limit",
-      llvm::cl::desc("Maximum exact DFB coloring search states before "
-                     "reporting an inconclusive allocation result."),
+      llvm::cl::desc("Maximum states examined by exact DFB allocation before "
+                     "reporting an inconclusive result."),
       llvm::cl::init(1000000)};
   Option<bool> specializeCores{
       *this, "specialize-cores",

--- a/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
+++ b/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
@@ -7,6 +7,8 @@
 
 #include "mlir/Pass/PassOptions.h"
 
+#include <cstdint>
+
 namespace mlir {
 class OpPassManager;
 } // namespace mlir
@@ -55,6 +57,16 @@ struct TTLToTTKernelPipelineOptions
                      "error if materialization through a compiler-allocated "
                      "DFB is required."),
       llvm::cl::init(true)};
+  Option<bool> reuseUserDFBs{
+      *this, "reuse-user-dfbs",
+      llvm::cl::desc("Reuse physical DFB indices when concurrent-kernel "
+                     "liveness proves that logical lifetimes do not overlap."),
+      llvm::cl::init(true)};
+  Option<std::uint64_t> exactColoringSearchStateLimit{
+      *this, "exact-coloring-search-limit",
+      llvm::cl::desc("Maximum exact DFB coloring search states before "
+                     "reporting an inconclusive allocation result."),
+      llvm::cl::init(1000000)};
   Option<bool> specializeCores{
       *this, "specialize-cores",
       llvm::cl::desc(

--- a/include/ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h
+++ b/include/ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h
@@ -135,6 +135,44 @@ struct InterferenceGraphColoringBounds {
 InterferenceGraphColoringBounds
 computeInterferenceGraphColoringBounds(const InterferenceGraph &graph);
 
+/// Completion status for exact coloring with a fixed color limit.
+enum class InterferenceGraphColorLimitStatus {
+  Feasible,
+  Infeasible,
+  SearchLimitReached,
+};
+
+/// Result of deciding whether an interference graph fits a fixed color limit.
+struct InterferenceGraphColorLimitResult {
+  InterferenceGraphColorLimitStatus status =
+      InterferenceGraphColorLimitStatus::Infeasible;
+
+  /// Dense zero-based color indexed by vertex number.
+  ///
+  /// Present only when `status` is `Feasible`.
+  llvm::SmallVector<unsigned> colors;
+
+  /// Number of colors used by the feasible assignment, or zero otherwise.
+  unsigned colorCount = 0;
+
+  /// Recursive search states examined before completion or termination.
+  std::uint64_t exploredStateCount = 0;
+
+  bool isFeasible() const {
+    return status == InterferenceGraphColorLimitStatus::Feasible;
+  }
+};
+
+/// Decides exactly whether `graph` can be colored with at most `colorLimit`
+/// colors using bounded DSATUR search.
+///
+/// `Infeasible` is returned only after an exhaustive proof. A search limit
+/// cannot be converted into a capacity rejection.
+InterferenceGraphColorLimitResult
+colorInterferenceGraphWithColorLimitExactly(const InterferenceGraph &graph,
+                                            unsigned colorLimit,
+                                            std::uint64_t searchStateLimit);
+
 /// Computes a deterministic minimum coloring with bounded DSATUR search.
 ///
 /// Connected components are solved independently and reuse the same color

--- a/include/ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h
+++ b/include/ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_INTERFERENCEGRAPHCOLORING_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_INTERFERENCEGRAPHCOLORING_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cassert>
+#include <cstdint>
+
+namespace mlir::tt::ttl {
+
+/// Undirected graph whose edges prohibit assigning the same color to both
+/// endpoint vertices.
+class InterferenceGraph {
+public:
+  /// Creates a graph with vertices numbered `[0, vertexCount)`.
+  explicit InterferenceGraph(unsigned vertexCount)
+      : adjacency(vertexCount, llvm::BitVector(vertexCount)) {}
+
+  /// Returns the number of vertices in the graph.
+  unsigned size() const { return adjacency.size(); }
+
+  /// Records that two distinct vertices cannot receive the same color.
+  void addInterference(unsigned lhs, unsigned rhs) {
+    assert(lhs < size() && rhs < size() && lhs != rhs);
+    adjacency[lhs].set(rhs);
+    adjacency[rhs].set(lhs);
+  }
+
+  /// Returns true when two vertices require distinct colors.
+  bool interferes(unsigned lhs, unsigned rhs) const {
+    assert(lhs < size() && rhs < size());
+    return adjacency[lhs].test(rhs);
+  }
+
+  /// Returns the neighbors of one vertex.
+  const llvm::BitVector &getNeighbors(unsigned vertex) const {
+    assert(vertex < size());
+    return adjacency[vertex];
+  }
+
+  /// Returns the degree of one vertex.
+  unsigned degree(unsigned vertex) const {
+    return getNeighbors(vertex).count();
+  }
+
+private:
+  llvm::SmallVector<llvm::BitVector> adjacency;
+};
+
+/// Visits vertices in priority order and assigns the lowest available color.
+///
+/// Production DFB allocation accepts this assignment when it satisfies the
+/// hardware limits and otherwise uses exact coloring below.
+inline llvm::SmallVector<unsigned>
+colorInterferenceGraphFirstFit(const InterferenceGraph &graph,
+                               llvm::ArrayRef<unsigned> priorityOrder) {
+  assert(priorityOrder.size() == graph.size());
+
+  llvm::BitVector visited(graph.size());
+  llvm::SmallVector<unsigned> vertexColors(graph.size());
+  llvm::SmallVector<llvm::SmallVector<unsigned>> colorUsers;
+  for (unsigned vertex : priorityOrder) {
+    assert(vertex < graph.size() && !visited.test(vertex));
+    visited.set(vertex);
+
+    unsigned selectedColor = 0;
+    for (; selectedColor < colorUsers.size(); ++selectedColor) {
+      bool hasInterference = false;
+      for (unsigned assignedVertex : colorUsers[selectedColor]) {
+        if (graph.interferes(vertex, assignedVertex)) {
+          hasInterference = true;
+          break;
+        }
+      }
+      if (!hasInterference) {
+        break;
+      }
+    }
+    if (selectedColor == colorUsers.size()) {
+      colorUsers.emplace_back();
+    }
+    colorUsers[selectedColor].push_back(vertex);
+    vertexColors[vertex] = selectedColor;
+  }
+  assert(visited.all() && "priority order must contain every graph vertex");
+  return vertexColors;
+}
+
+/// Completion status for bounded exact coloring.
+enum class ExactInterferenceGraphColoringStatus {
+  Optimal,
+  SearchLimitReached,
+};
+
+/// Result of bounded exact coloring of an interference graph.
+struct ExactInterferenceGraphColoring {
+  ExactInterferenceGraphColoringStatus status =
+      ExactInterferenceGraphColoringStatus::Optimal;
+
+  /// Dense zero-based color indexed by vertex number.
+  ///
+  /// Present only when `status` is `Optimal`.
+  llvm::SmallVector<unsigned> colors;
+
+  /// Proven chromatic number, or zero when search was inconclusive.
+  unsigned colorCount = 0;
+
+  /// Sound clique lower bound used to begin exact search.
+  unsigned cliqueLowerBound = 0;
+
+  /// Recursive search states examined before completion or termination.
+  std::uint64_t exploredStateCount = 0;
+
+  bool isOptimal() const {
+    return status == ExactInterferenceGraphColoringStatus::Optimal;
+  }
+};
+
+/// Deterministic feasible coloring with a sound clique lower bound.
+struct InterferenceGraphColoringBounds {
+  llvm::SmallVector<unsigned> colors;
+  unsigned colorCount = 0;
+  unsigned cliqueLowerBound = 0;
+
+  bool provesMinimum() const { return colorCount == cliqueLowerBound; }
+};
+
+/// Computes a deterministic greedy upper bound and explicit clique lower bound.
+InterferenceGraphColoringBounds
+computeInterferenceGraphColoringBounds(const InterferenceGraph &graph);
+
+/// Computes a deterministic minimum coloring with bounded DSATUR search.
+///
+/// Connected components are solved independently and reuse the same color
+/// range. Exhaustive infeasibility checks below the returned color count prove
+/// that an `Optimal` result is minimum. `SearchLimitReached` contains no
+/// coloring and cannot justify a capacity diagnostic.
+ExactInterferenceGraphColoring
+colorInterferenceGraphExactly(const InterferenceGraph &graph,
+                              std::uint64_t searchStateLimit);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_INTERFERENCEGRAPHCOLORING_H

--- a/include/ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h
+++ b/include/ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h
@@ -14,8 +14,12 @@
 
 namespace mlir::tt::ttl {
 
-/// Undirected graph whose edges prohibit assigning the same color to both
-/// endpoint vertices.
+/// Allocation constraints represented as an undirected graph.
+///
+/// Each vertex is one allocation candidate. An edge means its two candidates
+/// cannot share a resource. A color is one resource slot, so a valid coloring
+/// assigns different colors to the endpoints of every edge. For DFB allocation,
+/// vertices are logical DFBs and colors are physical DFB indices.
 class InterferenceGraph {
 public:
   /// Creates a graph with vertices numbered `[0, vertexCount)`.
@@ -25,26 +29,26 @@ public:
   /// Returns the number of vertices in the graph.
   unsigned size() const { return adjacency.size(); }
 
-  /// Records that two distinct vertices cannot receive the same color.
+  /// Records that two distinct candidates cannot share a resource slot.
   void addInterference(unsigned lhs, unsigned rhs) {
     assert(lhs < size() && rhs < size() && lhs != rhs);
     adjacency[lhs].set(rhs);
     adjacency[rhs].set(lhs);
   }
 
-  /// Returns true when two vertices require distinct colors.
+  /// Returns true when two candidates require distinct resource slots.
   bool interferes(unsigned lhs, unsigned rhs) const {
     assert(lhs < size() && rhs < size());
     return adjacency[lhs].test(rhs);
   }
 
-  /// Returns the neighbors of one vertex.
+  /// Returns the candidates that conflict with one candidate.
   const llvm::BitVector &getNeighbors(unsigned vertex) const {
     assert(vertex < size());
     return adjacency[vertex];
   }
 
-  /// Returns the degree of one vertex.
+  /// Returns the number of candidates that conflict with one candidate.
   unsigned degree(unsigned vertex) const {
     return getNeighbors(vertex).count();
   }
@@ -53,10 +57,11 @@ private:
   llvm::SmallVector<llvm::BitVector> adjacency;
 };
 
-/// Visits vertices in priority order and assigns the lowest available color.
+/// Assigns each candidate the lowest-numbered slot not used by a conflict.
 ///
-/// Production DFB allocation accepts this assignment when it satisfies the
-/// hardware limits and otherwise uses exact coloring below.
+/// Candidates are processed in `priorityOrder`, so the result is deterministic
+/// but may use more slots than necessary. The returned valid assignment gives
+/// an upper bound on the minimum required slot count.
 inline llvm::SmallVector<unsigned>
 colorInterferenceGraphFirstFit(const InterferenceGraph &graph,
                                llvm::ArrayRef<unsigned> priorityOrder) {
@@ -92,27 +97,31 @@ colorInterferenceGraphFirstFit(const InterferenceGraph &graph,
   return vertexColors;
 }
 
-/// Completion status for bounded exact coloring.
+/// Completion status for a bounded minimum-slot search.
 enum class ExactInterferenceGraphColoringStatus {
   Optimal,
   SearchLimitReached,
 };
 
-/// Result of bounded exact coloring of an interference graph.
+/// Result of proving the minimum number of slots required by a graph.
 struct ExactInterferenceGraphColoring {
   ExactInterferenceGraphColoringStatus status =
       ExactInterferenceGraphColoringStatus::Optimal;
 
-  /// Dense zero-based color indexed by vertex number.
+  /// Dense zero-based resource slot indexed by candidate number.
   ///
   /// Present only when `status` is `Optimal`.
   llvm::SmallVector<unsigned> colors;
 
-  /// Proven chromatic number, or zero when search was inconclusive.
+  /// Proven minimum slot count, or zero when search was inconclusive.
   unsigned colorCount = 0;
 
-  /// Sound clique lower bound used to begin exact search.
-  unsigned cliqueLowerBound = 0;
+  /// Size of a found set whose members all conflict with each other.
+  ///
+  /// Such a set is a clique. Every member needs a distinct slot, so its size is
+  /// a proved lower bound on the required slot count. The found clique need not
+  /// be the largest clique in the graph.
+  unsigned pairwiseConflictLowerBound = 0;
 
   /// Recursive search states examined before completion or termination.
   std::uint64_t exploredStateCount = 0;
@@ -122,37 +131,45 @@ struct ExactInterferenceGraphColoring {
   }
 };
 
-/// Deterministic feasible coloring with a sound clique lower bound.
+/// A valid first-fit assignment and a proved lower bound on required slots.
 struct InterferenceGraphColoringBounds {
+  /// Dense zero-based resource slot indexed by candidate number.
   llvm::SmallVector<unsigned> colors;
-  unsigned colorCount = 0;
-  unsigned cliqueLowerBound = 0;
 
-  bool provesMinimum() const { return colorCount == cliqueLowerBound; }
+  /// Slots used by `colors`, which is an upper bound on the minimum.
+  unsigned colorCount = 0;
+
+  /// Size of a found clique, which is a lower bound on the minimum.
+  unsigned pairwiseConflictLowerBound = 0;
+
+  /// Equal valid upper and proved lower bounds establish the minimum.
+  bool provesMinimum() const {
+    return colorCount == pairwiseConflictLowerBound;
+  }
 };
 
-/// Computes a deterministic greedy upper bound and explicit clique lower bound.
+/// Computes a first-fit assignment and a pairwise-conflict lower bound.
 InterferenceGraphColoringBounds
 computeInterferenceGraphColoringBounds(const InterferenceGraph &graph);
 
-/// Completion status for exact coloring with a fixed color limit.
+/// Completion status for deciding whether a fixed slot limit is sufficient.
 enum class InterferenceGraphColorLimitStatus {
   Feasible,
   Infeasible,
   SearchLimitReached,
 };
 
-/// Result of deciding whether an interference graph fits a fixed color limit.
+/// Result of deciding whether an allocation graph fits a fixed slot limit.
 struct InterferenceGraphColorLimitResult {
   InterferenceGraphColorLimitStatus status =
       InterferenceGraphColorLimitStatus::Infeasible;
 
-  /// Dense zero-based color indexed by vertex number.
+  /// Dense zero-based resource slot indexed by candidate number.
   ///
   /// Present only when `status` is `Feasible`.
   llvm::SmallVector<unsigned> colors;
 
-  /// Number of colors used by the feasible assignment, or zero otherwise.
+  /// Slots used by the feasible assignment, or zero otherwise.
   unsigned colorCount = 0;
 
   /// Recursive search states examined before completion or termination.
@@ -163,22 +180,28 @@ struct InterferenceGraphColorLimitResult {
   }
 };
 
-/// Decides exactly whether `graph` can be colored with at most `colorLimit`
-/// colors using bounded DSATUR search.
+/// Decides whether `graph` can use at most `colorLimit` resource slots.
 ///
-/// `Infeasible` is returned only after an exhaustive proof. A search limit
-/// cannot be converted into a capacity rejection.
+/// The deterministic backtracking search selects the unassigned candidate
+/// constrained by the most different slots among its already assigned
+/// conflicts, then tries legal slots in numeric order. This DSATUR ordering
+/// reduces branching by resolving candidates with the fewest remaining choices
+/// first; it does not change which assignments are feasible. `Infeasible` is
+/// returned only after the search exhausts every assignment. Reaching the state
+/// limit is inconclusive and cannot justify a capacity rejection.
 InterferenceGraphColorLimitResult
 colorInterferenceGraphWithColorLimitExactly(const InterferenceGraph &graph,
                                             unsigned colorLimit,
                                             std::uint64_t searchStateLimit);
 
-/// Computes a deterministic minimum coloring with bounded DSATUR search.
+/// Computes a deterministic assignment with the minimum resource-slot count.
 ///
-/// Connected components are solved independently and reuse the same color
-/// range. Exhaustive infeasibility checks below the returned color count prove
-/// that an `Optimal` result is minimum. `SearchLimitReached` contains no
-/// coloring and cannot justify a capacity diagnostic.
+/// Disconnected candidate groups have no conflicts between them, so they are
+/// solved independently and reuse the same slots. The search begins at the
+/// pairwise-conflict lower bound and tests increasing slot counts. Exhaustively
+/// rejecting every smaller count proves that an `Optimal` result is minimum.
+/// `SearchLimitReached` contains no assignment and cannot justify a capacity
+/// diagnostic.
 ExactInterferenceGraphColoring
 colorInterferenceGraphExactly(const InterferenceGraph &graph,
                               std::uint64_t searchStateLimit);

--- a/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
@@ -133,6 +133,8 @@ struct LaunchNodeDomainState {
       executionCountAnalysesByFunctionAndCoord;
   bool sawError = false;
   bool hasLaunchGrid = false;
+  Operation *errorOperation = nullptr;
+  std::string errorMessage;
 
   /// Return true if the module contains at least one declared PipeNet.
   bool hasPipes() const;
@@ -213,6 +215,10 @@ private:
 
 /// Optional callbacks and analysis behavior requested by a verifier.
 struct LaunchNodeDomainAnalysisOptions {
+  /// Emit malformed PipeNet-scope diagnostics during analysis. Analyses that
+  /// return typed failures disable this and forward the recorded error.
+  bool emitInvalidPipeNetDiagnostics = true;
+
   /// Intersect the active domain with each `ttl.pipenet_scope` role domain when
   /// entering the scope body.
   bool narrowPipeNetScopes = false;

--- a/include/ttlang/Dialect/TTL/Transforms/LiveIntervalUtils.h
+++ b/include/ttlang/Dialect/TTL/Transforms/LiveIntervalUtils.h
@@ -21,6 +21,8 @@
 #ifndef TTLANG_DIALECT_TTL_TRANSFORMS_LIVEINTERVALUTILS_H
 #define TTLANG_DIALECT_TTL_TRANSFORMS_LIVEINTERVALUTILS_H
 
+#include "ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h"
+
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
@@ -28,6 +30,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -190,25 +193,32 @@ assignGreedyIntervalColors(ArrayRef<ItemT> items, IsBeforeFn isBefore,
   SmallVector<ItemT> sortedItems(items.begin(), items.end());
   llvm::sort(sortedItems, isBefore);
 
-  SmallVector<SmallVector<ItemT>> colorUsers;
-  for (const ItemT &item : sortedItems) {
-    unsigned selectedColor = 0;
-    for (;; ++selectedColor) {
-      if (selectedColor == colorUsers.size()) {
-        colorUsers.push_back({});
-        break;
-      }
-      bool hasConflict =
-          llvm::any_of(colorUsers[selectedColor], [&](const ItemT &assigned) {
-            return conflicts(item, assigned);
-          });
-      if (!hasConflict) {
-        break;
+  InterferenceGraph graph(sortedItems.size());
+  for (unsigned lhs = 0; lhs < sortedItems.size(); ++lhs) {
+    for (unsigned rhs = lhs + 1; rhs < sortedItems.size(); ++rhs) {
+      if (conflicts(sortedItems[lhs], sortedItems[rhs])) {
+        graph.addInterference(lhs, rhs);
       }
     }
-    colorUsers[selectedColor].push_back(item);
   }
 
+  SmallVector<unsigned> priorityOrder;
+  priorityOrder.reserve(sortedItems.size());
+  for (unsigned vertex = 0; vertex < sortedItems.size(); ++vertex) {
+    priorityOrder.push_back(vertex);
+  }
+  SmallVector<unsigned> vertexColors =
+      colorInterferenceGraphFirstFit(graph, priorityOrder);
+
+  unsigned colorCount = 0;
+  for (unsigned color : vertexColors) {
+    colorCount = std::max(colorCount, color + 1);
+  }
+  SmallVector<SmallVector<ItemT>> colorUsers(colorCount);
+  for (auto indexedItem : llvm::enumerate(sortedItems)) {
+    colorUsers[vertexColors[indexedItem.index()]].push_back(
+        indexedItem.value());
+  }
   return colorUsers;
 }
 

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -33,7 +33,13 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
   // still distinct and before later transformations rewrite pipe operations.
   buildTTLVerifyPipeNetPipeline(pm);
   pm.addNestedPass<func::FuncOp>(createTTLCoalesceDFBAcquires());
-  pm.addPass(createTTLFinalizeDFBIndices());
+  {
+    TTLFinalizeDFBIndicesOptions finalizeOptions;
+    finalizeOptions.reuseUserDFBs = options.reuseUserDFBs;
+    finalizeOptions.exactColoringSearchStateLimit =
+        options.exactColoringSearchStateLimit;
+    pm.addPass(createTTLFinalizeDFBIndices(finalizeOptions));
+  }
   {
     TTLSetComputeKernelConfigOptions configOpts;
     configOpts.reduceFullFp32 = options.reduceFullFp32;

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -3,9 +3,13 @@ add_mlir_dialect_library(TTLangTTLTransforms
   IntermediateDFBPlanning.cpp
   ConvertTTLToTTKernel.cpp
   DFBAcquireReleaseAnalysis.cpp
+  DFBAllocationLimits.cpp
   DFBLogicalIdentityAnalysis.cpp
   DFBValueLifetimeAnalysis.cpp
   DFBMaterialization.cpp
+  DFBConcurrentKernelLivenessAnalysis.cpp
+  DFBPhysicalAllocationPlan.cpp
+  InterferenceGraphColoring.cpp
   PipeGraph.cpp
   PipeLowering.cpp
   PipeTransferAnalysis.cpp

--- a/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.cpp
@@ -5,6 +5,7 @@
 #include "DFBAcquireReleaseAnalysis.h"
 
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/DenseMap.h"
@@ -44,8 +45,10 @@ static bool directDFBUseMatchesAcquire(DFBAcquireInterval interval,
   llvm_unreachable("unknown DFB acquire/release kind");
 }
 
-static bool isLifecycleOrAttachOp(Operation *op) {
-  return isDFBAcquireOp(op) || isDFBReleaseOp(op) || isa<AttachCBOp>(op);
+/// Returns true when a direct DFB operand does not consume an acquired slot.
+static bool isLifecycleOrIdentityOnlyOp(Operation *operation) {
+  return isDFBAcquireOp(operation) || isDFBReleaseOp(operation) ||
+         !mayAccessDFBStorage(operation);
 }
 
 /// Project `op` into the acquire block so nested regions can be ordered
@@ -141,7 +144,7 @@ getDFBAcquireReleaseKind(Operation *op) {
   return std::nullopt;
 }
 
-static int64_t getDFBLifecycleTileCount(Operation *operation) {
+int64_t getDFBLifecycleTileCount(Operation *operation) {
   if (auto numTiles = operation->getAttrOfType<IntegerAttr>("num_tiles")) {
     return numTiles.getInt();
   }
@@ -183,6 +186,7 @@ static bool operationMatchesKind(Operation *operation,
 static FailureOr<SameBlockFIFOOwnership>
 buildSameBlockFIFOOwners(func::FuncOp kernel, ArrayRef<Operation *> reserves,
                          ArrayRef<Operation *> waits,
+                         ArrayRef<Operation *> releases,
                          std::optional<DFBLifecycleDiagnostic> &diagnostic) {
   SameBlockFIFOOwnership ownership;
 
@@ -270,30 +274,32 @@ buildSameBlockFIFOOwners(func::FuncOp kernel, ArrayRef<Operation *> reserves,
           processBlock(entryBlock, DFBAcquireReleaseKind::Consumer, waits))) {
     return failure();
   }
-  kernel.walk([&](Operation *operation) {
+  for (Operation *operation : releases) {
     if (operation->getBlock() != entryBlock && isDFBReleaseOp(operation)) {
       ownership.unresolvedReleases.insert(operation);
     }
-  });
+  }
   return ownership;
 }
 
-void collectDFBAcquireReleaseOps(func::FuncOp func,
-                                 SmallVectorImpl<Operation *> &reserves,
-                                 SmallVectorImpl<Operation *> &waits,
-                                 SmallVectorImpl<Operation *> &pushes,
-                                 SmallVectorImpl<Operation *> &pops) {
+DFBAcquireReleaseOperations collectDFBAcquireReleaseOps(func::FuncOp func) {
+  DFBAcquireReleaseOperations operations;
   func.walk([&](Operation *op) {
     if (isa<CBReserveOp>(op)) {
-      reserves.push_back(op);
+      operations.reserves.push_back(op);
+      operations.acquisitions.push_back(op);
     } else if (isa<CBWaitOp>(op)) {
-      waits.push_back(op);
+      operations.waits.push_back(op);
+      operations.acquisitions.push_back(op);
     } else if (isa<CBPushOp>(op)) {
-      pushes.push_back(op);
+      operations.pushes.push_back(op);
+      operations.releases.push_back(op);
     } else if (isa<CBPopOp>(op)) {
-      pops.push_back(op);
+      operations.pops.push_back(op);
+      operations.releases.push_back(op);
     }
   });
+  return operations;
 }
 
 DFBAcquireInterval makeDFBAcquireInterval(Operation *acquire,
@@ -347,7 +353,7 @@ Operation *findLastDFBAcquireOwnedUse(DFBAcquireInterval interval) {
     if (user == interval.acquire) {
       continue;
     }
-    if (isLifecycleOrAttachOp(user)) {
+    if (isLifecycleOrIdentityOnlyOp(user)) {
       continue;
     }
     if (!directDFBUseMatchesAcquire(interval, user)) {
@@ -434,11 +440,9 @@ DFBAcquireReleaseIndex::create(func::FuncOp kernel) {
 
 LogicalResult DFBAcquireReleaseIndex::build(
     func::FuncOp kernel, std::optional<DFBLifecycleDiagnostic> &diagnostic) {
-  SmallVector<Operation *> reserves;
-  SmallVector<Operation *> waits;
-  SmallVector<Operation *> pushes;
-  SmallVector<Operation *> pops;
-  collectDFBAcquireReleaseOps(kernel, reserves, waits, pushes, pops);
+  DFBAcquireReleaseOperations operations = collectDFBAcquireReleaseOps(kernel);
+  acquisitionOrder = operations.acquisitions;
+  releaseOrder = operations.releases;
 
   auto recordTransactions = [&](ArrayRef<Operation *> acquires) {
     for (Operation *acquire : acquires) {
@@ -448,16 +452,12 @@ LogicalResult DFBAcquireReleaseIndex::build(
                                         getDFBLifecycleTileCount(acquire)});
     }
   };
-  recordTransactions(reserves);
-  recordTransactions(waits);
-  kernel.walk([&](Operation *operation) {
-    if (isDFBAcquireOp(operation)) {
-      acquisitionOrder.push_back(operation);
-    }
-  });
+  recordTransactions(operations.reserves);
+  recordTransactions(operations.waits);
 
   FailureOr<SameBlockFIFOOwnership> fifoOwnershipResult =
-      buildSameBlockFIFOOwners(kernel, reserves, waits, diagnostic);
+      buildSameBlockFIFOOwners(kernel, operations.reserves, operations.waits,
+                               operations.releases, diagnostic);
   if (failed(fifoOwnershipResult)) {
     return failure();
   }
@@ -502,15 +502,10 @@ LogicalResult DFBAcquireReleaseIndex::build(
     return success();
   };
 
-  if (failed(recordReleaseOwnership(pushes, reserves)) ||
-      failed(recordReleaseOwnership(pops, waits))) {
+  if (failed(recordReleaseOwnership(operations.pushes, operations.reserves)) ||
+      failed(recordReleaseOwnership(operations.pops, operations.waits))) {
     return failure();
   }
-  kernel.walk([&](Operation *operation) {
-    if (isDFBReleaseOp(operation)) {
-      releaseOrder.push_back(operation);
-    }
-  });
   return success();
 }
 

--- a/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBAcquireReleaseAnalysis.h
@@ -133,18 +133,27 @@ bool isDFBAcquireOp(Operation *op);
 /// Returns true for DFB release ops accepted by this analysis.
 bool isDFBReleaseOp(Operation *op);
 
+/// Returns the explicit transaction count or the DFB block size.
+int64_t getDFBLifecycleTileCount(Operation *operation);
+
 /// Returns the DFB operand of a `ttl.cb_reserve` or `ttl.cb_wait`.
 Value getDFBAcquireDFB(Operation *op);
 
 /// Returns the DFB operand of a `ttl.cb_push` or `ttl.cb_pop`.
 Value getDFBReleaseDFB(Operation *op);
 
+/// DFB lifecycle operations collected in one function traversal.
+struct DFBAcquireReleaseOperations {
+  SmallVector<Operation *> reserves;
+  SmallVector<Operation *> waits;
+  SmallVector<Operation *> pushes;
+  SmallVector<Operation *> pops;
+  SmallVector<Operation *> acquisitions;
+  SmallVector<Operation *> releases;
+};
+
 /// Collects DFB lifecycle operations from `func` in walk order.
-void collectDFBAcquireReleaseOps(func::FuncOp func,
-                                 SmallVectorImpl<Operation *> &reserves,
-                                 SmallVectorImpl<Operation *> &waits,
-                                 SmallVectorImpl<Operation *> &pushes,
-                                 SmallVectorImpl<Operation *> &pops);
+DFBAcquireReleaseOperations collectDFBAcquireReleaseOps(func::FuncOp func);
 
 /// Builds the ownership interval for `acquire`.
 ///

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
@@ -17,10 +17,9 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-static constexpr uint64_t kFallbackUsableL1Bytes =
-    static_cast<uint64_t>(1432 * 1024);
+constexpr uint64_t kFallbackUsableL1Bytes = static_cast<uint64_t>(1432 * 1024);
 
-static std::optional<uint64_t> tryBudgetFromModule(ModuleOp module) {
+std::optional<uint64_t> tryBudgetFromModule(ModuleOp module) {
   auto systemDesc = module->getAttrOfType<ttcore::SystemDescAttr>(
       ttcore::SystemDescAttr::name);
   if (!systemDesc) {
@@ -96,9 +95,10 @@ DFBAllocationFootprint::getSortedPhysicalIndices() const {
   return physicalIndices;
 }
 
-uint64_t getUsableDFBL1Bytes(ModuleOp module, uint64_t overrideBytes) {
-  if (overrideBytes > 0) {
-    return overrideBytes;
+uint64_t getUsableDFBL1Bytes(ModuleOp module,
+                             std::optional<uint64_t> overrideBytes) {
+  if (overrideBytes) {
+    return *overrideBytes;
   }
   return tryBudgetFromModule(module).value_or(kFallbackUsableL1Bytes);
 }

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
@@ -84,9 +84,9 @@ uint64_t DFBAllocationFootprint::getBytes(int64_t physicalIndex) const {
   return indexIt->second;
 }
 
-llvm::SmallVector<int64_t, 32>
+llvm::SmallVector<int64_t, kMaxCircularBuffers>
 DFBAllocationFootprint::getSortedPhysicalIndices() const {
-  llvm::SmallVector<int64_t, 32> physicalIndices;
+  llvm::SmallVector<int64_t, kMaxCircularBuffers> physicalIndices;
   physicalIndices.reserve(maxBytesByIndex.size());
   for (int64_t physicalIndex : llvm::make_first_range(maxBytesByIndex)) {
     physicalIndices.push_back(physicalIndex);

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "DFBAllocationLimits.h"
+
+#include "ttlang/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttlang/Dialect/TTCore/IR/Utils.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+#include <cassert>
+#include <optional>
+
+namespace mlir::tt::ttl {
+
+namespace {
+
+static constexpr uint64_t kFallbackUsableL1Bytes =
+    static_cast<uint64_t>(1432 * 1024);
+
+static std::optional<uint64_t> tryBudgetFromModule(ModuleOp module) {
+  auto systemDesc = module->getAttrOfType<ttcore::SystemDescAttr>(
+      ttcore::SystemDescAttr::name);
+  if (!systemDesc) {
+    return std::nullopt;
+  }
+  auto device = ttcore::lookupDeviceOp(module, ttcore::getDefaultDeviceName());
+  if (!device) {
+    return std::nullopt;
+  }
+  auto chipIds = device.getDeviceAttr().getChipIds();
+  if (chipIds.empty()) {
+    return std::nullopt;
+  }
+  return *llvm::min_element(llvm::map_range(chipIds, [&](unsigned chipId) {
+    return systemDesc.getChipDesc(chipId).getUsableL1Size();
+  }));
+}
+
+} // namespace
+
+FailureOr<uint64_t> getDFBAllocationSizeBytes(CircularBufferType type) {
+  int64_t totalElements = type.getTotalElements();
+  if (totalElements < 0) {
+    return failure();
+  }
+  Type elementType = type.getElementType();
+  uint64_t elementBytes;
+  if (auto tileType = dyn_cast<ttcore::TileType>(elementType)) {
+    elementBytes = tileType.getSizeBytes();
+  } else {
+    elementBytes = ttcore::TileType::get(elementType).getSizeBytes();
+  }
+  return static_cast<uint64_t>(totalElements) * elementBytes;
+}
+
+FailureOr<bool> DFBAllocationFootprint::add(int64_t physicalIndex,
+                                            CircularBufferType type) {
+  FailureOr<uint64_t> allocationBytes = getDFBAllocationSizeBytes(type);
+  if (failed(allocationBytes)) {
+    return failure();
+  }
+  auto indexIt = maxBytesByIndex.find(physicalIndex);
+  if (indexIt != maxBytesByIndex.end() && indexIt->second >= *allocationBytes) {
+    return false;
+  }
+  maxBytesByIndex[physicalIndex] = *allocationBytes;
+  return true;
+}
+
+uint64_t DFBAllocationFootprint::getTotalBytes() const {
+  uint64_t totalBytes = 0;
+  for (uint64_t allocationBytes : llvm::make_second_range(maxBytesByIndex)) {
+    totalBytes += allocationBytes;
+  }
+  return totalBytes;
+}
+
+uint64_t DFBAllocationFootprint::getBytes(int64_t physicalIndex) const {
+  auto indexIt = maxBytesByIndex.find(physicalIndex);
+  assert(indexIt != maxBytesByIndex.end() &&
+         "physical index must be present in the footprint");
+  return indexIt->second;
+}
+
+llvm::SmallVector<int64_t, 32>
+DFBAllocationFootprint::getSortedPhysicalIndices() const {
+  llvm::SmallVector<int64_t, 32> physicalIndices;
+  physicalIndices.reserve(maxBytesByIndex.size());
+  for (int64_t physicalIndex : llvm::make_first_range(maxBytesByIndex)) {
+    physicalIndices.push_back(physicalIndex);
+  }
+  llvm::sort(physicalIndices);
+  return physicalIndices;
+}
+
+uint64_t getUsableDFBL1Bytes(ModuleOp module, uint64_t overrideBytes) {
+  if (overrideBytes > 0) {
+    return overrideBytes;
+  }
+  return tryBudgetFromModule(module).value_or(kFallbackUsableL1Bytes);
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace mlir::tt::ttl {
 
@@ -36,7 +37,9 @@ private:
 };
 
 /// Returns the target's usable per-node L1 bytes or the supported fallback.
-uint64_t getUsableDFBL1Bytes(ModuleOp module, uint64_t overrideBytes = 0);
+uint64_t
+getUsableDFBL1Bytes(ModuleOp module,
+                    std::optional<uint64_t> overrideBytes = std::nullopt);
 
 } // namespace mlir::tt::ttl
 

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONLIMITS_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONLIMITS_H
+
+#include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+
+namespace mlir::tt::ttl {
+
+/// Returns the per-node L1 bytes occupied by one physical DFB descriptor.
+FailureOr<uint64_t> getDFBAllocationSizeBytes(CircularBufferType type);
+
+/// Per-node L1 footprint aggregated by unique physical DFB index.
+class DFBAllocationFootprint {
+public:
+  /// Adds one assignment and returns true when it increases the index size.
+  FailureOr<bool> add(int64_t physicalIndex, CircularBufferType type);
+
+  bool empty() const { return maxBytesByIndex.empty(); }
+  uint64_t getTotalBytes() const;
+  uint64_t getBytes(int64_t physicalIndex) const;
+  llvm::SmallVector<int64_t, 32> getSortedPhysicalIndices() const;
+
+private:
+  llvm::DenseMap<int64_t, uint64_t> maxBytesByIndex;
+};
+
+/// Returns the target's usable per-node L1 bytes or the supported fallback.
+uint64_t getUsableDFBL1Bytes(ModuleOp module, uint64_t overrideBytes = 0);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONLIMITS_H

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
@@ -5,6 +5,7 @@
 #ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONLIMITS_H
 #define TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONLIMITS_H
 
+#include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 
 #include "mlir/IR/BuiltinOps.h"
@@ -30,7 +31,8 @@ public:
   bool empty() const { return maxBytesByIndex.empty(); }
   uint64_t getTotalBytes() const;
   uint64_t getBytes(int64_t physicalIndex) const;
-  llvm::SmallVector<int64_t, 32> getSortedPhysicalIndices() const;
+  llvm::SmallVector<int64_t, kMaxCircularBuffers>
+  getSortedPhysicalIndices() const;
 
 private:
   llvm::DenseMap<int64_t, uint64_t> maxBytesByIndex;

--- a/lib/Dialect/TTL/Transforms/DFBAnalysisFailure.h
+++ b/lib/Dialect/TTL/Transforms/DFBAnalysisFailure.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBANALYSISFAILURE_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBANALYSISFAILURE_H
+
+#include "mlir/IR/Operation.h"
+
+#include <string>
+#include <utility>
+
+namespace mlir::tt::ttl {
+
+/// First failure discovered while computing DFB analysis or allocation results.
+///
+/// Analysis helpers do not emit diagnostics. Retaining the first failure
+/// preserves the operation that first violated the input contract.
+struct DFBAnalysisFailure {
+  Operation *operation = nullptr;
+  std::string message;
+
+  /// Records the first failure so traversal order selects diagnostics.
+  void set(Operation *failureOperation, std::string failureMessage) {
+    if (!message.empty()) {
+      return;
+    }
+    operation = failureOperation;
+    message = std::move(failureMessage);
+  }
+};
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBANALYSISFAILURE_H

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -286,11 +286,27 @@ static LogicalResult verifyCustomFunctionIndexDependency(
   return success();
 }
 
+/// Propagates through every result except a boolean predicate, which cannot be
+/// the physical index consumed by a custom function.
+static bool shouldPropagatePhysicalIndex(Value result) {
+  return !result.getType().isInteger(1);
+}
+
+/// Adds only results that may preserve or compute a physical DFB index.
+static void appendPhysicalIndexResults(Operation *operation,
+                                       SmallVectorImpl<Value> &pending) {
+  for (Value result : operation->getResults()) {
+    if (shouldPropagatePhysicalIndex(result)) {
+      pending.push_back(result);
+    }
+  }
+}
+
 /// Verifies every transitive use of one physical DFB index. Pure SSA operations
-/// propagate the dependency conservatively to all results. Calls, terminators,
-/// region-bearing operations, resultless consumers and side-effecting
-/// operations are rejected because the analysis cannot prove where the integer
-/// is consumed.
+/// propagate the dependency conservatively to index-capable results. Calls,
+/// terminators, region-bearing operations, resultless consumers and
+/// side-effecting operations are rejected because the analysis cannot prove
+/// where the integer is consumed.
 static LogicalResult
 verifyPhysicalIndexUses(GetDfbIdOp getId,
                         const DFBLogicalIdentityAnalysis &identityAnalysis,
@@ -317,7 +333,7 @@ verifyPhysicalIndexUses(GetDfbIdOp getId,
                 call, *logicalId, identityAnalysis, analysisFailure))) {
           return failure();
         }
-        pending.append(call->getResults().begin(), call->getResults().end());
+        appendPhysicalIndexResults(call, pending);
         continue;
       }
       if (isa<CallOpInterface>(consumer) ||
@@ -330,8 +346,7 @@ verifyPhysicalIndexUses(GetDfbIdOp getId,
                                 " escapes through an unsupported operation");
         return failure();
       }
-      pending.append(consumer->getResults().begin(),
-                     consumer->getResults().end());
+      appendPhysicalIndexResults(consumer, pending);
     }
   }
   return success();

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -13,6 +13,7 @@
 
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Interfaces/CallInterfaces.h"
@@ -60,22 +61,20 @@ public:
     successors[source].push_back(destination);
   }
 
-  /// Materializes transitive reachability once after all program and protocol
-  /// constraints have been recorded.
+  /// Visits each edge once per source, which avoids cubic closure on sparse
+  /// per-node program-order graphs.
   void computeReachability() {
     unsigned eventCount = successors.size();
     reachable.assign(eventCount, llvm::BitVector(eventCount));
-    for (unsigned eventIndex = 0; eventIndex < eventCount; ++eventIndex) {
-      reachable[eventIndex].set(eventIndex);
-      for (unsigned successor : successors[eventIndex]) {
-        reachable[eventIndex].set(successor);
-      }
-    }
-    for (unsigned intermediate = 0; intermediate < eventCount; ++intermediate) {
-      for (unsigned source = 0; source < eventCount; ++source) {
-        if (reachable[source].test(intermediate)) {
-          reachable[source] |= reachable[intermediate];
+    for (unsigned source = 0; source < eventCount; ++source) {
+      SmallVector<unsigned> pending = {source};
+      while (!pending.empty()) {
+        unsigned event = pending.pop_back_val();
+        if (reachable[source].test(event)) {
+          continue;
         }
+        reachable[source].set(event);
+        pending.append(successors[event].begin(), successors[event].end());
       }
     }
   }
@@ -286,20 +285,14 @@ static LogicalResult verifyCustomFunctionIndexDependency(
   return success();
 }
 
-/// Propagates through every result except a boolean predicate, which cannot be
-/// the physical index consumed by a custom function.
-static bool shouldPropagatePhysicalIndex(Value result) {
-  return !result.getType().isInteger(1);
-}
-
-/// Adds only results that may preserve or compute a physical DFB index.
+/// Integer comparisons derive predicates from an index rather than another
+/// index value. Every other pure result remains conservative.
 static void appendPhysicalIndexResults(Operation *operation,
                                        SmallVectorImpl<Value> &pending) {
-  for (Value result : operation->getResults()) {
-    if (shouldPropagatePhysicalIndex(result)) {
-      pending.push_back(result);
-    }
+  if (isa<arith::CmpIOp>(operation)) {
+    return;
   }
+  pending.append(operation->result_begin(), operation->result_end());
 }
 
 /// Verifies every transitive use of one physical DFB index. Pure SSA operations

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -15,6 +15,8 @@
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -30,13 +32,19 @@ namespace mlir::tt::ttl {
 
 namespace {
 
+/// Entry and completion events keep operation duration distinct from source
+/// order and protocol completion edges.
 struct EventPair {
   unsigned entry = 0;
   unsigned completion = 0;
 };
 
+/// Represents only ordering proved for one launch node. Cyclic reachability is
+/// deliberately not treated as strict order.
 class HappensBeforeGraph {
 public:
+  /// Creates distinct entry and completion events so later constraints may
+  /// order either execution or completion.
   EventPair addOperation() {
     unsigned entry = successors.size();
     successors.emplace_back();
@@ -46,11 +54,14 @@ public:
     return {entry, completion};
   }
 
+  /// Records one proved ordering constraint without inferring its converse.
   void addEdge(unsigned source, unsigned destination) {
     assert(source < successors.size() && destination < successors.size());
     successors[source].push_back(destination);
   }
 
+  /// Materializes transitive reachability once after all program and protocol
+  /// constraints have been recorded.
   void computeReachability() {
     unsigned eventCount = successors.size();
     reachable.assign(eventCount, llvm::BitVector(eventCount));
@@ -69,6 +80,8 @@ public:
     }
   }
 
+  /// Requires asymmetric reachability because mutually reachable events do
+  /// not establish a safe lifetime order.
   bool strictlyPrecedes(unsigned source, unsigned destination) const {
     assert(source < reachable.size() && destination < reachable.size());
     return source != destination && reachable[source].test(destination) &&
@@ -80,15 +93,30 @@ private:
   SmallVector<llvm::BitVector> reachable;
 };
 
+/// Associates a storage access with its computed launch domain and the
+/// operation that prevented a precise result, when applicable.
 struct AccessDomain {
   LaunchNodeDomain domain = LaunchNodeDomain::unknown();
   Operation *unanalyzableOperation = nullptr;
 };
 
+/// Retains access-domain results from the shared launch-domain analysis.
 struct LivenessDomainState : LaunchNodeDomainState {
   DenseMap<Operation *, AccessDomain> accessDomains;
 };
 
+/// Identifies attributes that copy a provisional physical DFB index and would
+/// become stale after allocation changes declaration indices.
+static bool isDerivedDFBIndexAttribute(StringRef attributeName) {
+  return attributeName == kUnpackToDestFp32AttrName ||
+         attributeName.starts_with(kCBIndexAttrPrefix) ||
+         attributeName == kBcastOutputCBIndexAttrName ||
+         attributeName == kReduceOutputCBIndexAttrName ||
+         attributeName == kTransposeOutputCBIndexAttrName;
+}
+
+/// Classifies unknown storage users as opaque so they extend liveness instead
+/// of being ignored.
 static DFBProtocolEffect classifyEffect(Operation *operation) {
   if (isa<CBReserveOp>(operation)) {
     return DFBProtocolEffect::Reserve;
@@ -105,15 +133,22 @@ static DFBProtocolEffect classifyEffect(Operation *operation) {
   return DFBProtocolEffect::OpaqueAccess;
 }
 
+/// Reserve and push must resolve to one producer-side owner before reuse can
+/// preserve write-pointer progression.
 static bool effectAdvancesWritePointer(DFBProtocolEffect effect) {
   return effect == DFBProtocolEffect::Reserve ||
          effect == DFBProtocolEffect::Push;
 }
 
+/// Wait and pop must resolve to one consumer-side owner before reuse can
+/// preserve read-pointer progression.
 static bool effectAdvancesReadPointer(DFBProtocolEffect effect) {
   return effect == DFBProtocolEffect::Wait || effect == DFBProtocolEffect::Pop;
 }
 
+/// Resolves the hardware pointer owner only from explicit kernel semantics.
+/// Missing or invalid ownership attributes remain unknown because assuming a
+/// processor could permit unsafe physical-index reuse.
 static std::optional<DFBPointerOwner>
 getPointerOwner(Operation *operation, LaunchNodeCoord node,
                 DFBProtocolEffect effect) {
@@ -143,7 +178,11 @@ getPointerOwner(Operation *operation, LaunchNodeCoord node,
   if (thread.getValue() != ttkernel::ThreadType::Noc) {
     return std::nullopt;
   }
-  int64_t nocIndex = getNocIndex(operation);
+  auto nocIndexAttr = kernel->getAttrOfType<IntegerAttr>(kNocIndexAttrName);
+  if (!nocIndexAttr) {
+    return std::nullopt;
+  }
+  int64_t nocIndex = nocIndexAttr.getInt();
   if (nocIndex != 0 && nocIndex != 1) {
     return std::nullopt;
   }
@@ -152,6 +191,8 @@ getPointerOwner(Operation *operation, LaunchNodeCoord node,
   return DFBPointerOwner{node, processor, direction};
 }
 
+/// Projects nested accesses to their containing top-level operation because
+/// the graph models only source order that is unconditional at that level.
 static Operation *getTopLevelKernelOperation(Operation *operation) {
   func::FuncOp function = operation->getParentOfType<func::FuncOp>();
   if (!function || function.getBody().empty() ||
@@ -164,6 +205,8 @@ static Operation *getTopLevelKernelOperation(Operation *operation) {
              : functionBody.findAncestorOpInBlock(*operation);
 }
 
+/// Missing projected events remain unknown because nested source order alone
+/// cannot establish cross-region execution order.
 static std::optional<EventPair>
 getProjectedEvents(Operation *operation,
                    const DenseMap<Operation *, EventPair> &operationEvents) {
@@ -177,6 +220,8 @@ getProjectedEvents(Operation *operation,
              : std::optional<EventPair>(eventIt->second);
 }
 
+/// Requires a release to follow every use owned by its acquisition; textual
+/// acquire/release order alone does not prove storage quiescence.
 static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release) {
   if (acquire->getBlock() != release->getBlock()) {
     return false;
@@ -187,6 +232,8 @@ static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release) {
   return lastOwnedUse == acquire || lastOwnedUse->isBeforeInBlock(release);
 }
 
+/// Finds every access without a proved predecessor so all possible lifetime
+/// starts constrain reuse.
 static SmallVector<Operation *>
 findMinimalOperations(ArrayRef<Operation *> operations,
                       const HappensBeforeGraph &graph,
@@ -211,53 +258,88 @@ findMinimalOperations(ArrayRef<Operation *> operations,
   return minimal;
 }
 
-static LogicalResult verifyCustomFunctionIndexDependencies(
-    OpaqueCallOp call, const DFBLogicalIdentityAnalysis &identityAnalysis,
+/// Requires a custom function that consumes a physical index to name the same
+/// logical DFB as a direct storage dependency.
+static LogicalResult verifyCustomFunctionIndexDependency(
+    OpaqueCallOp call, int64_t logicalId,
+    const DFBLogicalIdentityAnalysis &identityAnalysis,
     DFBAnalysisFailure &analysisFailure) {
   SmallVector<int64_t> dependencyIds;
   for (Value operand : call.getArgOperands()) {
     if (!isa<CircularBufferType>(operand.getType())) {
       continue;
     }
-    FailureOr<int64_t> logicalId = identityAnalysis.getLogicalId(operand);
-    if (succeeded(logicalId)) {
-      dependencyIds.push_back(*logicalId);
+    FailureOr<int64_t> dependencyLogicalId =
+        identityAnalysis.getLogicalId(operand);
+    if (succeeded(dependencyLogicalId)) {
+      dependencyIds.push_back(*dependencyLogicalId);
     }
   }
 
-  auto verifyIndexDependency = [&](Value operand) {
-    auto getId = operand.getDefiningOp<GetDfbIdOp>();
-    if (!getId) {
-      return success();
-    }
-    FailureOr<int64_t> logicalId =
-        identityAnalysis.getLogicalId(getId.getDfb());
-    if (failed(logicalId)) {
-      return success();
-    }
-    if (!llvm::is_contained(dependencyIds, *logicalId)) {
-      analysisFailure.set(
-          call, "custom function consumes the physical index for logical DFB " +
-                    std::to_string(*logicalId) +
-                    " without listing that DFB as a dependency operand");
-      return failure();
-    }
-    return success();
-  };
-
-  for (Value operand : call.getTemplateArgVals()) {
-    if (failed(verifyIndexDependency(operand))) {
-      return failure();
-    }
+  if (!llvm::is_contained(dependencyIds, logicalId)) {
+    analysisFailure.set(
+        call, "custom function consumes the physical index for logical DFB " +
+                  std::to_string(logicalId) +
+                  " without listing that DFB as a dependency operand");
+    return failure();
   }
-  for (Value operand : call.getArgOperands()) {
-    if (failed(verifyIndexDependency(operand))) {
-      return failure();
+  return success();
+}
+
+/// Verifies every transitive use of one physical DFB index. Pure SSA operations
+/// propagate the dependency conservatively to all results. Calls, terminators,
+/// region-bearing operations, resultless consumers and side-effecting
+/// operations are rejected because the analysis cannot prove where the integer
+/// is consumed.
+static LogicalResult
+verifyPhysicalIndexUses(GetDfbIdOp getId,
+                        const DFBLogicalIdentityAnalysis &identityAnalysis,
+                        DFBAnalysisFailure &analysisFailure) {
+  FailureOr<int64_t> logicalId = identityAnalysis.getLogicalId(getId.getDfb());
+  if (failed(logicalId)) {
+    analysisFailure.set(
+        getId, "ttl.get_dfb_id operand must resolve to a logical DFB before "
+               "physical index allocation");
+    return failure();
+  }
+
+  SmallVector<Value> pending = {getId.getResult()};
+  DenseSet<Value> visited;
+  while (!pending.empty()) {
+    Value value = pending.pop_back_val();
+    if (!visited.insert(value).second) {
+      continue;
+    }
+    for (OpOperand &use : value.getUses()) {
+      Operation *consumer = use.getOwner();
+      if (auto call = dyn_cast<OpaqueCallOp>(consumer)) {
+        if (failed(verifyCustomFunctionIndexDependency(
+                call, *logicalId, identityAnalysis, analysisFailure))) {
+          return failure();
+        }
+        pending.append(call->getResults().begin(), call->getResults().end());
+        continue;
+      }
+      if (isa<CallOpInterface>(consumer) ||
+          consumer->hasTrait<OpTrait::IsTerminator>() ||
+          consumer->getNumRegions() != 0 || consumer->getNumResults() == 0 ||
+          !isPure(consumer)) {
+        analysisFailure.set(consumer,
+                            "physical index for logical DFB " +
+                                std::to_string(*logicalId) +
+                                " escapes through an unsupported operation");
+        return failure();
+      }
+      pending.append(consumer->getResults().begin(),
+                     consumer->getResults().end());
     }
   }
   return success();
 }
 
+/// Collects logical DFB declarations and storage accesses in one module walk.
+/// Stale copied indices, malformed identities, and untracked physical-index
+/// escapes are rejected before launch-domain or lifetime analysis begins.
 static LogicalResult collectLogicalDFBs(
     ModuleOp module, const DFBLogicalIdentityAnalysis &identityAnalysis,
     SmallVectorImpl<DFBLogicalLifecycle> &logicalDFBs,
@@ -285,12 +367,26 @@ static LogicalResult collectLogicalDFBs(
   }
 
   WalkResult collectionResult = module.walk([&](Operation *operation) {
+    for (NamedAttribute attribute : operation->getAttrs()) {
+      StringRef attributeName = attribute.getName().getValue();
+      if (!isDerivedDFBIndexAttribute(attributeName)) {
+        continue;
+      }
+      analysisFailure.set(
+          operation,
+          ("contains derived DFB-index attribute '" + attributeName +
+           "' before DFB index finalization; run ttl-finalize-dfb-indices "
+           "before ttl-set-compute-kernel-config and "
+           "ttl-annotate-cb-associations")
+              .str());
+      return WalkResult::interrupt();
+    }
     dependsOnLaunchNode |=
         isa<CoreXOp, CoreYOp, CreatePipeOp, PipeNetPredicateOpInterface>(
             operation);
-    if (auto call = dyn_cast<OpaqueCallOp>(operation);
-        call && failed(verifyCustomFunctionIndexDependencies(
-                    call, identityAnalysis, analysisFailure))) {
+    if (auto getId = dyn_cast<GetDfbIdOp>(operation);
+        getId && failed(verifyPhysicalIndexUses(getId, identityAnalysis,
+                                                analysisFailure))) {
       return WalkResult::interrupt();
     }
     if (!mayAccessDFBStorage(operation)) {
@@ -358,6 +454,8 @@ static LogicalResult collectLogicalDFBs(
   return success();
 }
 
+/// Builds source-order events only for accesses active on `node`. Operations
+/// in different kernels remain concurrent unless protocol edges order them.
 static void
 buildProgramOrderGraph(ModuleOp module,
                        ArrayRef<DFBLogicalLifecycle> logicalDFBs,
@@ -393,6 +491,9 @@ buildProgramOrderGraph(ModuleOp module,
   }
 }
 
+/// Derives the immutable per-node lifetime facts required for reuse. Any
+/// unsupported or ambiguous protocol fact returns a typed failed proof, which
+/// can only add conflicts.
 static DFBQuiescenceProof
 computePerNodeLifetime(DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
                        const HappensBeforeGraph &graph,
@@ -509,6 +610,8 @@ computePerNodeLifetime(DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
   return {};
 }
 
+/// Proves non-overlap only when every possible end of `before` strictly
+/// precedes every possible start of `after`.
 static bool
 proveOrderedBefore(const DFBPerNodeLifetime &before,
                    const DFBPerNodeLifetime &after,
@@ -533,6 +636,8 @@ proveOrderedBefore(const DFBPerNodeLifetime &before,
 
 } // namespace
 
+// Per-node facts are stored on each logical lifecycle because the conflict
+// model must compare identical logical DFBs across all shared launch nodes.
 const DFBPerNodeLifetime *
 DFBLogicalLifecycle::findNodeLifetime(LaunchNodeCoord node) const {
   auto lifetimeIt = llvm::find_if(nodeLifetimes, [&](const auto &lifetime) {
@@ -541,6 +646,8 @@ DFBLogicalLifecycle::findNodeLifetime(LaunchNodeCoord node) const {
   return lifetimeIt == nodeLifetimes.end() ? nullptr : &*lifetimeIt;
 }
 
+// Logical identity is obtained through the analysis manager so every lifetime
+// uses the same declaration aggregation as physical allocation.
 DFBConcurrentKernelLivenessAnalysis::DFBConcurrentKernelLivenessAnalysis(
     Operation *operation, AnalysisManager &analysisManager) {
   const DFBLogicalIdentityAnalysis &identityAnalysis =
@@ -553,6 +660,8 @@ DFBConcurrentKernelLivenessAnalysis::DFBConcurrentKernelLivenessAnalysis(
   analyze(operation, identityAnalysis);
 }
 
+// Completes validation and immutable fact construction before the finalizer
+// mutates any DFB index or derived attribute.
 void DFBConcurrentKernelLivenessAnalysis::analyze(
     Operation *operation, const DFBLogicalIdentityAnalysis &identityAnalysis) {
   ModuleOp module = cast<ModuleOp>(operation);
@@ -701,6 +810,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   }
 }
 
+// The planner queries cached reachability so allocation cannot depend on a
+// second IR traversal or on later mutation order.
 bool DFBConcurrentKernelLivenessAnalysis::isOrderedBefore(
     unsigned beforeIndex, unsigned afterIndex, LaunchNodeCoord node) const {
   auto nodeIt = llvm::find(launchNodes, node);

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1,0 +1,714 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "DFBConcurrentKernelLivenessAnalysis.h"
+
+#include "DFBAcquireReleaseAnalysis.h"
+#include "DFBAnalysisFailure.h"
+#include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+
+#include "mlir/Analysis/DataFlow/Utils.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Operation.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+
+namespace mlir::tt::ttl {
+
+namespace {
+
+struct EventPair {
+  unsigned entry = 0;
+  unsigned completion = 0;
+};
+
+class HappensBeforeGraph {
+public:
+  EventPair addOperation() {
+    unsigned entry = successors.size();
+    successors.emplace_back();
+    unsigned completion = successors.size();
+    successors.emplace_back();
+    addEdge(entry, completion);
+    return {entry, completion};
+  }
+
+  void addEdge(unsigned source, unsigned destination) {
+    assert(source < successors.size() && destination < successors.size());
+    successors[source].push_back(destination);
+  }
+
+  void computeReachability() {
+    unsigned eventCount = successors.size();
+    reachable.assign(eventCount, llvm::BitVector(eventCount));
+    for (unsigned eventIndex = 0; eventIndex < eventCount; ++eventIndex) {
+      reachable[eventIndex].set(eventIndex);
+      for (unsigned successor : successors[eventIndex]) {
+        reachable[eventIndex].set(successor);
+      }
+    }
+    for (unsigned intermediate = 0; intermediate < eventCount; ++intermediate) {
+      for (unsigned source = 0; source < eventCount; ++source) {
+        if (reachable[source].test(intermediate)) {
+          reachable[source] |= reachable[intermediate];
+        }
+      }
+    }
+  }
+
+  bool strictlyPrecedes(unsigned source, unsigned destination) const {
+    assert(source < reachable.size() && destination < reachable.size());
+    return source != destination && reachable[source].test(destination) &&
+           !reachable[destination].test(source);
+  }
+
+private:
+  SmallVector<SmallVector<unsigned>> successors;
+  SmallVector<llvm::BitVector> reachable;
+};
+
+struct AccessDomain {
+  LaunchNodeDomain domain = LaunchNodeDomain::unknown();
+  Operation *unanalyzableOperation = nullptr;
+};
+
+struct LivenessDomainState : LaunchNodeDomainState {
+  DenseMap<Operation *, AccessDomain> accessDomains;
+};
+
+static DFBProtocolEffect classifyEffect(Operation *operation) {
+  if (isa<CBReserveOp>(operation)) {
+    return DFBProtocolEffect::Reserve;
+  }
+  if (isa<CBPushOp>(operation)) {
+    return DFBProtocolEffect::Push;
+  }
+  if (isa<CBWaitOp>(operation)) {
+    return DFBProtocolEffect::Wait;
+  }
+  if (isa<CBPopOp>(operation)) {
+    return DFBProtocolEffect::Pop;
+  }
+  return DFBProtocolEffect::OpaqueAccess;
+}
+
+static bool effectAdvancesWritePointer(DFBProtocolEffect effect) {
+  return effect == DFBProtocolEffect::Reserve ||
+         effect == DFBProtocolEffect::Push;
+}
+
+static bool effectAdvancesReadPointer(DFBProtocolEffect effect) {
+  return effect == DFBProtocolEffect::Wait || effect == DFBProtocolEffect::Pop;
+}
+
+static std::optional<DFBPointerOwner>
+getPointerOwner(Operation *operation, LaunchNodeCoord node,
+                DFBProtocolEffect effect) {
+  if (!effectAdvancesWritePointer(effect) &&
+      !effectAdvancesReadPointer(effect)) {
+    return std::nullopt;
+  }
+  func::FuncOp kernel = operation->getParentOfType<func::FuncOp>();
+  if (!kernel) {
+    return std::nullopt;
+  }
+  auto thread =
+      kernel->getAttrOfType<ttkernel::ThreadTypeAttr>(kKernelThreadAttrName);
+  if (!thread) {
+    return std::nullopt;
+  }
+
+  DFBPointerDirection direction = effectAdvancesWritePointer(effect)
+                                      ? DFBPointerDirection::Write
+                                      : DFBPointerDirection::Read;
+  if (thread.getValue() == ttkernel::ThreadType::Compute) {
+    DFBPointerProcessor processor = direction == DFBPointerDirection::Write
+                                        ? DFBPointerProcessor::Pack
+                                        : DFBPointerProcessor::Unpack;
+    return DFBPointerOwner{node, processor, direction};
+  }
+  if (thread.getValue() != ttkernel::ThreadType::Noc) {
+    return std::nullopt;
+  }
+  int64_t nocIndex = getNocIndex(operation);
+  if (nocIndex != 0 && nocIndex != 1) {
+    return std::nullopt;
+  }
+  DFBPointerProcessor processor =
+      nocIndex == 0 ? DFBPointerProcessor::Noc0 : DFBPointerProcessor::Noc1;
+  return DFBPointerOwner{node, processor, direction};
+}
+
+static Operation *getTopLevelKernelOperation(Operation *operation) {
+  func::FuncOp function = operation->getParentOfType<func::FuncOp>();
+  if (!function || function.getBody().empty() ||
+      !function.getBody().hasOneBlock()) {
+    return nullptr;
+  }
+  Block &functionBody = function.getBody().front();
+  return operation->getBlock() == &functionBody
+             ? operation
+             : functionBody.findAncestorOpInBlock(*operation);
+}
+
+static std::optional<EventPair>
+getProjectedEvents(Operation *operation,
+                   const DenseMap<Operation *, EventPair> &operationEvents) {
+  Operation *projected = getTopLevelKernelOperation(operation);
+  if (!projected) {
+    return std::nullopt;
+  }
+  auto eventIt = operationEvents.find(projected);
+  return eventIt == operationEvents.end()
+             ? std::nullopt
+             : std::optional<EventPair>(eventIt->second);
+}
+
+static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release) {
+  if (acquire->getBlock() != release->getBlock()) {
+    return false;
+  }
+  SmallVector<Operation *> acquires = {acquire};
+  DFBAcquireInterval interval = makeDFBAcquireInterval(acquire, acquires);
+  Operation *lastOwnedUse = findLastDFBAcquireOwnedUse(interval);
+  return lastOwnedUse == acquire || lastOwnedUse->isBeforeInBlock(release);
+}
+
+static SmallVector<Operation *>
+findMinimalOperations(ArrayRef<Operation *> operations,
+                      const HappensBeforeGraph &graph,
+                      const DenseMap<Operation *, EventPair> &operationEvents) {
+  SmallVector<Operation *> minimal;
+  for (Operation *candidate : operations) {
+    std::optional<EventPair> candidateEvents =
+        getProjectedEvents(candidate, operationEvents);
+    if (!candidateEvents) {
+      continue;
+    }
+    bool hasPredecessor = llvm::any_of(operations, [&](Operation *other) {
+      std::optional<EventPair> otherEvents =
+          getProjectedEvents(other, operationEvents);
+      return otherEvents &&
+             graph.strictlyPrecedes(otherEvents->entry, candidateEvents->entry);
+    });
+    if (!hasPredecessor && !llvm::is_contained(minimal, candidate)) {
+      minimal.push_back(candidate);
+    }
+  }
+  return minimal;
+}
+
+static LogicalResult verifyCustomFunctionIndexDependencies(
+    OpaqueCallOp call, const DFBLogicalIdentityAnalysis &identityAnalysis,
+    DFBAnalysisFailure &analysisFailure) {
+  SmallVector<int64_t> dependencyIds;
+  for (Value operand : call.getArgOperands()) {
+    if (!isa<CircularBufferType>(operand.getType())) {
+      continue;
+    }
+    FailureOr<int64_t> logicalId = identityAnalysis.getLogicalId(operand);
+    if (succeeded(logicalId)) {
+      dependencyIds.push_back(*logicalId);
+    }
+  }
+
+  auto verifyIndexDependency = [&](Value operand) {
+    auto getId = operand.getDefiningOp<GetDfbIdOp>();
+    if (!getId) {
+      return success();
+    }
+    FailureOr<int64_t> logicalId =
+        identityAnalysis.getLogicalId(getId.getDfb());
+    if (failed(logicalId)) {
+      return success();
+    }
+    if (!llvm::is_contained(dependencyIds, *logicalId)) {
+      analysisFailure.set(
+          call, "custom function consumes the physical index for logical DFB " +
+                    std::to_string(*logicalId) +
+                    " without listing that DFB as a dependency operand");
+      return failure();
+    }
+    return success();
+  };
+
+  for (Value operand : call.getTemplateArgVals()) {
+    if (failed(verifyIndexDependency(operand))) {
+      return failure();
+    }
+  }
+  for (Value operand : call.getArgOperands()) {
+    if (failed(verifyIndexDependency(operand))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+static LogicalResult collectLogicalDFBs(
+    ModuleOp module, const DFBLogicalIdentityAnalysis &identityAnalysis,
+    SmallVectorImpl<DFBLogicalLifecycle> &logicalDFBs,
+    DFBAnalysisFailure &analysisFailure, bool &dependsOnLaunchNode) {
+  llvm::MapVector<int64_t, unsigned> logicalIndexById;
+  for (const DFBLogicalIdentityAssignment &assignment :
+       identityAnalysis.getAssignments()) {
+    BindCBOp declaration = assignment.declaration;
+    int64_t logicalId = assignment.logicalId;
+    auto [logicalIt, inserted] =
+        logicalIndexById.insert({logicalId, logicalDFBs.size()});
+    unsigned logicalIndex = logicalIt->second;
+    if (inserted) {
+      DFBLogicalLifecycle logicalDFB;
+      logicalDFB.logicalId = logicalId;
+      logicalDFB.type = declaration.getResult().getType();
+      logicalDFB.compilerCreated =
+          declaration->hasAttr(kCompilerAllocatedAttrName);
+      logicalDFBs.push_back(std::move(logicalDFB));
+    } else {
+      logicalDFBs[logicalIndex].compilerCreated &=
+          declaration->hasAttr(kCompilerAllocatedAttrName);
+    }
+    logicalDFBs[logicalIndex].declarations.push_back(declaration);
+  }
+
+  WalkResult collectionResult = module.walk([&](Operation *operation) {
+    dependsOnLaunchNode |=
+        isa<CoreXOp, CoreYOp, CreatePipeOp, PipeNetPredicateOpInterface>(
+            operation);
+    if (auto call = dyn_cast<OpaqueCallOp>(operation);
+        call && failed(verifyCustomFunctionIndexDependencies(
+                    call, identityAnalysis, analysisFailure))) {
+      return WalkResult::interrupt();
+    }
+    if (!mayAccessDFBStorage(operation)) {
+      return WalkResult::advance();
+    }
+    SmallVector<unsigned> operationLogicalIndices;
+    for (Value operand : operation->getOperands()) {
+      if (!isa<CircularBufferType>(operand.getType())) {
+        continue;
+      }
+      FailureOr<int64_t> logicalId = identityAnalysis.getLogicalId(operand);
+      if (failed(logicalId)) {
+        analysisFailure.set(
+            operation,
+            "DFB operand must resolve to ttl.bind_cb before physical index "
+            "allocation");
+        return WalkResult::interrupt();
+      }
+      auto logicalIt = logicalIndexById.find(*logicalId);
+      assert(logicalIt != logicalIndexById.end());
+      if (!llvm::is_contained(operationLogicalIndices, logicalIt->second)) {
+        operationLogicalIndices.push_back(logicalIt->second);
+      }
+    }
+    for (unsigned logicalIndex : operationLogicalIndices) {
+      logicalDFBs[logicalIndex].accesses.push_back(
+          {operation, classifyEffect(operation), LaunchNodeDomain::unknown(),
+           nullptr});
+    }
+    return WalkResult::advance();
+  });
+  if (collectionResult.wasInterrupted()) {
+    return failure();
+  }
+
+  for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    if (!logicalDFB.compilerCreated || logicalDFB.accesses.empty()) {
+      continue;
+    }
+    auto hasEffect = [&](DFBProtocolEffect effect) {
+      return llvm::any_of(logicalDFB.accesses,
+                          [&](const DFBAccessOccurrence &access) {
+                            return access.effect == effect;
+                          });
+    };
+    StringRef missingOperation;
+    if (!hasEffect(DFBProtocolEffect::Reserve)) {
+      missingOperation = "ttl.cb_reserve";
+    } else if (!hasEffect(DFBProtocolEffect::Push)) {
+      missingOperation = "ttl.cb_push";
+    } else if (!hasEffect(DFBProtocolEffect::Wait)) {
+      missingOperation = "ttl.cb_wait";
+    } else if (!hasEffect(DFBProtocolEffect::Pop)) {
+      missingOperation = "ttl.cb_pop";
+    } else {
+      continue;
+    }
+    analysisFailure.set(
+        logicalDFB.declarations.front(),
+        ("compiler-allocated logical DFB has a partial lifecycle: missing " +
+         missingOperation)
+            .str());
+    return failure();
+  }
+  return success();
+}
+
+static void
+buildProgramOrderGraph(ModuleOp module,
+                       ArrayRef<DFBLogicalLifecycle> logicalDFBs,
+                       LaunchNodeCoord node, HappensBeforeGraph &graph,
+                       DenseMap<Operation *, EventPair> &operationEvents) {
+  llvm::DenseSet<Operation *> modeledOperations;
+  for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+      if (!knownLaunchNodeDomainContains(access.launchDomain, node)) {
+        continue;
+      }
+      if (Operation *projected = getTopLevelKernelOperation(access.operation)) {
+        modeledOperations.insert(projected);
+      }
+    }
+  }
+  for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+    if (function.getBody().empty() || !function.getBody().hasOneBlock()) {
+      continue;
+    }
+    std::optional<EventPair> previousEvents;
+    for (Operation &operation : function.getBody().front()) {
+      if (!modeledOperations.contains(&operation)) {
+        continue;
+      }
+      EventPair events = graph.addOperation();
+      operationEvents[&operation] = events;
+      if (previousEvents) {
+        graph.addEdge(previousEvents->completion, events.entry);
+      }
+      previousEvents = events;
+    }
+  }
+}
+
+static DFBQuiescenceProof
+computePerNodeLifetime(DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
+                       const HappensBeforeGraph &graph,
+                       const DenseMap<Operation *, EventPair> &operationEvents,
+                       const LaunchNodeDomainState &domainState) {
+  DFBPerNodeLifetime &lifetime = logicalDFB.nodeLifetimes.emplace_back();
+  lifetime.node = node;
+  SmallVector<Operation *> reserves;
+  SmallVector<Operation *> pushes;
+  SmallVector<Operation *> waits;
+  SmallVector<Operation *> pops;
+  SmallVector<Operation *> activeOperations;
+  for (auto [accessIndex, access] : llvm::enumerate(logicalDFB.accesses)) {
+    if (!knownLaunchNodeDomainContains(access.launchDomain, node)) {
+      continue;
+    }
+    lifetime.occurrenceIndices.push_back(accessIndex);
+    activeOperations.push_back(access.operation);
+    switch (access.effect) {
+    case DFBProtocolEffect::Reserve:
+      reserves.push_back(access.operation);
+      break;
+    case DFBProtocolEffect::Push:
+      pushes.push_back(access.operation);
+      break;
+    case DFBProtocolEffect::Wait:
+      waits.push_back(access.operation);
+      break;
+    case DFBProtocolEffect::Pop:
+      pops.push_back(access.operation);
+      break;
+    case DFBProtocolEffect::OpaqueAccess:
+      break;
+    }
+  }
+
+  if (reserves.empty() || pushes.empty() || waits.empty() || pops.empty()) {
+    return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+            activeOperations.empty() ? logicalDFB.declarations.front()
+                                     : activeOperations.front()};
+  }
+  if (reserves.size() != 1 || pushes.size() != 1 || waits.size() != 1 ||
+      pops.size() != 1) {
+    return {DFBQuiescenceFailureReason::RepeatedProtocolEffect,
+            activeOperations.front()};
+  }
+
+  Operation *reserve = reserves.front();
+  Operation *push = pushes.front();
+  Operation *wait = waits.front();
+  Operation *pop = pops.front();
+  for (Operation *protocolOperation : {reserve, push, wait, pop}) {
+    std::optional<std::uint64_t> executionCount =
+        getExactExecutionCountAtLaunchNode(protocolOperation, node,
+                                           domainState);
+    if (!executionCount || *executionCount != 1) {
+      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+              protocolOperation};
+    }
+  }
+  if (reserve->getBlock() != push->getBlock() ||
+      wait->getBlock() != pop->getBlock() || !reserve->isBeforeInBlock(push) ||
+      !wait->isBeforeInBlock(pop) || !releaseFollowsOwnedUses(reserve, push) ||
+      !releaseFollowsOwnedUses(wait, pop)) {
+    return {DFBQuiescenceFailureReason::IncompleteUseOrder, pop};
+  }
+
+  int64_t transactionTileCount = getDFBLifecycleTileCount(reserve);
+  int64_t physicalTileCount =
+      cast<CircularBufferType>(logicalDFB.type).getTotalElements();
+  if (transactionTileCount <= 0 || physicalTileCount <= 0 ||
+      physicalTileCount % transactionTileCount != 0 ||
+      transactionTileCount != getDFBLifecycleTileCount(push) ||
+      transactionTileCount != getDFBLifecycleTileCount(wait) ||
+      transactionTileCount != getDFBLifecycleTileCount(pop)) {
+    return {DFBQuiescenceFailureReason::MismatchedTransaction, reserve};
+  }
+  lifetime.transactionTileCount = transactionTileCount;
+
+  std::optional<DFBPointerOwner> reserveOwner =
+      getPointerOwner(reserve, node, DFBProtocolEffect::Reserve);
+  std::optional<DFBPointerOwner> pushOwner =
+      getPointerOwner(push, node, DFBProtocolEffect::Push);
+  std::optional<DFBPointerOwner> waitOwner =
+      getPointerOwner(wait, node, DFBProtocolEffect::Wait);
+  std::optional<DFBPointerOwner> popOwner =
+      getPointerOwner(pop, node, DFBProtocolEffect::Pop);
+  if (!reserveOwner || !pushOwner || !waitOwner || !popOwner ||
+      *reserveOwner != *pushOwner || *waitOwner != *popOwner) {
+    return {DFBQuiescenceFailureReason::UnknownPointerOwner, reserve};
+  }
+  lifetime.writePointerOwner = reserveOwner;
+  lifetime.readPointerOwner = waitOwner;
+
+  std::optional<EventPair> popEvents = getProjectedEvents(pop, operationEvents);
+  if (!popEvents) {
+    return {DFBQuiescenceFailureReason::UnsupportedControlFlow, pop};
+  }
+  for (Operation *activeOperation : activeOperations) {
+    std::optional<EventPair> useEvents =
+        getProjectedEvents(activeOperation, operationEvents);
+    if (!useEvents || (useEvents->completion != popEvents->completion &&
+                       !graph.strictlyPrecedes(useEvents->completion,
+                                               popEvents->completion))) {
+      return {DFBQuiescenceFailureReason::IncompleteUseOrder, activeOperation};
+    }
+  }
+  lifetime.earliestOperations =
+      findMinimalOperations(activeOperations, graph, operationEvents);
+  lifetime.terminalOperations = {pop};
+  if (lifetime.earliestOperations.empty()) {
+    return {DFBQuiescenceFailureReason::IncompleteUseOrder, pop};
+  }
+  return {};
+}
+
+static bool
+proveOrderedBefore(const DFBPerNodeLifetime &before,
+                   const DFBPerNodeLifetime &after,
+                   const HappensBeforeGraph &graph,
+                   const DenseMap<Operation *, EventPair> &operationEvents) {
+  if (!before.quiescence.proven() || !after.quiescence.proven()) {
+    return false;
+  }
+  return llvm::all_of(before.terminalOperations, [&](Operation *terminal) {
+    std::optional<EventPair> terminalEvents =
+        getProjectedEvents(terminal, operationEvents);
+    return terminalEvents &&
+           llvm::all_of(after.earliestOperations, [&](Operation *earliest) {
+             std::optional<EventPair> earliestEvents =
+                 getProjectedEvents(earliest, operationEvents);
+             return earliestEvents &&
+                    graph.strictlyPrecedes(terminalEvents->completion,
+                                           earliestEvents->entry);
+           });
+  });
+}
+
+} // namespace
+
+const DFBPerNodeLifetime *
+DFBLogicalLifecycle::findNodeLifetime(LaunchNodeCoord node) const {
+  auto lifetimeIt = llvm::find_if(nodeLifetimes, [&](const auto &lifetime) {
+    return lifetime.node == node;
+  });
+  return lifetimeIt == nodeLifetimes.end() ? nullptr : &*lifetimeIt;
+}
+
+DFBConcurrentKernelLivenessAnalysis::DFBConcurrentKernelLivenessAnalysis(
+    Operation *operation, AnalysisManager &analysisManager) {
+  const DFBLogicalIdentityAnalysis &identityAnalysis =
+      analysisManager.getAnalysis<DFBLogicalIdentityAnalysis>();
+  if (!identityAnalysis.succeeded()) {
+    errorOperation = identityAnalysis.getErrorOperation();
+    errorMessage = identityAnalysis.getErrorMessage().str();
+    return;
+  }
+  analyze(operation, identityAnalysis);
+}
+
+void DFBConcurrentKernelLivenessAnalysis::analyze(
+    Operation *operation, const DFBLogicalIdentityAnalysis &identityAnalysis) {
+  ModuleOp module = cast<ModuleOp>(operation);
+  DFBAnalysisFailure analysisFailure;
+  bool dependsOnLaunchNode = false;
+  if (failed(collectLogicalDFBs(module, identityAnalysis, logicalDFBs,
+                                analysisFailure, dependsOnLaunchNode))) {
+    errorOperation = analysisFailure.operation;
+    errorMessage = std::move(analysisFailure.message);
+    return;
+  }
+  if (logicalDFBs.empty()) {
+    return;
+  }
+
+  LivenessDomainState domainState;
+  domainState.initialize(module);
+  if (!domainState.hasLaunchGrid) {
+    if (dependsOnLaunchNode) {
+      for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+        logicalDFB.launchDomain = LaunchNodeDomain::unknown();
+      }
+      return;
+    }
+    // Straight-line kernel lifetimes are identical on every launched node.
+    // One representative node proves the uniform relation without assuming a
+    // launch-grid extent that is not yet present in the pipeline.
+    domainState.hasLaunchGrid = true;
+    domainState.baseDomain.nodes.insert({0, 0});
+  }
+
+  DataFlowSolver solver;
+  dataflow::loadBaselineAnalyses(solver);
+  LaunchNodeDomainAnalysisOptions options;
+  options.narrowPipeNetScopes = true;
+  options.emitInvalidPipeNetDiagnostics = false;
+  options.operationCallback = [&](Operation *accessOperation,
+                                  const LaunchNodeDomain &domain,
+                                  Operation *unanalyzableOperation) {
+    domainState.accessDomains[accessOperation] = {domain,
+                                                  unanalyzableOperation};
+  };
+  solver.load<LaunchNodeDomainAnalysis>(domainState, options);
+  if (failed(solver.initializeAndRun(module))) {
+    errorOperation = module;
+    errorMessage = "failed to compute DFB launch-node domains";
+    return;
+  }
+  if (domainState.sawError) {
+    errorOperation = domainState.errorOperation;
+    errorMessage = domainState.errorMessage;
+    return;
+  }
+
+  for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    if (logicalDFB.accesses.empty()) {
+      logicalDFB.launchDomain = LaunchNodeDomain::unknown();
+      continue;
+    }
+    for (DFBAccessOccurrence &access : logicalDFB.accesses) {
+      auto domainIt = domainState.accessDomains.find(access.operation);
+      if (domainIt == domainState.accessDomains.end()) {
+        access.launchDomain = LaunchNodeDomain::unknown();
+        access.unanalyzableDomainOperation = access.operation;
+      } else {
+        access.launchDomain = domainIt->second.domain;
+        access.unanalyzableDomainOperation =
+            domainIt->second.unanalyzableOperation;
+      }
+      logicalDFB.launchDomain =
+          logicalDFB.launchDomain.unionWith(access.launchDomain);
+    }
+  }
+
+  launchNodes.append(domainState.baseDomain.nodes.begin(),
+                     domainState.baseDomain.nodes.end());
+  orderedBeforeByNode.reserve(launchNodes.size());
+  for (LaunchNodeCoord node : launchNodes) {
+    HappensBeforeGraph graph;
+    DenseMap<Operation *, EventPair> operationEvents;
+    buildProgramOrderGraph(module, logicalDFBs, node, graph, operationEvents);
+
+    for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+      SmallVector<Operation *> pushes;
+      SmallVector<Operation *> waits;
+      for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+        if (!knownLaunchNodeDomainContains(access.launchDomain, node)) {
+          continue;
+        }
+        if (access.effect == DFBProtocolEffect::Push) {
+          pushes.push_back(access.operation);
+        } else if (access.effect == DFBProtocolEffect::Wait) {
+          waits.push_back(access.operation);
+        }
+      }
+      if (pushes.size() == 1 && waits.size() == 1) {
+        std::optional<EventPair> pushEvents =
+            getProjectedEvents(pushes.front(), operationEvents);
+        std::optional<EventPair> waitEvents =
+            getProjectedEvents(waits.front(), operationEvents);
+        if (pushEvents && waitEvents) {
+          graph.addEdge(pushEvents->completion, waitEvents->completion);
+        }
+      }
+    }
+    graph.computeReachability();
+
+    for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+      if (!knownLaunchNodeDomainContains(logicalDFB.launchDomain, node)) {
+        continue;
+      }
+      DFBQuiescenceProof proof = computePerNodeLifetime(
+          logicalDFB, node, graph, operationEvents, domainState);
+      logicalDFB.nodeLifetimes.back().quiescence = proof;
+    }
+
+    SmallVector<llvm::BitVector> nodeOrdering(
+        logicalDFBs.size(), llvm::BitVector(logicalDFBs.size()));
+    for (unsigned beforeIndex = 0; beforeIndex < logicalDFBs.size();
+         ++beforeIndex) {
+      const DFBPerNodeLifetime *before =
+          logicalDFBs[beforeIndex].findNodeLifetime(node);
+      if (!before) {
+        continue;
+      }
+      for (unsigned afterIndex = 0; afterIndex < logicalDFBs.size();
+           ++afterIndex) {
+        const DFBPerNodeLifetime *after =
+            logicalDFBs[afterIndex].findNodeLifetime(node);
+        if (after &&
+            proveOrderedBefore(*before, *after, graph, operationEvents)) {
+          nodeOrdering[beforeIndex].set(afterIndex);
+        }
+      }
+    }
+    orderedBeforeByNode.push_back(std::move(nodeOrdering));
+  }
+
+  for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    logicalDFB.bounded = logicalDFB.launchDomain.known &&
+                         !logicalDFB.nodeLifetimes.empty() &&
+                         llvm::all_of(logicalDFB.nodeLifetimes,
+                                      [](const DFBPerNodeLifetime &lifetime) {
+                                        return lifetime.quiescence.proven();
+                                      });
+  }
+}
+
+bool DFBConcurrentKernelLivenessAnalysis::isOrderedBefore(
+    unsigned beforeIndex, unsigned afterIndex, LaunchNodeCoord node) const {
+  auto nodeIt = llvm::find(launchNodes, node);
+  assert(nodeIt != launchNodes.end() && "node must be in the launch grid");
+  unsigned nodeIndex = nodeIt - launchNodes.begin();
+  assert(beforeIndex < orderedBeforeByNode[nodeIndex].size() &&
+         afterIndex < orderedBeforeByNode[nodeIndex].size());
+  return orderedBeforeByNode[nodeIndex][beforeIndex].test(afterIndex);
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBCONCURRENTKERNELLIVENESSANALYSIS_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBCONCURRENTKERNELLIVENESSANALYSIS_H
+
+//===----------------------------------------------------------------------===//
+// Concurrent Kernel DFB Liveness Analysis
+//===----------------------------------------------------------------------===//
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
+#include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/AnalysisManager.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace mlir::tt::ttl {
+
+/// Protocol or opaque storage effect performed by one DFB access.
+enum class DFBProtocolEffect { Reserve, Push, Wait, Pop, OpaqueAccess };
+
+/// Hardware processor that owns one DFB ring pointer.
+enum class DFBPointerProcessor { Noc0, Noc1, Pack, Unpack };
+
+/// Ring pointer advanced by a protocol effect.
+enum class DFBPointerDirection { Read, Write };
+
+/// Physical owner of one DFB ring pointer on one launched node.
+struct DFBPointerOwner {
+  LaunchNodeCoord node;
+  DFBPointerProcessor processor = DFBPointerProcessor::Noc0;
+  DFBPointerDirection direction = DFBPointerDirection::Read;
+
+  bool operator==(const DFBPointerOwner &rhs) const {
+    return node == rhs.node && processor == rhs.processor &&
+           direction == rhs.direction;
+  }
+
+  bool operator!=(const DFBPointerOwner &rhs) const { return !(*this == rhs); }
+};
+
+/// Reason that a per-node lifetime did not prove a quiescent handoff.
+enum class DFBQuiescenceFailureReason {
+  None,
+  MissingProtocolEffect,
+  RepeatedProtocolEffect,
+  UnsupportedControlFlow,
+  MismatchedTransaction,
+  IncompleteUseOrder,
+  UnknownPointerOwner,
+};
+
+/// Typed quiescence result retained for conflict evidence.
+struct DFBQuiescenceProof {
+  DFBQuiescenceFailureReason failure = DFBQuiescenceFailureReason::None;
+  Operation *evidence = nullptr;
+
+  bool proven() const { return failure == DFBQuiescenceFailureReason::None; }
+};
+
+/// Immutable occurrence of one logical DFB access.
+struct DFBAccessOccurrence {
+  Operation *operation = nullptr;
+  DFBProtocolEffect effect = DFBProtocolEffect::OpaqueAccess;
+  LaunchNodeDomain launchDomain;
+  Operation *unanalyzableDomainOperation = nullptr;
+};
+
+/// Immutable lifetime and hardware-state facts for one launched node.
+struct DFBPerNodeLifetime {
+  LaunchNodeCoord node;
+  SmallVector<unsigned> occurrenceIndices;
+  SmallVector<Operation *> earliestOperations;
+  SmallVector<Operation *> terminalOperations;
+  std::optional<int64_t> transactionTileCount;
+  std::optional<DFBPointerOwner> writePointerOwner;
+  std::optional<DFBPointerOwner> readPointerOwner;
+  DFBQuiescenceProof quiescence;
+};
+
+/// Immutable protocol and per-node lifetime facts for one logical DFB.
+struct DFBLogicalLifecycle {
+  int64_t logicalId = 0;
+  Type type;
+  bool compilerCreated = false;
+  SmallVector<BindCBOp> declarations;
+  SmallVector<DFBAccessOccurrence> accesses;
+  LaunchNodeDomain launchDomain;
+  SmallVector<DFBPerNodeLifetime, 0> nodeLifetimes;
+  bool bounded = false;
+
+  /// Returns the lifetime for `node`, or null when the DFB is inactive there.
+  const DFBPerNodeLifetime *findNodeLifetime(LaunchNodeCoord node) const;
+};
+
+/// Builds per-node cross-kernel happens-before and DFB quiescence facts.
+class DFBConcurrentKernelLivenessAnalysis {
+public:
+  DFBConcurrentKernelLivenessAnalysis(Operation *operation,
+                                      AnalysisManager &analysisManager);
+
+  bool isInvalidated(const AnalysisManager::PreservedAnalyses &analyses) {
+    return !analyses.isPreserved<DFBConcurrentKernelLivenessAnalysis>() ||
+           !analyses.isPreserved<DFBLogicalIdentityAnalysis>();
+  }
+
+  bool succeeded() const { return errorMessage.empty(); }
+  StringRef getErrorMessage() const { return errorMessage; }
+  Operation *getErrorOperation() const { return errorOperation; }
+
+  ArrayRef<DFBLogicalLifecycle> getLogicalDFBLifecycles() const {
+    return logicalDFBs;
+  }
+
+  ArrayRef<LaunchNodeCoord> getLaunchNodes() const { return launchNodes; }
+
+  /// Returns true when one indexed lifetime ends before another on `node`.
+  bool isOrderedBefore(unsigned beforeIndex, unsigned afterIndex,
+                       LaunchNodeCoord node) const;
+
+private:
+  void analyze(Operation *operation,
+               const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis);
+
+  SmallVector<DFBLogicalLifecycle, 0> logicalDFBs;
+  SmallVector<LaunchNodeCoord> launchNodes;
+  SmallVector<SmallVector<llvm::BitVector>> orderedBeforeByNode;
+  Operation *errorOperation = nullptr;
+  std::string errorMessage;
+};
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBCONCURRENTKERNELLIVENESSANALYSIS_H

--- a/lib/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.cpp
@@ -24,10 +24,12 @@ DFBLogicalIdentityAnalysis::DFBLogicalIdentityAnalysis(Operation *operation) {
   int64_t maxExplicitId = -1;
   int64_t compilerDeclarationCount = 0;
   BindCBOp firstCompilerDeclaration;
+  SmallVector<BindCBOp> declarations;
 
   // Discover the complete explicit ID range before generating IDs. Assigning
   // generated IDs during this walk could collide with a later declaration.
   WalkResult discoveryResult = moduleOp.walk([&](BindCBOp bindOp) {
+    declarations.push_back(bindOp);
     if (auto dfbId = bindOp.getDfbId()) {
       int64_t logicalId = dfbId->getSExtValue();
       maxExplicitId = std::max(maxExplicitId, logicalId);
@@ -62,7 +64,7 @@ DFBLogicalIdentityAnalysis::DFBLogicalIdentityAnalysis(Operation *operation) {
   llvm::DenseMap<int64_t, BindCBOp> firstDeclarationById;
   // Declarations with one logical ID describe one allocation, so they must
   // agree on the complete DFB type in every participating kernel.
-  moduleOp.walk([&](BindCBOp bindOp) {
+  for (BindCBOp bindOp : declarations) {
     auto dfbId = bindOp.getDfbId();
     int64_t logicalId = dfbId ? dfbId->getSExtValue() : nextCompilerId++;
     auto [firstDeclarationIt, inserted] =
@@ -78,12 +80,11 @@ DFBLogicalIdentityAnalysis::DFBLogicalIdentityAnalysis(Operation *operation) {
           << bindOp.getResult().getType();
       errorOperation = bindOp;
       errorMessage = messageStream.str();
-      return WalkResult::interrupt();
+      return;
     }
     assignments.push_back({bindOp, logicalId});
     logicalIds[bindOp.getOperation()] = logicalId;
-    return WalkResult::advance();
-  });
+  }
 }
 
 int64_t DFBLogicalIdentityAnalysis::getLogicalId(BindCBOp declaration) const {

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -137,7 +137,7 @@ private:
 
 namespace {
 
-/// Coloring outcome for one selected subset of logical DFBs.
+/// Physical-index assignment and its proven bounds for selected logical DFBs.
 struct ConcurrentAssignmentResult {
   SmallVector<int32_t> assignments;
   unsigned colorCount = 0;
@@ -147,11 +147,15 @@ struct ConcurrentAssignmentResult {
   std::uint64_t exactSearchStateCount = 0;
 };
 
-/// Colors the selected logical DFBs using concurrent-lifetime interference.
-/// First-fit is accepted when it meets `availableIndices`; otherwise a single
-/// fixed-limit exact check decides capacity. Minimum-color search runs only
-/// when required for an L1-budget decision. `firstPhysicalIndex` reserves a
-/// prefix without changing the conflict or coloring model.
+/// Assigns indices by mapping each logical DFB to a graph vertex, each conflict
+/// to an edge, and each available physical index to a graph color.
+///
+/// First-fit processes DFBs in immutable declaration order and chooses the
+/// lowest index not used by a conflicting DFB. Its assignment is accepted when
+/// it fits `availableIndices`. Otherwise one exhaustive fixed-limit search
+/// decides whether some assignment fits. A minimum physical-index-count search
+/// runs only for an L1-budget decision. `firstPhysicalIndex` reserves lower
+/// index values without changing which DFB pairs may share.
 static FailureOr<ConcurrentAssignmentResult> computeConcurrentAssignments(
     ModuleOp moduleOp, ArrayRef<unsigned> candidateIndices,
     int32_t firstPhysicalIndex, const DFBPhysicalConflictModel &conflictModel,
@@ -176,7 +180,7 @@ static FailureOr<ConcurrentAssignmentResult> computeConcurrentAssignments(
       computeInterferenceGraphColoringBounds(interferenceGraph);
   SmallVector<unsigned> selectedColors = bounds.colors;
   unsigned colorCount = bounds.colorCount;
-  unsigned provenColorLowerBound = bounds.cliqueLowerBound;
+  unsigned provenColorLowerBound = bounds.pairwiseConflictLowerBound;
   bool minimumProven = bounds.provesMinimum();
   bool exactSearchLimitReached = false;
   std::uint64_t exactSearchStateCount = 0;
@@ -227,7 +231,7 @@ static FailureOr<ConcurrentAssignmentResult> computeConcurrentAssignments(
       }
       if (interferenceGraph.interferes(lhsVertex, rhsVertex)) {
         analysisFailure.set(
-            moduleOp, "internal DFB coloring assigned one physical index to "
+            moduleOp, "internal DFB allocation assigned one physical index to "
                       "conflicting logical DFBs");
         return failure();
       }
@@ -258,13 +262,19 @@ setExactSearchLimitFailure(ModuleOp moduleOp, unsigned firstFitCount,
   std::string message;
   llvm::raw_string_ostream messageStream(message);
   messageStream << "deterministic first-fit uses " << firstFitCount
-                << " physical DFB indices; exact coloring explored "
+                << " physical DFB indices; exact allocation search explored "
                 << exactSearchStateCount << " states and reached the "
                 << exactColoringSearchStateLimit
                 << "-state limit without proving whether the allocation fits "
                 << constrainedResource
                 << "; increase `exact-coloring-search-limit`";
   analysisFailure.set(moduleOp, messageStream.str());
+}
+
+/// Derives capacity text from the enforced constant so diagnostics cannot
+/// report a stale limit.
+static std::string getPhysicalIndexLimitDescription() {
+  return "the " + std::to_string(kMaxCircularBuffers) + "-index hardware limit";
 }
 
 /// Maps provisional user indices to a dense physical index range.
@@ -305,7 +315,7 @@ struct PhysicalAllocationCandidate {
   std::uint64_t exactSearchStateCount = 0;
 };
 
-/// Compacts user indices and colors compiler-created DFB lifetimes.
+/// Compacts user indices and assigns compiler-created DFBs after that range.
 ///
 /// User declarations retain sharing already expressed by equal provisional
 /// indices. Compiler-created DFBs use the same concurrent lifetime proof as
@@ -427,7 +437,7 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
       setExactSearchLimitFailure(
           moduleOp, allocation.physicalDFBCount,
           allocation.exactSearchStateCount, exactColoringSearchStateLimit,
-          "the 32-index hardware limit", analysisFailure);
+          getPhysicalIndexLimitDescription(), analysisFailure);
       return failure();
     }
     std::string message;
@@ -449,7 +459,7 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
   return allocation;
 }
 
-/// Colors every logical DFB together so user and compiler-created lifetimes
+/// Assigns every logical DFB together so user and compiler-created lifetimes
 /// may share physical indices under the same conflict model.
 static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
     ModuleOp moduleOp, const DFBConcurrentKernelLivenessAnalysis &liveness,
@@ -487,10 +497,10 @@ static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
     return allocation;
   }
   if (allocation.exactSearchLimitReached) {
-    setExactSearchLimitFailure(moduleOp, allocation.physicalDFBCount,
-                               allocation.exactSearchStateCount,
-                               exactColoringSearchStateLimit,
-                               "the 32-index hardware limit", analysisFailure);
+    setExactSearchLimitFailure(
+        moduleOp, allocation.physicalDFBCount, allocation.exactSearchStateCount,
+        exactColoringSearchStateLimit, getPhysicalIndexLimitDescription(),
+        analysisFailure);
     return failure();
   }
 
@@ -521,9 +531,9 @@ computeAllocationBytes(ArrayRef<DFBPhysicalIndexAssignment> assignments) {
   return footprint.getTotalBytes();
 }
 
-/// Recomputes a minimum assignment only when a valid first-fit assignment
-/// exceeds the L1 budget. Both user-reuse policies therefore share identical
-/// minimum-color search and diagnostic behavior.
+/// Recomputes an assignment with the minimum physical-index count only when a
+/// valid first-fit assignment exceeds the L1 budget. Both user-reuse policies
+/// therefore share identical search and diagnostic behavior.
 static FailureOr<PhysicalAllocationCandidate> computeAllocationWithinL1(
     ModuleOp moduleOp, std::uint64_t exactColoringSearchStateLimit,
     DFBAnalysisFailure &analysisFailure,

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -19,7 +19,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/ErrorHandling.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
@@ -31,44 +31,8 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-/// Returns true when an attribute contains a copied physical DFB index.
-static bool isDerivedDFBIndexAttribute(StringRef attributeName) {
-  return attributeName == kUnpackToDestFp32AttrName ||
-         attributeName.starts_with(kCBIndexAttrPrefix) ||
-         attributeName == kBcastOutputCBIndexAttrName ||
-         attributeName == kReduceOutputCBIndexAttrName ||
-         attributeName == kTransposeOutputCBIndexAttrName;
-}
-
-/// Rejects IR containing copies of provisional physical DFB indices.
-///
-/// The listed attributes directly copy `cb_index`. Reassigning a declaration
-/// after such a copy exists would leave the copy stale. Attribute-name matching
-/// remains valid across operation and region changes, but this predicate must
-/// include every attribute introduced by a pass that copies a DFB index.
-static LogicalResult
-verifyFinalizationPrecedesIndexCopies(ModuleOp moduleOp,
-                                      DFBAnalysisFailure &analysisFailure) {
-  WalkResult walkResult = moduleOp->walk([&](Operation *operation) {
-    for (NamedAttribute attribute : operation->getAttrs()) {
-      StringRef attributeName = attribute.getName().getValue();
-      if (!isDerivedDFBIndexAttribute(attributeName)) {
-        continue;
-      }
-      analysisFailure.set(
-          operation,
-          ("contains derived DFB-index attribute '" + attributeName +
-           "' before DFB index finalization; run ttl-finalize-dfb-indices "
-           "before ttl-set-compute-kernel-config and "
-           "ttl-annotate-cb-associations")
-              .str());
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  return success(!walkResult.wasInterrupted());
-}
-
+/// Preserves the operation that made a proof conservative, falling back to the
+/// declaration only when no more specific evidence exists.
 static Operation *getLifetimeEvidence(const DFBPerNodeLifetime *lifetime,
                                       const DFBLogicalLifecycle &logicalDFB) {
   if (lifetime && lifetime->quiescence.evidence) {
@@ -173,24 +137,26 @@ private:
 
 namespace {
 
-/// Colors the selected logical DFBs using concurrent-lifetime interference.
-///
-/// Candidate indices refer to the liveness analysis result. Physical indices
-/// begin at `firstPhysicalIndex`, which permits user assignments to reserve a
-/// prefix without changing the lifetime or coloring implementation.
+/// Coloring outcome for one selected subset of logical DFBs.
 struct ConcurrentAssignmentResult {
   SmallVector<int32_t> assignments;
   unsigned colorCount = 0;
-  unsigned cliqueLowerBound = 0;
+  unsigned provenColorLowerBound = 0;
   bool minimumProven = false;
   bool exactSearchLimitReached = false;
   std::uint64_t exactSearchStateCount = 0;
 };
 
-static ConcurrentAssignmentResult computeConcurrentAssignments(
-    ArrayRef<unsigned> candidateIndices, int32_t firstPhysicalIndex,
-    const DFBPhysicalConflictModel &conflictModel, unsigned availableIndices,
-    std::uint64_t exactColoringSearchStateLimit, bool requireMinimum = false) {
+/// Colors the selected logical DFBs using concurrent-lifetime interference.
+/// First-fit is accepted when it meets `availableIndices`; otherwise a single
+/// fixed-limit exact check decides capacity. Minimum-color search runs only
+/// when required for an L1-budget decision. `firstPhysicalIndex` reserves a
+/// prefix without changing the conflict or coloring model.
+static FailureOr<ConcurrentAssignmentResult> computeConcurrentAssignments(
+    ModuleOp moduleOp, ArrayRef<unsigned> candidateIndices,
+    int32_t firstPhysicalIndex, const DFBPhysicalConflictModel &conflictModel,
+    unsigned availableIndices, std::uint64_t exactColoringSearchStateLimit,
+    DFBAnalysisFailure &analysisFailure, bool requireMinimum = false) {
   SmallVector<unsigned> logicalIndices(candidateIndices.begin(),
                                        candidateIndices.end());
 
@@ -210,18 +176,38 @@ static ConcurrentAssignmentResult computeConcurrentAssignments(
       computeInterferenceGraphColoringBounds(interferenceGraph);
   SmallVector<unsigned> selectedColors = bounds.colors;
   unsigned colorCount = bounds.colorCount;
+  unsigned provenColorLowerBound = bounds.cliqueLowerBound;
   bool minimumProven = bounds.provesMinimum();
-  bool capacityAlreadyProven = colorCount > availableIndices &&
-                               bounds.cliqueLowerBound > availableIndices;
-  ExactInterferenceGraphColoring exactColoring;
-  if ((!minimumProven && requireMinimum) ||
-      (colorCount > availableIndices && !capacityAlreadyProven)) {
-    exactColoring = colorInterferenceGraphExactly(
-        interferenceGraph, exactColoringSearchStateLimit);
+  bool exactSearchLimitReached = false;
+  std::uint64_t exactSearchStateCount = 0;
+  if (!minimumProven && requireMinimum) {
+    ExactInterferenceGraphColoring exactColoring =
+        colorInterferenceGraphExactly(interferenceGraph,
+                                      exactColoringSearchStateLimit);
+    exactSearchStateCount = exactColoring.exploredStateCount;
     if (exactColoring.isOptimal()) {
       selectedColors = std::move(exactColoring.colors);
       colorCount = exactColoring.colorCount;
       minimumProven = true;
+      provenColorLowerBound = colorCount;
+    } else {
+      exactSearchLimitReached = true;
+    }
+  } else if (colorCount > availableIndices &&
+             provenColorLowerBound <= availableIndices) {
+    InterferenceGraphColorLimitResult fitResult =
+        colorInterferenceGraphWithColorLimitExactly(
+            interferenceGraph, availableIndices, exactColoringSearchStateLimit);
+    exactSearchStateCount = fitResult.exploredStateCount;
+    if (fitResult.status == InterferenceGraphColorLimitStatus::Feasible) {
+      selectedColors = std::move(fitResult.colors);
+      colorCount = fitResult.colorCount;
+      minimumProven = colorCount == provenColorLowerBound;
+    } else if (fitResult.status ==
+               InterferenceGraphColorLimitStatus::Infeasible) {
+      provenColorLowerBound = availableIndices + 1;
+    } else {
+      exactSearchLimitReached = true;
     }
   }
   ArrayRef<unsigned> colors = selectedColors;
@@ -240,7 +226,10 @@ static ConcurrentAssignmentResult computeConcurrentAssignments(
         continue;
       }
       if (interferenceGraph.interferes(lhsVertex, rhsVertex)) {
-        llvm_unreachable("exact coloring assigned one color to a conflict");
+        analysisFailure.set(
+            moduleOp, "internal DFB coloring assigned one physical index to "
+                      "conflicting logical DFBs");
+        return failure();
       }
     }
   }
@@ -251,13 +240,15 @@ static ConcurrentAssignmentResult computeConcurrentAssignments(
     result.assignments.push_back(assignmentByLogicalIndex.lookup(logicalIndex));
   }
   result.colorCount = colorCount;
-  result.cliqueLowerBound = bounds.cliqueLowerBound;
+  result.provenColorLowerBound = provenColorLowerBound;
   result.minimumProven = minimumProven;
-  result.exactSearchLimitReached = !exactColoring.isOptimal();
-  result.exactSearchStateCount = exactColoring.exploredStateCount;
+  result.exactSearchLimitReached = exactSearchLimitReached;
+  result.exactSearchStateCount = exactSearchStateCount;
   return result;
 }
 
+/// Diagnoses an inconclusive bounded search without reporting hardware or L1
+/// infeasibility that the search did not prove.
 static void
 setExactSearchLimitFailure(ModuleOp moduleOp, unsigned firstFitCount,
                            std::uint64_t exactSearchStateCount,
@@ -305,11 +296,11 @@ computeCompactedUserIndices(ArrayRef<DFBLogicalLifecycle> logicalDFBs) {
   return compactedIndices;
 }
 
-/// Assignments produced without introducing new sharing among user DFBs.
-struct DistinctUserAllocation {
+/// Complete assignment candidate before descriptor construction.
+struct PhysicalAllocationCandidate {
   SmallVector<DFBPhysicalIndexAssignment> assignments;
   int32_t physicalDFBCount = 0;
-  bool compilerMinimumProven = false;
+  bool minimumProven = false;
   bool exactSearchLimitReached = false;
   std::uint64_t exactSearchStateCount = 0;
 };
@@ -320,7 +311,7 @@ struct DistinctUserAllocation {
 /// indices. Compiler-created DFBs use the same concurrent lifetime proof as
 /// the all-DFB allocator, so the option changes allocation policy without
 /// selecting a second lifetime model.
-static FailureOr<DistinctUserAllocation> computeDistinctUserAllocation(
+static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
     ModuleOp moduleOp, const DFBConcurrentKernelLivenessAnalysis &liveness,
     const DFBPhysicalConflictModel &conflictModel,
     DFBAnalysisFailure &analysisFailure,
@@ -342,20 +333,25 @@ static FailureOr<DistinctUserAllocation> computeDistinctUserAllocation(
       firstCompilerIndex >= kMaxCircularBuffers
           ? 0
           : static_cast<unsigned>(kMaxCircularBuffers - firstCompilerIndex);
-  ConcurrentAssignmentResult compilerAssignment = computeConcurrentAssignments(
-      compilerLogicalIndices, firstCompilerIndex, conflictModel,
-      availableCompilerIndices, exactColoringSearchStateLimit, requireMinimum);
+  FailureOr<ConcurrentAssignmentResult> compilerAssignment =
+      computeConcurrentAssignments(
+          moduleOp, compilerLogicalIndices, firstCompilerIndex, conflictModel,
+          availableCompilerIndices, exactColoringSearchStateLimit,
+          analysisFailure, requireMinimum);
+  if (failed(compilerAssignment)) {
+    return failure();
+  }
   DenseMap<unsigned, int32_t> compilerIndexByLogicalIndex;
   for (auto indexedCompilerIndex : llvm::enumerate(compilerLogicalIndices)) {
     compilerIndexByLogicalIndex[indexedCompilerIndex.value()] =
-        compilerAssignment.assignments[indexedCompilerIndex.index()];
+        compilerAssignment->assignments[indexedCompilerIndex.index()];
   }
 
-  DistinctUserAllocation allocation;
-  allocation.compilerMinimumProven = compilerAssignment.minimumProven;
+  PhysicalAllocationCandidate allocation;
+  allocation.minimumProven = compilerAssignment->minimumProven;
   allocation.exactSearchLimitReached =
-      compilerAssignment.exactSearchLimitReached;
-  allocation.exactSearchStateCount = compilerAssignment.exactSearchStateCount;
+      compilerAssignment->exactSearchLimitReached;
+  allocation.exactSearchStateCount = compilerAssignment->exactSearchStateCount;
   for (auto indexedLogicalDFB : llvm::enumerate(logicalDFBs)) {
     unsigned logicalIndex = indexedLogicalDFB.index();
     const DFBLogicalLifecycle &logicalDFB = indexedLogicalDFB.value();
@@ -436,13 +432,13 @@ static FailureOr<DistinctUserAllocation> computeDistinctUserAllocation(
     }
     std::string message;
     llvm::raw_string_ostream messageStream(message);
-    if (allocation.compilerMinimumProven) {
+    if (allocation.minimumProven) {
       messageStream << "need " << allocation.physicalDFBCount;
     } else {
       messageStream << "need at least "
                     << firstCompilerIndex +
                            static_cast<int32_t>(
-                               compilerAssignment.cliqueLowerBound);
+                               compilerAssignment->provenColorLowerBound);
     }
     messageStream << " unspilled DFB indices but hardware supports at most "
                   << kMaxCircularBuffers << " (" << compilerSlotCount
@@ -451,6 +447,65 @@ static FailureOr<DistinctUserAllocation> computeDistinctUserAllocation(
     return failure();
   }
   return allocation;
+}
+
+/// Colors every logical DFB together so user and compiler-created lifetimes
+/// may share physical indices under the same conflict model.
+static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
+    ModuleOp moduleOp, const DFBConcurrentKernelLivenessAnalysis &liveness,
+    const DFBPhysicalConflictModel &conflictModel,
+    DFBAnalysisFailure &analysisFailure,
+    std::uint64_t exactColoringSearchStateLimit, bool requireMinimum) {
+  ArrayRef<DFBLogicalLifecycle> logicalDFBs =
+      liveness.getLogicalDFBLifecycles();
+  SmallVector<unsigned> logicalIndices =
+      llvm::to_vector(llvm::seq<unsigned>(0, logicalDFBs.size()));
+  FailureOr<ConcurrentAssignmentResult> assignment =
+      computeConcurrentAssignments(
+          moduleOp, logicalIndices, /*firstPhysicalIndex=*/0, conflictModel,
+          kMaxCircularBuffers, exactColoringSearchStateLimit, analysisFailure,
+          requireMinimum);
+  if (failed(assignment)) {
+    return failure();
+  }
+
+  PhysicalAllocationCandidate allocation;
+  allocation.minimumProven = assignment->minimumProven;
+  allocation.exactSearchLimitReached = assignment->exactSearchLimitReached;
+  allocation.exactSearchStateCount = assignment->exactSearchStateCount;
+  for (auto indexedLogicalDFB : llvm::enumerate(logicalDFBs)) {
+    const DFBLogicalLifecycle &logicalDFB = indexedLogicalDFB.value();
+    int32_t physicalIndex = assignment->assignments[indexedLogicalDFB.index()];
+    allocation.physicalDFBCount =
+        std::max(allocation.physicalDFBCount, physicalIndex + 1);
+    allocation.assignments.push_back({logicalDFB.logicalId, physicalIndex,
+                                      logicalDFB.type, logicalDFB.declarations,
+                                      logicalDFB.bounded});
+  }
+
+  if (allocation.physicalDFBCount <= kMaxCircularBuffers) {
+    return allocation;
+  }
+  if (allocation.exactSearchLimitReached) {
+    setExactSearchLimitFailure(moduleOp, allocation.physicalDFBCount,
+                               allocation.exactSearchStateCount,
+                               exactColoringSearchStateLimit,
+                               "the 32-index hardware limit", analysisFailure);
+    return failure();
+  }
+
+  std::string message;
+  llvm::raw_string_ostream messageStream(message);
+  if (allocation.minimumProven) {
+    messageStream << "DFB allocation needs " << allocation.physicalDFBCount;
+  } else {
+    messageStream << "DFB allocation needs at least "
+                  << assignment->provenColorLowerBound;
+  }
+  messageStream << " unspilled physical indices but hardware supports at most "
+                << kMaxCircularBuffers;
+  analysisFailure.set(moduleOp, messageStream.str());
+  return failure();
 }
 
 /// Returns the L1 bytes required by the unique physical assignments.
@@ -464,6 +519,54 @@ computeAllocationBytes(ArrayRef<DFBPhysicalIndexAssignment> assignments) {
     }
   }
   return footprint.getTotalBytes();
+}
+
+/// Recomputes a minimum assignment only when a valid first-fit assignment
+/// exceeds the L1 budget. Both user-reuse policies therefore share identical
+/// minimum-color search and diagnostic behavior.
+static FailureOr<PhysicalAllocationCandidate> computeAllocationWithinL1(
+    ModuleOp moduleOp, std::uint64_t exactColoringSearchStateLimit,
+    DFBAnalysisFailure &analysisFailure,
+    llvm::function_ref<FailureOr<PhysicalAllocationCandidate>(bool)>
+        computeAllocation) {
+  FailureOr<PhysicalAllocationCandidate> allocation =
+      computeAllocation(/*requireMinimum=*/false);
+  if (failed(allocation)) {
+    return failure();
+  }
+
+  FailureOr<uint64_t> allocationBytes =
+      computeAllocationBytes(allocation->assignments);
+  uint64_t l1BudgetBytes = getUsableDFBL1Bytes(moduleOp);
+  if (succeeded(allocationBytes) && *allocationBytes > l1BudgetBytes &&
+      !allocation->minimumProven) {
+    allocation = computeAllocation(/*requireMinimum=*/true);
+    if (failed(allocation)) {
+      return failure();
+    }
+    allocationBytes = computeAllocationBytes(allocation->assignments);
+  }
+  if (allocation->exactSearchLimitReached) {
+    setExactSearchLimitFailure(moduleOp, allocation->physicalDFBCount,
+                               allocation->exactSearchStateCount,
+                               exactColoringSearchStateLimit,
+                               "the target L1 budget", analysisFailure);
+    return failure();
+  }
+  if (failed(allocationBytes)) {
+    analysisFailure.set(moduleOp,
+                        "DFB allocation has an invalid negative element count");
+    return failure();
+  }
+  if (*allocationBytes > l1BudgetBytes) {
+    std::string message;
+    llvm::raw_string_ostream messageStream(message);
+    messageStream << "DFB allocation requires " << *allocationBytes
+                  << " L1 bytes but the target supports " << l1BudgetBytes;
+    analysisFailure.set(moduleOp, messageStream.str());
+    return failure();
+  }
+  return allocation;
 }
 
 /// Builds the dense runtime descriptor table without modifying IR.
@@ -497,7 +600,13 @@ buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
   for (auto [expectedIndex, indexedAssignment] : llvm::enumerate(sorted)) {
     auto [physicalIndex, assignment] = indexedAssignment;
     if (physicalIndex != static_cast<int32_t>(expectedIndex)) {
-      llvm_unreachable("physical DFB allocation plan is not dense");
+      std::string message;
+      llvm::raw_string_ostream messageStream(message);
+      messageStream << "physical DFB allocation plan is not dense: expected "
+                    << expectedIndex << " but found " << physicalIndex;
+      analysisFailure.set(assignment->declarations.front(),
+                          messageStream.str());
+      return failure();
     }
     auto dfbType = cast<CircularBufferType>(assignment->type);
     descriptors.push_back(
@@ -525,14 +634,6 @@ DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
     return;
   }
 
-  DFBAnalysisFailure analysisFailure;
-  if (failed(
-          verifyFinalizationPrecedesIndexCopies(moduleOp, analysisFailure))) {
-    errorOperation = analysisFailure.operation;
-    errorMessage = std::move(analysisFailure.message);
-    return;
-  }
-
   const DFBConcurrentKernelLivenessAnalysis &liveness =
       analysisManager.getAnalysis<DFBConcurrentKernelLivenessAnalysis>();
   if (!liveness.succeeded()) {
@@ -540,148 +641,30 @@ DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
     errorMessage = liveness.getErrorMessage().str();
     return;
   }
+  DFBAnalysisFailure analysisFailure;
   plan.conflictModel = DFBPhysicalConflictModelBuilder::build(liveness);
 
-  if (reuseUserDFBs) {
-    ArrayRef<DFBLogicalLifecycle> logicalDFBs =
-        liveness.getLogicalDFBLifecycles();
-    SmallVector<unsigned> logicalIndices =
-        llvm::to_vector(llvm::seq<unsigned>(0, logicalDFBs.size()));
-
-    ConcurrentAssignmentResult assignment = computeConcurrentAssignments(
-        logicalIndices, 0, plan.conflictModel, kMaxCircularBuffers,
-        exactColoringSearchStateLimit);
-    auto recordAssignments = [&]() {
-      plan.assignments.clear();
-      plan.physicalDFBCount = 0;
-      for (auto indexedLogicalDFB : llvm::enumerate(logicalDFBs)) {
-        const DFBLogicalLifecycle &logicalDFB = indexedLogicalDFB.value();
-        int32_t physicalIndex =
-            assignment.assignments[indexedLogicalDFB.index()];
-        plan.physicalDFBCount =
-            std::max(plan.physicalDFBCount, physicalIndex + 1);
-        plan.assignments.push_back({logicalDFB.logicalId, physicalIndex,
-                                    logicalDFB.type, logicalDFB.declarations,
-                                    logicalDFB.bounded});
-      }
-    };
-    recordAssignments();
-    if (plan.physicalDFBCount > kMaxCircularBuffers) {
-      if (assignment.exactSearchLimitReached) {
-        setExactSearchLimitFailure(
-            moduleOp, plan.physicalDFBCount, assignment.exactSearchStateCount,
-            exactColoringSearchStateLimit, "the 32-index hardware limit",
-            analysisFailure);
-        errorOperation = analysisFailure.operation;
-        errorMessage = std::move(analysisFailure.message);
-        return;
-      }
-      std::string message;
-      llvm::raw_string_ostream messageStream(message);
-      if (assignment.minimumProven) {
-        messageStream << "DFB allocation needs " << plan.physicalDFBCount;
-      } else {
-        messageStream << "DFB allocation needs at least "
-                      << assignment.cliqueLowerBound;
-      }
-      messageStream << " unspilled physical indices but hardware supports at "
-                       "most "
-                    << kMaxCircularBuffers;
-      errorOperation = moduleOp;
-      errorMessage = messageStream.str();
-      return;
-    }
-
-    FailureOr<uint64_t> allocationBytes =
-        computeAllocationBytes(plan.assignments);
-    uint64_t l1BudgetBytes = getUsableDFBL1Bytes(moduleOp);
-    if (mlir::succeeded(allocationBytes) && *allocationBytes > l1BudgetBytes &&
-        !assignment.minimumProven) {
-      assignment = computeConcurrentAssignments(
-          logicalIndices, 0, plan.conflictModel, kMaxCircularBuffers,
-          exactColoringSearchStateLimit,
-          /*requireMinimum=*/true);
-      recordAssignments();
-      allocationBytes = computeAllocationBytes(plan.assignments);
-    }
-    if (assignment.exactSearchLimitReached) {
-      setExactSearchLimitFailure(moduleOp, plan.physicalDFBCount,
-                                 assignment.exactSearchStateCount,
-                                 exactColoringSearchStateLimit,
-                                 "the target L1 budget", analysisFailure);
-      errorOperation = analysisFailure.operation;
-      errorMessage = std::move(analysisFailure.message);
-      return;
-    }
-    if (failed(allocationBytes)) {
-      errorOperation = moduleOp;
-      errorMessage = "DFB allocation has an invalid negative element count";
-      return;
-    }
-    if (*allocationBytes > l1BudgetBytes) {
-      std::string message;
-      llvm::raw_string_ostream messageStream(message);
-      messageStream << "DFB allocation requires " << *allocationBytes
-                    << " L1 bytes but the target supports " << l1BudgetBytes;
-      errorOperation = moduleOp;
-      errorMessage = messageStream.str();
-      return;
-    }
-  } else {
-    FailureOr<DistinctUserAllocation> allocation =
-        computeDistinctUserAllocation(moduleOp, liveness, plan.conflictModel,
-                                      analysisFailure,
-                                      exactColoringSearchStateLimit);
-    if (failed(allocation)) {
-      errorOperation = analysisFailure.operation;
-      errorMessage = std::move(analysisFailure.message);
-      return;
-    }
-    plan.assignments = std::move(allocation->assignments);
-    plan.physicalDFBCount = allocation->physicalDFBCount;
-
-    FailureOr<uint64_t> allocationBytes =
-        computeAllocationBytes(plan.assignments);
-    uint64_t l1BudgetBytes = getUsableDFBL1Bytes(moduleOp);
-    if (mlir::succeeded(allocationBytes) && *allocationBytes > l1BudgetBytes &&
-        !allocation->compilerMinimumProven) {
-      allocation = computeDistinctUserAllocation(
+  auto computeAllocation =
+      [&](bool requireMinimum) -> FailureOr<PhysicalAllocationCandidate> {
+    if (reuseUserDFBs) {
+      return computeReuseAllocation(
           moduleOp, liveness, plan.conflictModel, analysisFailure,
-          exactColoringSearchStateLimit,
-          /*requireMinimum=*/true);
-      if (failed(allocation)) {
-        errorOperation = analysisFailure.operation;
-        errorMessage = std::move(analysisFailure.message);
-        return;
-      }
-      plan.assignments = std::move(allocation->assignments);
-      plan.physicalDFBCount = allocation->physicalDFBCount;
-      allocationBytes = computeAllocationBytes(plan.assignments);
+          exactColoringSearchStateLimit, requireMinimum);
     }
-    if (allocation->exactSearchLimitReached) {
-      setExactSearchLimitFailure(moduleOp, plan.physicalDFBCount,
-                                 allocation->exactSearchStateCount,
-                                 exactColoringSearchStateLimit,
-                                 "the target L1 budget", analysisFailure);
-      errorOperation = analysisFailure.operation;
-      errorMessage = std::move(analysisFailure.message);
-      return;
-    }
-    if (failed(allocationBytes)) {
-      errorOperation = moduleOp;
-      errorMessage = "DFB allocation has an invalid negative element count";
-      return;
-    }
-    if (*allocationBytes > l1BudgetBytes) {
-      std::string message;
-      llvm::raw_string_ostream messageStream(message);
-      messageStream << "DFB allocation requires " << *allocationBytes
-                    << " L1 bytes but the target supports " << l1BudgetBytes;
-      errorOperation = moduleOp;
-      errorMessage = messageStream.str();
-      return;
-    }
+    return computeDistinctUserAllocation(
+        moduleOp, liveness, plan.conflictModel, analysisFailure,
+        exactColoringSearchStateLimit, requireMinimum);
+  };
+  FailureOr<PhysicalAllocationCandidate> allocation =
+      computeAllocationWithinL1(moduleOp, exactColoringSearchStateLimit,
+                                analysisFailure, computeAllocation);
+  if (failed(allocation)) {
+    errorOperation = analysisFailure.operation;
+    errorMessage = std::move(analysisFailure.message);
+    return;
   }
+  plan.assignments = std::move(allocation->assignments);
+  plan.physicalDFBCount = allocation->physicalDFBCount;
 
   FailureOr<SmallVector<DFBPhysicalAllocationDescriptor>> descriptors =
       buildDescriptors(plan.assignments, analysisFailure);

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -1,0 +1,704 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "DFBPhysicalAllocationPlan.h"
+
+#include "DFBAllocationLimits.h"
+#include "DFBAnalysisFailure.h"
+#include "DFBConcurrentKernelLivenessAnalysis.h"
+#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
+#include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
+#include "ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h"
+
+#include "mlir/IR/BuiltinOps.h"
+
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace mlir::tt::ttl {
+
+namespace {
+
+/// Returns true when an attribute contains a copied physical DFB index.
+static bool isDerivedDFBIndexAttribute(StringRef attributeName) {
+  return attributeName == kUnpackToDestFp32AttrName ||
+         attributeName.starts_with(kCBIndexAttrPrefix) ||
+         attributeName == kBcastOutputCBIndexAttrName ||
+         attributeName == kReduceOutputCBIndexAttrName ||
+         attributeName == kTransposeOutputCBIndexAttrName;
+}
+
+/// Rejects IR containing copies of provisional physical DFB indices.
+///
+/// The listed attributes directly copy `cb_index`. Reassigning a declaration
+/// after such a copy exists would leave the copy stale. Attribute-name matching
+/// remains valid across operation and region changes, but this predicate must
+/// include every attribute introduced by a pass that copies a DFB index.
+static LogicalResult
+verifyFinalizationPrecedesIndexCopies(ModuleOp moduleOp,
+                                      DFBAnalysisFailure &analysisFailure) {
+  WalkResult walkResult = moduleOp->walk([&](Operation *operation) {
+    for (NamedAttribute attribute : operation->getAttrs()) {
+      StringRef attributeName = attribute.getName().getValue();
+      if (!isDerivedDFBIndexAttribute(attributeName)) {
+        continue;
+      }
+      analysisFailure.set(
+          operation,
+          ("contains derived DFB-index attribute '" + attributeName +
+           "' before DFB index finalization; run ttl-finalize-dfb-indices "
+           "before ttl-set-compute-kernel-config and "
+           "ttl-annotate-cb-associations")
+              .str());
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return success(!walkResult.wasInterrupted());
+}
+
+static Operation *getLifetimeEvidence(const DFBPerNodeLifetime *lifetime,
+                                      const DFBLogicalLifecycle &logicalDFB) {
+  if (lifetime && lifetime->quiescence.evidence) {
+    return lifetime->quiescence.evidence;
+  }
+  return logicalDFB.declarations.front();
+}
+
+} // namespace
+
+class DFBPhysicalConflictModelBuilder {
+public:
+  static DFBPhysicalConflictModel
+  build(const DFBConcurrentKernelLivenessAnalysis &liveness) {
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs =
+        liveness.getLogicalDFBLifecycles();
+    DFBPhysicalConflictModel model;
+    model.adjacency.assign(logicalDFBs.size(),
+                           llvm::BitVector(logicalDFBs.size()));
+    for (unsigned lhsIndex = 0; lhsIndex < logicalDFBs.size(); ++lhsIndex) {
+      for (unsigned rhsIndex = lhsIndex + 1; rhsIndex < logicalDFBs.size();
+           ++rhsIndex) {
+        addPairConflicts(model, liveness, lhsIndex, rhsIndex);
+      }
+    }
+    return model;
+  }
+
+private:
+  static void addEvidence(DFBPhysicalConflictModel &model,
+                          const DFBLogicalLifecycle &lhs,
+                          const DFBLogicalLifecycle &rhs, unsigned lhsIndex,
+                          unsigned rhsIndex, DFBConflictReason reason,
+                          std::optional<LaunchNodeCoord> node,
+                          Operation *lhsOperation, Operation *rhsOperation) {
+    model.adjacency[lhsIndex].set(rhsIndex);
+    model.adjacency[rhsIndex].set(lhsIndex);
+    model.evidence.push_back({lhsIndex, rhsIndex, lhs.logicalId, rhs.logicalId,
+                              reason, node, lhsOperation, rhsOperation});
+  }
+
+  static void
+  addPairConflicts(DFBPhysicalConflictModel &model,
+                   const DFBConcurrentKernelLivenessAnalysis &liveness,
+                   unsigned lhsIndex, unsigned rhsIndex) {
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs =
+        liveness.getLogicalDFBLifecycles();
+    const DFBLogicalLifecycle &lhs = logicalDFBs[lhsIndex];
+    const DFBLogicalLifecycle &rhs = logicalDFBs[rhsIndex];
+    if (lhs.type != rhs.type) {
+      addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                  DFBConflictReason::DescriptorMismatch, std::nullopt,
+                  lhs.declarations.front(), rhs.declarations.front());
+      return;
+    }
+    if (!lhs.launchDomain.known || !rhs.launchDomain.known) {
+      addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                  DFBConflictReason::UnknownLaunchNodeDomain, std::nullopt,
+                  lhs.declarations.front(), rhs.declarations.front());
+      return;
+    }
+
+    LaunchNodeDomain sharedNodes =
+        lhs.launchDomain.intersectWith(rhs.launchDomain);
+    for (LaunchNodeCoord node : sharedNodes.nodes) {
+      const DFBPerNodeLifetime *lhsLifetime = lhs.findNodeLifetime(node);
+      const DFBPerNodeLifetime *rhsLifetime = rhs.findNodeLifetime(node);
+      if (!lhsLifetime || !rhsLifetime || !lhsLifetime->quiescence.proven() ||
+          !rhsLifetime->quiescence.proven()) {
+        addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                    DFBConflictReason::UnprovenQuiescence, node,
+                    getLifetimeEvidence(lhsLifetime, lhs),
+                    getLifetimeEvidence(rhsLifetime, rhs));
+        continue;
+      }
+      if (lhsLifetime->transactionTileCount !=
+          rhsLifetime->transactionTileCount) {
+        addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                    DFBConflictReason::TransactionMismatch, node,
+                    getLifetimeEvidence(lhsLifetime, lhs),
+                    getLifetimeEvidence(rhsLifetime, rhs));
+        continue;
+      }
+      if (lhsLifetime->writePointerOwner != rhsLifetime->writePointerOwner ||
+          lhsLifetime->readPointerOwner != rhsLifetime->readPointerOwner) {
+        addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                    DFBConflictReason::PointerOwnerMismatch, node,
+                    getLifetimeEvidence(lhsLifetime, lhs),
+                    getLifetimeEvidence(rhsLifetime, rhs));
+        continue;
+      }
+      if (!liveness.isOrderedBefore(lhsIndex, rhsIndex, node) &&
+          !liveness.isOrderedBefore(rhsIndex, lhsIndex, node)) {
+        addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                    DFBConflictReason::ConcurrentLifetime, node,
+                    getLifetimeEvidence(lhsLifetime, lhs),
+                    getLifetimeEvidence(rhsLifetime, rhs));
+      }
+    }
+  }
+};
+
+namespace {
+
+/// Colors the selected logical DFBs using concurrent-lifetime interference.
+///
+/// Candidate indices refer to the liveness analysis result. Physical indices
+/// begin at `firstPhysicalIndex`, which permits user assignments to reserve a
+/// prefix without changing the lifetime or coloring implementation.
+struct ConcurrentAssignmentResult {
+  SmallVector<int32_t> assignments;
+  unsigned colorCount = 0;
+  unsigned cliqueLowerBound = 0;
+  bool minimumProven = false;
+  bool exactSearchLimitReached = false;
+  std::uint64_t exactSearchStateCount = 0;
+};
+
+static ConcurrentAssignmentResult computeConcurrentAssignments(
+    ArrayRef<unsigned> candidateIndices, int32_t firstPhysicalIndex,
+    const DFBPhysicalConflictModel &conflictModel, unsigned availableIndices,
+    std::uint64_t exactColoringSearchStateLimit, bool requireMinimum = false) {
+  SmallVector<unsigned> logicalIndices(candidateIndices.begin(),
+                                       candidateIndices.end());
+
+  InterferenceGraph interferenceGraph(logicalIndices.size());
+  for (unsigned lhsVertex = 0; lhsVertex < logicalIndices.size(); ++lhsVertex) {
+    for (unsigned rhsVertex = lhsVertex + 1; rhsVertex < logicalIndices.size();
+         ++rhsVertex) {
+      unsigned lhsIndex = logicalIndices[lhsVertex];
+      unsigned rhsIndex = logicalIndices[rhsVertex];
+      if (conflictModel.conflicts(lhsIndex, rhsIndex)) {
+        interferenceGraph.addInterference(lhsVertex, rhsVertex);
+      }
+    }
+  }
+
+  InterferenceGraphColoringBounds bounds =
+      computeInterferenceGraphColoringBounds(interferenceGraph);
+  SmallVector<unsigned> selectedColors = bounds.colors;
+  unsigned colorCount = bounds.colorCount;
+  bool minimumProven = bounds.provesMinimum();
+  bool capacityAlreadyProven = colorCount > availableIndices &&
+                               bounds.cliqueLowerBound > availableIndices;
+  ExactInterferenceGraphColoring exactColoring;
+  if ((!minimumProven && requireMinimum) ||
+      (colorCount > availableIndices && !capacityAlreadyProven)) {
+    exactColoring = colorInterferenceGraphExactly(
+        interferenceGraph, exactColoringSearchStateLimit);
+    if (exactColoring.isOptimal()) {
+      selectedColors = std::move(exactColoring.colors);
+      colorCount = exactColoring.colorCount;
+      minimumProven = true;
+    }
+  }
+  ArrayRef<unsigned> colors = selectedColors;
+  assert(colors.size() == logicalIndices.size());
+
+  DenseMap<unsigned, int32_t> assignmentByLogicalIndex;
+  for (auto [vertex, color] : llvm::enumerate(colors)) {
+    assignmentByLogicalIndex[logicalIndices[vertex]] =
+        firstPhysicalIndex + static_cast<int32_t>(color);
+  }
+
+  for (unsigned lhsVertex = 0; lhsVertex < logicalIndices.size(); ++lhsVertex) {
+    for (unsigned rhsVertex = lhsVertex + 1; rhsVertex < logicalIndices.size();
+         ++rhsVertex) {
+      if (colors[lhsVertex] != colors[rhsVertex]) {
+        continue;
+      }
+      if (interferenceGraph.interferes(lhsVertex, rhsVertex)) {
+        llvm_unreachable("exact coloring assigned one color to a conflict");
+      }
+    }
+  }
+
+  ConcurrentAssignmentResult result;
+  result.assignments.reserve(candidateIndices.size());
+  for (unsigned logicalIndex : candidateIndices) {
+    result.assignments.push_back(assignmentByLogicalIndex.lookup(logicalIndex));
+  }
+  result.colorCount = colorCount;
+  result.cliqueLowerBound = bounds.cliqueLowerBound;
+  result.minimumProven = minimumProven;
+  result.exactSearchLimitReached = !exactColoring.isOptimal();
+  result.exactSearchStateCount = exactColoring.exploredStateCount;
+  return result;
+}
+
+static void
+setExactSearchLimitFailure(ModuleOp moduleOp, unsigned firstFitCount,
+                           std::uint64_t exactSearchStateCount,
+                           std::uint64_t exactColoringSearchStateLimit,
+                           StringRef constrainedResource,
+                           DFBAnalysisFailure &analysisFailure) {
+  std::string message;
+  llvm::raw_string_ostream messageStream(message);
+  messageStream << "deterministic first-fit uses " << firstFitCount
+                << " physical DFB indices; exact coloring explored "
+                << exactSearchStateCount << " states and reached the "
+                << exactColoringSearchStateLimit
+                << "-state limit without proving whether the allocation fits "
+                << constrainedResource
+                << "; increase `exact-coloring-search-limit`";
+  analysisFailure.set(moduleOp, messageStream.str());
+}
+
+/// Maps provisional user indices to a dense physical index range.
+///
+/// Frontend indices identify allocation groups before finalization but may
+/// contain gaps when an uncaptured DFB has no declarations. Compacting the
+/// distinct values preserves existing sharing without making logical identity
+/// depend on provisional numbering.
+static DenseMap<int64_t, int32_t>
+computeCompactedUserIndices(ArrayRef<DFBLogicalLifecycle> logicalDFBs) {
+  DenseSet<int64_t> provisionalIndices;
+  for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    for (BindCBOp declaration : logicalDFB.declarations) {
+      if (!declaration->hasAttr(kCompilerAllocatedAttrName)) {
+        provisionalIndices.insert(declaration.getCbIndex().getSExtValue());
+      }
+    }
+  }
+
+  SmallVector<int64_t> sortedIndices(provisionalIndices.begin(),
+                                     provisionalIndices.end());
+  llvm::sort(sortedIndices);
+
+  DenseMap<int64_t, int32_t> compactedIndices;
+  for (auto [physicalIndex, provisionalIndex] :
+       llvm::enumerate(sortedIndices)) {
+    compactedIndices[provisionalIndex] = static_cast<int32_t>(physicalIndex);
+  }
+  return compactedIndices;
+}
+
+/// Assignments produced without introducing new sharing among user DFBs.
+struct DistinctUserAllocation {
+  SmallVector<DFBPhysicalIndexAssignment> assignments;
+  int32_t physicalDFBCount = 0;
+  bool compilerMinimumProven = false;
+  bool exactSearchLimitReached = false;
+  std::uint64_t exactSearchStateCount = 0;
+};
+
+/// Compacts user indices and colors compiler-created DFB lifetimes.
+///
+/// User declarations retain sharing already expressed by equal provisional
+/// indices. Compiler-created DFBs use the same concurrent lifetime proof as
+/// the all-DFB allocator, so the option changes allocation policy without
+/// selecting a second lifetime model.
+static FailureOr<DistinctUserAllocation> computeDistinctUserAllocation(
+    ModuleOp moduleOp, const DFBConcurrentKernelLivenessAnalysis &liveness,
+    const DFBPhysicalConflictModel &conflictModel,
+    DFBAnalysisFailure &analysisFailure,
+    std::uint64_t exactColoringSearchStateLimit, bool requireMinimum = false) {
+  ArrayRef<DFBLogicalLifecycle> logicalDFBs =
+      liveness.getLogicalDFBLifecycles();
+  DenseMap<int64_t, int32_t> compactedUserIndices =
+      computeCompactedUserIndices(logicalDFBs);
+  int32_t firstCompilerIndex =
+      static_cast<int32_t>(compactedUserIndices.size());
+  SmallVector<unsigned> compilerLogicalIndices;
+  for (auto indexedLogicalDFB : llvm::enumerate(logicalDFBs)) {
+    if (indexedLogicalDFB.value().compilerCreated) {
+      compilerLogicalIndices.push_back(indexedLogicalDFB.index());
+    }
+  }
+
+  unsigned availableCompilerIndices =
+      firstCompilerIndex >= kMaxCircularBuffers
+          ? 0
+          : static_cast<unsigned>(kMaxCircularBuffers - firstCompilerIndex);
+  ConcurrentAssignmentResult compilerAssignment = computeConcurrentAssignments(
+      compilerLogicalIndices, firstCompilerIndex, conflictModel,
+      availableCompilerIndices, exactColoringSearchStateLimit, requireMinimum);
+  DenseMap<unsigned, int32_t> compilerIndexByLogicalIndex;
+  for (auto indexedCompilerIndex : llvm::enumerate(compilerLogicalIndices)) {
+    compilerIndexByLogicalIndex[indexedCompilerIndex.value()] =
+        compilerAssignment.assignments[indexedCompilerIndex.index()];
+  }
+
+  DistinctUserAllocation allocation;
+  allocation.compilerMinimumProven = compilerAssignment.minimumProven;
+  allocation.exactSearchLimitReached =
+      compilerAssignment.exactSearchLimitReached;
+  allocation.exactSearchStateCount = compilerAssignment.exactSearchStateCount;
+  for (auto indexedLogicalDFB : llvm::enumerate(logicalDFBs)) {
+    unsigned logicalIndex = indexedLogicalDFB.index();
+    const DFBLogicalLifecycle &logicalDFB = indexedLogicalDFB.value();
+    int32_t physicalIndex;
+    if (logicalDFB.compilerCreated) {
+      auto physicalIndexIt = compilerIndexByLogicalIndex.find(logicalIndex);
+      assert(physicalIndexIt != compilerIndexByLogicalIndex.end() &&
+             "every compiler-created DFB must have a physical index");
+      physicalIndex = physicalIndexIt->second;
+    } else {
+      std::optional<int32_t> logicalPhysicalIndex;
+      for (BindCBOp declaration : logicalDFB.declarations) {
+        if (declaration->hasAttr(kCompilerAllocatedAttrName)) {
+          continue;
+        }
+        int64_t provisionalIndex = declaration.getCbIndex().getSExtValue();
+        auto physicalIndexIt = compactedUserIndices.find(provisionalIndex);
+        assert(physicalIndexIt != compactedUserIndices.end() &&
+               "every user DFB must have a compacted physical index");
+        if (!logicalPhysicalIndex.has_value()) {
+          logicalPhysicalIndex = physicalIndexIt->second;
+        } else if (*logicalPhysicalIndex != physicalIndexIt->second) {
+          std::string message;
+          llvm::raw_string_ostream messageStream(message);
+          messageStream << "logical DFB " << logicalDFB.logicalId
+                        << " has inconsistent physical indices "
+                        << *logicalPhysicalIndex << " and "
+                        << physicalIndexIt->second;
+          analysisFailure.set(declaration, messageStream.str());
+          return failure();
+        }
+      }
+      assert(logicalPhysicalIndex.has_value() &&
+             "a user logical DFB must have a user declaration");
+      physicalIndex = *logicalPhysicalIndex;
+    }
+
+    allocation.assignments.push_back({logicalDFB.logicalId, physicalIndex,
+                                      logicalDFB.type, logicalDFB.declarations,
+                                      logicalDFB.bounded});
+    allocation.physicalDFBCount =
+        std::max(allocation.physicalDFBCount, physicalIndex + 1);
+  }
+
+  for (unsigned lhsIndex = 0; lhsIndex < logicalDFBs.size(); ++lhsIndex) {
+    if (logicalDFBs[lhsIndex].compilerCreated) {
+      continue;
+    }
+    for (unsigned rhsIndex = lhsIndex + 1; rhsIndex < logicalDFBs.size();
+         ++rhsIndex) {
+      if (logicalDFBs[rhsIndex].compilerCreated ||
+          allocation.assignments[lhsIndex].physicalIndex !=
+              allocation.assignments[rhsIndex].physicalIndex ||
+          !conflictModel.conflicts(lhsIndex, rhsIndex)) {
+        continue;
+      }
+      int32_t physicalIndex = allocation.assignments[rhsIndex].physicalIndex;
+      std::string message;
+      llvm::raw_string_ostream messageStream(message);
+      messageStream << "provisional physical DFB index " << physicalIndex
+                    << " aliases conflicting logical DFBs "
+                    << logicalDFBs[lhsIndex].logicalId << " and "
+                    << logicalDFBs[rhsIndex].logicalId;
+      analysisFailure.set(logicalDFBs[rhsIndex].declarations.front(),
+                          messageStream.str());
+      return failure();
+    }
+  }
+
+  int32_t compilerSlotCount = allocation.physicalDFBCount - firstCompilerIndex;
+  if (allocation.physicalDFBCount > kMaxCircularBuffers) {
+    if (allocation.exactSearchLimitReached) {
+      setExactSearchLimitFailure(
+          moduleOp, allocation.physicalDFBCount,
+          allocation.exactSearchStateCount, exactColoringSearchStateLimit,
+          "the 32-index hardware limit", analysisFailure);
+      return failure();
+    }
+    std::string message;
+    llvm::raw_string_ostream messageStream(message);
+    if (allocation.compilerMinimumProven) {
+      messageStream << "need " << allocation.physicalDFBCount;
+    } else {
+      messageStream << "need at least "
+                    << firstCompilerIndex +
+                           static_cast<int32_t>(
+                               compilerAssignment.cliqueLowerBound);
+    }
+    messageStream << " unspilled DFB indices but hardware supports at most "
+                  << kMaxCircularBuffers << " (" << compilerSlotCount
+                  << " compiler-allocated after proven reuse)";
+    analysisFailure.set(moduleOp, messageStream.str());
+    return failure();
+  }
+  return allocation;
+}
+
+/// Returns the L1 bytes required by the unique physical assignments.
+static FailureOr<uint64_t>
+computeAllocationBytes(ArrayRef<DFBPhysicalIndexAssignment> assignments) {
+  DFBAllocationFootprint footprint;
+  for (const DFBPhysicalIndexAssignment &assignment : assignments) {
+    if (failed(footprint.add(assignment.physicalIndex,
+                             cast<CircularBufferType>(assignment.type)))) {
+      return failure();
+    }
+  }
+  return footprint.getTotalBytes();
+}
+
+/// Builds the dense runtime descriptor table without modifying IR.
+static FailureOr<SmallVector<DFBPhysicalAllocationDescriptor>>
+buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
+                 DFBAnalysisFailure &analysisFailure) {
+  llvm::DenseMap<int32_t, const DFBPhysicalIndexAssignment *> uniqueByIndex;
+  for (const DFBPhysicalIndexAssignment &assignment : assignments) {
+    auto [existingIt, inserted] =
+        uniqueByIndex.try_emplace(assignment.physicalIndex, &assignment);
+    if (!inserted && existingIt->second->type != assignment.type) {
+      BindCBOp declaration = assignment.declarations.front();
+      std::string message;
+      llvm::raw_string_ostream messageStream(message);
+      messageStream << "physical DFB index " << assignment.physicalIndex
+                    << " has inconsistent CircularBufferType values "
+                    << existingIt->second->type << " and " << assignment.type;
+      analysisFailure.set(declaration, messageStream.str());
+      return failure();
+    }
+  }
+
+  SmallVector<std::pair<int32_t, const DFBPhysicalIndexAssignment *>> sorted(
+      uniqueByIndex.begin(), uniqueByIndex.end());
+  llvm::sort(sorted, [](const auto &lhs, const auto &rhs) {
+    return lhs.first < rhs.first;
+  });
+
+  SmallVector<DFBPhysicalAllocationDescriptor> descriptors;
+  descriptors.reserve(sorted.size());
+  for (auto [expectedIndex, indexedAssignment] : llvm::enumerate(sorted)) {
+    auto [physicalIndex, assignment] = indexedAssignment;
+    if (physicalIndex != static_cast<int32_t>(expectedIndex)) {
+      llvm_unreachable("physical DFB allocation plan is not dense");
+    }
+    auto dfbType = cast<CircularBufferType>(assignment->type);
+    descriptors.push_back(
+        {physicalIndex, static_cast<int32_t>(dfbType.getElementsPerBlock()),
+         dfbType.getElementType(),
+         static_cast<int32_t>(
+             ttcore::getElementSizeBytes(dfbType.getElementType())),
+         static_cast<int32_t>(dfbType.getBlockCount())});
+  }
+  return descriptors;
+}
+
+} // namespace
+
+DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
+    Operation *operation, bool reuseUserDFBs,
+    std::uint64_t exactColoringSearchStateLimit,
+    AnalysisManager analysisManager) {
+  ModuleOp moduleOp = cast<ModuleOp>(operation);
+  const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis =
+      analysisManager.getAnalysis<DFBLogicalIdentityAnalysis>();
+  if (!logicalIdentityAnalysis.succeeded()) {
+    errorOperation = logicalIdentityAnalysis.getErrorOperation();
+    errorMessage = logicalIdentityAnalysis.getErrorMessage().str();
+    return;
+  }
+
+  DFBAnalysisFailure analysisFailure;
+  if (failed(
+          verifyFinalizationPrecedesIndexCopies(moduleOp, analysisFailure))) {
+    errorOperation = analysisFailure.operation;
+    errorMessage = std::move(analysisFailure.message);
+    return;
+  }
+
+  const DFBConcurrentKernelLivenessAnalysis &liveness =
+      analysisManager.getAnalysis<DFBConcurrentKernelLivenessAnalysis>();
+  if (!liveness.succeeded()) {
+    errorOperation = liveness.getErrorOperation();
+    errorMessage = liveness.getErrorMessage().str();
+    return;
+  }
+  plan.conflictModel = DFBPhysicalConflictModelBuilder::build(liveness);
+
+  if (reuseUserDFBs) {
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs =
+        liveness.getLogicalDFBLifecycles();
+    SmallVector<unsigned> logicalIndices =
+        llvm::to_vector(llvm::seq<unsigned>(0, logicalDFBs.size()));
+
+    ConcurrentAssignmentResult assignment = computeConcurrentAssignments(
+        logicalIndices, 0, plan.conflictModel, kMaxCircularBuffers,
+        exactColoringSearchStateLimit);
+    auto recordAssignments = [&]() {
+      plan.assignments.clear();
+      plan.physicalDFBCount = 0;
+      for (auto indexedLogicalDFB : llvm::enumerate(logicalDFBs)) {
+        const DFBLogicalLifecycle &logicalDFB = indexedLogicalDFB.value();
+        int32_t physicalIndex =
+            assignment.assignments[indexedLogicalDFB.index()];
+        plan.physicalDFBCount =
+            std::max(plan.physicalDFBCount, physicalIndex + 1);
+        plan.assignments.push_back({logicalDFB.logicalId, physicalIndex,
+                                    logicalDFB.type, logicalDFB.declarations,
+                                    logicalDFB.bounded});
+      }
+    };
+    recordAssignments();
+    if (plan.physicalDFBCount > kMaxCircularBuffers) {
+      if (assignment.exactSearchLimitReached) {
+        setExactSearchLimitFailure(
+            moduleOp, plan.physicalDFBCount, assignment.exactSearchStateCount,
+            exactColoringSearchStateLimit, "the 32-index hardware limit",
+            analysisFailure);
+        errorOperation = analysisFailure.operation;
+        errorMessage = std::move(analysisFailure.message);
+        return;
+      }
+      std::string message;
+      llvm::raw_string_ostream messageStream(message);
+      if (assignment.minimumProven) {
+        messageStream << "DFB allocation needs " << plan.physicalDFBCount;
+      } else {
+        messageStream << "DFB allocation needs at least "
+                      << assignment.cliqueLowerBound;
+      }
+      messageStream << " unspilled physical indices but hardware supports at "
+                       "most "
+                    << kMaxCircularBuffers;
+      errorOperation = moduleOp;
+      errorMessage = messageStream.str();
+      return;
+    }
+
+    FailureOr<uint64_t> allocationBytes =
+        computeAllocationBytes(plan.assignments);
+    uint64_t l1BudgetBytes = getUsableDFBL1Bytes(moduleOp);
+    if (mlir::succeeded(allocationBytes) && *allocationBytes > l1BudgetBytes &&
+        !assignment.minimumProven) {
+      assignment = computeConcurrentAssignments(
+          logicalIndices, 0, plan.conflictModel, kMaxCircularBuffers,
+          exactColoringSearchStateLimit,
+          /*requireMinimum=*/true);
+      recordAssignments();
+      allocationBytes = computeAllocationBytes(plan.assignments);
+    }
+    if (assignment.exactSearchLimitReached) {
+      setExactSearchLimitFailure(moduleOp, plan.physicalDFBCount,
+                                 assignment.exactSearchStateCount,
+                                 exactColoringSearchStateLimit,
+                                 "the target L1 budget", analysisFailure);
+      errorOperation = analysisFailure.operation;
+      errorMessage = std::move(analysisFailure.message);
+      return;
+    }
+    if (failed(allocationBytes)) {
+      errorOperation = moduleOp;
+      errorMessage = "DFB allocation has an invalid negative element count";
+      return;
+    }
+    if (*allocationBytes > l1BudgetBytes) {
+      std::string message;
+      llvm::raw_string_ostream messageStream(message);
+      messageStream << "DFB allocation requires " << *allocationBytes
+                    << " L1 bytes but the target supports " << l1BudgetBytes;
+      errorOperation = moduleOp;
+      errorMessage = messageStream.str();
+      return;
+    }
+  } else {
+    FailureOr<DistinctUserAllocation> allocation =
+        computeDistinctUserAllocation(moduleOp, liveness, plan.conflictModel,
+                                      analysisFailure,
+                                      exactColoringSearchStateLimit);
+    if (failed(allocation)) {
+      errorOperation = analysisFailure.operation;
+      errorMessage = std::move(analysisFailure.message);
+      return;
+    }
+    plan.assignments = std::move(allocation->assignments);
+    plan.physicalDFBCount = allocation->physicalDFBCount;
+
+    FailureOr<uint64_t> allocationBytes =
+        computeAllocationBytes(plan.assignments);
+    uint64_t l1BudgetBytes = getUsableDFBL1Bytes(moduleOp);
+    if (mlir::succeeded(allocationBytes) && *allocationBytes > l1BudgetBytes &&
+        !allocation->compilerMinimumProven) {
+      allocation = computeDistinctUserAllocation(
+          moduleOp, liveness, plan.conflictModel, analysisFailure,
+          exactColoringSearchStateLimit,
+          /*requireMinimum=*/true);
+      if (failed(allocation)) {
+        errorOperation = analysisFailure.operation;
+        errorMessage = std::move(analysisFailure.message);
+        return;
+      }
+      plan.assignments = std::move(allocation->assignments);
+      plan.physicalDFBCount = allocation->physicalDFBCount;
+      allocationBytes = computeAllocationBytes(plan.assignments);
+    }
+    if (allocation->exactSearchLimitReached) {
+      setExactSearchLimitFailure(moduleOp, plan.physicalDFBCount,
+                                 allocation->exactSearchStateCount,
+                                 exactColoringSearchStateLimit,
+                                 "the target L1 budget", analysisFailure);
+      errorOperation = analysisFailure.operation;
+      errorMessage = std::move(analysisFailure.message);
+      return;
+    }
+    if (failed(allocationBytes)) {
+      errorOperation = moduleOp;
+      errorMessage = "DFB allocation has an invalid negative element count";
+      return;
+    }
+    if (*allocationBytes > l1BudgetBytes) {
+      std::string message;
+      llvm::raw_string_ostream messageStream(message);
+      messageStream << "DFB allocation requires " << *allocationBytes
+                    << " L1 bytes but the target supports " << l1BudgetBytes;
+      errorOperation = moduleOp;
+      errorMessage = messageStream.str();
+      return;
+    }
+  }
+
+  FailureOr<SmallVector<DFBPhysicalAllocationDescriptor>> descriptors =
+      buildDescriptors(plan.assignments, analysisFailure);
+  if (failed(descriptors)) {
+    errorOperation = analysisFailure.operation;
+    errorMessage = std::move(analysisFailure.message);
+    return;
+  }
+  plan.descriptors = std::move(*descriptors);
+
+  if (plan.physicalDFBCount > 0) {
+    for (func::FuncOp kernel : moduleOp.getOps<func::FuncOp>()) {
+      if (kernel->hasAttr(kBaseCTAIndexAttrName)) {
+        plan.kernelBaseIndices.push_back({kernel, plan.physicalDFBCount});
+      }
+    }
+  }
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBPHYSICALALLOCATIONPLAN_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBPHYSICALALLOCATIONPLAN_H
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/AnalysisManager.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace mlir::tt::ttl {
+
+class DFBPhysicalConflictModelBuilder;
+
+/// Physical index selected for one logical DFB.
+struct DFBPhysicalIndexAssignment {
+  int64_t logicalId = 0;
+  int32_t physicalIndex = 0;
+  Type type;
+  SmallVector<BindCBOp> declarations;
+  bool bounded = false;
+};
+
+/// Runtime allocation descriptor for one physical DFB.
+struct DFBPhysicalAllocationDescriptor {
+  int32_t physicalIndex = 0;
+  int32_t numTiles = 0;
+  Type elementType;
+  int32_t pageSize = 0;
+  int32_t blockCount = 0;
+};
+
+/// Final base CTA index for one kernel.
+struct DFBKernelBaseIndexAssignment {
+  func::FuncOp kernel;
+  int32_t baseIndex = 0;
+};
+
+/// Semantic reason that two logical DFBs cannot share one physical index.
+enum class DFBConflictReason {
+  DescriptorMismatch,
+  UnknownLaunchNodeDomain,
+  UnprovenQuiescence,
+  TransactionMismatch,
+  PointerOwnerMismatch,
+  ConcurrentLifetime,
+};
+
+/// Source evidence for one edge in the physical DFB conflict graph.
+struct DFBConflictEvidence {
+  unsigned lhsLogicalIndex = 0;
+  unsigned rhsLogicalIndex = 0;
+  int64_t lhsLogicalId = 0;
+  int64_t rhsLogicalId = 0;
+  DFBConflictReason reason = DFBConflictReason::ConcurrentLifetime;
+  std::optional<LaunchNodeCoord> node;
+  Operation *lhsOperation = nullptr;
+  Operation *rhsOperation = nullptr;
+};
+
+/// Immutable complete conflict relation used by every allocation policy.
+class DFBPhysicalConflictModel {
+public:
+  bool conflicts(unsigned lhsLogicalIndex, unsigned rhsLogicalIndex) const {
+    assert(lhsLogicalIndex < adjacency.size() &&
+           rhsLogicalIndex < adjacency.size());
+    return adjacency[lhsLogicalIndex].test(rhsLogicalIndex);
+  }
+
+  ArrayRef<DFBConflictEvidence> getEvidence() const { return evidence; }
+
+private:
+  friend class DFBPhysicalConflictModelBuilder;
+  friend class DFBPhysicalAllocationPlanner;
+
+  SmallVector<llvm::BitVector> adjacency;
+  SmallVector<DFBConflictEvidence> evidence;
+};
+
+/// Immutable assignments, runtime descriptors, and kernel base-index updates.
+class DFBPhysicalAllocationPlan {
+public:
+  /// Returns one physical assignment per logical DFB.
+  ArrayRef<DFBPhysicalIndexAssignment> getAssignments() const {
+    return assignments;
+  }
+
+  /// Returns one runtime descriptor per unique physical index.
+  ArrayRef<DFBPhysicalAllocationDescriptor> getDescriptors() const {
+    return descriptors;
+  }
+
+  /// Returns deferred kernel attribute updates.
+  ArrayRef<DFBKernelBaseIndexAssignment> getKernelBaseIndices() const {
+    return kernelBaseIndices;
+  }
+
+  /// Returns the size of the dense physical-index range.
+  int32_t getPhysicalDFBCount() const { return physicalDFBCount; }
+
+  /// Returns the complete typed conflict relation used for allocation.
+  const DFBPhysicalConflictModel &getConflictModel() const {
+    return conflictModel;
+  }
+
+private:
+  friend class DFBPhysicalAllocationPlanner;
+
+  SmallVector<DFBPhysicalIndexAssignment> assignments;
+  SmallVector<DFBPhysicalAllocationDescriptor> descriptors;
+  SmallVector<DFBKernelBaseIndexAssignment> kernelBaseIndices;
+  DFBPhysicalConflictModel conflictModel;
+  int32_t physicalDFBCount = 0;
+};
+
+/// Builds and validates a complete physical DFB allocation without mutation.
+class DFBPhysicalAllocationPlanner {
+public:
+  /// Builds a plan using deterministic first-fit with exact escalation.
+  ///
+  /// `operation` must be a `ModuleOp`. Failures are recorded for the consuming
+  /// pass to diagnose before any IR mutation.
+  DFBPhysicalAllocationPlanner(Operation *operation, bool reuseUserDFBs,
+                               std::uint64_t exactColoringSearchStateLimit,
+                               AnalysisManager analysisManager);
+
+  /// Returns true when the complete allocation plan is valid.
+  bool succeeded() const { return errorMessage.empty(); }
+
+  /// Returns the diagnostic message recorded for a failed plan.
+  StringRef getErrorMessage() const { return errorMessage; }
+
+  /// Returns the operation to which the plan diagnostic should attach.
+  Operation *getErrorOperation() const { return errorOperation; }
+
+  /// Returns the validated immutable allocation plan.
+  const DFBPhysicalAllocationPlan &getPlan() const {
+    assert(succeeded() && "failed planning has no valid allocation plan");
+    return plan;
+  }
+
+private:
+  DFBPhysicalAllocationPlan plan;
+  Operation *errorOperation = nullptr;
+  std::string errorMessage;
+};
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBPHYSICALALLOCATIONPLAN_H

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
@@ -129,7 +129,7 @@ private:
 /// Builds and validates a complete physical DFB allocation without mutation.
 class DFBPhysicalAllocationPlanner {
 public:
-  /// Builds a plan using deterministic first-fit with exact escalation.
+  /// Builds a plan using deterministic first-fit with bounded exact checks.
   ///
   /// `operation` must be a `ModuleOp`. Failures are recorded for the consuming
   /// pass to diagnose before any IR mutation.

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
@@ -59,7 +59,7 @@ enum class DFBConflictReason {
   ConcurrentLifetime,
 };
 
-/// Source evidence for one edge in the physical DFB conflict graph.
+/// Source evidence that explains why one logical DFB pair cannot share.
 struct DFBConflictEvidence {
   unsigned lhsLogicalIndex = 0;
   unsigned rhsLogicalIndex = 0;
@@ -129,10 +129,13 @@ private:
 /// Builds and validates a complete physical DFB allocation without mutation.
 class DFBPhysicalAllocationPlanner {
 public:
-  /// Builds a plan using deterministic first-fit with bounded exact checks.
+  /// Builds a plan using deterministic first-fit and bounded exhaustive checks.
   ///
   /// `operation` must be a `ModuleOp`. Failures are recorded for the consuming
-  /// pass to diagnose before any IR mutation.
+  /// pass to diagnose before any IR mutation. A successful plan has verified
+  /// sharing, dense indices, runtime descriptors, and hardware capacity.
+  /// Unknown lifetime facts add conflicts and can cause rejection, but cannot
+  /// permit unsafe sharing.
   DFBPhysicalAllocationPlanner(Operation *operation, bool reuseUserDFBs,
                                std::uint64_t exactColoringSearchStateLimit,
                                AnalysisManager analysisManager);

--- a/lib/Dialect/TTL/Transforms/InterferenceGraphColoring.cpp
+++ b/lib/Dialect/TTL/Transforms/InterferenceGraphColoring.cpp
@@ -236,6 +236,53 @@ computeInterferenceGraphColoringBounds(const InterferenceGraph &graph) {
   return bounds;
 }
 
+InterferenceGraphColorLimitResult
+colorInterferenceGraphWithColorLimitExactly(const InterferenceGraph &graph,
+                                            unsigned colorLimit,
+                                            std::uint64_t searchStateLimit) {
+  InterferenceGraphColorLimitResult result;
+  if (graph.size() == 0) {
+    result.status = InterferenceGraphColorLimitStatus::Feasible;
+    return result;
+  }
+  if (colorLimit == 0) {
+    return result;
+  }
+
+  result.colors.assign(graph.size(), 0);
+  ExactColoringSearchBudget searchBudget(searchStateLimit);
+  for (llvm::ArrayRef<unsigned> component : getConnectedComponents(graph)) {
+    if (getGreedyCliqueLowerBound(graph, component) > colorLimit) {
+      result.colors.clear();
+      result.exploredStateCount = searchBudget.getExploredStateCount();
+      return result;
+    }
+
+    FixedColorCountSearch search(graph, component, colorLimit, searchBudget);
+    FixedColorCountSearchResult searchResult = search.solve();
+    if (searchResult.status ==
+        FixedColorCountSearchStatus::SearchLimitReached) {
+      result.status = InterferenceGraphColorLimitStatus::SearchLimitReached;
+      result.colors.clear();
+      result.exploredStateCount = searchBudget.getExploredStateCount();
+      return result;
+    }
+    if (searchResult.status == FixedColorCountSearchStatus::Infeasible) {
+      result.colors.clear();
+      result.exploredStateCount = searchBudget.getExploredStateCount();
+      return result;
+    }
+    for (unsigned vertex : component) {
+      result.colors[vertex] = searchResult.colors[vertex];
+      result.colorCount =
+          std::max(result.colorCount, searchResult.colors[vertex] + 1);
+    }
+  }
+  result.status = InterferenceGraphColorLimitStatus::Feasible;
+  result.exploredStateCount = searchBudget.getExploredStateCount();
+  return result;
+}
+
 ExactInterferenceGraphColoring
 colorInterferenceGraphExactly(const InterferenceGraph &graph,
                               std::uint64_t searchStateLimit) {

--- a/lib/Dialect/TTL/Transforms/InterferenceGraphColoring.cpp
+++ b/lib/Dialect/TTL/Transforms/InterferenceGraphColoring.cpp
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace mlir::tt::ttl {
+
+namespace {
+
+class ExactColoringSearchBudget {
+public:
+  explicit ExactColoringSearchBudget(std::uint64_t stateLimit)
+      : stateLimit(stateLimit) {}
+
+  bool consumeState() {
+    if (exploredStateCount == stateLimit) {
+      return false;
+    }
+    ++exploredStateCount;
+    return true;
+  }
+
+  std::uint64_t getExploredStateCount() const { return exploredStateCount; }
+
+private:
+  std::uint64_t stateLimit = 0;
+  std::uint64_t exploredStateCount = 0;
+};
+
+enum class FixedColorCountSearchStatus {
+  Feasible,
+  Infeasible,
+  SearchLimitReached,
+};
+
+struct FixedColorCountSearchResult {
+  FixedColorCountSearchStatus status = FixedColorCountSearchStatus::Infeasible;
+  llvm::SmallVector<unsigned> colors;
+};
+
+static llvm::SmallVector<llvm::SmallVector<unsigned>>
+getConnectedComponents(const InterferenceGraph &graph) {
+  llvm::SmallVector<llvm::SmallVector<unsigned>> components;
+  llvm::BitVector visited(graph.size());
+  for (unsigned root = 0; root < graph.size(); ++root) {
+    if (visited.test(root)) {
+      continue;
+    }
+    llvm::SmallVector<unsigned> component;
+    llvm::SmallVector<unsigned> pending = {root};
+    visited.set(root);
+    while (!pending.empty()) {
+      unsigned vertex = pending.pop_back_val();
+      component.push_back(vertex);
+      for (int neighbor = graph.getNeighbors(vertex).find_first();
+           neighbor >= 0;
+           neighbor = graph.getNeighbors(vertex).find_next(neighbor)) {
+        unsigned neighborVertex = static_cast<unsigned>(neighbor);
+        if (!visited.test(neighborVertex)) {
+          visited.set(neighborVertex);
+          pending.push_back(neighborVertex);
+        }
+      }
+    }
+    llvm::sort(component);
+    components.push_back(std::move(component));
+  }
+  return components;
+}
+
+static unsigned getGreedyCliqueLowerBound(const InterferenceGraph &graph,
+                                          llvm::ArrayRef<unsigned> component) {
+  llvm::SmallVector<unsigned> candidates(component.begin(), component.end());
+  llvm::sort(candidates, [&](unsigned lhsVertex, unsigned rhsVertex) {
+    unsigned lhsDegree = graph.degree(lhsVertex);
+    unsigned rhsDegree = graph.degree(rhsVertex);
+    return lhsDegree != rhsDegree ? lhsDegree > rhsDegree
+                                  : lhsVertex < rhsVertex;
+  });
+
+  llvm::SmallVector<unsigned> clique;
+  for (unsigned candidate : candidates) {
+    if (llvm::all_of(clique, [&](unsigned member) {
+          return graph.interferes(candidate, member);
+        })) {
+      clique.push_back(candidate);
+    }
+  }
+  return std::max(1U, static_cast<unsigned>(clique.size()));
+}
+
+static llvm::SmallVector<unsigned>
+getDegreePriorityOrder(const InterferenceGraph &graph,
+                       llvm::ArrayRef<unsigned> component) {
+  llvm::SmallVector<unsigned> order(component.begin(), component.end());
+  llvm::sort(order, [&](unsigned lhsVertex, unsigned rhsVertex) {
+    unsigned lhsDegree = graph.degree(lhsVertex);
+    unsigned rhsDegree = graph.degree(rhsVertex);
+    return lhsDegree != rhsDegree ? lhsDegree > rhsDegree
+                                  : lhsVertex < rhsVertex;
+  });
+  return order;
+}
+
+class FixedColorCountSearch {
+public:
+  FixedColorCountSearch(const InterferenceGraph &graph,
+                        llvm::ArrayRef<unsigned> component, unsigned colorCount,
+                        ExactColoringSearchBudget &searchBudget)
+      : graph(graph), component(component.begin(), component.end()),
+        colorCount(colorCount), colors(graph.size(), kUnassigned),
+        active(graph.size()), searchBudget(searchBudget) {
+    for (unsigned vertex : component) {
+      active.set(vertex);
+    }
+  }
+
+  FixedColorCountSearchResult solve() {
+    FixedColorCountSearchStatus status =
+        assign(/*assignedCount=*/0, /*usedColorCount=*/0);
+    if (status != FixedColorCountSearchStatus::Feasible) {
+      return {status, {}};
+    }
+    return {status, colors};
+  }
+
+private:
+  static constexpr unsigned kUnassigned = std::numeric_limits<unsigned>::max();
+
+  unsigned selectVertex() const {
+    unsigned selected = kUnassigned;
+    unsigned selectedSaturation = 0;
+    unsigned selectedDegree = 0;
+    for (unsigned vertex : component) {
+      if (colors[vertex] != kUnassigned) {
+        continue;
+      }
+      llvm::BitVector neighborColors(colorCount);
+      unsigned activeDegree = 0;
+      for (int neighbor = graph.getNeighbors(vertex).find_first();
+           neighbor >= 0;
+           neighbor = graph.getNeighbors(vertex).find_next(neighbor)) {
+        unsigned neighborVertex = static_cast<unsigned>(neighbor);
+        if (!active.test(neighborVertex)) {
+          continue;
+        }
+        ++activeDegree;
+        if (colors[neighborVertex] != kUnassigned) {
+          neighborColors.set(colors[neighborVertex]);
+        }
+      }
+      unsigned saturation = neighborColors.count();
+      if (selected == kUnassigned || saturation > selectedSaturation ||
+          (saturation == selectedSaturation &&
+           (activeDegree > selectedDegree ||
+            (activeDegree == selectedDegree && vertex < selected)))) {
+        selected = vertex;
+        selectedSaturation = saturation;
+        selectedDegree = activeDegree;
+      }
+    }
+    assert(selected != kUnassigned && "search must select an uncolored vertex");
+    return selected;
+  }
+
+  bool canUseColor(unsigned vertex, unsigned color) const {
+    for (int neighbor = graph.getNeighbors(vertex).find_first(); neighbor >= 0;
+         neighbor = graph.getNeighbors(vertex).find_next(neighbor)) {
+      if (colors[static_cast<unsigned>(neighbor)] == color) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  FixedColorCountSearchStatus assign(unsigned assignedCount,
+                                     unsigned usedColorCount) {
+    if (!searchBudget.consumeState()) {
+      return FixedColorCountSearchStatus::SearchLimitReached;
+    }
+    if (assignedCount == component.size()) {
+      return FixedColorCountSearchStatus::Feasible;
+    }
+
+    unsigned vertex = selectVertex();
+    unsigned candidateColorCount = std::min(colorCount, usedColorCount + 1);
+    for (unsigned color = 0; color < candidateColorCount; ++color) {
+      if (!canUseColor(vertex, color)) {
+        continue;
+      }
+      colors[vertex] = color;
+      unsigned nextUsedColorCount = std::max(usedColorCount, color + 1);
+      FixedColorCountSearchStatus status =
+          assign(assignedCount + 1, nextUsedColorCount);
+      if (status == FixedColorCountSearchStatus::Feasible) {
+        return status;
+      }
+      colors[vertex] = kUnassigned;
+      if (status == FixedColorCountSearchStatus::SearchLimitReached) {
+        return status;
+      }
+    }
+    return FixedColorCountSearchStatus::Infeasible;
+  }
+
+  const InterferenceGraph &graph;
+  llvm::SmallVector<unsigned> component;
+  unsigned colorCount = 0;
+  llvm::SmallVector<unsigned> colors;
+  llvm::BitVector active;
+  ExactColoringSearchBudget &searchBudget;
+};
+
+} // namespace
+
+InterferenceGraphColoringBounds
+computeInterferenceGraphColoringBounds(const InterferenceGraph &graph) {
+  InterferenceGraphColoringBounds bounds;
+  if (graph.size() == 0) {
+    return bounds;
+  }
+  llvm::SmallVector<unsigned> vertices =
+      llvm::to_vector(llvm::seq<unsigned>(0, graph.size()));
+  bounds.cliqueLowerBound = getGreedyCliqueLowerBound(graph, vertices);
+  bounds.colors = colorInterferenceGraphFirstFit(graph, vertices);
+  for (unsigned color : bounds.colors) {
+    bounds.colorCount = std::max(bounds.colorCount, color + 1);
+  }
+  return bounds;
+}
+
+ExactInterferenceGraphColoring
+colorInterferenceGraphExactly(const InterferenceGraph &graph,
+                              std::uint64_t searchStateLimit) {
+  ExactInterferenceGraphColoring result;
+  result.colors.assign(graph.size(), 0);
+  if (graph.size() == 0) {
+    return result;
+  }
+
+  ExactColoringSearchBudget searchBudget(searchStateLimit);
+
+  for (llvm::ArrayRef<unsigned> component : getConnectedComponents(graph)) {
+    unsigned cliqueLowerBound = getGreedyCliqueLowerBound(graph, component);
+    result.cliqueLowerBound =
+        std::max(result.cliqueLowerBound, cliqueLowerBound);
+
+    llvm::SmallVector<unsigned> globalPriorityOrder =
+        getDegreePriorityOrder(graph, component);
+    InterferenceGraph componentGraph(component.size());
+    for (unsigned lhsIndex = 0; lhsIndex < component.size(); ++lhsIndex) {
+      for (unsigned rhsIndex = lhsIndex + 1; rhsIndex < component.size();
+           ++rhsIndex) {
+        if (graph.interferes(component[lhsIndex], component[rhsIndex])) {
+          componentGraph.addInterference(lhsIndex, rhsIndex);
+        }
+      }
+    }
+    llvm::SmallVector<unsigned> componentPriorityOrder;
+    componentPriorityOrder.reserve(component.size());
+    for (unsigned globalVertex : globalPriorityOrder) {
+      componentPriorityOrder.push_back(llvm::find(component, globalVertex) -
+                                       component.begin());
+    }
+    llvm::SmallVector<unsigned> upperColors =
+        colorInterferenceGraphFirstFit(componentGraph, componentPriorityOrder);
+    unsigned upperBound = 0;
+    for (unsigned color : upperColors) {
+      upperBound = std::max(upperBound, color + 1);
+    }
+
+    llvm::SmallVector<unsigned> exactColors;
+    for (unsigned candidateCount = cliqueLowerBound;
+         candidateCount <= upperBound; ++candidateCount) {
+      FixedColorCountSearch search(graph, component, candidateCount,
+                                   searchBudget);
+      FixedColorCountSearchResult searchResult = search.solve();
+      if (searchResult.status ==
+          FixedColorCountSearchStatus::SearchLimitReached) {
+        result.status =
+            ExactInterferenceGraphColoringStatus::SearchLimitReached;
+        result.colors.clear();
+        result.colorCount = 0;
+        result.exploredStateCount = searchBudget.getExploredStateCount();
+        return result;
+      }
+      if (searchResult.status == FixedColorCountSearchStatus::Feasible) {
+        exactColors = std::move(searchResult.colors);
+        result.colorCount = std::max(result.colorCount, candidateCount);
+        break;
+      }
+    }
+    assert(!exactColors.empty() && "first-fit upper bound must be feasible");
+    for (unsigned vertex : component) {
+      result.colors[vertex] = exactColors[vertex];
+    }
+  }
+  result.exploredStateCount = searchBudget.getExploredStateCount();
+  return result;
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/InterferenceGraphColoring.cpp
+++ b/lib/Dialect/TTL/Transforms/InterferenceGraphColoring.cpp
@@ -14,6 +14,8 @@ namespace mlir::tt::ttl {
 
 namespace {
 
+/// Applies one state limit across all independently solved candidate groups so
+/// splitting a graph cannot multiply the configured compile-time budget.
 class ExactColoringSearchBudget {
 public:
   explicit ExactColoringSearchBudget(std::uint64_t stateLimit)
@@ -45,6 +47,8 @@ struct FixedColorCountSearchResult {
   llvm::SmallVector<unsigned> colors;
 };
 
+/// Separates candidate groups that have no conflicts between them. Independent
+/// groups can reuse the same resource slots and are cheaper to search alone.
 static llvm::SmallVector<llvm::SmallVector<unsigned>>
 getConnectedComponents(const InterferenceGraph &graph) {
   llvm::SmallVector<llvm::SmallVector<unsigned>> components;
@@ -75,8 +79,14 @@ getConnectedComponents(const InterferenceGraph &graph) {
   return components;
 }
 
-static unsigned getGreedyCliqueLowerBound(const InterferenceGraph &graph,
-                                          llvm::ArrayRef<unsigned> component) {
+/// Finds a pairwise-conflicting set whose size proves a required slot count.
+///
+/// The degree-first greedy selection may miss a larger set, but every set it
+/// returns contains only members that conflict with every other member. Its
+/// size is therefore always a valid lower bound on the required slots.
+static unsigned
+getPairwiseConflictLowerBound(const InterferenceGraph &graph,
+                              llvm::ArrayRef<unsigned> component) {
   llvm::SmallVector<unsigned> candidates(component.begin(), component.end());
   llvm::sort(candidates, [&](unsigned lhsVertex, unsigned rhsVertex) {
     unsigned lhsDegree = graph.degree(lhsVertex);
@@ -85,17 +95,19 @@ static unsigned getGreedyCliqueLowerBound(const InterferenceGraph &graph,
                                   : lhsVertex < rhsVertex;
   });
 
-  llvm::SmallVector<unsigned> clique;
+  llvm::SmallVector<unsigned> conflictingSet;
   for (unsigned candidate : candidates) {
-    if (llvm::all_of(clique, [&](unsigned member) {
+    if (llvm::all_of(conflictingSet, [&](unsigned member) {
           return graph.interferes(candidate, member);
         })) {
-      clique.push_back(candidate);
+      conflictingSet.push_back(candidate);
     }
   }
-  return std::max(1U, static_cast<unsigned>(clique.size()));
+  return std::max(1U, static_cast<unsigned>(conflictingSet.size()));
 }
 
+/// Processes highly constrained candidates first to improve the first-fit
+/// assignment while retaining candidate number as a deterministic tie-breaker.
 static llvm::SmallVector<unsigned>
 getDegreePriorityOrder(const InterferenceGraph &graph,
                        llvm::ArrayRef<unsigned> component) {
@@ -109,6 +121,8 @@ getDegreePriorityOrder(const InterferenceGraph &graph,
   return order;
 }
 
+/// Fixing the slot count answers one capacity question without first proving
+/// that every smaller count fails.
 class FixedColorCountSearch {
 public:
   FixedColorCountSearch(const InterferenceGraph &graph,
@@ -134,6 +148,9 @@ public:
 private:
   static constexpr unsigned kUnassigned = std::numeric_limits<unsigned>::max();
 
+  /// Implements deterministic DSATUR selection. A candidate's saturation is
+  /// the number of different slots already used by its assigned conflicts;
+  /// higher saturation means fewer remaining choices and is searched first.
   unsigned selectVertex() const {
     unsigned selected = kUnassigned;
     unsigned selectedSaturation = 0;
@@ -180,6 +197,10 @@ private:
     return true;
   }
 
+  /// Backtracks over legal slots while removing equivalent slot renamings.
+  ///
+  /// At most one previously unused slot is tried at a state. Any other unused
+  /// slot differs only by its number and would produce an equivalent subtree.
   FixedColorCountSearchStatus assign(unsigned assignedCount,
                                      unsigned usedColorCount) {
     if (!searchBudget.consumeState()) {
@@ -228,7 +249,8 @@ computeInterferenceGraphColoringBounds(const InterferenceGraph &graph) {
   }
   llvm::SmallVector<unsigned> vertices =
       llvm::to_vector(llvm::seq<unsigned>(0, graph.size()));
-  bounds.cliqueLowerBound = getGreedyCliqueLowerBound(graph, vertices);
+  bounds.pairwiseConflictLowerBound =
+      getPairwiseConflictLowerBound(graph, vertices);
   bounds.colors = colorInterferenceGraphFirstFit(graph, vertices);
   for (unsigned color : bounds.colors) {
     bounds.colorCount = std::max(bounds.colorCount, color + 1);
@@ -252,7 +274,9 @@ colorInterferenceGraphWithColorLimitExactly(const InterferenceGraph &graph,
   result.colors.assign(graph.size(), 0);
   ExactColoringSearchBudget searchBudget(searchStateLimit);
   for (llvm::ArrayRef<unsigned> component : getConnectedComponents(graph)) {
-    if (getGreedyCliqueLowerBound(graph, component) > colorLimit) {
+    // More pairwise-conflicting candidates than available slots prove failure
+    // without backtracking.
+    if (getPairwiseConflictLowerBound(graph, component) > colorLimit) {
       result.colors.clear();
       result.exploredStateCount = searchBudget.getExploredStateCount();
       return result;
@@ -295,10 +319,13 @@ colorInterferenceGraphExactly(const InterferenceGraph &graph,
   ExactColoringSearchBudget searchBudget(searchStateLimit);
 
   for (llvm::ArrayRef<unsigned> component : getConnectedComponents(graph)) {
-    unsigned cliqueLowerBound = getGreedyCliqueLowerBound(graph, component);
-    result.cliqueLowerBound =
-        std::max(result.cliqueLowerBound, cliqueLowerBound);
+    unsigned pairwiseConflictLowerBound =
+        getPairwiseConflictLowerBound(graph, component);
+    result.pairwiseConflictLowerBound =
+        std::max(result.pairwiseConflictLowerBound, pairwiseConflictLowerBound);
 
+    // First-fit supplies a known-valid maximum for the increasing exact
+    // searches, so at least one tested slot count must succeed.
     llvm::SmallVector<unsigned> globalPriorityOrder =
         getDegreePriorityOrder(graph, component);
     InterferenceGraph componentGraph(component.size());
@@ -324,7 +351,7 @@ colorInterferenceGraphExactly(const InterferenceGraph &graph,
     }
 
     llvm::SmallVector<unsigned> exactColors;
-    for (unsigned candidateCount = cliqueLowerBound;
+    for (unsigned candidateCount = pairwiseConflictLowerBound;
          candidateCount <= upperBound; ++candidateCount) {
       FixedColorCountSearch search(graph, component, candidateCount,
                                    searchBudget);

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -799,28 +800,34 @@ getBranchLaunchNodeDomains(Value condition, const LaunchNodeDomain &current,
 /// Decode the PipeNet role metadata carried by one `ttl.pipenet_scope`.
 static std::optional<PipeNetScopeLaunchNodeDomains>
 getPipeNetScopeLaunchNodeDomains(PipeNetScopeOp scopeOp,
-                                 LaunchNodeDomainState &state) {
+                                 LaunchNodeDomainState &state,
+                                 bool emitDiagnostics) {
+  auto recordError = [&](const Twine &message) {
+    state.sawError = true;
+    state.errorOperation = scopeOp;
+    state.errorMessage = message.str();
+    if (emitDiagnostics) {
+      scopeOp.emitOpError() << message;
+    }
+  };
   SmallVector<int64_t> ids;
   SmallVector<int64_t> roles;
   if (!readI64ArrayAttr(scopeOp.getOperation(), kPipeNetIdsAttrName, ids) ||
       !readI64ArrayAttr(scopeOp.getOperation(), kPipeNetRolesAttrName, roles)) {
-    scopeOp.emitOpError() << "requires `" << kPipeNetIdsAttrName << "` and `"
-                          << kPipeNetRolesAttrName << "` attributes";
-    state.sawError = true;
+    recordError(Twine("requires `") + kPipeNetIdsAttrName + "` and `" +
+                kPipeNetRolesAttrName + "` attributes");
     return std::nullopt;
   }
   if (ids.size() != roles.size()) {
-    scopeOp.emitOpError() << "requires equal-length PipeNet id and role arrays";
-    state.sawError = true;
+    recordError("requires equal-length PipeNet id and role arrays");
     return std::nullopt;
   }
   PipeNetScopeLaunchNodeDomains result;
   for (auto [pipeNetId, roleValue] : llvm::zip_equal(ids, roles)) {
     if (roleValue != static_cast<int64_t>(PipeRole::Source) &&
         roleValue != static_cast<int64_t>(PipeRole::Destination)) {
-      scopeOp.emitOpError() << "has invalid PipeNet role " << roleValue
-                            << " (expected 0=src or 1=dst)";
-      state.sawError = true;
+      recordError(Twine("has invalid PipeNet role ") + Twine(roleValue) +
+                  " (expected 0=src or 1=dst)");
       return std::nullopt;
     }
     auto role = static_cast<PipeRole>(roleValue);
@@ -953,7 +960,8 @@ void LaunchNodeDomainAnalysis::visitRegionBranchControlFlowTransfer(
             getPipeDestinationLaunchNodeDomain(pipeType, state.baseDomain));
       })
       .Case<PipeNetScopeOp>([&](PipeNetScopeOp scopeOp) {
-        auto scope = getPipeNetScopeLaunchNodeDomains(scopeOp, state);
+        auto scope = getPipeNetScopeLaunchNodeDomains(
+            scopeOp, state, options.emitInvalidPipeNetDiagnostics);
         if (!scope) {
           return;
         }

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -6,31 +6,18 @@
 // TTL Finalize DFB Indices
 //===----------------------------------------------------------------------===//
 //
-// Plans module-wide logical identities, physical indices, and runtime metadata
-// after DFB creation and synchronization. Pass-order, lifecycle, identity,
-// capacity, and metadata checks complete before the plan modifies the IR.
+// Module-level pass that applies a validated physical DFB allocation plan.
 //
 //===----------------------------------------------------------------------===//
 
-#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "DFBPhysicalAllocationPlan.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
-#include "ttlang/Dialect/TTL/IR/TTLOps.h"
-#include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 #include "ttlang/Dialect/TTL/Passes.h"
-#include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
-#include "ttlang/Dialect/TTL/Transforms/LiveIntervalUtils.h"
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 
-#include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/MapVector.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
-
-#include <algorithm>
-#include <functional>
 
 #define DEBUG_TYPE "ttl-finalize-dfb-indices"
 
@@ -41,458 +28,79 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-static bool isDerivedDFBIndexAttribute(StringRef attributeName) {
-  return attributeName == kUnpackToDestFp32AttrName ||
-         attributeName.starts_with(kCBIndexAttrPrefix) ||
-         attributeName == kBcastOutputCBIndexAttrName ||
-         attributeName == kReduceOutputCBIndexAttrName ||
-         attributeName == kTransposeOutputCBIndexAttrName;
-}
-
-/// Verifies that no pass has copied provisional compiler DFB indices.
-///
-/// The listed attributes are assumed to contain direct copies of `cb_index`.
-/// Rejecting them before allocation prevents finalization from changing a DFB
-/// declaration while leaving a stale copy elsewhere. Matching by attribute
-/// name is independent of the containing operation or region structure. The
-/// predicate must include every attribute introduced by a pass that copies a
-/// DFB index.
-static LogicalResult verifyFinalizationPrecedesIndexCopies(ModuleOp moduleOp) {
-  WalkResult walkResult = moduleOp->walk([&](Operation *operation) {
-    for (NamedAttribute attribute : operation->getAttrs()) {
-      StringRef attributeName = attribute.getName().getValue();
-      if (!isDerivedDFBIndexAttribute(attributeName)) {
-        continue;
-      }
-      operation->emitOpError()
-          << "contains derived DFB-index attribute '" << attributeName
-          << "' before DFB index finalization; run ttl-finalize-dfb-indices "
-             "before ttl-set-compute-kernel-config and "
-             "ttl-annotate-cb-associations";
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  return success(!walkResult.wasInterrupted());
-}
-
-/// Rejects compiler-created DFB declarations missing a lifecycle operation.
-///
-/// Finalization may span any number of transactions. Auto-sync is assumed to
-/// have balanced every acquire with its corresponding release; this check
-/// diagnoses declarations with only part of the required producer/consumer
-/// protocol, which cannot define the expected compiler-created intermediate.
-static LogicalResult verifyCompilerDFBLifecycleOperations(BindCBOp bindOp) {
-  bool hasReserve = false;
-  bool hasPush = false;
-  bool hasWait = false;
-  bool hasPop = false;
-  for (OpOperand &use : bindOp.getResult().getUses()) {
-    Operation *user = use.getOwner();
-    hasReserve |= isa<CBReserveOp>(user);
-    hasPush |= isa<CBPushOp>(user);
-    hasWait |= isa<CBWaitOp>(user);
-    hasPop |= isa<CBPopOp>(user);
-  }
-
-  if (!hasReserve && !hasPush && !hasWait && !hasPop) {
-    return success();
-  }
-  const std::pair<bool, StringLiteral> requiredOperations[] = {
-      {hasReserve, "ttl.cb_reserve"},
-      {hasPush, "ttl.cb_push"},
-      {hasWait, "ttl.cb_wait"},
-      {hasPop, "ttl.cb_pop"},
-  };
-  for (auto [present, operationName] : requiredOperations) {
-    if (!present) {
-      return bindOp.emitOpError()
-             << "compiler-allocated DFB has a partial lifecycle: missing "
-             << operationName;
-    }
-  }
-  return success();
-}
-
-/// One DFB declaration's final physical index.
-struct DFBIndexAssignment {
-  BindCBOp declaration;
-  int32_t physicalIndex;
-};
-
-/// One runtime metadata entry for a physical DFB.
-struct DFBAllocationMetadataEntry {
-  int32_t physicalIndex;
-  /// Representative declaration supplying the exact DFB type.
-  BindCBOp declaration;
-};
-
-/// Complete DFB finalization plan validated before IR mutation.
-struct DFBAllocationPlan {
-  /// Physical-index updates for every DFB declaration.
-  SmallVector<DFBIndexAssignment> assignments;
-  /// One runtime descriptor for each unique physical index.
-  SmallVector<DFBAllocationMetadataEntry> metadata;
-  /// Size of the dense zero-based physical-index range.
-  int32_t physicalDFBCount = 0;
-  /// Compiler-owned slots reported if the hardware limit is exceeded.
-  int32_t compilerSlotCount = 0;
-};
-
-/// Plans physical indices for one kernel without modifying its declarations.
-///
-/// Compiler-created DFB declarations are assumed to be in the kernel body.
-/// Nested acquires and releases are projected to their body-block ancestor, so
-/// lifetimes within one top-level operation conservatively overlap. An unused
-/// or unreleased DFB remains live through the end of the kernel. Auto-sync is
-/// assumed to place the last pop after every use of the waited tensor, and
-/// compiler-created intermediates have no later direct DFB access. These rules
-/// may reduce reuse but cannot assign one index to potentially live DFBs. DFBs
-/// share an index only when their half-open intervals do not overlap and their
-/// exact types match. Returns the number of physical indices used by the
-/// kernel.
-static int32_t
-planPhysicalDFBIndices(func::FuncOp kernel, ArrayRef<BindCBOp> dfbOps,
-                       int32_t firstPhysicalIndex,
-                       SmallVectorImpl<DFBIndexAssignment> &assignments) {
-  Block &body = kernel.getBody().front();
-
-  DenseMap<Operation *, int64_t> operationIndices;
-  int64_t nextOperationIndex = 0;
-  for (Operation &operation : body) {
-    operationIndices[&operation] = nextOperationIndex++;
-  }
-  int64_t kernelEndIndex = nextOperationIndex;
-
-  auto getOperationIndex = [&](Operation *operation) -> int64_t {
-    auto operationIndex = operationIndices.find(operation);
-    assert(operationIndex != operationIndices.end() &&
-           "operation must belong to the kernel body");
-    return operationIndex->second;
-  };
-
-  auto getBodyIndex = [&](Operation *operation) -> int64_t {
-    if (operation->getBlock() == &body) {
-      return getOperationIndex(operation);
-    }
-    Operation *ancestor = body.findAncestorOpInBlock(*operation);
-    assert(ancestor && "operation must be reachable from kernel body");
-    return getOperationIndex(ancestor);
-  };
-
-  llvm::MapVector<Type, SmallVector<ValueLiveInterval>> typeToIntervals;
-  DenseMap<Value, BindCBOp> valueToDeclaration;
-
-  for (BindCBOp bindOp : dfbOps) {
-    assert(bindOp->getBlock() == &body &&
-           "compiler-allocated BindCBOp must be in kernel body block");
-
-    Value dfb = bindOp.getResult();
-    int64_t start = kernelEndIndex;
-    int64_t end = getOperationIndex(bindOp);
-    bool hasAcquire = false;
-
-    for (OpOperand &use : dfb.getUses()) {
-      Operation *user = use.getOwner();
-      int64_t useIndex = getBodyIndex(user);
-      if (isa<CBReserveOp, CBWaitOp>(user)) {
-        start = std::min(start, useIndex);
-        hasAcquire = true;
-      }
-      if (isa<CBPopOp>(user)) {
-        // Include the pop in the half-open interval. Acquires and pops
-        // projected to the same kernel-body operation must overlap.
-        end = std::max(end, useIndex + 1);
-      }
-    }
-
-    if (!hasAcquire) {
-      start = getOperationIndex(bindOp);
-    }
-    if (end <= start) {
-      end = kernelEndIndex;
-    }
-
-    SmallVector<ValueLiveInterval> &intervals = typeToIntervals[dfb.getType()];
-    int64_t ordinal = static_cast<int64_t>(intervals.size());
-    intervals.push_back({start, end, dfb, ordinal});
-    valueToDeclaration[dfb] = bindOp;
-  }
-
-  DenseMap<Operation *, int32_t> plannedIndices;
-  int32_t nextSlotOffset = 0;
-  for (SmallVector<ValueLiveInterval> &intervals :
-       llvm::make_second_range(typeToIntervals)) {
-    SmallVector<SmallVector<ValueLiveInterval>> colorUsers =
-        assignGreedyIntervalColors<ValueLiveInterval>(
-            intervals, std::less<ValueLiveInterval>(),
-            [](const ValueLiveInterval &lhs, const ValueLiveInterval &rhs) {
-              return intervalsOverlap(lhs, rhs);
-            });
-
-    for (auto indexedColor : llvm::enumerate(colorUsers)) {
-      int32_t color = static_cast<int32_t>(indexedColor.index());
-      for (const ValueLiveInterval &interval : indexedColor.value()) {
-        BindCBOp declaration = valueToDeclaration.lookup(interval.value);
-        assert(declaration && "every live interval must have a declaration");
-        plannedIndices[declaration.getOperation()] =
-            firstPhysicalIndex + nextSlotOffset + color;
-
-        LLVM_DEBUG({
-          llvm::dbgs() << "DFB reuse: [" << interval.start << ", "
-                       << interval.end << "] -> slot " << color << "\n";
-        });
-      }
-    }
-    nextSlotOffset += static_cast<int32_t>(colorUsers.size());
-  }
-
-  for (BindCBOp bindOp : dfbOps) {
-    auto plannedIndex = plannedIndices.find(bindOp.getOperation());
-    assert(plannedIndex != plannedIndices.end() &&
-           "every compiler-created DFB must have a planned index");
-    assignments.push_back({bindOp, plannedIndex->second});
-  }
-
-  LLVM_DEBUG({
-    llvm::dbgs() << "DFB reuse: " << dfbOps.size()
-                 << " compiler-allocated DFBs -> " << nextSlotOffset
-                 << " physical slot(s)\n";
-  });
-  return nextSlotOffset;
-}
-
-/// Builds all physical assignments and runtime metadata before modifying IR.
-///
-/// User-declared physical indices are compacted while preserving any existing
-/// sharing. Compiler indices follow the compacted user range, so allocation
-/// cannot alias user storage. Metadata includes every declaration because user
-/// DFBs and compiler-created DFBs use the same runtime allocation mechanism.
-/// Declarations may share a physical index only when their exact DFB types
-/// match.
-static FailureOr<DFBAllocationPlan> buildDFBAllocationPlan(
-    ModuleOp moduleOp,
-    const llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> &kernelToDFBs,
-    const DFBLogicalIdentityAnalysis &identityAnalysis) {
-  DFBAllocationPlan plan;
-
-  DenseSet<int64_t> uniqueUserProvisionalIndices;
-  for (const DFBLogicalIdentityAssignment &identity :
-       identityAnalysis.getAssignments()) {
-    BindCBOp declaration = identity.declaration;
-    if (declaration->hasAttr(kCompilerAllocatedAttrName)) {
-      continue;
-    }
-    int64_t provisionalIndex = declaration.getCbIndex().getSExtValue();
-    uniqueUserProvisionalIndices.insert(provisionalIndex);
-  }
-
-  SmallVector<int64_t> sortedUserProvisionalIndices(
-      uniqueUserProvisionalIndices.begin(), uniqueUserProvisionalIndices.end());
-  llvm::sort(sortedUserProvisionalIndices);
-
-  DenseMap<int64_t, int32_t> compactedUserIndices;
-  for (auto [physicalIndex, provisionalIndex] :
-       llvm::enumerate(sortedUserProvisionalIndices)) {
-    compactedUserIndices[provisionalIndex] =
-        static_cast<int32_t>(physicalIndex);
-  }
-  for (const DFBLogicalIdentityAssignment &identity :
-       identityAnalysis.getAssignments()) {
-    BindCBOp declaration = identity.declaration;
-    if (declaration->hasAttr(kCompilerAllocatedAttrName)) {
-      continue;
-    }
-    int64_t provisionalIndex = declaration.getCbIndex().getSExtValue();
-    plan.assignments.push_back(
-        {declaration, compactedUserIndices.lookup(provisionalIndex)});
-  }
-
-  int32_t nextCompilerDFBIndex =
-      static_cast<int32_t>(sortedUserProvisionalIndices.size());
-  for (const auto &[kernel, dfbOps] : kernelToDFBs) {
-    int32_t physicalSlotCount = planPhysicalDFBIndices(
-        kernel, dfbOps, nextCompilerDFBIndex, plan.assignments);
-    nextCompilerDFBIndex += physicalSlotCount;
-    plan.compilerSlotCount += physicalSlotCount;
-  }
-  plan.physicalDFBCount = nextCompilerDFBIndex;
-
-  if (plan.physicalDFBCount > kMaxCircularBuffers) {
-    moduleOp.emitError()
-        << "need " << plan.physicalDFBCount
-        << " DFB indices but hardware supports at most " << kMaxCircularBuffers
-        << " (" << plan.compilerSlotCount
-        << " compiler-allocated after reuse); reduce the number of "
-           "user-declared dataflow buffers or split the computation into "
-           "multiple kernels";
-    return failure();
-  }
-
-  DenseMap<Operation *, int32_t> plannedIndices;
-  for (const DFBIndexAssignment &assignment : plan.assignments) {
-    BindCBOp declaration = assignment.declaration;
-    plannedIndices[declaration.getOperation()] = assignment.physicalIndex;
-  }
-
-  DenseMap<int64_t, int32_t> physicalIndexByLogicalId;
-  DenseMap<int32_t, BindCBOp> uniqueByIndex;
-  for (const DFBLogicalIdentityAssignment &identity :
-       identityAnalysis.getAssignments()) {
-    BindCBOp declaration = identity.declaration;
-    auto plannedIndex = plannedIndices.find(declaration.getOperation());
-    assert(plannedIndex != plannedIndices.end() &&
-           "every DFB declaration must have a planned index");
-    int32_t physicalIndex = plannedIndex->second;
-
-    auto [logicalIndex, insertedLogicalIndex] =
-        physicalIndexByLogicalId.try_emplace(identity.logicalId, physicalIndex);
-    if (!insertedLogicalIndex && logicalIndex->second != physicalIndex) {
-      declaration.emitOpError()
-          << "logical DFB " << identity.logicalId
-          << " has inconsistent physical indices " << logicalIndex->second
-          << " and " << physicalIndex;
-      return failure();
-    }
-
-    auto [existingDeclaration, inserted] =
-        uniqueByIndex.try_emplace(physicalIndex, declaration);
-    if (!inserted && existingDeclaration->second.getResult().getType() !=
-                         declaration.getResult().getType()) {
-      declaration.emitOpError()
-          << "physical DFB index " << physicalIndex
-          << " has inconsistent CircularBufferType values "
-          << existingDeclaration->second.getResult().getType() << " and "
-          << declaration.getResult().getType();
-      return failure();
-    }
-  }
-
-  SmallVector<std::pair<int32_t, BindCBOp>> sortedMetadata(
-      uniqueByIndex.begin(), uniqueByIndex.end());
-  llvm::sort(sortedMetadata, [](const auto &lhs, const auto &rhs) {
-    return lhs.first < rhs.first;
-  });
-  for (auto [expectedIndex, metadata] : llvm::enumerate(sortedMetadata)) {
-    auto [physicalIndex, declaration] = metadata;
-    if (physicalIndex != static_cast<int32_t>(expectedIndex)) {
-      declaration.emitOpError()
-          << "physical DFB indices must form a dense zero-based range; "
-             "expected index "
-          << expectedIndex << " but found " << physicalIndex;
-      return failure();
-    }
-  }
-  for (auto [physicalIndex, declaration] : sortedMetadata) {
-    plan.metadata.push_back({physicalIndex, declaration});
-  }
-  return plan;
-}
-
-/// Applies a complete plan after every operation that can fail has succeeded.
-static void applyDFBAllocationPlan(
-    ModuleOp moduleOp, OpBuilder &builder, const DFBAllocationPlan &plan,
-    ArrayRef<DFBLogicalIdentityAssignment> identityAssignments) {
+/// Materializes decisions already validated by physical allocation analysis.
+static void
+applyPhysicalAllocationPlan(ModuleOp moduleOp, OpBuilder &builder,
+                            const DFBPhysicalAllocationPlan &allocationPlan) {
   MLIRContext *context = moduleOp.getContext();
-  for (const DFBIndexAssignment &assignment : plan.assignments) {
-    BindCBOp declaration = assignment.declaration;
-    declaration.setCbIndexAttr(
-        IntegerAttr::get(IndexType::get(context), assignment.physicalIndex));
-  }
-  for (const DFBLogicalIdentityAssignment &assignment : identityAssignments) {
-    BindCBOp declaration = assignment.declaration;
-    declaration.setDfbIdAttr(
-        IntegerAttr::get(IndexType::get(context), assignment.logicalId));
-  }
-
-  if (plan.physicalDFBCount > 0) {
-    moduleOp->walk([&](func::FuncOp kernel) {
-      if (kernel->hasAttr(kBaseCTAIndexAttrName)) {
-        kernel->setAttr(kBaseCTAIndexAttrName,
-                        builder.getI32IntegerAttr(plan.physicalDFBCount));
-      }
+  for (const DFBPhysicalIndexAssignment &assignment :
+       allocationPlan.getAssignments()) {
+    for (BindCBOp declaration : assignment.declarations) {
+      declaration.setDfbIdAttr(
+          IntegerAttr::get(IndexType::get(context), assignment.logicalId));
+      declaration.setCbIndexAttr(
+          IntegerAttr::get(IndexType::get(context), assignment.physicalIndex));
+    }
+    LLVM_DEBUG({
+      llvm::dbgs() << "DFB assignment: logical DFB " << assignment.logicalId
+                   << " -> physical index " << assignment.physicalIndex
+                   << (assignment.bounded ? " (bounded)\n" : " (unbounded)\n");
     });
   }
 
-  SmallVector<Attribute> metadataAttributes;
-  for (const DFBAllocationMetadataEntry &metadata : plan.metadata) {
-    BindCBOp declaration = metadata.declaration;
-    auto dfbType = cast<CircularBufferType>(declaration.getResult().getType());
+  for (const DFBKernelBaseIndexAssignment &baseIndex :
+       allocationPlan.getKernelBaseIndices()) {
+    baseIndex.kernel->setAttr(kBaseCTAIndexAttrName,
+                              builder.getI32IntegerAttr(baseIndex.baseIndex));
+  }
+
+  SmallVector<Attribute> descriptorAttributes;
+  for (const DFBPhysicalAllocationDescriptor &descriptor :
+       allocationPlan.getDescriptors()) {
     SmallVector<NamedAttribute> entryAttributes;
     entryAttributes.push_back(builder.getNamedAttr(
-        "dfb_index", builder.getI32IntegerAttr(metadata.physicalIndex)));
+        "dfb_index", builder.getI32IntegerAttr(descriptor.physicalIndex)));
     entryAttributes.push_back(builder.getNamedAttr(
-        "num_tiles", builder.getI32IntegerAttr(
-                         static_cast<int32_t>(dfbType.getElementsPerBlock()))));
+        "num_tiles", builder.getI32IntegerAttr(descriptor.numTiles)));
     entryAttributes.push_back(builder.getNamedAttr(
-        "element_type", TypeAttr::get(dfbType.getElementType())));
+        "element_type", TypeAttr::get(descriptor.elementType)));
     entryAttributes.push_back(builder.getNamedAttr(
-        "page_size",
-        builder.getI32IntegerAttr(static_cast<int32_t>(
-            ttcore::getElementSizeBytes(dfbType.getElementType())))));
+        "page_size", builder.getI32IntegerAttr(descriptor.pageSize)));
     entryAttributes.push_back(builder.getNamedAttr(
-        "block_count", builder.getI32IntegerAttr(
-                           static_cast<int32_t>(dfbType.getBlockCount()))));
-    metadataAttributes.push_back(DictionaryAttr::get(context, entryAttributes));
+        "block_count", builder.getI32IntegerAttr(descriptor.blockCount)));
+    descriptorAttributes.push_back(
+        DictionaryAttr::get(context, entryAttributes));
   }
   moduleOp->setAttr(kDFBAllocationsAttrName,
-                    ArrayAttr::get(context, metadataAttributes));
+                    ArrayAttr::get(context, descriptorAttributes));
 }
 
 struct TTLFinalizeDFBIndicesPass
     : public impl::TTLFinalizeDFBIndicesBase<TTLFinalizeDFBIndicesPass> {
-  void runOnOperation() override {
-    auto moduleOp = getOperation();
-    OpBuilder builder(moduleOp.getContext());
+  using Base::Base;
 
-    // Validate logical identities before building the physical allocation plan
-    // so every failure leaves the input IR unchanged.
-    const DFBLogicalIdentityAnalysis &identityAnalysis =
-        getAnalysis<DFBLogicalIdentityAnalysis>();
-    if (!identityAnalysis.succeeded()) {
-      Operation *errorOperation = identityAnalysis.getErrorOperation();
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    DFBPhysicalAllocationPlanner allocationPlanner(
+        moduleOp, reuseUserDFBs, exactColoringSearchStateLimit,
+        getAnalysisManager());
+    if (!allocationPlanner.succeeded()) {
+      Operation *errorOperation = allocationPlanner.getErrorOperation();
       if (!errorOperation) {
         errorOperation = moduleOp.getOperation();
       }
-      errorOperation->emitOpError() << identityAnalysis.getErrorMessage();
+      errorOperation->emitOpError() << allocationPlanner.getErrorMessage();
       signalPassFailure();
       return;
     }
 
-    llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> kernelToDFBs;
-    moduleOp->walk([&](BindCBOp bindOp) {
-      if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-        auto kernel = bindOp->getParentOfType<func::FuncOp>();
-        kernelToDFBs[kernel].push_back(bindOp);
-      }
-    });
+    const DFBPhysicalAllocationPlan &allocationPlan =
+        allocationPlanner.getPlan();
+    LLVM_DEBUG(llvm::dbgs() << "Total DFB count: "
+                            << allocationPlan.getPhysicalDFBCount() << "\n");
 
-    if (!kernelToDFBs.empty() &&
-        failed(verifyFinalizationPrecedesIndexCopies(moduleOp))) {
-      signalPassFailure();
-      return;
-    }
-
-    for (ArrayRef<BindCBOp> dfbOps : llvm::make_second_range(kernelToDFBs)) {
-      for (BindCBOp bindOp : dfbOps) {
-        if (failed(verifyCompilerDFBLifecycleOperations(bindOp))) {
-          signalPassFailure();
-          return;
-        }
-      }
-    }
-
-    FailureOr<DFBAllocationPlan> plan =
-        buildDFBAllocationPlan(moduleOp, kernelToDFBs, identityAnalysis);
-    if (failed(plan)) {
-      signalPassFailure();
-      return;
-    }
-
-    LLVM_DEBUG(llvm::dbgs()
-               << "Total DFB count: " << plan->physicalDFBCount << "\n");
-    applyDFBAllocationPlan(moduleOp, builder, *plan,
-                           identityAnalysis.getAssignments());
+    OpBuilder builder(moduleOp.getContext());
+    applyPhysicalAllocationPlan(moduleOp, builder, allocationPlan);
   }
 };
 

--- a/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertCBSync.cpp
@@ -68,12 +68,7 @@ struct TTLInsertCBSyncPass
   void runOnOperation() override {
     func::FuncOp func = getOperation();
 
-    SmallVector<Operation *> reserves;
-    SmallVector<Operation *> waits;
-    SmallVector<Operation *> pushes;
-    SmallVector<Operation *> pops;
-
-    collectDFBAcquireReleaseOps(func, reserves, waits, pushes, pops);
+    DFBAcquireReleaseOperations operations = collectDFBAcquireReleaseOps(func);
 
     OpBuilder builder(func.getContext());
 
@@ -82,13 +77,13 @@ struct TTLInsertCBSyncPass
     // must check the set before touching any op wrapper method.
     DenseSet<Operation *> erased;
 
-    insertMissingReleases(reserves, pushes, erased, builder,
-                          [](OpBuilder &b, Location loc, Value cb) {
+    insertMissingReleases(operations.reserves, operations.pushes, erased,
+                          builder, [](OpBuilder &b, Location loc, Value cb) {
                             CBPushOp::create(b, loc, cb,
                                              /*num_tiles=*/IntegerAttr{});
                           });
 
-    insertMissingReleases(waits, pops, erased, builder,
+    insertMissingReleases(operations.waits, operations.pops, erased, builder,
                           [](OpBuilder &b, Location loc, Value cb) {
                             CBPopOp::create(b, loc, cb,
                                             /*num_tiles=*/IntegerAttr{});

--- a/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
@@ -90,7 +90,7 @@ struct TTLValidateCBBudgetPass
     }
 
     uint64_t totalBytes = footprint.getTotalBytes();
-    SmallVector<int64_t, 32> sortedIndices =
+    SmallVector<int64_t, kMaxCircularBuffers> sortedIndices =
         footprint.getSortedPhysicalIndices();
 
     auto emitBreakdown = [&](InFlightDiagnostic &diag) {

--- a/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
@@ -15,6 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "DFBAllocationLimits.h"
+
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
@@ -26,11 +28,6 @@
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
-
-#include "ttlang/Dialect/TTCore/IR/TTCoreOps.h"
-#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
-#include "ttlang/Dialect/TTCore/IR/Utils.h"
-#include <optional>
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -45,14 +42,6 @@ namespace mlir::tt::ttl {
 
 namespace {
 
-/// Fallback when the module has no `system_desc` / device: same static CB
-/// region per core as Wormhole and Blackhole (1464 KiB L1 minus 32 KiB
-/// reserved in tt-metal dev_mem_map). Matches
-/// `ttl.constants.DEFAULT_L1_CB_BUDGET_BYTES` and
-/// `ChipDescAttr::getUsableL1Size()` for those chips when IR carries attrs.
-static constexpr uint64_t kFallbackUsableL1Bytes =
-    static_cast<uint64_t>(1432 * 1024);
-
 static std::string formatShape(llvm::ArrayRef<int64_t> shape) {
   std::string s;
   llvm::raw_string_ostream os(s);
@@ -62,53 +51,6 @@ static std::string formatShape(llvm::ArrayRef<int64_t> shape) {
   return os.str();
 }
 
-/// If the module has a system descriptor and default device, return usable L1
-/// for chip 0; otherwise return std::nullopt (caller uses the WH/BH fallback).
-static std::optional<uint64_t> tryBudgetFromModule(ModuleOp moduleOp) {
-  auto systemDesc = moduleOp->getAttrOfType<mlir::tt::ttcore::SystemDescAttr>(
-      mlir::tt::ttcore::SystemDescAttr::name);
-  if (!systemDesc) {
-    return std::nullopt;
-  }
-
-  auto deviceOp = mlir::tt::ttcore::lookupDeviceOp(
-      moduleOp, mlir::tt::ttcore::getDefaultDeviceName());
-  if (!deviceOp) {
-    return std::nullopt;
-  }
-
-  auto chipIds = deviceOp.getDeviceAttr().getChipIds();
-  if (chipIds.empty()) {
-    return std::nullopt;
-  }
-
-  return *llvm::min_element(llvm::map_range(chipIds, [&](unsigned chipId) {
-    return systemDesc.getChipDesc(chipId).getUsableL1Size();
-  }));
-}
-
-/// Bytes per CB slot: explicit ttcore.tile uses its shape/dtype; row-wise
-/// (scalar/builtin) element types use the default tile layout for that dtype,
-/// matching TTCore CB page sizing.
-static uint64_t bytesPerCbElement(mlir::Type elemTy) {
-  if (auto tileTy = mlir::dyn_cast<mlir::tt::ttcore::TileType>(elemTy)) {
-    return tileTy.getSizeBytes();
-  }
-  return mlir::tt::ttcore::TileType::get(elemTy).getSizeBytes();
-}
-
-static FailureOr<uint64_t> cbBytesForBind(BindCBOp bindOp) {
-  auto cbTy = mlir::cast<CircularBufferType>(bindOp.getResult().getType());
-  mlir::Type elemTy = cbTy.getElementType();
-  const uint64_t slotBytes = bytesPerCbElement(elemTy);
-  const int64_t totalEl = cbTy.getTotalElements();
-  if (totalEl < 0) {
-    bindOp.emitOpError() << "invalid negative total element count for CB";
-    return failure();
-  }
-  return static_cast<uint64_t>(totalEl) * slotBytes;
-}
-
 struct TTLValidateCBBudgetPass
     : public impl::TTLValidateCBBudgetBase<TTLValidateCBBudgetPass> {
   using Base::Base;
@@ -116,26 +58,21 @@ struct TTLValidateCBBudgetPass
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
 
-    uint64_t budgetBytes = kFallbackUsableL1Bytes;
-    if (l1BudgetOverride > 0) {
-      budgetBytes = l1BudgetOverride;
-    } else if (auto fromDevice = tryBudgetFromModule(moduleOp)) {
-      budgetBytes = *fromDevice;
-    }
+    uint64_t budgetBytes = getUsableDFBL1Bytes(moduleOp, l1BudgetOverride);
 
-    llvm::DenseMap<int64_t, uint64_t> maxBytesByIndex;
+    DFBAllocationFootprint footprint;
     llvm::DenseMap<int64_t, BindCBOp> bindForIndex;
 
     auto walkResult = moduleOp.walk([&](BindCBOp bindOp) -> WalkResult {
-      FailureOr<uint64_t> bytes = cbBytesForBind(bindOp);
-      if (failed(bytes)) {
+      auto cbType = cast<CircularBufferType>(bindOp.getResult().getType());
+      int64_t physicalIndex = bindOp.getCbIndex().getSExtValue();
+      FailureOr<bool> increased = footprint.add(physicalIndex, cbType);
+      if (failed(increased)) {
+        bindOp.emitOpError() << "invalid negative total element count for CB";
         return WalkResult::interrupt();
       }
-      int64_t idx = bindOp.getCbIndex().getSExtValue();
-      auto it = maxBytesByIndex.find(idx);
-      if (it == maxBytesByIndex.end() || *bytes > it->second) {
-        maxBytesByIndex[idx] = *bytes;
-        bindForIndex[idx] = bindOp;
+      if (*increased) {
+        bindForIndex[physicalIndex] = bindOp;
       }
       return WalkResult::advance();
     });
@@ -145,21 +82,13 @@ struct TTLValidateCBBudgetPass
       return;
     }
 
-    if (maxBytesByIndex.empty()) {
+    if (footprint.empty()) {
       return;
     }
 
-    uint64_t totalBytes = 0;
-    for (auto &e : maxBytesByIndex) {
-      totalBytes += e.second;
-    }
-
-    SmallVector<int64_t, 32> sortedIndices;
-    sortedIndices.reserve(maxBytesByIndex.size());
-    for (auto &e : maxBytesByIndex) {
-      sortedIndices.push_back(e.first);
-    }
-    llvm::sort(sortedIndices);
+    uint64_t totalBytes = footprint.getTotalBytes();
+    SmallVector<int64_t, 32> sortedIndices =
+        footprint.getSortedPhysicalIndices();
 
     auto emitBreakdown = [&](InFlightDiagnostic &diag) {
       for (int64_t idx : sortedIndices) {
@@ -169,7 +98,7 @@ struct TTLValidateCBBudgetPass
         diag << "\n  CB[" << idx << "]: shape=" << formatShape(cbTy.getShape())
              << ", element_type=" << cbTy.getElementType()
              << ", block_count=" << cbTy.getBlockCount() << ", "
-             << maxBytesByIndex[idx] << " bytes";
+             << footprint.getBytes(idx) << " bytes";
         if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
           diag << " (compiler-allocated)";
         }
@@ -186,11 +115,11 @@ struct TTLValidateCBBudgetPass
     // slot.
     auto bindForLargestAllocation = [&]() -> BindCBOp {
       int64_t reportIdx = sortedIndices.front();
-      uint64_t reportMax = maxBytesByIndex[reportIdx];
+      uint64_t reportMax = footprint.getBytes(reportIdx);
       for (int64_t idx : sortedIndices) {
-        const uint64_t b = maxBytesByIndex[idx];
-        if (b > reportMax) {
-          reportMax = b;
+        uint64_t allocationBytes = footprint.getBytes(idx);
+        if (allocationBytes > reportMax) {
+          reportMax = allocationBytes;
           reportIdx = idx;
         }
       }

--- a/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
@@ -58,7 +58,10 @@ struct TTLValidateCBBudgetPass
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
 
-    uint64_t budgetBytes = getUsableDFBL1Bytes(moduleOp, l1BudgetOverride);
+    std::optional<uint64_t> overrideBytes =
+        l1BudgetOverride == 0 ? std::nullopt
+                              : std::optional<uint64_t>(l1BudgetOverride);
+    uint64_t budgetBytes = getUsableDFBL1Bytes(moduleOp, overrideBytes);
 
     DFBAllocationFootprint footprint;
     llvm::DenseMap<int64_t, BindCBOp> bindForIndex;

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -20,6 +20,13 @@ import sys
 from typing import Optional, Sequence
 
 
+def _nonnegative_int(value: str) -> int:
+    parsed_value = int(value)
+    if parsed_value < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
+    return parsed_value
+
+
 def _make_parser() -> argparse.ArgumentParser:
     """Build the compiler options parser.
 
@@ -91,8 +98,25 @@ def _make_parser() -> argparse.ArgumentParser:
         help=(
             "Insert compiler-allocated intermediate DFBs when materialization "
             "is required for DFB-only operands, source lifetimes, or computed "
-            "values stored from multiple blocks (default: enabled)."
+            "values stored by operations in multiple MLIR basic blocks "
+            "(default: enabled)."
         ),
+    )
+    p.add_argument(
+        "--ttl-reuse-user-dfbs",
+        default=None,
+        dest="reuse_user_dfbs",
+        action=argparse.BooleanOptionalAction,
+        help="Reuse physical DFB indices only for logical lifetimes proven "
+        "not to overlap across concurrent kernels (default: enabled).",
+    )
+    p.add_argument(
+        "--ttl-dfb-exact-coloring-search-limit",
+        default=None,
+        dest="dfb_exact_coloring_search_limit",
+        type=_nonnegative_int,
+        help="Limit exact DFB coloring to this many deterministic search "
+        "states (default: 1000000).",
     )
     p.add_argument(
         "--ttl-specialize-cores",
@@ -158,6 +182,8 @@ class CompilerOptions:
     matmul_full_fp32: bool = True
     strict_f32_acc: bool = False
     compiler_dfbs: bool = True
+    reuse_user_dfbs: bool = True
+    dfb_exact_coloring_search_limit: int = 1_000_000
     specialize_cores: bool = False
     l1_budget: int = dataclasses.field(default=0, compare=False, hash=False)
 

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -115,7 +115,7 @@ def _make_parser() -> argparse.ArgumentParser:
         default=None,
         dest="dfb_exact_coloring_search_limit",
         type=_nonnegative_int,
-        help="Limit exact DFB coloring to this many deterministic search "
+        help="Limit exact DFB allocation to this many deterministic search "
         "states (default: 1000000).",
     )
     p.add_argument(

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1838,6 +1838,10 @@ def _lower_program_to_kernel(
         assign_dst_pass = "ttl-assign-dst"
 
         compiler_dfbs_flag = int(compiler_options.compiler_dfbs)
+        reuse_user_dfbs_flag = int(compiler_options.reuse_user_dfbs)
+        exact_coloring_search_limit = (
+            compiler_options.dfb_exact_coloring_search_limit
+        )
         pipeline_passes = [
             "func.func(ttl-materialize-loop-state)",
             "func.func(ttl-insert-copy-wait)",
@@ -1848,7 +1852,10 @@ def _lower_program_to_kernel(
             "func.func(ttl-insert-cb-sync)",
             "ttl-verify-pipenet",
             "func.func(ttl-coalesce-dfb-acquires)",
-            "ttl-finalize-dfb-indices",
+            "ttl-finalize-dfb-indices{"
+            f"reuse-user-dfbs={reuse_user_dfbs_flag} "
+            f"exact-coloring-search-limit={exact_coloring_search_limit}"
+            "}",
             set_compute_config_pass,
             f"func.func({assign_dst_pass})",
         ]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ configure_lit_site_cfg(
 
 set(TTLANG_TEST_DEPENDS
   ttlang-execution-count-test
+  ttlang-dfb-allocation-oracle-test
   ttlang-launch-node-domain-test
   ttlang-op-stats
   ttlang-value-origin-test

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -21,6 +21,7 @@ mlir_check_link_libraries(ttlang-execution-count-test)
 
 add_subdirectory(ValueOrigin)
 add_subdirectory(LaunchNodeDomain)
+add_subdirectory(DFBAllocation)
 
 # This toy client demonstrates aggregate operation statistics without making
 # the output format a supported command-line interface.

--- a/test/lib/Analysis/DFBAllocation/CMakeLists.txt
+++ b/test/lib/Analysis/DFBAllocation/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_llvm_executable(ttlang-dfb-allocation-oracle-test
+  DFBAllocationOracleTest.cpp
+)
+
+llvm_update_compile_flags(ttlang-dfb-allocation-oracle-test)
+set_target_properties(ttlang-dfb-allocation-oracle-test PROPERTIES
+  EXCLUDE_FROM_ALL ON
+  FOLDER "Tests"
+)
+
+target_link_libraries(ttlang-dfb-allocation-oracle-test PRIVATE
+  TTLangTTLTransforms
+)
+
+mlir_check_link_libraries(ttlang-dfb-allocation-oracle-test)

--- a/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
+++ b/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This test uses exhaustive assignment enumeration as an independent oracle.
+// It does not call the production search while computing expected minima.
+
+#include "ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+using mlir::tt::ttl::ExactInterferenceGraphColoring;
+using mlir::tt::ttl::ExactInterferenceGraphColoringStatus;
+using mlir::tt::ttl::InterferenceGraph;
+
+constexpr uint64_t kUnlimitedSearchStates =
+    std::numeric_limits<uint64_t>::max();
+
+static bool oracleCanColor(const InterferenceGraph &graph,
+                           llvm::MutableArrayRef<unsigned> colors,
+                           unsigned vertex, unsigned colorCount) {
+  if (vertex == graph.size()) {
+    return true;
+  }
+  for (unsigned color = 0; color < colorCount; ++color) {
+    bool permitted = true;
+    for (unsigned otherVertex = 0; otherVertex < vertex; ++otherVertex) {
+      if (colors[otherVertex] == color &&
+          graph.interferes(vertex, otherVertex)) {
+        permitted = false;
+        break;
+      }
+    }
+    if (!permitted) {
+      continue;
+    }
+    colors[vertex] = color;
+    if (oracleCanColor(graph, colors, vertex + 1, colorCount)) {
+      return true;
+    }
+  }
+  colors[vertex] = std::numeric_limits<unsigned>::max();
+  return false;
+}
+
+static unsigned oracleChromaticNumber(const InterferenceGraph &graph) {
+  if (graph.size() == 0) {
+    return 0;
+  }
+  llvm::SmallVector<unsigned> colors(graph.size(),
+                                     std::numeric_limits<unsigned>::max());
+  for (unsigned colorCount = 1; colorCount <= graph.size(); ++colorCount) {
+    std::fill(colors.begin(), colors.end(),
+              std::numeric_limits<unsigned>::max());
+    if (oracleCanColor(graph, colors, /*vertex=*/0, colorCount)) {
+      return colorCount;
+    }
+  }
+  llvm_unreachable("every finite graph is colorable");
+}
+
+static InterferenceGraph buildGraph(unsigned vertexCount, uint64_t edgeMask) {
+  InterferenceGraph graph(vertexCount);
+  unsigned edgeIndex = 0;
+  for (unsigned lhsVertex = 0; lhsVertex < vertexCount; ++lhsVertex) {
+    for (unsigned rhsVertex = lhsVertex + 1; rhsVertex < vertexCount;
+         ++rhsVertex, ++edgeIndex) {
+      if (edgeMask & (uint64_t{1} << edgeIndex)) {
+        graph.addInterference(lhsVertex, rhsVertex);
+      }
+    }
+  }
+  return graph;
+}
+
+static bool verifyColoring(const InterferenceGraph &graph,
+                           const ExactInterferenceGraphColoring &coloring) {
+  if (coloring.colors.size() != graph.size()) {
+    return false;
+  }
+  for (unsigned lhsVertex = 0; lhsVertex < graph.size(); ++lhsVertex) {
+    if (coloring.colors[lhsVertex] >= coloring.colorCount) {
+      return false;
+    }
+    for (unsigned rhsVertex = lhsVertex + 1; rhsVertex < graph.size();
+         ++rhsVertex) {
+      if (graph.interferes(lhsVertex, rhsVertex) &&
+          coloring.colors[lhsVertex] == coloring.colors[rhsVertex]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+static bool compareProductionSolverWithOracle() {
+  uint64_t checkedGraphCount = 0;
+  for (unsigned vertexCount = 0; vertexCount <= 6; ++vertexCount) {
+    unsigned edgeCount = vertexCount * (vertexCount - 1) / 2;
+    uint64_t graphCount = uint64_t{1} << edgeCount;
+    for (uint64_t edgeMask = 0; edgeMask < graphCount; ++edgeMask) {
+      InterferenceGraph graph = buildGraph(vertexCount, edgeMask);
+      unsigned oracleCount = oracleChromaticNumber(graph);
+      ExactInterferenceGraphColoring production =
+          mlir::tt::ttl::colorInterferenceGraphExactly(graph,
+                                                       kUnlimitedSearchStates);
+      if (!production.isOptimal() || production.colorCount != oracleCount ||
+          !verifyColoring(graph, production)) {
+        llvm::errs() << "solver mismatch: vertices=" << vertexCount
+                     << " edge_mask=" << edgeMask << " oracle=" << oracleCount
+                     << " production=" << production.colorCount << "\n";
+        return false;
+      }
+      ++checkedGraphCount;
+    }
+  }
+  llvm::outs() << "solver_graphs=" << checkedGraphCount << "\n";
+  return true;
+}
+
+static bool verifyGreedyCapacityReproducer() {
+  InterferenceGraph pathGraph(4);
+  pathGraph.addInterference(0, 1);
+  pathGraph.addInterference(1, 2);
+  pathGraph.addInterference(2, 3);
+  llvm::SmallVector<unsigned> adversarialOrder = {0, 3, 1, 2};
+  llvm::SmallVector<unsigned> greedy =
+      mlir::tt::ttl::colorInterferenceGraphFirstFit(pathGraph,
+                                                    adversarialOrder);
+  unsigned greedyCount = *std::max_element(greedy.begin(), greedy.end()) + 1;
+  ExactInterferenceGraphColoring exact =
+      mlir::tt::ttl::colorInterferenceGraphExactly(pathGraph,
+                                                   kUnlimitedSearchStates);
+  if (greedyCount != 3 || exact.colorCount != 2) {
+    llvm::errs() << "four-vertex reproducer mismatch\n";
+    return false;
+  }
+
+  InterferenceGraph capacityGraph(34);
+  for (unsigned singleton = 0; singleton < 30; ++singleton) {
+    for (unsigned otherVertex = singleton + 1; otherVertex < 34;
+         ++otherVertex) {
+      capacityGraph.addInterference(singleton, otherVertex);
+    }
+  }
+  // Vertex order A, D, B, C makes first-fit use three colors for the path
+  // A-B-C-D after the 30-color clique.
+  capacityGraph.addInterference(30, 32);
+  capacityGraph.addInterference(32, 33);
+  capacityGraph.addInterference(33, 31);
+  mlir::tt::ttl::InterferenceGraphColoringBounds capacityBounds =
+      mlir::tt::ttl::computeInterferenceGraphColoringBounds(capacityGraph);
+  ExactInterferenceGraphColoring capacity =
+      mlir::tt::ttl::colorInterferenceGraphExactly(capacityGraph,
+                                                   kUnlimitedSearchStates);
+  if (capacityBounds.colorCount != 33 || capacity.colorCount != 32) {
+    llvm::errs() << "capacity reproducer expected greedy 33 and exact 32, got "
+                 << capacityBounds.colorCount << " and " << capacity.colorCount
+                 << "\n";
+    return false;
+  }
+  llvm::outs() << "capacity_reproducer=32\n";
+  llvm::outs() << "capacity_search_states=" << capacity.exploredStateCount
+               << "\n";
+  return true;
+}
+
+static bool verifySearchLimitOutcome() {
+  InterferenceGraph pathGraph(4);
+  pathGraph.addInterference(0, 1);
+  pathGraph.addInterference(1, 2);
+  pathGraph.addInterference(2, 3);
+  ExactInterferenceGraphColoring limited =
+      mlir::tt::ttl::colorInterferenceGraphExactly(pathGraph,
+                                                   /*searchStateLimit=*/1);
+  if (limited.status !=
+          ExactInterferenceGraphColoringStatus::SearchLimitReached ||
+      !limited.colors.empty() || limited.colorCount != 0 ||
+      limited.exploredStateCount != 1) {
+    llvm::errs() << "bounded search did not report an inconclusive result\n";
+    return false;
+  }
+  llvm::outs() << "bounded_search_states=" << limited.exploredStateCount
+               << "\n";
+  return true;
+}
+
+static bool compareAssignmentContracts() {
+  constexpr unsigned kVertexCount = 4;
+  constexpr unsigned kPossibleEdgeCount = 6;
+  constexpr unsigned kGraphCount = 1U << kPossibleEdgeCount;
+  unsigned chromaticNumbers[kGraphCount];
+  for (unsigned edgeMask = 0; edgeMask < kGraphCount; ++edgeMask) {
+    chromaticNumbers[edgeMask] =
+        oracleChromaticNumber(buildGraph(kVertexCount, edgeMask));
+  }
+
+  uint64_t caseCount = 0;
+  uint64_t perNodeImprovementCount = 0;
+  uint64_t twoGroupImprovementCount = 0;
+  unsigned maximumUniformPenalty = 0;
+  for (unsigned firstNode = 0; firstNode < kGraphCount; ++firstNode) {
+    for (unsigned secondNode = 0; secondNode < kGraphCount; ++secondNode) {
+      for (unsigned thirdNode = 0; thirdNode < kGraphCount; ++thirdNode) {
+        unsigned uniformCount =
+            chromaticNumbers[firstNode | secondNode | thirdNode];
+        unsigned perNodeCount =
+            std::max({chromaticNumbers[firstNode], chromaticNumbers[secondNode],
+                      chromaticNumbers[thirdNode]});
+        unsigned twoGroupCount =
+            std::min({std::max(chromaticNumbers[firstNode | secondNode],
+                               chromaticNumbers[thirdNode]),
+                      std::max(chromaticNumbers[firstNode | thirdNode],
+                               chromaticNumbers[secondNode]),
+                      std::max(chromaticNumbers[secondNode | thirdNode],
+                               chromaticNumbers[firstNode])});
+        ++caseCount;
+        if (perNodeCount < uniformCount) {
+          ++perNodeImprovementCount;
+          maximumUniformPenalty =
+              std::max(maximumUniformPenalty, uniformCount - perNodeCount);
+        }
+        if (twoGroupCount < uniformCount) {
+          ++twoGroupImprovementCount;
+        }
+      }
+    }
+  }
+
+  if (caseCount != 262144 || perNodeImprovementCount != 149268 ||
+      twoGroupImprovementCount != 142536 || maximumUniformPenalty != 2) {
+    llvm::errs() << "assignment-contract comparison mismatch\n";
+    return false;
+  }
+  llvm::outs() << "contract_cases=" << caseCount << "\n"
+               << "per_node_improvements=" << perNodeImprovementCount << "\n"
+               << "two_group_improvements=" << twoGroupImprovementCount << "\n"
+               << "maximum_uniform_penalty=" << maximumUniformPenalty << "\n";
+  return true;
+}
+
+} // namespace
+
+int main() {
+  return compareProductionSolverWithOracle() &&
+                 verifyGreedyCapacityReproducer() &&
+                 verifySearchLimitOutcome() && compareAssignmentContracts()
+             ? 0
+             : 1;
+}

--- a/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
+++ b/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
@@ -20,10 +20,14 @@ namespace {
 using mlir::tt::ttl::ExactInterferenceGraphColoring;
 using mlir::tt::ttl::ExactInterferenceGraphColoringStatus;
 using mlir::tt::ttl::InterferenceGraph;
+using mlir::tt::ttl::InterferenceGraphColorLimitResult;
+using mlir::tt::ttl::InterferenceGraphColorLimitStatus;
 
 constexpr uint64_t kUnlimitedSearchStates =
     std::numeric_limits<uint64_t>::max();
 
+/// Enumerates color choices in vertex order so expected results do not depend
+/// on the production DSATUR implementation or its priority rules.
 static bool oracleCanColor(const InterferenceGraph &graph,
                            llvm::MutableArrayRef<unsigned> colors,
                            unsigned vertex, unsigned colorCount) {
@@ -51,6 +55,7 @@ static bool oracleCanColor(const InterferenceGraph &graph,
   return false;
 }
 
+/// Finds the minimum feasible count by exhaustive enumeration.
 static unsigned oracleChromaticNumber(const InterferenceGraph &graph) {
   if (graph.size() == 0) {
     return 0;
@@ -67,6 +72,7 @@ static unsigned oracleChromaticNumber(const InterferenceGraph &graph) {
   llvm_unreachable("every finite graph is colorable");
 }
 
+/// Decodes a compact edge mask used to enumerate every labeled small graph.
 static InterferenceGraph buildGraph(unsigned vertexCount, uint64_t edgeMask) {
   InterferenceGraph graph(vertexCount);
   unsigned edgeIndex = 0;
@@ -81,19 +87,21 @@ static InterferenceGraph buildGraph(unsigned vertexCount, uint64_t edgeMask) {
   return graph;
 }
 
+/// Checks the solver's assignment independently of its completion status.
 static bool verifyColoring(const InterferenceGraph &graph,
-                           const ExactInterferenceGraphColoring &coloring) {
-  if (coloring.colors.size() != graph.size()) {
+                           llvm::ArrayRef<unsigned> colors,
+                           unsigned colorCount) {
+  if (colors.size() != graph.size()) {
     return false;
   }
   for (unsigned lhsVertex = 0; lhsVertex < graph.size(); ++lhsVertex) {
-    if (coloring.colors[lhsVertex] >= coloring.colorCount) {
+    if (colors[lhsVertex] >= colorCount) {
       return false;
     }
     for (unsigned rhsVertex = lhsVertex + 1; rhsVertex < graph.size();
          ++rhsVertex) {
       if (graph.interferes(lhsVertex, rhsVertex) &&
-          coloring.colors[lhsVertex] == coloring.colors[rhsVertex]) {
+          colors[lhsVertex] == colors[rhsVertex]) {
         return false;
       }
     }
@@ -101,6 +109,8 @@ static bool verifyColoring(const InterferenceGraph &graph,
   return true;
 }
 
+/// Compares minimum and fixed-limit production queries against exhaustive
+/// expected results for every graph with at most six vertices.
 static bool compareProductionSolverWithOracle() {
   uint64_t checkedGraphCount = 0;
   for (unsigned vertexCount = 0; vertexCount <= 6; ++vertexCount) {
@@ -113,11 +123,30 @@ static bool compareProductionSolverWithOracle() {
           mlir::tt::ttl::colorInterferenceGraphExactly(graph,
                                                        kUnlimitedSearchStates);
       if (!production.isOptimal() || production.colorCount != oracleCount ||
-          !verifyColoring(graph, production)) {
+          !verifyColoring(graph, production.colors, production.colorCount)) {
         llvm::errs() << "solver mismatch: vertices=" << vertexCount
                      << " edge_mask=" << edgeMask << " oracle=" << oracleCount
                      << " production=" << production.colorCount << "\n";
         return false;
+      }
+      for (unsigned colorLimit = 0; colorLimit <= vertexCount; ++colorLimit) {
+        InterferenceGraphColorLimitResult fit =
+            mlir::tt::ttl::colorInterferenceGraphWithColorLimitExactly(
+                graph, colorLimit, kUnlimitedSearchStates);
+        bool expectedFeasible = oracleCount <= colorLimit;
+        bool resultFeasible =
+            fit.status == InterferenceGraphColorLimitStatus::Feasible;
+        if (resultFeasible != expectedFeasible ||
+            (resultFeasible &&
+             !verifyColoring(graph, fit.colors, fit.colorCount)) ||
+            (!resultFeasible &&
+             fit.status != InterferenceGraphColorLimitStatus::Infeasible)) {
+          llvm::errs() << "fixed-limit mismatch: vertices=" << vertexCount
+                       << " edge_mask=" << edgeMask
+                       << " color_limit=" << colorLimit
+                       << " oracle=" << oracleCount << "\n";
+          return false;
+        }
       }
       ++checkedGraphCount;
     }
@@ -126,6 +155,8 @@ static bool compareProductionSolverWithOracle() {
   return true;
 }
 
+/// Confirms that a fixed-limit exact check repairs the adversarial first-fit
+/// ordering used by the positive 32-index capacity test.
 static bool verifyGreedyCapacityReproducer() {
   InterferenceGraph pathGraph(4);
   pathGraph.addInterference(0, 1);
@@ -158,21 +189,24 @@ static bool verifyGreedyCapacityReproducer() {
   capacityGraph.addInterference(33, 31);
   mlir::tt::ttl::InterferenceGraphColoringBounds capacityBounds =
       mlir::tt::ttl::computeInterferenceGraphColoringBounds(capacityGraph);
-  ExactInterferenceGraphColoring capacity =
-      mlir::tt::ttl::colorInterferenceGraphExactly(capacityGraph,
-                                                   kUnlimitedSearchStates);
-  if (capacityBounds.colorCount != 33 || capacity.colorCount != 32) {
-    llvm::errs() << "capacity reproducer expected greedy 33 and exact 32, got "
-                 << capacityBounds.colorCount << " and " << capacity.colorCount
-                 << "\n";
+  InterferenceGraphColorLimitResult capacityFit =
+      mlir::tt::ttl::colorInterferenceGraphWithColorLimitExactly(
+          capacityGraph, /*colorLimit=*/32, kUnlimitedSearchStates);
+  if (capacityBounds.colorCount != 33 || !capacityFit.isFeasible() ||
+      capacityFit.colorCount != 32) {
+    llvm::errs()
+        << "capacity reproducer expected first-fit 33 and fixed-limit 32, got "
+        << capacityBounds.colorCount << " and " << capacityFit.colorCount
+        << "\n";
     return false;
   }
   llvm::outs() << "capacity_reproducer=32\n";
-  llvm::outs() << "capacity_search_states=" << capacity.exploredStateCount
+  llvm::outs() << "capacity_search_states=" << capacityFit.exploredStateCount
                << "\n";
   return true;
 }
 
+/// Distinguishes an exhausted search budget from a proof of infeasibility.
 static bool verifySearchLimitOutcome() {
   InterferenceGraph pathGraph(4);
   pathGraph.addInterference(0, 1);
@@ -188,11 +222,94 @@ static bool verifySearchLimitOutcome() {
     llvm::errs() << "bounded search did not report an inconclusive result\n";
     return false;
   }
+  InterferenceGraphColorLimitResult fixedLimit =
+      mlir::tt::ttl::colorInterferenceGraphWithColorLimitExactly(
+          pathGraph, /*colorLimit=*/2, /*searchStateLimit=*/1);
+  if (fixedLimit.status !=
+          InterferenceGraphColorLimitStatus::SearchLimitReached ||
+      !fixedLimit.colors.empty() || fixedLimit.colorCount != 0 ||
+      fixedLimit.exploredStateCount != 1) {
+    llvm::errs()
+        << "fixed-limit search did not report an inconclusive result\n";
+    return false;
+  }
   llvm::outs() << "bounded_search_states=" << limited.exploredStateCount
                << "\n";
   return true;
 }
 
+/// Builds one Mycielskian while preserving deterministic vertex numbering.
+/// Repeated application creates low-clique, high-chromatic witnesses.
+static InterferenceGraph buildMycielskian(const InterferenceGraph &graph) {
+  unsigned vertexCount = graph.size();
+  InterferenceGraph result(2 * vertexCount + 1);
+  for (unsigned lhsVertex = 0; lhsVertex < vertexCount; ++lhsVertex) {
+    for (unsigned rhsVertex = lhsVertex + 1; rhsVertex < vertexCount;
+         ++rhsVertex) {
+      if (!graph.interferes(lhsVertex, rhsVertex)) {
+        continue;
+      }
+      result.addInterference(lhsVertex, rhsVertex);
+      result.addInterference(lhsVertex, vertexCount + rhsVertex);
+      result.addInterference(rhsVertex, vertexCount + lhsVertex);
+    }
+  }
+  unsigned apex = 2 * vertexCount;
+  for (unsigned clone = vertexCount; clone < 2 * vertexCount; ++clone) {
+    result.addInterference(clone, apex);
+  }
+  return result;
+}
+
+/// Verifies a C5 witness and demonstrates why a fixed acceptance query avoids
+/// the harder minimum proof when the clique bound is far below chromatic count.
+static bool verifyLowCliqueFixedLimitCheck() {
+  InterferenceGraph completeGraph(2);
+  completeGraph.addInterference(0, 1);
+  InterferenceGraph cycleFive = buildMycielskian(completeGraph);
+  mlir::tt::ttl::InterferenceGraphColoringBounds cycleBounds =
+      mlir::tt::ttl::computeInterferenceGraphColoringBounds(cycleFive);
+  InterferenceGraphColorLimitResult cycleTwoColors =
+      mlir::tt::ttl::colorInterferenceGraphWithColorLimitExactly(
+          cycleFive, /*colorLimit=*/2, kUnlimitedSearchStates);
+  InterferenceGraphColorLimitResult cycleThreeColors =
+      mlir::tt::ttl::colorInterferenceGraphWithColorLimitExactly(
+          cycleFive, /*colorLimit=*/3, kUnlimitedSearchStates);
+  if (cycleBounds.cliqueLowerBound != 2 ||
+      cycleTwoColors.status != InterferenceGraphColorLimitStatus::Infeasible ||
+      !cycleThreeColors.isFeasible()) {
+    llvm::errs() << "C5 exact-coloring witness mismatch\n";
+    return false;
+  }
+
+  InterferenceGraph fourChromatic = buildMycielskian(cycleFive);
+  InterferenceGraph fiveChromatic = buildMycielskian(fourChromatic);
+  constexpr uint64_t kComparisonSearchStates = 100;
+  InterferenceGraphColorLimitResult fixedLimit =
+      mlir::tt::ttl::colorInterferenceGraphWithColorLimitExactly(
+          fiveChromatic, /*colorLimit=*/5, kComparisonSearchStates);
+  ExactInterferenceGraphColoring minimum =
+      mlir::tt::ttl::colorInterferenceGraphExactly(fiveChromatic,
+                                                   kComparisonSearchStates);
+  if (!fixedLimit.isFeasible() ||
+      minimum.status !=
+          ExactInterferenceGraphColoringStatus::SearchLimitReached) {
+    llvm::errs() << "low-clique fixed-limit comparison mismatch: fixed="
+                 << static_cast<unsigned>(fixedLimit.status)
+                 << " minimum=" << static_cast<unsigned>(minimum.status)
+                 << " fixed_states=" << fixedLimit.exploredStateCount
+                 << " minimum_states=" << minimum.exploredStateCount << "\n";
+    return false;
+  }
+  llvm::outs() << "low_clique_fixed_states=" << fixedLimit.exploredStateCount
+               << "\n"
+               << "low_clique_minimum_states=" << minimum.exploredStateCount
+               << "\n";
+  return true;
+}
+
+/// Exhaustively measures the assignment-count penalty of uniform coloring
+/// relative to per-node and two-group contracts.
 static bool compareAssignmentContracts() {
   constexpr unsigned kVertexCount = 4;
   constexpr unsigned kPossibleEdgeCount = 6;
@@ -252,7 +369,9 @@ static bool compareAssignmentContracts() {
 int main() {
   return compareProductionSolverWithOracle() &&
                  verifyGreedyCapacityReproducer() &&
-                 verifySearchLimitOutcome() && compareAssignmentContracts()
+                 verifySearchLimitOutcome() &&
+                 verifyLowCliqueFixedLimitCheck() &&
+                 compareAssignmentContracts()
              ? 0
              : 1;
 }

--- a/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
+++ b/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
@@ -2,8 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// This test uses exhaustive assignment enumeration as an independent oracle.
-// It does not call the production search while computing expected minima.
+// This test treats each graph vertex as one DFB, each edge as a required
+// distinct-index relation, and each color as one physical index. Exhaustive
+// assignment enumeration supplies expected results without calling the
+// production search.
 
 #include "ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h"
 
@@ -26,8 +28,8 @@ using mlir::tt::ttl::InterferenceGraphColorLimitStatus;
 constexpr uint64_t kUnlimitedSearchStates =
     std::numeric_limits<uint64_t>::max();
 
-/// Enumerates color choices in vertex order so expected results do not depend
-/// on the production DSATUR implementation or its priority rules.
+/// Enumerates index choices in vertex order so expected results do not depend
+/// on the production search order.
 static bool oracleCanColor(const InterferenceGraph &graph,
                            llvm::MutableArrayRef<unsigned> colors,
                            unsigned vertex, unsigned colorCount) {
@@ -55,8 +57,8 @@ static bool oracleCanColor(const InterferenceGraph &graph,
   return false;
 }
 
-/// Finds the minimum feasible count by exhaustive enumeration.
-static unsigned oracleChromaticNumber(const InterferenceGraph &graph) {
+/// Finds the minimum feasible physical-index count by exhaustive enumeration.
+static unsigned oracleMinimumIndexCount(const InterferenceGraph &graph) {
   if (graph.size() == 0) {
     return 0;
   }
@@ -118,7 +120,7 @@ static bool compareProductionSolverWithOracle() {
     uint64_t graphCount = uint64_t{1} << edgeCount;
     for (uint64_t edgeMask = 0; edgeMask < graphCount; ++edgeMask) {
       InterferenceGraph graph = buildGraph(vertexCount, edgeMask);
-      unsigned oracleCount = oracleChromaticNumber(graph);
+      unsigned oracleCount = oracleMinimumIndexCount(graph);
       ExactInterferenceGraphColoring production =
           mlir::tt::ttl::colorInterferenceGraphExactly(graph,
                                                        kUnlimitedSearchStates);
@@ -182,8 +184,8 @@ static bool verifyGreedyCapacityReproducer() {
       capacityGraph.addInterference(singleton, otherVertex);
     }
   }
-  // Vertex order A, D, B, C makes first-fit use three colors for the path
-  // A-B-C-D after the 30-color clique.
+  // A, D, B, C processing makes first-fit use three indices for the conflict
+  // chain A-B-C-D after the 30 pairwise-conflicting DFBs.
   capacityGraph.addInterference(30, 32);
   capacityGraph.addInterference(32, 33);
   capacityGraph.addInterference(33, 31);
@@ -238,8 +240,8 @@ static bool verifySearchLimitOutcome() {
   return true;
 }
 
-/// Builds one Mycielskian while preserving deterministic vertex numbering.
-/// Repeated application creates low-clique, high-chromatic witnesses.
+/// Preserves small pairwise-conflicting sets while increasing the required
+/// index count, producing cases where the lower bound is intentionally weak.
 static InterferenceGraph buildMycielskian(const InterferenceGraph &graph) {
   unsigned vertexCount = graph.size();
   InterferenceGraph result(2 * vertexCount + 1);
@@ -261,9 +263,9 @@ static InterferenceGraph buildMycielskian(const InterferenceGraph &graph) {
   return result;
 }
 
-/// Verifies a C5 witness and demonstrates why a fixed acceptance query avoids
-/// the harder minimum proof when the clique bound is far below chromatic count.
-static bool verifyLowCliqueFixedLimitCheck() {
+/// Demonstrates why asking whether five indices fit is cheaper than proving
+/// the minimum when the pairwise-conflict lower bound is weak.
+static bool verifyFixedLimitAvoidsMinimumSearch() {
   InterferenceGraph completeGraph(2);
   completeGraph.addInterference(0, 1);
   InterferenceGraph cycleFive = buildMycielskian(completeGraph);
@@ -275,10 +277,10 @@ static bool verifyLowCliqueFixedLimitCheck() {
   InterferenceGraphColorLimitResult cycleThreeColors =
       mlir::tt::ttl::colorInterferenceGraphWithColorLimitExactly(
           cycleFive, /*colorLimit=*/3, kUnlimitedSearchStates);
-  if (cycleBounds.cliqueLowerBound != 2 ||
+  if (cycleBounds.pairwiseConflictLowerBound != 2 ||
       cycleTwoColors.status != InterferenceGraphColorLimitStatus::Infeasible ||
       !cycleThreeColors.isFeasible()) {
-    llvm::errs() << "C5 exact-coloring witness mismatch\n";
+    llvm::errs() << "five-cycle allocation witness mismatch\n";
     return false;
   }
 
@@ -294,30 +296,28 @@ static bool verifyLowCliqueFixedLimitCheck() {
   if (!fixedLimit.isFeasible() ||
       minimum.status !=
           ExactInterferenceGraphColoringStatus::SearchLimitReached) {
-    llvm::errs() << "low-clique fixed-limit comparison mismatch: fixed="
+    llvm::errs() << "fixed-limit and minimum-search comparison mismatch: fixed="
                  << static_cast<unsigned>(fixedLimit.status)
                  << " minimum=" << static_cast<unsigned>(minimum.status)
                  << " fixed_states=" << fixedLimit.exploredStateCount
                  << " minimum_states=" << minimum.exploredStateCount << "\n";
     return false;
   }
-  llvm::outs() << "low_clique_fixed_states=" << fixedLimit.exploredStateCount
-               << "\n"
-               << "low_clique_minimum_states=" << minimum.exploredStateCount
-               << "\n";
+  llvm::outs() << "fixed_limit_states=" << fixedLimit.exploredStateCount << "\n"
+               << "minimum_proof_states=" << minimum.exploredStateCount << "\n";
   return true;
 }
 
-/// Exhaustively measures the assignment-count penalty of uniform coloring
+/// Exhaustively measures the assignment-count penalty of uniform assignment
 /// relative to per-node and two-group contracts.
 static bool compareAssignmentContracts() {
   constexpr unsigned kVertexCount = 4;
   constexpr unsigned kPossibleEdgeCount = 6;
   constexpr unsigned kGraphCount = 1U << kPossibleEdgeCount;
-  unsigned chromaticNumbers[kGraphCount];
+  unsigned minimumIndexCounts[kGraphCount];
   for (unsigned edgeMask = 0; edgeMask < kGraphCount; ++edgeMask) {
-    chromaticNumbers[edgeMask] =
-        oracleChromaticNumber(buildGraph(kVertexCount, edgeMask));
+    minimumIndexCounts[edgeMask] =
+        oracleMinimumIndexCount(buildGraph(kVertexCount, edgeMask));
   }
 
   uint64_t caseCount = 0;
@@ -328,17 +328,17 @@ static bool compareAssignmentContracts() {
     for (unsigned secondNode = 0; secondNode < kGraphCount; ++secondNode) {
       for (unsigned thirdNode = 0; thirdNode < kGraphCount; ++thirdNode) {
         unsigned uniformCount =
-            chromaticNumbers[firstNode | secondNode | thirdNode];
-        unsigned perNodeCount =
-            std::max({chromaticNumbers[firstNode], chromaticNumbers[secondNode],
-                      chromaticNumbers[thirdNode]});
+            minimumIndexCounts[firstNode | secondNode | thirdNode];
+        unsigned perNodeCount = std::max({minimumIndexCounts[firstNode],
+                                          minimumIndexCounts[secondNode],
+                                          minimumIndexCounts[thirdNode]});
         unsigned twoGroupCount =
-            std::min({std::max(chromaticNumbers[firstNode | secondNode],
-                               chromaticNumbers[thirdNode]),
-                      std::max(chromaticNumbers[firstNode | thirdNode],
-                               chromaticNumbers[secondNode]),
-                      std::max(chromaticNumbers[secondNode | thirdNode],
-                               chromaticNumbers[firstNode])});
+            std::min({std::max(minimumIndexCounts[firstNode | secondNode],
+                               minimumIndexCounts[thirdNode]),
+                      std::max(minimumIndexCounts[firstNode | thirdNode],
+                               minimumIndexCounts[secondNode]),
+                      std::max(minimumIndexCounts[secondNode | thirdNode],
+                               minimumIndexCounts[firstNode])});
         ++caseCount;
         if (perNodeCount < uniformCount) {
           ++perNodeImprovementCount;
@@ -370,7 +370,7 @@ int main() {
   return compareProductionSolverWithOracle() &&
                  verifyGreedyCapacityReproducer() &&
                  verifySearchLimitOutcome() &&
-                 verifyLowCliqueFixedLimitCheck() &&
+                 verifyFixedLimitAvoidsMinimumSearch() &&
                  compareAssignmentContracts()
              ? 0
              : 1;

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -96,6 +96,7 @@ if llvm_config is not None:
 # Add tt-lang tools used by lit tests.
 tools = [
     "ttlang-execution-count-test",
+    "ttlang-dfb-allocation-oracle-test",
     "ttlang-launch-node-domain-test",
     "ttlang-op-stats",
     "ttlang-value-origin-test",

--- a/test/python/dfb_reuse_specialize_cores.py
+++ b/test/python/dfb_reuse_specialize_cores.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-specialize-cores > %t.generic 2>&1
+# RUN: FileCheck %s --check-prefix=GENERIC-CPP < %t.generic
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --ttl-specialize-cores > %t.specialized 2>&1
+# RUN: FileCheck %s --check-prefix=SPECIALIZED-CPP < %t.specialized
+
+"""Verify that per-core specialization preserves reused DFB indices in C++."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttnn
+
+import ttl
+from ttlang_test_utils import to_dram
+
+
+@ttl.operation(grid=(2, 1))
+def dfb_reuse_specialize_cores(input_tensor, output_tensor):
+    first_dfb = ttl.make_dataflow_buffer_like(
+        input_tensor, shape=(1, 1), block_count=2
+    )
+    acknowledgment_dfb = ttl.make_dataflow_buffer_like(
+        input_tensor, shape=(1, 1), block_count=2
+    )
+    second_dfb = ttl.make_dataflow_buffer_like(
+        input_tensor, shape=(1, 1), block_count=2
+    )
+    output_dfb = ttl.make_dataflow_buffer_like(
+        output_tensor, shape=(1, 1), block_count=2
+    )
+
+    @ttl.compute()
+    def compute():
+        with first_dfb.wait():
+            pass
+
+        with acknowledgment_dfb.reserve() as acknowledgment:
+            acknowledgment.store(
+                ttl.block.fill(
+                    0,
+                    shape=acknowledgment.shape,
+                    dtype=acknowledgment.dtype,
+                )
+            )
+
+        with second_dfb.wait() as second_block, output_dfb.reserve() as output_block:
+            output_block.store(second_block)
+
+    @ttl.datamovement()
+    def dm_read():
+        node_x, _ = ttl.node(dims=2)
+        with first_dfb.reserve() as first_block:
+            transaction = ttl.copy(input_tensor[0, 0], first_block)
+            if node_x == 0:
+                transaction = ttl.copy(input_tensor[0, 1], first_block)
+            transaction.wait()
+
+        with acknowledgment_dfb.wait():
+            pass
+
+        with second_dfb.reserve() as second_block:
+            ttl.copy(input_tensor[0, node_x], second_block).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        node_x, _ = ttl.node(dims=2)
+        with output_dfb.wait() as output_block:
+            ttl.copy(output_block, output_tensor[0, node_x]).wait()
+
+
+# The unspecialized reader retains one coordinate branch. The two reserve calls
+# around the acknowledgment wait use the same physical DFB index because the
+# acknowledgment proves that the first lifetime ends before the second begins.
+# GENERIC-CPP-LABEL: === dm_read kernel written to {{.*}} ===
+# GENERIC-CPP: CircularBuffer [[ACK:cb_ctarg_[0-9]+]](get_compile_time_arg_val([[ACK_INDEX:[0-9]+]]))
+# GENERIC-CPP-NEXT: CircularBuffer [[REUSED:cb_ctarg_[0-9]+]](get_compile_time_arg_val([[REUSED_INDEX:[0-9]+]]))
+# GENERIC-CPP: [[REUSED]].reserve_back
+# GENERIC-CPP: [[ACK]].wait_front
+# GENERIC-CPP: [[REUSED]].reserve_back
+
+# Specialization emits one reader clone per launch coordinate. Both clones must
+# preserve the same physical DFB assignment after their branches are folded.
+# SPECIALIZED-CPP-LABEL: === dm_read_c0_0 kernel written to {{.*}} ===
+# SPECIALIZED-CPP: CircularBuffer [[C0_ACK:cb_ctarg_[0-9]+]](get_compile_time_arg_val([[C0_ACK_INDEX:[0-9]+]]))
+# SPECIALIZED-CPP-NEXT: CircularBuffer [[C0_REUSED:cb_ctarg_[0-9]+]](get_compile_time_arg_val([[C0_REUSED_INDEX:[0-9]+]]))
+# SPECIALIZED-CPP: [[C0_REUSED]].reserve_back
+# SPECIALIZED-CPP: [[C0_ACK]].wait_front
+# SPECIALIZED-CPP: [[C0_REUSED]].reserve_back
+# SPECIALIZED-CPP-LABEL: === dm_read_c1_0 kernel written to {{.*}} ===
+# SPECIALIZED-CPP: CircularBuffer [[C1_ACK:cb_ctarg_[0-9]+]](get_compile_time_arg_val([[C1_ACK_INDEX:[0-9]+]]))
+# SPECIALIZED-CPP-NEXT: CircularBuffer [[C1_REUSED:cb_ctarg_[0-9]+]](get_compile_time_arg_val([[C1_REUSED_INDEX:[0-9]+]]))
+# SPECIALIZED-CPP: [[C1_REUSED]].reserve_back
+# SPECIALIZED-CPP: [[C1_ACK]].wait_front
+# SPECIALIZED-CPP: [[C1_REUSED]].reserve_back
+
+
+if __name__ == "__main__":
+    device = ttnn.open_device(device_id=0)
+    try:
+        tensor_shape = (32, 64)
+        input_tensor = to_dram(
+            torch.zeros(tensor_shape, dtype=torch.bfloat16), device
+        )
+        output_tensor = to_dram(
+            torch.zeros(tensor_shape, dtype=torch.bfloat16), device
+        )
+        dfb_reuse_specialize_cores(input_tensor, output_tensor)
+    finally:
+        ttnn.close_device(device)

--- a/test/python/dfb_reuse_specialize_cores.py
+++ b/test/python/dfb_reuse_specialize_cores.py
@@ -23,9 +23,7 @@ from ttlang_test_utils import to_dram
 
 @ttl.operation(grid=(2, 1))
 def dfb_reuse_specialize_cores(input_tensor, output_tensor):
-    first_dfb = ttl.make_dataflow_buffer_like(
-        input_tensor, shape=(1, 1), block_count=2
-    )
+    first_dfb = ttl.make_dataflow_buffer_like(input_tensor, shape=(1, 1), block_count=2)
     acknowledgment_dfb = ttl.make_dataflow_buffer_like(
         input_tensor, shape=(1, 1), block_count=2
     )
@@ -105,12 +103,8 @@ if __name__ == "__main__":
     device = ttnn.open_device(device_id=0)
     try:
         tensor_shape = (32, 64)
-        input_tensor = to_dram(
-            torch.zeros(tensor_shape, dtype=torch.bfloat16), device
-        )
-        output_tensor = to_dram(
-            torch.zeros(tensor_shape, dtype=torch.bfloat16), device
-        )
+        input_tensor = to_dram(torch.zeros(tensor_shape, dtype=torch.bfloat16), device)
+        output_tensor = to_dram(torch.zeros(tensor_shape, dtype=torch.bfloat16), device)
         dfb_reuse_specialize_cores(input_tensor, output_tensor)
     finally:
         ttnn.close_device(device)

--- a/test/python/get_dfb_id.py
+++ b/test/python/get_dfb_id.py
@@ -12,8 +12,9 @@ Verify that ttl.get_dfb_id() in template_args emits ttl.get_dfb_id in the
 initial MLIR and lowers to a raw integer literal in the generated C++.
 
 The compute thread calls ttl.call_extern_func with DFB IDs and a literal
-constant as template args.  Stub data-movement threads satisfy the TTNN
-interop 3-kernel requirement.
+constant as template args. The same DFBs are direct function arguments so the
+allocator can retain their storage dependencies. Stub data-movement threads
+satisfy the TTNN interop 3-kernel requirement.
 """
 
 import os
@@ -38,6 +39,7 @@ def get_dfb_id_kernel(inp):
             FAKE_HEADER,
             "my_shim",
             template_args=[ttl.get_dfb_id(scratch), ttl.get_dfb_id(in_dfb), 1],
+            func_args=[scratch, in_dfb],
         )
 
     @ttl.datamovement()
@@ -67,14 +69,15 @@ def get_dfb_id_kernel(inp):
 # CHECK: %[[C1:.*]] = arith.constant 1 : i32
 
 # The opaque_call receives template arg values as SSA operands
-# CHECK: ttl.opaque_call "my_shim" template_args(%[[ID_SCRATCH]], %[[ID_IN]], %[[C1]])
+# CHECK: ttl.opaque_call "my_shim" template_args(%[[ID_SCRATCH]], %[[ID_IN]], %[[C1]]) (%[[SCRATCH]], %[[IN_CB]])
 
 # =============================================================================
 # C++ output checks -- verify raw integers in template args
 # =============================================================================
 
 # CHECK-CPP: === compute kernel written to {{.*}} ===
-# CHECK-CPP: my_shim<1, 0, 1>()
+# CHECK-CPP: my_shim<[[SCRATCH_INDEX:[0-9]+]], [[IN_INDEX:[0-9]+]], 1>
+# CHECK-CPP-SAME: (get_compile_time_arg_val([[SCRATCH_INDEX]]), get_compile_time_arg_val([[IN_INDEX]]))
 
 
 if __name__ == "__main__":

--- a/test/python/include/external_eltwise_mul.hpp
+++ b/test/python/include/external_eltwise_mul.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// External compute operation used to validate direct DFB operands. The
+// external function owns the compute-thread DFB protocol.
+#pragma once
+
+#if defined(COMPILE_FOR_TRISC)
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#endif
+
+static inline void ttl_external_eltwise_mul(int lhs, int rhs, int result) {
+#if defined(COMPILE_FOR_TRISC)
+  using namespace ckernel;
+
+  cb_reserve_back(result, 1);
+  cb_wait_front(lhs, 1);
+  cb_wait_front(rhs, 1);
+  binary_op_init_common(lhs, rhs, result);
+  mul_tiles_init(lhs, rhs);
+  tile_regs_acquire();
+  mul_tiles(lhs, rhs, 0, 0, 0);
+  tile_regs_commit();
+  cb_pop_front(lhs, 1);
+  cb_pop_front(rhs, 1);
+  tile_regs_wait();
+  pack_tile(0, result);
+  cb_push_back(result, 1);
+  tile_regs_release();
+#else
+  (void)lhs;
+  (void)rhs;
+  (void)result;
+#endif
+}

--- a/test/python/include/negate_tile_op.hpp
+++ b/test/python/include/negate_tile_op.hpp
@@ -60,9 +60,12 @@ struct NegateTileOp {
 
 } // namespace test_ops
 
-// Shim callable from ttl.call_extern_func via template_args.
+// The function operands declare the DFB access set; template arguments retain
+// the constexpr configuration required by the external operation.
 template <uint32_t InCB, uint32_t OutCB>
-void negate_tile_shim() {
+void negate_tile_shim(int inDfb, int outDfb) {
+  (void)inDfb;
+  (void)outDfb;
   using Config = test_ops::NegateTileConfig<InCB, OutCB>;
   test_ops::NegateTileOp<Config> op;
   op.init();

--- a/test/python/include/typed_args_op.hpp
+++ b/test/python/include/typed_args_op.hpp
@@ -13,6 +13,7 @@
 //
 // Func args (runtime):
 //   in_cb       -- input CB index (from a DFB passed as func_args)
+//   out_cb      -- output CB index, declaring the output DFB dependency
 //   scale_f     -- float scale
 //   int_factor   -- integer factor multiplied into the scale
 //   also_negate -- bool: also request negate
@@ -53,8 +54,9 @@ inline uint32_t bits_from_float(float value) {
 } // namespace
 
 template <uint32_t OutCB, int IntScale, bool NegateTpl, uint32_t ScaleTplBits>
-void typed_args_shim(uint32_t in_cb, float scale_f, int32_t int_factor,
-                     bool also_negate) {
+void typed_args_shim(uint32_t in_cb, uint32_t out_cb, float scale_f,
+                     int32_t int_factor, bool also_negate) {
+  (void)out_cb;
 #if defined(COMPILE_FOR_TRISC)
   using namespace ckernel;
 

--- a/test/python/invalid/invalid_dfb_capacity.py
+++ b/test/python/invalid/invalid_dfb_capacity.py
@@ -3,15 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: ttnn, tt-device
-# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s 2>&1 | FileCheck %s --check-prefix=REUSE
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s --no-ttl-reuse-user-dfbs 2>&1 | FileCheck %s --check-prefix=NOREUSE
 
 """Compile-only coverage for the Python-visible physical DFB limit error.
 
-The nested conditional keeps every logical DFB lifetime unbounded. Recursive
-composition therefore requires 33 distinct physical DFB indices.
+With user DFB reuse disabled, recursive composition preserves 33 distinct
+logical assignments and must report the Python-visible physical-index limit.
 """
 
-# CHECK: DFB allocation needs 33 unspilled physical indices but hardware supports at most 32
+# REUSE: Compiled kernel ready
+# NOREUSE: need 33 unspilled DFB indices but hardware supports at most 32
 
 import os
 

--- a/test/python/invalid/invalid_dfb_capacity.py
+++ b/test/python/invalid/invalid_dfb_capacity.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn, tt-device
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Compile-only coverage for the Python-visible physical DFB limit error.
+
+The nested conditional keeps every logical DFB lifetime unbounded. Recursive
+composition therefore requires 33 distinct physical DFB indices.
+"""
+
+# CHECK: DFB allocation needs 33 unspilled physical indices but hardware supports at most 32
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch  # noqa: E402
+import ttnn  # noqa: E402
+
+import ttl  # noqa: E402
+
+
+COMPOSITION_LEVELS = 5
+
+
+def _host_ttnn():
+    return ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+
+def _make_nested_conditional_copy():
+    @ttl.operation()
+    def conditional_copy(source: ttl.DFB, destination: ttl.DFB):
+        node_x, _ = ttl.node(dims=2)
+        if node_x == 0:
+            source_block = source.wait()
+            destination_block = destination.reserve()
+            destination_block.store(source_block)
+
+    nested_copy = conditional_copy
+    for composition_level in range(COMPOSITION_LEVELS):
+        inner_copy = nested_copy
+
+        @ttl.operation()
+        def doubled_copy(source: ttl.DFB, destination: ttl.DFB):
+            intermediate_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+            inner_copy(source, intermediate_dfb)
+            inner_copy(intermediate_dfb, destination)
+
+        nested_copy = doubled_copy
+
+    return nested_copy
+
+
+_nested_conditional_copy = _make_nested_conditional_copy()
+
+
+@ttl.operation(grid=(1, 1))
+def over_capacity(input_tensor, output_tensor):
+    input_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    output_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+
+    ttl.copy(input_tensor[0, 0], input_dfb.reserve()).wait()
+    _nested_conditional_copy(input_dfb, output_dfb)
+    ttl.copy(output_dfb.wait(), output_tensor[0, 0]).wait()
+
+
+def main():
+    over_capacity(_host_ttnn(), _host_ttnn())
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/pipe/test_pipenet_sync.py
+++ b/test/python/pipe/test_pipenet_sync.py
@@ -1013,8 +1013,10 @@ def make_non_uniform_multicast_destination_address_kernel():
 
         send_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
         first_recv_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+        # Incompatible descriptors keep the receive DFBs physically distinct,
+        # so both allocation modes reach the multicast-address validation.
         second_recv_dfb = ttl.make_dataflow_buffer_like(
-            inp, shape=(1, 1), block_count=2
+            inp, shape=(1, 1), block_count=3
         )
 
         @ttl.compute()
@@ -1360,7 +1362,10 @@ def test_many_pipe_sync_sites_fit_hardware_semaphore_limit(device):
     ttnn.synchronize_device(device)
 
 
-def test_multicast_destination_addresses_differ_by_destination_rejected(device):
+@pytest.mark.parametrize("reuse_user_dfbs", [True, False], ids=["reuse", "distinct"])
+def test_multicast_destination_addresses_differ_by_destination_rejected(
+    device, reuse_user_dfbs
+):
     inp_torch = torch.randn(TILE, TILE, dtype=torch.bfloat16)
     out_torch = torch.zeros(TILE, 2 * TILE, dtype=torch.bfloat16)
 
@@ -1375,4 +1380,7 @@ def test_multicast_destination_addresses_differ_by_destination_rejected(device):
             "address for all receivers"
         ),
     ):
-        non_uniform_multicast_destination_address_kernel(inp, out)
+        reuse_option = (
+            "--ttl-reuse-user-dfbs" if reuse_user_dfbs else "--no-ttl-reuse-user-dfbs"
+        )
+        non_uniform_multicast_destination_address_kernel(inp, out, options=reuse_option)

--- a/test/python/simple_add.py
+++ b/test/python/simple_add.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: ttnn, tt-device
-# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.reuse.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP-REUSE < %t.reuse.output
+# Stable logical-index checks run separately from the default allocator checks.
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
-# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.sfpu.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.sfpu.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-SFPU < %t.sfpu.output
 
 """
@@ -136,6 +139,24 @@ def add_kernel(lhs, rhs, out):
 # =============================================================================
 # C++ Kernel Checks - Verify generated compute kernel
 # =============================================================================
+
+# Default allocation may permute physical indices while preserving every
+# logical DFB use across the three kernels.
+# CHECK-CPP-REUSE-LABEL: === add_compute kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_read kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_2.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_write kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.wait_front(
+# CHECK-CPP-REUSE: cb_ctarg_1.pop_front(
 
 # CHECK-CPP: === add_compute kernel written to {{.*}} ===
 # CHECK-CPP: void kernel_main()

--- a/test/python/simple_add_3d.py
+++ b/test/python/simple_add_3d.py
@@ -3,12 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: ttnn, tt-device
-# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.reuse.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP-REUSE < %t.reuse.output
+# Stable logical-index checks run separately from the default allocator checks.
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
-# RUN: env TTLANG_COMPILE_ONLY=1 %python %s > %t.fpu.block.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs > %t.fpu.block.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-FPU-BLOCK < %t.fpu.block.output
-# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-combine-pack-tiles > %t.fpu.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs --no-ttl-combine-pack-tiles > %t.fpu.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-FPU < %t.fpu.output
 
 """
@@ -111,6 +114,24 @@ def add_3d_kernel(lhs, rhs, out):
 # =============================================================================
 # C++ Kernel Checks - Verify 3D loop nests in generated code
 # =============================================================================
+
+# Default allocation may permute physical indices while preserving every
+# logical DFB use across the three kernels.
+# CHECK-CPP-REUSE-LABEL: === add_compute kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_read kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_2.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_write kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.wait_front(
+# CHECK-CPP-REUSE: cb_ctarg_1.pop_front(
 
 # Compute kernel: 3 nested loops over 2x2x2 tile grid
 # CHECK-CPP: === add_compute kernel written to {{.*}} ===

--- a/test/python/simple_add_dram.py
+++ b/test/python/simple_add_dram.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: ttnn, tt-device
-# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.reuse.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP-REUSE < %t.reuse.output
+# Stable logical-index checks run separately from the default allocator checks.
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
-# RUN: env TTLANG_COMPILE_ONLY=1 %python %s > %t.fpu.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs > %t.fpu.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-FPU < %t.fpu.output
 
 """
@@ -129,6 +132,24 @@ def add_dram_kernel(lhs, rhs, out):
 # =============================================================================
 # C++ Kernel Checks - Verify generated compute kernel
 # =============================================================================
+
+# Default allocation may permute physical indices while preserving every
+# logical DFB use across the three kernels.
+# CHECK-CPP-REUSE-LABEL: === add_compute kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_read kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_2.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_write kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.wait_front(
+# CHECK-CPP-REUSE: cb_ctarg_1.pop_front(
 
 # CHECK-CPP: === add_compute kernel written to {{.*}} ===
 # CHECK-CPP: void kernel_main()

--- a/test/python/simple_add_loop.py
+++ b/test/python/simple_add_loop.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: ttnn, tt-device
-# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.reuse.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP-REUSE < %t.reuse.output
+# Stable logical-index checks run separately from the default allocator checks.
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
-# RUN: env TTLANG_COMPILE_ONLY=1 %python %s > %t.fpu.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs > %t.fpu.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-FPU < %t.fpu.output
 
 """
@@ -79,6 +82,24 @@ def add_loop_kernel(lhs, rhs, out):
 # =============================================================================
 # C++ Kernel Checks - Verify for loop in generated compute code
 # =============================================================================
+
+# Default allocation may permute physical indices while preserving every
+# logical DFB use across the three kernels.
+# CHECK-CPP-REUSE-LABEL: === add_compute kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_1.push_back(
+# CHECK-CPP-REUSE: cb_ctarg_2.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_0.pop_front(
+# CHECK-CPP-REUSE-LABEL: === dm_read kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_2.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_write kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.wait_front(
+# CHECK-CPP-REUSE: cb_ctarg_1.pop_front(
 
 # CHECK-CPP: === add_compute kernel written to {{.*}} ===
 # CHECK-CPP: void kernel_main()

--- a/test/python/simple_add_multitile.py
+++ b/test/python/simple_add_multitile.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: ttnn, tt-device
-# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.reuse.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP-REUSE < %t.reuse.output
+# Stable logical-index checks run separately from the default allocator checks.
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
-# RUN: env TTLANG_COMPILE_ONLY=1 %python %s > %t.fpu.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 %python %s --no-ttl-reuse-user-dfbs > %t.fpu.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-FPU < %t.fpu.output
 
 """
@@ -94,6 +97,24 @@ def add_multitile_kernel(lhs, rhs, out):
 # =============================================================================
 # C++ Kernel Checks - Verify loops are generated for multi-tile
 # =============================================================================
+
+# Default allocation may permute physical indices while preserving every
+# logical DFB use across the three kernels.
+# CHECK-CPP-REUSE-LABEL: === add_compute kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_read kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_2.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_write kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.wait_front(
+# CHECK-CPP-REUSE: cb_ctarg_1.pop_front(
 
 # CHECK-CPP: === add_compute kernel written to {{.*}} ===
 # CHECK-CPP: void kernel_main()

--- a/test/python/simple_add_with_stmt.py
+++ b/test/python/simple_add_with_stmt.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: tt-device
-# RUN: env TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.reuse.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP-REUSE < %t.reuse.output
+# Stable logical-index checks run separately from the default allocator checks.
+# RUN: env %python %s --no-ttl-reuse-user-dfbs --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
-# RUN: env %python %s > %t.fpu.output 2>&1
+# RUN: env %python %s --no-ttl-reuse-user-dfbs > %t.fpu.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-FPU < %t.fpu.output
 
 """
@@ -134,6 +137,24 @@ def add_with_kernel(lhs, rhs, out):
 # =============================================================================
 # C++ Kernel Checks - Verify generated code
 # =============================================================================
+
+# Default allocation may permute physical indices while preserving every
+# logical DFB use across the three kernels.
+# CHECK-CPP-REUSE-LABEL: === add_compute kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_1.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_1.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_0.pop_front(
+# CHECK-CPP-REUSE-LABEL: === dm_read kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_0.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_2.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_write kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.wait_front(
+# CHECK-CPP-REUSE: cb_ctarg_1.pop_front(
 
 # CHECK-CPP: === add_compute kernel written to {{.*}} ===
 # CHECK-CPP: void kernel_main()

--- a/test/python/simple_fused.py
+++ b/test/python/simple_fused.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: tt-device
-# RUN: env TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.reuse.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP-REUSE < %t.reuse.output
+# Stable logical-index checks run separately from the default allocator checks.
+# RUN: env %python %s --no-ttl-reuse-user-dfbs --no-ttl-maximize-dst --no-ttl-fpu-binary-ops > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
-# RUN: env %python %s > %t.fpu.output 2>&1
+# RUN: env %python %s --no-ttl-reuse-user-dfbs > %t.fpu.output 2>&1
 # RUN: FileCheck %s --check-prefix=CHECK-CPP-FPU < %t.fpu.output
 
 """
@@ -91,6 +94,24 @@ def fused_kernel(inp, bias, out):
 # =============================================================================
 # C++ Kernel Checks - Verify generated fused compute kernel
 # =============================================================================
+
+# Default allocation may permute physical indices while preserving every
+# logical DFB use across the three kernels.
+# CHECK-CPP-REUSE-LABEL: === fused_compute kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_0.wait_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_1.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_0.pop_front(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_2.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_read kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_1.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_1.push_back(
+# CHECK-CPP-REUSE-NEXT: cb_ctarg_0.reserve_back(
+# CHECK-CPP-REUSE: cb_ctarg_0.push_back(
+# CHECK-CPP-REUSE-LABEL: === dm_write kernel written to {{.*}} ===
+# CHECK-CPP-REUSE: cb_ctarg_2.wait_front(
+# CHECK-CPP-REUSE: cb_ctarg_2.pop_front(
 
 # CHECK-CPP: === fused_compute kernel written to {{.*}} ===
 # CHECK-CPP: void kernel_main()

--- a/test/python/test_call_extern_func.py
+++ b/test/python/test_call_extern_func.py
@@ -6,7 +6,8 @@
 End-to-end tests for ttl.call_extern_func.
 
 Covers:
-- Struct-based compute header with DFB IDs as template args (negate).
+- Struct-based compute header with DFB IDs as template args and direct DFB
+  operands (negate).
 - int/bool/float values as both template_args and func_args.
 - A DFB passed directly as a func_arg (CB index via get_compile_time_arg_val).
 """
@@ -44,6 +45,7 @@ def negate_extern(inp, out):
                     ttl.get_dfb_id(in_dfb),
                     ttl.get_dfb_id(out_dfb),
                 ],
+                func_args=[in_dfb, out_dfb],
             )
 
     @ttl.datamovement()
@@ -68,7 +70,8 @@ def typed_args_extern(inp, out):
     template_args:
       OutCB=get_dfb_id(out), IntScale=2, NegateTpl=True, ScaleTpl=0.5
     func_args:
-      in_dfb (DFB), scale_f=3.0, int_factor=2, also_negate=False
+      in_dfb and out_dfb (DFBs), scale_f=3.0, int_factor=2,
+      also_negate=False
 
     expected = -inp * 2 * 0.5 * 3.0 * 2 = -inp * 6
     """
@@ -89,6 +92,7 @@ def typed_args_extern(inp, out):
                 ],
                 func_args=[
                     in_dfb,  # DFB -> CB index
+                    out_dfb,  # DFB -> CB index
                     3.0,  # float
                     2,  # int
                     False,  # bool

--- a/test/python/test_compiler_allocated_dfb.py
+++ b/test/python/test_compiler_allocated_dfb.py
@@ -340,9 +340,6 @@ def test_matmul_both_intermediates(device):
 
 
 # --- two reduces on same intermediate, results feed elementwise sub ---
-# The add result is materialized as an operand DFB for each reduce.
-# Each reduce result feeds sub without a store, requiring result DFB
-# materialization (not yet implemented, see #508).
 
 
 @ttl.operation(grid=(1, 1))
@@ -359,9 +356,6 @@ def two_reduces_kernel(a, b, out):
             out_dfb.reserve() as o,
         ):
             added = ttl.add(av, bv)
-            # Both reduces consume the same non-CB-attached add result.
-            # Each reduce result feeds sub without a store, requiring
-            # result DFB materialization (#508).
             sm = ttl.math.reduce_sum(added, dims=[0, 1])
             mx = ttl.math.reduce_max(added, dims=[0, 1])
             o.store(ttl.sub(sm, mx))
@@ -568,9 +562,8 @@ def test_nested_loop_conditional(device):
             assert_allclose(result[r0, c0], expected[r0, c0], rtol=0.01, atol=1.0)
 
 
-@pytest.mark.xfail(reason="Requires result DFB materialization (#508)")
 def test_two_reduces(device):
-    """Two reduces on same input, results feed sub; requires result DFBs (#508)."""
+    """Materialize a shared input and two results consumed together."""
     a_torch = torch.randn(32, 32, dtype=torch.bfloat16)
     b_torch = torch.randn(32, 32, dtype=torch.bfloat16)
     out_torch = torch.zeros(32, 32, dtype=torch.bfloat16)

--- a/test/python/test_compiler_options.py
+++ b/test/python/test_compiler_options.py
@@ -19,6 +19,8 @@ class TestDefaults:
         assert opts.maximize_dst is True
         assert opts.enable_fpu_binary_ops is True
         assert opts.subblock_sync is False
+        assert opts.reuse_user_dfbs is True
+        assert opts.dfb_exact_coloring_search_limit == 1_000_000
         assert opts.specialize_cores is False
         assert opts._explicit == frozenset()
 
@@ -57,6 +59,22 @@ class TestFromString:
         opts = CompilerOptions.from_string("--ttl-specialize-cores")
         assert opts.specialize_cores is True
         assert "specialize_cores" in opts._explicit
+
+    def test_disable_user_dfb_reuse(self):
+        opts = CompilerOptions.from_string("--no-ttl-reuse-user-dfbs")
+        assert opts.reuse_user_dfbs is False
+        assert "reuse_user_dfbs" in opts._explicit
+
+    def test_exact_coloring_search_limit(self):
+        opts = CompilerOptions.from_string(
+            "--ttl-dfb-exact-coloring-search-limit 250000"
+        )
+        assert opts.dfb_exact_coloring_search_limit == 250_000
+        assert "dfb_exact_coloring_search_limit" in opts._explicit
+
+    def test_negative_exact_coloring_search_limit_is_invalid(self):
+        with pytest.raises(SystemExit):
+            CompilerOptions.from_string("--ttl-dfb-exact-coloring-search-limit -1")
 
     def test_enable_flags_explicitly(self):
         opts = CompilerOptions.from_string("--ttl-maximize-dst --ttl-fpu-binary-ops")

--- a/test/python/test_external_dfb_reuse.py
+++ b/test/python/test_external_dfb_reuse.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime coverage for DFB allocation with external C++ operations.
+
+The external multiply follows a direct-DFB interface: every accessed DFB is a
+function argument, while the C++ body owns its compute-thread DFB protocol.
+The larger inlinable atom composition separates two calls with native data
+movement and compute. The allocator cannot inspect the external DFB accesses,
+so their DFBs remain live until all known uses complete.
+"""
+
+import os
+import re
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+# TTNN interop rejects non-tilized tensors before DFB lowering, so TILE is the
+# only supported tensor layout for these runtime cases.
+TILE = 32
+OVER_CAPACITY_COMPOSITION_LEVELS = 5
+EXTERNAL_COMPOSITION_LOGICAL_DFBS = (1 << OVER_CAPACITY_COMPOSITION_LEVELS) + 6
+EXTERNAL_COMPOSITION_PHYSICAL_DFBS = 8
+# The external fp32 pack step produces approximately 1/256 output increments.
+# These bounds cover measured relative errors of 3.51e-3 for multiplication and
+# 1.76e-3 for the composition while retaining small absolute bounds near zero.
+F32_EXTERNAL_MULTIPLY_RTOL = 5e-3
+F32_EXTERNAL_MULTIPLY_ATOL = 1e-4
+F32_EXTERNAL_COMPOSITION_RTOL = 2e-3
+F32_EXTERNAL_COMPOSITION_ATOL = 5e-4
+EXTERNAL_MULTIPLY_HEADER = os.path.join(
+    os.path.dirname(__file__), "include", "external_eltwise_mul.hpp"
+)
+
+
+@ttl.operation()
+def _external_eltwise_mul(lhs: ttl.DFB, rhs: ttl.DFB, result: ttl.DFB):
+    call_extern_func(
+        EXTERNAL_MULTIPLY_HEADER,
+        "ttl_external_eltwise_mul",
+        func_args=[lhs, rhs, result],
+    )
+
+
+def _make_external_multiply_kernel(data_format):
+    @ttl.operation(grid=(1, 1))
+    def external_multiply_kernel(lhs, rhs, result):
+        lhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        rhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        result_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        lhs_destination = lhs_dfb.reserve()
+        ttl.copy(lhs[0, 0], lhs_destination).wait()
+        lhs_destination.push()
+        rhs_destination = rhs_dfb.reserve()
+        ttl.copy(rhs[0, 0], rhs_destination).wait()
+        rhs_destination.push()
+
+        _external_eltwise_mul(lhs_dfb, rhs_dfb, result_dfb)
+
+        result_source = result_dfb.wait()
+        ttl.copy(result_source, result[0, 0]).wait()
+        result_source.pop()
+
+    return external_multiply_kernel
+
+
+def _make_nested_copy_atom(data_format, level_count):
+    @ttl.operation()
+    def copy_stage(source: ttl.DFB, destination: ttl.DFB):
+        destination_block = destination.reserve()
+        destination_block.store(source.wait())
+
+    nested_copy = copy_stage
+    for _composition_level in range(level_count):
+        inner_copy = nested_copy
+
+        @ttl.operation()
+        def doubled_copy(source: ttl.DFB, destination: ttl.DFB):
+            intermediate_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+            inner_copy(source, intermediate_dfb)
+            inner_copy(intermediate_dfb, destination)
+
+        nested_copy = doubled_copy
+
+    return nested_copy
+
+
+def _make_external_composition_kernel(data_format):
+    nested_copy = _make_nested_copy_atom(data_format, OVER_CAPACITY_COMPOSITION_LEVELS)
+
+    @ttl.operation(grid=(1, 1))
+    def external_composition_kernel(lhs, rhs, result):
+        lhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        first_rhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        second_rhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        product_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        copied_product_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        computed_product_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        result_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        lhs_destination = lhs_dfb.reserve()
+        ttl.copy(lhs[0, 0], lhs_destination).wait()
+        lhs_destination.push()
+        first_rhs_destination = first_rhs_dfb.reserve()
+        ttl.copy(rhs[0, 0], first_rhs_destination).wait()
+        first_rhs_destination.push()
+        second_rhs_destination = second_rhs_dfb.reserve()
+        ttl.copy(rhs[0, 0], second_rhs_destination).wait()
+        second_rhs_destination.push()
+
+        _external_eltwise_mul(lhs_dfb, first_rhs_dfb, product_dfb)
+        nested_copy(product_dfb, copied_product_dfb)
+
+        copied_product = copied_product_dfb.wait()
+        computed_product = computed_product_dfb.reserve()
+        computed_product.store(ttl.exp(copied_product))
+        computed_product.push()
+
+        _external_eltwise_mul(computed_product_dfb, second_rhs_dfb, result_dfb)
+
+        result_source = result_dfb.wait()
+        ttl.copy(result_source, result[0, 0]).wait()
+        result_source.pop()
+
+    return external_composition_kernel
+
+
+_external_bf16_multiply = _make_external_multiply_kernel("bf16")
+_external_f32_multiply = _make_external_multiply_kernel("float32")
+_external_bf16_composition = _make_external_composition_kernel("bf16")
+_external_f32_composition = _make_external_composition_kernel("float32")
+
+assert EXTERNAL_COMPOSITION_LOGICAL_DFBS > 32
+
+
+def _count_final_dfb_allocations(final_mlir_path):
+    final_mlir = final_mlir_path.read_text()
+    allocations = re.search(
+        r"ttl\.dfb_allocations = \[(.*?)\](?:,|})", final_mlir, re.DOTALL
+    )
+    assert allocations is not None
+    return allocations.group(1).count("dfb_index =")
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_external_bf16_multiply, torch.bfloat16),
+        (_external_f32_multiply, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize("reuse_user_dfbs", [True, False], ids=["reuse", "distinct"])
+def test_external_multiply_with_dfb_allocation(
+    device, operation, dtype, memory_config, to_device, reuse_user_dfbs
+):
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
+    rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)
+
+    lhs = to_device(lhs_host, device)
+    rhs = to_device(rhs_host, device)
+    result = to_device(torch.zeros_like(lhs_host), device)
+
+    reuse_option = (
+        "--ttl-reuse-user-dfbs" if reuse_user_dfbs else "--no-ttl-reuse-user-dfbs"
+    )
+    operation(lhs, rhs, result, options=reuse_option)
+
+    actual = ttnn.to_torch(result).float()
+    expected = lhs_host.float() * rhs_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(
+            actual,
+            expected,
+            rtol=F32_EXTERNAL_MULTIPLY_RTOL,
+            atol=F32_EXTERNAL_MULTIPLY_ATOL,
+        )
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_external_bf16_composition, torch.bfloat16),
+        (_external_f32_composition, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_external_composition_requires_dfb_reuse(
+    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
+    rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)
+
+    lhs = to_device(lhs_host, device)
+    rhs = to_device(rhs_host, device)
+    result = to_device(torch.zeros_like(lhs_host), device)
+
+    # The disabled mode requires one physical index for each of the 38 logical
+    # DFBs, proving that enabled execution cannot fit without index reuse.
+    with pytest.raises(
+        RuntimeError,
+        match=("need 38 unspilled DFB indices " "but hardware supports at most 32"),
+    ):
+        operation(lhs, rhs, result, options="--no-ttl-reuse-user-dfbs")
+
+    final_mlir_path = tmp_path / "external_atom_composition.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    operation(lhs, rhs, result, options="--ttl-reuse-user-dfbs")
+    assert (
+        _count_final_dfb_allocations(final_mlir_path)
+        == EXTERNAL_COMPOSITION_PHYSICAL_DFBS
+    )
+
+    actual = ttnn.to_torch(result).float()
+    expected = torch.exp(lhs_host.float() * rhs_host.float()) * rhs_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(
+            actual,
+            expected,
+            rtol=F32_EXTERNAL_COMPOSITION_RTOL,
+            atol=F32_EXTERNAL_COMPOSITION_ATOL,
+        )

--- a/test/python/test_flash_chain_8node.py
+++ b/test/python/test_flash_chain_8node.py
@@ -1,0 +1,587 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Eight-node flash-attention chain composed from operation atoms.
+
+Each node computes streaming-softmax state for its K/V shard. A binary tree
+combines the per-node states before node 0 normalizes and writes the result.
+Frontend composition inlines both atoms into one operation whose logical DFB
+count exceeds the hardware limit; concurrent-kernel liveness maps the logical DFBs
+to a legal set of physical indices.
+"""
+
+import math
+
+import pytest
+import torch
+import ttnn
+import ttl
+
+from ttlang_test_utils import is_hardware_available, to_dram
+from utils.correctness import assert_pcc
+
+
+TILE = ttnn.TILE_SIZE
+PNHt = 1
+DHt = 18
+vDHt = 8
+Sk_chunk_t = 4
+N_CHUNKS = 1
+NNODES = 8
+# The generated Wormhole program exceeds the 96 KiB kernel-config default.
+KERNEL_CONFIG_BUFFER_RESERVE_BYTES = 128 * 1024
+
+St_per_node = Sk_chunk_t * N_CHUNKS
+HEAD_DIM = DHt * TILE
+HEAD_DIM_V = vDHt * TILE
+SEQ_PER_NODE = St_per_node * TILE
+SEQ = SEQ_PER_NODE * NNODES
+Q_ROWS = PNHt * TILE
+SCALE = 1.0 / math.sqrt(HEAD_DIM)
+PCC_THRESHOLD = 0.99
+
+
+if N_CHUNKS != 1:
+    raise ValueError("flash_chain_8node requires N_CHUNKS == 1")
+
+
+@ttl.operation()
+def flash_shard_kd(
+    query,
+    key,
+    value,
+    local_max_dfb: ttl.DFB,
+    local_sum_dfb: ttl.DFB,
+    local_output_dfb: ttl.DFB,
+):
+    """Compute streaming-softmax state for one node's K/V shard."""
+    query_dfb = ttl.make_dataflow_buffer_like(key, shape=(PNHt, DHt), block_count=2)
+    key_dfb = ttl.make_dataflow_buffer_like(key, shape=(Sk_chunk_t, DHt), block_count=2)
+    value_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(Sk_chunk_t, vDHt), block_count=2
+    )
+    transposed_key_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(DHt, Sk_chunk_t), block_count=2
+    )
+    scores_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, Sk_chunk_t), block_count=2
+    )
+    scores_for_reduce_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, Sk_chunk_t), block_count=2
+    )
+    scores_for_exp_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, Sk_chunk_t), block_count=2
+    )
+    max_broadcast_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, Sk_chunk_t), block_count=2
+    )
+    exp_scores_for_reduce_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, Sk_chunk_t), block_count=2
+    )
+    exp_scores_for_matmul_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, Sk_chunk_t), block_count=2
+    )
+    chunk_max_dfb = ttl.make_dataflow_buffer_like(key, shape=(PNHt, 1), block_count=2)
+    merged_max_for_alpha_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, 1), block_count=2
+    )
+    merged_max_for_broadcast_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, 1), block_count=2
+    )
+    merged_max_for_state_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, 1), block_count=2
+    )
+    chunk_sum_dfb = ttl.make_dataflow_buffer_like(key, shape=(PNHt, 1), block_count=2)
+    alpha_for_sum_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, 1), block_count=2
+    )
+    alpha_for_broadcast_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, 1), block_count=2
+    )
+    running_max_dfb = ttl.make_dataflow_buffer_like(key, shape=(PNHt, 1), block_count=2)
+    running_sum_dfb = ttl.make_dataflow_buffer_like(key, shape=(PNHt, 1), block_count=2)
+    alpha_broadcast_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, vDHt), block_count=2
+    )
+    corrected_output_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, vDHt), block_count=2
+    )
+    partial_value_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, vDHt), block_count=2
+    )
+    running_output_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, vDHt), block_count=2
+    )
+
+    initial_max = running_max_dfb.reserve()
+    initial_max.store(ttl.block.fill(-1e30, shape=(PNHt, 1)))
+    initial_sum = running_sum_dfb.reserve()
+    initial_sum.store(ttl.block.fill(0, shape=(PNHt, 1)))
+    initial_output = running_output_dfb.reserve()
+    initial_output.store(ttl.block.fill(0, shape=(PNHt, vDHt)))
+
+    query_block = query_dfb.wait()
+    key_block = key_dfb.wait()
+    transposed_key_output = transposed_key_dfb.reserve()
+    transposed_key_output.store(ttl.transpose(key_block))
+    transposed_key = transposed_key_dfb.wait()
+    scores_output = scores_dfb.reserve()
+    scores_output.store(query_block @ transposed_key)
+
+    scores = scores_dfb.wait()
+    scores_for_reduce_output = scores_for_reduce_dfb.reserve()
+    scores_for_reduce_output.store(scores)
+    scores_for_reduce = scores_for_reduce_dfb.wait()
+    chunk_max_output = chunk_max_dfb.reserve()
+    chunk_max_output.store(ttl.math.reduce_max(scores_for_reduce, dims=[1]))
+    scores_for_exp_output = scores_for_exp_dfb.reserve()
+    scores_for_exp_output.store(scores_for_reduce)
+
+    previous_max = running_max_dfb.wait()
+    chunk_max = chunk_max_dfb.wait()
+    merged_max_for_alpha_output = merged_max_for_alpha_dfb.reserve()
+    merged_max_for_alpha_output.store(ttl.math.max(previous_max, chunk_max))
+    merged_max_for_alpha = merged_max_for_alpha_dfb.wait()
+    alpha_for_sum_output = alpha_for_sum_dfb.reserve()
+    alpha_for_sum_output.store(
+        ttl.exp(ttl.sub(previous_max, merged_max_for_alpha) * SCALE)
+    )
+    merged_max_for_broadcast_output = merged_max_for_broadcast_dfb.reserve()
+    merged_max_for_broadcast_output.store(merged_max_for_alpha)
+
+    merged_max_for_broadcast = merged_max_for_broadcast_dfb.wait()
+    max_broadcast_output = max_broadcast_dfb.reserve()
+    max_broadcast_output.store(
+        ttl.block.broadcast(
+            merged_max_for_broadcast,
+            dims=[1],
+            shape=(PNHt, Sk_chunk_t),
+        )
+    )
+    merged_max_for_state_output = merged_max_for_state_dfb.reserve()
+    merged_max_for_state_output.store(merged_max_for_broadcast)
+
+    merged_max_for_state = merged_max_for_state_dfb.wait()
+    next_max = running_max_dfb.reserve()
+    next_max.store(merged_max_for_state)
+
+    scores_for_exp = scores_for_exp_dfb.wait()
+    max_broadcast = max_broadcast_dfb.wait()
+    exp_scores_for_reduce_output = exp_scores_for_reduce_dfb.reserve()
+    exp_scores_for_reduce_output.store(
+        ttl.exp(ttl.sub(scores_for_exp, max_broadcast) * SCALE)
+    )
+    exp_scores_for_reduce = exp_scores_for_reduce_dfb.wait()
+    chunk_sum_output = chunk_sum_dfb.reserve()
+    chunk_sum_output.store(ttl.math.reduce_sum(exp_scores_for_reduce, dims=[1]))
+    exp_scores_for_matmul_output = exp_scores_for_matmul_dfb.reserve()
+    exp_scores_for_matmul_output.store(exp_scores_for_reduce)
+
+    alpha_for_sum = alpha_for_sum_dfb.wait()
+    previous_sum = running_sum_dfb.wait()
+    chunk_sum = chunk_sum_dfb.wait()
+    next_sum = running_sum_dfb.reserve()
+    next_sum.store(ttl.add(ttl.mul(alpha_for_sum, previous_sum), chunk_sum))
+    alpha_for_broadcast_output = alpha_for_broadcast_dfb.reserve()
+    alpha_for_broadcast_output.store(alpha_for_sum)
+
+    alpha_for_broadcast = alpha_for_broadcast_dfb.wait()
+    alpha_broadcast_output = alpha_broadcast_dfb.reserve()
+    alpha_broadcast_output.store(
+        ttl.block.broadcast(
+            alpha_for_broadcast,
+            dims=[1],
+            shape=(PNHt, vDHt),
+        )
+    )
+    alpha_broadcast = alpha_broadcast_dfb.wait()
+    previous_output = running_output_dfb.wait()
+    corrected_output = corrected_output_dfb.reserve()
+    corrected_output.store(ttl.mul(alpha_broadcast, previous_output))
+
+    exp_scores_for_matmul = exp_scores_for_matmul_dfb.wait()
+    value_block = value_dfb.wait()
+    partial_value_output = partial_value_dfb.reserve()
+    partial_value_output.store(exp_scores_for_matmul @ value_block)
+
+    corrected_output_block = corrected_output_dfb.wait()
+    partial_value = partial_value_dfb.wait()
+    next_output = running_output_dfb.reserve()
+    next_output.store(ttl.add(corrected_output_block, partial_value))
+
+    final_max = running_max_dfb.wait()
+    local_max_output = local_max_dfb.reserve()
+    local_max_output.store(final_max)
+    final_sum = running_sum_dfb.wait()
+    local_sum_output = local_sum_dfb.reserve()
+    local_sum_output.store(final_sum)
+    final_output = running_output_dfb.wait()
+    local_output = local_output_dfb.reserve()
+    local_output.store(final_output)
+
+    node_x, _ = ttl.node(dims=2)
+    query_destination = query_dfb.reserve()
+    ttl.copy(query[0:PNHt, 0:DHt], query_destination)
+    key_base = node_x * St_per_node
+    key_destination = key_dfb.reserve()
+    ttl.copy(
+        key[key_base : key_base + Sk_chunk_t, 0:DHt],
+        key_destination,
+    )
+    value_destination = value_dfb.reserve()
+    ttl.copy(
+        value[key_base : key_base + Sk_chunk_t, 0:vDHt],
+        value_destination,
+    )
+
+
+@ttl.operation()
+def _merge_softmax_state(
+    left_max_dfb: ttl.DFB,
+    left_sum_dfb: ttl.DFB,
+    left_output_dfb: ttl.DFB,
+    right_max_dfb: ttl.DFB,
+    right_sum_dfb: ttl.DFB,
+    right_output_dfb: ttl.DFB,
+    result_max_dfb: ttl.DFB,
+    result_sum_dfb: ttl.DFB,
+    result_output_dfb: ttl.DFB,
+    merged_max_dfb: ttl.DFB,
+    left_scale_dfb: ttl.DFB,
+    right_scale_dfb: ttl.DFB,
+):
+    """Combine two streaming-softmax states."""
+    left_max = left_max_dfb.wait()
+    left_sum = left_sum_dfb.wait()
+    left_output = left_output_dfb.wait()
+    right_max = right_max_dfb.wait()
+    right_sum = right_sum_dfb.wait()
+    right_output = right_output_dfb.wait()
+
+    merged_max_output = merged_max_dfb.reserve()
+    merged_max_output.store(ttl.math.max(left_max, right_max))
+    merged_max = merged_max_dfb.wait()
+    left_scale_output = left_scale_dfb.reserve()
+    left_scale_output.store(ttl.exp(ttl.sub(left_max, merged_max) * SCALE))
+    right_scale_output = right_scale_dfb.reserve()
+    right_scale_output.store(ttl.exp(ttl.sub(right_max, merged_max) * SCALE))
+
+    left_scale = left_scale_dfb.wait()
+    right_scale = right_scale_dfb.wait()
+    merged_sum = ttl.add(
+        ttl.mul(left_scale, left_sum),
+        ttl.mul(right_scale, right_sum),
+    )
+    left_scale_broadcast = ttl.block.broadcast(left_scale, dims=[1], shape=(PNHt, vDHt))
+    right_scale_broadcast = ttl.block.broadcast(
+        right_scale, dims=[1], shape=(PNHt, vDHt)
+    )
+    merged_output = ttl.add(
+        ttl.mul(left_scale_broadcast, left_output),
+        ttl.mul(right_scale_broadcast, right_output),
+    )
+
+    result_max = result_max_dfb.reserve()
+    result_max.store(merged_max)
+    result_sum = result_sum_dfb.reserve()
+    result_sum.store(merged_sum)
+    result_output = result_output_dfb.reserve()
+    result_output.store(merged_output)
+
+
+@ttl.operation()
+def _transfer_state_component(
+    pipe_net: ttl.PipeNet,
+    send_dfb: ttl.DFB,
+    received_dfb: ttl.DFB,
+):
+    pipe_net.if_src(lambda state_pipe: ttl.copy(send_dfb.wait(), state_pipe).wait())
+    pipe_net.if_dst(
+        lambda state_pipe: ttl.copy(state_pipe, received_dfb.reserve()).wait()
+    )
+
+
+@ttl.operation()
+def _transfer_softmax_state(
+    max_pipe_net: ttl.PipeNet,
+    sum_pipe_net: ttl.PipeNet,
+    output_pipe_net: ttl.PipeNet,
+    send_max_dfb: ttl.DFB,
+    send_sum_dfb: ttl.DFB,
+    send_output_dfb: ttl.DFB,
+    received_max_dfb: ttl.DFB,
+    received_sum_dfb: ttl.DFB,
+    received_output_dfb: ttl.DFB,
+):
+    """Transfer one streaming-softmax state over a tree level."""
+    _transfer_state_component(max_pipe_net, send_max_dfb, received_max_dfb)
+    _transfer_state_component(sum_pipe_net, send_sum_dfb, received_sum_dfb)
+    _transfer_state_component(output_pipe_net, send_output_dfb, received_output_dfb)
+
+
+@ttl.operation()
+def flash_tree_reduce_8(
+    local_max_dfb: ttl.DFB,
+    local_sum_dfb: ttl.DFB,
+    local_output_dfb: ttl.DFB,
+    output,
+):
+    """Reduce eight streaming-softmax states and write the normalized result."""
+    level_zero_max = ttl.PipeNet(
+        [ttl.Pipe(src=(2 * index + 1, 0), dst=(2 * index, 0)) for index in range(4)]
+    )
+    level_zero_sum = ttl.PipeNet(
+        [ttl.Pipe(src=(2 * index + 1, 0), dst=(2 * index, 0)) for index in range(4)]
+    )
+    level_zero_output = ttl.PipeNet(
+        [ttl.Pipe(src=(2 * index + 1, 0), dst=(2 * index, 0)) for index in range(4)]
+    )
+    level_one_max = ttl.PipeNet(
+        [ttl.Pipe(src=(4 * index + 2, 0), dst=(4 * index, 0)) for index in range(2)]
+    )
+    level_one_sum = ttl.PipeNet(
+        [ttl.Pipe(src=(4 * index + 2, 0), dst=(4 * index, 0)) for index in range(2)]
+    )
+    level_one_output = ttl.PipeNet(
+        [ttl.Pipe(src=(4 * index + 2, 0), dst=(4 * index, 0)) for index in range(2)]
+    )
+    level_two_max = ttl.PipeNet([ttl.Pipe(src=(4, 0), dst=(0, 0))])
+    level_two_sum = ttl.PipeNet([ttl.Pipe(src=(4, 0), dst=(0, 0))])
+    level_two_output = ttl.PipeNet([ttl.Pipe(src=(4, 0), dst=(0, 0))])
+
+    send_max_dfb = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+    send_sum_dfb = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+    merged_max_dfb = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+    left_scale_dfb = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+    right_scale_dfb = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=2)
+    send_output_dfb = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
+    normalized_output_dfb = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=2)
+    received_max_dfb = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=3)
+    received_sum_dfb = ttl.make_dfb("bf16", shape=(PNHt, 1), block_count=3)
+    received_output_dfb = ttl.make_dfb("bf16", shape=(PNHt, vDHt), block_count=3)
+
+    if level_zero_max.is_src():
+        local_max = local_max_dfb.wait()
+        local_sum = local_sum_dfb.wait()
+        local_output = local_output_dfb.wait()
+        send_max_output = send_max_dfb.reserve()
+        send_max_output.store(local_max)
+        send_sum_output = send_sum_dfb.reserve()
+        send_sum_output.store(local_sum)
+        send_output = send_output_dfb.reserve()
+        send_output.store(local_output)
+
+    if level_zero_max.is_dst():
+        if level_one_max.is_dst():
+            _merge_softmax_state(
+                local_max_dfb,
+                local_sum_dfb,
+                local_output_dfb,
+                received_max_dfb,
+                received_sum_dfb,
+                received_output_dfb,
+                local_max_dfb,
+                local_sum_dfb,
+                local_output_dfb,
+                merged_max_dfb,
+                left_scale_dfb,
+                right_scale_dfb,
+            )
+        if level_one_max.is_src():
+            _merge_softmax_state(
+                local_max_dfb,
+                local_sum_dfb,
+                local_output_dfb,
+                received_max_dfb,
+                received_sum_dfb,
+                received_output_dfb,
+                send_max_dfb,
+                send_sum_dfb,
+                send_output_dfb,
+                merged_max_dfb,
+                left_scale_dfb,
+                right_scale_dfb,
+            )
+
+    if level_one_max.is_dst():
+        if level_two_max.is_dst():
+            _merge_softmax_state(
+                local_max_dfb,
+                local_sum_dfb,
+                local_output_dfb,
+                received_max_dfb,
+                received_sum_dfb,
+                received_output_dfb,
+                local_max_dfb,
+                local_sum_dfb,
+                local_output_dfb,
+                merged_max_dfb,
+                left_scale_dfb,
+                right_scale_dfb,
+            )
+        if level_two_max.is_src():
+            _merge_softmax_state(
+                local_max_dfb,
+                local_sum_dfb,
+                local_output_dfb,
+                received_max_dfb,
+                received_sum_dfb,
+                received_output_dfb,
+                send_max_dfb,
+                send_sum_dfb,
+                send_output_dfb,
+                merged_max_dfb,
+                left_scale_dfb,
+                right_scale_dfb,
+            )
+
+    if level_two_max.is_dst():
+        state_max = local_max_dfb.wait()
+        state_sum = local_sum_dfb.wait()
+        state_output = local_output_dfb.wait()
+        received_max = received_max_dfb.wait()
+        received_sum = received_sum_dfb.wait()
+        received_output = received_output_dfb.wait()
+        merged_max_output = merged_max_dfb.reserve()
+        merged_max_output.store(ttl.math.max(state_max, received_max))
+        merged_max = merged_max_dfb.wait()
+        state_scale_output = left_scale_dfb.reserve()
+        state_scale_output.store(ttl.exp(ttl.sub(state_max, merged_max) * SCALE))
+        received_scale_output = right_scale_dfb.reserve()
+        received_scale_output.store(ttl.exp(ttl.sub(received_max, merged_max) * SCALE))
+        state_scale = left_scale_dfb.wait()
+        received_scale = right_scale_dfb.wait()
+        merged_sum = ttl.add(
+            ttl.mul(state_scale, state_sum),
+            ttl.mul(received_scale, received_sum),
+        )
+        state_scale_broadcast = ttl.block.broadcast(
+            state_scale, dims=[1], shape=(PNHt, vDHt)
+        )
+        received_scale_broadcast = ttl.block.broadcast(
+            received_scale, dims=[1], shape=(PNHt, vDHt)
+        )
+        merged_output = ttl.add(
+            ttl.mul(state_scale_broadcast, state_output),
+            ttl.mul(received_scale_broadcast, received_output),
+        )
+        normalization_sum_output = merged_max_dfb.reserve()
+        normalization_sum_output.store(merged_sum)
+        normalization_sum_scalar = merged_max_dfb.wait()
+        normalized_output = normalized_output_dfb.reserve()
+        normalization_sum = ttl.block.broadcast(
+            normalization_sum_scalar,
+            dims=[1],
+            shape=(PNHt, vDHt),
+        )
+        normalized_output.store(
+            ttl.mul(merged_output, ttl.math.recip(normalization_sum))
+        )
+
+    _transfer_softmax_state(
+        level_zero_max,
+        level_zero_sum,
+        level_zero_output,
+        send_max_dfb,
+        send_sum_dfb,
+        send_output_dfb,
+        received_max_dfb,
+        received_sum_dfb,
+        received_output_dfb,
+    )
+    _transfer_softmax_state(
+        level_one_max,
+        level_one_sum,
+        level_one_output,
+        send_max_dfb,
+        send_sum_dfb,
+        send_output_dfb,
+        received_max_dfb,
+        received_sum_dfb,
+        received_output_dfb,
+    )
+    _transfer_softmax_state(
+        level_two_max,
+        level_two_sum,
+        level_two_output,
+        send_max_dfb,
+        send_sum_dfb,
+        send_output_dfb,
+        received_max_dfb,
+        received_sum_dfb,
+        received_output_dfb,
+    )
+
+    if level_two_max.is_dst():
+        output_block = normalized_output_dfb.wait()
+        ttl.copy(output_block, output[0:PNHt, 0:vDHt])
+
+
+@ttl.operation(grid=(NNODES, 1), fp32_dest_acc_en=False)
+def flash_chain_8node(query, key, value, output):
+    """Compose local flash attention with an eight-node tree reduction."""
+    local_max_dfb = ttl.make_dataflow_buffer_like(key, shape=(PNHt, 1), block_count=2)
+    local_sum_dfb = ttl.make_dataflow_buffer_like(key, shape=(PNHt, 1), block_count=2)
+    local_output_dfb = ttl.make_dataflow_buffer_like(
+        key, shape=(PNHt, vDHt), block_count=2
+    )
+
+    flash_shard_kd(
+        query,
+        key,
+        value,
+        local_max_dfb,
+        local_sum_dfb,
+        local_output_dfb,
+    )
+    flash_tree_reduce_8(
+        local_max_dfb,
+        local_sum_dfb,
+        local_output_dfb,
+        output,
+    )
+
+
+@pytest.fixture(scope="module")
+def flash_device():
+    """Provide enough kernel-config L1 for the composed compute program."""
+    if not is_hardware_available():
+        pytest.skip("No Tenstorrent device available")
+
+    max_worker_l1_size = ttnn.device.get_max_worker_l1_unreserved_size()
+    worker_l1_size = max_worker_l1_size - KERNEL_CONFIG_BUFFER_RESERVE_BYTES
+    device = ttnn.open_device(device_id=0, worker_l1_size=worker_l1_size)
+    yield device
+    ttnn.close_device(device)
+
+
+def test_flash_chain_8node(flash_device):
+    torch.manual_seed(2026)
+    query_host = torch.randn(Q_ROWS, HEAD_DIM, dtype=torch.bfloat16) * 0.1
+    key_host = torch.randn(SEQ, HEAD_DIM, dtype=torch.bfloat16) * 0.1
+    value_host = torch.randn(SEQ, HEAD_DIM_V, dtype=torch.bfloat16) * 0.1
+    expected = (
+        torch.nn.functional.scaled_dot_product_attention(
+            query_host.float().unsqueeze(0).unsqueeze(0),
+            key_host.float().unsqueeze(0).unsqueeze(0),
+            value_host.float().unsqueeze(0).unsqueeze(0),
+            scale=SCALE,
+        )
+        .squeeze(0)
+        .squeeze(0)
+        .to(torch.bfloat16)
+    )
+
+    query = to_dram(query_host, flash_device)
+    key = to_dram(key_host, flash_device)
+    value = to_dram(value_host, flash_device)
+    output = to_dram(
+        torch.zeros(Q_ROWS, HEAD_DIM_V, dtype=torch.bfloat16),
+        flash_device,
+    )
+
+    flash_chain_8node(query, key, value, output)
+
+    actual = ttnn.to_torch(output).reshape(Q_ROWS, HEAD_DIM_V).float()
+    assert_pcc(expected.float(), actual, threshold=PCC_THRESHOLD)

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime coverage for physical reuse of user-declared DFBs."""
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+# TTNN interop rejects non-tilized tensors before DFB lowering, so TILE is the
+# only supported tensor layout for these runtime cases.
+TILE = 32
+OVER_CAPACITY_COMPOSITION_LEVELS = 5
+OVER_CAPACITY_LOGICAL_DFBS = (1 << OVER_CAPACITY_COMPOSITION_LEVELS) + 1
+
+
+def _make_exp_via_scratch_atom(data_format, shape=(1, 1)):
+    @ttl.operation()
+    def exp_via_scratch(source: ttl.DFB, destination: ttl.DFB):
+        scratch_dfb = ttl.make_dfb(data_format, shape=shape, block_count=2)
+        scratch_output = scratch_dfb.reserve()
+        scratch_output.store(ttl.exp(source.wait()))
+        destination_output = destination.reserve()
+        destination_output.store(scratch_dfb.wait())
+
+    return exp_via_scratch
+
+
+@ttl.operation()
+def _increment_in_place(source: ttl.DFB, result: ttl.DFB):
+    source_block = source.wait()
+    result_block = result.reserve()
+    result_block.store(
+        ttl.add(
+            source_block,
+            ttl.block.fill(
+                1,
+                shape=source_block.shape,
+                dtype=source_block.dtype,
+            ),
+        )
+    )
+
+
+def _make_in_place_atom_kernel(data_format):
+    @ttl.operation(grid=(1, 1))
+    def in_place_atom_kernel(input_tensor, output_tensor):
+        input_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        state_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        ttl.copy(input_tensor[0, 0], input_dfb.reserve()).wait()
+        input_block = input_dfb.wait()
+        state_block = state_dfb.reserve()
+        state_block.store(input_block)
+        _increment_in_place(state_dfb, state_dfb)
+        state_block = state_dfb.wait()
+        output_block = output_dfb.reserve()
+        output_block.store(state_block)
+        ttl.copy(output_dfb.wait(), output_tensor[0, 0]).wait()
+
+    return in_place_atom_kernel
+
+
+def _make_repeated_dfb_atom_kernel(data_format):
+    exp_via_scratch = _make_exp_via_scratch_atom(data_format)
+
+    @ttl.operation(grid=(1, 1))
+    def repeated_dfb_atom_kernel(input_tensor, output_tensor):
+        first_stage_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        second_stage_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        third_stage_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        ttl.copy(input_tensor[0, 0], first_stage_dfb.reserve()).wait()
+        exp_via_scratch(first_stage_dfb, second_stage_dfb)
+        exp_via_scratch(second_stage_dfb, third_stage_dfb)
+        ttl.copy(third_stage_dfb.wait(), output_tensor[0, 0]).wait()
+
+    return repeated_dfb_atom_kernel
+
+
+def _make_nested_copy_atom(data_format, level_count):
+    @ttl.operation()
+    def copy_stage(source: ttl.DFB, destination: ttl.DFB):
+        destination_block = destination.reserve()
+        destination_block.store(source.wait())
+
+    nested_copy = copy_stage
+    for composition_level in range(level_count):
+        inner_copy = nested_copy
+
+        @ttl.operation()
+        def doubled_copy(source: ttl.DFB, destination: ttl.DFB):
+            intermediate_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+            inner_copy(source, intermediate_dfb)
+            inner_copy(intermediate_dfb, destination)
+
+        nested_copy = doubled_copy
+
+    return nested_copy
+
+
+def _make_over_capacity_atom_kernel(data_format):
+    nested_copy = _make_nested_copy_atom(data_format, OVER_CAPACITY_COMPOSITION_LEVELS)
+
+    @ttl.operation(grid=(1, 1))
+    def over_capacity_atom_kernel(input_tensor, output_tensor):
+        first_stage_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        last_stage_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        ttl.copy(input_tensor[0, 0], first_stage_dfb.reserve()).wait()
+        nested_copy(first_stage_dfb, last_stage_dfb)
+        ttl.copy(last_stage_dfb.wait(), output_tensor[0, 0]).wait()
+
+    return over_capacity_atom_kernel
+
+
+_repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
+_repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
+_in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
+_in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
+_over_capacity_bf16_atom_kernel = _make_over_capacity_atom_kernel("bf16")
+_over_capacity_f32_atom_kernel = _make_over_capacity_atom_kernel("float32")
+
+assert OVER_CAPACITY_LOGICAL_DFBS > 32
+
+
+_exp_scalar_via_scratch = _make_exp_via_scratch_atom("bf16", shape=(1, 1))
+_exp_two_tiles_via_scratch = _make_exp_via_scratch_atom("bf16", shape=(1, 2))
+
+
+@ttl.operation(grid=(1, 1))
+def _mixed_capacity_atom_kernel(
+    scalar_input, scalar_output, two_tile_input, two_tile_output
+):
+    scalar_input_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    scalar_intermediate_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    scalar_output_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+    two_tile_input_dfb = ttl.make_dfb("bf16", shape=(1, 2), block_count=2)
+    two_tile_intermediate_dfb = ttl.make_dfb("bf16", shape=(1, 2), block_count=2)
+    two_tile_output_dfb = ttl.make_dfb("bf16", shape=(1, 2), block_count=2)
+
+    ttl.copy(scalar_input[0, 0], scalar_input_dfb.reserve()).wait()
+    ttl.copy(two_tile_input[0:1, 0:2], two_tile_input_dfb.reserve()).wait()
+    _exp_scalar_via_scratch(scalar_input_dfb, scalar_intermediate_dfb)
+    _exp_two_tiles_via_scratch(two_tile_input_dfb, two_tile_intermediate_dfb)
+    _exp_scalar_via_scratch(scalar_intermediate_dfb, scalar_output_dfb)
+    _exp_two_tiles_via_scratch(two_tile_intermediate_dfb, two_tile_output_dfb)
+    ttl.copy(scalar_output_dfb.wait(), scalar_output[0, 0]).wait()
+    ttl.copy(two_tile_output_dfb.wait(), two_tile_output[0:1, 0:2]).wait()
+
+
+@ttl.operation(grid=(1, 1))
+def _user_dfb_reuse_kernel(first, second, out):
+    first_dfb = ttl.make_dataflow_buffer_like(first, shape=(1, 1), block_count=2)
+    acknowledgment_dfb = ttl.make_dataflow_buffer_like(
+        first, shape=(1, 1), block_count=2
+    )
+    second_dfb = ttl.make_dataflow_buffer_like(second, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        with first_dfb.wait():
+            pass
+
+        with acknowledgment_dfb.reserve() as acknowledgment:
+            acknowledgment.store(
+                ttl.block.fill(
+                    0,
+                    shape=acknowledgment.shape,
+                    dtype=acknowledgment.dtype,
+                )
+            )
+
+        with second_dfb.wait() as second_block, out_dfb.reserve() as out_block:
+            out_block.store(second_block)
+
+    @ttl.datamovement()
+    def dm_read():
+        with first_dfb.reserve() as first_block:
+            ttl.copy(first[0, 0], first_block).wait()
+
+        with acknowledgment_dfb.wait():
+            pass
+
+        with second_dfb.reserve() as second_block:
+            ttl.copy(second[0, 0], second_block).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with out_dfb.wait() as out_block:
+            ttl.copy(out_block, out[0, 0]).wait()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize("reuse_user_dfbs", [True, False], ids=["reuse", "distinct"])
+def test_user_dfb_allocation_runtime(
+    device, dtype, memory_config, to_device, reuse_user_dfbs
+):
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    first_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    second_host = (((17 * element_indices).remainder(509) - 254) / 128).to(dtype)
+    out_host = torch.zeros((TILE, TILE), dtype=dtype)
+
+    first = to_device(first_host, device)
+    second = to_device(second_host, device)
+    out = to_device(out_host, device)
+
+    reuse_option = (
+        "--ttl-reuse-user-dfbs" if reuse_user_dfbs else "--no-ttl-reuse-user-dfbs"
+    )
+    _user_dfb_reuse_kernel(first, second, out, options=reuse_option)
+
+    actual = ttnn.to_torch(out).float()
+    expected = second_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_repeated_bf16_atom_kernel, torch.bfloat16),
+        (_repeated_f32_atom_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+def test_repeated_dfb_declaring_atom_runtime(
+    device, memory_config, to_device, operation, dtype
+):
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    input_host = ((element_indices.remainder(97) - 48) / 128).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros((TILE, TILE), dtype=dtype), device)
+
+    operation(input_tensor, output_tensor)
+
+    intermediate = torch.exp(input_host.float()).to(dtype)
+    expected = torch.exp(intermediate.float()).to(dtype).float()
+    actual = ttnn.to_torch(output_tensor).float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_in_place_bf16_atom_kernel, torch.bfloat16),
+        (_in_place_f32_atom_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+def test_atom_accepts_same_dfb_as_source_and_result(
+    device, memory_config, to_device, operation, dtype
+):
+    input_host = (
+        torch.arange(TILE * TILE, dtype=torch.float32).remainder(7).reshape(TILE, TILE)
+        - 3
+    ).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    operation(input_tensor, output_tensor)
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float() + 1
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_over_capacity_bf16_atom_kernel, torch.bfloat16),
+        (_over_capacity_f32_atom_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+def test_over_capacity_atom_composition_requires_dfb_reuse(
+    device, memory_config, to_device, operation, dtype
+):
+    input_host = torch.linspace(-1.0, 1.0, TILE * TILE, dtype=torch.float32).reshape(
+        TILE, TILE
+    )
+    input_host = input_host.to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    operation(input_tensor, output_tensor)
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-3, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_mixed_capacity_dfb_atoms_runtime(device, memory_config, to_device):
+    scalar_input_host = (
+        torch.linspace(-0.375, 0.375, TILE * TILE, dtype=torch.float32)
+        .reshape(TILE, TILE)
+        .to(torch.bfloat16)
+    )
+    two_tile_input_host = (
+        torch.linspace(-0.375, 0.375, TILE * TILE * 2, dtype=torch.float32)
+        .reshape(TILE, 2 * TILE)
+        .to(torch.bfloat16)
+    )
+
+    scalar_input = to_device(scalar_input_host, device)
+    scalar_output = to_device(torch.zeros_like(scalar_input_host), device)
+    two_tile_input = to_device(two_tile_input_host, device)
+    two_tile_output = to_device(torch.zeros_like(two_tile_input_host), device)
+
+    _mixed_capacity_atom_kernel(
+        scalar_input, scalar_output, two_tile_input, two_tile_output
+    )
+
+    for input_host, output_tensor in (
+        (scalar_input_host, scalar_output),
+        (two_tile_input_host, two_tile_output),
+    ):
+        intermediate = torch.exp(input_host.float()).to(torch.bfloat16)
+        expected = torch.exp(intermediate.float()).to(torch.bfloat16).float()
+        actual = ttnn.to_torch(output_tensor).float()
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -205,6 +205,53 @@ def _user_dfb_reuse_kernel(first, second, out):
             ttl.copy(out_block, out[0, 0]).wait()
 
 
+@ttl.operation(grid=(1, 1))
+def _distinct_noc_owner_kernel(first, second, out):
+    first_dfb = ttl.make_dataflow_buffer_like(first, shape=(1, 1), block_count=2)
+    acknowledgment_dfb = ttl.make_dataflow_buffer_like(
+        first, shape=(1, 1), block_count=2
+    )
+    second_dfb = ttl.make_dataflow_buffer_like(second, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        with first_dfb.wait():
+            pass
+
+        # The acknowledgment proves that the first DFB is quiescent before
+        # NOC1 produces the second DFB.
+        with acknowledgment_dfb.reserve() as acknowledgment:
+            acknowledgment.store(
+                ttl.block.fill(
+                    0,
+                    shape=acknowledgment.shape,
+                    dtype=acknowledgment.dtype,
+                )
+            )
+
+        with second_dfb.wait() as second_block, out_dfb.reserve() as out_block:
+            out_block.store(second_block)
+
+    @ttl.datamovement()
+    def dm_read():
+        with first_dfb.reserve() as first_block:
+            ttl.copy(first[0, 0], first_block).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with acknowledgment_dfb.wait():
+            pass
+
+        # NOC1 owns this producer pointer, while NOC0 owns first_dfb's
+        # producer pointer. They must remain distinct despite ordered lifetimes.
+        with second_dfb.reserve() as second_block:
+            ttl.copy(second[0, 0], second_block).wait()
+
+        with out_dfb.wait() as out_block:
+            ttl.copy(out_block, out[0, 0]).wait()
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
 @pytest.mark.parametrize(
     ("memory_config", "to_device"),
@@ -228,6 +275,38 @@ def test_user_dfb_allocation_runtime(
         "--ttl-reuse-user-dfbs" if reuse_user_dfbs else "--no-ttl-reuse-user-dfbs"
     )
     _user_dfb_reuse_kernel(first, second, out, options=reuse_option)
+
+    actual = ttnn.to_torch(out).float()
+    expected = second_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize("reuse_user_dfbs", [True, False], ids=["reuse", "distinct"])
+def test_ordered_dfbs_with_distinct_noc_owners(
+    device, dtype, memory_config, to_device, reuse_user_dfbs
+):
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    first_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    second_host = (((17 * element_indices).remainder(509) - 254) / 128).to(dtype)
+    out_host = torch.zeros((TILE, TILE), dtype=dtype)
+
+    first = to_device(first_host, device)
+    second = to_device(second_host, device)
+    out = to_device(out_host, device)
+
+    reuse_option = (
+        "--ttl-reuse-user-dfbs" if reuse_user_dfbs else "--no-ttl-reuse-user-dfbs"
+    )
+    _distinct_noc_owner_kernel(first, second, out, options=reuse_option)
 
     actual = ttnn.to_torch(out).float()
     expected = second_host.float()

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -20,6 +20,10 @@ pytestmark = pytest.mark.requires_device
 TILE = 32
 OVER_CAPACITY_COMPOSITION_LEVELS = 5
 OVER_CAPACITY_LOGICAL_DFBS = (1 << OVER_CAPACITY_COMPOSITION_LEVELS) + 1
+# Two approximate SFPU exponential evaluations need operation-level error
+# bounds; f32 data movement and addition tests retain 1e-5 relative tolerance.
+F32_REPEATED_EXP_RTOL = 2e-3
+F32_REPEATED_EXP_ATOL = 5e-4
 
 
 def _make_exp_via_scratch_atom(data_format, shape=(1, 1)):
@@ -246,15 +250,23 @@ def test_user_dfb_allocation_runtime(
     ],
     ids=["bf16", "f32"],
 )
+@pytest.mark.parametrize(
+    "specialize_cores",
+    [False, True],
+    ids=["generic-cores", "specialized-cores"],
+)
 def test_repeated_dfb_declaring_atom_runtime(
-    device, memory_config, to_device, operation, dtype
+    device, memory_config, to_device, operation, dtype, specialize_cores
 ):
     element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
     input_host = ((element_indices.remainder(97) - 48) / 128).to(dtype)
     input_tensor = to_device(input_host, device)
     output_tensor = to_device(torch.zeros((TILE, TILE), dtype=dtype), device)
 
-    operation(input_tensor, output_tensor)
+    specialization_option = (
+        "--ttl-specialize-cores" if specialize_cores else "--no-ttl-specialize-cores"
+    )
+    operation(input_tensor, output_tensor, options=specialization_option)
 
     intermediate = torch.exp(input_host.float()).to(dtype)
     expected = torch.exp(intermediate.float()).to(dtype).float()
@@ -262,7 +274,12 @@ def test_repeated_dfb_declaring_atom_runtime(
     if dtype == torch.bfloat16:
         assert_allclose(actual, expected, rtol=0.05, atol=1.0)
     else:
-        assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)
+        assert_allclose(
+            actual,
+            expected,
+            rtol=F32_REPEATED_EXP_RTOL,
+            atol=F32_REPEATED_EXP_ATOL,
+        )
 
 
 @pytest.mark.parametrize(

--- a/test/ttlang/Analysis/dfb_allocation_oracle.mlir
+++ b/test/ttlang/Analysis/dfb_allocation_oracle.mlir
@@ -1,0 +1,12 @@
+// Tests the exact DFB coloring solver against an independent exhaustive oracle
+// and compares uniform, per-node, and two-group hybrid assignment contracts.
+// RUN: ttlang-dfb-allocation-oracle-test | FileCheck %s
+
+// CHECK: solver_graphs=33868
+// CHECK-NEXT: capacity_reproducer=32
+// CHECK-NEXT: capacity_search_states={{[1-9][0-9]*}}
+// CHECK-NEXT: bounded_search_states=1
+// CHECK-NEXT: contract_cases=262144
+// CHECK-NEXT: per_node_improvements=149268
+// CHECK-NEXT: two_group_improvements=142536
+// CHECK-NEXT: maximum_uniform_penalty=2

--- a/test/ttlang/Analysis/dfb_allocation_oracle.mlir
+++ b/test/ttlang/Analysis/dfb_allocation_oracle.mlir
@@ -1,13 +1,13 @@
-// Tests minimum and fixed-limit exact DFB coloring against an independent
-// exhaustive oracle and compares uniform, per-node, and hybrid assignments.
+// Tests minimum and fixed-limit DFB index assignment against an independent
+// exhaustive oracle and compares uniform, per-node, and hybrid contracts.
 // RUN: ttlang-dfb-allocation-oracle-test | FileCheck %s
 
 // CHECK: solver_graphs=33868
 // CHECK-NEXT: capacity_reproducer=32
 // CHECK-NEXT: capacity_search_states={{[1-9][0-9]*}}
 // CHECK-NEXT: bounded_search_states=1
-// CHECK-NEXT: low_clique_fixed_states={{[1-9][0-9]*}}
-// CHECK-NEXT: low_clique_minimum_states=100
+// CHECK-NEXT: fixed_limit_states={{[1-9][0-9]*}}
+// CHECK-NEXT: minimum_proof_states=100
 // CHECK-NEXT: contract_cases=262144
 // CHECK-NEXT: per_node_improvements=149268
 // CHECK-NEXT: two_group_improvements=142536

--- a/test/ttlang/Analysis/dfb_allocation_oracle.mlir
+++ b/test/ttlang/Analysis/dfb_allocation_oracle.mlir
@@ -1,11 +1,13 @@
-// Tests the exact DFB coloring solver against an independent exhaustive oracle
-// and compares uniform, per-node, and two-group hybrid assignment contracts.
+// Tests minimum and fixed-limit exact DFB coloring against an independent
+// exhaustive oracle and compares uniform, per-node, and hybrid assignments.
 // RUN: ttlang-dfb-allocation-oracle-test | FileCheck %s
 
 // CHECK: solver_graphs=33868
 // CHECK-NEXT: capacity_reproducer=32
 // CHECK-NEXT: capacity_search_states={{[1-9][0-9]*}}
 // CHECK-NEXT: bounded_search_states=1
+// CHECK-NEXT: low_clique_fixed_states={{[1-9][0-9]*}}
+// CHECK-NEXT: low_clique_minimum_states=100
 // CHECK-NEXT: contract_cases=262144
 // CHECK-NEXT: per_node_improvements=149268
 // CHECK-NEXT: two_group_improvements=142536

--- a/test/ttlang/Dialect/TTL/Pipelines/pipe_verifier_order.mlir
+++ b/test/ttlang/Dialect/TTL/Pipelines/pipe_verifier_order.mlir
@@ -21,7 +21,7 @@
 // CHECK-NEXT: func.func(
 // CHECK-NEXT:   ttl-coalesce-dfb-acquires
 // CHECK-NEXT: ),
-// CHECK-NEXT: ttl-finalize-dfb-indices,
+// CHECK-NEXT: ttl-finalize-dfb-indices{exact-coloring-search-limit=1000000 reuse-user-dfbs=true},
 // CHECK-NEXT: func.func(
 // CHECK-NOT:    ttl-verify-pipenet-guards
 // CHECK-NOT:    ttl-verify-pipenet-schedule

--- a/test/ttlang/Dialect/TTL/Transforms/Inputs/generate_dfb_exact_coloring_permutations.py
+++ b/test/ttlang/Dialect/TTL/Transforms/Inputs/generate_dfb_exact_coloring_permutations.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from itertools import permutations
+
+
+DFB_TYPE = "!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>"
+PROTOCOL_TYPE = "<[1, 1], !ttcore.tile<32x32, bf16>, 2>"
+TENSOR_TYPE = "tensor<1x1x!ttcore.tile<32x32, bf16>>"
+
+
+def emit_bind(name, physical_index, logical_id):
+    print(
+        f"    %{name} = ttl.bind_cb {{cb_index = {physical_index}, "
+        f"block_count = 2}} {{dfb_id = {logical_id} : index}} : {DFB_TYPE}"
+    )
+
+
+def emit_protocol(name, effect):
+    result_name = "reserved" if effect == "reserve" else "waited"
+    print(
+        f"    %{result_name}_{name} = ttl.cb_{effect} %{name} : "
+        f"{PROTOCOL_TYPE} -> {TENSOR_TYPE}"
+    )
+    completion_effect = "push" if effect == "reserve" else "pop"
+    print(f"    ttl.cb_{completion_effect} %{name} : {PROTOCOL_TYPE}")
+
+
+def emit_module(logical_ids):
+    print("module {")
+    print("  func.func @exact_coloring_permutation()")
+    print("      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,")
+    print("                  ttl.base_cta_index = 34 : i32, ttl.crta_indices = []} {")
+    for persistent_index in range(30):
+        emit_bind(f"persistent{persistent_index}", persistent_index, persistent_index)
+
+    path_names = ("path_a", "path_d", "path_b", "path_c")
+    for declaration_index, (name, logical_id) in enumerate(
+        zip(path_names, logical_ids), start=30
+    ):
+        emit_bind(name, declaration_index, logical_id)
+
+    emit_protocol("path_a", "reserve")
+    emit_protocol("path_b", "reserve")
+    emit_protocol("path_a", "wait")
+    emit_protocol("path_c", "reserve")
+    emit_protocol("path_b", "wait")
+    emit_protocol("path_d", "reserve")
+    emit_protocol("path_c", "wait")
+    emit_protocol("path_d", "wait")
+    print("    return")
+    print("  }")
+    print("}")
+
+
+for permutation_index, logical_ids in enumerate(permutations(range(30, 34))):
+    if permutation_index:
+        print("// -----")
+    emit_module(logical_ids)

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
@@ -39,12 +39,12 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // -----
 
-// The four data DFBs have a path interference graph. Logical-ID first-fit
-// visits A, D, B, C and uses three data colors, while the exact assignment uses
-// two. The greedy assignment is valid and fits the hardware limit, so the
-// production allocator accepts its six total indices. The independent oracle
-// joins this graph with a 30-vertex clique to verify a fixed-limit check from 33
-// to 32 indices.
+// Each data DFB conflicts only with the next DFB in A-B-C-D order. Processing
+// them as A, D, B, C makes first-fit use three indices although two suffice.
+// This six-index result is valid and below the hardware limit, so proving the
+// smaller assignment would not change acceptance. The independent oracle adds
+// 30 DFBs that all conflict pairwise to verify the case where exact search must
+// reduce 33 first-fit indices to the available 32.
 
 // CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}, {{.*}}dfb_index = 3 : i32{{.*}}, {{.*}}dfb_index = 4 : i32{{.*}}, {{.*}}dfb_index = 5 : i32{{.*}}]}
 // CHECK-LABEL: func.func @path_producer

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
@@ -12,7 +12,8 @@
 
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @split_compiler_producer()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         {dfb_id = 7 : index, ttl.compiler_allocated}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -42,7 +43,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // visits A, D, B, C and uses three data colors, while the exact assignment uses
 // two. The greedy assignment is valid and fits the hardware limit, so the
 // production allocator accepts its six total indices. The independent oracle
-// joins this graph with a 30-vertex clique to verify exact escalation from 33
+// joins this graph with a 30-vertex clique to verify a fixed-limit check from 33
 // to 32 indices.
 
 // CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}, {{.*}}dfb_index = 3 : i32{{.*}}, {{.*}}dfb_index = 4 : i32{{.*}}, {{.*}}dfb_index = 5 : i32{{.*}}]}
@@ -57,7 +58,8 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @path_producer()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
     %first_path_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
     %last_path_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
     %second_path_dfb = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
@@ -1,0 +1,112 @@
+// Tests logical lifecycle aggregation, safe alias preservation, and exact
+// physical DFB allocation for the confirmed PR #775 review cases.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+
+// Compiler-created declarations with one logical ID form one lifecycle across
+// producer and consumer functions.
+
+// CHECK-LABEL: func.func @split_compiler_producer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 7 : index, ttl.compiler_allocated}
+// CHECK-LABEL: func.func @split_compiler_consumer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 7 : index, ttl.compiler_allocated}
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @split_compiler_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 7 : index, ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @split_compiler_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 7 : index, ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// The four data DFBs have a path interference graph. Logical-ID first-fit
+// visits A, D, B, C and uses three data colors, while the exact assignment uses
+// two. The greedy assignment is valid and fits the hardware limit, so the
+// production allocator accepts its six total indices. The independent oracle
+// joins this graph with a 30-vertex clique to verify exact escalation from 33
+// to 32 indices.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}, {{.*}}dfb_index = 3 : i32{{.*}}, {{.*}}dfb_index = 4 : i32{{.*}}, {{.*}}dfb_index = 5 : i32{{.*}}]}
+// CHECK-LABEL: func.func @path_producer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 2 : index}
+// CHECK: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 3 : index}
+// CHECK: ttl.bind_cb{cb_index = [[ACK_AC_INDEX:[0-9]+]], block_count = 2} {dfb_id = 4 : index}
+// CHECK: ttl.bind_cb{cb_index = [[ACK_AD_INDEX:[0-9]+]], block_count = 2} {dfb_id = 5 : index}
+// CHECK: ttl.bind_cb{cb_index = [[ACK_BD_INDEX:[0-9]+]], block_count = 2} {dfb_id = 6 : index}
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @path_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %first_path_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %last_path_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_path_dfb = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %third_path_dfb = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_ac = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %ack_ad = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %ack_bd = ttl.bind_cb {cb_index = 6, block_count = 2} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+
+    %first_path_slot = ttl.cb_reserve %first_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %first_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_path_slot = ttl.cb_reserve %second_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %second_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_ac_block = ttl.cb_wait %ack_ac : <[1, 1], !ttcore.tile<1x16, f32>, 2> -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_pop %ack_ac : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %third_path_slot = ttl.cb_reserve %third_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %third_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_ad_block = ttl.cb_wait %ack_ad : <[1, 1], !ttcore.tile<1x16, f32>, 2> -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_pop %ack_ad : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %ack_bd_block = ttl.cb_wait %ack_bd : <[1, 1], !ttcore.tile<1x16, f32>, 2> -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_pop %ack_bd : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %last_path_slot = ttl.cb_reserve %last_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %last_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+
+  func.func @path_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %first_path_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %last_path_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_path_dfb = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %third_path_dfb = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_ac = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %ack_ad = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %ack_bd = ttl.bind_cb {cb_index = 6, block_count = 2} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+
+    %first_path_value = ttl.cb_wait %first_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %first_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_ac_block = ttl.cb_reserve %ack_ac : <[1, 1], !ttcore.tile<1x16, f32>, 2> -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_push %ack_ac : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %second_path_value = ttl.cb_wait %second_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %second_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_ad_block = ttl.cb_reserve %ack_ad : <[1, 1], !ttcore.tile<1x16, f32>, 2> -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_push %ack_ad : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %ack_bd_block = ttl.cb_reserve %ack_bd : <[1, 1], !ttcore.tile<1x16, f32>, 2> -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_push %ack_bd : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %last_path_value = ttl.cb_wait %last_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %last_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %third_path_value = ttl.cb_wait %third_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %third_path_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
@@ -50,6 +50,7 @@
 
 func.func @synchronized_dm()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
   %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
   %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
@@ -101,6 +102,7 @@ func.func @synchronized_compute()
 
 func.func @three_kernel_producer()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
   %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %relay_to_producer = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -131,6 +133,7 @@ func.func @three_kernel_consumer()
 
 func.func @three_kernel_relay()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
   %consumer_to_relay = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %relay_to_producer = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -158,6 +161,7 @@ func.func @three_kernel_relay()
 
 func.func @unordered_dm()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
   %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -199,6 +203,7 @@ func.func @unordered_compute()
 
 func.func @early_wait_producer()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
   %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -226,6 +231,7 @@ func.func @early_wait_compute()
 
 func.func @early_wait_consumer()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
   %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %b_view = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -250,6 +256,7 @@ func.func @early_wait_consumer()
 
 func.func @unbalanced_dm()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
   %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -373,6 +380,7 @@ func.func @loop_lifecycle()
 
 func.func @producer_transition_dm()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
   %input = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %input_producer = ttl.cb_reserve %input : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -429,6 +437,7 @@ func.func @consumer_transition_compute()
 
 func.func @consumer_transition_dm()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
   %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
@@ -1,0 +1,440 @@
+// Tests conservative DFB reuse across concurrently executing kernel functions.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=REUSE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=REUSE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=DISABLED
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true},ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=REPEAT
+
+// The acknowledgment DFB orders B's reserve and wait after A's pop. A and B may
+// share physical index 0; the acknowledgment requires physical index 1.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}]}
+// REUSE-LABEL: func.func @synchronized_dm
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: %[[DM_A:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE: %[[DM_ACK:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// REUSE: %[[DM_B:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// REUSE: ttl.cb_reserve %[[DM_A]]
+// REUSE: ttl.cb_push %[[DM_A]]
+// REUSE: ttl.cb_wait %[[DM_ACK]]
+// REUSE: ttl.cb_pop %[[DM_ACK]]
+// REUSE: ttl.cb_reserve %[[DM_B]]
+// REUSE: ttl.cb_push %[[DM_B]]
+// REUSE-LABEL: func.func @synchronized_compute
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: %[[COMPUTE_A:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE: %[[COMPUTE_ACK:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// REUSE: %[[COMPUTE_B:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+
+// A repeated finalization preserves logical identities after A and B receive
+// the same physical index.
+// REPEAT-LABEL: func.func @synchronized_dm
+// REPEAT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REPEAT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// REPEAT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// REPEAT-LABEL: func.func @synchronized_compute
+// REPEAT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REPEAT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// REPEAT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+
+// DISABLED: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {block_count = 2 : i32, dfb_index = 2 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}]}
+// DISABLED-LABEL: func.func @synchronized_dm
+// DISABLED-SAME: ttl.base_cta_index = 3 : i32
+// DISABLED: ttl.bind_cb{cb_index = 0,
+// DISABLED: ttl.bind_cb{cb_index = 1,
+// DISABLED: ttl.bind_cb{cb_index = 2,
+// DISABLED-LABEL: func.func @synchronized_compute
+// DISABLED-SAME: ttl.base_cta_index = 3 : i32
+// DISABLED: ttl.bind_cb{cb_index = 0,
+// DISABLED: ttl.bind_cb{cb_index = 1,
+// DISABLED: ttl.bind_cb{cb_index = 2,
+
+func.func @synchronized_dm()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %a_view = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack_view = ttl.cb_wait %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b_view = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  return
+}
+
+func.func @synchronized_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %a_view = ttl.cb_wait %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack_view = ttl.cb_reserve %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b_view = ttl.cb_wait %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  return
+}
+
+// -----
+
+// A relay through the second data-movement kernel orders the second DFB's
+// reserve and wait after the first DFB's pop. Both DFBs use the same producer
+// and consumer kernels and may share physical index 0.
+
+// REUSE-LABEL: func.func @three_kernel_producer
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 2 : index}
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 3 : index}
+// REUSE-LABEL: func.func @three_kernel_consumer
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 1 : index}
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 3 : index}
+// REUSE-LABEL: func.func @three_kernel_relay
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+// REUSE: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 1 : index}
+// REUSE: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 2 : index}
+
+func.func @three_kernel_producer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
+  %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %relay_to_producer = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %second_dfb = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %first_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %producer_ack = ttl.cb_wait %relay_to_producer : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %relay_to_producer : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @three_kernel_consumer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
+  %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %consumer_to_relay = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %second_dfb = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %relay_reserved = ttl.cb_reserve %consumer_to_relay : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %consumer_to_relay : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @three_kernel_relay()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
+  %consumer_to_relay = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %relay_to_producer = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %consumer_ack = ttl.cb_wait %consumer_to_relay : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %consumer_to_relay : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %producer_ack = ttl.cb_reserve %relay_to_producer : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %relay_to_producer : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Source order in both kernels does not order A's consumer completion before
+// B's producer entry. The two DFBs must retain separate physical indices.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @unordered_dm
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0,
+// REUSE: ttl.bind_cb{cb_index = 1,
+// REUSE-LABEL: func.func @unordered_compute
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0,
+// REUSE: ttl.bind_cb{cb_index = 1,
+
+func.func @unordered_dm()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_view = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_view = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @unordered_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_view = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_view = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// B's consumer wait enters before A's terminal pop. The acknowledgment orders
+// B's producer entry after A's pop, but does not order the wait entry after
+// A's pop. A, the acknowledgment, and B require separate physical indices.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 2 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @early_wait_producer
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+// REUSE: ttl.bind_cb{cb_index = 0,
+// REUSE: ttl.bind_cb{cb_index = 1,
+// REUSE: ttl.bind_cb{cb_index = 2,
+// REUSE-LABEL: func.func @early_wait_compute
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+// REUSE-LABEL: func.func @early_wait_consumer
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+
+func.func @early_wait_producer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_view = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %ack_view = ttl.cb_wait %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_view = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @early_wait_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_view = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %ack_view = ttl.cb_reserve %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @early_wait_consumer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_view = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// A missing pop leaves A unbounded. Source order alone cannot permit A and B
+// to share a physical index.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @unbalanced_dm
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0,
+// REUSE: ttl.bind_cb{cb_index = 1,
+// REUSE-LABEL: func.func @unbalanced_compute
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0,
+// REUSE: ttl.bind_cb{cb_index = 1,
+
+func.func @unbalanced_dm()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_view = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_view = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @unbalanced_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_view = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %b_view = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Sequential DFBs with different exact types cannot share an index. Immutable
+// declaration order determines the physical assignment, not logical numbering.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @different_types
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, {{.*}}} : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+// REUSE: ttl.bind_cb{cb_index = 1, {{.*}}} : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+
+func.func @different_types()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %a_producer = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %a_consumer = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  ttl.cb_pop %a : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %b_producer = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_consumer = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Declaration-only compiler-created DFBs are valid. They receive distinct
+// identities even when their provisional cb_index values match.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @first_compiler_dfb
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, {{.*}}} {dfb_id = 0 : index, ttl.compiler_allocated}
+// REUSE-LABEL: func.func @second_compiler_dfb
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 1, {{.*}}} {dfb_id = 1 : index, ttl.compiler_allocated}
+
+func.func @first_compiler_dfb()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+  %compiler_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @second_compiler_dfb()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+  %compiler_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Repeated lifecycle operations cannot be matched by static operation site, so
+// the loop DFB remains unbounded even though B starts after the loop completes.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @loop_lifecycle
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0,
+// REUSE: ttl.bind_cb{cb_index = 1,
+
+func.func @loop_lifecycle()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %loop_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %lower_bound = arith.constant 0 : index
+  %upper_bound = arith.constant 4 : index
+  %step = arith.constant 1 : index
+  scf.for %iteration = %lower_bound to %upper_bound step %step {
+    %producer_view = ttl.cb_reserve %loop_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %loop_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %consumer_view = ttl.cb_wait %loop_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %loop_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  }
+  %b_producer = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_consumer = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Ordered lifetimes cannot share when the producer pointer changes from NOC0
+// to Pack. Quiescence does not transfer write-pointer ownership.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @producer_transition_dm
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, {{.*}}} {dfb_id = 0 : index}
+// REUSE-LABEL: func.func @producer_transition_compute
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, {{.*}}} {dfb_id = 0 : index}
+// REUSE: ttl.bind_cb{cb_index = 1, {{.*}}} {dfb_id = 1 : index, ttl.compiler_allocated}
+
+func.func @producer_transition_dm()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %input = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %input_producer = ttl.cb_reserve %input : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %input : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @producer_transition_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %input = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %intermediate = ttl.bind_cb {cb_index = 1, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %input_consumer = ttl.cb_wait %input : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %input : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %intermediate_producer = ttl.cb_reserve %intermediate : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %intermediate : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %intermediate_consumer = ttl.cb_wait %intermediate : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %intermediate : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Ordered lifetimes cannot share when the consumer pointer changes from Unpack
+// to NOC0. The acknowledgment orders B's reserve and wait after A's pop.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 2 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @consumer_transition_compute
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, {{.*}}} {dfb_id = 0 : index}
+// REUSE: ttl.bind_cb{cb_index = 1, {{.*}}} {dfb_id = 1 : index}
+// REUSE: ttl.bind_cb{cb_index = 2, {{.*}}} {dfb_id = 2 : index}
+// REUSE-LABEL: func.func @consumer_transition_dm
+// REUSE-SAME: ttl.base_cta_index = 3 : i32
+// REUSE: ttl.bind_cb{cb_index = 1, {{.*}}} {dfb_id = 1 : index}
+// REUSE: ttl.bind_cb{cb_index = 2, {{.*}}} {dfb_id = 2 : index}
+
+func.func @consumer_transition_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_producer = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %a_consumer = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %ack_producer = ttl.cb_reserve %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_producer = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @consumer_transition_dm()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %ack_consumer = ttl.cb_wait %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %ack : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %b_consumer = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_capacity.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_capacity.mlir
@@ -1,0 +1,70 @@
+// Tests physical DFB allocation at the 32-index hardware boundary.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// Thirty-one unbounded DFBs interfere with every other DFB. The last three
+// each have one reserve, push, wait, and pop. Their ordered lifetimes share
+// physical index 31, reducing 34 logical DFBs to exactly 32 physical indices.
+
+// CHECK: module attributes {ttl.dfb_allocations = [
+// CHECK-COUNT-32: dfb_index = {{[0-9]+}} : i32
+// CHECK-NOT: dfb_index = 32
+// CHECK-LABEL: func.func @capacity_boundary
+// CHECK-SAME: ttl.base_cta_index = 32 : i32
+// CHECK: %[[REUSABLE0:.*]] = ttl.bind_cb{cb_index = 31, block_count = 2} {dfb_id = 31 : index}
+// CHECK-NEXT: %[[REUSABLE1:.*]] = ttl.bind_cb{cb_index = 31, block_count = 2} {dfb_id = 32 : index}
+// CHECK-NEXT: %[[REUSABLE2:.*]] = ttl.bind_cb{cb_index = 31, block_count = 2} {dfb_id = 33 : index}
+// CHECK-NOT: ttl.bind_cb{cb_index = 32
+
+module {
+  func.func @capacity_boundary()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 34 : i32, ttl.crta_indices = []} {
+    %persistent0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent3 = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent4 = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent5 = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent6 = ttl.bind_cb {cb_index = 6, block_count = 2} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent7 = ttl.bind_cb {cb_index = 7, block_count = 2} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent8 = ttl.bind_cb {cb_index = 8, block_count = 2} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent9 = ttl.bind_cb {cb_index = 9, block_count = 2} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent10 = ttl.bind_cb {cb_index = 10, block_count = 2} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent11 = ttl.bind_cb {cb_index = 11, block_count = 2} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent12 = ttl.bind_cb {cb_index = 12, block_count = 2} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent13 = ttl.bind_cb {cb_index = 13, block_count = 2} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent14 = ttl.bind_cb {cb_index = 14, block_count = 2} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent15 = ttl.bind_cb {cb_index = 15, block_count = 2} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent16 = ttl.bind_cb {cb_index = 16, block_count = 2} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent17 = ttl.bind_cb {cb_index = 17, block_count = 2} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent18 = ttl.bind_cb {cb_index = 18, block_count = 2} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent19 = ttl.bind_cb {cb_index = 19, block_count = 2} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent20 = ttl.bind_cb {cb_index = 20, block_count = 2} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent21 = ttl.bind_cb {cb_index = 21, block_count = 2} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent22 = ttl.bind_cb {cb_index = 22, block_count = 2} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent23 = ttl.bind_cb {cb_index = 23, block_count = 2} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent24 = ttl.bind_cb {cb_index = 24, block_count = 2} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent25 = ttl.bind_cb {cb_index = 25, block_count = 2} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent26 = ttl.bind_cb {cb_index = 26, block_count = 2} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent27 = ttl.bind_cb {cb_index = 27, block_count = 2} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent28 = ttl.bind_cb {cb_index = 28, block_count = 2} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent29 = ttl.bind_cb {cb_index = 29, block_count = 2} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent30 = ttl.bind_cb {cb_index = 30, block_count = 2} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reusable0 = ttl.bind_cb {cb_index = 31, block_count = 2} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reusable1 = ttl.bind_cb {cb_index = 32, block_count = 2} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reusable2 = ttl.bind_cb {cb_index = 33, block_count = 2} {dfb_id = 33 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %producer0 = ttl.cb_reserve %reusable0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %reusable0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %consumer0 = ttl.cb_wait %reusable0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %reusable0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %producer1 = ttl.cb_reserve %reusable1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %reusable1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %consumer1 = ttl.cb_wait %reusable1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %reusable1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %producer2 = ttl.cb_reserve %reusable2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %reusable2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %consumer2 = ttl.cb_wait %reusable2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %reusable2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
@@ -1,0 +1,106 @@
+// Tests external-call DFB uses in concurrent-kernel lifetime analysis.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+
+// A direct DFB operand keeps A live through the external call. The call
+// completes before A's pop, so the acknowledgment still orders B after A and
+// permits A and B to share physical index 0. The index query after the pop does
+// not access physical storage and does not extend A's lifetime.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
+// CHECK-LABEL: func.func @external_use_before_release_dm
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// CHECK-LABEL: func.func @external_use_before_release_compute
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK-DAG: %[[A:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// CHECK: %[[ACTIVE_A_INDEX:.*]] = ttl.get_dfb_id %[[A]]
+// CHECK: ttl.opaque_call "inspect_dfb" template_args(%[[ACTIVE_A_INDEX]]) (%[[A]]) {header = "inspect_dfb.hpp"}
+// CHECK: ttl.cb_pop %[[A]]
+// CHECK: ttl.get_dfb_id %[[A]]
+
+func.func @external_use_before_release_dm()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %a_view = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack_view = ttl.cb_wait %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b_view = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  return
+}
+
+func.func @external_use_before_release_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %a_view = ttl.cb_wait %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  %active_a_index = ttl.get_dfb_id %a : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  ttl.opaque_call "inspect_dfb" template_args(%active_a_index) (%a) {header = "inspect_dfb.hpp"} : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+  ttl.cb_pop %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %a_index = ttl.get_dfb_id %a : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack_view = ttl.cb_reserve %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b_view = ttl.cb_wait %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  return
+}
+
+// -----
+
+// A direct DFB operand after A's pop is an access after the proposed terminal
+// event. A is unbounded and cannot share a physical index with B.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}]}
+// CHECK-LABEL: func.func @external_use_after_release_dm
+// CHECK-SAME: ttl.base_cta_index = 3 : i32
+// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+// CHECK-LABEL: func.func @external_use_after_release_compute
+// CHECK-SAME: ttl.base_cta_index = 3 : i32
+// CHECK-DAG: %[[A:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+// CHECK: ttl.cb_pop %[[A]]
+// CHECK: ttl.opaque_call "inspect_dfb" (%[[A]]) {header = "inspect_dfb.hpp"}
+
+func.func @external_use_after_release_dm()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %a_view = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack_view = ttl.cb_wait %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b_view = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  return
+}
+
+func.func @external_use_after_release_compute()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %a_view = ttl.cb_wait %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %a : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  ttl.opaque_call "inspect_dfb" (%a) {header = "inspect_dfb.hpp"} : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+  %ack_view = ttl.cb_reserve %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_push %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  %b_view = ttl.cb_wait %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2> -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+  ttl.cb_pop %b : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
@@ -24,6 +24,7 @@
 
 func.func @external_use_before_release_dm()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
   %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
   %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
@@ -76,6 +77,7 @@ func.func @external_use_before_release_compute()
 
 func.func @external_use_after_release_dm()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.noc_index = 0 : i32,
                 ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
   %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
   %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
@@ -98,6 +98,69 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // -----
 
+// Pure integer operations cannot hide a physical DFB index from the custom
+// function dependency check.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @custom_function_laundered_dependency()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb_index = ttl.get_dfb_id %dfb
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %zero = arith.constant 0 : i32
+    %laundered = arith.addi %dfb_index, %zero : i32
+    // expected-error @below {{'ttl.opaque_call' op custom function consumes the physical index for logical DFB 0 without listing that DFB as a dependency operand}}
+    ttl.opaque_call "custom_consume" (%laundered)
+        {header = "custom_consume.hpp"} : (i32) -> ()
+    return
+  }
+}
+
+// -----
+
+// Passing a physical DFB index across a function boundary is an unanalyzable
+// escape even when the local callee would return the value unchanged.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func private @forward_index(i32) -> i32
+
+  func.func @function_forwarded_dependency()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb_index = ttl.get_dfb_id %dfb
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{'func.call' op physical index for logical DFB 0 escapes through an unsupported operation}}
+    %forwarded = func.call @forward_index(%dfb_index) : (i32) -> i32
+    ttl.opaque_call "custom_consume" (%forwarded)
+        {header = "custom_consume.hpp"} : (i32) -> ()
+    return
+  }
+}
+
+// -----
+
+// A physical DFB index cannot influence untracked control flow.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @control_flow_index_escape()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb_index = ttl.get_dfb_id %dfb
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %zero = arith.constant 0 : i32
+    %is_zero = arith.cmpi eq, %dfb_index, %zero : i32
+    // expected-error @below {{'scf.if' op physical index for logical DFB 0 escapes through an unsupported operation}}
+    scf.if %is_zero {
+    }
+    return
+  }
+}
+
+// -----
+
 // Default-mode allocation rejects a compiler-created DFB without a producer
 // acquire.
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
@@ -141,26 +141,6 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // -----
 
-// A physical DFB index cannot influence untracked control flow.
-
-module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
-  func.func @control_flow_index_escape()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %dfb_index = ttl.get_dfb_id %dfb
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %zero = arith.constant 0 : i32
-    %is_zero = arith.cmpi eq, %dfb_index, %zero : i32
-    // expected-error @below {{'scf.if' op physical index for logical DFB 0 escapes through an unsupported operation}}
-    scf.if %is_zero {
-    }
-    return
-  }
-}
-
-// -----
-
 // Default-mode allocation rejects a compiler-created DFB without a producer
 // acquire.
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
@@ -1,0 +1,165 @@
+// Tests invalid logical DFB declarations for concurrent-kernel liveness.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)'
+
+// One logical DFB must have one exact type across all kernel functions.
+
+func.func @type_mismatch_producer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+func.func @type_mismatch_consumer()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  // expected-error @below {{logical DFB 0 has inconsistent types across kernel functions}}
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  return
+}
+
+// -----
+
+// Default-mode allocation rejects a compiler-created DFB without a consumer
+// acquire.
+
+module {
+  func.func @producer_only()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_wait}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A cast does not hide a partial compiler-created lifecycle from validation.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @cast_partial_lifecycle()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_wait}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %cast = builtin.unrealized_conversion_cast %dfb
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        to !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved = ttl.cb_reserve %cast
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cast : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A compiler-created DFB accessed only by a custom function is used and must
+// provide a visible lifecycle.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @custom_function_without_lifecycle()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_reserve}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "custom_consume" (%dfb) {header = "custom_consume.hpp"}
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
+    return
+  }
+}
+
+// -----
+
+// A physical index passed to a custom function must have a direct DFB
+// dependency operand on the same call.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @custom_function_missing_dependency()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb_index = ttl.get_dfb_id %dfb
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{'ttl.opaque_call' op custom function consumes the physical index for logical DFB 0 without listing that DFB as a dependency operand}}
+    ttl.opaque_call "custom_consume" (%dfb_index)
+        {header = "custom_consume.hpp"} : (i32) -> ()
+    return
+  }
+}
+
+// -----
+
+// Default-mode allocation rejects a compiler-created DFB without a producer
+// acquire.
+
+module {
+  func.func @consumer_only()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_reserve}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %available = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// An unbounded lifetime conflicts with every other lifetime. Thirty-three
+// unbounded logical DFBs must be rejected rather than unsafely compacted.
+
+// expected-error @below {{DFB allocation needs 33 unspilled physical indices but hardware supports at most 32}}
+module {
+  func.func @unbounded_over_capacity()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 33 : i32, ttl.crta_indices = []} {
+    %dfb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb3 = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb4 = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb5 = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb6 = ttl.bind_cb {cb_index = 6, block_count = 2} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb7 = ttl.bind_cb {cb_index = 7, block_count = 2} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb8 = ttl.bind_cb {cb_index = 8, block_count = 2} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb9 = ttl.bind_cb {cb_index = 9, block_count = 2} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb10 = ttl.bind_cb {cb_index = 10, block_count = 2} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb11 = ttl.bind_cb {cb_index = 11, block_count = 2} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb12 = ttl.bind_cb {cb_index = 12, block_count = 2} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb13 = ttl.bind_cb {cb_index = 13, block_count = 2} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb14 = ttl.bind_cb {cb_index = 14, block_count = 2} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb15 = ttl.bind_cb {cb_index = 15, block_count = 2} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb16 = ttl.bind_cb {cb_index = 16, block_count = 2} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb17 = ttl.bind_cb {cb_index = 17, block_count = 2} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb18 = ttl.bind_cb {cb_index = 18, block_count = 2} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb19 = ttl.bind_cb {cb_index = 19, block_count = 2} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb20 = ttl.bind_cb {cb_index = 20, block_count = 2} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb21 = ttl.bind_cb {cb_index = 21, block_count = 2} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb22 = ttl.bind_cb {cb_index = 22, block_count = 2} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb23 = ttl.bind_cb {cb_index = 23, block_count = 2} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb24 = ttl.bind_cb {cb_index = 24, block_count = 2} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb25 = ttl.bind_cb {cb_index = 25, block_count = 2} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb26 = ttl.bind_cb {cb_index = 26, block_count = 2} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb27 = ttl.bind_cb {cb_index = 27, block_count = 2} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb28 = ttl.bind_cb {cb_index = 28, block_count = 2} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb29 = ttl.bind_cb {cb_index = 29, block_count = 2} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb30 = ttl.bind_cb {cb_index = 30, block_count = 2} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb31 = ttl.bind_cb {cb_index = 31, block_count = 2} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb32 = ttl.bind_cb {cb_index = 32, block_count = 2} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_page_stride.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_page_stride.mlir
@@ -1,0 +1,111 @@
+// Tests transaction page-count compatibility for physical DFB reuse.
+//
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// Equal transaction counts divide the four-page DFB capacity, so reuse is
+// legal.
+
+// CHECK-LABEL: func.func @uniform_page_count
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}
+// CHECK: ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 1 : index}
+
+func.func @uniform_page_count()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %first_reserved = ttl.cb_reserve %first : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %first : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %first_waited = ttl.cb_wait %first : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %first : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %second_reserved = ttl.cb_reserve %second : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %second : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %second_waited = ttl.cb_wait %second : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %second : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Different transaction page counts cannot share one physical DFB because
+// their cumulative ring-pointer offsets do not preserve transaction alignment.
+
+// CHECK-LABEL: func.func @mixed_page_count
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}
+// CHECK: ttl.bind_cb{cb_index = 1, {{.*}} {dfb_id = 1 : index}
+
+func.func @mixed_page_count()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %partial = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %full = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %partial_reserved = ttl.cb_reserve %partial {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %partial {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %partial_waited = ttl.cb_wait %partial {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %partial {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %full_reserved = ttl.cb_reserve %full : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %full : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %full_waited = ttl.cb_wait %full : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %full : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// The two-page transactions may reuse one DFB, but the one-page transaction
+// remains separate.
+
+// CHECK-LABEL: func.func @compatible_subset
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}
+// CHECK: ttl.bind_cb{cb_index = 1, {{.*}} {dfb_id = 1 : index}
+// CHECK: ttl.bind_cb{cb_index = 1, {{.*}} {dfb_id = 2 : index}
+
+func.func @compatible_subset()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %one = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %two = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %three = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %one_reserved = ttl.cb_reserve %one {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %one {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %one_waited = ttl.cb_wait %one {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %one {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %two_reserved = ttl.cb_reserve %two : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %two : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %two_waited = ttl.cb_wait %two : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %two : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %three_reserved = ttl.cb_reserve %three : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %three : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %three_waited = ttl.cb_wait %three : <[1, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %three : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Equal three-page transactions cannot share a four-page physical DFB because
+// the transaction count does not divide the capacity.
+
+// CHECK-LABEL: func.func @page_count_does_not_divide_capacity
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}
+// CHECK: ttl.bind_cb{cb_index = 1, {{.*}} {dfb_id = 1 : index}
+
+func.func @page_count_does_not_divide_capacity()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %first = ttl.bind_cb {cb_index = 0, block_count = 4} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+  %second = ttl.bind_cb {cb_index = 1, block_count = 4} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+  %first_reserved = ttl.cb_reserve %first {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4> -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %first {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+  %first_waited = ttl.cb_wait %first {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4> -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %first {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+  %second_reserved = ttl.cb_reserve %second {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4> -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  ttl.cb_push %second {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+  %second_waited = ttl.cb_wait %second {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4> -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %second {num_tiles = 3 : i64} : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
@@ -1,0 +1,256 @@
+// Tests each conservative condition that leaves a DFB lifetime unbounded.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// The valid baseline proves that two ordered lifetimes with one reserve, push,
+// wait, and pop share one physical index. Each following section changes one
+// condition and requires separate indices.
+
+// CHECK-LABEL: func.func @bounded_baseline
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @bounded_baseline()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// More than one reserve prevents matching one reserve/push and wait/pop pair.
+
+// CHECK-LABEL: func.func @multiple_reserves
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @multiple_reserves()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved_0 = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %first_reserved_1 = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// The analysis does not model operations inside nested regions, so the DFB's
+// lifetime remains unbounded even though the region executes exactly once.
+
+// CHECK-LABEL: func.func @nested_reserve
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @nested_reserve()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = scf.execute_region -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+      %nested_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      scf.yield %nested_reserved : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A multi-block function has no modeled linear program order.
+
+// CHECK-LABEL: func.func @multiple_blocks
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @multiple_blocks()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    cf.br ^lifecycle
+  ^lifecycle:
+    %first_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A reserve does not acquire a writable slot when its push executes first.
+
+// CHECK-LABEL: func.func @push_before_reserve
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @push_before_reserve()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A pop does not release a readable slot when its wait executes later.
+
+// CHECK-LABEL: func.func @pop_before_wait
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @pop_before_wait()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A push before the last producer-owned use does not terminate that producer
+// interval.
+
+// CHECK-LABEL: func.func @producer_use_after_push
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @producer_use_after_push()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %late_producer_use = tensor.extract_slice %first_reserved[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A pop before the last consumer-owned use does not terminate that consumer
+// interval.
+
+// CHECK-LABEL: func.func @consumer_use_after_pop
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @consumer_use_after_pop()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %late_consumer_use = tensor.extract_slice %first_waited[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// Unequal transfer counts do not prove zero occupancy after the pop.
+
+// CHECK-LABEL: func.func @mismatched_tile_count
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @mismatched_tile_count()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 2], !ttcore.tile<16x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 2], !ttcore.tile<16x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first_dfb : <[1, 2], !ttcore.tile<16x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<16x32, bf16>>
+    ttl.cb_push %first_dfb {num_tiles = 1 : i64} : <[1, 2], !ttcore.tile<16x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 2], !ttcore.tile<16x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<16x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 2], !ttcore.tile<16x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 2], !ttcore.tile<16x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<16x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 2], !ttcore.tile<16x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 2], !ttcore.tile<16x32, bf16>, 2> -> tensor<1x2x!ttcore.tile<16x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 2], !ttcore.tile<16x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_escalation_permutations.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_escalation_permutations.mlir
@@ -1,0 +1,9 @@
+// Tests successful exact-coloring escalation for every logical-ID permutation.
+// RUN: %python %S/Inputs/generate_dfb_exact_coloring_permutations.py | ttlang-opt --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// Thirty mutually conflicting DFBs join a four-vertex path declared in the
+// first-fit order A,D,B,C. First-fit requires 33 indices. Exact coloring finds
+// a 32-index assignment for all 24 permutations of the path's logical IDs.
+
+// CHECK-COUNT-24: ttl.base_cta_index = 32 : i32
+// CHECK-NOT: ttl.base_cta_index = 33

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_search_limit_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_search_limit_invalid.mlir
@@ -1,10 +1,13 @@
 // Tests the distinct diagnostic for an inconclusive bounded exact search.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{exact-coloring-search-limit=1})' --verify-diagnostics
 
-// Thirty persistent DFBs form a clique joined to the four-vertex path
-// declared in A,D,B,C order. First-fit uses 33 indices, while 32 suffice.
+// Thirty persistent DFBs all conflict pairwise and therefore require distinct
+// indices. The remaining four DFBs conflict in A-B-C-D order but are processed
+// as A,D,B,C, making first-fit use three indices when two suffice. The combined
+// first-fit result uses 33 indices, but an exact assignment can use 32. A
+// one-state limit must report an inconclusive search, not a capacity failure.
 
-// expected-error @below {{'builtin.module' op deterministic first-fit uses 33 physical DFB indices; exact coloring explored 1 states and reached the 1-state limit without proving whether the allocation fits the 32-index hardware limit; increase `exact-coloring-search-limit`}}
+// expected-error @below {{'builtin.module' op deterministic first-fit uses 33 physical DFB indices; exact allocation search explored 1 states and reached the 1-state limit without proving whether the allocation fits the 32-index hardware limit; increase `exact-coloring-search-limit`}}
 module {
   func.func @bounded_exact_search()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_search_limit_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_search_limit_invalid.mlir
@@ -1,0 +1,65 @@
+// Tests the distinct diagnostic for an inconclusive bounded exact search.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{exact-coloring-search-limit=1})' --verify-diagnostics
+
+// Thirty persistent DFBs form a clique joined to the four-vertex path
+// declared in A,D,B,C order. First-fit uses 33 indices, while 32 suffice.
+
+// expected-error @below {{'builtin.module' op deterministic first-fit uses 33 physical DFB indices; exact coloring explored 1 states and reached the 1-state limit without proving whether the allocation fits the 32-index hardware limit; increase `exact-coloring-search-limit`}}
+module {
+  func.func @bounded_exact_search()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 34 : i32, ttl.crta_indices = []} {
+    %persistent0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent3 = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent4 = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent5 = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent6 = ttl.bind_cb {cb_index = 6, block_count = 2} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent7 = ttl.bind_cb {cb_index = 7, block_count = 2} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent8 = ttl.bind_cb {cb_index = 8, block_count = 2} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent9 = ttl.bind_cb {cb_index = 9, block_count = 2} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent10 = ttl.bind_cb {cb_index = 10, block_count = 2} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent11 = ttl.bind_cb {cb_index = 11, block_count = 2} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent12 = ttl.bind_cb {cb_index = 12, block_count = 2} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent13 = ttl.bind_cb {cb_index = 13, block_count = 2} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent14 = ttl.bind_cb {cb_index = 14, block_count = 2} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent15 = ttl.bind_cb {cb_index = 15, block_count = 2} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent16 = ttl.bind_cb {cb_index = 16, block_count = 2} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent17 = ttl.bind_cb {cb_index = 17, block_count = 2} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent18 = ttl.bind_cb {cb_index = 18, block_count = 2} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent19 = ttl.bind_cb {cb_index = 19, block_count = 2} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent20 = ttl.bind_cb {cb_index = 20, block_count = 2} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent21 = ttl.bind_cb {cb_index = 21, block_count = 2} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent22 = ttl.bind_cb {cb_index = 22, block_count = 2} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent23 = ttl.bind_cb {cb_index = 23, block_count = 2} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent24 = ttl.bind_cb {cb_index = 24, block_count = 2} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent25 = ttl.bind_cb {cb_index = 25, block_count = 2} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent26 = ttl.bind_cb {cb_index = 26, block_count = 2} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent27 = ttl.bind_cb {cb_index = 27, block_count = 2} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent28 = ttl.bind_cb {cb_index = 28, block_count = 2} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %persistent29 = ttl.bind_cb {cb_index = 29, block_count = 2} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %path_a = ttl.bind_cb {cb_index = 30, block_count = 2} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %path_d = ttl.bind_cb {cb_index = 31, block_count = 2} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %path_b = ttl.bind_cb {cb_index = 32, block_count = 2} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %path_c = ttl.bind_cb {cb_index = 33, block_count = 2} {dfb_id = 33 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+
+    %reserved_a = ttl.cb_reserve %path_a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved_b = ttl.cb_reserve %path_b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %waited_a = ttl.cb_wait %path_a : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved_c = ttl.cb_reserve %path_c : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_c : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %waited_b = ttl.cb_wait %path_b : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved_d = ttl.cb_reserve %path_d : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_d : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %waited_c = ttl.cb_wait %path_c : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_c : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %waited_d = ttl.cb_wait %path_d : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_d : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_fixed_limit_exact_permutations.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_fixed_limit_exact_permutations.mlir
@@ -1,9 +1,11 @@
 // Tests a successful fixed-limit exact check for every logical-ID permutation.
 // RUN: %python %S/Inputs/generate_dfb_exact_coloring_permutations.py | ttlang-opt --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
 
-// Thirty mutually conflicting DFBs join a four-vertex path declared in the
-// first-fit order A,D,B,C. First-fit requires 33 indices. Exact coloring finds
-// a 32-index assignment for all 24 permutations of the path's logical IDs.
+// Thirty mutually conflicting DFBs join a four-DFB conflict chain declared in
+// first-fit order A,D,B,C. The first group requires 30 distinct indices; the
+// chain makes first-fit use three more although two suffice. Exhaustive
+// fixed-limit search finds a 32-index assignment for all 24 permutations of the
+// chain's logical IDs.
 
 // CHECK-COUNT-24: ttl.base_cta_index = 32 : i32
 // CHECK-NOT: ttl.base_cta_index = 33

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_fixed_limit_exact_permutations.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_fixed_limit_exact_permutations.mlir
@@ -1,4 +1,4 @@
-// Tests successful exact-coloring escalation for every logical-ID permutation.
+// Tests a successful fixed-limit exact check for every logical-ID permutation.
 // RUN: %python %S/Inputs/generate_dfb_exact_coloring_permutations.py | ttlang-opt --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
 
 // Thirty mutually conflicting DFBs join a four-vertex path declared in the

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_interference_graph_witnesses.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_interference_graph_witnesses.mlir
@@ -1,0 +1,135 @@
+// Tests interference graphs produced by launch-node-local DFB lifetimes.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+
+// Each DFB is active on the launch node it shares with each adjacent DFB.
+// Non-adjacent DFBs have disjoint launch domains. The resulting five-cycle has
+// maximum clique size two but requires three physical indices.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}]}
+// CHECK-LABEL: func.func @cycle_vertex_zero
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 50 : index}
+// CHECK-LABEL: func.func @cycle_vertex_one
+// CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 51 : index}
+// CHECK-LABEL: func.func @cycle_vertex_two
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 52 : index}
+// CHECK-LABEL: func.func @cycle_vertex_three
+// CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 53 : index}
+// CHECK-LABEL: func.func @cycle_vertex_four
+// CHECK: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 54 : index}
+
+module attributes {ttl.launch_grid = [5 : i64, 1 : i64]} {
+  func.func @cycle_vertex_zero()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 50 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %four = arith.constant 4 : index
+    %is_zero = arith.cmpi eq, %core_x, %zero : index
+    %is_four = arith.cmpi eq, %core_x, %four : index
+    %is_active = arith.ori %is_zero, %is_four : i1
+    scf.if %is_active {
+      %slot = ttl.cb_reserve %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %value = ttl.cb_wait %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    return
+  }
+
+  func.func @cycle_vertex_one()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 51 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %is_zero = arith.cmpi eq, %core_x, %zero : index
+    %is_one = arith.cmpi eq, %core_x, %one : index
+    %is_active = arith.ori %is_zero, %is_one : i1
+    scf.if %is_active {
+      %slot = ttl.cb_reserve %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %value = ttl.cb_wait %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    return
+  }
+
+  func.func @cycle_vertex_two()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 52 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %one = arith.constant 1 : index
+    %two = arith.constant 2 : index
+    %is_one = arith.cmpi eq, %core_x, %one : index
+    %is_two = arith.cmpi eq, %core_x, %two : index
+    %is_active = arith.ori %is_one, %is_two : i1
+    scf.if %is_active {
+      %slot = ttl.cb_reserve %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %value = ttl.cb_wait %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    return
+  }
+
+  func.func @cycle_vertex_three()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 53 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %two = arith.constant 2 : index
+    %three = arith.constant 3 : index
+    %is_two = arith.cmpi eq, %core_x, %two : index
+    %is_three = arith.cmpi eq, %core_x, %three : index
+    %is_active = arith.ori %is_two, %is_three : i1
+    scf.if %is_active {
+      %slot = ttl.cb_reserve %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %value = ttl.cb_wait %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    return
+  }
+
+  func.func @cycle_vertex_four()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 54 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %three = arith.constant 3 : index
+    %four = arith.constant 4 : index
+    %is_three = arith.cmpi eq, %core_x, %three : index
+    %is_four = arith.cmpi eq, %core_x, %four : index
+    %is_active = arith.ori %is_three, %is_four : i1
+    scf.if %is_active {
+      %slot = ttl.cb_reserve %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %value = ttl.cb_wait %dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_interference_graph_witnesses.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_interference_graph_witnesses.mlir
@@ -1,9 +1,11 @@
-// Tests interference graphs produced by launch-node-local DFB lifetimes.
+// Tests physical-index conflict graphs from launch-node-local DFB lifetimes.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
 
-// Each DFB is active on the launch node it shares with each adjacent DFB.
-// Non-adjacent DFBs have disjoint launch domains. The resulting five-cycle has
-// maximum clique size two but requires three physical indices.
+// Each DFB conflicts with its two neighbors in a five-DFB cycle. Non-neighbors
+// have disjoint launch domains and may share. At most two DFBs conflict
+// pairwise, which proves only a two-index lower bound, but alternating two
+// indices cannot close an odd cycle. The required third index demonstrates why
+// the lower bound alone cannot decide every allocation.
 
 // CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}]}
 // CHECK-LABEL: func.func @cycle_vertex_zero

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_l1_exact_assignment.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_l1_exact_assignment.mlir
@@ -1,0 +1,45 @@
+// Tests minimum physical-index count when first-fit exceeds the L1 budget.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// The DFBs conflict in A-B-C-D order but are declared A,D,B,C, so first-fit
+// uses three indices although two suffice. Each physical DFB occupies 491520
+// bytes: three exceed the 1466368-byte fallback budget, while two fit.
+// Compilation therefore requires exact search to replace the valid first-fit
+// assignment with one that uses the minimum physical-index count.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
+// CHECK-LABEL: func.func @l1_requires_minimum_assignment
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 3 : index}
+
+module {
+  func.func @l1_requires_minimum_assignment()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
+    %path_a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_d = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_c = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+
+    %path_a_output = ttl.cb_reserve %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_b_output = ttl.cb_reserve %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_a_input = ttl.cb_wait %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_c_output = ttl.cb_reserve %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_b_input = ttl.cb_wait %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_d_output = ttl.cb_reserve %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_c_input = ttl.cb_wait %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_d_input = ttl.cb_wait %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_l1_exact_assignment_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_l1_exact_assignment_invalid.mlir
@@ -1,0 +1,36 @@
+// Tests an inconclusive L1-triggered minimum physical-index-count search.
+// RUN: ttlang-opt %s --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{exact-coloring-search-limit=1})'
+
+// The valid three-index first-fit assignment exceeds L1, while a two-index
+// assignment fits. A one-state search limit cannot establish the minimum, so
+// the diagnostic must distinguish an inconclusive search from L1 exhaustion.
+
+// expected-error @below {{'builtin.module' op deterministic first-fit uses 3 physical DFB indices; exact allocation search explored 1 states and reached the 1-state limit without proving whether the allocation fits the target L1 budget; increase `exact-coloring-search-limit`}}
+module {
+  func.func @l1_minimum_search_limit()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
+    %path_a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_d = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_c = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 120], !ttcore.tile<32x32, bf16>, 2>
+
+    %path_a_output = ttl.cb_reserve %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_b_output = ttl.cb_reserve %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_a_input = ttl.cb_wait %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_a : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_c_output = ttl.cb_reserve %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_b_input = ttl.cb_wait %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_b : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_d_output = ttl.cb_reserve %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_c_input = ttl.cb_wait %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_c : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    %path_d_input = ttl.cb_wait %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x120x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %path_d : <[1, 120], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
@@ -13,7 +13,8 @@
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @disjoint_node_producer()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
     %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         {dfb_id = 10 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
@@ -90,7 +91,8 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @first_owner_producer()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
     %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         {dfb_id = 20 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
@@ -132,7 +134,8 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   }
 
   func.func @second_owner_producer()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
     %producer_ack = ttl.bind_cb {cb_index = 1, block_count = 2}
         {dfb_id = 21 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
@@ -165,6 +168,49 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
         -> tensor<1x1x!ttcore.tile<1x16, f32>>
     ttl.cb_pop %consumer_ack
         : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %second_value = ttl.cb_wait %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// Missing NOC ownership information prevents a quiescence proof and therefore
+// prevents otherwise ordered lifetimes from sharing one physical index.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
+// CHECK-LABEL: func.func @unknown_noc_owner
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 24 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 25 : index}
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @unknown_noc_owner()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 24 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 25 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_slot = ttl.cb_reserve %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_value = ttl.cb_wait %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_slot = ttl.cb_reserve %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
     %second_value = ttl.cb_wait %second_dfb
         : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<1x16, bf16>>
@@ -217,6 +263,114 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
         -> tensor<1x2x!ttcore.tile<1x16, bf16>>
     ttl.cb_pop %two_tile_dfb {num_tiles = 2 : i64}
         : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// Pairwise lifetime order may differ by launch node without creating a
+// conflict: A precedes B on node 0, B precedes C on node 1, and C precedes A on
+// node 2. Each pair overlaps on only that node, so all three DFBs may share one
+// uniform physical index despite the cyclic union of per-node order relations.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}]}
+// CHECK-LABEL: func.func @cyclic_node_local_order
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 40 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 41 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 42 : index}
+
+module attributes {ttl.launch_grid = [3 : i64, 1 : i64]} {
+  func.func @cyclic_node_local_order()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb_a = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 40 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %dfb_b = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 41 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %dfb_c = ttl.bind_cb {cb_index = 2, block_count = 2}
+        {dfb_id = 42 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %two = arith.constant 2 : index
+    %is_node_zero = arith.cmpi eq, %core_x, %zero : index
+    %is_node_one = arith.cmpi eq, %core_x, %one : index
+    %is_node_two = arith.cmpi eq, %core_x, %two : index
+    scf.if %is_node_zero {
+      %a_zero_slot = ttl.cb_reserve %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %a_zero_value = ttl.cb_wait %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    scf.if %is_node_zero {
+      %b_zero_slot = ttl.cb_reserve %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %b_zero_value = ttl.cb_wait %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    scf.if %is_node_one {
+      %b_one_slot = ttl.cb_reserve %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %b_one_value = ttl.cb_wait %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb_b
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    scf.if %is_node_one {
+      %c_one_slot = ttl.cb_reserve %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %c_one_value = ttl.cb_wait %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    scf.if %is_node_two {
+      %c_two_slot = ttl.cb_reserve %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %c_two_value = ttl.cb_wait %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb_c
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    scf.if %is_node_two {
+      %a_two_slot = ttl.cb_reserve %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      %a_two_value = ttl.cb_wait %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %dfb_a
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
@@ -1,0 +1,222 @@
+// Tests launch-node-local DFB lifetimes and hardware pointer ownership.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+
+// DFBs used on disjoint launch nodes may share without a global lifetime order.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}]}
+// CHECK-LABEL: func.func @disjoint_node_producer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 11 : index}
+// CHECK-LABEL: func.func @disjoint_node_consumer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 11 : index}
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @disjoint_node_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 11 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %is_node_zero = arith.cmpi eq, %core_x, %zero : index
+    %is_node_one = arith.cmpi eq, %core_x, %one : index
+    scf.if %is_node_zero {
+      %first_slot = ttl.cb_reserve %first_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %first_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    scf.if %is_node_one {
+      %second_slot = ttl.cb_reserve %second_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_push %second_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    return
+  }
+
+  func.func @disjoint_node_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 11 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %is_node_zero = arith.cmpi eq, %core_x, %zero : index
+    %is_node_one = arith.cmpi eq, %core_x, %one : index
+    scf.if %is_node_zero {
+      %first_value = ttl.cb_wait %first_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %first_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    scf.if %is_node_one {
+      %second_value = ttl.cb_wait %second_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+      ttl.cb_pop %second_dfb
+          : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// Distinct function symbols may share when their per-node pointer processors
+// match and both producer and consumer entries follow a quiescent handoff.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}]}
+// CHECK-LABEL: func.func @first_owner_producer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 20 : index}
+// CHECK-LABEL: func.func @first_owner_consumer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 20 : index}
+// CHECK-LABEL: func.func @second_owner_producer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 23 : index}
+// CHECK-LABEL: func.func @second_owner_consumer
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 23 : index}
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @first_owner_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 20 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_slot = ttl.cb_reserve %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+
+  func.func @first_owner_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 20 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %producer_ack = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 21 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %consumer_ack = ttl.bind_cb {cb_index = 2, block_count = 2}
+        {dfb_id = 22 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %first_value = ttl.cb_wait %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %first_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %producer_ack_slot = ttl.cb_reserve %producer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_push %producer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %consumer_ack_slot = ttl.cb_reserve %consumer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_push %consumer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    return
+  }
+
+  func.func @second_owner_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %producer_ack = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 21 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 3, block_count = 2}
+        {dfb_id = 23 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %producer_ack_value = ttl.cb_wait %producer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_pop %producer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %second_slot = ttl.cb_reserve %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+
+  func.func @second_owner_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %consumer_ack = ttl.bind_cb {cb_index = 2, block_count = 2}
+        {dfb_id = 22 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 3, block_count = 2}
+        {dfb_id = 23 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %consumer_ack_value = ttl.cb_wait %consumer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, f32>>
+    ttl.cb_pop %consumer_ack
+        : <[1, 1], !ttcore.tile<1x16, f32>, 2>
+    %second_value = ttl.cb_wait %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %second_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// Quiescent lifetimes with different transaction sizes retain separate ring
+// pointer progressions and therefore cannot share a physical index.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
+// CHECK-LABEL: func.func @different_transaction_sizes
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 30 : index}
+// CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 31 : index}
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @different_transaction_sizes()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %single_tile_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 30 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %two_tile_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 31 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %single_tile_slot = ttl.cb_reserve %single_tile_dfb
+        {num_tiles = 1 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %single_tile_dfb {num_tiles = 1 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %single_tile_value = ttl.cb_wait %single_tile_dfb
+        {num_tiles = 1 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %single_tile_dfb {num_tiles = 1 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %two_tile_slot = ttl.cb_reserve %two_tile_dfb
+        {num_tiles = 2 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x2x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %two_tile_dfb {num_tiles = 2 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %two_tile_value = ttl.cb_wait %two_tile_dfb
+        {num_tiles = 2 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x2x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %two_tile_dfb {num_tiles = 2 : i64}
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_physical_alias_idempotent.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_physical_alias_idempotent.mlir
@@ -1,0 +1,59 @@
+// Tests preservation of a proven physical DFB alias across finalization.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true},ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s
+
+// A proven alias remains valid when a second finalization runs with user reuse
+// disabled.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
+// CHECK-LABEL: func.func @safe_alias_producer
+// CHECK: ttl.bind_cb{cb_index = [[DATA_INDEX:[0-9]+]], block_count = 2} {dfb_id = 0 : index}
+// CHECK: ttl.bind_cb{cb_index = [[ACK_INDEX:[0-9]+]], block_count = 2} {dfb_id = 1 : index}
+// CHECK: ttl.bind_cb{cb_index = [[DATA_INDEX]], block_count = 2} {dfb_id = 2 : index}
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @safe_alias_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_block = ttl.cb_reserve %first
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %first : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_block = ttl.cb_wait %ack
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_block = ttl.cb_reserve %second
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %second : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+
+  func.func @safe_alias_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_block = ttl.cb_wait %first
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %first : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %ack_block = ttl.cb_reserve %ack
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %ack : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_block = ttl.cb_wait %second
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %second : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_physical_alias_idempotent.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_physical_alias_idempotent.mlir
@@ -12,7 +12,8 @@
 
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @safe_alias_producer()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
     %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
     %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_physical_alias_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_physical_alias_invalid.mlir
@@ -1,0 +1,42 @@
+// Tests rejection of unsafe provisional physical DFB aliases.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})'
+
+// Overlapping logical DFBs cannot preserve the same provisional physical
+// index when reuse is disabled.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @overlapping_producers()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{'ttl.bind_cb' op provisional physical DFB index 0 aliases conflicting logical DFBs 0 and 1}}
+    %second = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_block = ttl.cb_reserve %first
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_block = ttl.cb_reserve %second
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @overlapping_consumers()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_block = ttl.cb_wait %first
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_block = ttl.cb_wait %second
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_physical_index_uses.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_physical_index_uses.mlir
@@ -1,0 +1,27 @@
+// Tests physical DFB-index dataflow through pure integer operations.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// A comparison derives a predicate, not another physical index. The predicate
+// may control a region without hiding a DFB-index use from the analysis.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}]}
+// CHECK-LABEL: func.func @compare_physical_index
+// CHECK: %[[DFB:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK: %[[INDEX:.*]] = ttl.get_dfb_id %[[DFB]]
+// CHECK: %[[IS_ZERO:.*]] = arith.cmpi eq, %[[INDEX]], %{{.*}} : i32
+// CHECK: scf.if %[[IS_ZERO]]
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @compare_physical_index()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dfb_index = ttl.get_dfb_id %dfb
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %zero = arith.constant 0 : i32
+    %is_zero = arith.cmpi eq, %dfb_index, %zero : i32
+    scf.if %is_zero {
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_physical_index_uses_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_physical_index_uses_invalid.mlir
@@ -1,0 +1,55 @@
+// Tests invalid physical DFB-index dataflow through pure integer operations.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)'
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})'
+
+// Truncating an index to i1 preserves index data, so widening the value again
+// cannot hide a custom-function use that omits the source DFB dependency.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @producer() attributes {ttl.noc_index = 0 : i32,
+      ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %a_slot = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %ack_val = ttl.cb_wait %ack : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.cb_pop %ack : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %b_slot = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %ack = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %b = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %a_val = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %ack_slot = ttl.cb_reserve %ack : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.cb_push %ack : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %b_val = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %a_index = ttl.get_dfb_id %a
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %narrow = arith.trunci %a_index : i32 to i1
+    %wide = arith.extui %narrow : i1 to i32
+    // expected-error @below {{'ttl.opaque_call' op custom function consumes the physical index for logical DFB 0 without listing that DFB as a dependency operand}}
+    ttl.opaque_call "read_dfb_by_index" (%wide)
+        {header = "read_dfb_by_index.hpp"} : (i32) -> ()
+    ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
@@ -1,18 +1,18 @@
 // Tests for ttl-finalize-dfb-indices pass.
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=CHECK
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=REUSE
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=OVERLAP
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=FOUR
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s --check-prefix=DEBUG
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=MIXED
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=UNUSED
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=THREE
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SINGLE
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=GLOBAL
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=CHECK
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=REUSE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=OVERLAP
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=FOUR
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=MIXED
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=UNUSED
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=THREE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=SINGLE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=GLOBAL
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SUBTILE
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=RANK3
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=NESTED
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefixes=COMPACT-GAP,COMPACT-NOZERO
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefixes=COMPACT-GAP,COMPACT-NOZERO
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=PAGE-TYPES
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SCALAR
 
@@ -22,11 +22,7 @@
 // The pass should update base_cta_index to 4 and emit the complete allocation
 // table.
 
-// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32},
-// CHECK-SAME: {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32},
-// CHECK-SAME: {block_count = 2 : i32, dfb_index = 2 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32},
-// CHECK-SAME: {block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32}
-// CHECK-SAME: ]}
+// CHECK: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // CHECK-LABEL: func.func @reader
 // CHECK-SAME: ttl.base_cta_index = 4 : i32
@@ -81,9 +77,6 @@ func.func @compute_only()
 
 // Non-overlapping compiler-allocated DFB lifecycles share index 3.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
-// DEBUG: Total DFB count: 4
-
 // REUSE: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // REUSE-LABEL: func.func @non_overlapping_reuse
@@ -114,9 +107,6 @@ func.func @non_overlapping_reuse()
 
 // Overlapping compiler-allocated DFBs: DFB #4 is allocated while DFB #3
 // is still live. They must keep separate indices.
-
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
-// DEBUG: Total DFB count: 5
 
 // OVERLAP: module attributes {ttl.dfb_allocations = {{.*}}}
 
@@ -153,9 +143,6 @@ func.func @overlapping_no_reuse()
 // DFB-C [reserve, pop]: starts after A dies, spans past DFB-D
 // DFB-D [reserve, pop]: nested within C, dies before C
 // Result: A and C share slot 0 (index 3), B and D share slot 1 (index 4).
-
-// DEBUG: DFB reuse: 4 compiler-allocated DFBs -> 2 physical slot(s)
-// DEBUG: Total DFB count: 5
 
 // FOUR: module attributes {ttl.dfb_allocations = {{.*}}}
 
@@ -217,9 +204,6 @@ func.func @four_dfbs_nested_reuse()
 // [2,4] partition: #4 alone -> 1 slot (index 4)
 // Total: 2 physical compiler-allocated slots.
 
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 2 physical slot(s)
-// DEBUG: Total DFB count: 5
-
 // MIXED: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // MIXED-LABEL: func.func @mixed_types_no_cross_reuse
@@ -264,9 +248,6 @@ func.func @mixed_types_no_cross_reuse()
 // Unused compiler-allocated DFB declarations remain live for the entire
 // kernel. No reuse is possible.
 
-// DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
-// DEBUG: Total DFB count: 5
-
 // UNUSED: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // UNUSED-LABEL: func.func @unused_declarations_conservative
@@ -290,9 +271,6 @@ func.func @unused_declarations_conservative()
 
 // Three sequential non-overlapping DFBs. All should map to a single
 // physical slot (multi-round slot recycling).
-
-// DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 1 physical slot(s)
-// DEBUG: Total DFB count: 4
 
 // THREE: module attributes {ttl.dfb_allocations = {{.*}}}
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_atomic_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_atomic_invalid.mlir
@@ -1,8 +1,8 @@
-// Verifies that allocation failure leaves provisional DFB indices and kernel
-// configuration unchanged and does not create runtime metadata.
-// RUN: ttlang-opt %s --verify-diagnostics --mlir-print-ir-after=ttl-finalize-dfb-indices --mlir-print-ir-after-failure -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' 2>&1 | FileCheck %s --implicit-check-not=ttl.dfb_allocations
+// Verifies that allocation with user reuse disabled leaves provisional DFB
+// indices and kernel configuration unchanged and creates no runtime metadata.
+// RUN: ttlang-opt %s --verify-diagnostics --mlir-print-ir-after=ttl-finalize-dfb-indices --mlir-print-ir-after-failure -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' 2>&1 | FileCheck %s --implicit-check-not=ttl.dfb_allocations
 
-// expected-error @below {{need 33 DFB indices but hardware supports at most 32 (1 compiler-allocated after reuse)}}
+// expected-error @below {{need 33 unspilled DFB indices but hardware supports at most 32 (1 compiler-allocated after proven reuse)}}
 module {
   func.func @all_user_indices()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_before_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_before_config.mlir
@@ -1,6 +1,6 @@
 // Summary: Verify compute configuration captures finalized physical DFB indices.
 //
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,func.func(ttl-set-compute-kernel-config))' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false},func.func(ttl-set-compute-kernel-config))' | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_debug.mlir
@@ -1,0 +1,45 @@
+// Tests debug reporting of the complete logical-to-physical DFB assignment.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s
+
+// CHECK: Total DFB count: 4
+// CHECK-NEXT: DFB assignment: logical DFB 0 -> physical index 0
+// CHECK-NEXT: DFB assignment: logical DFB 1 -> physical index 1
+// CHECK-NEXT: DFB assignment: logical DFB 2 -> physical index 2
+// CHECK-NEXT: DFB assignment: logical DFB 3 -> physical index 3
+// CHECK-NEXT: DFB assignment: logical DFB 4 -> physical index 3
+
+module {
+  func.func @non_overlapping_reuse()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+    %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2}
+        {ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserve3 = ttl.cb_reserve %alloc3
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %wait3 = ttl.cb_wait %alloc3
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %alloc4 = ttl.bind_cb {cb_index = 4, block_count = 2}
+        {ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserve4 = ttl.cb_reserve %alloc4
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %alloc4 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %wait4 = ttl.cb_wait %alloc4
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %alloc4 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
@@ -1,8 +1,9 @@
 // Verify diagnostics for unresolved logical identities, incompatible physical
 // assignments, and partial compiler-created lifecycles.
-// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)'
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})'
 
-// One physical index requires one exact DFB type.
+// Distinct logical DFBs with incompatible types cannot retain one provisional
+// physical index.
 module {
   func.func @bf16_declaration()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
@@ -15,7 +16,7 @@ module {
   func.func @f32_declaration()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                   ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
-    // expected-error @below {{physical DFB index 0 has inconsistent CircularBufferType values}}
+    // expected-error @below {{provisional physical DFB index 0 aliases conflicting logical DFBs 1 and 0}}
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     return
@@ -107,7 +108,7 @@ module {
 // A producer lifecycle requires a reserve before its push.
 func.func @missing_reserve()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  // expected-error @below {{'ttl.bind_cb' op compiler-allocated DFB has a partial lifecycle: missing ttl.cb_reserve}}
+  // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_reserve}}
   %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %wait = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -120,7 +121,7 @@ func.func @missing_reserve()
 // A producer lifecycle requires a push after its reserve.
 func.func @missing_push()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  // expected-error @below {{'ttl.bind_cb' op compiler-allocated DFB has a partial lifecycle: missing ttl.cb_push}}
+  // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_push}}
   %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %reserve = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %wait = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -133,7 +134,7 @@ func.func @missing_push()
 // A consumer lifecycle requires a wait before its pop.
 func.func @missing_wait()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  // expected-error @below {{'ttl.bind_cb' op compiler-allocated DFB has a partial lifecycle: missing ttl.cb_wait}}
+  // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_wait}}
   %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %reserve = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
@@ -146,7 +147,7 @@ func.func @missing_wait()
 // A consumer lifecycle requires a pop after its wait.
 func.func @missing_pop()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  // expected-error @below {{'ttl.bind_cb' op compiler-allocated DFB has a partial lifecycle: missing ttl.cb_pop}}
+  // expected-error @below {{'ttl.bind_cb' op compiler-allocated logical DFB has a partial lifecycle: missing ttl.cb_pop}}
   %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %reserve = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
@@ -10,6 +10,7 @@
 module {
   func.func @producer()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32,
                   ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
     %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
@@ -1,0 +1,60 @@
+// Tests default-mode debug reporting when three logical DFBs use two physical
+// indices.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s
+
+// CHECK: Total DFB count: 2
+// CHECK-NEXT: DFB assignment: logical DFB 0 -> physical index 0 (bounded)
+// CHECK-NEXT: DFB assignment: logical DFB 1 -> physical index 1 (bounded)
+// CHECK-NEXT: DFB assignment: logical DFB 2 -> physical index 0 (bounded)
+
+module {
+  func.func @producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %acknowledgment = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_block = ttl.cb_reserve %first
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %first : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %acknowledgment_block = ttl.cb_wait %acknowledgment
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %acknowledgment : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_block = ttl.cb_reserve %second
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %second : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+
+  func.func @consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %acknowledgment = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_block = ttl.cb_wait %first
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %first : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %acknowledgment_block = ttl.cb_reserve %acknowledgment
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %acknowledgment : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_block = ttl.cb_wait %second
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %second : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
@@ -1,8 +1,7 @@
 // Tests for ttl-insert-intermediate-dfbs pass.
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs))' | FileCheck %s
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync,convert-ttl-to-compute))' | FileCheck %s --check-prefix=PIPELINE
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=FINALIZE
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s --check-prefix=DBG
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=FINALIZE
 
 // -----
 
@@ -123,9 +122,6 @@ func.func @shared_materialization()
 // Two sequential elementwise->reduce chains. Each chain creates a
 // compiler-allocated DFB. The first DFB is consumed and released (cb_pop)
 // before the second is created, so finalize should reuse the same index.
-
-// DBG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
-// DBG: Total DFB count: 5
 
 // After insert: two compiler-allocated DFBs at indices 4, 5, both at
 // function body entry.

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
@@ -1,7 +1,7 @@
 // Negative test: exceeding maximum circular buffer count.
 // The insert pass creates compiler-allocated DFBs without checking the limit;
 // the finalize pass enforces the hardware maximum after index reuse.
-// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices)'
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices{reuse-user-dfbs=false})'
 
 // -----
 
@@ -10,7 +10,7 @@
 // After reuse (only one intermediate, nothing to reuse), the total DFB
 // count is 33, exceeding the hardware maximum of 32.
 
-// expected-error @below {{need 33 DFB indices but hardware supports at most 32 (1 compiler-allocated after reuse)}}
+// expected-error @below {{need 33 unspilled DFB indices but hardware supports at most 32 (1 compiler-allocated after proven reuse)}}
 module {
 func.func @exceeds_max_cb_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
@@ -4,7 +4,7 @@
 // (scf.for, scf.if), only bind_cb hoists; reserve/store/wait/attach
 // stay at the def site to keep per-invocation accounting intact.
 
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices)' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s
 
 // -----
 

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
@@ -1,19 +1,19 @@
-// Tests that SPSC verification preserves distinct logical identities when
-// different kernels use one physical DFB index.
+// Tests that finalization separates conflicting provisional aliases before
+// SPSC verification.
 //
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true},ttl-verify-dfb-spsc)' | FileCheck %s
 
-// Distinct logical DFBs may share one physical index without becoming one SPSC
-// participant set.
+// The two producer functions execute concurrently, so their distinct logical
+// DFBs cannot retain the same provisional physical index.
 
 // CHECK: module attributes {ttl.dfb_allocations = [
 // CHECK-SAME: {block_count = 2 : i32, dfb_index = 0 : i32,
 // CHECK-LABEL: func.func @producer_a
-// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
 // CHECK: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}
 // CHECK-LABEL: func.func @producer_b
-// CHECK-SAME: ttl.base_cta_index = 1 : i32
-// CHECK: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 1 : index}
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 1, {{.*}} {dfb_id = 1 : index}
 
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @producer_a()


### PR DESCRIPTION
Chain: #704 (merged) -> #778 (merged) -> this PR

### Problem description

#778 separates module-wide logical DFB identity from physical allocation, but composed operations can still exceed the 32-index hardware limit when non-overlapping logical DFBs retain distinct physical indices.

Reuse must be proved per launch node across complete DFB transactions, concurrent kernels, hardware pointer owners and custom-function dependencies. Unknown analysis results must remain conservative, and a search limit must not become a false capacity failure.

### What's changed

This PR adds immutable module analysis and a typed allocation plan validated before IR mutation. It models per-node DFB lifetimes, quiescence, pointer ownership, descriptor compatibility and custom-function dependencies. Unknown behavior adds conflicts, so imprecision may reject reuse but cannot permit unsafe sharing. Both reuse modes validate the same conflict model.

Allocation produces a verified assignment, a proved capacity diagnostic or a distinct inconclusive-search diagnostic. Finalization updates DFB indices and runtime metadata atomically. The `Index Reuse` section of `docs/development/DFBManagement.md` documents the algorithm and correctness argument.

### Follow-up work

- #809 adds DRAM spilling for allocations that exceed the physical-index or L1 limit.
- Per-node or hybrid assignment requires specialized kernels and per-core-range metadata.
- #798 should provide per-logical-DFB unpack requirements before physical allocation. #806 and #807 can generalize custom-function effects and extract shared event analysis.
- Real-model measurements should precede additional exact-solver work.

### Validation

- An independent oracle checks every graph through six vertices and compares 262,144 uniform, per-node and hybrid assignment cases.
- MLIR tests cover the lifetime and conflict invariants, all 24 permutations of the 32-index acceptance case, proved and inconclusive failures and L1-triggered exact allocation.
- Python compile and device tests cover atom composition, more than 32 logical DFBs, custom calls and distinct NOC pointer owners across bf16/f32, DRAM/L1 and generic/specialized-core lowering.

### Checklist

- [x] New/Existing tests provide coverage for changes
