### PR TITLE
[ttl] Add TileFillOp to  classifyTileOp

### DIFF
--- a/docs/development/DST_Utilization.md
+++ b/docs/development/DST_Utilization.md
@@ -547,7 +547,7 @@ algorithm assigns each op a depth (longest path from any root in the
 dependency graph), then sorts by a 6-component key:
 
 1. depthLevel — dependency depth (correctness constraint)
-2. category — [`TileOpCategory`](https://github.com/tenstorrent/tt-lang/blob/main/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h#L178-L187) enum: Bcast < Transpose < CopyTile < FPUBinary < SFPUUnary < SFPUBinary < CopyDst < DstIndex (no Reduce entry yet — reduction ops do not exist in TTL; when added, they would likely slot between Bcast and Transpose as full-init CB-input ops)
+2. category — [`TileOpCategory`](https://github.com/tenstorrent/tt-lang/blob/main/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h) enum: Bcast < Transpose < CopyTile < FPUBinary < SFPUUnary < SFPUBinary < CopyDst < DstIndex < Fill (Fill is a constant `fill_tile` write to DST with no tile operands)
 3. opName — groups identical op types for init sharing (string comparison for determinism)
 4. initAffinity — groups ops sharing one init call (e.g., COL vs ROW bcasts, copies from different CBs)
 5. dstIdx — DST register index for deterministic ordering

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -481,6 +481,7 @@ enum class TileOpCategory : uint8_t {
   SFPUBinary = 5, // DST -> DST binary (MATH-only init)
   CopyDst = 6,    // DST -> DST copy
   DstIndex = 7,   // Zero-cost SSA name for one existing DST slot
+  Fill = 8,       // const -> DST (MATH-only fill_tile_init, no tile operands)
   Unknown = 255
 };
 

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -756,6 +756,9 @@ TileOpCategory classifyTileOp(Operation *op) {
   if (isa<TileTransposeOp>(op)) {
     return TileOpCategory::Transpose;
   }
+  if (isa<TileFillOp>(op)) {
+    return TileOpCategory::Fill;
+  }
 
   if (op->hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
     FailureOr<TileExecutionStrategy> strategy =

--- a/test/python/test_dst_fill_clobber.py
+++ b/test/python/test_dst_fill_clobber.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: an inline ``ttl.block.fill(k)`` operand under DST pressure.
+
+The kernel computes ``out = tanh(a) * sigmoid(a) * ttl.block.fill(k)`` (k a
+compile-time constant) and must match the golden. ``a`` has two consumers so
+AssignDST inserts a copy_tile for the sigmoid subtree; the expression has to be
+this deep for the inline fill to share that copy_tile's DST slot (shallower forms
+like ``(a + b) * fill(k)`` don't exercise the hazard).
+
+Parameterized over bf16 and f32: f32 halves the usable DST slots (8 -> 4), so the
+allocation pressure that forces the fill to share a slot differs between them.
+Both consumers of ``a`` are SFPU (tanh/sigmoid) so a single f32 input CB is legal;
+an FPU+SFPU mix on one CB is rejected in f32.
+"""
+
+import pytest
+import torch
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import assert_allclose, to_dram
+
+K = 3.0
+
+_DTYPE_PARAMS = [
+    pytest.param(torch.bfloat16, id="bf16"),
+    pytest.param(torch.float32, id="f32"),
+]
+_DTYPE_TOL = {
+    torch.bfloat16: dict(rtol=5e-2, atol=1.0),
+    torch.float32: dict(rtol=1e-3, atol=1e-3),
+}
+
+
+@ttl.operation(grid=(1, 1))
+def fill_inline_kernel(a, out):
+    """out = tanh(a) * sigmoid(a) * fill(K)  -- the regression."""
+    a_dfb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        with a_dfb.wait() as av:
+            with out_dfb.reserve() as o:
+                core = ttl.math.tanh(av) * ttl.math.sigmoid(av)
+                # Inline fill as an operand to the outer multiply -- clobbered.
+                # Typing the fill from o covers both dtypes with one kernel: a
+                # thread closure may only capture ints, floats, tensors and
+                # buffers, so the dtype cannot be passed in as a parameter.
+                o.store(core * ttl.block.fill(K, shape=o.shape, dtype=o.dtype))
+
+    @ttl.datamovement()
+    def dm_read():
+        with a_dfb.reserve() as a_blk:
+            ttl.copy(a[0, 0], a_blk).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with out_dfb.wait() as blk:
+            ttl.copy(blk, out[0, 0]).wait()
+
+
+def _golden(a, k):
+    return torch.tanh(a.float()) * torch.sigmoid(a.float()) * float(k)
+
+
+def _inputs(dtype):
+    torch.manual_seed(0)
+    return torch.randn(32, 32, dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", _DTYPE_PARAMS)
+def test_fill_inline_matches_golden(device, dtype):
+    """The inline fill constant survives DST scheduling and reaches the mul."""
+    a = _inputs(dtype)
+    expected = _golden(a, K).to(dtype)
+
+    a_t = to_dram(a, device)
+    out_t = to_dram(torch.zeros(32, 32, dtype=dtype), device)
+
+    fill_inline_kernel(a_t, out_t)
+
+    result = ttnn.to_torch(out_t)
+    assert_allclose(result.float(), expected.float(), **_DTYPE_TOL[dtype])
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-rxX", "--tb=short"]))

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_fill_participation.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_fill_participation.mlir
@@ -1,0 +1,68 @@
+// Summary: A classified tile_fill participates in scheduling instead of
+// bounding it. Companion to schedule_ordering_boundaries.mlir, which covers the
+// operations that do bound a schedule. Both cases below place an independent
+// broadcast after the fill: the broadcast may only reach the front of the
+// section if the fill is scheduled with everything else, because an
+// unclassified fill is an ordering boundary that splits the section into two
+// independently sorted groups.
+// RUN: ttlang-opt %s --split-input-file \
+// RUN:   -pass-pipeline='builtin.module(func.func(ttl-schedule-operations))' \
+// RUN:   | FileCheck %s
+
+// The fill writes a register no other operation touches, so it carries no
+// dependency and sorts by category alone. It lands after the operations that
+// configure MATH from a dataflow buffer and before the exponential that depends
+// on the named register.
+
+// CHECK-LABEL: func.func @schedule_across_fill
+// CHECK:       ttl.dst_section {
+// CHECK-NEXT:    %[[BCAST:.*]] = ttl.tile_bcast
+// CHECK-NEXT:    %[[DST:.*]] = ttl.dst_index
+// CHECK-NEXT:    %[[FILL:.*]] = ttl.tile_fill
+// CHECK-NEXT:    %[[EXP:.*]] = ttl.tile_exp %[[DST]]
+// CHECK-NEXT:  }
+func.func @schedule_across_fill(
+    %input: !ttcore.tile<32x32, bf16>,
+    %output: !ttcore.tile<32x32, bf16>) {
+  %dst0 = arith.constant 0 : index
+  %dst1 = arith.constant 1 : index
+  %dst2 = arith.constant 2 : index
+  ttl.dst_section {
+    %dst = ttl.dst_index %input[%dst0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %exp = ttl.tile_exp %dst into dst[%dst0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %fill = ttl.tile_fill 3.000000e+00 into dst[%dst1] : !ttcore.tile<32x32, bf16>
+    %bcast = ttl.tile_bcast %input, %output 1 : i32 into dst[%dst2] : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+    ttl.yield
+  }
+  return
+}
+
+// -----
+
+// Participation does not weaken the register hazards. Here the fill overwrites
+// the register the exponential reads, so the write-after-read dependency gives
+// it a greater depth and pins it behind that reader. The broadcast still
+// reaches the front, which distinguishes a scheduled fill from a boundary: a
+// section that merely failed to sort would leave every operation in place.
+
+// CHECK-LABEL: func.func @fill_stays_after_last_reader
+// CHECK:       ttl.dst_section {
+// CHECK-NEXT:    %[[BCAST:.*]] = ttl.tile_bcast
+// CHECK-NEXT:    %[[DST:.*]] = ttl.dst_index
+// CHECK-NEXT:    %[[EXP:.*]] = ttl.tile_exp %[[DST]]
+// CHECK-NEXT:    %[[FILL:.*]] = ttl.tile_fill
+// CHECK-NEXT:  }
+func.func @fill_stays_after_last_reader(
+    %input: !ttcore.tile<32x32, bf16>,
+    %output: !ttcore.tile<32x32, bf16>) {
+  %dst0 = arith.constant 0 : index
+  %dst1 = arith.constant 1 : index
+  ttl.dst_section {
+    %dst = ttl.dst_index %input[%dst0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %exp = ttl.tile_exp %dst into dst[%dst0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %fill = ttl.tile_fill 3.000000e+00 into dst[%dst0] : !ttcore.tile<32x32, bf16>
+    %bcast = ttl.tile_bcast %input, %output 1 : i32 into dst[%dst1] : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+    ttl.yield
+  }
+  return
+}


### PR DESCRIPTION
### Problem description
classifyTileOp has no case for TileFillOp, so a tile_fill falls through
to TileOpCategory::Unknown and ttl-schedule-operations never schedules it.

### What's changed
Classify TileFillOp as a dedicated TileOpCategory::Fill so the fill
participates in scheduling instead of bounding it. The depth analysis already
models WAW and WAR hazards on DST, so the fill sorts after the last reader of
its slot and before its consumer while the operations around it stay in one
group.

### Test coverage

`schedule_fill_participation.mlir` places an independent broadcast after a
fill in two cases. The broadcast can only reach the front of the DST section if
the fill is scheduled alongside it; while the fill is a boundary, the section
splits in two, each half is already sorted, and nothing moves. The second case
additionally overwrites a register an earlier operation reads, so the
write-after-read dependency still pins the fill behind that reader even though
it now participates in the sort. 
