### PR TITLE
[frontend] Support statically indexed DFB collections [dfb-reuse-1]

### DIFF
--- a/docs/sphinx/specs/TTLangSpecification.externalized.md
+++ b/docs/sphinx/specs/TTLangSpecification.externalized.md
@@ -175,6 +175,8 @@ Shape determines the shape of a *block* returned by one of the *acquisition func
 
 A dataflow buffer is constructed in the scope of an operation function but its object functions run on threads. Acquisition functions can be used with Python `with` statement, which will automatically release acquired blocks at the end of the `with` scope. Alternatively, if acquisition functions are used without the `with` the user must explicitly call a corresponding release function on the acquired block: `pop` for `wait` and `push` for `reserve`.
 
+An operation may declare a list or tuple of dataflow buffers, including through a list comprehension of `ttl.make_dataflow_buffer_like` or `ttl.make_dfb` calls. Each element is a distinct dataflow buffer and must be accessed with a non-negative integer literal index. A collection may instead be destructured into simple names when the target count matches the collection size. Dynamic indexing is not supported because the dataflow buffer identity is resolved during compilation.
+
 #### Dataflow buffer example
 
 <!-- @spec:example dataflow_buffer/dataflow_buffer.py -->

--- a/docs/sphinx/specs/TTLangSpecification.externalized.md
+++ b/docs/sphinx/specs/TTLangSpecification.externalized.md
@@ -175,7 +175,7 @@ Shape determines the shape of a *block* returned by one of the *acquisition func
 
 A dataflow buffer is constructed in the scope of an operation function but its object functions run on threads. Acquisition functions can be used with Python `with` statement, which will automatically release acquired blocks at the end of the `with` scope. Alternatively, if acquisition functions are used without the `with` the user must explicitly call a corresponding release function on the acquired block: `pop` for `wait` and `push` for `reserve`.
 
-An operation may declare a list or tuple of dataflow buffers, including through a list comprehension of `ttl.make_dataflow_buffer_like` or `ttl.make_dfb` calls. Each element is a distinct dataflow buffer and must be accessed with a non-negative integer literal index. A collection may instead be destructured into simple names when the target count matches the collection size. Dynamic indexing is not supported because the dataflow buffer identity is resolved during compilation.
+In the unified-body operation form, an operation may declare a list or tuple of dataflow buffers, including through a list comprehension of `ttl.make_dataflow_buffer_like` or `ttl.make_dfb` calls. Each element is a distinct dataflow buffer and must be accessed with a non-negative integer literal index. A collection may instead be destructured into simple names when the target count matches the collection size. Dynamic indexing is not supported in this form because the dataflow buffer identity is resolved during compilation. Every declared collection element is allocated, including elements that the operation does not reference.
 
 #### Dataflow buffer example
 

--- a/docs/sphinx/specs/TTLangSpecification.md
+++ b/docs/sphinx/specs/TTLangSpecification.md
@@ -320,7 +320,7 @@ Shape determines the shape of a *block* returned by one of the *acquisition func
 
 A dataflow buffer is constructed in the scope of an operation function but its object functions run on threads. Acquisition functions can be used with Python `with` statement, which will automatically release acquired blocks at the end of the `with` scope. Alternatively, if acquisition functions are used without the `with` the user must explicitly call a corresponding release function on the acquired block: `pop` for `wait` and `push` for `reserve`.
 
-An operation may declare a list or tuple of dataflow buffers, including through a list comprehension of `ttl.make_dataflow_buffer_like` or `ttl.make_dfb` calls. Each element is a distinct dataflow buffer and must be accessed with a non-negative integer literal index. A collection may instead be destructured into simple names when the target count matches the collection size. Dynamic indexing is not supported because the dataflow buffer identity is resolved during compilation.
+In the unified-body operation form, an operation may declare a list or tuple of dataflow buffers, including through a list comprehension of `ttl.make_dataflow_buffer_like` or `ttl.make_dfb` calls. Each element is a distinct dataflow buffer and must be accessed with a non-negative integer literal index. A collection may instead be destructured into simple names when the target count matches the collection size. Dynamic indexing is not supported in this form because the dataflow buffer identity is resolved during compilation. Every declared collection element is allocated, including elements that the operation does not reference.
 
 #### Dataflow buffer example
 

--- a/docs/sphinx/specs/TTLangSpecification.md
+++ b/docs/sphinx/specs/TTLangSpecification.md
@@ -320,6 +320,8 @@ Shape determines the shape of a *block* returned by one of the *acquisition func
 
 A dataflow buffer is constructed in the scope of an operation function but its object functions run on threads. Acquisition functions can be used with Python `with` statement, which will automatically release acquired blocks at the end of the `with` scope. Alternatively, if acquisition functions are used without the `with` the user must explicitly call a corresponding release function on the acquired block: `pop` for `wait` and `push` for `reserve`.
 
