### PR TITLE
[ttl] Separate logical DFB identity from physical allocation [dfb-reuse-1]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -12,6 +12,13 @@ kernels assign compiler DFBs kernel-local provisional indices. The module-level
 finalization pass assigns module-wide physical indices after the last
 user-declared DFB and applies lifetime-based index reuse.
 
+`ttl.bind_cb` separates logical and physical identity. `dfb_id` identifies one
+logical DFB across kernel functions, while `cb_index` identifies its assigned
+hardware slot. Keeping both identities allows non-overlapping logical DFBs to
+share one physical index without merging their producer and consumer
+protocols. Every user declaration carries `dfb_id`. Compiler-created
+declarations may omit it until module finalization assigns a unique ID.
+
 ## Pipeline
 
 The DFB-related passes in `ttl-to-ttkernel-pipeline` execute in this order:
@@ -23,8 +30,11 @@ ttl-annotate-l1-acc-loops      (FuncOp)   Mark user accumulation loops
 ttl-create-producer-compute    (FuncOp)   Create producer ttl.compute ops
 ttl-insert-intermediate-dfbs   (FuncOp)   Materialize compiler-allocated DFBs
 convert-ttl-to-compute         (FuncOp)   Lower remaining tensor ops
-ttl-auto-sync                  (FuncOp)   Insert/coalesce remaining DFB sync
-ttl-finalize-dfb-indices       (Module)   Index reuse + limit check
+ttl-insert-cb-sync             (FuncOp)   Insert remaining DFB synchronization
+ttl-verify-pipenet-guards      (Module)   Verify PipeNet launch-node domains
+ttl-verify-pipenet-schedule    (Module)   Verify PipeNet event ordering
+ttl-coalesce-dfb-acquires      (FuncOp)   Coalesce adjacent DFB acquisitions
+ttl-finalize-dfb-indices       (Module)   Finalize identities and allocations
 ttl-set-compute-kernel-config  (FuncOp)   Set per-kernel configuration
   ... DST assignment, loop lowering, scheduling ...
 ttl-annotate-cb-associations   (FuncOp)   Copy CB indices to tile ops
@@ -40,7 +50,17 @@ Compute configuration copies selected indices into
 operations (`bcast`, `reduce`, `transpose`). Running either pass first would
 leave stale attributes after finalization rewrites the indices.
 
-`ttl-verify-dfb-spsc` must run after `ttl-finalize-dfb-indices` so every `bind_cb` carries its final `cb_index`. The pass asserts on unresolvable indices.
+The PipeNet verifiers run before DFB acquire coalescing and physical index
+finalization. Guard verification uses the read-only logical identity analysis,
+which assigns temporary IDs to compiler-created DFBs without modifying IR.
+Schedule verification uses exact transfer provenance and does not depend on DFB
+allocation.
+
+`ttl-verify-dfb-spsc` must run after `ttl-finalize-dfb-indices` so every
+`bind_cb` carries its final `cb_index` and module-wide logical `dfb_id`. The
+pass requires the `ttl.dfb_allocations` module attribute emitted by successful
+finalization, then verifies that every declaration and lifecycle operand has a
+resolved logical ID.
 
 ## DFB Lifecycle
 
@@ -218,13 +238,16 @@ consumer for that DFB.
 
 The `ttl-verify-dfb-spsc` module-level pass runs after
 `ttl-annotate-cb-associations`. It walks every `cb_reserve` and `cb_wait` op,
-groups them by `cb_index` and enclosing `ttl.kernel_thread`-tagged
-`func.func`, and tracks the launch-node domain for each producer or consumer.
+groups them by logical `dfb_id` and enclosing
+`ttl.kernel_thread`-tagged `func.func`, and tracks the launch-node domain for
+each producer or consumer. Distinct logical DFBs therefore remain separate
+after physical allocation assigns them the same `cb_index`.
+
 The pass rejects a DFB when two producer domains overlap or when two consumer
 domains overlap. If multiple threads participate and a coordinate-dependent
 predicate cannot be analyzed statically, the pass rejects the DFB rather than
-assuming disjointness. The diagnostic identifies the cb_index, the role
-(producer or consumer), an overlapping launched node when available, the
+assuming disjointness. The diagnostic identifies the logical `dfb_id`, the
+role (producer or consumer), an overlapping launched node when available, the
 participating operation sites, and the originating `ttl.bind_cb`.
 
 See `test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir` for the rejected patterns and `verify_dfb_spsc.mlir` for the accepted ones.
@@ -252,8 +275,8 @@ Values produced by `ttl.compute` are materialized by the compiler-created
 intermediate lifecycle described above: the compute gains extra DFB outputs,
 and consumers receive attached tensor values instead of the original
 non-attached compute results. The final `convert-ttl-to-compute` pass lowers
-consumers that now receive DFB-attached operands. The following `ttl-auto-sync`
-run inserts the consumer `cb_pop`.
+consumers that now receive DFB-attached operands. The following
+`ttl-insert-cb-sync` pass inserts the consumer `cb_pop`.
 
 ### DFB Lifetime and `ComputeOp` Creation Planning
 
@@ -386,7 +409,7 @@ The correctness argument relies on these pipeline assumptions:
   operation, materialization splits the tensor SSA frontier first.
 - A plan is applied only to the unchanged kernel from which it was built.
   Application verifies recorded operands and uses before rewriting them.
-- `ttl-auto-sync` runs after final creation and inserts absent pushes and pops
+- `ttl-insert-cb-sync` runs after final creation and inserts absent pushes and pops
   after the resulting final uses.
 
 #### Compiler-Created Intermediate DFB Analysis and Materialization
@@ -617,7 +640,7 @@ MLIR executes them concurrently.
 
 Non-compute producers use standalone tensor materialization. The helper emits
 the reserve/store and wait/attach after an insertion operation recorded by the
-plan, while `ttl-auto-sync` inserts the missing releases:
+plan, while `ttl-insert-cb-sync` inserts the missing releases:
 
 ```
 bind_cb {ttl.compiler_allocated}
@@ -646,11 +669,16 @@ value, they share one materialization. The selected insertion operation
 properly dominates every rewritten consumer, so the attached replacement is
 valid for consumers in nested or incomparable regions.
 
-When one computed value has direct `ttl.store` users in multiple blocks, the
-stores cannot be represented by one `ComputeOp` output-publication position.
-`ttl-insert-intermediate-dfbs` materializes the value once and rewrites those
-stores to read the attached compiler DFB value. Final compute creation then
-sees one store for that producer result: the compiler DFB store inserted at the
+When one computed value has direct `ttl.store` users in multiple MLIR basic
+blocks, one `ttl.compute` cannot absorb all of them. A compute operation is
+located in one MLIR basic block, and all output stores in its body execute
+whenever that operation executes. Moving stores from different MLIR basic
+blocks into one compute could therefore change their conditional execution or
+violate SSA dominance.
+`ttl-insert-intermediate-dfbs` therefore materializes the value once and
+rewrites each original store to read the attached compiler DFB value while
+remaining in its original MLIR basic block. Final compute creation sees one
+store for the producer result: the compiler DFB store inserted at the
 materialization point.
 
 For `ttl.compute` results, the attached value is created immediately after the
@@ -1031,9 +1059,52 @@ uniqued type, this is a pointer comparison. The algorithm partitions DFBs by
 type and applies deterministic first-fit interval coloring within each
 partition.
 
+### Logical identity
+
+The frontend assigns each user-declared DFB a module-wide logical `dfb_id` and
+copies that ID to the declaration in every participating kernel.
+Compiler-created declarations receive distinct logical IDs after the largest
+explicit ID. A user declaration without `dfb_id` is rejected before physical
+allocation.
+
+Declarations with one `dfb_id` must have the same `CircularBufferType`.
+Compiler-created DFBs are currently kernel-local and receive distinct logical
+IDs.
+
+Logical identity resolution is a read-only analysis. The finalizer
+materializes its complete assignment on `ttl.bind_cb` only after the identity
+and capacity checks succeed. Rewriting `cb_index` therefore does not merge
+the SPSC or PipeNet protocol state of distinct logical DFBs.
+
+```
+resolveLogicalDFBIdentities(module):
+  maxExplicitId = max(dfb_id for declarations that have dfb_id, default=-1)
+  reject any user declaration without dfb_id
+  compilerCount = count(compiler-created declarations without dfb_id)
+  reject if maxExplicitId + compilerCount exceeds the index domain
+  nextCompilerId = maxExplicitId + 1 if compilerCount > 0 else 0
+
+  for declaration in module traversal order:
+    logicalId = declaration.dfb_id
+    if declaration has no dfb_id:
+      logicalId = nextCompilerId++
+    reject logicalId if another declaration with that ID has a different type
+    assignments.append({declaration, logicalId})
+
+  return assignments
+```
+
+Generated IDs are strictly greater than every explicit ID, and each
+compiler-created declaration consumes the next ID exactly once. Generated and
+explicit identities therefore cannot collide. Equal types for repeated
+explicit IDs ensure that one logical identity denotes one DFB representation.
+
 ### Algorithm
 
 ```
+identityAssignments = resolveLogicalDFBIdentities(module)
+reject if logical identity validation fails
+
 if any compiler-created DFB exists and a derived DFB-index attribute exists:
   reject the invalid pass order
 
@@ -1042,7 +1113,10 @@ for bindOp in compilerAllocatedBindCBOps:
   if lifecycleOps is not empty and any operation kind is missing:
     reject the partial lifecycle
 
-nextCompilerIndex = max(userDeclaredDFBIndices) + 1
+compact distinct user physical indices into a dense zero-based range
+record the compacted index for every user declaration
+
+nextCompilerIndex = number of distinct user physical indices
 for kernel in module:
   slots = planPhysicalDFBIndices(
       kernel, compilerAllocatedBindCBOps[kernel], nextCompilerIndex, plan)
@@ -1050,10 +1124,14 @@ for kernel in module:
 
 if nextCompilerIndex > 32:
   reject the allocation
-assert every shared planned index has one exact DFB type
 
-apply every planned cb_index assignment
-apply ttl.base_cta_index and ttl.compiler_allocated_dfbs
+for declaration in module:
+  physicalIndex = planned user or compiler index
+  reject if logicalId previously mapped to a different physicalIndex
+  reject if another declaration at physicalIndex has a different exact type
+
+apply every planned cb_index and dfb_id assignment
+apply ttl.base_cta_index and ttl.dfb_allocations
 
 planPhysicalDFBIndices(
     kernel, compilerAllocatedBindCBOps, firstPhysicalIndex, plan):
@@ -1104,12 +1182,13 @@ have balanced each acquire with its corresponding release before finalization.
 A declaration with no lifecycle operations is legal but conservatively remains
 live through the end of its kernel.
 
-Planning separates all fallible work from mutation. Pass-order, lifecycle, and
-capacity validation complete before any `cb_index`, `ttl.base_cta_index`, or
-`ttl.compiler_allocated_dfbs` update. A failed pass therefore leaves the input
-IR unchanged. Type-partitioned allocation guarantees that DFBs sharing a
-planned compiler index have one exact type; the metadata builder asserts this
-internal invariant.
+Planning separates all fallible work from mutation. Pass-order, lifecycle,
+logical-identity, capacity, and metadata validation complete before any
+`cb_index`, `dfb_id`, `ttl.base_cta_index`, or `ttl.dfb_allocations` update. A
+failed pass therefore leaves the input IR unchanged. Type-partitioned allocation
+guarantees that compiler-created DFBs sharing a planned index have one exact
+type. Metadata validation applies the same requirement to every declaration at
+each physical index.
 
 Intervals are half-open. A pop at kernel-body ordinal `N` produces endpoint
 `N + 1`, so the interval includes the release operation. A reserve in the next
@@ -1138,19 +1217,52 @@ different slots.
 
 ### Module attribute and runtime integration
 
-The planned physical DFB count is one greater than the greatest assigned index.
-This is the index space usage, not a count of distinct DFBs; sparse user indices
-inflate it. The pass verifies this does not exceed `kMaxCircularBuffers` (32).
+The pass compacts distinct user physical indices before placing
+compiler-created DFBs after them. This removes gaps caused by declarations that
+the frontend created but no kernel captured, without changing logical identity
+or existing physical-index sharing. The planned physical DFB count is one
+greater than the greatest assigned index, and the pass verifies this does not
+exceed `kMaxCircularBuffers` (32).
 
 The pass then sets `ttl.base_cta_index` on every kernel function. Compile-time
 arguments (CTAs) to each kernel are laid out as `[CB indices..., other args...]`.
 `base_cta_index` is the starting index of the non-CB arguments -- equivalently,
 one past the last CB index. CB indices occupy `[0, base_cta_index)`.
 
-Finally, the pass builds the `ttl.compiler_allocated_dfbs` module attribute
-with one entry per unique physical index, deduplicated from the potentially
-many `BindCBOp`s that now share an index. The Python runtime reads this
-attribute to allocate L1 buffers at dispatch time.
+Finally, the pass builds the `ttl.dfb_allocations` module attribute with one
+descriptor per physical index. Each descriptor contains `dfb_index`,
+`num_tiles`, `element_type`, `page_size`, and `block_count`. The finalizer
+computes `page_size` with `ttcore::getElementSizeBytes()` on the finalized
+element type, so subtile dimensions affect the allocation without requiring
+runtime device initialization.
+
+```
+emitDFBAllocations(declarations, plannedIndices):
+  for declaration in declarations:
+    index = plannedIndices[declaration]
+    reject index if another declaration at that index has a different type
+    allocationByIndex.insert(index, declaration.type)
+
+  for (index, type) in allocationByIndex sorted by index:
+    emit {dfb_index = index,
+          num_tiles = type.elementsPerBlock,
+          element_type = type.elementType,
+          page_size = byteSize(type.elementType),
+          block_count = type.blockCount}
+```
+
+Every finalized declaration contributes to the table. Type equality makes
+each deduplicated descriptor valid for every declaration at that physical
+index, and deriving the page size from the same element type used by lowering
+keeps compiler and runtime allocation sizes equal.
+
+The Python runtime validates that the descriptors form a dense index range and
+builds all `ttnn.CBDescriptor` objects from this final allocation table. It
+does not use the frontend's logical DFB list after physical assignment. This
+preserves compiler-computed page sizes, tile dimensions, and data formats.
+Scalar element types omit the optional TTNN tile descriptor, so their page
+size is not paired with an invented 32x32 tile. Standalone runner emission uses
+the same physical configuration as direct execution.
 
 ## Limitations and Future Work
 

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -138,9 +138,8 @@ constexpr llvm::StringLiteral
 /// Placeholder marker on copy_tile (replaced during DST assignment).
 constexpr llvm::StringLiteral kPlaceholderCopyAttrName("ttl.placeholder_copy");
 
-/// Module attribute carrying compiler-allocated DFB metadata.
-constexpr llvm::StringLiteral
-    kCompilerAllocatedDFBsAttrName("ttl.compiler_allocated_dfbs");
+/// Module attribute containing one runtime descriptor per physical DFB index.
+constexpr llvm::StringLiteral kDFBAllocationsAttrName("ttl.dfb_allocations");
 
 /// Module attributes carrying compiler-owned pipe resource allocation.
 constexpr llvm::StringLiteral

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -34,16 +34,21 @@ def TTL_BindCBOp : TTL_Op<"bind_cb", [Pure]> {
 
     - `cb_index` is the circular buffer hardware slot index (0-31).
     - `block_count` is the number of blocks (default 2 for double buffering).
+    - `dfb_id`, when present, identifies the logical dataflow buffer
+      independently of the physical slot selected by `cb_index`. Bindings in
+      different kernels with the same `dfb_id` refer to the same logical
+      buffer.
     Example:
 
     ```mlir
-    %cb = ttl.bind_cb {cb_index = 0 : index, block_count = 2}
-          : !ttl.cb<[1, 1], f32, 2>
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     ```
   }];
   let arguments = (ins
     IndexAttr:$cb_index,
-    DefaultValuedAttr<I64Attr, "2">:$block_count
+    DefaultValuedAttr<I64Attr, "2">:$block_count,
+    OptionalAttr<IndexAttr>:$dfb_id
   );
   let results = (outs TTL_CircularBuffer:$result);
   let assemblyFormat = "`{` `cb_index` `=` $cb_index `,` `block_count` `=` $block_count `}` attr-dict `:` type($result)";

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -95,6 +95,13 @@ inline mlir::tt::ttl::CBReserveOp findCBReserveForPipeReceive(mlir::Value dst) {
   return mlir::dyn_cast_or_null<CBReserveOp>(findCBAcquireOp(dst));
 }
 
+/// Returns the DFB declaration reached through unrealized conversion casts.
+///
+/// Returns a null operation when `dfb` does not resolve to `ttl.bind_cb`.
+inline BindCBOp getDFBDeclaration(mlir::Value dfb) {
+  return traceUnrealizedCasts(dfb).getDefiningOp<BindCBOp>();
+}
+
 /// Resolve the CB index attached to `cb`, accepting either the pre-conversion
 /// BindCBOp or the post-conversion GetCompileArgValOp.
 inline std::optional<int64_t> getCBIndex(mlir::Value cb) {
@@ -107,6 +114,39 @@ inline std::optional<int64_t> getCBIndex(mlir::Value cb) {
   }
   return std::nullopt;
 }
+
+/// Returns the logical DFB ID on the `ttl.bind_cb` reached from `cb`.
+///
+/// Returns failure when `cb` does not resolve to a declaration with `dfb_id`.
+FailureOr<int64_t> getDFBId(mlir::Value cb);
+
+/// Selects the identity contract diagnosed by verifyDFBOperandIdentities.
+enum class DFBIdentityRequirement {
+  /// The caller's analysis can resolve logical identity before finalization.
+  Logical,
+  /// The declaration must contain its finalized `dfb_id` attribute.
+  Finalized
+};
+
+/// Verifies the DFB operands selected by `operationFilter` with one resolver.
+///
+/// The caller defines which operations its analysis consumes and supplies the
+/// identity resolver appropriate to its pipeline position. Centralizing the
+/// operand walk prevents analyses from selecting different DFB operands when
+/// a recognized operation gains another operand.
+LogicalResult verifyDFBOperandIdentities(
+    ModuleOp moduleOp, StringRef consumerPass,
+    llvm::function_ref<bool(Operation *)> operationFilter,
+    llvm::function_ref<FailureOr<int64_t>(Value)> identityResolver,
+    StringRef operandDescription, DFBIdentityRequirement requirement);
+
+/// Verifies that DFB finalization completed and every logical ID is resolvable.
+///
+/// Requires allocation metadata, a `dfb_id` on every declaration, and a
+/// resolvable declaration for every DFB lifecycle operand. `consumerPass` is
+/// included in diagnostics so the required pipeline ordering is explicit.
+LogicalResult verifyResolvedDFBIdentities(ModuleOp moduleOp,
+                                          StringRef consumerPass);
 
 /// Return the element type for a ttcore::TileType.
 inline std::optional<mlir::Type> getTileElementType(mlir::Type type) {

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -234,11 +234,14 @@ def TTLInsertIntermediateDFBs
   let description = [{
     Walks ops implementing `DFBInputOpInterface` and checks whether the
     operands they declare as requiring DFB-attached values are satisfied.
-    It also records direct `ttl.store` operands whose computed source value is
-    stored in multiple blocks. Those stores cannot share one
-    output-publication position during `ttl.compute` creation, so that source
-    value is first routed through compiler DFB storage and each store reads the
-    attached value.
+    It also records direct `ttl.store` operands when one computed SSA value is
+    stored by operations in multiple MLIR basic blocks. A `ttl.compute`
+    operation is located in one MLIR basic block, and all output stores in its
+    body execute whenever the operation executes. Moving stores from different
+    MLIR basic blocks into one compute could therefore change their conditional
+    execution or violate SSA dominance. The pass materializes the computed
+    value once in a compiler DFB; each original store reads the attached value
+    and remains in its original MLIR basic block.
 
     When an operand comes from `ttl.compute`, the pass materializes it as an
     extra compute output backed by a compiler-allocated DFB. The pass creates
@@ -659,9 +662,11 @@ def TTLVerifyPipeNetGuards
 
     The pass expects one module per `@ttl.operation`, a well-formed
     `ttl.launch_grid` (i64 array of length 2 with positive entries), static
-    `I64Attr` coordinates on `ttl.create_pipe`, explicit DFB synchronization
-    inserted by `ttl-insert-cb-sync`, and a concrete provisional or final
-    `cb_index` on every `ttl.bind_cb`.
+    `I64Attr` coordinates on `ttl.create_pipe`, and explicit DFB synchronization
+    inserted by `ttl-insert-cb-sync`. Every user-declared DFB must have its
+    module-wide logical `dfb_id`; compiler-created DFBs receive analysis-only
+    logical IDs until physical index finalization. DFB lifecycle operands used
+    by the guard analysis must resolve to `ttl.bind_cb` declarations.
   }];
 }
 
@@ -714,7 +719,9 @@ def TTLVerifyPipeNetSchedule
     `ttl.launch_grid` attribute, and static `ttl.create_pipe` endpoints within
     that launch grid.
     `ttl-verify-pipenet-guards` must run first in the compiler pipeline so
-    invalid launch domains are reported separately.
+    invalid launch domains are reported separately. Both verifiers run after
+    DFB synchronization insertion and before DFB acquire coalescing and physical
+    index finalization.
   }];
 }
 
