### PR TITLE
[ttl][pipes] Plan PipeNet lowering before emission [pipes-6]

### DIFF
--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -346,13 +346,13 @@ that can complete the receive.
 
 ## Pipe transfer resource model and TTKernel lowering
 
-Pipe lowering first expands public pipe operations to Pipe Transfer IR:
+Pipe lowering first expands high-level pipe operations to Pipe Transfer IR:
 
 - `ttl.copy(pipe, dst_blk)` expands to `ttl.pipe_transfer.post`.
 - `ttl.copy(src_blk, pipe)` expands to `ttl.pipe_transfer.send`.
 - `ttl.wait` on a pipe receive handle expands to
   `ttl.pipe_transfer.wait`.
-- `ttl.wait` on a pipe send handle remains a public `ttl.wait` until
+- `ttl.wait` on a pipe send handle remains a high-level `ttl.wait` until
   TTKernel conversion, where it is erased because `ttl.pipe_transfer.send`
   has already waited for the payload write and signaled completion.
 
@@ -471,7 +471,8 @@ future typed device APIs should change only the runtime binding
 mechanism, not the IR-level resource model.
 
 The `RA/RP` address-table entry and `RP` sender-ready counter do not
-remain live until the public transfer handle is waited on. They carry
+remain live until the transfer handle returned by `ttl.copy` is waited
+on. They carry
 only pre-send state: the receiver-published DFB address and the count
 proving that the required receivers have posted. After the send resets
 the ready counter and, for `RA/RP`, reads the address-table entry, those
@@ -1527,7 +1528,8 @@ The analyses have non-overlapping responsibilities:
 | DFB acquire/release ownership | Relate reserves, posts, waits, pushes, waits-front, and pops without inferring ownership from lexical proximity. |
 | Pipe rendezvous schedule | Verify one-to-one send/post occurrence counts and the wait-for dependencies of exact receive handles. |
 | `PipeGraph` | Match each send with one post per receiver, connect its endpoints to physical receiver DFBs, and prove endpoint address sequences. |
-| Pipe resource plan | Select protocols and allocate counters, address storage, and sender-local sequence state from graph facts. |
+| Pipe capacity analysis | Prove which receiver endpoints have unambiguous one-block capacity releases. |
+| Pipe module plan | Select protocols and allocate counters, address storage, and sender-local sequence state from analysis facts. |
 
 Synchronization verification and `PipeGraph` share execution-multiplicity
 proofs. The verifier diagnoses invalid occurrence correspondence. `PipeGraph`

--- a/include/ttlang/Dialect/Utils/ConversionUtils.h
+++ b/include/ttlang/Dialect/Utils/ConversionUtils.h
@@ -22,6 +22,23 @@
 
 namespace mlir::tt::ttl::utils {
 
+/// Return the TTL DFB type of `value` or its sole unrealized-cast input.
+/// Return failure when neither value has a TTL DFB type.
+inline FailureOr<CircularBufferType> getTTLCircularBufferType(Value value) {
+  if (auto dfbType = mlir::dyn_cast<CircularBufferType>(value.getType())) {
+    return dfbType;
+  }
+  if (auto castOp = value.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp.getInputs().size() == 1 && castOp.getOutputs().size() == 1) {
+      if (auto dfbType = mlir::dyn_cast<CircularBufferType>(
+              castOp.getInputs().front().getType())) {
+        return dfbType;
+      }
+    }
+  }
+  return failure();
+}
+
 /// Convert a local DFB index (within a subblock) to a global DFB index (within
 /// the full block) when `operand` traces to a tensor.extract_slice.
 ///

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   InterferenceGraphColoring.cpp
   PipeGraph.cpp
   PipeLowering.cpp
+  PipePlanning.cpp
   PipeTransferAnalysis.cpp
   ConvertTTLToCompute.cpp
   ConvertTTLComputeToSCF.cpp

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1727,9 +1727,11 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
     return failure();
   }
 
+  PipePlanningOptions pipePlanningOptions;
+  pipePlanningOptions.enableComputedAddresses = pipeComputedAddresses;
   FailureOr<PipeModulePlan> maybePipeModulePlan =
       buildPipeModulePlan(mod, transferAnalysis, transferIndex, *pipeGraphOrErr,
-                          pipeComputedAddresses);
+                          pipePlanningOptions);
   if (failed(maybePipeModulePlan)) {
     return failure();
   }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -6,6 +6,7 @@
 
 #include "PipeGraph.h"
 #include "PipeLowering.h"
+#include "PipePlanning.h"
 #include "ttlang/Dialect/TTKernel/Transforms/TTKernelCleanupPatterns.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -20,7 +21,6 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LogicalResult.h"
@@ -42,7 +42,6 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Casting.h"
 #include <cstdlib>
 #include <utility>
@@ -94,10 +93,10 @@ public:
     addConversion([](PipeTokenType type) -> Type {
       return IntegerType::get(type.getContext(), 32);
     });
-    // Public pipe copies expose TransferHandleType and may carry the dynamic
-    // post sequence through SCF or tensor containers. DMA handles use the same
-    // runtime representation, but their waits depend only on precomputed
-    // provenance and lower to barriers without inspecting this value.
+    // High-level pipe copies return TransferHandleType. Their post sequence may
+    // pass through SCF or tensor containers. DMA handles use the same runtime
+    // representation, but their waits depend only on precomputed provenance
+    // and lower to barriers without inspecting this value.
     addConversion([](TransferHandleType type) -> Type {
       return IntegerType::get(type.getContext(), 32);
     });
@@ -315,33 +314,16 @@ struct BindCBLowering : OpConversionPattern<BindCBOp> {
 // CB synchronization operation lowering patterns
 //===----------------------------------------------------------------------===//
 
-// Trace through unrealized casts to get the original TTL CB type.
-static CircularBufferType getTTLCBType(Value cb) {
-  if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(cb.getType())) {
-    return ttlCbTy;
-  }
-  if (auto castOp = cb.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (castOp.getInputs().size() == 1) {
-      if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(
-              castOp.getInputs()[0].getType())) {
-        return ttlCbTy;
-      }
-    }
-  }
-  return nullptr;
-}
-
 // Tile count: use the `num_tiles` attribute if present (per-subblock
 // reserve/push), otherwise derive from the DFB type shape (full block).