+An operation may declare a list or tuple of dataflow buffers, including through a list comprehension of `ttl.make_dataflow_buffer_like` or `ttl.make_dfb` calls. Each element is a distinct dataflow buffer and must be accessed with a non-negative integer literal index. A collection may instead be destructured into simple names when the target count matches the collection size. Dynamic indexing is not supported because the dataflow buffer identity is resolved during compilation.
+
 #### Dataflow buffer example
 
 ```py

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -374,6 +374,17 @@ def _fresh_name(base: str, suffix: str, reserved_names: Set[str]) -> str:
     return candidate
 
 
+def _is_static_dfb_collection_element(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and isinstance(node.slice, ast.Constant)
+        and not isinstance(node.slice.value, bool)
+        and isinstance(node.slice.value, int)
+        and node.slice.value >= 0
+    )
+
+
 def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, ast.expr]:
     if any(isinstance(argument, ast.Starred) for argument in call.args):
         raise ValueError(
@@ -425,13 +436,22 @@ def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, as
             )
         bindings[parameter.name] = keyword_arguments[parameter.name]
 
+    parameters = {parameter.name: parameter for parameter in spec.params}
     for name, argument in bindings.items():
-        if not isinstance(argument, ast.Name):
-            raise TypeError(
-                f"@ttl.operation: argument {name!r} while composing "
-                f"{spec.name!r} into {caller_name!r} must be a tensor or "
-                "resource name"
-            )
+        if isinstance(argument, ast.Name):
+            continue
+        parameter = parameters[name]
+        if parameter.kind == "dfb" and _is_static_dfb_collection_element(argument):
+            continue
+        requirement = (
+            "a resource name or statically indexed DFB collection element"
+            if parameter.kind == "dfb"
+            else "a tensor or resource name"
+        )
+        raise TypeError(
+            f"@ttl.operation: argument {name!r} while composing "
+            f"{spec.name!r} into {caller_name!r} must be {requirement}"
+        )
     return bindings
 
 
@@ -526,8 +546,7 @@ def _validate_nested_bindings(
     protected_names = set(bindings)
     protected_names.update(local_names)
     for replacement in bindings.values():
-        if isinstance(replacement, ast.Name):
-            protected_names.add(replacement.id)
+        protected_names.update(_loaded_names([replacement]))
 
     for scope in ast.walk(spec.fn_ast):
         if scope is spec.fn_ast or not isinstance(scope, _NESTED_SCOPES):

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -124,6 +124,7 @@ def inline_atom_calls(
     fn_def: ast.FunctionDef,
     fn_globals: Dict[str, object],
     caller_name: str,
+    dfb_collection_names: Set[str],
 ) -> Dict[str, object]:
     reserved_names = _identifier_names(fn_def)
     external_pipenets = {}
@@ -133,6 +134,7 @@ def inline_atom_calls(
         caller_name,
         reserved_names,
         external_pipenets,
+        dfb_collection_names,
     )
     return external_pipenets
 
@@ -143,6 +145,7 @@ def _inline_statements(
     caller_name: str,
     reserved_names: Set[str],
     external_pipenets: Dict[str, object],
+    dfb_collection_names: Set[str],
 ) -> List[ast.stmt]:
     result: List[ast.stmt] = []
     for statement in statements:
@@ -152,6 +155,7 @@ def _inline_statements(
             caller_name,
             reserved_names,
             external_pipenets,
+            dfb_collection_names,
         )
         match = _standalone_operation_call(statement, scope)
         if match is None:
@@ -167,6 +171,7 @@ def _inline_statements(
                 scope,
                 reserved_names,
                 external_pipenets,
+                dfb_collection_names,
             )
         )
     return result
@@ -178,6 +183,7 @@ def _inline_compound_bodies(
     caller_name: str,
     reserved_names: Set[str],
     external_pipenets: Dict[str, object],
+    dfb_collection_names: Set[str],
 ) -> None:
     for attribute in ("body", "orelse", "finalbody"):
         body = getattr(statement, attribute, None)
@@ -191,6 +197,7 @@ def _inline_compound_bodies(
             caller_name,
             reserved_names,
             external_pipenets,
+            dfb_collection_names,
         )
         setattr(statement, attribute, inlined)
 
@@ -205,6 +212,7 @@ def _inline_compound_bodies(
                 caller_name,
                 reserved_names,
                 external_pipenets,
+                dfb_collection_names,
             )
 
 
@@ -278,9 +286,15 @@ def _expand_call(
     scope: Dict[str, object],
     reserved_names: Set[str],
     external_pipenets: Dict[str, object],
+    dfb_collection_names: Set[str],
 ) -> List[ast.stmt]:
     spec = callee._spec
-    bindings = _bind_args_to_params(spec, call, caller_name)
+    bindings = _bind_args_to_params(
+        spec,
+        call,
+        caller_name,
+        dfb_collection_names,
+    )
     suffix = f"__{spec.name}_inl{next(_inline_counter)}"
     _add_capture_bindings(spec, bindings)
     _add_external_pipenet_bindings(
@@ -374,18 +388,23 @@ def _fresh_name(base: str, suffix: str, reserved_names: Set[str]) -> str:
     return candidate
 
 
-def _is_static_dfb_collection_element(node: ast.expr) -> bool:
-    return (
-        isinstance(node, ast.Subscript)
-        and isinstance(node.value, ast.Name)
-        and isinstance(node.slice, ast.Constant)
-        and not isinstance(node.slice.value, bool)
-        and isinstance(node.slice.value, int)
-        and node.slice.value >= 0
-    )
+def _static_subscript_index(node: ast.expr) -> Optional[int]:
+    if not isinstance(node, ast.Subscript):
+        return None
+    if not isinstance(node.slice, ast.Constant):
+        return None
+    index = node.slice.value
+    if isinstance(index, bool) or not isinstance(index, int) or index < 0:
+        return None
+    return index
 
 
-def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, ast.expr]:
+def _bind_args_to_params(
+    spec,
+    call: ast.Call,
+    caller_name: str,
+    dfb_collection_names: Set[str],
+) -> Dict[str, ast.expr]:
     if any(isinstance(argument, ast.Starred) for argument in call.args):
         raise ValueError(
             f"@ttl.operation: composing {spec.name!r} into {caller_name!r} "
@@ -436,13 +455,23 @@ def _bind_args_to_params(spec, call: ast.Call, caller_name: str) -> Dict[str, as
             )
         bindings[parameter.name] = keyword_arguments[parameter.name]
 
-    parameters = {parameter.name: parameter for parameter in spec.params}
     for name, argument in bindings.items():
         if isinstance(argument, ast.Name):
             continue
-        parameter = parameters[name]
-        if parameter.kind == "dfb" and _is_static_dfb_collection_element(argument):
-            continue
+        parameter = spec.params_by_name[name]
+        if (
+            parameter.kind == "dfb"
+            and isinstance(argument, ast.Subscript)
+            and isinstance(argument.value, ast.Name)
+            and argument.value.id in dfb_collection_names
+        ):
+            if _static_subscript_index(argument) is not None:
+                continue
+            raise ValueError(
+                f"@ttl.operation {caller_name!r}: DFB collection "
+                f"{argument.value.id!r} requires a non-negative integer "
+                "literal index"
+            )
         requirement = (
             "a resource name or statically indexed DFB collection element"
             if parameter.kind == "dfb"
@@ -470,6 +499,8 @@ def _identifier_names(root: ast.AST) -> Set[str]:
         elif isinstance(node, ast.arg):
             names.add(node.arg)
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.ExceptHandler) and node.name is not None:
             names.add(node.name)
     return names
 

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -18,16 +18,14 @@ operation with resource parameters is expand-only and cannot be called as a
 TT-NN operation.
 
 DFB declarations sit inline with the compute/copy work in a unified body, so
-after the split they land inside each kernel body. Declarations may be single
-assignments, list/tuple declarations, list comprehensions whose elements are
-accessed with non-negative integer literal indices, or named destructuring of a
-DFB collection. The existing per-kernel compiler is capture-based (kernel
-functions take no parameters; DFBs arrive as closure captures), so before
-splitting we lift these declarations out of the body, evaluate them to
-DataflowBuffer objects, and pass them as captures -- the same form the
-@ttl.operation flow produces by running its setup body. After that the
-per-kernel compile, DFB sizing, pass pipeline, and runner are identical to
-@ttl.operation.
+after the split they land inside each thread body. Declarations may be
+individual assignments or statically indexed collections. The existing
+per-thread compiler is capture-based (thread functions take no parameters;
+DFBs arrive as closure captures), so before splitting we lift these
+declarations out of the body, evaluate them to DataflowBuffer objects, and pass
+them as captures -- the same shape the @ttl.operation flow produces by running
+its setup body. After that the per-thread compile, CB sizing, pass pipeline, and
+runner are identical to @ttl.operation.
 """
 
 from __future__ import annotations
@@ -45,7 +43,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import ttl as _ttl
 from ttl.pykernel._src.utils import _cleanup_source_code
 
-from ._src.atom_inline import inline_atom_calls
+from ._src.atom_inline import (
+    _identifier_names,
+    _static_subscript_index,
+    inline_atom_calls,
+)
 from ._src.atom_split import split_function_body
 from ._src.tensor_registry import register_tensor_name
 from .compiler_options import CompilerOptions
@@ -106,6 +108,7 @@ class _AtomSpec:
     line_offset: int
     fn_ast: ast.FunctionDef  # post-inline
     params: List[_ParamInfo]
+    params_by_name: Dict[str, _ParamInfo]
     dfb_param_names: List[str]
     compile_time_captures: Dict[str, Any]
     frozen_scope: Dict[str, Any]
@@ -271,7 +274,12 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
 
     # Inline statement-level calls to other unified operations, then keep
     # the post-inline AST + source.
-    inlined_pipenets = inline_atom_calls(fn_def, scope, caller_name=name)
+    inlined_pipenets = inline_atom_calls(
+        fn_def,
+        scope,
+        caller_name=name,
+        dfb_collection_names=_dfb_collection_names(fn_def),
+    )
     _validate_resource_declarations(fn_def, name)
 
     loaded_names = set()
@@ -314,6 +322,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         line_offset=line_offset,
         fn_ast=fn_def,
         params=params,
+        params_by_name={parameter.name: parameter for parameter in params},
         dfb_param_names=[p.name for p in params if p.kind == "dfb"],
         compile_time_captures=compile_time_captures,
         frozen_scope=frozen_scope,
@@ -364,6 +373,30 @@ def _is_dfb_collection_expr(node: ast.expr) -> bool:
     if isinstance(node, ast.ListComp):
         return _call_name(node.elt) in _DFB_FACTORY_NAMES
     return False
+
+
+def _dfb_collection_declaration_name(stmt: ast.stmt) -> Optional[str]:
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    if not isinstance(stmt.targets[0], ast.Name):
+        return None
+    if not _is_dfb_collection_expr(stmt.value):
+        return None
+    return stmt.targets[0].id
+
+
+def _dfb_collection_names(fn_def: ast.FunctionDef) -> set:
+    return {
+        name
+        for statement in fn_def.body
+        if (name := _dfb_collection_declaration_name(statement)) is not None
+    }
+
+
+def _is_dfb_generator_expr(node: ast.AST) -> bool:
+    return isinstance(node, ast.GeneratorExp) and (
+        _call_name(node.elt) in _DFB_FACTORY_NAMES
+    )
 
 
 def _destructured_names(target: ast.expr) -> Optional[List[str]]:
@@ -434,9 +467,24 @@ def _validate_resource_declarations(
     fn_def: ast.FunctionDef, operation_name: str
 ) -> None:
     """Require resource construction to use simple top-level assignments."""
+    if any(_is_dfb_generator_expr(node) for node in ast.walk(fn_def)):
+        raise ValueError(
+            f"@ttl.operation {operation_name!r}: DFB collections do not "
+            "support generator expressions; use a list comprehension"
+        )
+
     allowed_calls = set()
+    collection_names = set()
     resource_statements = []
     for statement in fn_def.body:
+        collection_name = _dfb_collection_declaration_name(statement)
+        if collection_name is not None:
+            if collection_name in collection_names:
+                raise ValueError(
+                    f"@ttl.operation {operation_name!r}: DFB collection "
+                    f"{collection_name!r} is declared more than once"
+                )
+            collection_names.add(collection_name)
         target_names = _setup_assign_targets(statement)
         if target_names is None:
             continue
@@ -496,19 +544,14 @@ class _DFBCollectionSubscriptRewriter(ast.NodeTransformer):
                 f"@ttl.operation {self.operation_name!r}: DFB collection "
                 f"{collection_name!r} elements cannot be rebound"
             )
-        if (
-            not isinstance(node.slice, ast.Constant)
-            or isinstance(node.slice.value, bool)
-            or not isinstance(node.slice.value, int)
-            or node.slice.value < 0
-        ):
+        index = _static_subscript_index(node)
+        if index is None:
             raise ValueError(
                 f"@ttl.operation {self.operation_name!r}: DFB collection "
                 f"{collection_name!r} requires a non-negative integer literal "
                 "index"
             )
 
-        index = node.slice.value
         elements = self.collection_elements[collection_name]
         if index >= len(elements):
             raise ValueError(
@@ -520,7 +563,14 @@ class _DFBCollectionSubscriptRewriter(ast.NodeTransformer):
         return ast.copy_location(replacement, node)
 
     def visit_Name(self, node):
-        if isinstance(node.ctx, ast.Load) and node.id in self.collection_elements:
+        if node.id not in self.collection_elements:
+            return node
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            raise ValueError(
+                f"@ttl.operation {self.operation_name!r}: DFB collection "
+                f"{node.id!r} cannot be rebound"
+            )
+        if isinstance(node.ctx, ast.Load):
             raise ValueError(
                 f"@ttl.operation {self.operation_name!r}: DFB collection "
                 f"{node.id!r} must be accessed with a non-negative integer "
@@ -554,19 +604,23 @@ def _lift_setup(
     dfbs: Dict[str, DataflowBuffer] = {}
     nets: Dict[str, PipeNet] = {}
     collection_elements: Dict[str, List[str]] = {}
-    reserved_names = {
-        node.id for node in ast.walk(fn_def) if isinstance(node, ast.Name)
-    }
+    reserved_names = _identifier_names(fn_def)
     kept: List[ast.stmt] = []
     for stmt in fn_def.body:
         target_names = _setup_assign_targets(stmt)
         if target_names is None:
             kept.append(stmt)
             continue
+        collection_name = _dfb_collection_declaration_name(stmt)
+        if collection_name is not None and collection_name in collection_elements:
+            raise ValueError(
+                f"@ttl.operation {operation_name!r}: DFB collection "
+                f"{collection_name!r} is declared more than once"
+            )
         value = eval(ast.unparse(stmt.value), ns)  # noqa: S307
         target = stmt.targets[0]
         if not isinstance(target, ast.Name):
-            if not isinstance(value, (list, tuple)) or not value:
+            if not value:
                 raise ValueError(
                     f"@ttl.operation {operation_name!r}: DFB collection "
                     "destructuring requires at least one DFB"
@@ -592,7 +646,7 @@ def _lift_setup(
         if isinstance(value, DataflowBuffer):
             dfbs[name] = value
         elif _is_dfb_collection_expr(stmt.value):
-            if not isinstance(value, (list, tuple)) or not value:
+            if not value:
                 raise ValueError(
                     f"@ttl.operation {operation_name!r}: DFB collection "
                     f"{name!r} must contain at least one DFB"
@@ -626,7 +680,7 @@ def _lift_setup(
         collection_elements,
         operation_name,
     )
-    new_fn.body = [rewriter.visit(statement) for statement in kept]
+    new_fn.body = [rewriter.visit(copy.deepcopy(statement)) for statement in kept]
     ast.fix_missing_locations(new_fn)
     return new_fn, dfbs, nets
 
@@ -656,7 +710,7 @@ def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
     by_index = {dfb._cb_index: dfb for dfb in lifted.values()}
     if not by_index:
         return []
-    return [by_index.get(index) for index in range(max(by_index) + 1)]
+    return [by_index.get(i) for i in range(max(by_index) + 1)]
 
 
 def _make_thread_callable(spec, kernel_type, fn_name, body, captures):

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -17,15 +17,17 @@ buffers used within a top-level operation are declared in its body. An
 operation with resource parameters is expand-only and cannot be called as a
 TT-NN operation.
 
-DFB declarations sit inline with the compute/copy work in a unified
-body, so after the split they land inside each thread body. The existing
-per-thread compiler is capture-based (thread functions take no
-parameters; DFBs arrive as closure captures), so before splitting we
-lift the top-level ``name = make_dfb(...)`` assigns out of the body,
-evaluate them to DataflowBuffer objects, and pass them as captures --
-the same shape the @ttl.operation flow produces by running its setup
-body. After that the per-thread compile, CB sizing, pass pipeline, and
-runner are identical to @ttl.operation.
+DFB declarations sit inline with the compute/copy work in a unified body, so
+after the split they land inside each kernel body. Declarations may be single
+assignments, list/tuple declarations, list comprehensions whose elements are
+accessed with non-negative integer literal indices, or named destructuring of a
+DFB collection. The existing per-kernel compiler is capture-based (kernel
+functions take no parameters; DFBs arrive as closure captures), so before
+splitting we lift these declarations out of the body, evaluate them to
+DataflowBuffer objects, and pass them as captures -- the same form the
+@ttl.operation flow produces by running its setup body. After that the
+per-kernel compile, DFB sizing, pass pipeline, and runner are identical to
+@ttl.operation.
 """
 
 from __future__ import annotations
@@ -353,17 +355,48 @@ def _is_pipe_list_expr(node: ast.expr) -> bool:
     return False
 
 
-def _setup_assign_target(stmt: ast.stmt) -> Optional[str]:
-    """If ``stmt`` is a DFB/Pipe/PipeNet construction assign, return its name.
+def _is_dfb_collection_expr(node: ast.expr) -> bool:
+    """Return whether `node` uses a supported DFB collection syntax."""
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return bool(node.elts) and all(
+            _call_name(element) in _DFB_FACTORY_NAMES for element in node.elts
+        )
+    if isinstance(node, ast.ListComp):
+        return _call_name(node.elt) in _DFB_FACTORY_NAMES
+    return False
 
-    Recognizes ``name = <dfb/pipe-factory>(...)`` and ``name = [<pipes>]``
-    (a pipe list feeding a later PipeNet)."""
+
+def _destructured_names(target: ast.expr) -> Optional[List[str]]:
+    if not isinstance(target, (ast.List, ast.Tuple)):
+        return None
+    if not target.elts or not all(
+        isinstance(element, ast.Name) for element in target.elts
+    ):
+        return None
+    return [element.id for element in target.elts]
+
+
+def _setup_assign_targets(stmt: ast.stmt) -> Optional[List[str]]:
+    """Return names assigned by a top-level resource declaration.
+
+    Recognizes direct DFB/Pipe/PipeNet factory calls, DFB collections, and pipe
+    lists that feed a later PipeNet. DFB collections may destructure into
+    multiple simple names.
+    """
     if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
         return None
-    if not isinstance(stmt.targets[0], ast.Name):
+    target = stmt.targets[0]
+    is_dfb_collection = _is_dfb_collection_expr(stmt.value)
+    if not (
+        _call_name(stmt.value) in _SETUP_FACTORY_NAMES
+        or is_dfb_collection
+        or _is_pipe_list_expr(stmt.value)
+    ):
         return None
-    if _call_name(stmt.value) in _SETUP_FACTORY_NAMES or _is_pipe_list_expr(stmt.value):
-        return stmt.targets[0].id
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if is_dfb_collection:
+        return _destructured_names(target)
     return None
 
 
@@ -379,7 +412,7 @@ def _collect_assignment_targets(target: ast.expr, names: set) -> None:
 def _non_resource_assignment_names(fn_def: ast.FunctionDef) -> set:
     names = set()
     for statement in fn_def.body:
-        if _setup_assign_target(statement) is not None:
+        if _setup_assign_targets(statement) is not None:
             continue
         if isinstance(statement, ast.Assign):
             for target in statement.targets:
@@ -404,8 +437,14 @@ def _validate_resource_declarations(
     allowed_calls = set()
     resource_statements = []
     for statement in fn_def.body:
-        if _setup_assign_target(statement) is None:
+        target_names = _setup_assign_targets(statement)
+        if target_names is None:
             continue
+        if len(target_names) != len(set(target_names)):
+            raise ValueError(
+                f"@ttl.operation {operation_name!r}: DFB collection "
+                "destructuring targets must be unique"
+            )
         resource_statements.append(statement)
         for node in ast.walk(statement):
             if not isinstance(node, ast.Call):
@@ -437,9 +476,63 @@ def _validate_resource_declarations(
         )
 
 
+class _DFBCollectionSubscriptRewriter(ast.NodeTransformer):
+    def __init__(
+        self,
+        collection_elements: Dict[str, List[str]],
+        operation_name: str,
+    ):
+        self.collection_elements = collection_elements
+        self.operation_name = operation_name
+
+    def visit_Subscript(self, node):
+        if not isinstance(node.value, ast.Name):
+            return self.generic_visit(node)
+        collection_name = node.value.id
+        if collection_name not in self.collection_elements:
+            return self.generic_visit(node)
+        if not isinstance(node.ctx, ast.Load):
+            raise ValueError(
+                f"@ttl.operation {self.operation_name!r}: DFB collection "
+                f"{collection_name!r} elements cannot be rebound"
+            )
+        if (
+            not isinstance(node.slice, ast.Constant)
+            or isinstance(node.slice.value, bool)
+            or not isinstance(node.slice.value, int)
+            or node.slice.value < 0
+        ):
+            raise ValueError(
+                f"@ttl.operation {self.operation_name!r}: DFB collection "
+                f"{collection_name!r} requires a non-negative integer literal "
+                "index"
+            )
+
+        index = node.slice.value
+        elements = self.collection_elements[collection_name]
+        if index >= len(elements):
+            raise ValueError(
+                f"@ttl.operation {self.operation_name!r}: DFB collection "
+                f"{collection_name!r} index {index} is out of range for "
+                f"{len(elements)} elements"
+            )
+        replacement = ast.Name(id=elements[index], ctx=ast.Load())
+        return ast.copy_location(replacement, node)
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, ast.Load) and node.id in self.collection_elements:
+            raise ValueError(
+                f"@ttl.operation {self.operation_name!r}: DFB collection "
+                f"{node.id!r} must be accessed with a non-negative integer "
+                "literal index"
+            )
+        return node
+
+
 def _lift_setup(
     fn_def: ast.FunctionDef,
     scope: Dict[str, Any],
+    operation_name: str,
 ) -> Tuple[ast.FunctionDef, Dict[str, DataflowBuffer], Dict[str, PipeNet]]:
     """Strip and evaluate the top-level DFB / Pipe / PipeNet construction
     assigns.
@@ -460,23 +553,81 @@ def _lift_setup(
 
     dfbs: Dict[str, DataflowBuffer] = {}
     nets: Dict[str, PipeNet] = {}
+    collection_elements: Dict[str, List[str]] = {}
+    reserved_names = {
+        node.id for node in ast.walk(fn_def) if isinstance(node, ast.Name)
+    }
     kept: List[ast.stmt] = []
     for stmt in fn_def.body:
-        name = _setup_assign_target(stmt)
-        if name is None:
+        target_names = _setup_assign_targets(stmt)
+        if target_names is None:
             kept.append(stmt)
             continue
         value = eval(ast.unparse(stmt.value), ns)  # noqa: S307
+        target = stmt.targets[0]
+        if not isinstance(target, ast.Name):
+            if not isinstance(value, (list, tuple)) or not value:
+                raise ValueError(
+                    f"@ttl.operation {operation_name!r}: DFB collection "
+                    "destructuring requires at least one DFB"
+                )
+            if not all(isinstance(element, DataflowBuffer) for element in value):
+                raise TypeError(
+                    f"@ttl.operation {operation_name!r}: DFB collection "
+                    "destructuring contains a non-DFB element"
+                )
+            if len(target_names) != len(value):
+                raise ValueError(
+                    f"@ttl.operation {operation_name!r}: DFB collection "
+                    f"destructuring has {len(target_names)} targets for "
+                    f"{len(value)} elements"
+                )
+            for element_name, element in zip(target_names, value):
+                ns[element_name] = element
+                dfbs[element_name] = element
+            continue
+
+        name = target_names[0]
         ns[name] = value
         if isinstance(value, DataflowBuffer):
             dfbs[name] = value
+        elif _is_dfb_collection_expr(stmt.value):
+            if not isinstance(value, (list, tuple)) or not value:
+                raise ValueError(
+                    f"@ttl.operation {operation_name!r}: DFB collection "
+                    f"{name!r} must contain at least one DFB"
+                )
+            if not all(isinstance(element, DataflowBuffer) for element in value):
+                raise TypeError(
+                    f"@ttl.operation {operation_name!r}: DFB collection "
+                    f"{name!r} contains a non-DFB element"
+                )
+            element_names = []
+            for index, element in enumerate(value):
+                element_name = f"{name}_{index}"
+                if element_name in reserved_names:
+                    raise ValueError(
+                        f"@ttl.operation {operation_name!r}: generated DFB "
+                        f"collection element name {element_name!r} conflicts "
+                        "with another operation identifier"
+                    )
+                reserved_names.add(element_name)
+                element_names.append(element_name)
+                ns[element_name] = element
+                dfbs[element_name] = element
+            collection_elements[name] = element_names
         elif isinstance(value, PipeNet):
             nets[name] = value
         # A bare Pipe stays in ns for a later PipeNet reference but is not a
         # capture; only DataflowBuffers and PipeNets are bound on threads.
 
     new_fn = copy.copy(fn_def)
-    new_fn.body = kept
+    rewriter = _DFBCollectionSubscriptRewriter(
+        collection_elements,
+        operation_name,
+    )
+    new_fn.body = [rewriter.visit(statement) for statement in kept]
+    ast.fix_missing_locations(new_fn)
     return new_fn, dfbs, nets
 
 
@@ -505,7 +656,7 @@ def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
     by_index = {dfb._cb_index: dfb for dfb in lifted.values()}
     if not by_index:
         return []
-    return [by_index.get(i) for i in range(max(by_index) + 1)]
+    return [by_index.get(index) for index in range(max(by_index) + 1)]
 
 
 def _make_thread_callable(spec, kernel_type, fn_name, body, captures):
@@ -574,7 +725,11 @@ def _compile_atom(
     _reset_cb_counter()
     _set_current_grid(grid)
 
-    stripped_fn, dfbs, nets = _lift_setup(copy.deepcopy(spec.fn_ast), eval_scope)
+    stripped_fn, dfbs, nets = _lift_setup(
+        copy.deepcopy(spec.fn_ast),
+        eval_scope,
+        spec.name,
+    )
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe

--- a/test/python/atom/test_atom_dfb_collections.py
+++ b/test/python/atom/test_atom_dfb_collections.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python -m pytest %s -v
+
+"""Off-device tests for DFB collections in operations."""
+
+import ast
+import importlib
+import textwrap
+import types
+
+import pytest
+
+import ttl
+
+
+atom_module = importlib.import_module("ttl.atom")
+
+
+class _FakeDFB:
+    pass
+
+
+def _function(source: str) -> ast.FunctionDef:
+    return ast.parse(textwrap.dedent(source)).body[0]
+
+
+def _lift(source: str, monkeypatch):
+    def make_dfb(*positional_args, **keyword_args):
+        return _FakeDFB()
+
+    monkeypatch.setattr(atom_module, "DataflowBuffer", _FakeDFB)
+    fake_ttl = types.SimpleNamespace(make_dfb=make_dfb)
+    return atom_module._lift_setup(
+        _function(source),
+        {"ttl": fake_ttl},
+        "collection_test",
+    )
+
+
+def test_dfb_collection_is_flattened_into_static_captures(monkeypatch):
+    stripped, dfbs, pipe_nets = _lift(
+        """
+        def kernel():
+            buffers = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for buffer_index in range(3)
+            ]
+            first = buffers[0].wait()
+            second = buffers[1].reserve()
+            third = buffers[2].wait()
+        """,
+        monkeypatch,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1", "buffers_2"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers =" not in stripped_source
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+    assert "buffers_2.wait()" in stripped_source
+
+
+def test_dfb_collection_accepts_list_literal(monkeypatch):
+    stripped, dfbs, pipe_nets = _lift(
+        """
+        def kernel():
+            buffers = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2),
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2),
+            ]
+            first = buffers[0].wait()
+            second = buffers[1].reserve()
+        """,
+        monkeypatch,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+
+
+def test_dfb_collection_accepts_static_comprehension_filter(monkeypatch):
+    stripped, dfbs, pipe_nets = _lift(
+        """
+        def kernel():
+            buffers = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for buffer_index in range(4)
+                if buffer_index % 2 == 0
+            ]
+            first = buffers[0].wait()
+            second = buffers[1].reserve()
+        """,
+        monkeypatch,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+
+
+@pytest.mark.parametrize(("open_target", "close_target"), [("(", ")"), ("[", "]")])
+def test_dfb_collection_destructuring_preserves_names(
+    open_target, close_target, monkeypatch
+):
+    stripped, dfbs, pipe_nets = _lift(
+        f"""
+        def kernel():
+            {open_target}
+            first_buffer,
+            second_buffer,
+            third_buffer,
+            {close_target} = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for buffer_index in range(3)
+            ]
+            first = first_buffer.wait()
+            second = second_buffer.reserve()
+            third = third_buffer.wait()
+        """,
+        monkeypatch,
+    )
+
+    assert list(dfbs) == ["first_buffer", "second_buffer", "third_buffer"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "ttl.make_dfb" not in stripped_source
+    assert "first_buffer.wait()" in stripped_source
+    assert "second_buffer.reserve()" in stripped_source
+    assert "third_buffer.wait()" in stripped_source
+
+
+def test_dfb_collection_destructuring_rejects_arity_mismatch(monkeypatch):
+    with pytest.raises(
+        ValueError,
+        match="destructuring has 2 targets for 3 elements",
+    ):
+        _lift(
+            """
+            def kernel():
+                first_buffer, second_buffer = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for buffer_index in range(3)
+                ]
+            """,
+            monkeypatch,
+        )
+
+
+def test_dfb_collection_destructuring_rejects_duplicate_targets(monkeypatch):
+    function = _function(
+        """
+        def kernel():
+            buffer, buffer = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for buffer_index in range(2)
+            ]
+        """
+    )
+
+    with pytest.raises(ValueError, match="destructuring targets must be unique"):
+        atom_module._validate_resource_declarations(function, "collection_test")
+
+
+@pytest.mark.parametrize(
+    ("index_expression", "message"),
+    [
+        ("buffer_index", "requires a non-negative integer literal index"),
+        ("-1", "requires a non-negative integer literal index"),
+        ("True", "requires a non-negative integer literal index"),
+        ("2", "index 2 is out of range for 2 elements"),
+    ],
+)
+def test_dfb_collection_rejects_non_static_or_out_of_range_indices(
+    index_expression, message, monkeypatch
+):
+    with pytest.raises(ValueError, match=message):
+        _lift(
+            f"""
+            def kernel():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for collection_index in range(2)
+                ]
+                buffer_index = 0
+                block = buffers[{index_expression}].wait()
+            """,
+            monkeypatch,
+        )
+
+
+def test_dfb_collection_rejects_empty_comprehension(monkeypatch):
+    with pytest.raises(ValueError, match="must contain at least one DFB"):
+        _lift(
+            """
+            def kernel():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for collection_index in range(0)
+                ]
+            """,
+            monkeypatch,
+        )
+
+
+def test_dfb_collection_rejects_generated_name_collision(monkeypatch):
+    with pytest.raises(ValueError, match="element name 'buffers_0' conflicts"):
+        _lift(
+            """
+            def kernel():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for collection_index in range(2)
+                ]
+                buffers_0 = 0
+                block = buffers[0].wait()
+            """,
+            monkeypatch,
+        )
+
+
+def test_dfb_collection_rejects_bare_collection_use(monkeypatch):
+    with pytest.raises(ValueError, match="must be accessed with"):
+        _lift(
+            """
+            def kernel():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for collection_index in range(2)
+                ]
+                alias = buffers
+            """,
+            monkeypatch,
+        )
+
+
+def test_dfb_collection_rejects_element_rebinding(monkeypatch):
+    with pytest.raises(
+        ValueError,
+        match="DFB collection 'buffers' elements cannot be rebound",
+    ):
+        _lift(
+            """
+            def kernel():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for collection_index in range(2)
+                ]
+                buffers[0] = buffers[1]
+            """,
+            monkeypatch,
+        )
+
+
+def test_dfb_collection_rejects_nested_kernel_declaration():
+    function = _function(
+        """
+        def kernel():
+            @ttl.compute()
+            def compute():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for buffer_index in range(2)
+                ]
+        """
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="resource declaration 'make_dfb' must be a simple top-level assignment",
+    ):
+        atom_module._validate_resource_declarations(function, "collection_test")
+
+
+def test_dfb_collection_elements_are_rewritten_inside_nested_kernel(monkeypatch):
+    stripped, dfbs, pipe_nets = _lift(
+        """
+        def kernel():
+            buffers = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for buffer_index in range(2)
+            ]
+
+            @ttl.compute()
+            def compute():
+                source = buffers[0].wait()
+                destination = buffers[1].reserve()
+                destination.store(source)
+        """,
+        monkeypatch,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+
+
+def test_composed_operation_accepts_static_dfb_collection_elements():
+    @ttl.operation()
+    def copy_stage(source: ttl.DFB, destination: ttl.DFB):
+        source_block = source.wait()
+        destination_block = destination.reserve()
+        destination_block.store(source_block)
+
+    @ttl.operation(grid=(1, 1))
+    def chain():
+        buffers = [
+            ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+            for buffer_index in range(2)
+        ]
+        copy_stage(buffers[0], buffers[1])
+
+    assert "buffers[0].wait()" in chain._spec.source
+    assert "buffers[1].reserve()" in chain._spec.source
+
+
+def test_composed_operation_rejects_dynamic_dfb_collection_index():
+    @ttl.operation()
+    def copy_stage(source: ttl.DFB, destination: ttl.DFB):
+        source_block = source.wait()
+        destination_block = destination.reserve()
+        destination_block.store(source_block)
+
+    with pytest.raises(
+        TypeError,
+        match="must be a resource name or statically indexed DFB collection element",
+    ):
+
+        @ttl.operation(grid=(1, 1))
+        def chain(buffer_index):
+            buffers = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for collection_index in range(2)
+            ]
+            copy_stage(buffers[buffer_index], buffers[0])

--- a/test/python/atom/test_atom_dfb_collections.py
+++ b/test/python/atom/test_atom_dfb_collections.py
@@ -7,6 +7,7 @@
 """Off-device tests for DFB collections in operations."""
 
 import ast
+import copy
 import importlib
 import textwrap
 import types
@@ -27,17 +28,24 @@ def _function(source: str) -> ast.FunctionDef:
     return ast.parse(textwrap.dedent(source)).body[0]
 
 
-def _lift(source: str, monkeypatch):
-    def make_dfb(*positional_args, **keyword_args):
-        return _FakeDFB()
-
+def _lift_with_factory(source: str, monkeypatch, dfb_factory):
     monkeypatch.setattr(atom_module, "DataflowBuffer", _FakeDFB)
-    fake_ttl = types.SimpleNamespace(make_dfb=make_dfb)
+    fake_ttl = types.SimpleNamespace(
+        make_dfb=dfb_factory,
+        make_dataflow_buffer_like=dfb_factory,
+    )
     return atom_module._lift_setup(
         _function(source),
         {"ttl": fake_ttl},
         "collection_test",
     )
+
+
+def _lift(source: str, monkeypatch):
+    def make_dfb(*positional_args, **keyword_args):
+        return _FakeDFB()
+
+    return _lift_with_factory(source, monkeypatch, make_dfb)
 
 
 def test_dfb_collection_is_flattened_into_static_captures(monkeypatch):
@@ -71,6 +79,50 @@ def test_dfb_collection_accepts_list_literal(monkeypatch):
             buffers = [
                 ttl.make_dfb("bf16", shape=(1, 1), block_count=2),
                 ttl.make_dfb("bf16", shape=(1, 1), block_count=2),
+            ]
+            first = buffers[0].wait()
+            second = buffers[1].reserve()
+        """,
+        monkeypatch,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+
+
+def test_dfb_collection_accepts_tuple_literal(monkeypatch):
+    stripped, dfbs, pipe_nets = _lift(
+        """
+        def kernel():
+            buffers = (
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2),
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2),
+            )
+            first = buffers[0].wait()
+            second = buffers[1].reserve()
+        """,
+        monkeypatch,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+
+
+def test_dfb_collection_accepts_make_dataflow_buffer_like(monkeypatch):
+    stripped, dfbs, pipe_nets = _lift(
+        """
+        def kernel():
+            buffers = [
+                ttl.make_dataflow_buffer_like(
+                    None, shape=(1, 1), block_count=2
+                )
+                for buffer_index in range(2)
             ]
             first = buffers[0].wait()
             second = buffers[1].reserve()
@@ -170,6 +222,27 @@ def test_dfb_collection_destructuring_rejects_duplicate_targets(monkeypatch):
         atom_module._validate_resource_declarations(function, "collection_test")
 
 
+def test_dfb_collection_rejects_redeclaration(monkeypatch):
+    with pytest.raises(
+        ValueError,
+        match="DFB collection 'buffers' is declared more than once",
+    ):
+        _lift(
+            """
+            def kernel():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for buffer_index in range(2)
+                ]
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for buffer_index in range(2)
+                ]
+            """,
+            monkeypatch,
+        )
+
+
 @pytest.mark.parametrize(
     ("index_expression", "message"),
     [
@@ -211,6 +284,49 @@ def test_dfb_collection_rejects_empty_comprehension(monkeypatch):
         )
 
 
+def test_dfb_collection_rejects_generator_expression():
+    function = _function(
+        """
+        def kernel():
+            buffers = (
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for buffer_index in range(2)
+            )
+        """
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="generator expressions; use a list comprehension",
+    ):
+        atom_module._validate_resource_declarations(function, "collection_test")
+
+
+@pytest.mark.parametrize(
+    ("target", "message"),
+    [
+        ("buffers", "contains a non-DFB element"),
+        ("first_buffer, second_buffer", "destructuring contains a non-DFB element"),
+    ],
+)
+def test_dfb_collection_rejects_non_dfb_elements(target, message, monkeypatch):
+    def make_non_dfb(*positional_args, **keyword_args):
+        return object()
+
+    with pytest.raises(TypeError, match=message):
+        _lift_with_factory(
+            f"""
+            def kernel():
+                {target} = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for buffer_index in range(2)
+                ]
+            """,
+            monkeypatch,
+            make_non_dfb,
+        )
+
+
 def test_dfb_collection_rejects_generated_name_collision(monkeypatch):
     with pytest.raises(ValueError, match="element name 'buffers_0' conflicts"):
         _lift(
@@ -221,6 +337,21 @@ def test_dfb_collection_rejects_generated_name_collision(monkeypatch):
                     for collection_index in range(2)
                 ]
                 buffers_0 = 0
+                block = buffers[0].wait()
+            """,
+            monkeypatch,
+        )
+
+
+def test_dfb_collection_generated_name_reserves_parameter_names(monkeypatch):
+    with pytest.raises(ValueError, match="element name 'buffers_0' conflicts"):
+        _lift(
+            """
+            def kernel(buffers_0):
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for collection_index in range(2)
+                ]
                 block = buffers[0].wait()
             """,
             monkeypatch,
@@ -260,12 +391,57 @@ def test_dfb_collection_rejects_element_rebinding(monkeypatch):
         )
 
 
-def test_dfb_collection_rejects_nested_kernel_declaration():
+def test_dfb_collection_rejects_collection_name_rebinding(monkeypatch):
+    with pytest.raises(
+        ValueError,
+        match="DFB collection 'buffers' cannot be rebound",
+    ):
+        _lift(
+            """
+            def kernel():
+                buffers = [
+                    ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                    for collection_index in range(2)
+                ]
+                buffers = 5
+                block = buffers[0].wait()
+            """,
+            monkeypatch,
+        )
+
+
+def test_lift_setup_does_not_mutate_input_ast(monkeypatch):
     function = _function(
         """
         def kernel():
-            @ttl.compute()
-            def compute():
+            buffers = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for collection_index in range(2)
+            ]
+            block = buffers[0].wait()
+        """
+    )
+    original_source = ast.unparse(function)
+
+    def make_dfb(*positional_args, **keyword_args):
+        return _FakeDFB()
+
+    monkeypatch.setattr(atom_module, "DataflowBuffer", _FakeDFB)
+    fake_ttl = types.SimpleNamespace(make_dfb=make_dfb)
+    atom_module._lift_setup(
+        function,
+        {"ttl": fake_ttl},
+        "collection_test",
+    )
+
+    assert ast.unparse(function) == original_source
+
+
+def test_dfb_collection_rejects_nested_function_declaration():
+    function = _function(
+        """
+        def kernel():
+            def helper():
                 buffers = [
                     ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
                     for buffer_index in range(2)
@@ -280,7 +456,7 @@ def test_dfb_collection_rejects_nested_kernel_declaration():
         atom_module._validate_resource_declarations(function, "collection_test")
 
 
-def test_dfb_collection_elements_are_rewritten_inside_nested_kernel(monkeypatch):
+def test_dfb_collection_elements_are_rewritten_inside_nested_function(monkeypatch):
     stripped, dfbs, pipe_nets = _lift(
         """
         def kernel():
@@ -289,8 +465,7 @@ def test_dfb_collection_elements_are_rewritten_inside_nested_kernel(monkeypatch)
                 for buffer_index in range(2)
             ]
 
-            @ttl.compute()
-            def compute():
+            def helper():
                 source = buffers[0].wait()
                 destination = buffers[1].reserve()
                 destination.store(source)
@@ -320,8 +495,67 @@ def test_composed_operation_accepts_static_dfb_collection_elements():
         ]
         copy_stage(buffers[0], buffers[1])
 
-    assert "buffers[0].wait()" in chain._spec.source
-    assert "buffers[1].reserve()" in chain._spec.source
+    stripped, dfbs, pipe_nets = atom_module._lift_setup(
+        copy.deepcopy(chain._spec.fn_ast),
+        chain._spec.frozen_scope,
+        chain.name,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+
+
+def test_composed_operation_accepts_keyword_dfb_collection_elements():
+    @ttl.operation()
+    def copy_stage(source: ttl.DFB, destination: ttl.DFB):
+        source_block = source.wait()
+        destination_block = destination.reserve()
+        destination_block.store(source_block)
+
+    @ttl.operation(grid=(1, 1))
+    def chain():
+        buffers = [
+            ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+            for buffer_index in range(2)
+        ]
+        copy_stage(source=buffers[0], destination=buffers[1])
+
+    stripped, dfbs, pipe_nets = atom_module._lift_setup(
+        copy.deepcopy(chain._spec.fn_ast),
+        chain._spec.frozen_scope,
+        chain.name,
+    )
+
+    assert list(dfbs) == ["buffers_0", "buffers_1"]
+    assert pipe_nets == {}
+    stripped_source = ast.unparse(stripped)
+    assert "buffers_0.wait()" in stripped_source
+    assert "buffers_1.reserve()" in stripped_source
+
+
+def test_composed_operation_rejects_non_dfb_collection_subscript():
+    @ttl.operation()
+    def copy_stage(source: ttl.DFB, destination: ttl.DFB):
+        source_block = source.wait()
+        destination_block = destination.reserve()
+        destination_block.store(source_block)
+
+    tensors = [1, 2]
+    with pytest.raises(
+        TypeError,
+        match="must be a resource name or statically indexed DFB collection element",
+    ):
+
+        @ttl.operation(grid=(1, 1))
+        def chain():
+            buffers = [
+                ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
+                for collection_index in range(2)
+            ]
+            copy_stage(tensors[0], buffers[1])
 
 
 def test_composed_operation_rejects_dynamic_dfb_collection_index():
@@ -332,8 +566,8 @@ def test_composed_operation_rejects_dynamic_dfb_collection_index():
         destination_block.store(source_block)
 
     with pytest.raises(
-        TypeError,
-        match="must be a resource name or statically indexed DFB collection element",
+        ValueError,
+        match="requires a non-negative integer literal index",
     ):
 
         @ttl.operation(grid=(1, 1))

--- a/test/python/atom/test_atom_dfb_collections_runtime.py
+++ b/test/python/atom/test_atom_dfb_collections_runtime.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Device coverage for composed operations using indexed DFB collections."""
+
+import pytest
+import torch
+
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import to_dram
+from utils.correctness import assert_allclose
+
+
+@ttl.operation()
+def _copy_collection_stage(source: ttl.DFB, destination: ttl.DFB):
+    source_block = source.wait()
+    destination_block = destination.reserve()
+    destination_block.store(source_block)
+
+
+@ttl.operation(grid=(1, 1), fp32_dest_acc_en=True)
+def _copy_through_dfb_collection(input_tensor, output_tensor):
+    buffers = [
+        ttl.make_dataflow_buffer_like(
+            input_tensor,
+            shape=(1, 1),
+            block_count=2,
+        ),
+        ttl.make_dataflow_buffer_like(
+            output_tensor,
+            shape=(1, 1),
+            block_count=2,
+        ),
+    ]
+
+    ttl.copy(input_tensor[0:1, 0:1], buffers[0].reserve()).wait()
+    _copy_collection_stage(buffers[0], buffers[1])
+    ttl.copy(buffers[1].wait(), output_tensor[0:1, 0:1]).wait()
+
+
+@pytest.mark.parametrize(
+    ("dtype", "rtol", "atol"),
+    [
+        pytest.param(torch.bfloat16, 0.05, 1.0, id="bf16"),
+        pytest.param(torch.float32, 1.0e-3, 1.0e-3, id="fp32"),
+    ],
+)
+def test_composed_operation_executes_with_indexed_dfb_collection(
+    device, dtype, rtol, atol
+):
+    tile_size = ttnn.TILE_SIZE
+    input_data = torch.randn(tile_size, tile_size, dtype=dtype) * 8.0
+    input_tensor = to_dram(input_data, device)
+    output_tensor = to_dram(
+        torch.zeros(tile_size, tile_size, dtype=dtype),
+        device,
+    )
+
+    _copy_through_dfb_collection(input_tensor, output_tensor)
+
+    result = ttnn.to_torch(output_tensor).reshape(tile_size, tile_size)
+    assert_allclose(result.float(), input_data.float(), rtol=rtol, atol=atol)


### PR DESCRIPTION
Chain: #704 -> #777 (this PR) -> #778 -> #775

### Problem description

Composed operations can create repeated groups of dataflow buffers, but the frontend requires every DFB declaration and argument to be written individually. This makes repeated composition verbose and prevents collections from using the same static resource handling as individual DFBs.

### What's changed

Support non-empty list and tuple literals and statically evaluated list comprehensions built from `ttl.make_dfb` or `ttl.make_dataflow_buffer_like`. Collection elements can be referenced by non-negative integer literal index, destructured into named DFBs, and passed as composed-operation arguments. The frontend expands each element into an ordinary static DFB capture before the kernel split and diagnoses dynamic, negative, out-of-range, rebound, and ambiguous uses.

For example, a composed operation can declare its repeated DFBs as a collection and pass statically indexed elements to another operation:

```python
@ttl.operation()
def copy_stage(source: ttl.DFB, destination: ttl.DFB):
    source_block = source.wait()
    destination_block = destination.reserve()
    destination_block.store(source_block)


@ttl.operation(grid=(1, 1))
def chain():
    stage_dfbs = [
        ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
        for _ in range(3)
    ]
    copy_stage(stage_dfbs[0], stage_dfbs[1])
    copy_stage(stage_dfbs[1], stage_dfbs[2])
```

Indexed elements remain explicit during operation composition, then become distinct static captures before kernel splitting and lowering. Dynamic subscripts remain invalid.

### Checklist

- [x] New/Existing tests provide coverage for changes