@@ -736,12 +743,13 @@ def TTLVerifyDFBSPSC
     : Pass<"ttl-verify-dfb-spsc", "::mlir::ModuleOp"> {
   let summary = "Reject DFBs with overlapping producer or consumer launch domains";
   let description = [{
-    Walks every `ttl.cb_reserve` and `ttl.cb_wait`, groups them by `cb_index`
-    (resolved via `getCBIndex`) and enclosing `ttl.kernel_thread`-tagged
-    `func.func`, and tracks the launch-node domain for each producer or
-    consumer participant. A DFB is valid when, for each launched node, at most
-    one producer thread reserves it and at most one consumer thread waits on it.
-    Disjoint domains across different kernel-thread functions are accepted.
+    Walks every `ttl.cb_reserve` and `ttl.cb_wait`, groups them by module-wide
+    logical `dfb_id` and enclosing `ttl.kernel_thread`-tagged `func.func`, and
+    tracks the launch-node domain for each producer or consumer participant.
+    A DFB is valid when, for each launched node, at most one producer kernel
+    reserves it and at most one consumer kernel waits on it. Disjoint domains
+    across different kernel functions are accepted. Distinct logical DFBs
+    remain separate when physical allocation assigns them the same `cb_index`.
 
     tt-metal circular buffers expose a counter pair (`pages_received`,
     `pages_acked`) that is not multi-writer safe on either side, so the
@@ -751,10 +759,10 @@ def TTLVerifyDFBSPSC
     domains, and for unknown domains when multiple threads participate and SPSC
     cannot be proven statically.
 
-    Prerequisite: `ttl-finalize-dfb-indices` must run first so that every
-    `bind_cb` carries a concrete `cb_index`, and modules with DFB acquire ops
-    must carry a valid `ttl.launch_grid` attribute. The pass asserts on
-    unresolvable indices.
+    The module must contain the `ttl.dfb_allocations` metadata emitted by
+    `ttl-finalize-dfb-indices`, and every DFB declaration and lifecycle operand
+    must resolve to a `ttl.bind_cb` with `dfb_id`. Modules with DFB acquire ops
+    must also carry a valid `ttl.launch_grid` attribute.
   }];
 
   let dependentDialects = [];
@@ -798,14 +806,19 @@ def TTLLowerSignpostToEmitC
 
 def TTLFinalizeDFBIndices
     : Pass<"ttl-finalize-dfb-indices", "::mlir::ModuleOp"> {
-  let summary = "Reuse compiler-allocated DFB indices and emit DFB metadata";
+  let summary = "Assign physical DFB indices and emit allocation metadata";
   let description = [{
     Module-level pass that runs after all DFB-creating and synchronization
     passes. Must precede `ttl-set-compute-kernel-config` and
     `ttl-annotate-cb-associations`, which copy DFB indices into attributes and
     would otherwise capture provisional indices.
 
-    Compiler-allocated DFBs enter this pass with kernel-local provisional
+    User-declared DFBs enter this pass with module-wide logical `dfb_id`
+    attributes. Compiler-created DFB declarations receive unique logical IDs.
+    The logical identity remains independent of the physical `cb_index`, so
+    later analyses can distinguish DFBs that share one hardware slot.
+
+    Compiler-created DFBs enter this pass with kernel-local provisional
     indices. The pass assigns each kernel a disjoint module-wide index range,
     then applies deterministic first-fit interval coloring, partitioned by
     CircularBufferType. A half-open lifetime starts at the first `cb_reserve` or
@@ -817,8 +830,11 @@ def TTLFinalizeDFBIndices
     all physical assignments and runtime metadata and validates capacity before
     modifying the IR, so a capacity error leaves provisional
     indices and existing kernel attributes unchanged. After validation, it
-    applies the assignments, updates `ttl.base_cta_index`, and builds the
-    `ttl.compiler_allocated_dfbs` module attribute for the Python runtime.
+    applies the physical assignments and logical identities, updates
+    `ttl.base_cta_index`, and builds the `ttl.dfb_allocations` module attribute
+    for the Python runtime. The attribute contains one descriptor per physical
+    index, including user-declared and compiler-created DFBs, and records the
+    page size computed from the finalized element type.
   }];
 }
 
@@ -863,7 +879,8 @@ def TTLDumpCBFlowGraph
   let summary = "Analyze and dump CB producer/consumer flow graph";
   let description = [{
     Analysis pass that builds a flow graph showing how data moves through
-    circular buffers between kernels. For each CB, identifies:
+    dataflow buffers between kernels. Logical DFB identity separates flows that
+    reuse one physical CB index. For each DFB, the graph identifies:
     - Producers: operations that write to the CB (cb_reserve + copy/store)
     - Consumers: operations that read from the CB (cb_wait)
     - DMA operations: copy ops with their direction (read/write)
@@ -871,7 +888,9 @@ def TTLDumpCBFlowGraph
 
     Outputs the graph in a human-readable format and optionally as JSON
     for consumption by the auto-profiler. The graph maps source locations
-    to CB operations, enabling correlation with runtime profiler data.
+    to CB operations, enabling correlation with runtime profiler data. JSON
+    entries include the logical `dfb_id` when available and the physical
+    `cb_index` used by runtime events.
 
     Example output:
     ```

--- a/include/ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBLOGICALIDENTITYANALYSIS_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBLOGICALIDENTITYANALYSIS_H
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <string>
+
+namespace mlir::tt::ttl {
+
+/// Resolved logical identity for one `ttl.bind_cb` declaration.
+struct DFBLogicalIdentityAssignment {
+  /// DFB declaration associated with `logicalId`.
+  BindCBOp declaration;
+
+  /// Module-wide identity shared by declarations of the same logical DFB.
+  int64_t logicalId = 0;
+};
+
+/// Resolves the module-wide logical identity of every DFB declaration.
+///
+/// User declarations must carry `dfb_id`. Compiler-created declarations
+/// receive IDs in module traversal order after all explicit IDs. The analysis
+/// does not modify IR, so callers can validate the complete identity assignment
+/// before materializing generated IDs.
+class DFBLogicalIdentityAnalysis {
+public:
+  /// Resolves every DFB declaration nested under the given `ModuleOp`.
+  ///
+  /// `operation` must be a `ModuleOp`. Invalid declarations are recorded as a
+  /// diagnostic operation and message rather than emitted by the analysis.
+  explicit DFBLogicalIdentityAnalysis(Operation *operation);
+
+  /// Returns true when every declaration has a valid logical identity.
+  bool succeeded() const { return errorMessage.empty(); }
+
+  /// Returns the diagnostic message recorded for a failed analysis.
+  StringRef getErrorMessage() const { return errorMessage; }
+
+  /// Returns the operation to which the analysis diagnostic should attach.
+  Operation *getErrorOperation() const { return errorOperation; }
+
+  /// Returns each DFB declaration and its resolved logical ID.
+  ArrayRef<DFBLogicalIdentityAssignment> getAssignments() const {
+    return assignments;
+  }
+
+  /// Returns the logical ID resolved for `declaration`.
+  ///
+  /// The declaration must belong to a successful analysis result.
+  int64_t getLogicalId(BindCBOp declaration) const;
+
+  /// Returns the logical ID for the declaration reached from `dfb`.
+  ///
+  /// Returns failure when `dfb` does not resolve to an analyzed declaration.
+  FailureOr<int64_t> getLogicalId(Value dfb) const;
+
+private:
+  SmallVector<DFBLogicalIdentityAssignment> assignments;
+  DenseMap<Operation *, int64_t> logicalIds;
+  Operation *errorOperation = nullptr;
+  std::string errorMessage;
+};
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBLOGICALIDENTITYANALYSIS_H

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -104,6 +104,9 @@ mlir::LogicalResult mlir::tt::ttl::BindCBOp::verify() {
   if (idx < 0) {
     return emitOpError() << "cb_index must be non-negative";
   }
+  if (auto dfbId = getDfbId(); dfbId && dfbId->isNegative()) {
+    return emitOpError() << "dfb_id must be non-negative";
+  }
 
   int64_t blockCount = getBlockCount();
   if (blockCount <= 0) {

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -9,6 +9,95 @@
 
 namespace mlir::tt::ttl {
 
+FailureOr<int64_t> getDFBId(Value cb) {
+  auto bindOp = getDFBDeclaration(cb);
+  if (!bindOp) {
+    return failure();
+  }
+  auto dfbId = bindOp.getDfbId();
+  if (!dfbId.has_value()) {
+    return failure();
+  }
+  return dfbId->getSExtValue();
+}
+
+LogicalResult verifyDFBOperandIdentities(
+    ModuleOp moduleOp, StringRef consumerPass,
+    llvm::function_ref<bool(Operation *)> operationFilter,
+    llvm::function_ref<FailureOr<int64_t>(Value)> identityResolver,
+    StringRef operandDescription, DFBIdentityRequirement requirement) {
+  WalkResult result = moduleOp.walk([&](Operation *operation) {
+    if (!operationFilter(operation)) {
+      return WalkResult::advance();
+    }
+    for (Value operand : operation->getOperands()) {
+      if (!isa<CircularBufferType>(operand.getType())) {
+        continue;
+      }
+      if (succeeded(identityResolver(operand))) {
+        continue;
+      }
+      InFlightDiagnostic diagnostic = operation->emitOpError();
+      diagnostic << "`" << consumerPass << "` requires every "
+                 << operandDescription
+                 << " operand to resolve to `ttl.bind_cb`";
+      if (requirement == DFBIdentityRequirement::Finalized) {
+        diagnostic << " with `dfb_id` after finalization";
+      }
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+
+LogicalResult verifyResolvedDFBIdentities(ModuleOp moduleOp,
+                                          StringRef consumerPass) {
+  bool hasAllocationMetadata = moduleOp->hasAttr(kDFBAllocationsAttrName);
+  bool hasDFB = false;
+  WalkResult result =
+      moduleOp.walk([&](Operation *nestedOperation) {
+        if (!isa<BindCBOp, CBReserveOp, CBPushOp, CBWaitOp, CBPopOp>(
+                nestedOperation)) {
+          return WalkResult::advance();
+        }
+        hasDFB = true;
+        if (!hasAllocationMetadata) {
+          return WalkResult::interrupt();
+        }
+        if (auto bindOp = dyn_cast<BindCBOp>(nestedOperation);
+            bindOp && !bindOp.getDfbId().has_value()) {
+          bindOp.emitOpError()
+              << "`" << consumerPass
+              << "` requires every `ttl.bind_cb` to have `dfb_id` after "
+                 "finalization";
+          return WalkResult::interrupt();
+        }
+
+        return WalkResult::advance();
+      });
+
+  if (!hasDFB) {
+    return success();
+  }
+  if (!hasAllocationMetadata) {
+    moduleOp.emitOpError()
+        << "`" << consumerPass
+        << "` requires finalized DFB allocation metadata; run "
+           "`ttl-finalize-dfb-indices` first";
+    return failure();
+  }
+  if (result.wasInterrupted()) {
+    return failure();
+  }
+  return verifyDFBOperandIdentities(
+      moduleOp, consumerPass,
+      [](Operation *operation) {
+        return isa<CBReserveOp, CBPushOp, CBWaitOp, CBPopOp>(operation);
+      },
+      getDFBId, "DFB lifecycle", DFBIdentityRequirement::Finalized);
+}
+
 std::optional<BcastType> getTileBroadcastType(ArrayRef<int64_t> dims,
                                               int64_t rank) {
   llvm::SmallDenseSet<int64_t> normalizedDims = normalizeDimsToSet(dims, rank);

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   IntermediateDFBPlanning.cpp
   ConvertTTLToTTKernel.cpp
   DFBAcquireReleaseAnalysis.cpp
+  DFBLogicalIdentityAnalysis.cpp
   DFBValueLifetimeAnalysis.cpp
   DFBMaterialization.cpp
   PipeGraph.cpp

--- a/lib/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+
+#include "mlir/IR/BuiltinOps.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace mlir::tt::ttl {
+
+DFBLogicalIdentityAnalysis::DFBLogicalIdentityAnalysis(Operation *operation) {
+  ModuleOp moduleOp = cast<ModuleOp>(operation);
+  int64_t maxExplicitId = -1;
+  int64_t compilerDeclarationCount = 0;
+  BindCBOp firstCompilerDeclaration;
+
+  // Discover the complete explicit ID range before generating IDs. Assigning
+  // generated IDs during this walk could collide with a later declaration.
+  WalkResult discoveryResult = moduleOp.walk([&](BindCBOp bindOp) {
+    if (auto dfbId = bindOp.getDfbId()) {
+      int64_t logicalId = dfbId->getSExtValue();
+      maxExplicitId = std::max(maxExplicitId, logicalId);
+      return WalkResult::advance();
+    }
+    if (!bindOp->hasAttr(kCompilerAllocatedAttrName)) {
+      errorOperation = bindOp;
+      errorMessage =
+          "user-declared DFB requires dfb_id before physical allocation";
+      return WalkResult::interrupt();
+    }
+    if (!firstCompilerDeclaration) {
+      firstCompilerDeclaration = bindOp;
+    }
+    ++compilerDeclarationCount;
+    return WalkResult::advance();
+  });
+  if (discoveryResult.wasInterrupted()) {
+    return;
+  }
+
+  if (compilerDeclarationCount > 0 &&
+      maxExplicitId >
+          std::numeric_limits<int64_t>::max() - compilerDeclarationCount) {
+    errorOperation = firstCompilerDeclaration;
+    errorMessage =
+        "logical DFB identifiers leave no space for compiler-created DFBs";
+    return;
+  }
+
+  int64_t nextCompilerId = compilerDeclarationCount > 0 ? maxExplicitId + 1 : 0;
+  llvm::DenseMap<int64_t, BindCBOp> firstDeclarationById;
+  // Declarations with one logical ID describe one allocation, so they must
+  // agree on the complete DFB type in every participating kernel.
+  moduleOp.walk([&](BindCBOp bindOp) {
+    auto dfbId = bindOp.getDfbId();
+    int64_t logicalId = dfbId ? dfbId->getSExtValue() : nextCompilerId++;
+    auto [firstDeclarationIt, inserted] =
+        firstDeclarationById.try_emplace(logicalId, bindOp);
+    if (!inserted && firstDeclarationIt->second.getResult().getType() !=
+                         bindOp.getResult().getType()) {
+      std::string message;
+      llvm::raw_string_ostream messageStream(message);
+      messageStream
+          << "logical DFB " << logicalId
+          << " has inconsistent types across kernel functions: expected "
+          << firstDeclarationIt->second.getResult().getType() << " but found "
+          << bindOp.getResult().getType();
+      errorOperation = bindOp;
+      errorMessage = messageStream.str();
+      return WalkResult::interrupt();
+    }
+    assignments.push_back({bindOp, logicalId});
+    logicalIds[bindOp.getOperation()] = logicalId;
+    return WalkResult::advance();
+  });
+}
+
+int64_t DFBLogicalIdentityAnalysis::getLogicalId(BindCBOp declaration) const {
+  auto logicalId = logicalIds.find(declaration.getOperation());
+  assert(logicalId != logicalIds.end() &&
+         "every DFB declaration must have a resolved logical identity");
+  return logicalId->second;
+}
+
+FailureOr<int64_t> DFBLogicalIdentityAnalysis::getLogicalId(Value dfb) const {
+  BindCBOp declaration = getDFBDeclaration(dfb);
+  if (!declaration) {
+    return failure();
+  }
+  auto logicalId = logicalIds.find(declaration.getOperation());
+  if (logicalId == logicalIds.end()) {
+    return failure();
+  }
+  return logicalId->second;
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBMaterialization.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBMaterialization.cpp
@@ -60,8 +60,8 @@ BindCBOp createCompilerAllocatedDFB(RankedTensorType tensorType, Location loc,
 
   auto indexAttr = builder.getIndexAttr(dfbIndex);
   auto blockCountAttr = builder.getI64IntegerAttr(blockCount);
-  auto bindDFB =
-      BindCBOp::create(builder, loc, dfbType, indexAttr, blockCountAttr);
+  auto bindDFB = BindCBOp::create(builder, loc, dfbType, indexAttr,
+                                  blockCountAttr, /*dfbId=*/nullptr);
   bindDFB->setAttr(kCompilerAllocatedAttrName, builder.getUnitAttr());
   return bindDFB;
 }

--- a/lib/Dialect/TTL/Transforms/TTLDumpCBFlowGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLDumpCBFlowGraph.cpp
@@ -22,6 +22,8 @@
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <optional>
+
 #define DEBUG_TYPE "ttl-dump-cb-flow-graph"
 
 namespace mlir::tt::ttl {
@@ -42,8 +44,8 @@ struct CBOpInfo {
 
 /// Information about a circular buffer in the flow graph.
 struct CBFlowInfo {
+  std::optional<int64_t> dfbId;
   int64_t cbIndex;
-  std::string name; // Variable name if available
   llvm::SmallVector<CBOpInfo> producers;
   llvm::SmallVector<CBOpInfo> consumers;
   llvm::SmallVector<CBOpInfo> dmaOps;  // copy operations
@@ -103,6 +105,18 @@ static std::string getThreadType(func::FuncOp func) {
 /// Check if a type is a CB type.
 static bool isCBType(Type type) { return isa<CircularBufferType>(type); }
 
+/// Return logical identity when available so physical reuse does not merge
+/// distinct DFB flows. Pre-finalization compiler DFBs fall back to their
+/// provisional physical index.
+static int64_t getDFBFlowKey(Value dfb) {
+  if (FailureOr<int64_t> dfbId = getDFBId(dfb); succeeded(dfbId)) {
+    return *dfbId;
+  }
+  std::optional<int64_t> cbIndex = getCBIndex(dfb);
+  assert(cbIndex.has_value() && "DFB operand must trace to a declaration");
+  return -*cbIndex - 1;
+}
+
 /// Get transfer direction from transfer handle type.
 static std::string getTransferDirection(Type handleType) {
   if (auto thType = dyn_cast<TransferHandleType>(handleType)) {
@@ -123,7 +137,7 @@ struct TTLDumpCBFlowGraphPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
-    // Map from CB index to flow info
+    // Map from logical DFB identity to flow info when identity is available.
     llvm::DenseMap<int64_t, CBFlowInfo> cbFlows;
 
     // Walk all functions
@@ -136,47 +150,50 @@ struct TTLDumpCBFlowGraphPass
         if (auto bindOp = dyn_cast<BindCBOp>(op)) {
           // Initialize CB flow info
           int64_t cbIndex = bindOp.getCbIndex().getSExtValue();
-          if (cbFlows.find(cbIndex) == cbFlows.end()) {
-            cbFlows[cbIndex] = CBFlowInfo{cbIndex, "", {}, {}, {}, {}};
+          FailureOr<int64_t> dfbId = getDFBId(bindOp.getResult());
+          int64_t flowKey = succeeded(dfbId) ? *dfbId : -cbIndex - 1;
+          if (cbFlows.find(flowKey) == cbFlows.end()) {
+            cbFlows[flowKey] =
+                CBFlowInfo{succeeded(dfbId) ? std::optional<int64_t>(*dfbId)
+                                            : std::nullopt,
+                           cbIndex,
+                           {},
+                           {},
+                           {},
+                           {}};
           }
         } else if (auto waitOp = dyn_cast<CBWaitOp>(op)) {
           // Consumer: cb_wait
-          std::optional<int64_t> cbIndex = getCBIndex(waitOp.getCb());
-          assert(cbIndex.has_value() &&
-                 "cb_wait operand must trace to a bind_cb");
+          int64_t flowKey = getDFBFlowKey(waitOp.getCb());
           CBOpInfo info{kernelName, threadType, getLineNumber(op), "cb_wait",
                         ""};
-          cbFlows[cbIndex.value()].consumers.push_back(info);
+          cbFlows[flowKey].consumers.push_back(info);
         } else if (auto reserveOp = dyn_cast<CBReserveOp>(op)) {
           // Producer: cb_reserve
-          std::optional<int64_t> cbIndex = getCBIndex(reserveOp.getCb());
-          assert(cbIndex.has_value() &&
-                 "cb_reserve operand must trace to a bind_cb");
+          int64_t flowKey = getDFBFlowKey(reserveOp.getCb());
           CBOpInfo info{kernelName, threadType, getLineNumber(op), "cb_reserve",
                         ""};
-          cbFlows[cbIndex.value()].producers.push_back(info);
+          cbFlows[flowKey].producers.push_back(info);
         } else if (auto copyOp = dyn_cast<CopyOp>(op)) {
           // DMA operation: one operand is a CB, the other a tensor.
           Value src = copyOp.getSrc();
           Value dst = copyOp.getDst();
           std::string direction;
-          std::optional<int64_t> cbIndex;
+          int64_t flowKey;
 
           if (isCBType(dst.getType())) {
-            cbIndex = getCBIndex(dst);
+            flowKey = getDFBFlowKey(dst);
             direction = "read"; // Reading from DRAM to CB
           } else if (isCBType(src.getType())) {
-            cbIndex = getCBIndex(src);
+            flowKey = getDFBFlowKey(src);
             direction = "write"; // Writing from CB to DRAM
           } else {
             return; // Tensor-to-tensor copy: no CB to record.
           }
 
-          assert(cbIndex.has_value() &&
-                 "copy CB operand must trace to a bind_cb");
           CBOpInfo info{kernelName, threadType, getLineNumber(op), "copy",
                         direction};
-          cbFlows[cbIndex.value()].dmaOps.push_back(info);
+          cbFlows[flowKey].dmaOps.push_back(info);
         } else if (auto waitOp = dyn_cast<WaitOp>(op)) {
           // DMA wait/barrier — trace back to the copy op to find the CB.
           auto copyOp = waitOp.getXf().getDefiningOp<CopyOp>();
@@ -187,21 +204,19 @@ struct TTLDumpCBFlowGraphPass
               getTransferDirection(waitOp.getXf().getType());
           Value src = copyOp.getSrc();
           Value dst = copyOp.getDst();
-          std::optional<int64_t> cbIndex;
+          int64_t flowKey;
 
           if (isCBType(dst.getType())) {
-            cbIndex = getCBIndex(dst);
+            flowKey = getDFBFlowKey(dst);
           } else if (isCBType(src.getType())) {
-            cbIndex = getCBIndex(src);
+            flowKey = getDFBFlowKey(src);
           } else {
             return; // Tensor-to-tensor copy: no CB to record.
           }
 
-          assert(cbIndex.has_value() &&
-                 "copy CB operand must trace to a bind_cb");
           CBOpInfo info{kernelName, threadType, getLineNumber(op), "wait",
                         direction};
-          cbFlows[cbIndex.value()].waitOps.push_back(info);
+          cbFlows[flowKey].waitOps.push_back(info);
         }
       });
     });
@@ -223,8 +238,14 @@ struct TTLDumpCBFlowGraphPass
     llvm::errs() << "CB Flow Graph\n";
     llvm::errs() << "========================================\n";
 
-    for (const auto &[cbIndex, info] : cbFlows) {
-      llvm::errs() << "\nCB[" << cbIndex << "]:\n";
+    for (const auto &flowEntry : cbFlows) {
+      const CBFlowInfo &info = flowEntry.second;
+      if (info.dfbId) {
+        llvm::errs() << "\nDFB[" << *info.dfbId << "] CB[" << info.cbIndex
+                     << "]:\n";
+      } else {
+        llvm::errs() << "\nCB[" << info.cbIndex << "]:\n";
+      }
 
       if (!info.producers.empty()) {
         llvm::errs() << "  producers:\n";
@@ -266,9 +287,13 @@ struct TTLDumpCBFlowGraphPass
     llvm::json::Object root;
     llvm::json::Array cbArray;
 
-    for (const auto &[cbIndex, info] : cbFlows) {
+    for (const auto &flowEntry : cbFlows) {
+      const CBFlowInfo &info = flowEntry.second;
       llvm::json::Object cbObj;
-      cbObj["cb_index"] = cbIndex;
+      cbObj["cb_index"] = info.cbIndex;
+      if (info.dfbId) {
+        cbObj["dfb_id"] = *info.dfbId;
+      }
 
       auto opsToArray = [](const llvm::SmallVector<CBOpInfo> &ops) {
         llvm::json::Array arr;

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -6,23 +6,25 @@
 // TTL Finalize DFB Indices
 //===----------------------------------------------------------------------===//
 //
-// Plans module-wide physical indices for compiler-created DFBs after DFB
-// creation and synchronization. Pass-order, lifecycle, and capacity checks
-// complete before the plan updates declarations, kernel attributes, or runtime
-// metadata.
+// Plans module-wide logical identities, physical indices, and runtime metadata
+// after DFB creation and synchronization. Pass-order, lifecycle, identity,
+// capacity, and metadata checks complete before the plan modifies the IR.
 //
 //===----------------------------------------------------------------------===//
 
+#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 #include "ttlang/Dialect/TTL/Passes.h"
+#include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/LiveIntervalUtils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
@@ -74,18 +76,6 @@ static LogicalResult verifyFinalizationPrecedesIndexCopies(ModuleOp moduleOp) {
   return success(!walkResult.wasInterrupted());
 }
 
-static int32_t getFirstCompilerDFBIndex(ModuleOp moduleOp) {
-  int32_t maxUserIndex = -1;
-  moduleOp->walk([&](BindCBOp bindOp) {
-    if (bindOp->hasAttr(kCompilerAllocatedAttrName)) {
-      return;
-    }
-    maxUserIndex = std::max(
-        maxUserIndex, static_cast<int32_t>(bindOp.getCbIndex().getSExtValue()));
-  });
-  return maxUserIndex + 1;
-}
-
 /// Rejects compiler-created DFB declarations missing a lifecycle operation.
 ///
 /// Finalization may span any number of transactions. Auto-sync is assumed to
@@ -124,23 +114,28 @@ static LogicalResult verifyCompilerDFBLifecycleOperations(BindCBOp bindOp) {
   return success();
 }
 
-/// One compiler-created DFB's final physical index.
+/// One DFB declaration's final physical index.
 struct DFBIndexAssignment {
   BindCBOp declaration;
   int32_t physicalIndex;
 };
 
-/// One runtime metadata entry for a physical compiler-created DFB.
-struct CompilerDFBMetadataEntry {
+/// One runtime metadata entry for a physical DFB.
+struct DFBAllocationMetadataEntry {
   int32_t physicalIndex;
+  /// Representative declaration supplying the exact DFB type.
   BindCBOp declaration;
 };
 
-/// Complete compiler-created DFB allocation validated before IR mutation.
-struct CompilerDFBAllocationPlan {
+/// Complete DFB finalization plan validated before IR mutation.
+struct DFBAllocationPlan {
+  /// Physical-index updates for every DFB declaration.
   SmallVector<DFBIndexAssignment> assignments;
-  SmallVector<CompilerDFBMetadataEntry> metadata;
+  /// One runtime descriptor for each unique physical index.
+  SmallVector<DFBAllocationMetadataEntry> metadata;
+  /// Size of the dense zero-based physical-index range.
   int32_t physicalDFBCount = 0;
+  /// Compiler-owned slots reported if the hardware limit is exceeded.
   int32_t compilerSlotCount = 0;
 };
 
@@ -267,19 +262,54 @@ planPhysicalDFBIndices(func::FuncOp kernel, ArrayRef<BindCBOp> dfbOps,
   return nextSlotOffset;
 }
 
-/// Builds all physical assignments and metadata before applying either.
+/// Builds all physical assignments and runtime metadata before modifying IR.
 ///
-/// User-declared indices are assumed to be final. Compiler indices are placed
-/// after the greatest user index, so allocation cannot alias user storage. The
-/// type partition used by `planPhysicalDFBIndices` guarantees that shared
-/// compiler indices have one exact DFB type; an assertion protects that
-/// internal invariant while constructing the runtime metadata table.
-static FailureOr<CompilerDFBAllocationPlan> buildCompilerDFBAllocationPlan(
+/// User-declared physical indices are compacted while preserving any existing
+/// sharing. Compiler indices follow the compacted user range, so allocation
+/// cannot alias user storage. Metadata includes every declaration because user
+/// DFBs and compiler-created DFBs use the same runtime allocation mechanism.
+/// Declarations may share a physical index only when their exact DFB types
+/// match.
+static FailureOr<DFBAllocationPlan> buildDFBAllocationPlan(
     ModuleOp moduleOp,
-    const llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> &kernelToDFBs) {
-  CompilerDFBAllocationPlan plan;
-  int32_t firstCompilerDFBIndex = getFirstCompilerDFBIndex(moduleOp);
-  int32_t nextCompilerDFBIndex = firstCompilerDFBIndex;
+    const llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> &kernelToDFBs,
+    const DFBLogicalIdentityAnalysis &identityAnalysis) {
+  DFBAllocationPlan plan;
+
+  DenseSet<int64_t> uniqueUserProvisionalIndices;
+  for (const DFBLogicalIdentityAssignment &identity :
+       identityAnalysis.getAssignments()) {
+    BindCBOp declaration = identity.declaration;
+    if (declaration->hasAttr(kCompilerAllocatedAttrName)) {
+      continue;
+    }
+    int64_t provisionalIndex = declaration.getCbIndex().getSExtValue();
+    uniqueUserProvisionalIndices.insert(provisionalIndex);
+  }
+
+  SmallVector<int64_t> sortedUserProvisionalIndices(
+      uniqueUserProvisionalIndices.begin(), uniqueUserProvisionalIndices.end());
+  llvm::sort(sortedUserProvisionalIndices);
+
+  DenseMap<int64_t, int32_t> compactedUserIndices;
+  for (auto [physicalIndex, provisionalIndex] :
+       llvm::enumerate(sortedUserProvisionalIndices)) {
+    compactedUserIndices[provisionalIndex] =
+        static_cast<int32_t>(physicalIndex);
+  }
+  for (const DFBLogicalIdentityAssignment &identity :
+       identityAnalysis.getAssignments()) {
+    BindCBOp declaration = identity.declaration;
+    if (declaration->hasAttr(kCompilerAllocatedAttrName)) {
+      continue;
+    }
+    int64_t provisionalIndex = declaration.getCbIndex().getSExtValue();
+    plan.assignments.push_back(
+        {declaration, compactedUserIndices.lookup(provisionalIndex)});
+  }
+
+  int32_t nextCompilerDFBIndex =
+      static_cast<int32_t>(sortedUserProvisionalIndices.size());
   for (const auto &[kernel, dfbOps] : kernelToDFBs) {
     int32_t physicalSlotCount = planPhysicalDFBIndices(
         kernel, dfbOps, nextCompilerDFBIndex, plan.assignments);
@@ -299,15 +329,42 @@ static FailureOr<CompilerDFBAllocationPlan> buildCompilerDFBAllocationPlan(
     return failure();
   }
 
-  DenseMap<int32_t, BindCBOp> uniqueByIndex;
+  DenseMap<Operation *, int32_t> plannedIndices;
   for (const DFBIndexAssignment &assignment : plan.assignments) {
     BindCBOp declaration = assignment.declaration;
-    auto [existingAssignment, inserted] =
-        uniqueByIndex.try_emplace(assignment.physicalIndex, declaration);
-    if (!inserted) {
-      assert(existingAssignment->second.getResult().getType() ==
-                 declaration.getResult().getType() &&
-             "shared compiler DFB index must have one exact type");
+    plannedIndices[declaration.getOperation()] = assignment.physicalIndex;
+  }
+
+  DenseMap<int64_t, int32_t> physicalIndexByLogicalId;
+  DenseMap<int32_t, BindCBOp> uniqueByIndex;
+  for (const DFBLogicalIdentityAssignment &identity :
+       identityAnalysis.getAssignments()) {
+    BindCBOp declaration = identity.declaration;
+    auto plannedIndex = plannedIndices.find(declaration.getOperation());
+    assert(plannedIndex != plannedIndices.end() &&
+           "every DFB declaration must have a planned index");
+    int32_t physicalIndex = plannedIndex->second;
+
+    auto [logicalIndex, insertedLogicalIndex] =
+        physicalIndexByLogicalId.try_emplace(identity.logicalId, physicalIndex);
+    if (!insertedLogicalIndex && logicalIndex->second != physicalIndex) {
+      declaration.emitOpError()
+          << "logical DFB " << identity.logicalId
+          << " has inconsistent physical indices " << logicalIndex->second
+          << " and " << physicalIndex;
+      return failure();
+    }
+
+    auto [existingDeclaration, inserted] =
+        uniqueByIndex.try_emplace(physicalIndex, declaration);
+    if (!inserted && existingDeclaration->second.getResult().getType() !=
+                         declaration.getResult().getType()) {
+      declaration.emitOpError()
+          << "physical DFB index " << physicalIndex
+          << " has inconsistent CircularBufferType values "
+          << existingDeclaration->second.getResult().getType() << " and "
+          << declaration.getResult().getType();
+      return failure();
     }
   }
 
@@ -316,6 +373,16 @@ static FailureOr<CompilerDFBAllocationPlan> buildCompilerDFBAllocationPlan(
   llvm::sort(sortedMetadata, [](const auto &lhs, const auto &rhs) {
     return lhs.first < rhs.first;
   });
+  for (auto [expectedIndex, metadata] : llvm::enumerate(sortedMetadata)) {
+    auto [physicalIndex, declaration] = metadata;
+    if (physicalIndex != static_cast<int32_t>(expectedIndex)) {
+      declaration.emitOpError()
+          << "physical DFB indices must form a dense zero-based range; "
+             "expected index "
+          << expectedIndex << " but found " << physicalIndex;
+      return failure();
+    }
+  }
   for (auto [physicalIndex, declaration] : sortedMetadata) {
     plan.metadata.push_back({physicalIndex, declaration});
   }
@@ -323,31 +390,32 @@ static FailureOr<CompilerDFBAllocationPlan> buildCompilerDFBAllocationPlan(
 }
 
 /// Applies a complete plan after every operation that can fail has succeeded.
-static void
-applyCompilerDFBAllocationPlan(ModuleOp moduleOp, OpBuilder &builder,
-                               const CompilerDFBAllocationPlan &plan) {
+static void applyDFBAllocationPlan(
+    ModuleOp moduleOp, OpBuilder &builder, const DFBAllocationPlan &plan,
+    ArrayRef<DFBLogicalIdentityAssignment> identityAssignments) {
   MLIRContext *context = moduleOp.getContext();
   for (const DFBIndexAssignment &assignment : plan.assignments) {
     BindCBOp declaration = assignment.declaration;
     declaration.setCbIndexAttr(
         IntegerAttr::get(IndexType::get(context), assignment.physicalIndex));
   }
-
-  if (plan.physicalDFBCount <= 0) {
-    return;
+  for (const DFBLogicalIdentityAssignment &assignment : identityAssignments) {
+    BindCBOp declaration = assignment.declaration;
+    declaration.setDfbIdAttr(
+        IntegerAttr::get(IndexType::get(context), assignment.logicalId));
   }
-  moduleOp->walk([&](func::FuncOp kernel) {
-    if (kernel->hasAttr(kBaseCTAIndexAttrName)) {
-      kernel->setAttr(kBaseCTAIndexAttrName,
-                      builder.getI32IntegerAttr(plan.physicalDFBCount));
-    }
-  });
 
-  if (plan.metadata.empty()) {
-    return;
+  if (plan.physicalDFBCount > 0) {
+    moduleOp->walk([&](func::FuncOp kernel) {
+      if (kernel->hasAttr(kBaseCTAIndexAttrName)) {
+        kernel->setAttr(kBaseCTAIndexAttrName,
+                        builder.getI32IntegerAttr(plan.physicalDFBCount));
+      }
+    });
   }
+
   SmallVector<Attribute> metadataAttributes;
-  for (const CompilerDFBMetadataEntry &metadata : plan.metadata) {
+  for (const DFBAllocationMetadataEntry &metadata : plan.metadata) {
     BindCBOp declaration = metadata.declaration;
     auto dfbType = cast<CircularBufferType>(declaration.getResult().getType());
     SmallVector<NamedAttribute> entryAttributes;
@@ -359,11 +427,15 @@ applyCompilerDFBAllocationPlan(ModuleOp moduleOp, OpBuilder &builder,
     entryAttributes.push_back(builder.getNamedAttr(
         "element_type", TypeAttr::get(dfbType.getElementType())));
     entryAttributes.push_back(builder.getNamedAttr(
+        "page_size",
+        builder.getI32IntegerAttr(static_cast<int32_t>(
+            ttcore::getElementSizeBytes(dfbType.getElementType())))));
+    entryAttributes.push_back(builder.getNamedAttr(
         "block_count", builder.getI32IntegerAttr(
                            static_cast<int32_t>(dfbType.getBlockCount()))));
     metadataAttributes.push_back(DictionaryAttr::get(context, entryAttributes));
   }
-  moduleOp->setAttr(kCompilerAllocatedDFBsAttrName,
+  moduleOp->setAttr(kDFBAllocationsAttrName,
                     ArrayAttr::get(context, metadataAttributes));
 }
 
@@ -372,6 +444,20 @@ struct TTLFinalizeDFBIndicesPass
   void runOnOperation() override {
     auto moduleOp = getOperation();
     OpBuilder builder(moduleOp.getContext());
+
+    // Validate logical identities before building the physical allocation plan
+    // so every failure leaves the input IR unchanged.
+    const DFBLogicalIdentityAnalysis &identityAnalysis =
+        getAnalysis<DFBLogicalIdentityAnalysis>();
+    if (!identityAnalysis.succeeded()) {
+      Operation *errorOperation = identityAnalysis.getErrorOperation();
+      if (!errorOperation) {
+        errorOperation = moduleOp.getOperation();
+      }
+      errorOperation->emitOpError() << identityAnalysis.getErrorMessage();
+      signalPassFailure();
+      return;
+    }
 
     llvm::MapVector<func::FuncOp, SmallVector<BindCBOp>> kernelToDFBs;
     moduleOp->walk([&](BindCBOp bindOp) {
@@ -396,8 +482,8 @@ struct TTLFinalizeDFBIndicesPass
       }
     }
 
-    FailureOr<CompilerDFBAllocationPlan> plan =
-        buildCompilerDFBAllocationPlan(moduleOp, kernelToDFBs);
+    FailureOr<DFBAllocationPlan> plan =
+        buildDFBAllocationPlan(moduleOp, kernelToDFBs, identityAnalysis);
     if (failed(plan)) {
       signalPassFailure();
       return;
@@ -405,7 +491,8 @@ struct TTLFinalizeDFBIndicesPass
 
     LLVM_DEBUG(llvm::dbgs()
                << "Total DFB count: " << plan->physicalDFBCount << "\n");
-    applyCompilerDFBAllocationPlan(moduleOp, builder, *plan);
+    applyDFBAllocationPlan(moduleOp, builder, *plan,
+                           identityAnalysis.getAssignments());
   }
 };
 

--- a/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
@@ -6,9 +6,10 @@
 // TTL Verify DFB SPSC
 //===----------------------------------------------------------------------===//
 //
-// Rejects modules in which a dataflow buffer (identified by its `cb_index`) has
-// more than one producer or consumer kernel thread active on the same launched
-// node. tt-metal CBs are single-producer single-consumer at the API level; see
+// Rejects modules in which a logical dataflow buffer has more than one producer
+// or consumer kernel active on the same launched node. Logical identity
+// remains distinct when non-overlapping DFBs share a physical `cb_index`.
+// tt-metal CBs are single-producer single-consumer at the API level; see
 // `docs/development/DFBManagement.md` for the rationale.
 //
 //===----------------------------------------------------------------------===//
@@ -52,7 +53,7 @@ struct DFBParticipant {
   Operation *unanalyzableOp = nullptr;
 };
 
-/// Producers or consumers for one finalized dataflow buffer index.
+/// Producers or consumers for one logical dataflow buffer.
 struct DFBParticipantSet {
   llvm::SmallMapVector<func::FuncOp, DFBParticipant, 2> participants;
 };
@@ -98,14 +99,14 @@ void attachCommonNotes(InFlightDiagnostic &diag, Operation *bindSite,
 }
 
 /// Emit the error for two participant domains with a proven common launch node.
-void emitOverlapError(int64_t cbIndex, const DFBParticipant &lhs,
+void emitOverlapError(int64_t logicalId, const DFBParticipant &lhs,
                       const DFBParticipant &rhs,
                       const LaunchNodeDomain &overlap, Operation *bindSite,
                       llvm::StringRef role, llvm::StringRef verbedHere) {
   InFlightDiagnostic diag = lhs.op->emitError()
-                            << "dataflow buffer cb_index=" << cbIndex << " has "
-                            << "multiple " << role
-                            << " threads active on the same launched node";
+                            << "logical DFB " << logicalId << " has multiple "
+                            << role
+                            << " kernels active on the same launched node";
   if (!overlap.nodes.empty()) {
     LaunchNodeCoord example = *overlap.nodes.begin();
     diag.attachNote() << "example overlapping node: core_x=" << example.x
@@ -117,7 +118,7 @@ void emitOverlapError(int64_t cbIndex, const DFBParticipant &lhs,
 
 /// Emit the conservative error used when a domain-dependent predicate could not
 /// be evaluated statically.
-void emitUnknownDomainError(int64_t cbIndex, const DFBParticipantSet &set,
+void emitUnknownDomainError(int64_t logicalId, const DFBParticipantSet &set,
                             Operation *bindSite, llvm::StringRef role,
                             llvm::StringRef verbedHere) {
   auto unknownIt = llvm::find_if(set.participants, [](const auto &entry) {
@@ -127,10 +128,11 @@ void emitUnknownDomainError(int64_t cbIndex, const DFBParticipantSet &set,
          "expected at least one unknown participant domain");
 
   const DFBParticipant &primary = unknownIt->second;
-  InFlightDiagnostic diag =
-      primary.op->emitError()
-      << "dataflow buffer cb_index=" << cbIndex << " has multiple " << role
-      << " threads, but SPSC could not be statically proven";
+  InFlightDiagnostic diag = primary.op->emitError()
+                            << "logical DFB " << logicalId << " has multiple "
+                            << role
+                            << " kernels, but SPSC could not be statically "
+                               "proven";
   if (primary.unanalyzableOp) {
     diag.attachNote(primary.unanalyzableOp->getLoc())
         << "this expression is not statically analyzable";
@@ -148,7 +150,7 @@ void emitUnknownDomainError(int64_t cbIndex, const DFBParticipantSet &set,
 
 /// Verify one dataflow buffer role after participants have been coalesced by
 /// kernel thread.
-bool verifyParticipantSet(int64_t cbIndex, const DFBParticipantSet &set,
+bool verifyParticipantSet(int64_t logicalId, const DFBParticipantSet &set,
                           Operation *bindSite, llvm::StringRef role,
                           llvm::StringRef verbedHere) {
   if (set.participants.size() <= 1) {
@@ -162,7 +164,7 @@ bool verifyParticipantSet(int64_t cbIndex, const DFBParticipantSet &set,
       const DFBParticipant &rhs = rhsIt->second;
       LaunchNodeDomain overlap = lhs.domain.intersectWith(rhs.domain);
       if (overlap.known && !overlap.nodes.empty()) {
-        emitOverlapError(cbIndex, lhs, rhs, overlap, bindSite, role,
+        emitOverlapError(logicalId, lhs, rhs, overlap, bindSite, role,
                          verbedHere);
         return true;
       }
@@ -172,7 +174,7 @@ bool verifyParticipantSet(int64_t cbIndex, const DFBParticipantSet &set,
   if (llvm::any_of(set.participants, [](const auto &entry) {
         return !entry.second.domain.known;
       })) {
-    emitUnknownDomainError(cbIndex, set, bindSite, role, verbedHere);
+    emitUnknownDomainError(logicalId, set, bindSite, role, verbedHere);
     return true;
   }
   return false;
@@ -183,26 +185,47 @@ struct TTLVerifyDFBSPSCPass
   void runOnOperation() override {
     ModuleOp module = getOperation();
 
-    ModuleState state;
-    state.initialize(module);
+    if (failed(verifyResolvedDFBIdentities(module, getArgument()))) {
+      signalPassFailure();
+      return;
+    }
 
-    bool hasAcquire = false;
     llvm::DenseMap<int64_t, Operation *> bindSites;
+    llvm::DenseMap<int64_t, int64_t> physicalIndices;
+    bool hasInconsistentIndex = false;
 
-    module.walk([&](Operation *op) {
-      if (isa<CBReserveOp, CBWaitOp>(op) && getEnclosingKernelThread(op)) {
-        hasAcquire = true;
-      } else if (auto bindOp = dyn_cast<BindCBOp>(op)) {
-        std::optional<int64_t> idx = getCBIndex(bindOp.getResult());
-        if (idx.has_value()) {
-          bindSites.try_emplace(*idx, op);
-        }
+    // Finalization normally guarantees this mapping. The check remains here
+    // because the verifier also supports direct invocation on finalized IR.
+    module.walk([&](BindCBOp bindOp) {
+      FailureOr<int64_t> dfbId = getDFBId(bindOp.getResult());
+      assert(succeeded(dfbId) && "DFB identities were verified");
+      int64_t cbIndex = bindOp.getCbIndex().getSExtValue();
+      bindSites.try_emplace(*dfbId, bindOp);
+      auto [indexIt, inserted] = physicalIndices.try_emplace(*dfbId, cbIndex);
+      if (!inserted && indexIt->second != cbIndex) {
+        bindOp.emitOpError() << "logical DFB " << *dfbId
+                             << " has inconsistent finalized cb_index values "
+                             << indexIt->second << " and " << cbIndex;
+        hasInconsistentIndex = true;
       }
     });
 
+    if (hasInconsistentIndex) {
+      signalPassFailure();
+      return;
+    }
+
+    bool hasAcquire = false;
+    module.walk([&](Operation *op) {
+      hasAcquire |=
+          isa<CBReserveOp, CBWaitOp>(op) && getEnclosingKernelThread(op);
+    });
     if (!hasAcquire) {
       return;
     }
+
+    ModuleState state;
+    state.initialize(module);
     if (!state.hasLaunchGrid) {
       module.emitError()
           << "ttl-verify-dfb-spsc requires a `ttl.launch_grid` module "
@@ -231,43 +254,41 @@ struct TTLVerifyDFBSPSCPass
       return;
     }
 
-    llvm::MapVector<int64_t, DFBParticipantSet> producers;
-    llvm::MapVector<int64_t, DFBParticipantSet> consumers;
+    llvm::MapVector<int64_t, DFBParticipantSet> producersByDFB;
+    llvm::MapVector<int64_t, DFBParticipantSet> consumersByDFB;
 
-    auto record = [&](llvm::MapVector<int64_t, DFBParticipantSet> &perCB,
+    auto record = [&](llvm::MapVector<int64_t, DFBParticipantSet> &perDFB,
                       Operation *op, Value cb) {
       func::FuncOp thread = getEnclosingKernelThread(op);
       if (!thread) {
         return;
       }
-      std::optional<int64_t> idx = getCBIndex(cb);
-      assert(idx.has_value() &&
-             "ttl-verify-dfb-spsc requires finalized cb_index; run "
-             "ttl-finalize-dfb-indices first");
+      FailureOr<int64_t> dfbId = getDFBId(cb);
+      assert(succeeded(dfbId) && "DFB identities were verified");
       auto domainIt = state.acquireDomains.find(op);
       AcquireDomain acquireDomain =
           domainIt == state.acquireDomains.end()
               ? AcquireDomain{LaunchNodeDomain::unknown(), op}
               : domainIt->second;
-      addParticipant(perCB[*idx], thread, op, acquireDomain.domain,
+      addParticipant(perDFB[*dfbId], thread, op, acquireDomain.domain,
                      acquireDomain.unanalyzableOp);
     };
 
     module.walk([&](Operation *op) {
       if (auto reserveOp = dyn_cast<CBReserveOp>(op)) {
-        record(producers, op, reserveOp.getCb());
+        record(producersByDFB, op, reserveOp.getCb());
       } else if (auto waitOp = dyn_cast<CBWaitOp>(op)) {
-        record(consumers, op, waitOp.getCb());
+        record(consumersByDFB, op, waitOp.getCb());
       }
     });
 
     bool sawError = false;
-    for (auto &entry : producers) {
+    for (auto &entry : producersByDFB) {
       sawError |= verifyParticipantSet(entry.first, entry.second,
                                        bindSites.lookup(entry.first),
                                        "producer", "reserved");
     }
-    for (auto &entry : consumers) {
+    for (auto &entry : consumersByDFB) {
       sawError |= verifyParticipantSet(entry.first, entry.second,
                                        bindSites.lookup(entry.first),
                                        "consumer", "waited on");

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -20,6 +20,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
+#include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/PipeTransferAnalysis.h"
 #include "llvm/ADT/DenseMap.h"
@@ -61,7 +62,7 @@ constexpr std::size_t kMaxPipeScheduleNodesPerLaunchNode = 4096;
 struct WaitUse {
   CBWaitOp op;
   LaunchNodeDomain domain;
-  int64_t cbIndex;
+  int64_t dfbId;
 };
 
 /// Pipe synchronization event used by the wait-for graph verifier.
@@ -100,14 +101,24 @@ void checkKnownSubset(Operation *op, const LaunchNodeDomain &current,
 
 /// Mutable facts recorded during one verifier pass.
 struct ModuleState {
+  /// Constructs state for schedule verification.
   ModuleState(const PipeTransferIndex &transfers,
               const LaunchNodeDomainState &launchDomains)
       : transfers(transfers), launchDomains(launchDomains) {}
 
+  /// Constructs state for guard verification with resolved DFB identities.
+  ModuleState(const PipeTransferIndex &transfers,
+              const LaunchNodeDomainState &launchDomains,
+              const DFBLogicalIdentityAnalysis &dfbIdentities)
+      : transfers(transfers), launchDomains(launchDomains),
+        dfbIdentities(&dfbIdentities) {}
+
   const PipeTransferIndex &transfers;
   const LaunchNodeDomainState &launchDomains;
+  /// Logical identities required by guard verification.
+  const DFBLogicalIdentityAnalysis *dfbIdentities = nullptr;
   bool sawError = false;
-  llvm::DenseMap<int64_t, LaunchNodeDomain> cbProducerDomains;
+  llvm::DenseMap<int64_t, LaunchNodeDomain> dfbProducerDomains;
   SmallVector<WaitUse> waitUses;
   SmallVector<PipeEvent> pipeEvents;
   llvm::DenseMap<Operation *, std::size_t> pipeEventIndices;
@@ -432,6 +443,7 @@ void verifyPipeNetScope(PipeNetScopeOp scopeOp, const LaunchNodeDomain &domain,
 /// a specific operation kind.
 void recordGuardOperation(Operation *op, const LaunchNodeDomain &domain,
                           Operation *unanalyzableOp, ModuleState &state) {
+  assert(state.dfbIdentities && "guard verification requires DFB identities");
   TypeSwitch<Operation *>(op)
       .Case<CopyOp>(
           [&](CopyOp copy) { verifyCopy(copy, domain, unanalyzableOp, state); })
@@ -439,15 +451,17 @@ void recordGuardOperation(Operation *op, const LaunchNodeDomain &domain,
         verifyPipeWaitGuard(wait, domain, unanalyzableOp, state);
       })
       .Case<CBPushOp>([&](CBPushOp push) {
-        if (auto cbIndex = getCBIndex(push.getCb())) {
-          state.cbProducerDomains[*cbIndex] =
-              state.cbProducerDomains[*cbIndex].unionWith(domain);
-        }
+        FailureOr<int64_t> dfbId =
+            state.dfbIdentities->getLogicalId(push.getCb());
+        assert(succeeded(dfbId) && "DFB operands were verified");
+        state.dfbProducerDomains[*dfbId] =
+            state.dfbProducerDomains[*dfbId].unionWith(domain);
       })
       .Case<CBWaitOp>([&](CBWaitOp wait) {
-        if (auto cbIndex = getCBIndex(wait.getCb())) {
-          state.waitUses.push_back({wait, domain, *cbIndex});
-        }
+        FailureOr<int64_t> dfbId =
+            state.dfbIdentities->getLogicalId(wait.getCb());
+        assert(succeeded(dfbId) && "DFB operands were verified");
+        state.waitUses.push_back({wait, domain, *dfbId});
       });
 }
 
@@ -468,8 +482,8 @@ void recordScheduleOperation(Operation *op, const LaunchNodeDomain &domain,
 // covered by any producer (deadlock-prone IR).
 void verifyCBWaits(ModuleState &state) {
   for (WaitUse &use : state.waitUses) {
-    auto it = state.cbProducerDomains.find(use.cbIndex);
-    if (it == state.cbProducerDomains.end()) {
+    auto it = state.dfbProducerDomains.find(use.dfbId);
+    if (it == state.dfbProducerDomains.end()) {
       use.op.emitOpError()
           << "this `cb_wait` reads from a dataflow buffer that no other "
              "thread fills; check that another `@ttl.compute()` or "
@@ -486,6 +500,26 @@ void verifyCBWaits(ModuleState &state) {
                      "...` predicate the producer uses",
                      /*roles=*/{}, state);
   }
+}
+
+/// Validate logical DFB identities and every operand read by guard analysis.
+LogicalResult
+verifyGuardDFBIdentities(ModuleOp module,
+                         const DFBLogicalIdentityAnalysis &dfbIdentities) {
+  if (!dfbIdentities.succeeded()) {
+    Operation *errorOperation = dfbIdentities.getErrorOperation();
+    if (!errorOperation) {
+      errorOperation = module.getOperation();
+    }
+    errorOperation->emitOpError() << dfbIdentities.getErrorMessage();
+    return failure();
+  }
+
+  return verifyDFBOperandIdentities(
+      module, "ttl-verify-pipenet-guards",
+      [](Operation *operation) { return isa<CBPushOp, CBWaitOp>(operation); },
+      [&](Value dfb) { return dfbIdentities.getLogicalId(dfb); },
+      "`ttl.cb_push` and `ttl.cb_wait` DFB", DFBIdentityRequirement::Logical);
 }
 
 enum class PipeScheduleEdgeKind {
@@ -1836,6 +1870,13 @@ struct TTLVerifyPipeNetGuardsPass
       return;
     }
 
+    const DFBLogicalIdentityAnalysis &dfbIdentities =
+        getAnalysis<DFBLogicalIdentityAnalysis>();
+    if (failed(verifyGuardDFBIdentities(module, dfbIdentities))) {
+      signalPassFailure();
+      return;
+    }
+
     ValueOriginAnalysis &valueOrigins = getAnalysis<ValueOriginAnalysis>();
     FailureOr<std::unique_ptr<PipeTransferIndex>> maybeTransfers =
         PipeTransferIndex::create(module, valueOrigins);
@@ -1843,7 +1884,7 @@ struct TTLVerifyPipeNetGuardsPass
       signalPassFailure();
       return;
     }
-    ModuleState state(**maybeTransfers, launchDomains);
+    ModuleState state(**maybeTransfers, launchDomains, dfbIdentities);
 
     module.walk([&](Operation *op) {
       if (const PipeNetOperationDomainInfo *info =

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -857,8 +857,14 @@ class TTLGenericCompiler(TTCompilerBase):
             element_type,
             cb.block_count,
         )
-        # Emit: %cb = ttl.bind_cb {cb_index = N, block_count = M} : !ttl.cb<...>
-        return ttl.bind_cb(cb_type, cb._cb_index, block_count=cb.block_count)
+        # The frontend index identifies the logical DFB; finalization may
+        # replace cb_index when reusing physical storage.
+        return ttl.bind_cb(
+            cb_type,
+            cb._cb_index,
+            block_count=cb.block_count,
+            dfb_id=cb._cb_index,
+        )
 
     def _emit_pipe_from_capture(
         self, pipe, pipe_net_name=None, source_file=None, source_line=None

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -500,14 +500,6 @@ def _synthesize_thread_module(fn_name: str, body: List[ast.stmt]) -> ast.Module:
     return ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
 
 
-def _cb_configs_from_lifted(lifted: Dict[str, DataflowBuffer]):
-    """DataflowBuffer list indexed by CB index, matching _collect_cb_configs."""
-    by_index = {dfb._cb_index: dfb for dfb in lifted.values()}
-    if not by_index:
-        return []
-    return [by_index.get(i) for i in range(max(by_index) + 1)]
-
-
 def _make_thread_callable(spec, kernel_type, fn_name, body, captures):
     def _compile_thread(*args, **kwargs):
         kwargs = dict(kwargs)
@@ -648,7 +640,6 @@ def _compile_atom(
         args=args,
         launch_grid=grid,
         num_outs=num_outs,
-        cb_configs=_cb_configs_from_lifted(dfbs),
         pipenets=pipe_graph,
         target_arch=target_arch,
         fp32_dest_acc_en=fp32_dest_acc_en,

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -5,7 +5,7 @@
 """Dataflow buffer (DFB) operations for inter-thread communication."""
 
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 from ttl.ir import *
 
@@ -138,20 +138,22 @@ class DataflowBuffer:
 CircularBuffer = DataflowBuffer
 
 
-@dataclass
-class CompilerAllocatedDFBConfig:
-    """Configuration for a compiler-allocated dataflow buffer.
+@dataclass(frozen=True)
+class PhysicalDFBConfig:
+    """Runtime configuration for one physical dataflow buffer allocation.
 
-    Created by the Python runtime after reading the ttl.compiler_allocated_dfbs
-    module attribute produced by the ttl-finalize-dfb-indices pass. Carries
-    the same information as a user-declared DataflowBuffer but without a
-    backing tensor -- the data format comes directly from the MLIR attribute.
+    The final DFB index assignment determines this configuration. It is
+    independent of whether the allocation serves user-declared,
+    compiler-created, or multiple non-overlapping logical DFBs.
+    `tile` is present only when the DFB element type is a TTCore tile.
     """
 
     dfb_index: int
     num_tiles: int
-    data_format: str  # e.g., "bf16", "f32", "f16"
+    data_format: str  # e.g., "bfloat16", "float32", "float16"
     block_count: int
+    page_size: int
+    tile: Optional[Tuple[int, int]]
 
 
 def make_dataflow_buffer_like(

--- a/python/ttl/dtype_utils.py
+++ b/python/ttl/dtype_utils.py
@@ -177,50 +177,23 @@ def format_name_to_ttnn_dtype(name: str):
     match name:
         case "bfloat16" | "bf16":
             return ttnn.DataType.BFLOAT16
+        case "bfloat4_b" | "bfp_bf4":
+            return ttnn.DataType.BFLOAT4_B
+        case "bfloat8_b" | "bfp_bf8":
+            return ttnn.DataType.BFLOAT8_B
         case "float16" | "f16":
             return ttnn.DataType.BFLOAT16  # hardware implements f16 as bf16
         case "float32" | "f32":
             return ttnn.DataType.FLOAT32
-        case "int32" | "i32":
+        case "int32" | "i32" | "si32":
             return ttnn.DataType.INT32
-        case "uint32" | "u32":
+        case "uint32" | "u32" | "ui32":
             return ttnn.DataType.UINT32
-        case "uint16" | "u16":
+        case "uint16" | "u16" | "ui16":
             return ttnn.DataType.UINT16
+        case "uint8" | "u8" | "ui8":
+            return ttnn.DataType.UINT8
         case _:
             raise ValueError(
                 f"Unrecognized data format name '{name}' for ttnn.DataType"
             )
-
-
-def tile_bytes_from_dtype(dtype) -> int:
-    """
-    Calculate tile size in bytes from ttnn dtype.
-
-    For tiled tensors, each tile is 32x32 elements. The byte size depends on
-    the data type's element size plus any format-specific overhead.
-
-    Args:
-        dtype: ttnn.DataType enum value
-
-    Returns:
-        Tile size in bytes
-
-    Raises:
-        ValueError: If dtype is not supported
-    """
-    dtype_int = dtype.value
-    # Map ttnn DataType enum values to tile sizes
-    # Reference: tt-metal/tt_metal/common/constants.hpp
-    if dtype_int in (0, 6):  # BFloat16, UInt16
-        return 32 * 32 * 2  # 2048
-    elif dtype_int in (1, 2, 7):  # Float32, Int32, UInt32
-        return 32 * 32 * 4  # 4096
-    elif dtype_int == 3:  # BFP8
-        return 32 * 32 + 64  # 1088
-    elif dtype_int == 5:  # UInt8/Int8
-        return 32 * 32  # 1024
-    elif dtype_int == 4:  # BFP4
-        return 512 + 64  # 576
-    else:
-        raise ValueError(f"Unsupported dtype for tile size calculation: {dtype}")

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -34,21 +34,58 @@ def _ensure_ttnn():
     return ttnn
 
 
-from .dataflow_buffer import CompilerAllocatedDFBConfig
+from .dataflow_buffer import PhysicalDFBConfig
 from .constants import DEFAULT_L1_CB_BUDGET_BYTES
-from .dtype_utils import (
-    format_name_to_ttnn_dtype,
-    tile_bytes_from_dtype,
-    torch_dtype_to_ttnn_datatype,
-)
+from .dtype_utils import format_name_to_ttnn_dtype
 
 
-def _cb_data_format(cb):
-    """ttnn data format for a DataflowBuffer, from its (torch or ttnn) dtype."""
-    dtype = cb.dtype
-    if hasattr(dtype, "name"):  # already a ttnn.DataType enum
-        return dtype
-    return torch_dtype_to_ttnn_datatype(dtype)
+@dataclass(frozen=True)
+class _DFBAllocation:
+    """Derived tt-metal descriptor fields for one physical DFB."""
+
+    data_format: Any
+    num_tiles: int
+    block_count: int
+    tile: Optional[Tuple[int, int]]
+    page_size: int
+    total_size: int
+
+
+def _validate_physical_dfb_config(
+    config: PhysicalDFBConfig, physical_index: int
+) -> None:
+    """Enforce dense table order required by compile-time DFB indices."""
+    if config.dfb_index != physical_index:
+        raise ValueError(
+            f"DFB config at physical index {physical_index} has dfb_index "
+            f"{config.dfb_index}"
+        )
+
+
+def _get_dfb_allocation(config: PhysicalDFBConfig) -> _DFBAllocation:
+    """Derive the runtime layout and L1 size of one physical DFB."""
+    if not isinstance(config, PhysicalDFBConfig):
+        raise TypeError(
+            "DFB runtime configuration must be a finalized PhysicalDFBConfig, "
+            f"got {type(config).__name__}"
+        )
+    _ensure_ttnn()
+    if ttnn is None:
+        raise RuntimeError("ttnn is not available")
+
+    data_format = format_name_to_ttnn_dtype(config.data_format)
+    num_tiles = config.num_tiles
+    block_count = config.block_count
+    tile_shape = config.tile
+    page_size = config.page_size
+    return _DFBAllocation(
+        data_format=data_format,
+        num_tiles=num_tiles,
+        block_count=block_count,
+        tile=tile_shape,
+        page_size=page_size,
+        total_size=num_tiles * block_count * page_size,
+    )
 
 
 def get_min_remaining_l1_for_device(device):
@@ -381,7 +418,7 @@ def normalize_program_hash(program_hash: Optional[int]) -> Optional[int]:
 
 def build_cb_descriptors(
     tensors: List[Any],
-    cb_configs: List[Any],
+    cb_configs: List[PhysicalDFBConfig],
     core_ranges: Any,
 ) -> List[Any]:
     """
@@ -391,8 +428,8 @@ def build_cb_descriptors(
         tensors: List of ttnn.Tensor objects. Each tensor's position (0, 1, 2, ...)
             corresponds to its CB index. For intermediate CBs (not backed by
             input/output tensors), pass None in the corresponding position.
-        cb_configs: List of DataflowBuffer objects for each DFB, indexed by DFB index.
-            Each DFB has shape, block_count, tensor (for dtype), and _cb_index attributes.
+        cb_configs: Finalized runtime configurations indexed by physical DFB
+            index.
         core_ranges: ttnn.CoreRangeSet for DFB allocation.
 
     Returns:
@@ -405,45 +442,26 @@ def build_cb_descriptors(
     # Compute sizes first so we fail before allocating ttnn descriptors on overflow.
     rows = []
     total_cb_bytes = 0
-    for i, cb in enumerate(cb_configs):
-        if cb is None:
-            raise ValueError(
-                f"Missing CB config for index {i}. "
-                f"All DFB indices must have associated DataflowBuffer configurations."
+    for physical_index, config in enumerate(cb_configs):
+        allocation = _get_dfb_allocation(config)
+        _validate_physical_dfb_config(config, physical_index)
+        description = (
+            f"  DFB[{physical_index}]: num_tiles={allocation.num_tiles} "
+            f"block_count={allocation.block_count} "
+            f"format={config.data_format} tile={allocation.tile} -> "
+            f"{allocation.total_size} bytes"
+        )
+        rows.append(
+            (
+                allocation.data_format,
+                allocation.page_size,
+                allocation.total_size,
+                allocation.tile,
+                description,
             )
+        )
 
-        if isinstance(cb, CompilerAllocatedDFBConfig):
-            data_format = format_name_to_ttnn_dtype(cb.data_format)
-            page_size = tile_bytes_from_dtype(data_format)
-            total_size = cb.num_tiles * cb.block_count * page_size
-            rows.append(
-                (
-                    data_format,
-                    page_size,
-                    total_size,
-                    None,
-                    f"  CB[{i}]: compiler-allocated num_tiles={cb.num_tiles} "
-                    f"block_count={cb.block_count} format={cb.data_format} -> {total_size} bytes",
-                )
-            )
-        else:
-            data_format = _cb_data_format(cb)
-            tile = ttnn.Tile(cb.tile)
-            tile_descriptor = ttnn.TileDescriptor(tile)
-            page_size = tile.get_tile_size(data_format)
-            num_tiles = cb.shape[0] * cb.shape[1] * cb.block_count
-            total_size = num_tiles * page_size
-            rows.append(
-                (
-                    data_format,
-                    page_size,
-                    total_size,
-                    tile_descriptor,
-                    f"  CB[{i}]: shape={cb.shape} block_count={cb.block_count} -> {total_size} bytes",
-                )
-            )
-
-        total_cb_bytes += total_size
+        total_cb_bytes += allocation.total_size
 
     remaining_bytes = DEFAULT_L1_CB_BUDGET_BYTES
     for tensor in tensors:
@@ -454,8 +472,8 @@ def build_cb_descriptors(
             remaining_bytes = get_min_remaining_l1_for_device(device)
             break
 
-    # Must stay aligned with MLIR ttl-validate-cb-budget (TileType::getSizeBytes) and
-    # tile_bytes_from_dtype; see issue #511.
+    # Keep this L1 calculation identical to ttl-validate-cb-budget's
+    # TileType::getSizeBytes calculation; see issue #511.
     if total_cb_bytes > remaining_bytes:
         breakdown = "\n".join(r[-1] for r in rows)
         raise ValueError(
@@ -469,7 +487,9 @@ def build_cb_descriptors(
     cb_descriptors = []
     for i, row in enumerate(rows):
         data_format, page_size, total_size = row[:3]
-        tile_descriptor = row[3]
+        tile_descriptor = None
+        if row[3] is not None:
+            tile_descriptor = ttnn.TileDescriptor(ttnn.Tile(row[3]))
         cb_format = ttnn.CBFormatDescriptor(
             buffer_index=i,
             data_format=data_format,
@@ -502,7 +522,7 @@ def build_generic_op_io_tensors(
 def run_kernel_on_device(
     kernel_specs: List[KernelSpec],
     tensors: List[Any],
-    cb_configs: List[Any],
+    cb_configs: List[PhysicalDFBConfig],
     core_ranges: Any,
     program_hash: Optional[int] = None,
     num_pipe_sync_semaphores: int = 0,
@@ -521,9 +541,8 @@ def run_kernel_on_device(
         tensors: List of ttnn.Tensor objects. Position in this list determines the
             global tensor index. Individual kernels access subsets via tensor_indices
             in each KernelSpec.
-        cb_configs: List of DataflowBuffer objects for each DFB, indexed by DFB index.
-            Includes both tensor-backed DFBs and intermediate DFBs. Each DFB has shape,
-            block_count, tensor (for dtype), and _cb_index attributes.
+        cb_configs: Finalized physical DFB configurations, in physical-index
+            order.
         core_ranges: ttnn.CoreRangeSet for kernel execution.
         program_hash: Hash for tt-metal program cache.
         num_pipe_sync_semaphores: Number of pipe synchronization semaphores
@@ -615,7 +634,11 @@ def run_kernel_on_device(
 def _dtype_to_ttnn_str(data_format) -> str:
     """Convert a data format to ttnn.dtype string for code emission."""
     dtype_str = str(data_format)
-    if "bfloat16" in dtype_str.lower():
+    if "bfloat4" in dtype_str.lower():
+        return "ttnn.bfloat4_b"
+    elif "bfloat8" in dtype_str.lower():
+        return "ttnn.bfloat8_b"
+    elif "bfloat16" in dtype_str.lower():
         return "ttnn.bfloat16"
     elif "float32" in dtype_str.lower():
         return "ttnn.float32"
@@ -625,9 +648,11 @@ def _dtype_to_ttnn_str(data_format) -> str:
         return "ttnn.uint32"
     elif "uint16" in dtype_str.lower():
         return "ttnn.uint16"
+    elif "uint8" in dtype_str.lower():
+        return "ttnn.uint8"
     elif "int32" in dtype_str.lower():
         return "ttnn.int32"
-    return "ttnn.bfloat16"
+    raise ValueError(f"Unsupported data format for runner emission: {data_format}")
 
 
 def _serialize_core_ranges(
@@ -673,7 +698,7 @@ def _serialize_noc_role(spec: KernelSpec) -> Optional[int]:
 
 def emit_runner_source(
     kernel_specs: List[KernelSpec],
-    cb_configs: List[Any],
+    cb_configs: List[PhysicalDFBConfig],
     grid_cols: int,
     grid_rows: int,
     num_tensors: int,
@@ -753,17 +778,14 @@ def emit_runner_source(
     lines.append("")
 
     lines.append("CB_CONFIGS = [")
-    for i, cb in enumerate(cb_configs):
-        if cb is None:
-            lines.append(f"    None,  # CB {i}")
-            continue
-        data_format = _cb_data_format(cb)
-        page_size = tile_bytes_from_dtype(data_format)
-        dtype_str = _dtype_to_ttnn_str(data_format)
-        num_tiles = cb.shape[0] * cb.shape[1] * cb.block_count
-        total_size = num_tiles * page_size
+    for physical_index, config in enumerate(cb_configs):
+        allocation = _get_dfb_allocation(config)
+        _validate_physical_dfb_config(config, physical_index)
+        dtype_str = _dtype_to_ttnn_str(allocation.data_format)
         lines.append(
-            f"    ({cb.shape!r}, {cb.block_count}, {dtype_str}, {page_size}, {total_size}),  # CB {i}"
+            f"    ({allocation.num_tiles}, {allocation.block_count}, "
+            f"{dtype_str}, {allocation.tile!r}, {allocation.page_size}, "
+            f"{allocation.total_size}),  # CB {physical_index}"
         )
     lines.append("]")
     lines.append("")
@@ -797,12 +819,20 @@ def emit_runner_source(
 
     lines.append("    cb_descriptors = []")
     lines.append(
-        "    for i, (shape, block_count, dtype, page_size, total_size) in enumerate(CB_CONFIGS):"
+        "    for i, (num_tiles, block_count, dtype, tile_shape, page_size, "
+        "total_size) in enumerate(CB_CONFIGS):"
+    )
+    lines.append("        format_options = {}")
+    lines.append("        if tile_shape is not None:")
+    lines.append(
+        '            format_options["tile"] = ttnn.TileDescriptor('
+        "ttnn.Tile(tile_shape))"
     )
     lines.append("        cb_format = ttnn.CBFormatDescriptor(")
     lines.append("            buffer_index=i,")
     lines.append("            data_format=dtype,")
     lines.append("            page_size=page_size,")
+    lines.append("            **format_options,")
     lines.append("        )")
     lines.append("        cb_desc = ttnn.CBDescriptor(")
     lines.append("            total_size=total_size,")
@@ -896,7 +926,7 @@ def emit_runner_source(
 
 def emit_runner_file(
     kernel_specs: List[KernelSpec],
-    cb_configs: List[Any],
+    cb_configs: List[PhysicalDFBConfig],
     grid_cols: int,
     grid_rows: int,
     num_tensors: int,

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -48,7 +48,7 @@ def _ensure_ttnn():
 import ttl._mlir_libs._ttlang  # Register tt-lang passes
 from ttl._mlir_libs._ttlang import ttl_ir as _ttl_ir
 from ttl.pykernel._src.utils import _cleanup_source_code
-from ttl.dialects import ttkernel
+from ttl.dialects import ttcore, ttkernel
 from ttl.ir import *
 from ttl.ir import DenseI32ArrayAttr
 from ttl.passes import (
@@ -79,8 +79,8 @@ from ._src.tensor_registry import (
 from ._src.ttl_ast import TTLGenericCompiler
 from .dataflow_buffer import (
     CircularBuffer,
-    CompilerAllocatedDFBConfig,
     DataflowBuffer,
+    PhysicalDFBConfig,
     get_cb_count,
 )
 from .pipe import Pipe, PipeNet
@@ -93,7 +93,6 @@ from .diagnostics import (
 )
 from .dtype_utils import (
     is_ttnn_tensor,
-    tile_bytes_from_dtype,
     torch_dtype_to_ttnn_datatype,
 )
 from .kernel_runner import (
@@ -582,7 +581,7 @@ class CompiledTTNNKernel:
                 with kernel_paths. Set by the per-core specialization path so
                 each specialized clone is dispatched only to its own core; None
                 entries fall back to the whole-grid core_ranges.
-            cb_configs: List of (shape, block_count) tuples for each CB, indexed by cb_index
+            cb_configs: Final physical DFB configurations indexed by cb_index
             program_hash: Hash for tt-metal program cache
             source_lines: Source code lines for auto-profiling reports (deprecated)
             all_source_lines: Dict mapping kernel name to source lines
@@ -1211,87 +1210,128 @@ def _collect_captures(
     }
 
 
-def _collect_cb_configs(threads):
-    """Extract DataflowBuffer objects from thread closures, indexed by dfb index.
-
-    Returns a list of DataflowBuffer objects indexed by dfb index. Each DFB has
-    shape, block_count, tensor (for dtype), and _cb_index attributes.
-    """
-    cb_configs_dict = {}
-    for thread_fn in threads:
-        wrapped = getattr(thread_fn, "__wrapped__", None)
-        closure = getattr(wrapped, "__closure__", None) if wrapped else None
-        if not closure:
-            continue
-        for cell in closure:
-            val = cell.cell_contents
-            if isinstance(val, DataflowBuffer):
-                cb_configs_dict[val._cb_index] = val
-
-    if not cb_configs_dict:
-        return []
-    max_idx = max(cb_configs_dict.keys())
-    return [cb_configs_dict.get(i) for i in range(max_idx + 1)]
-
-
 # Map MLIR element type names to ttnn-compatible data format names.
 # Keyed by exact MLIR type mnemonic (no substring matching).
 _MLIR_TYPE_TO_FORMAT = {
     "bf16": "bfloat16",
+    "bfp_bf4": "bfloat4_b",
+    "bfp_bf8": "bfloat8_b",
     "f16": "float16",
     "f32": "float32",
     "i32": "int32",
+    "si32": "int32",
+    "u8": "uint8",
+    "u16": "uint16",
+    "u32": "uint32",
+    "ui8": "uint8",
     "ui32": "uint32",
     "ui16": "uint16",
 }
 
 
-def _parse_mlir_element_type(type_str: str) -> str:
-    """Extract the base data format name from an MLIR TypeAttr string.
+def _parse_mlir_element_type(element_type) -> tuple[str, Optional[tuple[int, int]]]:
+    """Extract the data format and optional tile dimensions from a TypeAttr.
 
     The TypeAttr prints as e.g. "bf16" or "!ttcore.tile<32x32, bf16>".
-    This function extracts the trailing type mnemonic and maps it to a
-    ttnn-compatible format name.
     """
+    tile = None
+    type_value = getattr(element_type, "value", None)
+    if type_value is None:
+        raise TypeError(f"element_type must be an MLIR TypeAttr, got {element_type!r}")
+    tile_type = ttcore.ir.TileType.maybe_downcast(type_value)
+    if tile_type is not None:
+        tile = tuple(tile_type.shape)
+
     # For compound types like "!ttcore.tile<32x32, bf16>", extract the
     # type after the last comma. For bare types like "bf16", use as-is.
+    type_str = str(element_type)
     token = type_str.strip()
     if "," in token:
         token = token.rsplit(",", 1)[1].strip().rstrip(">").strip()
     fmt = _MLIR_TYPE_TO_FORMAT.get(token)
     if fmt is not None:
-        return fmt
+        return fmt, tile
     raise ValueError(
         f"Unrecognized MLIR element type '{token}' (from '{type_str}'). "
         f"Known types: {list(_MLIR_TYPE_TO_FORMAT.keys())}"
     )
 
 
-def _extract_compiler_allocated_dfbs(module):
-    """Read ttl.compiler_allocated_dfbs module attribute.
-
-    Returns an empty list when the attribute is absent (no compiler-allocated
-    DFBs). Each entry is a DictionaryAttr with dfb_index, num_tiles,
-    element_type, and block_count.
-    """
-    attr = module.operation.attributes.get("ttl.compiler_allocated_dfbs", None)
+def _extract_dfb_allocations(module):
+    """Read `ttl.dfb_allocations` and require dense physical indices."""
+    attribute_name = "ttl.dfb_allocations"
+    attr = module.operation.attributes.get(attribute_name, None)
     if attr is None:
-        return []
+        return None
 
     configs = []
-    for entry in attr:
-        dfb_index = int(entry["dfb_index"])
-        num_tiles = int(entry["num_tiles"])
-        block_count = int(entry["block_count"])
-        data_format = _parse_mlir_element_type(str(entry["element_type"]))
+    seen_indices = set()
+    required_fields = (
+        "dfb_index",
+        "num_tiles",
+        "element_type",
+        "block_count",
+        "page_size",
+    )
+    for position, entry in enumerate(attr):
+        for field in required_fields:
+            if field not in entry:
+                raise ValueError(f"{attribute_name}[{position}] is missing '{field}'")
+        values = {field: entry[field] for field in required_fields}
 
+        try:
+            dfb_index = int(values["dfb_index"])
+            num_tiles = int(values["num_tiles"])
+            block_count = int(values["block_count"])
+            page_size = int(values["page_size"])
+            data_format, tile = _parse_mlir_element_type(values["element_type"])
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"Invalid {attribute_name}[{position}]: {error}") from None
+
+        if dfb_index < 0:
+            raise ValueError(
+                f"{attribute_name}[{position}].dfb_index must be non-negative, "
+                f"got {dfb_index}"
+            )
+        if dfb_index in seen_indices:
+            raise ValueError(
+                f"{attribute_name} contains duplicate dfb_index {dfb_index}"
+            )
+        if num_tiles <= 0:
+            raise ValueError(
+                f"{attribute_name}[{position}].num_tiles must be positive, "
+                f"got {num_tiles}"
+            )
+        if block_count <= 0:
+            raise ValueError(
+                f"{attribute_name}[{position}].block_count must be positive, "
+                f"got {block_count}"
+            )
+        if page_size <= 0:
+            raise ValueError(
+                f"{attribute_name}[{position}].page_size must be positive, "
+                f"got {page_size}"
+            )
+
+        seen_indices.add(dfb_index)
         configs.append(
-            CompilerAllocatedDFBConfig(
+            PhysicalDFBConfig(
                 dfb_index=dfb_index,
                 num_tiles=num_tiles,
                 data_format=data_format,
                 block_count=block_count,
+                page_size=page_size,
+                tile=tile,
             )
+        )
+
+    configs.sort(key=lambda config: config.dfb_index)
+    indices = [config.dfb_index for config in configs]
+    expected_indices = list(range(len(configs)))
+    if indices != expected_indices:
+        raise ValueError(
+            "ttl.dfb_allocations must contain a dense physical index range "
+            f"{expected_indices}, got {indices}"
         )
     return configs
 
@@ -1322,28 +1362,15 @@ def _extract_pipe_global_semaphore_count(module) -> int:
     return int(attr)
 
 
-def _merge_dfb_configs(cb_configs, compiler_allocated_dfbs):
-    """Merge compiler-allocated DFBs into the CB config list.
-
-    Extends cb_configs to cover all DFB indices. Compiler-allocated DFBs
-    are placed at their dfb_index positions.
-    """
-    if not compiler_allocated_dfbs:
-        return cb_configs
-
-    user_max = len(cb_configs) - 1 if cb_configs else -1
-    alloc_max = max(dfb.dfb_index for dfb in compiler_allocated_dfbs)
-    total = max(user_max, alloc_max) + 1
-
-    merged = list(cb_configs) + [None] * (total - len(cb_configs))
-    for dfb in compiler_allocated_dfbs:
-        if merged[dfb.dfb_index] is not None:
-            raise ValueError(
-                f"Compiler-allocated DFB index {dfb.dfb_index} collides with "
-                f"an existing DFB."
-            )
-        merged[dfb.dfb_index] = dfb
-    return merged
+def _resolve_dfb_configs(module):
+    """Return finalized physical DFB configurations from required metadata."""
+    physical_allocations = _extract_dfb_allocations(module)
+    if physical_allocations is None:
+        raise ValueError(
+            "compiled module is missing ttl.dfb_allocations; "
+            "ttl-finalize-dfb-indices must run before runtime construction"
+        )
+    return physical_allocations
 
 
 def _run_thread_compiler(
@@ -1631,8 +1658,6 @@ def _compile_kernel(
 
     launch_grid = grid
 
-    cb_configs = _collect_cb_configs(threads)
-
     injected_program_kwargs = {
         "grid": grid,
         "memory_space": memory_space,
@@ -1650,7 +1675,6 @@ def _compile_kernel(
         args=args,
         launch_grid=launch_grid,
         num_outs=num_outs,
-        cb_configs=cb_configs,
         pipenets=pipenets,
         target_arch=target_arch,
         fp32_dest_acc_en=fp32_dest_acc_en,
@@ -1669,7 +1693,6 @@ def _lower_program_to_kernel(
     args,
     launch_grid,
     num_outs,
-    cb_configs,
     pipenets,
     target_arch,
     fp32_dest_acc_en,
@@ -1963,9 +1986,7 @@ def _lower_program_to_kernel(
             first_thread = next(iter(all_source_lines.keys()))
             profile_source_lines = all_source_lines[first_thread]
 
-        # Merge compiler-allocated DFBs into the CB config list.
-        compiler_allocated_dfbs = _extract_compiler_allocated_dfbs(module)
-        cb_configs = _merge_dfb_configs(cb_configs, compiler_allocated_dfbs)
+        cb_configs = _resolve_dfb_configs(module)
         pipe_sync_semaphore_count = _extract_pipe_sync_semaphore_count(module)
         if pipe_sync_semaphore_count is None:
             raise RuntimeError(

--- a/test/me2e/builder/dm_builder.py
+++ b/test/me2e/builder/dm_builder.py
@@ -47,10 +47,7 @@ class DMThreadBuilder(StringBasedThreadBuilder):
 
         # Generate CB bindings.
         cb_binds = "\n".join(
-            [
-                f"  %cb{i} = ttl.bind_cb {{cb_index = {i}, block_count = {self._block_count}}} : {self.cb_type_str}"
-                for i in range(num_inputs)
-            ]
+            ["  " + self._bind_cb_str(f"%cb{i}", i) for i in range(num_inputs)]
         )
 
         # Generate loop structure.
@@ -113,7 +110,7 @@ func.func @{name}({args})
         # Generate CB bindings.
         cb_binds = "\n".join(
             [
-                f"  %cb_out{i} = ttl.bind_cb {{cb_index = {output_cbs[i]}, block_count = {self._block_count}}} : {self.cb_type_str}"
+                "  " + self._bind_cb_str(f"%cb_out{i}", output_cbs[i])
                 for i in range(num_outputs)
             ]
         )

--- a/test/me2e/builder/thread_builder.py
+++ b/test/me2e/builder/thread_builder.py
@@ -156,6 +156,7 @@ class ThreadBuilder(ABC):
             self._cb_type,
             cb_index=cb_index,
             block_count=self._block_count,
+            dfb_id=cb_index,
             loc=self.loc,
         )
 
@@ -438,6 +439,14 @@ class StringBasedThreadBuilder:
     # =========================================================================
     # CB Operation Strings
     # =========================================================================
+
+    def _bind_cb_str(self, result_var: str, cb_index: int) -> str:
+        """Emit a binding whose logical ID is stable across final allocation."""
+        return (
+            f"{result_var} = ttl.bind_cb "
+            f"{{cb_index = {cb_index}, block_count = {self._block_count}}} "
+            f"{{dfb_id = {cb_index} : index}} : {self.cb_type_str}"
+        )
 
     def _cb_reserve_str(self, cb_var: str, result_var: str) -> str:
         """Generate cb_reserve operation string."""

--- a/test/me2e/builder/ttl_builder.py
+++ b/test/me2e/builder/ttl_builder.py
@@ -110,6 +110,7 @@ def build_ttl_module(
                         cb_type,
                         cb_index=i,
                         block_count=config.block_count,
+                        dfb_id=i,
                         loc=loc,
                     )
                     attached = ttl.attach_cb(
@@ -125,6 +126,7 @@ def build_ttl_module(
                     cb_type,
                     cb_index=arity,  # Next index after inputs.
                     block_count=config.block_count,
+                    dfb_id=arity,
                     loc=loc,
                 )
                 reserve = ttl.cb_reserve(tile_tensor_type, output_cb, loc=loc)

--- a/test/me2e/builder/ttnn_runner.py
+++ b/test/me2e/builder/ttnn_runner.py
@@ -25,13 +25,26 @@ from ttl.kernel_runner import (
     KernelSpec as RunnerKernelSpec,
     run_kernel_on_device,
 )
-from ttl.dataflow_buffer import DataflowBuffer
+from ttl.dataflow_buffer import PhysicalDFBConfig
 
 from .kernels import KernelSpec
 
 # Tile dimensions.
 TILE_HEIGHT = 32
 TILE_WIDTH = 32
+
+
+def _data_format_name(dtype: torch.dtype) -> str:
+    """Return the runtime DFB format; ME2E builders construct bf16/f32 only."""
+
+    data_formats = {
+        torch.bfloat16: "bfloat16",
+        torch.float32: "float32",
+    }
+    try:
+        return data_formats[dtype]
+    except KeyError:
+        raise ValueError(f"Unsupported me2e tensor dtype: {dtype}") from None
 
 
 def run_binary_op(
@@ -127,6 +140,8 @@ def _run_op(
     """
     shape = list(inputs[0].shape)
     dtype = inputs[0].dtype
+    if any(input_tensor.dtype != dtype for input_tensor in inputs[1:]):
+        raise ValueError("ME2E runner requires all input tensors to have one dtype")
 
     # Create device tensors using to_dram (respects tensor dtype).
     device_inputs = []
@@ -183,11 +198,17 @@ def _run_op(
         ),
     ]
 
-    # Build DFB configs: DataflowBuffer objects for each tensor.
-    # Shape is (1, 1) for single tile, block_count is 1 for single buffering.
-    dfb_configs: List[DataflowBuffer] = [
-        DataflowBuffer(tensor=tensor, shape=(1, 1), block_count=1)
-        for tensor in io_tensors
+    data_format = _data_format_name(dtype)
+    dfb_configs = [
+        PhysicalDFBConfig(
+            dfb_index=dfb_index,
+            num_tiles=1,
+            data_format=data_format,
+            block_count=1,
+            page_size=ttnn.tile_size(io_tensor.dtype),
+            tile=(TILE_HEIGHT, TILE_WIDTH),
+        )
+        for dfb_index, io_tensor in enumerate(io_tensors)
     ]
 
     # Execute using shared kernel runner.

--- a/test/me2e/ops/test_fused.py
+++ b/test/me2e/ops/test_fused.py
@@ -165,9 +165,9 @@ class TestExpAddFused(FusedOpTestBase):
         compute_mlir = f"""
 // Compute thread for exp(a + b) fused operation.
 func.func @compute_exp_add() attributes {{ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}} {{
-  %cb0 = ttl.bind_cb {{cb_index = 0, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
-  %cb1 = ttl.bind_cb {{cb_index = 1, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
-  %cb_out = ttl.bind_cb {{cb_index = 2, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb0 = ttl.bind_cb {{cb_index = 0, block_count = {bc}}} {{dfb_id = 0 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb1 = ttl.bind_cb {{cb_index = 1, block_count = {bc}}} {{dfb_id = 1 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb_out = ttl.bind_cb {{cb_index = 2, block_count = {bc}}} {{dfb_id = 2 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
 
   // Wait for input data from reader.
   %a = ttl.cb_wait %cb0 : <[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}> -> tensor<{rows}x{cols}x!ttcore.tile<32x32, {dtype}>>
@@ -241,9 +241,9 @@ class TestReluMulFused(FusedOpTestBase):
         compute_mlir = f"""
 // Compute thread for relu(a * b) fused operation.
 func.func @compute_relu_mul() attributes {{ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}} {{
-  %cb0 = ttl.bind_cb {{cb_index = 0, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
-  %cb1 = ttl.bind_cb {{cb_index = 1, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
-  %cb_out = ttl.bind_cb {{cb_index = 2, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb0 = ttl.bind_cb {{cb_index = 0, block_count = {bc}}} {{dfb_id = 0 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb1 = ttl.bind_cb {{cb_index = 1, block_count = {bc}}} {{dfb_id = 1 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb_out = ttl.bind_cb {{cb_index = 2, block_count = {bc}}} {{dfb_id = 2 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
 
   // Wait for input data from reader.
   %a = ttl.cb_wait %cb0 : <[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}> -> tensor<{rows}x{cols}x!ttcore.tile<32x32, {dtype}>>
@@ -318,8 +318,8 @@ class TestSqrtAbsFused(FusedOpTestBase):
         compute_mlir = f"""
 // Compute thread for sqrt(abs(a)) fused operation.
 func.func @compute_sqrt_abs() attributes {{ttl.base_cta_index = 2 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}} {{
-  %cb0 = ttl.bind_cb {{cb_index = 0, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
-  %cb_out = ttl.bind_cb {{cb_index = 1, block_count = {bc}}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb0 = ttl.bind_cb {{cb_index = 0, block_count = {bc}}} {{dfb_id = 0 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
+  %cb_out = ttl.bind_cb {{cb_index = 1, block_count = {bc}}} {{dfb_id = 1 : index}} : !ttl.cb<[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}>
 
   // Wait for input data from reader.
   %a = ttl.cb_wait %cb0 : <[{rows}, {cols}], !ttcore.tile<32x32, {dtype}>, {bc}> -> tensor<{rows}x{cols}x!ttcore.tile<32x32, {dtype}>>

--- a/test/me2e/ops/test_simple.py
+++ b/test/me2e/ops/test_simple.py
@@ -35,6 +35,7 @@ class TestMLIRGeneration:
         assert f"ttl.{op_name}" in mlir_str
         # Verify CB binding and attachment.
         assert "ttl.bind_cb" in mlir_str
+        assert "dfb_id = 0 : index" in mlir_str
         assert "ttl.attach_cb" in mlir_str
         # Verify two inputs.
         assert "%arg0" in mlir_str
@@ -58,6 +59,7 @@ class TestMLIRGeneration:
         assert f"ttl.{op_name}" in mlir_str
         # Verify CB binding and attachment.
         assert "ttl.bind_cb" in mlir_str
+        assert "dfb_id = 0 : index" in mlir_str
         assert "ttl.attach_cb" in mlir_str
         # Verify one input.
         assert "%arg0" in mlir_str

--- a/test/python/invalid/invalid_cb_l1_overflow.py
+++ b/test/python/invalid/invalid_cb_l1_overflow.py
@@ -14,19 +14,21 @@ Validation test: total CB descriptor size must not exceed per-core L1 CB budget.
 
 import ttnn
 
-from ttl.dataflow_buffer import CompilerAllocatedDFBConfig
+from ttl.dataflow_buffer import PhysicalDFBConfig
 from ttl.kernel_runner import build_cb_descriptors
 
-# Single compiler-allocated CB: large enough to exceed DEFAULT_L1_CB_BUDGET_BYTES.
+# Single physical DFB: large enough to exceed DEFAULT_L1_CB_BUDGET_BYTES.
 # 400 * 2 * 2048 (bf16 tile) = 1,638,400 bytes > 1,466,368.
 build_cb_descriptors(
     [None],
     [
-        CompilerAllocatedDFBConfig(
+        PhysicalDFBConfig(
             dfb_index=0,
             num_tiles=400,
             data_format="bfloat16",
             block_count=2,
+            page_size=ttnn.tile_size(ttnn.bfloat16),
+            tile=(32, 32),
         )
     ],
     None,

--- a/test/python/invalid/invalid_dfb_spsc_overlap.py
+++ b/test/python/invalid/invalid_dfb_spsc_overlap.py
@@ -12,7 +12,7 @@ movement thread over the full launch grid. The verifier must reject the shared
 DFB because the consumer launch-node domains overlap.
 """
 
-# CHECK: dataflow buffer cb_index={{[0-9]+}} has multiple consumer threads active on the same launched node
+# CHECK: logical DFB 0 has multiple consumer kernels active on the same launched node
 # CHECK: tt-metal CBs are single-producer single-consumer; allocate one DFB per consumer
 
 import os

--- a/test/python/simple_add.py
+++ b/test/python/simple_add.py
@@ -70,9 +70,9 @@ def add_kernel(lhs, rhs, out):
 # CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
 
 # Bind circular buffers (alphabetical order of capture names: lhs_cb, out_cb, rhs_cb)
-# CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0
-# CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2
-# CHECK: %[[CB1:.+]] = ttl.bind_cb{cb_index = 1
+# CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+# CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+# CHECK: %[[CB1:.+]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
 
 # Wait for input CBs
 # CHECK: %[[L:.+]] = ttl.cb_wait %[[CB0]]
@@ -104,8 +104,8 @@ def add_kernel(lhs, rhs, out):
 # CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32}
 
 # Bind CBs (alphabetical order: lhs_cb, rhs_cb)
-# CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0
-# CHECK: %[[CB1:.+]] = ttl.bind_cb{cb_index = 1
+# CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+# CHECK: %[[CB1:.+]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
 
 # First input: reserve, slice, copy, wait, push
 # CHECK: ttl.cb_reserve %[[CB0]]
@@ -126,7 +126,7 @@ def add_kernel(lhs, rhs, out):
 # CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32}
 
 # Wait for output DFB, slice, copy to device, pop
-# CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2
+# CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
 # CHECK: ttl.cb_wait %[[CB2]]
 # CHECK: %[[SLICE2:.+]] = ttl.tensor_slice %arg0
 # CHECK: %[[TX:.+]] = ttl.copy %[[CB2]], %[[SLICE2]] : {{.*}} -> !ttl.transfer_handle<write>

--- a/test/python/simple_add_3d.py
+++ b/test/python/simple_add_3d.py
@@ -74,9 +74,9 @@ def add_3d_kernel(lhs, rhs, out):
 # CHECK-LABEL: func.func @add_compute
 
 # 3D CB shapes
-# CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} : <[2, 2, 2], !ttcore.tile<32x32, bf16>, 2>
-# CHECK: ttl.bind_cb{cb_index = 2, block_count = 2} : <[2, 2, 2], !ttcore.tile<32x32, bf16>, 2>
-# CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} : <[2, 2, 2], !ttcore.tile<32x32, bf16>, 2>
+# CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index} : <[2, 2, 2], !ttcore.tile<32x32, bf16>, 2>
+# CHECK: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index} : <[2, 2, 2], !ttcore.tile<32x32, bf16>, 2>
+# CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index} : <[2, 2, 2], !ttcore.tile<32x32, bf16>, 2>
 
 # Wait/reserve produce 3D tensors of tiles
 # CHECK: ttl.cb_wait %{{.*}} : <[2, 2, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x2x2x!ttcore.tile<32x32, bf16>>

--- a/test/python/test_dfb_index_compaction.py
+++ b/test/python/test_dfb_index_compaction.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime coverage for compacting unused frontend DFB indices."""
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+TILE = 32
+
+
+@ttl.operation(grid=(1, 1))
+def _add_with_unused_dfb(lhs, rhs, result):
+    lhs_dfb = ttl.make_dataflow_buffer_like(lhs, shape=(1, 1), block_count=2)
+    _unused_dfb = ttl.make_dataflow_buffer_like(rhs, shape=(1, 1), block_count=2)
+    rhs_dfb = ttl.make_dataflow_buffer_like(rhs, shape=(1, 1), block_count=2)
+    result_dfb = ttl.make_dataflow_buffer_like(result, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        lhs_block = lhs_dfb.wait()
+        rhs_block = rhs_dfb.wait()
+        result_block = result_dfb.reserve()
+        result_block.store(lhs_block + rhs_block)
+        lhs_block.pop()
+        rhs_block.pop()
+        result_block.push()
+
+    @ttl.datamovement()
+    def read_inputs():
+        lhs_block = lhs_dfb.reserve()
+        ttl.copy(lhs[0, 0], lhs_block).wait()
+        lhs_block.push()
+        rhs_block = rhs_dfb.reserve()
+        ttl.copy(rhs[0, 0], rhs_block).wait()
+        rhs_block.push()
+
+    @ttl.datamovement()
+    def write_result():
+        result_block = result_dfb.wait()
+        ttl.copy(result_block, result[0, 0]).wait()
+        result_block.pop()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_unused_dfb_index_is_compacted(device, dtype, memory_config, to_device):
+    # The unused second declaration leaves frontend indices 0, 2, and 3 in the
+    # kernel IR; successful execution requires finalization to compact them.
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
+    rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)
+    lhs = to_device(lhs_host, device)
+    rhs = to_device(rhs_host, device)
+    result = to_device(torch.zeros_like(lhs_host), device)
+
+    _add_with_unused_dfb(lhs, rhs, result)
+
+    actual = ttnn.to_torch(result).float()
+    expected = lhs_host.float() + rhs_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)

--- a/test/python/test_dfb_runtime_config.py
+++ b/test/python/test_dfb_runtime_config.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for resolving final physical DFB allocation metadata."""
+
+import pytest
+
+from ttl.dataflow_buffer import PhysicalDFBConfig
+from ttl.dialects import ttcore  # noqa: F401
+from ttl.ir import Context, Module
+from ttl.ttl_api import _resolve_dfb_configs
+
+
+def _entry(
+    dfb_index,
+    *,
+    num_tiles=1,
+    element_type="bf16",
+    block_count=2,
+    page_size=2048,
+):
+    """Build one textual physical-allocation metadata entry."""
+
+    return (
+        f"{{dfb_index = {dfb_index} : i32, num_tiles = {num_tiles} : i32, "
+        f"element_type = {element_type}, block_count = {block_count} : i32, "
+        f"page_size = {page_size} : i32}}"
+    )
+
+
+def _module(allocations=None):
+    """Parse a module with optional physical-allocation metadata."""
+
+    if allocations is None:
+        return Module.parse("module {}")
+    entries = ", ".join(allocations)
+    return Module.parse(f"module attributes {{ttl.dfb_allocations = [{entries}]}} {{}}")
+
+
+def test_complete_physical_allocations_are_sorted():
+    with Context():
+        module = _module(
+            [
+                _entry(
+                    1,
+                    num_tiles=4,
+                    element_type="f32",
+                    block_count=3,
+                    page_size=4096,
+                ),
+                _entry(0, num_tiles=2),
+            ]
+        )
+
+        assert _resolve_dfb_configs(module) == [
+            PhysicalDFBConfig(0, 2, "bfloat16", 2, 2048, None),
+            PhysicalDFBConfig(1, 4, "float32", 3, 4096, None),
+        ]
+
+
+@pytest.mark.parametrize(
+    ("element_type", "data_format", "tile", "page_size"),
+    [
+        ("!ttcore.tile<32x32, bfp_bf4>", "bfloat4_b", (32, 32), 576),
+        ("!ttcore.tile<32x32, bfp_bf8>", "bfloat8_b", (32, 32), 1088),
+        ("!ttcore.tile<1x16, bf16>", "bfloat16", (1, 16), 32),
+        ("!ttcore.tile<1x16, u8>", "uint8", (1, 16), 16),
+        ("!ttcore.tile<32x32, u16>", "uint16", (32, 32), 2048),
+        ("!ttcore.tile<32x32, u32>", "uint32", (32, 32), 4096),
+        ("!ttcore.tile<32x32, si32>", "int32", (32, 32), 4096),
+    ],
+)
+def test_complete_physical_allocations_preserve_tile_types(
+    element_type, data_format, tile, page_size
+):
+    with Context():
+        module = _module([_entry(0, element_type=element_type, page_size=page_size)])
+
+        assert _resolve_dfb_configs(module) == [
+            PhysicalDFBConfig(0, 1, data_format, 2, page_size, tile)
+        ]
+
+
+def test_empty_complete_physical_allocations_replace_frontend_configs():
+    with Context():
+        module = _module([])
+
+        assert _resolve_dfb_configs(module) == []
+
+
+def test_missing_complete_allocations_are_rejected():
+    with Context():
+        module = _module()
+
+        with pytest.raises(ValueError, match="missing ttl.dfb_allocations"):
+            _resolve_dfb_configs(module)
+
+
+@pytest.mark.parametrize(
+    ("allocations", "message"),
+    [
+        ([_entry(-1)], "dfb_index must be non-negative"),
+        ([_entry(0, num_tiles=0)], "num_tiles must be positive"),
+        ([_entry(0, block_count=0)], "block_count must be positive"),
+        ([_entry(0, page_size=0)], "page_size must be positive"),
+        ([_entry(0, element_type="i1")], "Unrecognized MLIR element type"),
+        ([_entry(0), _entry(0)], "duplicate dfb_index 0"),
+        ([_entry(1)], "dense physical index range"),
+        (
+            [
+                "{dfb_index = 0 : i32, num_tiles = 1 : i32, "
+                "element_type = bf16, page_size = 2048 : i32}"
+            ],
+            "missing 'block_count'",
+        ),
+        (
+            [
+                "{dfb_index = 0 : i32, num_tiles = 1 : i32, "
+                "element_type = bf16, block_count = 2 : i32}"
+            ],
+            "missing 'page_size'",
+        ),
+    ],
+)
+def test_invalid_complete_physical_allocations_are_rejected(allocations, message):
+    with Context():
+        module = _module(allocations)
+
+        with pytest.raises(ValueError, match=message):
+            _resolve_dfb_configs(module)

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -7,6 +7,7 @@
 import pytest
 
 from ttl import kernel_runner
+from ttl.dataflow_buffer import PhysicalDFBConfig
 
 
 class _FakeTensor:
@@ -337,6 +338,157 @@ def test_emit_runner_source_uses_shared_pipe_resource_helpers():
     assert "build_generic_op_io_tensors(" in source
     assert "program.custom_program_hash = PROGRAM_HASH" in source
     assert "ttnn.create_global_semaphore(device, core_ranges, 0)" not in source
+
+
+def test_emit_runner_source_accepts_physical_dfb_configs():
+    source = kernel_runner.emit_runner_source(
+        kernel_specs=[],
+        cb_configs=[
+            PhysicalDFBConfig(
+                dfb_index=0,
+                num_tiles=3,
+                data_format="bfloat16",
+                block_count=2,
+                page_size=32,
+                tile=(1, 16),
+            )
+        ],
+        grid_cols=1,
+        grid_rows=1,
+        num_tensors=1,
+    )
+
+    assert "(3, 2, ttnn.bfloat16, (1, 16), 32, 192),  # CB 0" in source
+    assert (
+        "for i, (num_tiles, block_count, dtype, tile_shape, page_size, "
+        "total_size) "
+        "in enumerate(CB_CONFIGS):"
+    ) in source
+    assert 'format_options["tile"] = ttnn.TileDescriptor(' in source
+    assert "**format_options," in source
+
+
+def test_emit_runner_source_omits_tile_descriptor_for_scalar_dfb():
+    source = kernel_runner.emit_runner_source(
+        kernel_specs=[],
+        cb_configs=[PhysicalDFBConfig(0, 128, "float32", 2, 4, None)],
+        grid_cols=1,
+        grid_rows=1,
+        num_tensors=1,
+    )
+
+    assert "(128, 2, ttnn.float32, None, 4, 1024),  # CB 0" in source
+    assert "if tile_shape is not None:" in source
+
+
+def test_physical_dfb_allocation_scales_with_subtile_area():
+    full_tile = kernel_runner._get_dfb_allocation(
+        PhysicalDFBConfig(0, 1, "bfloat16", 2, 2048, (32, 32))
+    )
+    two_half_tiles = kernel_runner._get_dfb_allocation(
+        PhysicalDFBConfig(0, 2, "bfloat16", 2, 1024, (16, 32))
+    )
+
+    assert two_half_tiles.page_size * 2 == full_tile.page_size
+    assert two_half_tiles.total_size == full_tile.total_size
+
+
+def test_physical_dfb_allocation_uses_complete_rank_three_shape():
+    allocation = kernel_runner._get_dfb_allocation(
+        PhysicalDFBConfig(0, 8, "bfloat16", 2, 2048, (32, 32))
+    )
+
+    assert allocation.total_size == 8 * 2 * 2048
+
+
+def test_dfb_allocation_requires_finalized_config(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+
+    with pytest.raises(
+        TypeError,
+        match="must be a finalized PhysicalDFBConfig",
+    ):
+        kernel_runner._get_dfb_allocation(object())
+
+
+@pytest.mark.parametrize(
+    ("cb_configs", "error_type", "message"),
+    [
+        (
+            [None],
+            TypeError,
+            "must be a finalized PhysicalDFBConfig",
+        ),
+        (
+            [PhysicalDFBConfig(1, 1, "bfloat16", 2, 2048, (32, 32))],
+            ValueError,
+            "DFB config at physical index 0",
+        ),
+    ],
+    ids=["missing-config", "wrong-index"],
+)
+def test_emit_runner_source_rejects_invalid_physical_dfb_sequence(
+    cb_configs, error_type, message
+):
+    with pytest.raises(error_type, match=message):
+        kernel_runner.emit_runner_source(
+            kernel_specs=[],
+            cb_configs=cb_configs,
+            grid_cols=1,
+            grid_rows=1,
+            num_tensors=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("data_format", "emitted_dtype", "page_size"),
+    [
+        ("bfloat4_b", "ttnn.bfloat4_b", 576),
+        ("bfloat8_b", "ttnn.bfloat8_b", 1088),
+        ("uint8", "ttnn.uint8", 1024),
+    ],
+)
+def test_emit_runner_source_preserves_physical_dfb_format(
+    data_format, emitted_dtype, page_size
+):
+    source = kernel_runner.emit_runner_source(
+        kernel_specs=[],
+        cb_configs=[
+            PhysicalDFBConfig(
+                dfb_index=0,
+                num_tiles=1,
+                data_format=data_format,
+                block_count=2,
+                page_size=page_size,
+                tile=(32, 32),
+            )
+        ],
+        grid_cols=1,
+        grid_rows=1,
+        num_tensors=1,
+    )
+
+    assert f"(1, 2, {emitted_dtype}," in source
+
+
+def test_emit_runner_source_rejects_unknown_physical_dfb_format():
+    with pytest.raises(ValueError, match="Unrecognized data format"):
+        kernel_runner.emit_runner_source(
+            kernel_specs=[],
+            cb_configs=[
+                PhysicalDFBConfig(
+                    dfb_index=0,
+                    num_tiles=1,
+                    data_format="unknown",
+                    block_count=2,
+                    page_size=2048,
+                    tile=(32, 32),
+                )
+            ],
+            grid_cols=1,
+            grid_rows=1,
+            num_tensors=1,
+        )
 
 
 def test_emit_runner_source_omits_program_hash_by_default():

--- a/test/python/test_l1_budget_device.py
+++ b/test/python/test_l1_budget_device.py
@@ -21,7 +21,7 @@ import torch
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
-from ttl.dataflow_buffer import CompilerAllocatedDFBConfig
+from ttl.dataflow_buffer import PhysicalDFBConfig
 from ttl.constants import DEFAULT_L1_CB_BUDGET_BYTES
 from ttl.kernel_runner import build_cb_descriptors, get_min_remaining_l1_for_device
 
@@ -34,24 +34,32 @@ pytestmark = pytest.mark.skipif(
     not is_hardware_available(), reason="No Tenstorrent device available"
 )
 
-TILE_BYTES = 2048  # bf16 tile: 32 * 32 * 2
+DFB_FORMATS = [
+    ("bfloat16", ttnn.tile_size(ttnn.bfloat16)),
+    ("float32", ttnn.tile_size(ttnn.float32)),
+]
 
 
-def _overflow_config(remaining_bytes):
-    """Build a single CompilerAllocatedDFBConfig whose size exceeds *remaining_bytes*."""
-    overflow_tiles = (remaining_bytes // TILE_BYTES) + 1
-    return CompilerAllocatedDFBConfig(
+def _overflow_config(remaining_bytes, data_format, page_size):
+    """Build a physical DFB configuration larger than *remaining_bytes*."""
+    overflow_tiles = (remaining_bytes // page_size) + 1
+    return PhysicalDFBConfig(
         dfb_index=0,
         num_tiles=overflow_tiles,
-        data_format="bfloat16",
+        data_format=data_format,
         block_count=1,
+        page_size=page_size,
+        tile=(32, 32),
     )
 
 
 class TestReducedWorkerL1:
     """Reduced worker_l1_size lowers cb_limit, triggering the budget check."""
 
-    def test_overflow(self):
+    @pytest.mark.parametrize(
+        ("data_format", "page_size"), DFB_FORMATS, ids=["bf16", "f32"]
+    )
+    def test_overflow(self, data_format, page_size):
         default_size = ttnn.device.get_max_worker_l1_unreserved_size()
         reduced_size = default_size - 1_200_000
         device = ttnn.open_device(device_id=0, worker_l1_size=reduced_size)
@@ -64,7 +72,11 @@ class TestReducedWorkerL1:
             ), f"Expected reduced budget, got {remaining} >= {DEFAULT_L1_CB_BUDGET_BYTES}"
 
             with pytest.raises(ValueError, match="exceeds L1 budget"):
-                build_cb_descriptors([probe], [_overflow_config(remaining)], None)
+                build_cb_descriptors(
+                    [probe],
+                    [_overflow_config(remaining, data_format, page_size)],
+                    None,
+                )
         finally:
             ttnn.close_device(device)
 
@@ -72,7 +84,10 @@ class TestReducedWorkerL1:
 class TestL1TensorAllocation:
     """L1 tensor allocations reduce remaining budget on the target core."""
 
-    def test_overflow(self):
+    @pytest.mark.parametrize(
+        ("data_format", "page_size"), DFB_FORMATS, ids=["bf16", "f32"]
+    )
+    def test_overflow(self, data_format, page_size):
         device = ttnn.open_device(device_id=0)
         try:
             remaining_empty = get_min_remaining_l1_for_device(device)
@@ -88,7 +103,11 @@ class TestL1TensorAllocation:
             )
 
             with pytest.raises(ValueError, match="exceeds L1 budget"):
-                build_cb_descriptors([big], [_overflow_config(remaining_after)], None)
+                build_cb_descriptors(
+                    [big],
+                    [_overflow_config(remaining_after, data_format, page_size)],
+                    None,
+                )
         finally:
             ttnn.close_device(device)
 
@@ -96,7 +115,10 @@ class TestL1TensorAllocation:
 class TestBothReducedL1AndTensorAllocation:
     """Reduced worker_l1_size combined with L1 tensor allocations."""
 
-    def test_overflow(self):
+    @pytest.mark.parametrize(
+        ("data_format", "page_size"), DFB_FORMATS, ids=["bf16", "f32"]
+    )
+    def test_overflow(self, data_format, page_size):
         default_size = ttnn.device.get_max_worker_l1_unreserved_size()
         reduced_size = default_size - 800_000
         device = ttnn.open_device(device_id=0, worker_l1_size=reduced_size)
@@ -116,6 +138,10 @@ class TestBothReducedL1AndTensorAllocation:
             )
 
             with pytest.raises(ValueError, match="exceeds L1 budget"):
-                build_cb_descriptors([big], [_overflow_config(remaining)], None)
+                build_cb_descriptors(
+                    [big],
+                    [_overflow_config(remaining, data_format, page_size)],
+                    None,
+                )
         finally:
             ttnn.close_device(device)

--- a/test/ttlang/Dialect/TTL/IR/cb_ops_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/cb_ops_invalid.mlir
@@ -180,6 +180,18 @@ module {
 
 // -----
 
+// Logical DFB identities must be non-negative.
+module {
+  func.func @negative_dfb_id() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-error @below {{dfb_id must be non-negative}}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = -1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+}
+
+// -----
+
 // cb_reserve must acquire a positive tile count.
 module {
   func.func @cb_reserve_non_positive_num_tiles(%cb: !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/dump_cb_flow_graph.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dump_cb_flow_graph.mlir
@@ -1,0 +1,34 @@
+// Verify that the CB flow dump keeps logical DFBs separate after physical
+// index reuse.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-dump-cb-flow-graph{output=%t.json})'
+// RUN: FileCheck %s --input-file=%t.json
+
+// Distinct logical DFBs at one physical index require distinct JSON entries.
+
+// CHECK-DAG: {"cb_index":0,"consumers":[],"dfb_id":10
+// CHECK-DAG: {"cb_index":0,"consumers":[],"dfb_id":11
+module attributes {
+  ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32,
+                          element_type = !ttcore.tile<32x32, bf16>,
+                          num_tiles = 1 : i32, page_size = 2048 : i32}]
+} {
+  func.func @first_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+
+  func.func @second_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 11 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
@@ -9,22 +9,32 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=THREE
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SINGLE
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=GLOBAL
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SUBTILE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=RANK3
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=NESTED
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefixes=COMPACT-GAP,COMPACT-NOZERO
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=PAGE-TYPES
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=SCALAR
 
 // -----
 
 // User DFBs at indices 0, 1, 2 and a compiler-allocated DFB at index 3.
-// The pass should update base_cta_index to 4 and emit ttl.compiler_allocated_dfbs.
+// The pass should update base_cta_index to 4 and emit the complete allocation
+// table.
 
-// CHECK: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32},
+// CHECK-SAME: {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32},
+// CHECK-SAME: {block_count = 2 : i32, dfb_index = 2 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32},
+// CHECK-SAME: {block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32}
+// CHECK-SAME: ]}
 
 // CHECK-LABEL: func.func @reader
 // CHECK-SAME: ttl.base_cta_index = 4 : i32
 func.func @reader()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = [0 : i32, 1 : i32]} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }
 
@@ -33,9 +43,9 @@ func.func @reader()
 func.func @compute()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }
@@ -45,25 +55,25 @@ func.func @compute()
 func.func @writer()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = [0 : i32, 1 : i32]} {
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }
 
 // -----
 
-// No compiler-allocated DFBs: pass should not add ttl.compiler_allocated_dfbs,
-// but should still update base_cta_index to the true DFB count (3).
+// With no compiler-allocated DFBs, the pass still updates base_cta_index to
+// the true DFB count (3).
 
-// CHECK-NOT: ttl.compiler_allocated_dfbs
+// CHECK: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // CHECK-LABEL: func.func @compute_only
 // CHECK-SAME: ttl.base_cta_index = 3 : i32
 func.func @compute_only()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }
 
@@ -74,7 +84,7 @@ func.func @compute_only()
 // DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 1 physical slot(s)
 // DEBUG: Total DFB count: 4
 
-// REUSE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// REUSE: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // REUSE-LABEL: func.func @non_overlapping_reuse
 // REUSE-SAME: ttl.base_cta_index = 4 : i32
@@ -84,9 +94,9 @@ func.func @compute_only()
 func.func @non_overlapping_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserve3 = ttl.cb_reserve %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.cb_push %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -108,7 +118,7 @@ func.func @non_overlapping_reuse()
 // DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
-// OVERLAP: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// OVERLAP: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // OVERLAP-LABEL: func.func @overlapping_no_reuse
 // OVERLAP-SAME: ttl.base_cta_index = 5 : i32
@@ -119,9 +129,9 @@ func.func @non_overlapping_reuse()
 func.func @overlapping_no_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserve3 = ttl.cb_reserve %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %alloc4 = ttl.bind_cb {cb_index = 4, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -147,21 +157,21 @@ func.func @overlapping_no_reuse()
 // DEBUG: DFB reuse: 4 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
-// FOUR: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// FOUR: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // FOUR-LABEL: func.func @four_dfbs_nested_reuse
 // FOUR-SAME: ttl.base_cta_index = 5 : i32
 //
 // DFB-A -> slot 0 (index 3)
-// FOUR: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated}
+// FOUR: ttl.bind_cb{cb_index = 3, {{.*}}} {dfb_id = 3 : index, ttl.compiler_allocated}
 // DFB-B -> slot 1 (index 4)
-// FOUR: ttl.bind_cb{cb_index = 4, {{.*}}} {ttl.compiler_allocated}
+// FOUR: ttl.bind_cb{cb_index = 4, {{.*}}} {dfb_id = 4 : index, ttl.compiler_allocated}
 // FOUR: ttl.cb_pop
 // FOUR: ttl.cb_pop
 // DFB-C -> slot 0 (index 3, reused from A)
-// FOUR: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated}
+// FOUR: ttl.bind_cb{cb_index = 3, {{.*}}} {dfb_id = 5 : index, ttl.compiler_allocated}
 // DFB-D -> slot 1 (index 4, reused from B)
-// FOUR: ttl.bind_cb{cb_index = 4, {{.*}}} {ttl.compiler_allocated}
+// FOUR: ttl.bind_cb{cb_index = 4, {{.*}}} {dfb_id = 6 : index, ttl.compiler_allocated}
 // FOUR: ttl.cb_pop
 // FOUR: ttl.cb_pop
 // FOUR-NOT: cb_index = 5
@@ -170,9 +180,9 @@ func.func @overlapping_no_reuse()
 func.func @four_dfbs_nested_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %allocA = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserveA = ttl.cb_reserve %allocA : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %allocB = ttl.bind_cb {cb_index = 4, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -210,24 +220,24 @@ func.func @four_dfbs_nested_reuse()
 // DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
-// MIXED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32}]}
+// MIXED: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // MIXED-LABEL: func.func @mixed_types_no_cross_reuse
 // MIXED-SAME: ttl.base_cta_index = 5 : i32
 // [1,1] partition slot
-// MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
+// MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {dfb_id = 3 : index, ttl.compiler_allocated} : <[1, 1],
 // [2,4] partition slot
-// MIXED: ttl.bind_cb{cb_index = 4, {{.*}}} {ttl.compiler_allocated} : <[2, 4],
+// MIXED: ttl.bind_cb{cb_index = 4, {{.*}}} {dfb_id = 4 : index, ttl.compiler_allocated} : <[2, 4],
 // [1,1] partition slot reused
-// MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated} : <[1, 1],
+// MIXED: ttl.bind_cb{cb_index = 3, {{.*}}} {dfb_id = 5 : index, ttl.compiler_allocated} : <[1, 1],
 // MIXED-NOT: cb_index = 5
 // MIXED: return
 func.func @mixed_types_no_cross_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   // [1,1] DFB
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserve3 = ttl.cb_reserve %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -257,7 +267,7 @@ func.func @mixed_types_no_cross_reuse()
 // DEBUG: DFB reuse: 2 compiler-allocated DFBs -> 2 physical slot(s)
 // DEBUG: Total DFB count: 5
 
-// UNUSED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// UNUSED: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // UNUSED-LABEL: func.func @unused_declarations_conservative
 // UNUSED-SAME: ttl.base_cta_index = 5 : i32
@@ -268,9 +278,9 @@ func.func @mixed_types_no_cross_reuse()
 func.func @unused_declarations_conservative()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc4 = ttl.bind_cb {cb_index = 4, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
@@ -284,7 +294,7 @@ func.func @unused_declarations_conservative()
 // DEBUG: DFB reuse: 3 compiler-allocated DFBs -> 1 physical slot(s)
 // DEBUG: Total DFB count: 4
 
-// THREE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// THREE: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // THREE-LABEL: func.func @three_sequential_one_slot
 // THREE-SAME: ttl.base_cta_index = 4 : i32
@@ -294,9 +304,9 @@ func.func @unused_declarations_conservative()
 func.func @three_sequential_one_slot()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserve3 = ttl.cb_reserve %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.cb_push %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -320,19 +330,19 @@ func.func @three_sequential_one_slot()
 // A single compiler-allocated DFB is assigned the first physical index after
 // the user-declared range.
 
-// SINGLE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 3 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// SINGLE: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // SINGLE-LABEL: func.func @single_dfb_no_reuse
 // SINGLE-SAME: ttl.base_cta_index = 4 : i32
-// SINGLE: ttl.bind_cb{cb_index = 3, {{.*}}} {ttl.compiler_allocated}
+// SINGLE: ttl.bind_cb{cb_index = 3, {{.*}}} {dfb_id = 3 : index, ttl.compiler_allocated}
 // SINGLE-NOT: cb_index = 4
 // SINGLE: return
 func.func @single_dfb_no_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
                 ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %alloc3 = ttl.bind_cb {cb_index = 3, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserve3 = ttl.cb_reserve %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.cb_push %alloc3 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -348,7 +358,7 @@ func.func @single_dfb_no_reuse()
 // physical indices after the highest user-declared index, including user
 // indices in other kernels.
 
-// GLOBAL: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 5 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 2 : i32, dfb_index = 6 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// GLOBAL: module attributes {ttl.dfb_allocations = {{.*}}}
 
 // GLOBAL-LABEL: func.func @global_user_index
 // GLOBAL-SAME: ttl.base_cta_index = 7 : i32
@@ -356,17 +366,20 @@ func.func @single_dfb_no_reuse()
 func.func @global_user_index()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 5 : i32,
                 ttl.crta_indices = []} {
-  %user4 = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %user1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %user2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %user3 = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %user4 = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   return
 }
 
 // GLOBAL-LABEL: func.func @first_provisional_index
 // GLOBAL-SAME: ttl.base_cta_index = 7 : i32
-// GLOBAL: ttl.bind_cb{cb_index = 5, {{.*}}} {ttl.compiler_allocated}
+// GLOBAL: ttl.bind_cb{cb_index = 5, {{.*}}} {dfb_id = 5 : index, ttl.compiler_allocated}
 func.func @first_provisional_index()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 1 : i32,
                 ttl.crta_indices = []} {
-  %user0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %user0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %compiler1 = ttl.bind_cb {cb_index = 1, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserve1 = ttl.cb_reserve %compiler1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.cb_push %compiler1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -377,11 +390,11 @@ func.func @first_provisional_index()
 
 // GLOBAL-LABEL: func.func @second_provisional_index
 // GLOBAL-SAME: ttl.base_cta_index = 7 : i32
-// GLOBAL: ttl.bind_cb{cb_index = 6, {{.*}}} {ttl.compiler_allocated}
+// GLOBAL: ttl.bind_cb{cb_index = 6, {{.*}}} {dfb_id = 6 : index, ttl.compiler_allocated}
 func.func @second_provisional_index()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 1 : i32,
                 ttl.crta_indices = []} {
-  %user0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %user0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %compiler1 = ttl.bind_cb {cb_index = 1, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %reserve1 = ttl.cb_reserve %compiler1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.cb_push %compiler1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -392,11 +405,112 @@ func.func @second_provisional_index()
 
 // -----
 
+// The runtime allocation table records the byte size of the complete subtile,
+// rather than assuming a 32x32 tile.
+
+// SUBTILE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}
+// SUBTILE-SAME: ]}
+// SUBTILE-LABEL: func.func @subtile_page_size
+func.func @subtile_page_size()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+      : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+  return
+}
+
+// -----
+
+// The runtime allocation table records every dimension in the DFB block shape.
+
+// RANK3: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 8 : i32, page_size = 2048 : i32}
+// RANK3-SAME: ]}
+// RANK3-LABEL: func.func @rank_three_num_tiles
+func.func @rank_three_num_tiles()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+      : !ttl.cb<[2, 2, 2], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Sparse frontend indices are compacted because physical allocation does not
+// inherit logical DFB numbering.
+
+// COMPACT-GAP: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32}, {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, f32>, num_tiles = 1 : i32, page_size = 4096 : i32}]}
+// COMPACT-GAP-LABEL: func.func @compact_middle_gap
+// COMPACT-GAP-SAME: ttl.base_cta_index = 2 : i32
+// COMPACT-GAP-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// COMPACT-GAP-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 2 : index}
+func.func @compact_middle_gap()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %third = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  return
+}
+
+// -----
+
+// A user range that starts above zero receives the same compaction.
+
+// COMPACT-NOZERO: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bfp_bf8>, num_tiles = 1 : i32, page_size = 1088 : i32}, {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32}]}
+// COMPACT-NOZERO-LABEL: func.func @compact_missing_zero
+// COMPACT-NOZERO-SAME: ttl.base_cta_index = 2 : i32
+// COMPACT-NOZERO-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// COMPACT-NOZERO-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 2 : index}
+func.func @compact_missing_zero()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+  %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bfp_bf8>, 2>
+  %third = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
+// Finalization derives page size from each exact tile element type.
+
+// PAGE-TYPES: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, f32>, num_tiles = 1 : i32, page_size = 4096 : i32}, {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, bfp_bf8>, num_tiles = 1 : i32, page_size = 1088 : i32}]}
+// PAGE-TYPES-LABEL: func.func @tile_page_sizes
+func.func @tile_page_sizes()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %f32 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %bfp_bf8 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bfp_bf8>, 2>
+  return
+}
+
+// -----
+
+// Scalar DFBs use one scalar element per hardware page and do not imply tile
+// dimensions.
+
+// SCALAR: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = f32, num_tiles = 128 : i32, page_size = 4 : i32}]}
+// SCALAR-LABEL: func.func @scalar_page_size
+func.func @scalar_page_size()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+      : !ttl.cb<[128], f32, 2>
+  return
+}
+
+// -----
+
 // A reserve before another DFB's pop inside the same region-bearing kernel-body
 // operation makes both DFBs live concurrently. Projection gives both events
 // the same ordinal, so the pop endpoint must include that ordinal.
 
-// NESTED: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}, {block_count = 1 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// NESTED: module attributes {ttl.dfb_allocations = [{block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32}, {block_count = 1 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32}]}
 // NESTED-LABEL: func.func @nested_lifecycles_overlap
 // NESTED-SAME: ttl.base_cta_index = 2 : i32
 // NESTED: ttl.bind_cb{cb_index = 0,

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_atomic_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_atomic_invalid.mlir
@@ -1,13 +1,43 @@
 // Verifies that allocation failure leaves provisional DFB indices and kernel
 // configuration unchanged and does not create runtime metadata.
-// RUN: ttlang-opt %s --verify-diagnostics --mlir-print-ir-after=ttl-finalize-dfb-indices --mlir-print-ir-after-failure -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' 2>&1 | FileCheck %s --implicit-check-not=ttl.compiler_allocated_dfbs
+// RUN: ttlang-opt %s --verify-diagnostics --mlir-print-ir-after=ttl-finalize-dfb-indices --mlir-print-ir-after-failure -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' 2>&1 | FileCheck %s --implicit-check-not=ttl.dfb_allocations
 
 // expected-error @below {{need 33 DFB indices but hardware supports at most 32 (1 compiler-allocated after reuse)}}
 module {
-  func.func @user_index_31()
+  func.func @all_user_indices()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %user_dfb = ttl.bind_cb {cb_index = 31, block_count = 1}
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user0 = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user1 = ttl.bind_cb {cb_index = 1, block_count = 1} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user2 = ttl.bind_cb {cb_index = 2, block_count = 1} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user3 = ttl.bind_cb {cb_index = 3, block_count = 1} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user4 = ttl.bind_cb {cb_index = 4, block_count = 1} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user5 = ttl.bind_cb {cb_index = 5, block_count = 1} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user6 = ttl.bind_cb {cb_index = 6, block_count = 1} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user7 = ttl.bind_cb {cb_index = 7, block_count = 1} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user8 = ttl.bind_cb {cb_index = 8, block_count = 1} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user9 = ttl.bind_cb {cb_index = 9, block_count = 1} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user10 = ttl.bind_cb {cb_index = 10, block_count = 1} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user11 = ttl.bind_cb {cb_index = 11, block_count = 1} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user12 = ttl.bind_cb {cb_index = 12, block_count = 1} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user13 = ttl.bind_cb {cb_index = 13, block_count = 1} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user14 = ttl.bind_cb {cb_index = 14, block_count = 1} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user15 = ttl.bind_cb {cb_index = 15, block_count = 1} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user16 = ttl.bind_cb {cb_index = 16, block_count = 1} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user17 = ttl.bind_cb {cb_index = 17, block_count = 1} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user18 = ttl.bind_cb {cb_index = 18, block_count = 1} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user19 = ttl.bind_cb {cb_index = 19, block_count = 1} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user20 = ttl.bind_cb {cb_index = 20, block_count = 1} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user21 = ttl.bind_cb {cb_index = 21, block_count = 1} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user22 = ttl.bind_cb {cb_index = 22, block_count = 1} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user23 = ttl.bind_cb {cb_index = 23, block_count = 1} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user24 = ttl.bind_cb {cb_index = 24, block_count = 1} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user25 = ttl.bind_cb {cb_index = 25, block_count = 1} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user26 = ttl.bind_cb {cb_index = 26, block_count = 1} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user27 = ttl.bind_cb {cb_index = 27, block_count = 1} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user28 = ttl.bind_cb {cb_index = 28, block_count = 1} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user29 = ttl.bind_cb {cb_index = 29, block_count = 1} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user30 = ttl.bind_cb {cb_index = 30, block_count = 1} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %user31 = ttl.bind_cb {cb_index = 31, block_count = 1} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     return
   }
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_before_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_before_config.mlir
@@ -8,7 +8,10 @@
 func.func @global_user_index()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>, ttl.base_cta_index = 5 : i32,
                 ttl.crta_indices = []} {
-  %user4 = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %user1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %user2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %user3 = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %user4 = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   return
 }
 
@@ -16,11 +19,11 @@ func.func @global_user_index()
 // 1. Finalization moves it to physical index 5 before compute configuration
 // records the SFPU f32 input index.
 
-// CHECK: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 2 : i32, dfb_index = 5 : i32, element_type = !ttcore.tile<32x32, f32>, num_tiles = 1 : i32}]}
+// CHECK: module attributes {ttl.dfb_allocations = {{.*}}}
 // CHECK-LABEL: func.func @compiler_f32_sfpu
 // CHECK-SAME: ttl.base_cta_index = 6 : i32
 // CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 5>
-// CHECK: %[[COMPILER_DFB:.*]] = ttl.bind_cb{cb_index = 5, {{.*}}} {ttl.compiler_allocated}
+// CHECK: %[[COMPILER_DFB:.*]] = ttl.bind_cb{cb_index = 5, {{.*}}} {dfb_id = 5 : index, ttl.compiler_allocated}
 func.func @compiler_f32_sfpu(
     %input: tensor<1x1x!ttcore.tile<32x32, f32>>)
     -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -29,7 +32,7 @@ func.func @compiler_f32_sfpu(
   %c0 = arith.constant 0 : index
   %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
 
-  %output_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
   %compiler_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
 
   %compiler_reserve = ttl.cb_reserve %compiler_dfb

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
@@ -1,6 +1,108 @@
-// Verify that final DFB allocation rejects incomplete compiler-created
-// lifecycles before rewriting physical indices.
+// Verify diagnostics for unresolved logical identities, incompatible physical
+// assignments, and partial compiler-created lifecycles.
 // RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)'
+
+// One physical index requires one exact DFB type.
+module {
+  func.func @bf16_declaration()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @f32_declaration()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    // expected-error @below {{physical DFB index 0 has inconsistent CircularBufferType values}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    return
+  }
+}
+
+// -----
+
+// User-declared DFBs require an explicit module-wide logical identity.
+module {
+  func.func @missing_user_identity()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    // expected-error @below {{user-declared DFB requires dfb_id before physical allocation}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// Generated identities must not overflow the index attribute domain.
+module {
+  func.func @exhausted_identity_domain()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %user = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 9223372036854775807 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{logical DFB identifiers leave no space for compiler-created DFBs}}
+    %compiler = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// Declarations of one logical DFB require one exact type.
+module {
+  func.func @type_mismatch_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @type_mismatch_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    // expected-error @below {{logical DFB 0 has inconsistent types across kernel functions}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    return
+  }
+}
+
+// -----
+
+// One logical DFB requires one physical index in every participating kernel.
+module {
+  func.func @physical_index_mismatch_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @physical_index_mismatch_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    // expected-error @below {{logical DFB 0 has inconsistent physical indices 0 and 1}}
+    %dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
 
 // A producer lifecycle requires a reserve before its push.
 func.func @missing_reserve()

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_order_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_order_invalid.mlir
@@ -25,7 +25,7 @@ func.func @compute_association_before_finalization()
   %compiler_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
       {ttl.compiler_allocated}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
-  %output_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+  %output_dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %input = ttl.attach_cb %empty, %compiler_dfb
       : (tensor<1x1x!ttcore.tile<32x32, bf16>>,

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs.mlir
@@ -18,9 +18,9 @@
 // CHECK: ttl.reduce {{.*}} 0 : i32
 func.func @elementwise_into_reduce()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[2, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<2x4x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x4x!ttcore.tile<32x32, bf16>>
   %b_wait = ttl.cb_wait %cb1 : <[2, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
@@ -44,8 +44,8 @@ func.func @elementwise_into_reduce()
 // CHECK: return
 func.func @already_cb_attached()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[2, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<2x4x!ttcore.tile<32x32, bf16>>, !ttl.cb<[2, 4], !ttcore.tile<32x32, bf16>, 2>) -> tensor<2x4x!ttcore.tile<32x32, bf16>>
   %s_wait = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -64,10 +64,10 @@ func.func @already_cb_attached()
 // PIPELINE: ttl.compute
 func.func @add_then_reduce()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -100,9 +100,9 @@ func.func @add_then_reduce()
 // CHECK: ttl.reduce
 func.func @shared_materialization()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %b_wait = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -138,7 +138,7 @@ func.func @shared_materialization()
 // CHECK: ttl.reduce
 
 // After finalize with reuse: both DFBs get index 4 (one physical slot).
-// FINALIZE: module attributes {ttl.compiler_allocated_dfbs = [{block_count = 1 : i32, dfb_index = 4 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32}]}
+// FINALIZE: module attributes {ttl.dfb_allocations = {{.*}}}
 // FINALIZE-LABEL: func.func @sequential_intermediates_reuse
 // FINALIZE-SAME: ttl.base_cta_index = 5 : i32
 // FINALIZE-NOT: cb_index = 5
@@ -146,10 +146,10 @@ func.func @shared_materialization()
 func.func @sequential_intermediates_reuse()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                 ttl.base_cta_index = 4 : i32, ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %b_wait = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -183,8 +183,8 @@ func.func @sequential_intermediates_reuse()
 // CHECK: return
 func.func @mul_unary_const_skips_fusible_input()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %b_wait = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -208,8 +208,8 @@ func.func @mul_unary_const_skips_fusible_input()
 // CHECK: return
 func.func @mul_skips_two_fusible_inputs()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %b_wait = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -239,9 +239,9 @@ func.func @mul_skips_two_fusible_inputs()
 // CHECK: return
 func.func @mul_materializes_only_reduce_side()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_s = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_s = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %b_wait = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_deferred.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_deferred.mlir
@@ -39,11 +39,11 @@
 // FULL: ttl.cb_pop %[[INTERMEDIATE_DFB]]
 func.func @stored_add_then_reduce()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_sum = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_sum = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -90,10 +90,10 @@ func.func @stored_add_then_reduce()
 // FULL: ttl.cb_pop %[[INTERMEDIATE_DFB]]
 func.func @state_update_feeds_broadcast()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb_state_old = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_max = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_state_next = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb_state_old = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_max = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_state_next = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
 
   %state_wait = ttl.cb_wait %cb_state_old : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %state_old = ttl.attach_cb %state_wait, %cb_state_old : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -139,9 +139,9 @@ func.func @state_update_feeds_broadcast()
 // FULL: ttl.cb_pop %[[INTERMEDIATE_DFB]]
 func.func @same_dfb_state_update_feeds_broadcast()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb_state = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_max = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb_state = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_max = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
 
   %state_wait = ttl.cb_wait %cb_state : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %state_old = ttl.attach_cb %state_wait, %cb_state : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -184,10 +184,10 @@ func.func @same_dfb_state_update_feeds_broadcast()
 // FULL: ttl.cb_pop %[[INTERMEDIATE_DFB]]
 func.func @broadcast_result_then_reduce()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_bcast = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_bcast = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -235,12 +235,12 @@ func.func @broadcast_result_then_reduce()
 // FULL: ttl.cb_pop %[[INTERMEDIATE_DFB]]
 func.func @branch_local_reductions(%cond: i1)
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_sum = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_then = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_else = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_sum = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_then = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_else = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -287,14 +287,14 @@ func.func @branch_local_reductions(%cond: i1)
 func.func @multi_output_reuse_after_rebuild()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %c-1 = arith.constant -1 : index
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_sum = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_prod = ttl.bind_cb {cb_index = 4, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out0 = ttl.bind_cb {cb_index = 5, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out1 = ttl.bind_cb {cb_index = 6, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_out2 = ttl.bind_cb {cb_index = 7, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_sum = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_prod = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out0 = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out1 = ttl.bind_cb {cb_index = 6, block_count = 2} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_out2 = ttl.bind_cb {cb_index = 7, block_count = 2} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_disabled.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_disabled.mlir
@@ -6,8 +6,8 @@
 // CHECK-NOT: ttl.compiler_allocated
 func.func @already_cb_attached_disabled()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %s_wait = ttl.cb_wait %cb1 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
@@ -14,11 +14,38 @@
 module {
 func.func @exceeds_max_cb_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  // Use index 31 to occupy the last slot.
-  %cb31 = ttl.bind_cb {cb_index = 31, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb4 = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb5 = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb6 = ttl.bind_cb {cb_index = 6, block_count = 2} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb7 = ttl.bind_cb {cb_index = 7, block_count = 2} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb8 = ttl.bind_cb {cb_index = 8, block_count = 2} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb9 = ttl.bind_cb {cb_index = 9, block_count = 2} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb10 = ttl.bind_cb {cb_index = 10, block_count = 2} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb11 = ttl.bind_cb {cb_index = 11, block_count = 2} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb12 = ttl.bind_cb {cb_index = 12, block_count = 2} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb13 = ttl.bind_cb {cb_index = 13, block_count = 2} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb14 = ttl.bind_cb {cb_index = 14, block_count = 2} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb15 = ttl.bind_cb {cb_index = 15, block_count = 2} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb16 = ttl.bind_cb {cb_index = 16, block_count = 2} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb17 = ttl.bind_cb {cb_index = 17, block_count = 2} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb18 = ttl.bind_cb {cb_index = 18, block_count = 2} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb19 = ttl.bind_cb {cb_index = 19, block_count = 2} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb20 = ttl.bind_cb {cb_index = 20, block_count = 2} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb21 = ttl.bind_cb {cb_index = 21, block_count = 2} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb22 = ttl.bind_cb {cb_index = 22, block_count = 2} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb23 = ttl.bind_cb {cb_index = 23, block_count = 2} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb24 = ttl.bind_cb {cb_index = 24, block_count = 2} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb25 = ttl.bind_cb {cb_index = 25, block_count = 2} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb26 = ttl.bind_cb {cb_index = 26, block_count = 2} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb27 = ttl.bind_cb {cb_index = 27, block_count = 2} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb28 = ttl.bind_cb {cb_index = 28, block_count = 2} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb29 = ttl.bind_cb {cb_index = 29, block_count = 2} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb30 = ttl.bind_cb {cb_index = 30, block_count = 2} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb31 = ttl.bind_cb {cb_index = 31, block_count = 2} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %a = ttl.attach_cb %a_wait, %cb0 : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
@@ -12,7 +12,7 @@
 // entry, the rest of the materialization bundle stays inside the loop.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_for
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {dfb_id = 3 : index, ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   ttl.add
 // CHECK:   ttl.cb_reserve
@@ -30,9 +30,9 @@ func.func @intermediate_in_scf_for()
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   scf.for %iv = %c0 to %c4 step %c1 {
     %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -58,7 +58,7 @@ func.func @intermediate_in_scf_for()
 // function body entry, not inside the if region.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {dfb_id = 3 : index, ttl.compiler_allocated}
 // CHECK: scf.if
 // CHECK-NOT: ttl.compiler_allocated
 // CHECK:   ttl.add
@@ -72,9 +72,9 @@ func.func @intermediate_in_scf_for()
 func.func @intermediate_in_scf_if(%cond: i1)
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                 ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   scf.if %cond {
     %a_wait = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -101,7 +101,7 @@ func.func @intermediate_in_scf_if(%cond: i1)
 // Before the fix, this crashed in TTLFinalizeDFBIndices.
 
 // CHECK-LABEL: func.func @intermediate_in_nested_for_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 1} {dfb_id = 3 : index, ttl.compiler_allocated}
 // CHECK: scf.for
 // CHECK:   scf.if
 // CHECK-NOT: ttl.compiler_allocated
@@ -116,9 +116,9 @@ func.func @intermediate_in_nested_for_if(%cond: i1)
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb_scaler = ttl.bind_cb {cb_index = 2, block_count = 2} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
 
   scf.for %iv = %c0 to %c4 step %c1 {
     scf.if %cond {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
@@ -1,11 +1,11 @@
-// RUN: ttlang-opt %s --split-input-file -ttl-verify-dfb-spsc | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' | FileCheck %s
 
 // Producer in one thread, consumer in another: classic SPSC, accepted.
 // CHECK-LABEL: func.func @producer
 // CHECK-LABEL: func.func @consumer
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %v = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -14,7 +14,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   }
 
   func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %v = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -30,7 +30,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // CHECK-LABEL: func.func @produce_and_consume
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @produce_and_consume() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 2, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 2 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %r = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -49,7 +49,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // CHECK-LABEL: func.func @consumer_multi_wait
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 1, block_count = 4}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 4} {dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
     %v = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
@@ -58,7 +58,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   }
 
   func.func @consumer_multi_wait() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 1, block_count = 4}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 4} {dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
     %a = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
@@ -79,7 +79,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // CHECK-LABEL: func.func @untagged_helper
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @kernel_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 4, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 4 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %v = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -88,7 +88,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   }
 
   func.func @untagged_helper() {
-    %cb = ttl.bind_cb {cb_index = 4, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 4 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %v = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -104,7 +104,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // CHECK-LABEL: func.func @producer_multi_reserve
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @producer_multi_reserve() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 6, block_count = 4}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 4} {dfb_id = 6 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
     %a = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
@@ -116,7 +116,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   }
 
   func.func @single_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 6, block_count = 4}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 4} {dfb_id = 6 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
     %v = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
@@ -127,15 +127,15 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // -----
 
-// Two distinct CBs each correctly SPSC across the same two threads: the
-// verifier disambiguates by `cb_index` and accepts both.
+// Two logical DFBs are each SPSC across the same two kernels. Their distinct
+// `dfb_id` values keep their participant sets separate.
 // CHECK-LABEL: func.func @two_cb_producer
 // CHECK-LABEL: func.func @two_cb_consumer
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @two_cb_producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb_a = ttl.bind_cb {cb_index = 10, block_count = 2}
+    %cb_a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 10 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %cb_b = ttl.bind_cb {cb_index = 11, block_count = 2}
+    %cb_b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 11 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %a = ttl.cb_reserve %cb_a
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -147,9 +147,9 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   }
 
   func.func @two_cb_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb_a = ttl.bind_cb {cb_index = 10, block_count = 2}
+    %cb_a = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 10 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %cb_b = ttl.bind_cb {cb_index = 11, block_count = 2}
+    %cb_b = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 11 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %a = ttl.cb_wait %cb_a
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -169,7 +169,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // CHECK-LABEL: func.func @consumer_x1
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @producer_all_nodes() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 20, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 20 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %slot = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -179,7 +179,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   }
 
   func.func @consumer_x0() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 20, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 20 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %zero = arith.constant 0 : index
@@ -194,7 +194,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   }
 
   func.func @consumer_x1() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 20, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 20 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %one = arith.constant 1 : index
@@ -211,13 +211,58 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 
 // -----
 
+// Two logical DFBs may share a physical index when each remains SPSC.
+// CHECK-LABEL: func.func @first_reused_producer
+// CHECK-LABEL: func.func @first_reused_consumer
+// CHECK-LABEL: func.func @second_reused_producer
+// CHECK-LABEL: func.func @second_reused_consumer
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @first_reused_producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @first_reused_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %view = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @second_reused_producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 11 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @second_reused_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 11 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %view = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
 // Two producer kernels may reserve the same DFB when their launch-node domains
 // are disjoint.
 // CHECK-LABEL: func.func @producer_x0
 // CHECK-LABEL: func.func @producer_x1
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @producer_x0() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 21, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 21 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %zero = arith.constant 0 : index
@@ -231,7 +276,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   }
 
   func.func @producer_x1() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 21, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 21 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %one = arith.constant 1 : index
@@ -254,7 +299,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @consumer_dst() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %pipe = ttl.create_pipe src(1, 0) dst(0, 0) to(0, 0) net 0
         : !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 21, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 21 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_dst %pipe : !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0> {
       %view = ttl.cb_wait %cb
@@ -268,7 +313,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @consumer_src() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(1, 0) dst(0, 0) to(0, 0) net 0
         : !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 21, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 21 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_src %pipe : !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0> {
       %view = ttl.cb_wait %cb

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
@@ -1,0 +1,42 @@
+// Tests that SPSC verification preserves distinct logical identities when
+// different kernels use one physical DFB index.
+//
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' | FileCheck %s
+
+// Distinct logical DFBs may share one physical index without becoming one SPSC
+// participant set.
+
+// CHECK: module attributes {ttl.dfb_allocations = [
+// CHECK-SAME: {block_count = 2 : i32, dfb_index = 0 : i32,
+// CHECK-LABEL: func.func @producer_a
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}
+// CHECK-LABEL: func.func @producer_b
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 1 : index}
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @producer_a()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+
+  func.func @producer_b()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %second = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-dfb-spsc
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)'
 
 // Summary: Negative tests for per-launch-node DFB SPSC verification.
 
@@ -7,9 +7,9 @@
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @consumer_all_nodes() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-note @+1 {{dataflow buffer declared here}}
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    // expected-error @below {{dataflow buffer cb_index=0 has multiple consumer threads active on the same launched node}}
+    // expected-error @below {{logical DFB 0 has multiple consumer kernels active on the same launched node}}
     // expected-note @below {{example overlapping node: core_x=0, core_y=0}}
     // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per consumer}}
     %view = ttl.cb_wait %cb
@@ -19,7 +19,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   }
 
   func.func @consumer_x0() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %zero = arith.constant 0 : index
@@ -41,9 +41,9 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @producer_all_nodes() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-note @+1 {{dataflow buffer declared here}}
-    %cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    // expected-error @below {{dataflow buffer cb_index=1 has multiple producer threads active on the same launched node}}
+    // expected-error @below {{logical DFB 1 has multiple producer kernels active on the same launched node}}
     // expected-note @below {{example overlapping node: core_x=1, core_y=0}}
     // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per producer}}
     %slot = ttl.cb_reserve %cb
@@ -53,7 +53,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   }
 
   func.func @producer_x1() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %one = arith.constant 1 : index
@@ -76,7 +76,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unknown_consumer(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-note @+1 {{dataflow buffer declared here}}
-    %cb = ttl.bind_cb {cb_index = 2, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 2 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %scaled = arith.muli %core_x, %runtime : index
@@ -86,7 +86,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     scf.if %cond {
       %is_x0 = arith.cmpi eq, %core_x, %zero : index
       scf.if %is_x0 {
-        // expected-error @below {{dataflow buffer cb_index=2 has multiple consumer threads, but SPSC could not be statically proven}}
+        // expected-error @below {{logical DFB 2 has multiple consumer kernels, but SPSC could not be statically proven}}
         // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per consumer}}
         %view = ttl.cb_wait %cb
             : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -97,7 +97,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   }
 
   func.func @other_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 2, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 2 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-note @below {{also waited on here}}
     %view = ttl.cb_wait %cb
@@ -115,7 +115,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unknown_producer(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-note @+1 {{dataflow buffer declared here}}
-    %cb = ttl.bind_cb {cb_index = 6, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 6 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %scaled = arith.muli %core_x, %runtime : index
@@ -125,7 +125,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     scf.if %cond {
       %is_x0 = arith.cmpi eq, %core_x, %zero : index
       scf.if %is_x0 {
-        // expected-error @below {{dataflow buffer cb_index=6 has multiple producer threads, but SPSC could not be statically proven}}
+        // expected-error @below {{logical DFB 6 has multiple producer kernels, but SPSC could not be statically proven}}
         // expected-note @below {{tt-metal CBs are single-producer single-consumer; allocate one DFB per producer}}
         %slot = ttl.cb_reserve %cb
             : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -136,7 +136,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   }
 
   func.func @other_producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %cb = ttl.bind_cb {cb_index = 6, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 6 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-note @below {{also reserved here}}
     %slot = ttl.cb_reserve %cb
@@ -153,7 +153,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 // expected-error @below {{ttl-verify-dfb-spsc requires a `ttl.launch_grid` module attribute}}
 module {
   func.func @missing_launch_grid() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 3, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 3 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %view = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -169,7 +169,7 @@ module {
 // expected-error @below {{ttl-verify-dfb-spsc requires a `ttl.launch_grid` module attribute}}
 module attributes {ttl.launch_grid = [0 : i64, 1 : i64]} {
   func.func @malformed_launch_grid() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 4, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 4 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %view = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -185,7 +185,7 @@ module attributes {ttl.launch_grid = [0 : i64, 1 : i64]} {
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @malformed_pipenet_scope() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-    %cb = ttl.bind_cb {cb_index = 5, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 5 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{has invalid PipeNet role 7}}
     ttl.pipenet_scope attributes {ttl.pipe_net_ids = [0 : i64], ttl.pipe_net_roles = [7 : i64]} {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_preconditions_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_preconditions_invalid.mlir
@@ -1,0 +1,80 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-dfb-spsc
+
+// Summary: Negative tests for finalized DFB identity preconditions.
+
+// SPSC verification requires the allocation metadata emitted by DFB
+// finalization, even when the frontend already assigned a logical ID.
+
+// expected-error @below {{`ttl-verify-dfb-spsc` requires finalized DFB allocation metadata; run `ttl-finalize-dfb-indices` first}}
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @missing_finalization()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// A finalized DFB declaration must contain its module-wide logical ID.
+// The empty allocation table is synthetic and isolates this precondition.
+
+module attributes {
+  ttl.dfb_allocations = [],
+  ttl.launch_grid = [1 : i64, 1 : i64]
+} {
+  func.func @missing_logical_id()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-error @below {{`ttl-verify-dfb-spsc` requires every `ttl.bind_cb` to have `dfb_id` after finalization}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// A finalized lifecycle operand must resolve to a DFB declaration.
+// The empty allocation table is synthetic and isolates this precondition.
+
+module attributes {
+  ttl.dfb_allocations = [],
+  ttl.launch_grid = [1 : i64, 1 : i64]
+} {
+  func.func @unresolved_dfb_operand(
+      %dfb: !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-error @below {{`ttl-verify-dfb-spsc` requires every DFB lifecycle operand to resolve to `ttl.bind_cb` with `dfb_id` after finalization}}
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// One logical DFB must have one finalized physical index.
+// The empty allocation table is synthetic and isolates this precondition.
+
+module attributes {
+  ttl.dfb_allocations = [],
+  ttl.launch_grid = [1 : i64, 1 : i64]
+} {
+  func.func @inconsistent_physical_indices()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{logical DFB 10 has inconsistent finalized cb_index values 0 and 1}}
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards.mlir
@@ -20,7 +20,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @copy_roles_valid() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_src %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %send = ttl.copy %cb, %pipe
@@ -71,7 +71,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 // -----
 
 // DFB waits are accepted when every waiting node is covered by a producer
-// domain for the same DFB index.
+// domain for the same logical DFB.
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   // CHECK-LABEL: func.func @producer
@@ -81,7 +81,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 4, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_src %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -92,7 +92,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 4, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 4, block_count = 2} {dfb_id = 4 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_src %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %view = ttl.cb_wait %cb
@@ -105,10 +105,11 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 
 // -----
 
-// `getCBIndex` traces through a chain of `unrealized_conversion_cast` ops
-// before reaching the `bind_cb`. Without iteration, only the first cast
-// is followed and the producer domain is silently lost, causing a false
-// "no other thread fills" diagnostic on the consumer's `cb_wait`.
+// Logical DFB resolution traces through a chain of
+// `unrealized_conversion_cast` ops before reaching the `bind_cb`. Without
+// iteration, only the first cast is followed and the producer domain is
+// silently lost, causing a false "no other thread fills" diagnostic on the
+// consumer's `cb_wait`.
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   // CHECK-LABEL: func.func @producer_chained_cb_casts
@@ -116,7 +117,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @producer_chained_cb_casts() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 5, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %cast1 = builtin.unrealized_conversion_cast %cb
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -133,7 +134,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @consumer_chained_cb_casts() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 5, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 5, block_count = 2} {dfb_id = 5 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_src %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %view = ttl.cb_wait %cb
@@ -156,7 +157,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @is_src_predicate() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %cond = ttl.is_src {pipe_net_id = 0 : i64}
     scf.if %cond {
@@ -181,7 +182,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @is_dst_predicate() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %cond = ttl.is_dst {pipe_net_id = 0 : i64}
     scf.if %cond {
@@ -213,7 +214,7 @@ module attributes {ttl.launch_grid = [4 : i64, 4 : i64]} {
         : !ttl.pipe<src(0, 0) dst(0, 1) to(0, 3) net 0>
     %pb = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 1
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 1>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_dst %pa : !ttl.pipe<src(0, 0) dst(0, 1) to(0, 3) net 0> {
       %recv_a_dst = ttl.cb_reserve %cb
@@ -249,7 +250,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @scf_for_no_predicate() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %c0 = arith.constant 0 : index
     %c4 = arith.constant 4 : index
@@ -279,7 +280,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
   func.func @affine_if_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #srcSet(%x) {
@@ -297,7 +298,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
 // Repeated occurrences of one PipeKey form independent FIFO rendezvous. The
 // first send must not acquire a dependency on the second receiver post.
 
-module attributes {ttl.dfb_allocations = [], ttl.launch_grid = [1 : i64, 1 : i64]} {
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   // CHECK-LABEL: func.func @repeated_pipe_key_schedule
   // CHECK: return
   func.func @repeated_pipe_key_schedule() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -345,7 +346,7 @@ module attributes {ttl.dfb_allocations = [], ttl.launch_grid = [1 : i64, 1 : i64
 // splitting. The receiver posts once, and the sender executes only on the last
 // loop iteration, so both endpoints execute one rendezvous event.
 
-module attributes {ttl.dfb_allocations = [], ttl.launch_grid = [2 : i64, 1 : i64]} {
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   // CHECK-LABEL: func.func @post_outside_sender_loop
   // CHECK: return
   func.func @post_outside_sender_loop() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -400,7 +401,7 @@ module attributes {ttl.dfb_allocations = [], ttl.launch_grid = [2 : i64, 1 : i64
 // A common unresolved loop gives the source and destination equal execution
 // counts because its runtime bounds are identical at both launch nodes.
 
-module attributes {ttl.dfb_allocations = [], ttl.launch_grid = [2 : i64, 1 : i64]} {
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   // CHECK-LABEL: func.func @shared_runtime_loop_schedule
   // CHECK: return
   func.func @shared_runtime_loop_schedule(%upper: index)
@@ -448,7 +449,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
   func.func @is_active_scope() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %cond = ttl.is_active {pipe_net_id = 0 : i64}
     scf.if %cond {
@@ -475,7 +476,7 @@ module attributes {ttl.launch_grid = [4 : i64, 4 : i64]} {
         : !ttl.pipe<src(0, 0) dst(0, 1) to(0, 3) net 0>
     %pb = ttl.create_pipe src(0, 1) dst(1, 1) to(3, 1) net 1
         : !ttl.pipe<src(0, 1) dst(1, 1) to(3, 1) net 1>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %a_active = ttl.is_active {pipe_net_id = 0 : i64}
     scf.if %a_active {
@@ -508,7 +509,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unsigned_wrapped_coordinate_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %zero = arith.constant 0 : index
@@ -537,7 +538,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @remainder_coordinate_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %zero = arith.constant 0 : index
@@ -566,7 +567,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @cmpi_ne_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %c1 = arith.constant 1 : index
@@ -592,7 +593,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @cmpi_sle_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %c0 = arith.constant 0 : index
@@ -619,7 +620,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @cmpi_sgt_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %c0 = arith.constant 0 : index
@@ -649,7 +650,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @cmpi_sge_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %c1 = arith.constant 1 : index
@@ -678,7 +679,7 @@ module attributes {ttl.launch_grid = [4 : i64, 4 : i64]} {
   func.func @andi_two_coords() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %y = ttl.core_y : index
@@ -709,7 +710,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @ori_two_coords() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %c0 = arith.constant 0 : index
@@ -748,7 +749,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @xori_guard() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %c0 = arith.constant 0 : index
@@ -784,7 +785,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @evalindex_subi_indexcast() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %x_i32 = arith.index_cast %x : index to i32
@@ -814,7 +815,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
   func.func @affine_if_mul() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #mulSet(%x) {
@@ -842,7 +843,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
   func.func @affine_if_mod() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #modSet(%x) {
@@ -870,7 +871,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
   func.func @affine_if_floordiv() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #floordivSet(%x) {
@@ -899,7 +900,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
   func.func @affine_if_ceildiv() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #ceildivSet(%x) {
@@ -926,7 +927,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @affine_if_symbol() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %s0 = arith.constant 0 : index
@@ -955,7 +956,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @multi_block(%flag: i1) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     cf.cond_br %flag, ^bb1, ^bb2
   ^bb1:
@@ -987,7 +988,7 @@ module attributes {ttl.launch_grid = [3 : i64, 2 : i64]} {
   func.func @mixed_predicate_andi() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %is_src = ttl.is_src {pipe_net_id = 0 : i64}
     %y = ttl.core_y : index
@@ -1022,7 +1023,7 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
   func.func @andi_else_domain() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(0, 0) to(1, 1) net 0
         : !ttl.pipe<src(0, 0) dst(0, 0) to(1, 1) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %y = ttl.core_y : index
@@ -1064,7 +1065,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @affine_if_else_branch() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #srcOnly(%x) {
@@ -1097,7 +1098,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @scf_while_no_predicate() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %c0 = arith.constant 0 : index
     %c4 = arith.constant 4 : index
@@ -1132,7 +1133,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @scf_execute_region_no_predicate() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %cond = ttl.is_src {pipe_net_id = 0 : i64}
     scf.if %cond {
@@ -1161,7 +1162,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @scf_while_top_level() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %c0 = arith.constant 0 : index
     %c4 = arith.constant 4 : index
@@ -1195,7 +1196,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @affine_for_no_predicate() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %cond = ttl.is_src {pipe_net_id = 0 : i64}
     scf.if %cond {
@@ -1234,7 +1235,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @kernel_caller_guards() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_src %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       func.call @send_helper(%cb, %pipe) : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>) -> ()
@@ -1259,7 +1260,7 @@ module attributes {ttl.launch_grid = [3 : i64, 1 : i64]} {
   func.func @affine_if_inequality() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #dstRange(%x) {
@@ -1288,7 +1289,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
     // CHECK: %[[RECV_CB:.*]] = ttl.bind_cb
-    %recv_cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %recv_cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // CHECK: %[[IS_DST:.*]] = ttl.is_dst
     %is_dst = ttl.is_dst {pipe_net_id = 0 : i64}
@@ -1329,7 +1330,7 @@ module attributes {ttl.launch_grid = [4 : i64, 1 : i64]} {
   func.func @affine_if_multi_constraint() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #twoConstraints(%x) {
@@ -1357,7 +1358,7 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
   func.func @affine_if_multi_dim() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 1) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 1) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %y = ttl.core_y : index
@@ -1388,7 +1389,7 @@ module attributes {ttl.launch_grid = [3 : i64, 1 : i64]} {
   func.func @affine_if_inequality_else() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(2, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(2, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #dstHalf(%x) {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_invalid.mlir
@@ -25,7 +25,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{this `ttl.copy(buffer, pipe)` sends data on PipeNet net_0 from a node that is not a source}}
     // expected-note @below {{example node where the guard does not hold: core_x=1}}
@@ -47,7 +47,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_dst %pipe
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
@@ -86,7 +86,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %recv_reserve = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -135,7 +135,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     scf.if %flag {
     } else {
@@ -158,7 +158,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unsupported_predicate(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %scaled = arith.muli %core_x, %runtime : index
@@ -186,7 +186,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @pipe_receive_wait_unanalyzable_guard(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_dst %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       %reserve = ttl.cb_reserve %cb
@@ -225,7 +225,7 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
   func.func @two_unanalyzable_predicates_andi(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %core_y = ttl.core_y : index
@@ -258,7 +258,7 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
   func.func @source_order_beats_operand_position(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %core_y = ttl.core_y : index
@@ -289,7 +289,7 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
   func.func @two_unanalyzable_predicates_ori(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
     %core_y = ttl.core_y : index
@@ -319,7 +319,33 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @wait_without_producer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %pipe = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 0) net 0
         : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{this `cb_wait` reads from a dataflow buffer that no other thread fills}}
+    %view = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// A producer for another logical DFB cannot satisfy a wait after both DFBs
+// receive the same physical index.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @producer_for_reused_index() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %pipe = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
+  func.func @wait_on_distinct_dfb() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 11 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{this `cb_wait` reads from a dataflow buffer that no other thread fills}}
     %view = ttl.cb_wait %cb
@@ -337,7 +363,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 7, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 7, block_count = 2} {dfb_id = 7 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.if_src %pipe : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
       ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -348,7 +374,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 7, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 7, block_count = 2} {dfb_id = 7 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{this `cb_wait` runs on launched nodes where no thread pushes data to the buffer}}
     // expected-note @below {{example node where the guard does not hold: core_x=1}}
@@ -377,7 +403,7 @@ module attributes {ttl.launch_grid = [4 : i64, 4 : i64]} {
     %pb = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 1
         {pipeNetName = "net_b"}
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 1>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %cond = ttl.is_dst {pipe_net_id = 1 : i64}
     scf.if %cond {
@@ -429,7 +455,7 @@ module attributes {ttl.launch_grid = [4 : i64, 4 : i64]} {
         : !ttl.pipe<src(0, 0) dst(0, 1) to(0, 3) net 0>
     %pb = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 1
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 1>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %a_active = ttl.is_active {pipe_net_id = 0 : i64}
     scf.if %a_active {
@@ -467,7 +493,7 @@ module attributes {ttl.launch_grid = [8 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(4, 0) to(7, 0) net 0
         : !ttl.pipe<src(0, 0) dst(4, 0) to(7, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #multiWide(%x) {
@@ -490,7 +516,7 @@ module attributes {ttl.launch_grid = [8 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(3, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(3, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     affine.if #wideSet(%x) {
@@ -515,7 +541,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unknown_pipenet_id() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{references unknown PipeNet net_7}}
     %cond = ttl.is_src {pipe_net_id = 7 : i64}
@@ -540,7 +566,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @affine_if_div_by_zero() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     // expected-note @below {{this expression is not statically analyzable}}
@@ -564,7 +590,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unknown_pipenet_id_dst() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{references unknown PipeNet net_9}}
     %cond = ttl.is_dst {pipe_net_id = 9 : i64}
@@ -593,7 +619,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unknown_pipenet_id_active() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{references unknown PipeNet net_5}}
     %cond = ttl.is_active {pipe_net_id = 5 : i64}
@@ -665,7 +691,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %x = ttl.core_x : index
     %c0 = arith.constant 0 : index
@@ -692,7 +718,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %c0 = arith.constant 0 : index
     %c4 = arith.constant 4 : index
@@ -718,7 +744,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     scf.execute_region {
       // expected-error @below {{this `ttl.copy(buffer, pipe)` sends data on PipeNet net_0 from a node that is not a source}}
@@ -755,7 +781,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     // expected-note @below {{PipeNet net_0 declared here}}
     %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
         : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     func.call @send_helper(%cb, %pipe) : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>) -> ()
     func.return

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_preconditions_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_preconditions_invalid.mlir
@@ -1,0 +1,37 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-pipenet-guards
+
+// Summary: Negative tests for logical DFB identity preconditions.
+
+// A user-declared DFB must provide its module-wide logical identity before
+// PipeNet guard verification.
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @missing_logical_id()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    // expected-error @below {{user-declared DFB requires dfb_id before physical allocation}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+}
+
+// -----
+
+// Guard analysis requires each DFB operand that it reads to resolve to a DFB
+// declaration.
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @unresolved_dfb_operand(
+      %dfb: !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    // expected-error @below {{`ttl-verify-pipenet-guards` requires every `ttl.cb_push` and `ttl.cb_wait` DFB operand to resolve to `ttl.bind_cb`}}
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}

--- a/test/ttlang/Translate/TTLToCpp/cb_to_tensor_single_tile_write.mlir
+++ b/test/ttlang/Translate/TTLToCpp/cb_to_tensor_single_tile_write.mlir
@@ -24,7 +24,7 @@
 module {
   func.func @cb_to_tensor(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #layout>) attributes {ttl.base_cta_index = 1 : i32, ttl.crta_indices = [0], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %slice = ttl.tensor_slice %arg0[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x!ttcore.tile<32x32, f32>, #layout>
     %xf = ttl.copy %cb, %slice : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>, tensor<1x1x!ttcore.tile<32x32, f32>, #layout>) -> !ttl.transfer_handle<write>
     ttl.wait %xf : !ttl.transfer_handle<write>

--- a/test/ttlang/Translate/TTLToCpp/dma_batched_single_tile.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_batched_single_tile.mlir
@@ -33,8 +33,8 @@
 module {
   func.func @dma_batched(%t0: tensor<1x1x!ttcore.tile<32x32, f32>, #layout>, %t1: tensor<1x1x!ttcore.tile<32x32, f32>, #layout>) attributes {ttl.base_cta_index = 2 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-    %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %slice0 = ttl.tensor_slice %t0[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x!ttcore.tile<32x32, f32>, #layout>
     %slice1 = ttl.tensor_slice %t1[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x!ttcore.tile<32x32, f32>, #layout>
     %xf0 = ttl.copy %slice0, %cb0 : (tensor<1x1x!ttcore.tile<32x32, f32>, #layout>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> !ttl.transfer_handle<read>

--- a/test/ttlang/Translate/TTLToCpp/dma_loop_multi_tile_nontrivial_cb.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_loop_multi_tile_nontrivial_cb.mlir
@@ -98,8 +98,8 @@ module {
   func.func @dma_loop_multi_tile(%arg0: tensor<2x2x!ttcore.tile<32x32, f32>, #layout_2x2>, %arg1: tensor<3x2x!ttcore.tile<32x32, f32>, #layout_3x2>)
       attributes {ttl.base_cta_index = 2 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb1 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-    %cb2 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[3, 2], !ttcore.tile<32x32, f32>, 2>
+    %cb1 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+    %cb2 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[3, 2], !ttcore.tile<32x32, f32>, 2>
     %c4 = arith.constant 4 : index
     %c1 = arith.constant 1 : index
 

--- a/test/ttlang/Translate/TTLToCpp/dma_loop_single_tile.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_loop_single_tile.mlir
@@ -35,7 +35,7 @@
 module {
   func.func @dma_pipelined_loop(%t: tensor<1x1x!ttcore.tile<32x32, f32>, #layout>) attributes {ttl.base_cta_index = 1 : i32, ttl.crta_indices = [0], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %c3 = arith.constant 3 : index
     %c1 = arith.constant 1 : index
 

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_batched_in_user_loop.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_batched_in_user_loop.mlir
@@ -103,8 +103,8 @@ module {
   func.func @batched_multi_tile_user_loop(%arg0: tensor<2x2x!ttcore.tile<32x32, f32>, #layout>, %arg1: tensor<2x2x!ttcore.tile<32x32, f32>, #layout>)
       attributes {ttl.base_cta_index = 2 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb1 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-    %cb2 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+    %cb1 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+    %cb2 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
     %c3 = arith.constant 3 : index
     %c1 = arith.constant 1 : index
 

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_read.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_read.mlir
@@ -47,7 +47,7 @@
 module {
   func.func @dma_multi_tile_read(%arg0: tensor<2x2x!ttcore.tile<32x32, f32>, #layout>) attributes {ttl.base_cta_index = 1 : i32, ttl.crta_indices = [0], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
     %slice = ttl.tensor_slice %arg0[%c0, %c0] : tensor<2x2x!ttcore.tile<32x32, f32>, #layout> -> tensor<2x2x!ttcore.tile<32x32, f32>, #layout>
     %xf = ttl.copy %slice, %cb : (tensor<2x2x!ttcore.tile<32x32, f32>, #layout>, !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>) -> !ttl.transfer_handle<read>
     ttl.wait %xf : !ttl.transfer_handle<read>

--- a/test/ttlang/Translate/TTLToCpp/dma_multi_tile_same_layout_different_cb.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_multi_tile_same_layout_different_cb.mlir
@@ -84,8 +84,8 @@ module {
   func.func @same_layout_different_cb(%arg0: tensor<2x2x!ttcore.tile<32x32, f32>, #layout>, %arg1: tensor<2x2x!ttcore.tile<32x32, f32>, #layout>)
       attributes {ttl.base_cta_index = 2 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb1 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-    %cb2 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+    %cb1 = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
+    %cb2 = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
 
     // First copy: 64x64 → CB [2,2]
     %slice0 = ttl.tensor_slice %arg0[%c0, %c0] : tensor<2x2x!ttcore.tile<32x32, f32>, #layout> -> tensor<2x2x!ttcore.tile<32x32, f32>, #layout>

--- a/test/ttlang/Translate/TTLToCpp/dma_single_tile_read.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dma_single_tile_read.mlir
@@ -24,7 +24,7 @@
 module {
   func.func @dma_single(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #layout>) attributes {ttl.base_cta_index = 1 : i32, ttl.crta_indices = [0], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %slice = ttl.tensor_slice %arg0[%c0, %c0] : tensor<1x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x!ttcore.tile<32x32, f32>, #layout>
     %xf = ttl.copy %slice, %cb : (tensor<1x1x!ttcore.tile<32x32, f32>, #layout>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> !ttl.transfer_handle<read>
     ttl.wait %xf : !ttl.transfer_handle<read>

--- a/test/ttlang/Translate/TTLToCpp/loopback_full_single_tile.mlir
+++ b/test/ttlang/Translate/TTLToCpp/loopback_full_single_tile.mlir
@@ -37,7 +37,7 @@
 module {
   func.func @loopback(%src: tensor<1x1x!ttcore.tile<32x32, f32>, #layout>, %dst: tensor<1x1x!ttcore.tile<32x32, f32>, #layout>) attributes {ttl.base_cta_index = 1 : i32, ttl.crta_indices = [0, 1], ttl.kernel_thread = #ttkernel.thread<noc>} {
     %c0 = arith.constant 0 : index
-    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
     %c4 = arith.constant 4 : index
     %c1 = arith.constant 1 : index
 


### PR DESCRIPTION
Chain: #704 (merged) -> this PR -> #775

### Problem description

`cb_index` currently represents both logical DFB identity and the assigned hardware slot. This prevents later physical-index reuse from preserving producer and consumer protocols, and leaves runtime DFB configuration dependent on frontend declarations rather than finalized compiler allocation.

### What's changed

Add module-wide `dfb_id` identity to DFB declarations and a read-only analysis that resolves and validates every logical DFB before allocation mutates IR. PipeNet guard verification uses that analysis before physical index finalization, while PipeNet schedule verification remains an exact transfer-protocol analysis independent of DFB allocation. Post-finalization DFB SPSC verification requires materialized logical identities and diagnoses incorrect pass ordering.

Finalization emits a complete `ttl.dfb_allocations` runtime contract with physical indices, types, capacities, and compiler-computed page sizes. Runtime configuration consumes that contract. Distinct provisional user indices are compacted before compiler-created DFB slots are assigned, while existing logical aliases remain aliases. Finalized metadata computes the product of every DFB block-shape dimension and omits the optional tile descriptor for scalar element types.

This PR does not infer cross-kernel user-DFB lifetime ordering. #775 adds that analysis and reuses physical indices only when non-overlap is proven.

### Checklist

- [x] New/Existing tests provide coverage for changes