-static Value computeNumTiles(Operation *sourceOp, Value cb,
+static Value computeNumTiles(Operation *sourceOp, CircularBufferType dfbType,
                              ConversionPatternRewriter &rewriter,
                              Location loc) {
   if (auto attr = sourceOp->getAttrOfType<IntegerAttr>("num_tiles")) {
     return arith::ConstantIntOp::create(rewriter, loc, attr.getInt(), 32);
   }
-  auto ttlCbTy = getTTLCBType(cb);
-  int64_t numTiles = ttlCbTy ? ttlCbTy.getElementsPerBlock() : 1;
-  return arith::ConstantIntOp::create(rewriter, loc, numTiles, 32);
+  return arith::ConstantIntOp::create(rewriter, loc,
+                                      dfbType.getElementsPerBlock(), 32);
 }
 
 template <typename SourceOp, typename TargetOp, bool HasResult>
@@ -353,8 +335,9 @@ struct CBOpLowering : OpConversionPattern<SourceOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     Value originalCb = op.getCb();
-    auto ttlCbTy = getTTLCBType(originalCb);
-    if (!ttlCbTy) {
+    FailureOr<CircularBufferType> maybeDFBType =
+        utils::getTTLCircularBufferType(originalCb);
+    if (failed(maybeDFBType)) {
       return rewriter.notifyMatchFailure(op, "failed to get TTL CB type");
     }
 
@@ -364,7 +347,7 @@ struct CBOpLowering : OpConversionPattern<SourceOp> {
       return rewriter.notifyMatchFailure(op, "failed to convert CB operand");
     }
 
-    Value numTiles = computeNumTiles(op, originalCb, rewriter, loc);
+    Value numTiles = computeNumTiles(op, *maybeDFBType, rewriter, loc);
     TargetOp::create(rewriter, loc, *convertedCb, numTiles);
 
     if constexpr (HasResult) {
@@ -616,17 +599,32 @@ static Value getOrCreatePipeTransfer(
   return createPipeTransfer(builder, loc, pipe, contract).getTransfer();
 }
 
-static LogicalResult expandPipeTransferOps(ModuleOp mod,
-                                           ValueOriginAnalysis &analysis) {
-  SmallVector<CreatePipeOp> createPipes;
-  mod.walk([&](CreatePipeOp op) { createPipes.push_back(op); });
+/// High-level pipe copy and its proven transfer contract.
+struct PipeCopyExpansion {
+  CopyOp copy;
+  PipeTransferContract contract;
+};
 
-  struct PipeCopyExpansion {
-    CopyOp copy;
-    PipeTransferContract contract;
-  };
+/// Receive-handle wait and the PipeNet id used to create its typed token.
+struct PipeReceiveWaitExpansion {
+  WaitOp wait;
+  int64_t pipeNetId = 0;
+};
+
+/// Operations replaced when high-level pipe copies become Pipe Transfer IR.
+struct PipeTransferExpansionPlan {
+  SmallVector<CreatePipeOp> createPipes;
   SmallVector<PipeCopyExpansion> receiveCopies;
   SmallVector<PipeCopyExpansion> sendCopies;
+  SmallVector<PipeReceiveWaitExpansion> receiveWaits;
+  SmallVector<WaitOp> unreachableReceiveWaits;
+};
+
+static FailureOr<PipeTransferExpansionPlan>
+buildPipeTransferExpansionPlan(ModuleOp mod, ValueOriginAnalysis &analysis) {
+  PipeTransferExpansionPlan plan;
+  mod.walk([&](CreatePipeOp op) { plan.createPipes.push_back(op); });
+
   LogicalResult result = success();
   mod.walk([&](CopyOp op) {
     if (isPipeReceiveCopy(op)) {
@@ -638,7 +636,7 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
                "pipe values";
         result = failure();
       } else {
-        receiveCopies.push_back({op, *contract});
+        plan.receiveCopies.push_back({op, *contract});
       }
       return;
     }
@@ -651,7 +649,7 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
                "pipe values";
         result = failure();
       } else {
-        sendCopies.push_back({op, *contract});
+        plan.sendCopies.push_back({op, *contract});
       }
     }
   });
@@ -659,12 +657,6 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
     return failure();
   }
 
-  struct ReceiveWaitExpansion {
-    WaitOp waitOp;
-    int64_t pipeNetId;
-  };
-  SmallVector<ReceiveWaitExpansion> receiveWaits;
-  SmallVector<WaitOp> unreachableReceiveWaits;
   mod.walk([&](WaitOp waitOp) {
     auto handleType =
         mlir::dyn_cast<TransferHandleType>(waitOp.getXf().getType());
@@ -672,7 +664,7 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
       return;
     }
     if (analysis.getOrigins(waitOp.getXf()).empty()) {
-      unreachableReceiveWaits.push_back(waitOp);
+      plan.unreachableReceiveWaits.push_back(waitOp);
       return;
     }
     FailureOr<CopyOp> maybeCopyOp =
@@ -687,20 +679,26 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
     CopyOp copyOp = *maybeCopyOp;
     auto pipeType =
         mlir::cast<PipeType>(traceUnrealizedCasts(copyOp.getSrc()).getType());
-    receiveWaits.push_back({waitOp, pipeType.getPipeNetId()});
+    plan.receiveWaits.push_back({waitOp, pipeType.getPipeNetId()});
   });
   if (failed(result)) {
     return failure();
   }
+  return plan;
+}
 
-  // No dynamic value reaches these waits, so they have no observable effect.
-  for (WaitOp waitOp : unreachableReceiveWaits) {
+static void
+applyPipeTransferExpansionPlan(ModuleOp mod,
+                               const PipeTransferExpansionPlan &plan) {
+  // Origin analysis proved that no reachable transfer handle reaches these
+  // waits, so they have no observable effect.
+  for (WaitOp waitOp : plan.unreachableReceiveWaits) {
     waitOp.erase();
   }
 
   OpBuilder builder(mod.getContext());
   llvm::MapVector<Value, Value> transferByDirectCreatePipe;
-  for (CreatePipeOp createPipe : createPipes) {
+  for (CreatePipeOp createPipe : plan.createPipes) {
     builder.setInsertionPointAfter(createPipe);
     auto transferOp =
         createPipeTransfer(builder, createPipe.getLoc(), createPipe.getResult(),
@@ -709,7 +707,7 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
         transferOp.getTransfer();
   }
 
-  for (const PipeCopyExpansion &expansion : receiveCopies) {
+  for (const PipeCopyExpansion &expansion : plan.receiveCopies) {
     CopyOp copyOp = expansion.copy;
     auto pipeType =
         mlir::cast<PipeType>(traceUnrealizedCasts(copyOp.getSrc()).getType());
@@ -728,7 +726,7 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
     copyOp->erase();
   }
 
-  for (const PipeCopyExpansion &expansion : sendCopies) {
+  for (const PipeCopyExpansion &expansion : plan.sendCopies) {
     CopyOp copyOp = expansion.copy;
     builder.setInsertionPoint(copyOp);
     Value transfer =
@@ -741,8 +739,8 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
     copyOp->erase();
   }
 
-  for (const ReceiveWaitExpansion &wait : receiveWaits) {
-    WaitOp waitOp = wait.waitOp;
+  for (const PipeReceiveWaitExpansion &wait : plan.receiveWaits) {
+    WaitOp waitOp = wait.wait;
     builder.setInsertionPoint(waitOp);
     auto tokenCast = UnrealizedConversionCastOp::create(
         builder, waitOp.getLoc(),
@@ -752,8 +750,6 @@ static LogicalResult expandPipeTransferOps(ModuleOp mod,
                                tokenCast.getResult(0));
     waitOp->erase();
   }
-
-  return success();
 }
 
 /// Compute CTA index for a tensor function argument.
@@ -922,15 +918,16 @@ static LogicalResult lowerTensorCBCopy(CopyOp op, TensorSliceOp sliceOp,
     return failure();
   }
 
-  auto cbType = getTTLCBType(cb);
-  if (!cbType) {
+  FailureOr<CircularBufferType> maybeDFBType =
+      utils::getTTLCircularBufferType(cb);
+  if (failed(maybeDFBType)) {
     return rewriter.notifyMatchFailure(op, "failed to get CB type");
   }
 
   SmallVector<int64_t> tensorGridShape = getTileGridShapeFromValue(tensor);
   unsigned tensorRank = tensorGridShape.size();
 
-  auto cbShape = cbType.getShape();
+  auto cbShape = (*maybeDFBType).getShape();
 
   if (startIndices.size() != tensorRank) {
     return rewriter.notifyMatchFailure(op, [&](Diagnostic &diag) {
@@ -1117,24 +1114,30 @@ struct CopyLowering : OpConversionPattern<CopyOp> {
 
 struct PipeTransferPostLowering : OpConversionPattern<PipeTransferPostOp> {
   PipeTransferPostLowering(const TypeConverter &typeConverter,
-                           MLIRContext *context, ValueOriginAnalysis &analysis,
+                           MLIRContext *context,
+                           const PipeModulePlan &pipeModulePlan,
                            const PipeCounterProgressMap &counters,
                            const PipeResourcePlan &pipeResourcePlan)
-      : OpConversionPattern(typeConverter, context), analysis(analysis),
-        counters(counters), pipeResourcePlan(pipeResourcePlan) {}
+      : OpConversionPattern(typeConverter, context),
+        pipeModulePlan(pipeModulePlan), counters(counters),
+        pipeResourcePlan(pipeResourcePlan) {}
 
   LogicalResult
   matchAndRewrite(PipeTransferPostOp op, OpAdaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // The receive destination is inspected for its TTL DFB provenance
-    // (`ttl.cb_reserve`, `ttl.attach_cb`, and slice offset), so this lowering
-    // must use the original SSA value rather than the converted adaptor value.
-    return lowerPipeTransferPost(op, op.getDst(), analysis, counters,
-                                 pipeResourcePlan, rewriter);
+    // Slice-offset materialization requires the original destination tensor,
+    // while the plan supplies the already-resolved receiver DFB.
+    if (pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation())) {
+      lowerInactivePipeTransferPost(op, rewriter);
+      return success();
+    }
+    return lowerPipeTransferPost(
+        op, op.getDst(), pipeModulePlan.getTransferPlan(op.getOperation()),
+        counters, pipeResourcePlan, rewriter);
   }
 
 private:
-  ValueOriginAnalysis &analysis;
+  const PipeModulePlan &pipeModulePlan;
   const PipeCounterProgressMap &counters;
   const PipeResourcePlan &pipeResourcePlan;
 };
@@ -1142,33 +1145,27 @@ private:
 struct PipeTransferSendLowering : OpConversionPattern<PipeTransferSendOp> {
   PipeTransferSendLowering(
       const TypeConverter &typeConverter, MLIRContext *context,
-      ValueOriginAnalysis &analysis, const PipeResourcePlan &pipeResourcePlan,
+      const PipeModulePlan &pipeModulePlan,
+      const PipeResourcePlan &pipeResourcePlan,
       const PipeComputedAddressCounterMap &computedAddressCounters)
-      : OpConversionPattern(typeConverter, context), analysis(analysis),
-        pipeResourcePlan(pipeResourcePlan),
+      : OpConversionPattern(typeConverter, context),
+        pipeModulePlan(pipeModulePlan), pipeResourcePlan(pipeResourcePlan),
         computedAddressCounters(computedAddressCounters) {}
 
   LogicalResult
   matchAndRewrite(PipeTransferSendOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // DFB -> Pipe: source core sends data to the pipe receivers.
-    // Determine DFB access context: consumer (cb_wait/cb_pop) vs producer
-    // (cb_reserve/cb_push). This controls whether the source address comes
-    // from the DFB read pointer or write pointer.
-    DominanceInfo domInfo(op->getParentOfType<func::FuncOp>());
-    bool isConsumerCB =
-        llvm::any_of(op.getSrc().getUsers(), [&](Operation *user) {
-          return mlir::isa<CBWaitOp>(user) &&
-                 user->getOperand(0) == op.getSrc() &&
-                 domInfo.dominates(user, op);
-        });
-    return lowerPipeTransferSend(op, adaptor.getSrc(), isConsumerCB, analysis,
-                                 pipeResourcePlan, computedAddressCounters,
-                                 rewriter);
+    if (pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation())) {
+      lowerInactivePipeTransferSend(op, rewriter);
+      return success();
+    }
+    return lowerPipeTransferSend(
+        op, adaptor.getSrc(), pipeModulePlan.getTransferPlan(op.getOperation()),
+        pipeResourcePlan, computedAddressCounters, rewriter);
   }
 
 private:
-  ValueOriginAnalysis &analysis;
+  const PipeModulePlan &pipeModulePlan;
   const PipeResourcePlan &pipeResourcePlan;
   const PipeComputedAddressCounterMap &computedAddressCounters;
 };
@@ -1207,8 +1204,8 @@ struct WaitLowering : OpConversionPattern<WaitOp> {
       return success();
     }
 
-    // TODO(ttl): Lower ttl.wait to TRID-specific barriers keyed by the transfer
-    // handle (read vs write barrier based on transfer direction). Issue: #87.
+    // TODO(ttl): Lower ttl.wait to the TRID-specific barrier selected by the
+    // transfer handle direction (read or write). Issue: #87.
     //
     // MVP behavior: emit the corresponding global barrier based on transfer
     // direction. Pipe receive waits are expanded to ttl.pipe_transfer.wait
@@ -1696,14 +1693,19 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
            typeConverter.isLegal(&op.getBody());
   });
 
-  // Validate explicit transfer IR and resolve every public pipe copy before
+  // Validate explicit transfer IR and resolve every high-level pipe copy before
   // expansion mutates the values used by the analysis.
   {
-    ValueOriginAnalysis publicAnalysis(mod);
-    if (failed(verifyTransferProvenance(mod, publicAnalysis)) ||
-        failed(expandPipeTransferOps(mod, publicAnalysis))) {
+    ValueOriginAnalysis preExpansionAnalysis(mod);
+    if (failed(verifyTransferProvenance(mod, preExpansionAnalysis))) {
       return failure();
     }
+    FailureOr<PipeTransferExpansionPlan> maybeExpansionPlan =
+        buildPipeTransferExpansionPlan(mod, preExpansionAnalysis);
+    if (failed(maybeExpansionPlan)) {
+      return failure();
+    }
+    applyPipeTransferExpansionPlan(mod, *maybeExpansionPlan);
   }
 
   // All remaining provenance consumers share this root-scoped cache.
@@ -1718,15 +1720,6 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
   }
   const PipeTransferIndex &transferIndex = **maybeTransferIndex;
 
-  llvm::SmallPtrSet<Operation *, 8> completedPipeSendWaits;
-  mod.walk([&](WaitOp waitOp) {
-    if (transferAnalysis.getOrigins(waitOp.getXf()).allMatch([](Value origin) {
-          return static_cast<bool>(origin.getDefiningOp<PipeTransferSendOp>());
-        })) {
-      completedPipeSendWaits.insert(waitOp);
-    }
-  });
-
   // Validate receiver DFB consistency before lowering emits the pipe
   // synchronization protocol.
   auto pipeGraphOrErr = PipeGraph::build(mod, transferIndex);
@@ -1734,31 +1727,15 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
     return failure();
   }
 
-  // Per-net-id pipe list, shared by IsSrc/IsDst/IsActive lowerings so they
-  // don't walk the module per match.
-  PipeNetIndex pipeNetIndex;
-  buildPipeNetIndex(mod, pipeNetIndex);
-  PipeResourcePlan pipeResourcePlan;
-  if (failed(buildPipeResourcePlan(mod, transferIndex, *pipeGraphOrErr,
-                                   pipeResourcePlan, pipeComputedAddresses))) {
+  FailureOr<PipeModulePlan> maybePipeModulePlan =
+      buildPipeModulePlan(mod, transferAnalysis, transferIndex, *pipeGraphOrErr,
+                          pipeComputedAddresses);
+  if (failed(maybePipeModulePlan)) {
     return failure();
   }
-  PipeResourceRequirements pipeResourceRequirements =
-      getPipeResourceRequirements(pipeResourcePlan);
-  mod->setAttr(kPipeSyncSemaphoreCountAttrName,
-               IntegerAttr::get(IntegerType::get(&ctx, 64),
-                                pipeResourceRequirements.syncSemaphoreCount));
-  if (pipeResourceRequirements.globalSemaphoreCount > 0) {
-    mod->setAttr(
-        kPipeGlobalSemaphoreCountAttrName,
-        IntegerAttr::get(IntegerType::get(&ctx, 64),
-                         pipeResourceRequirements.globalSemaphoreCount));
-  }
-  if (pipeResourceRequirements.sramScratchBytes > 0) {
-    mod->setAttr(kPipeSramScratchBytesAttrName,
-                 IntegerAttr::get(IntegerType::get(&ctx, 64),
-                                  pipeResourceRequirements.sramScratchBytes));
-  }
+  PipeModulePlan pipeModulePlan = std::move(*maybePipeModulePlan);
+  applyPipeModuleAttributes(mod, pipeModulePlan);
+  const PipeResourcePlan &pipeResourcePlan = pipeModulePlan.getResourcePlan();
   // [Device 2.0] The kPipeSyncSemaphoreCountAttrName,
   // kPipeGlobalSemaphoreCountAttrName, and kPipeSramScratchBytesAttrName attrs
   // are the current host/runtime ABI for pipe resource binding. Keep the
@@ -1780,21 +1757,23 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
                TensorOpTypeConversion<tensor::ExtractOp>,
                TensorOpTypeConversion<tensor::CastOp>>(typeConverter, &ctx);
   patterns.add<CopyLowering>(typeConverter, &ctx);
-  patterns.add<PipeTransferPostLowering>(typeConverter, &ctx, transferAnalysis,
+  patterns.add<PipeTransferPostLowering>(typeConverter, &ctx, pipeModulePlan,
                                          postSequenceCounters,
                                          pipeResourcePlan);
-  patterns.add<PipeTransferSendLowering>(typeConverter, &ctx, transferAnalysis,
+  patterns.add<PipeTransferSendLowering>(typeConverter, &ctx, pipeModulePlan,
                                          pipeResourcePlan,
                                          computedAddressCounters);
   patterns.add<PipeTransferWaitLowering>(typeConverter, &ctx, pipeResourcePlan);
-  patterns.add<WaitLowering>(typeConverter, &ctx, completedPipeSendWaits);
+  patterns.add<WaitLowering>(typeConverter, &ctx,
+                             pipeModulePlan.getCompletedPipeSendWaits());
   patterns
       .add<BindCBLowering, TensorSliceLowering, CBReserveLowering,
            CBPushLowering, CBWaitLowering, CBPopLowering, TileStoreLowering,
            StoreLowering, CoreXLowering, CoreYLowering, RawElementReadLowering,
            RawElementWriteLowering, OpaqueCallLowering, GetDfbIdLowering>(
           typeConverter, &ctx);
-  populatePipeLoweringPatterns(patterns, typeConverter, pipeNetIndex);
+  populatePipeLoweringPatterns(patterns, typeConverter,
+                               pipeModulePlan.getPipeNetIndex());
   populateFunctionOpInterfaceTypeConversionPattern(
       func::FuncOp::getOperationName(), patterns, typeConverter);
 
@@ -1828,7 +1807,7 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
   return success();
 }
 
-/// Phase 2: Lower tile compute ops and DST lifecycle ops to TTKernel.
+/// Lower tile compute operations and DST lifecycle operations to TTKernel.
 /// Tile compute ops are identified by TTLTileComputeOpTrait. ttl.compute is
 /// kept legal here because it is lowered to loops in an earlier pass
 /// (ttl-lower-to-loops).

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -4,6 +4,7 @@
 
 #include "PipeLowering.h"
 
+#include "PipePlanning.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -48,21 +49,6 @@ static constexpr int64_t kPipeSramScratchAlignmentBytes = 32;
 //===----------------------------------------------------------------------===//
 // Helpers
 //===----------------------------------------------------------------------===//
-
-static CircularBufferType getTTLCBType(Value cb) {
-  if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(cb.getType())) {
-    return ttlCbTy;
-  }
-  if (auto castOp = cb.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (castOp.getInputs().size() == 1) {
-      if (auto ttlCbTy = mlir::dyn_cast<CircularBufferType>(
-              castOp.getInputs()[0].getType())) {
-        return ttlCbTy;
-      }
-    }
-  }
-  return nullptr;
-}
 
 static Value makeZeroI32(Location loc, ConversionPatternRewriter &rewriter) {
   return arith::ConstantIntOp::create(rewriter, loc, 0, 32);
@@ -339,39 +325,11 @@ static Value buildComputedReceiverDFBDestinationAddress(
   return receiverAddress;
 }
 
-struct ReceiverPublishedAddressInfo {
-  Value receiverDFB;
-  ttcore::TileType tileType;
-};
-
-static FailureOr<ReceiverPublishedAddressInfo>
-getReceiverPublishedAddressInfo(Operation *op, Value dst,
-                                ConversionPatternRewriter &rewriter) {
-  Value receiverDFB = getAttachedCB(dst);
-  if (!receiverDFB) {
-    return rewriter.notifyMatchFailure(
-        op, "pipe receive destination is not attached to a DFB");
-  }
-
-  auto receiverDFBType = getTTLCBType(receiverDFB);
-  if (!receiverDFBType) {
-    return rewriter.notifyMatchFailure(op, "failed to get receiver DFB type");
-  }
-  auto tileType =
-      llvm::dyn_cast<ttcore::TileType>(receiverDFBType.getElementType());
-  if (!tileType) {
-    return rewriter.notifyMatchFailure(
-        op, "receiver DFB element type must be tile");
-  }
-
-  return ReceiverPublishedAddressInfo{receiverDFB, tileType};
-}
-
 /// Compute the exact DFB address selected by ttl.copy(pipe, dst). Receivers
 /// publish this address so senders do not have to infer receiver DFB state.
 static Value
 buildReceiverPublishedAddress(Value dst, Location loc,
-                              const ReceiverPublishedAddressInfo &info,
+                              const PipeReceiverAddressPublicationPlan &info,
                               ConversionPatternRewriter &rewriter) {
   auto receiverCBConverted =
       utils::convertTTLCBToTTKernel(info.receiverDFB, rewriter, loc);
@@ -391,9 +349,9 @@ buildReceiverPublishedAddress(Value dst, Location loc,
 
   auto tileOffsetI32 = arith::IndexCastOp::create(
       rewriter, loc, rewriter.getI32Type(), globalTileIndex);
-  auto pageSizeBytes = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32Type(),
-      rewriter.getI32IntegerAttr(info.tileType.getSizeBytes()));
+  auto pageSizeBytes =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                rewriter.getI32IntegerAttr(info.tileSizeBytes));
   auto byteOffset =
       arith::MulIOp::create(rewriter, loc, tileOffsetI32, pageSizeBytes);
   return arith::AddIOp::create(rewriter, loc, receiverWritePtr, byteOffset)
@@ -780,46 +738,30 @@ lookupPipeCounterProgress(const PipeCounterProgressMap *progress, FuncOp func,
   return progressIt->value;
 }
 
-/// Lower CB -> Pipe copy: write source DFB data to the selected destination
-/// address, then signal arrival.
+void lowerInactivePipeTransferSend(PipeTransferSendOp op,
+                                   ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOp(op, makeZeroI32(op.getLoc(), rewriter));
+}
+
+/// Write source DFB data to the selected destination and signal completion.
 LogicalResult lowerPipeTransferSend(
-    PipeTransferSendOp op, Value srcCB, bool isConsumerCB,
-    ValueOriginAnalysis &analysis, const PipeResourcePlan &pipeResourcePlan,
+    PipeTransferSendOp op, Value srcCB, const PipeTransferPlan &transferPlan,
+    const PipeResourcePlan &pipeResourcePlan,
     const PipeComputedAddressCounterMap &computedAddressCounters,
     ConversionPatternRewriter &rewriter) {
   auto loc = op.getLoc();
-  if (pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation())) {
-    rewriter.replaceOp(op, makeZeroI32(loc, rewriter));
-    return success();
-  }
-  FailureOr<PipeTransferCreateOp> maybeCreateOp =
-      getPipeTransferCreate(op.getOperation(), op.getTransfer(), analysis);
-  if (failed(maybeCreateOp)) {
-    return failure();
-  }
-  PipeTransferCreateOp createOp = *maybeCreateOp;
-  auto pipeType = mlir::cast<PipeType>(createOp.getPipe().getType());
-  const PipeResourceInfo &pipeResource =
-      lookupPipeResourceInfo(op.getOperation(), pipeResourcePlan);
+  assert(!pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation()) &&
+         "inactive send must not use an active transfer plan");
+  assert(transferPlan.isSend() && "send operation has a receiver-post plan");
+  PipeType pipeType = transferPlan.getPipeType();
+  const PipeResourceInfo &pipeResource = transferPlan.getResources();
+  const PipeSendPlan &sendPlan = transferPlan.getSend();
   PipeCompletionInfo completionInfo = pipeResource.completion;
   FuncOp senderFunc = op->getParentOfType<FuncOp>();
   assert(senderFunc && "pipe transfer send must be inside a function");
   auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
   NocPipeTransportEmitter nocTransport(op, pipeType, rewriter);
   PipeTransportEmitter &transport = nocTransport;
-
-  auto cbType = getTTLCBType(srcCB);
-  if (!cbType) {
-    return rewriter.notifyMatchFailure(op, "failed to get CB type");
-  }
-  auto cbShape = cbType.getShape();
-
-  auto elementType = cbType.getElementType();
-  auto tileType = llvm::dyn_cast<ttcore::TileType>(elementType);
-  if (!tileType) {
-    return rewriter.notifyMatchFailure(op, "CB element type must be tile");
-  }
-  int64_t pageSizeBytes = tileType.getSizeBytes();
 
   int64_t numDests = pipeType.getNumDests();
 
@@ -845,15 +787,10 @@ LogicalResult lowerPipeTransferSend(
   ttk::NocSemaphoreSetOp::create(rewriter, loc, senderReadyCounterPtr,
                                  readyCounterResetValue);
 
-  SmallVector<int64_t> cbBounds(cbShape.begin(), cbShape.end());
-  int64_t cbNumTiles = 1;
-  for (int64_t dimension : cbBounds) {
-    cbNumTiles *= dimension;
-  }
   // Producer source address is at the source DFB's write_ptr (data is staged
   // there before push_back); consumer source address is at its read_ptr.
   Value srcPtrIdx;
-  if (isConsumerCB) {
+  if (sendPlan.usesReadPointer) {
     auto cbReadPtr = ttk::GetReadPtrOp::create(rewriter, loc, *cbConverted);
     srcPtrIdx = arith::IndexCastOp::create(rewriter, loc, indexTy, cbReadPtr);
   } else {
@@ -865,9 +802,9 @@ LogicalResult lowerPipeTransferSend(
   // Transfer the entire block in one NoC write. Tiles are contiguous in the
   // DFB, and destination DFB layout is uniform across nodes, so lowering sends
   // all tiles at once instead of one per tile.
-  int64_t totalSizeBytes = cbNumTiles * pageSizeBytes;
   auto totalSizeVal = arith::ConstantOp::create(
-      rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(totalSizeBytes));
+      rewriter, loc, i32Ty,
+      rewriter.getI32IntegerAttr(sendPlan.payloadSizeBytes));
 
   Value srcAddr = arith::IndexCastOp::create(rewriter, loc, i32Ty, srcPtrIdx);
 
@@ -907,28 +844,26 @@ LogicalResult lowerPipeTransferSend(
   return success();
 }
 
+void lowerInactivePipeTransferPost(PipeTransferPostOp op,
+                                   ConversionPatternRewriter &rewriter) {
+  auto token = UnrealizedConversionCastOp::create(
+      rewriter, op.getLoc(), op.getToken().getType(), ValueRange{});
+  rewriter.replaceOp(op, token.getResult(0));
+}
+
 LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
-                                    ValueOriginAnalysis &analysis,
+                                    const PipeTransferPlan &transferPlan,
                                     const PipeCounterProgressMap &counters,
                                     const PipeResourcePlan &pipeResourcePlan,
                                     ConversionPatternRewriter &rewriter) {
   auto loc = op.getLoc();
-  if (pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation())) {
-    auto token = UnrealizedConversionCastOp::create(
-        rewriter, loc, op.getToken().getType(), ValueRange{});
-    rewriter.replaceOp(op, token.getResult(0));
-    return success();
-  }
-  FailureOr<PipeTransferCreateOp> maybeCreateOp =
-      getPipeTransferCreate(op.getOperation(), op.getTransfer(), analysis);
-  if (failed(maybeCreateOp)) {
-    return failure();
-  }
-  PipeTransferCreateOp createOp = *maybeCreateOp;
-  auto pipeType = mlir::cast<PipeType>(createOp.getPipe().getType());
-  const PipeResourceInfo &pipeResource =
-      lookupPipeResourceInfo(op.getOperation(), pipeResourcePlan);
-  FuncOp func = op->getParentOfType<FuncOp>();
+  assert(!pipeResourcePlan.staticallyInactiveOps.contains(op.getOperation()) &&
+         "inactive receiver post must not use an active transfer plan");
+  assert(!transferPlan.isSend() && "receiver post has a send plan");
+  PipeType pipeType = transferPlan.getPipeType();
+  const PipeResourceInfo &pipeResource = transferPlan.getResources();
+  const PipePostPlan &postPlan = transferPlan.getPost();
+  auto func = op->getParentOfType<func::FuncOp>();
   assert(func && "pipe transfer post must be inside a function");
   FailureOr<Value> maybeSequenceCounter = lookupPipeCounterProgress(
       &counters, func, pipeResource.completion.counter);
@@ -942,25 +877,10 @@ LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
   NocPipeTransportEmitter nocTransport(op, pipeType, rewriter);
   PipeTransportEmitter &transport = nocTransport;
 
-  // Preflight the only fallible validation before emitting any ops, so a match
-  // failure leaves no partially-built IR for the conversion driver to roll
-  // back.
-  bool usesComputedReceiverDFB =
-      pipeResource.addressStorage.usesComputedReceiverDFB();
-  std::optional<ReceiverPublishedAddressInfo> maybePublishedAddressInfo;
-  if (!usesComputedReceiverDFB) {
-    FailureOr<ReceiverPublishedAddressInfo> info =
-        getReceiverPublishedAddressInfo(op, dst, rewriter);
-    if (failed(info)) {
-      return failure();
-    }
-    maybePublishedAddressInfo = *info;
-  }
-
-  if (!usesComputedReceiverDFB) {
+  if (postPlan.addressPublication) {
     AddressTableInfo addressTableInfo = getAddressTableInfo(op, pipeResource);
     Value publishedAddress = buildReceiverPublishedAddress(
-        dst, loc, *maybePublishedAddressInfo, rewriter);
+        dst, loc, *postPlan.addressPublication, rewriter);
     Value tableAddress =
         buildAddressTableAddress(loc, addressTableInfo, rewriter);
     if (failed(transport.emitReceiverAddressPublish(tableAddress,
@@ -1508,11 +1428,11 @@ struct ComputedAddressPlan {
   llvm::DenseMap<std::size_t, PipeComputedAddressInfo> infoByUnitIndex;
   llvm::MapVector<FuncOp, SmallVector<PipeComputedAddressCounterInitInfo>>
       counterInitializations;
+  llvm::MapVector<FuncOp, SmallVector<int32_t>> dfbIndices;
 };
 
 static ComputedAddressPlan
-buildComputedAddressPlan(ModuleOp mod,
-                         MutableArrayRef<PipeTransferAllocationUnit> units,
+buildComputedAddressPlan(MutableArrayRef<PipeTransferAllocationUnit> units,
                          const PipeGraph &pipeGraph) {
   ComputedAddressPlan plan;
 
@@ -1553,19 +1473,16 @@ buildComputedAddressPlan(ModuleOp mod,
     return plan;
   }
 
-  OpBuilder builder(mod.getContext());
   llvm::DenseMap<FuncOp, SmallVector<int64_t>> sortedDFBIndicesByFunc;
   for (auto &[func, dfbSet] : dfbIndicesByFunc) {
     SmallVector<int64_t> sortedDFBIndices(dfbSet.begin(), dfbSet.end());
     llvm::sort(sortedDFBIndices);
     sortedDFBIndicesByFunc[func] = sortedDFBIndices;
 
-    SmallVector<int32_t> dfbAttrs =
+    plan.dfbIndices[func] =
         llvm::map_to_vector(sortedDFBIndices, [](int64_t dfbIndex) {
           return static_cast<int32_t>(dfbIndex);
         });
-    func->setAttr(kPipeComputedAddressDFBIndicesAttrName,
-                  builder.getDenseI32ArrayAttr(dfbAttrs));
   }
 
   llvm::MapVector<FuncOp, int64_t> nextDynamicSlotCounterIndexByFunc;
@@ -1605,8 +1522,8 @@ buildComputedAddressPlan(ModuleOp mod,
 }
 
 // Compact the per-source colors whose units need a resource into a dense
-// 0..N-1 index range, keyed by original color index. Returns the compacted map
-// and the maximum compacted count across sources.
+// 0..N-1 index range. The result maps each original color index to its
+// compacted index and includes the maximum compacted count across sources.
 template <typename PredT>
 static std::pair<
     llvm::MapVector<PipeSourceKey, llvm::DenseMap<std::size_t, int64_t>>,
@@ -1649,10 +1566,11 @@ LogicalResult buildPipeResourcePlan(ModuleOp mod,
       assignLiveIntervalColors(units, dominanceInfo);
   ComputedAddressPlan computedAddressPlan;
   if (enableComputedAddresses) {
-    computedAddressPlan = buildComputedAddressPlan(mod, units, pipeGraph);
+    computedAddressPlan = buildComputedAddressPlan(units, pipeGraph);
   }
   info.computedAddressCounterInitializations =
       computedAddressPlan.counterInitializations;
+  info.computedAddressDFBIndices = computedAddressPlan.dfbIndices;
 
   SmallVector<SmallVector<PipeKey>> pipesByCompletionCounterColor;
   for (PipeTransferAllocationUnit &unit : units) {

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -83,19 +83,6 @@ static PipeSourceKey getPipeSourceKey(PipeType pipeType) {
   return {pipeType.getSrcX(), pipeType.getSrcY()};
 }
 
-static FailureOr<PipeTransferCreateOp>
-getPipeTransferCreate(Operation *op, Value transfer,
-                      ValueOriginAnalysis &analysis) {
-  FailureOr<PipeTransferCreateOp> maybeCreateOp =
-      findPipeTransferCreateForTransfer(analysis, transfer);
-  if (failed(maybeCreateOp)) {
-    return op->emitError() << op->getName()
-                           << " requires every possible transfer value to "
-                              "derive from the same ttl.pipe_transfer.create";
-  }
-  return *maybeCreateOp;
-}
-
 static const PipeResourceInfo &
 lookupPipeResourceInfo(Operation *protocolOp,
                        const PipeResourcePlan &pipeResourcePlan) {

--- a/lib/Dialect/TTL/Transforms/PipeLowering.h
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.h
@@ -61,6 +61,7 @@ enum class PipeAddressMode {
 };
 
 struct PipeResourcePlan;
+class PipeTransferPlan;
 
 /// Receiver-side completion state for one transfer definition.
 struct PipeCompletionInfo {
@@ -148,6 +149,8 @@ struct PipeResourcePlan {
   /// the same transfer definition.
   llvm::MapVector<func::FuncOp, SmallVector<PipeComputedAddressCounterInitInfo>>
       computedAddressCounterInitializations;
+  /// Receiver DFB indices supplied as common runtime arguments to each sender.
+  llvm::MapVector<func::FuncOp, SmallVector<int32_t>> computedAddressDFBIndices;
 };
 
 /// Resource totals consumed by TTKernel lowering and runtime setup.
@@ -187,16 +190,24 @@ void initializePipePostSequenceCounters(
     const PipeResourcePlan &pipeResourcePlan,
     PipeCounterProgressMap &postSequenceCounters);
 
+/// Remove a sender operation proven unreachable at its pipe endpoint.
+void lowerInactivePipeTransferSend(PipeTransferSendOp op,
+                                   ConversionPatternRewriter &rewriter);
+
 /// Lower the sender-side pipe transfer and signal receiver completion.
 LogicalResult lowerPipeTransferSend(
-    PipeTransferSendOp op, Value srcCB, bool isConsumerCB,
-    ValueOriginAnalysis &analysis, const PipeResourcePlan &pipeResourcePlan,
+    PipeTransferSendOp op, Value srcCB, const PipeTransferPlan &transferPlan,
+    const PipeResourcePlan &pipeResourcePlan,
     const PipeComputedAddressCounterMap &computedAddressCounters,
     ConversionPatternRewriter &rewriter);
 
+/// Remove a receiver post proven unreachable at its pipe endpoint.
+void lowerInactivePipeTransferPost(PipeTransferPostOp op,
+                                   ConversionPatternRewriter &rewriter);
+
 /// Lower the receiver-side pipe rendezvous.
 LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
-                                    ValueOriginAnalysis &analysis,
+                                    const PipeTransferPlan &transferPlan,
                                     const PipeCounterProgressMap &counters,
                                     const PipeResourcePlan &pipeResourcePlan,
                                     ConversionPatternRewriter &rewriter);

--- a/lib/Dialect/TTL/Transforms/PipePlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.cpp
@@ -91,13 +91,14 @@ buildPipePostPlan(PipeTransferPostOp postOp,
 FailureOr<PipeModulePlan>
 buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
                     const PipeTransferIndex &transferIndex,
-                    const PipeGraph &pipeGraph, bool enableComputedAddresses) {
+                    const PipeGraph &pipeGraph,
+                    const PipePlanningOptions &options) {
   PipeModulePlan plan;
   buildPipeNetIndex(module, plan.pipeNetIndex);
 
   if (failed(buildPipeResourcePlan(module, transferIndex, pipeGraph,
                                    plan.resourcePlan,
-                                   enableComputedAddresses))) {
+                                   options.enableComputedAddresses))) {
     return failure();
   }
 
@@ -115,6 +116,14 @@ buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
   for (const auto &resourceEntry : plan.resourcePlan.resources) {
     Operation *operation = resourceEntry.first;
     const PipeResourceInfo &resources = resourceEntry.second;
+    auto sendOp = dyn_cast<PipeTransferSendOp>(operation);
+    auto postOp = dyn_cast<PipeTransferPostOp>(operation);
+    if (!sendOp && !postOp) {
+      assert(isa<PipeTransferWaitOp>(operation) &&
+             "pipe resources assigned to an unsupported operation");
+      continue;
+    }
+
     auto addTransferPlan = [&](auto operationPlan) {
       PipeTransferPlan transferPlan(getPipeType(module.getContext(), resources),
                                     resources, std::move(operationPlan));
@@ -124,14 +133,14 @@ buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
       assert(inserted && "pipe operation has more than one transfer plan");
     };
 
-    if (auto sendOp = dyn_cast<PipeTransferSendOp>(operation)) {
+    if (sendOp) {
       FailureOr<PipeSendPlan> maybeSendPlan =
           buildPipeSendPlan(sendOp, dominanceInfo);
       if (failed(maybeSendPlan)) {
         return failure();
       }
       addTransferPlan(*maybeSendPlan);
-    } else if (auto postOp = dyn_cast<PipeTransferPostOp>(operation)) {
+    } else {
       FailureOr<PipePostPlan> maybePostPlan =
           buildPipePostPlan(postOp, resources);
       if (failed(maybePostPlan)) {

--- a/lib/Dialect/TTL/Transforms/PipePlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "PipePlanning.h"
+
+#include "mlir/IR/Dominance.h"
+#include "ttlang/Analysis/ValueOriginAnalysis.h"
+#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+#include "ttlang/Dialect/Utils/ConversionUtils.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir::tt::ttl {
+
+const PipeTransferPlan &
+PipeModulePlan::getTransferPlan(Operation *operation) const {
+  auto planIt = transferPlans.find(operation);
+  assert(planIt != transferPlans.end() &&
+         "active pipe send or receiver post has no transfer plan");
+  return planIt->second;
+}
+
+static PipeType getPipeType(MLIRContext *context,
+                            const PipeResourceInfo &resources) {
+  const PipeKey &pipe = resources.pipe;
+  return PipeType::get(context, pipe.srcX, pipe.srcY, pipe.dstStartX,
+                       pipe.dstStartY, pipe.dstEndX, pipe.dstEndY,
+                       pipe.pipeNetId);
+}
+
+static FailureOr<PipeSendPlan>
+buildPipeSendPlan(PipeTransferSendOp sendOp,
+                  const DominanceInfo &dominanceInfo) {
+  FailureOr<CircularBufferType> maybeDFBType =
+      utils::getTTLCircularBufferType(sendOp.getSrc());
+  if (failed(maybeDFBType)) {
+    sendOp.emitError("pipe transfer source must have a TTL DFB type");
+    return failure();
+  }
+  auto tileType =
+      llvm::dyn_cast<ttcore::TileType>((*maybeDFBType).getElementType());
+  if (!tileType) {
+    sendOp.emitError("pipe transfer source DFB element type must be tile");
+    return failure();
+  }
+
+  bool readFromDFB =
+      llvm::any_of(sendOp.getSrc().getUsers(), [&](Operation *user) {
+        return isa<CBWaitOp>(user) && user->getOperand(0) == sendOp.getSrc() &&
+               dominanceInfo.dominates(user, sendOp);
+      });
+
+  int64_t elementCount = 1;
+  for (int64_t dimension : (*maybeDFBType).getShape()) {
+    elementCount *= dimension;
+  }
+  return PipeSendPlan{readFromDFB, elementCount * static_cast<int64_t>(
+                                                      tileType.getSizeBytes())};
+}
+
+static FailureOr<PipePostPlan>
+buildPipePostPlan(PipeTransferPostOp postOp,
+                  const PipeResourceInfo &resources) {
+  if (resources.addressStorage.usesComputedReceiverDFB()) {
+    return PipePostPlan{};
+  }
+
+  Value receiverDFB = getAttachedCB(postOp.getDst());
+  if (!receiverDFB) {
+    postOp.emitError("pipe receive destination is not attached to a DFB");
+    return failure();
+  }
+  FailureOr<CircularBufferType> maybeDFBType =
+      utils::getTTLCircularBufferType(receiverDFB);
+  if (failed(maybeDFBType)) {
+    postOp.emitError("pipe receive destination is not attached to a TTL DFB");
+    return failure();
+  }
+  auto tileType =
+      llvm::dyn_cast<ttcore::TileType>((*maybeDFBType).getElementType());
+  if (!tileType) {
+    postOp.emitError("pipe receiver DFB element type must be tile");
+    return failure();
+  }
+  return PipePostPlan{PipeReceiverAddressPublicationPlan{
+      receiverDFB, static_cast<int64_t>(tileType.getSizeBytes())}};
+}
+
+FailureOr<PipeModulePlan>
+buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
+                    const PipeTransferIndex &transferIndex,
+                    const PipeGraph &pipeGraph, bool enableComputedAddresses) {
+  PipeModulePlan plan;
+  buildPipeNetIndex(module, plan.pipeNetIndex);
+
+  if (failed(buildPipeResourcePlan(module, transferIndex, pipeGraph,
+                                   plan.resourcePlan,
+                                   enableComputedAddresses))) {
+    return failure();
+  }
+
+  plan.resourceRequirements = getPipeResourceRequirements(plan.resourcePlan);
+
+  module.walk([&](WaitOp waitOp) {
+    if (analysis.getOrigins(waitOp.getXf()).allMatch([](Value origin) {
+          return static_cast<bool>(origin.getDefiningOp<PipeTransferSendOp>());
+        })) {
+      plan.completedPipeSendWaits.insert(waitOp);
+    }
+  });
+
+  DominanceInfo dominanceInfo(module);
+  for (const auto &resourceEntry : plan.resourcePlan.resources) {
+    Operation *operation = resourceEntry.first;
+    const PipeResourceInfo &resources = resourceEntry.second;
+    auto addTransferPlan = [&](auto operationPlan) {
+      PipeTransferPlan transferPlan(getPipeType(module.getContext(), resources),
+                                    resources, std::move(operationPlan));
+      auto [planIt, inserted] =
+          plan.transferPlans.insert({operation, std::move(transferPlan)});
+      (void)planIt;
+      assert(inserted && "pipe operation has more than one transfer plan");
+    };
+
+    if (auto sendOp = dyn_cast<PipeTransferSendOp>(operation)) {
+      FailureOr<PipeSendPlan> maybeSendPlan =
+          buildPipeSendPlan(sendOp, dominanceInfo);
+      if (failed(maybeSendPlan)) {
+        return failure();
+      }
+      addTransferPlan(*maybeSendPlan);
+    } else if (auto postOp = dyn_cast<PipeTransferPostOp>(operation)) {
+      FailureOr<PipePostPlan> maybePostPlan =
+          buildPipePostPlan(postOp, resources);
+      if (failed(maybePostPlan)) {
+        return failure();
+      }
+      addTransferPlan(*maybePostPlan);
+    }
+  }
+
+  return plan;
+}
+
+void applyPipeModuleAttributes(ModuleOp module, const PipeModulePlan &plan) {
+  Builder builder(module.getContext());
+  const PipeResourcePlan &resources = plan.getResourcePlan();
+  for (const auto &[function, dfbIndices] :
+       resources.computedAddressDFBIndices) {
+    function->setAttr(kPipeComputedAddressDFBIndicesAttrName,
+                      builder.getDenseI32ArrayAttr(dfbIndices));
+  }
+
+  const PipeResourceRequirements &requirements = plan.getResourceRequirements();
+  module->setAttr(kPipeSyncSemaphoreCountAttrName,
+                  builder.getI64IntegerAttr(requirements.syncSemaphoreCount));
+  if (requirements.globalSemaphoreCount > 0) {
+    module->setAttr(
+        kPipeGlobalSemaphoreCountAttrName,
+        builder.getI64IntegerAttr(requirements.globalSemaphoreCount));
+  }
+  if (requirements.sramScratchBytes > 0) {
+    module->setAttr(kPipeSramScratchBytesAttrName,
+                    builder.getI64IntegerAttr(requirements.sramScratchBytes));
+  }
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/PipePlanning.h
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.h
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//===----------------------------------------------------------------------===//
+// PipeNet Lowering Plans
+//===----------------------------------------------------------------------===//
+//
+// This file declares the immutable protocol and resource decisions consumed by
+// TTL-to-TTKernel PipeNet lowering.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_PIPEPLANNING_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_PIPEPLANNING_H
+
+#include "PipeLowering.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+#include <variant>
+
+namespace mlir::tt {
+class ValueOriginAnalysis;
+}
+
+namespace mlir::tt::ttl {
+
+class PipeModulePlan;
+class PipeTransferIndex;
+
+/// Sender-side DFB access and payload size for one transfer.
+struct PipeSendPlan {
+  bool usesReadPointer = false;
+  int64_t payloadSizeBytes = 0;
+};
+
+/// Receiver information needed to publish a destination DFB address.
+struct PipeReceiverAddressPublicationPlan {
+  Value receiverDFB;
+  int64_t tileSizeBytes = 0;
+};
+
+/// Receiver-side address publication for one transfer post.
+struct PipePostPlan {
+  std::optional<PipeReceiverAddressPublicationPlan> addressPublication;
+};
+
+/// Complete lowering decisions for one send or receiver post operation.
+class PipeTransferPlan {
+public:
+  /// Return the transfer's source, receiver range, and PipeNet id.
+  PipeType getPipeType() const { return pipeType; }
+
+  /// Return the completion, readiness, and address resources.
+  const PipeResourceInfo &getResources() const { return resources; }
+
+  /// Return whether this plan describes a sender operation.
+  bool isSend() const {
+    return std::holds_alternative<PipeSendPlan>(operationPlan);
+  }
+
+  /// Return sender-only lowering information.
+  const PipeSendPlan &getSend() const {
+    assert(isSend() && "send plan requested for a receiver post");
+    return std::get<PipeSendPlan>(operationPlan);
+  }
+
+  /// Return receiver-post-only lowering information.
+  const PipePostPlan &getPost() const {
+    assert(!isSend() && "receiver-post plan requested for a send");
+    return std::get<PipePostPlan>(operationPlan);
+  }
+
+private:
+  friend FailureOr<PipeModulePlan> buildPipeModulePlan(ModuleOp,
+                                                       ValueOriginAnalysis &,
+                                                       const PipeTransferIndex &,
+                                                       const PipeGraph &, bool);
+
+  PipeTransferPlan(PipeType pipeType, const PipeResourceInfo &resources,
+                   PipeSendPlan sendPlan)
+      : pipeType(pipeType), resources(resources),
+        operationPlan(std::move(sendPlan)) {}
+
+  PipeTransferPlan(PipeType pipeType, const PipeResourceInfo &resources,
+                   PipePostPlan postPlan)
+      : pipeType(pipeType), resources(resources),
+        operationPlan(std::move(postPlan)) {}
+
+  PipeType pipeType;
+  PipeResourceInfo resources;
+  std::variant<PipeSendPlan, PipePostPlan> operationPlan;
+};
+
+/// PipeNet decisions shared by all lowering patterns for one module.
+class PipeModulePlan {
+public:
+  /// Return the resource assignment for every transfer operation.
+  const PipeResourcePlan &getResourcePlan() const { return resourcePlan; }
+
+  /// Return the module-level PipeNet resource totals.
+  const PipeResourceRequirements &getResourceRequirements() const {
+    return resourceRequirements;
+  }
+
+  /// Return transfer topology grouped by PipeNet id.
+  const PipeNetIndex &getPipeNetIndex() const { return pipeNetIndex; }
+
+  /// Return send waits whose payload writes complete within the send operation.
+  const llvm::SmallPtrSetImpl<Operation *> &getCompletedPipeSendWaits() const {
+    return completedPipeSendWaits;
+  }
+
+  /// Return the lowering plan for an active send or receiver post.
+  const PipeTransferPlan &getTransferPlan(Operation *operation) const;
+
+private:
+  friend FailureOr<PipeModulePlan> buildPipeModulePlan(ModuleOp,
+                                                       ValueOriginAnalysis &,
+                                                       const PipeTransferIndex &,
+                                                       const PipeGraph &, bool);
+
+  PipeResourcePlan resourcePlan;
+  PipeResourceRequirements resourceRequirements;
+  PipeNetIndex pipeNetIndex;
+  llvm::SmallPtrSet<Operation *, 8> completedPipeSendWaits;
+  llvm::MapVector<Operation *, PipeTransferPlan> transferPlans;
+};
+
+/// Compute all PipeNet decisions required after transfer IR expansion.
+FailureOr<PipeModulePlan>
+buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
+                    const PipeTransferIndex &transferIndex,
+                    const PipeGraph &pipeGraph, bool enableComputedAddresses);
+
+/// Materialize the module and function attributes recorded by `plan`.
+void applyPipeModuleAttributes(ModuleOp module, const PipeModulePlan &plan);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_PIPEPLANNING_H

--- a/lib/Dialect/TTL/Transforms/PipePlanning.h
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.h
@@ -35,6 +35,11 @@ namespace mlir::tt::ttl {
 class PipeModulePlan;
 class PipeTransferIndex;
 
+/// Options that control PipeNet protocol and resource planning.
+struct PipePlanningOptions {
+  /// Compute receiver DFB addresses instead of publishing them at runtime.
+  bool enableComputedAddresses = false;
+};
 /// Sender-side DFB access and payload size for one transfer.
 struct PipeSendPlan {
   bool usesReadPointer = false;
@@ -79,10 +84,10 @@ public:
   }
 
 private:
-  friend FailureOr<PipeModulePlan> buildPipeModulePlan(ModuleOp,
-                                                       ValueOriginAnalysis &,
-                                                       const PipeTransferIndex &,
-                                                       const PipeGraph &, bool);
+  friend FailureOr<PipeModulePlan>
+  buildPipeModulePlan(ModuleOp, ValueOriginAnalysis &,
+                      const PipeTransferIndex &, const PipeGraph &,
+                      const PipePlanningOptions &);
 
   PipeTransferPlan(PipeType pipeType, const PipeResourceInfo &resources,
                    PipeSendPlan sendPlan)
@@ -122,10 +127,10 @@ public:
   const PipeTransferPlan &getTransferPlan(Operation *operation) const;
 
 private:
-  friend FailureOr<PipeModulePlan> buildPipeModulePlan(ModuleOp,
-                                                       ValueOriginAnalysis &,
-                                                       const PipeTransferIndex &,
-                                                       const PipeGraph &, bool);
+  friend FailureOr<PipeModulePlan>
+  buildPipeModulePlan(ModuleOp, ValueOriginAnalysis &,
+                      const PipeTransferIndex &, const PipeGraph &,
+                      const PipePlanningOptions &);
 
   PipeResourcePlan resourcePlan;
   PipeResourceRequirements resourceRequirements;
@@ -138,7 +143,8 @@ private:
 FailureOr<PipeModulePlan>
 buildPipeModulePlan(ModuleOp module, ValueOriginAnalysis &analysis,
                     const PipeTransferIndex &transferIndex,
-                    const PipeGraph &pipeGraph, bool enableComputedAddresses);
+                    const PipeGraph &pipeGraph,
+                    const PipePlanningOptions &options);
 
 /// Materialize the module and function attributes recorded by `plan`.
 void applyPipeModuleAttributes(ModuleOp module, const PipeModulePlan &plan);

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops.mlir
@@ -1559,3 +1559,38 @@ func.func @pipe_block_argument_sender(
   ttl.wait %handle : !ttl.transfer_handle<write>
   func.return
 }
+
+// -----
+
+// Transfers in a zero-trip loop require no resources or transfer plans and are
+// removed without reaching active send, post, or wait lowering.
+// CHECK-LABEL: func.func @zero_trip_transfer
+// CHECK-NOT: ttl.pipe_transfer
+// CHECK-NOT: ttkernel.noc_
+func.func @zero_trip_transfer()
+    attributes {"ttl.kernel_thread" = #ttkernel.thread<noc>} {
+  %zero = arith.constant 0 : index
+  %one = arith.constant 1 : index
+  %src_cb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %dst_cb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  scf.for %iteration = %zero to %zero step %one {
+    %dst = ttl.cb_reserve %dst_cb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %receive = ttl.copy %pipe, %dst
+        : (!ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>,
+           tensor<1x1x!ttcore.tile<32x32, f32>>)
+        -> !ttl.transfer_handle
+    %send = ttl.copy %src_cb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>,
+           !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>)
+        -> !ttl.transfer_handle<write>
+    ttl.wait %send : !ttl.transfer_handle<write>
+    ttl.wait %receive : !ttl.transfer_handle
+  }
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_invalid.mlir
@@ -594,3 +594,32 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     func.return
   }
 }
+
+// -----
+
+// Pipe payload writes require a tile element type because the NoC transfer size
+// is derived from the tile storage size.
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @pipe_payload_requires_tile_element_type()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %src = ttl.bind_cb {cb_index = 0, block_count = 1}
+        : !ttl.cb<[1, 1], f32, 1>
+    %dst = ttl.bind_cb {cb_index = 1, block_count = 1}
+        : !ttl.cb<[1, 1], f32, 1>
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    %recv = ttl.cb_reserve %dst
+        : <[1, 1], f32, 1> -> tensor<1x1xf32>
+    %post = ttl.copy %pipe, %recv
+        : (!ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>,
+           tensor<1x1xf32>)
+        -> !ttl.transfer_handle
+    // expected-error @below {{pipe transfer source DFB element type must be tile}}
+    %send = ttl.copy %src, %pipe
+        : (!ttl.cb<[1, 1], f32, 1>,
+           !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>)
+        -> !ttl.transfer_handle<write>
+    func.return
+  }
+}


### PR DESCRIPTION
PipeNet PR tree:

```text
main (includes #756, #768, #704, #782, #778, #775, and #783; all merged)
  -> [pipes-3] #765
    -> [pipes-4] #700
      -> [pipes-5] #740
        -> [pipes-6] #784 (this PR)
          |-> [pipes-7] #780
          |-> [pipes-8] #754
          `-> [pipes-fabric] #734
```

### Problem description

PipeNet lowering previously discovered protocol and resource decisions while emitting TTKernel IR. A late failure could occur after partial mutation, and transport emitters had to query mutable analysis state during emission.

### What's changed

- Build and validate immutable transfer plans before modifying transfer IR.
- Record protocol, address, resource, payload, completion, and capacity decisions in each plan.
- Separate capacity facts from protocol selection and allocate counters from the complete resource plan.
- Reuse one checked DFB element-type query and diagnose unsupported payload types before emission.

The transport emitter consumes a validated plan and does not repeat protocol analysis.

### Validation

New regressions verify that unsupported payloads are diagnosed before mutation
and that emission uses the planned protocol, counter, payload, and address
decisions.

### Checklist

- [x] New and existing tests provide coverage for the changes.
