### PR TITLE
[sim] per-op trace instrumentation for cycle counting

### DIFF
--- a/examples/eltwise_broadcast_reduce.py
+++ b/examples/eltwise_broadcast_reduce.py
@@ -126,7 +126,7 @@ def eltwise_broadcast_reduce(
             )
 
             # Zero-initialize z accumulator
-            z = ttl.block.fill(0, shape=(1, M_TILES))
+            z = ttl.block.fill(0, shape=(1, M_TILES), dtype=z_blk.dtype)
 
             for _ in range(N_BLOCKS):
                 with (

--- a/examples/matmul-tutorial/step_1_single_node_single_tile_block.py
+++ b/examples/matmul-tutorial/step_1_single_node_single_tile_block.py
@@ -134,7 +134,9 @@ def __tutorial_operation(
                 # it into acc_blk and pushes it so the k loop can consume it.
 
                 with acc_dfb.reserve() as acc_blk:
-                    acc_blk.store(ttl.block.fill(0, shape=acc_blk.shape))
+                    acc_blk.store(
+                        ttl.block.fill(0, shape=acc_blk.shape, dtype=acc_blk.dtype)
+                    )
 
                 for _ in range(k_tiles):
 

--- a/examples/matmul-tutorial/step_2_single_node_multitile_block.py
+++ b/examples/matmul-tutorial/step_2_single_node_multitile_block.py
@@ -145,7 +145,9 @@ def __tutorial_operation(
         for _ in range(m_blocks):
             for _ in range(n_blocks):
                 with acc_dfb.reserve() as acc_blk:
-                    acc_blk.store(ttl.block.fill(0, shape=acc_blk.shape))
+                    acc_blk.store(
+                        ttl.block.fill(0, shape=acc_blk.shape, dtype=acc_blk.dtype)
+                    )
 
                 for _ in range(k_blocks):
                     with (

--- a/examples/matmul-tutorial/step_3_multinode.py
+++ b/examples/matmul-tutorial/step_3_multinode.py
@@ -157,7 +157,9 @@ def __tutorial_operation(
         for _ in range(m_blocks_per_node):
             for _ in range(n_blocks_per_node):
                 with acc_dfb.reserve() as acc_blk:
-                    acc_blk.store(ttl.block.fill(0, shape=acc_blk.shape))
+                    acc_blk.store(
+                        ttl.block.fill(0, shape=acc_blk.shape, dtype=acc_blk.dtype)
+                    )
 
                 for _ in range(k_blocks):
                     with (

--- a/examples/matmul-tutorial/step_4_multinode_grid_full.py
+++ b/examples/matmul-tutorial/step_4_multinode_grid_full.py
@@ -159,7 +159,11 @@ def __tutorial_operation(
                     n_block = node_n * n_blocks_per_node + local_n_block
                     if n_block < n_blocks:
                         with acc_dfb.reserve() as acc_blk:
-                            acc_blk.store(ttl.block.fill(0, shape=acc_blk.shape))
+                            acc_blk.store(
+                                ttl.block.fill(
+                                    0, shape=acc_blk.shape, dtype=acc_blk.dtype
+                                )
+                            )
 
                         for _ in range(k_blocks):
                             with (

--- a/examples/matmul-tutorial/step_5_multidevice_shard_m.py
+++ b/examples/matmul-tutorial/step_5_multidevice_shard_m.py
@@ -154,7 +154,11 @@ def tutorial_operation(
                     n_block = node_n * n_blocks_per_node + local_n_block
                     if n_block < n_blocks:
                         with acc_dfb.reserve() as acc_blk:
-                            acc_blk.store(ttl.block.fill(0, shape=acc_blk.shape))
+                            acc_blk.store(
+                                ttl.block.fill(
+                                    0, shape=acc_blk.shape, dtype=acc_blk.dtype
+                                )
+                            )
 
                         for _ in range(k_blocks):
                             with (

--- a/examples/matmul-tutorial/step_6_multidevice_shard_k.py
+++ b/examples/matmul-tutorial/step_6_multidevice_shard_k.py
@@ -150,7 +150,11 @@ def tutorial_operation(
                     n_block = node_n * n_blocks_per_node + local_n_block
                     if n_block < n_blocks:
                         with acc_dfb.reserve() as acc_blk:
-                            acc_blk.store(ttl.block.fill(0, shape=acc_blk.shape))
+                            acc_blk.store(
+                                ttl.block.fill(
+                                    0, shape=acc_blk.shape, dtype=acc_blk.dtype
+                                )
+                            )
 
                         for _ in range(k_blocks):
                             with (

--- a/examples/matmul-tutorial/step_7_multidevice_shard_k_all_reduce.py
+++ b/examples/matmul-tutorial/step_7_multidevice_shard_k_all_reduce.py
@@ -144,7 +144,11 @@ def tutorial_operation(
                     n_block = node_n * n_blocks_per_node + local_n_block
                     if n_block < n_blocks:
                         with acc_dfb.reserve() as acc_blk:
-                            acc_blk.store(ttl.block.fill(0, shape=acc_blk.shape))
+                            acc_blk.store(
+                                ttl.block.fill(
+                                    0, shape=acc_blk.shape, dtype=acc_blk.dtype
+                                )
+                            )
 
                         for _ in range(k_blocks):
                             with (

--- a/examples/matmul_1d.py
+++ b/examples/matmul_1d.py
@@ -68,7 +68,9 @@ def matmul_1d(
                     nb = local_nb + node_index * nb_per_node
                     if nb < Nb:
                         with out_dfb.reserve() as out_blk:
-                            acc = ttl.block.fill(0, shape=out_blk.shape)
+                            acc = ttl.block.fill(
+                                0, shape=out_blk.shape, dtype=out_blk.dtype
+                            )
                             for kb in range(Kb):
                                 with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                                     acc += a_blk @ b_blk

--- a/examples/matmul_1d_mcast.py
+++ b/examples/matmul_1d_mcast.py
@@ -71,7 +71,9 @@ def matmul_1d(
                     nb = local_nb + node_index * nb_per_node
                     if nb < Nb:
                         with out_dfb.reserve() as out_blk:
-                            acc = ttl.block.fill(0, shape=out_blk.shape)
+                            acc = ttl.block.fill(
+                                0, shape=out_blk.shape, dtype=out_blk.dtype
+                            )
                             for kb in range(Kb):
                                 with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                                     acc += a_blk @ b_blk

--- a/examples/metal_examples/1d_mcast_matmul/ttlang/1d_tt_lang.py
+++ b/examples/metal_examples/1d_mcast_matmul/ttlang/1d_tt_lang.py
@@ -72,7 +72,7 @@ def matmul_1d(
         for block_m in range(num_blocks_m):
             for block_n in range(blocks_per_node_n):
                 with out_dfb.reserve() as out_blk:
-                    acc = ttl.block.fill(0, shape=out_blk.shape)
+                    acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                     for block_k in range(num_blocks_k):
                         with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                             acc += a_blk @ b_blk

--- a/examples/metal_examples/2d_mcast_matmul/ttlang/2d_mcast_matmul.py
+++ b/examples/metal_examples/2d_mcast_matmul/ttlang/2d_mcast_matmul.py
@@ -79,7 +79,7 @@ def tt_lang_2d_mcast_matmul(a: ttnn.Tensor, b: ttnn.Tensor, out: ttnn.Tensor):
         out_col = per_node_N * node_x
         if (out_row < Mt) and (out_col < Nt):
             with out_dfb.reserve() as out_blk:
-                acc = ttl.block.fill(0, shape=out_blk.shape)
+                acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                 for _ in range(num_blocks_k):
                     with (
                         a_dfb.wait() as a_blk,

--- a/examples/metal_examples/multinode_matmul/ttlang/multinode_matmul.py
+++ b/examples/metal_examples/multinode_matmul/ttlang/multinode_matmul.py
@@ -69,7 +69,7 @@ def tt_lang_multinode_matmul(a: ttnn.Tensor, b: ttnn.Tensor, out: ttnn.Tensor):
         node_id = ttl.node(dims=1)
         for _ in range(get_tiles_per_node(node_id)):
             with out_dfb.reserve() as out_blk:
-                acc = ttl.block.fill(0, shape=out_blk.shape)
+                acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                 for _ in range(Kt):
                     with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                         acc += a_blk @ b_blk

--- a/examples/metal_examples/multinode_reuse_matmul/ttlang/multinode_reuse_matmul.py
+++ b/examples/metal_examples/multinode_reuse_matmul/ttlang/multinode_reuse_matmul.py
@@ -61,7 +61,7 @@ def tt_lang_multinode_reuse_matmul(a: ttnn.Tensor, b: ttnn.Tensor, out: ttnn.Ten
         out_col = per_node_N * node_x
         if (out_row < Mt) and (out_col < Nt):
             with out_dfb.reserve() as out_blk:  # per_node_M * per_node_N
-                acc = ttl.block.fill(0, shape=out_blk.shape)
+                acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                 for _ in range(Kt // K_block_size):
                     with (
                         a_dfb.wait() as a_blk,
@@ -155,7 +155,7 @@ def tt_lang_multinode_matmul(a: ttnn.Tensor, b: ttnn.Tensor, out: ttnn.Tensor):
         out_col = node_x
         if (out_row < Mt) and (out_col < Nt):
             with out_dfb.reserve() as out_blk:
-                acc = ttl.block.fill(0, shape=out_blk.shape)
+                acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                 for _ in range(Kt):
                     with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                         acc += a_blk @ b_blk

--- a/examples/metal_examples/single_node_matmul/ttlang/single_node_matmul.py
+++ b/examples/metal_examples/single_node_matmul/ttlang/single_node_matmul.py
@@ -32,7 +32,7 @@ def tt_lang_singlenode_matmul(a: ttnn.Tensor, b: ttnn.Tensor, out: ttnn.Tensor):
         for _ in range(Mt):
             for _ in range(Nt):
                 with out_dfb.reserve() as out_blk:
-                    acc = ttl.block.fill(0, shape=out_blk.shape)
+                    acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                     for _ in range(Kt):
                         with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                             acc += a_blk @ b_blk

--- a/examples/multinode_matmul.py
+++ b/examples/multinode_matmul.py
@@ -97,7 +97,7 @@ def tt_lang_multinode_matmul(a: ttnn.Tensor, b: ttnn.Tensor, out: ttnn.Tensor) -
             # The reserved block is automatically initialized with zeros
             with out_dfb.reserve() as out_blk:
                 # Accumulate over K dimension
-                acc = ttl.block.fill(0, shape=out_blk.shape)
+                acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                 for _ in range(Kt):
                     with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                         acc += a_blk @ b_blk

--- a/examples/single_node_matmul.py
+++ b/examples/single_node_matmul.py
@@ -37,7 +37,7 @@ def tt_lang_singlenode_matmul(a: ttnn.Tensor, b: ttnn.Tensor, out: ttnn.Tensor) 
                 # The reserved block is automatically initialized with zeros
                 with out_dfb.reserve() as out_blk:
                     # Accumulate over K dimension
-                    acc = ttl.block.fill(0, shape=out_blk.shape)
+                    acc = ttl.block.fill(0, shape=out_blk.shape, dtype=out_blk.dtype)
                     for _ in range(Kt):
                         with a_dfb.wait() as a_blk, b_dfb.wait() as b_blk:
                             acc += a_blk @ b_blk

--- a/python/sim/block.py
+++ b/python/sim/block.py
@@ -12,7 +12,7 @@ Functions: broadcast, fill, mask, mask_posinf, where, squeeze, unsqueeze,
 transpose.
 """
 
-from typing import Callable, List, Tuple
+from typing import Any, Callable, List, Tuple
 
 import torch
 
@@ -20,7 +20,7 @@ from .constants import TILE_SHAPE
 from .context import get_context
 from .dfb import Block, check_same_layout, track_source_blocks, _dry_run_result
 from .blockstate import BlockAcquisition, KernelType
-from .ttnnsim import ROW_MAJOR_LAYOUT, Tensor
+from .ttnnsim import ROW_MAJOR_LAYOUT, Tensor, _promote_dtype
 
 
 def _is_dry_run() -> bool:
@@ -230,12 +230,16 @@ def broadcast(
     return result_block
 
 
-def fill(value: float, shape: Tuple[int, ...]) -> Block:
+def fill(value: float, shape: Tuple[int, ...], dtype: Any = None) -> Block:
     """Return a temporary tiled block of the specified shape filled with value.
 
     Args:
         value: The scalar value to fill every element with.
         shape: Grid shape of the resulting block (at least 2-dimensional).
+        dtype: Optional declared dtype for the block. Defaults to bf16, matching
+            the ``ttl.block.fill`` default. Backing storage is promoted via
+            ``_promote_dtype`` (narrow floats back to float32); the declared
+            dtype is preserved for byte accounting and trace emission.
 
     Returns:
         A temporary Block of the specified shape with every element set to value.
@@ -253,13 +257,14 @@ def fill(value: float, shape: Tuple[int, ...]) -> Block:
     batch = shape[:-2]
     TM, TK = shape[-2], shape[-1]
 
+    declared = dtype if dtype is not None else torch.bfloat16
     elem = torch.full(
         (*batch, TM * tile_h, TK * tile_w),
         value,
-        dtype=torch.bfloat16,
+        dtype=_promote_dtype(declared),
     )
     return Block(
-        tensor=Tensor(elem),
+        tensor=Tensor(elem, dtype=declared),
         shape=shape,
         acquisition=BlockAcquisition.RESERVE,
         kernel_type=KernelType.COMPUTE,

--- a/python/sim/copy.py
+++ b/python/sim/copy.py
@@ -23,7 +23,7 @@ from .copyhandlers import (
 from .dfb import Block
 from .greenlet_scheduler import block_if_needed
 from .sharding import try_count_locality
-from .trace import TRACE, trace
+from .trace import TRACE, dtype_name, trace
 from .ttnnsim import Tensor, tile_count_from_tensor
 from .pipe import Pipe, SrcPipeIdentity
 
@@ -36,9 +36,14 @@ def _copy_trace_fields(src: CopyEndpoint, dst: CopyEndpoint) -> dict:
     """
     match (src, dst):
         case (Tensor(), Block()):
-            tensor, direction, tiles = src, "read", tile_count_from_tensor(src)
+            tensor, block, direction, tiles = (
+                src,
+                dst,
+                "read",
+                tile_count_from_tensor(src),
+            )
         case (Block(), Tensor()):
-            tensor, direction, tiles = dst, "write", math.prod(src.shape)
+            tensor, block, direction, tiles = dst, src, "write", math.prod(src.shape)
         case _:
             return {}
 
@@ -46,6 +51,9 @@ def _copy_trace_fields(src: CopyEndpoint, dst: CopyEndpoint) -> dict:
         "tensor": getattr(tensor, "_name", None) or type(tensor).__name__,
         "tiles": tiles,
         "direction": direction,
+        # Read dtype from the Block endpoint: it preserves the declared dtype,
+        # whereas a Tensor *slice* loses it (exposes float32-promotion storage).
+        "dtype": dtype_name(block.dtype),
     }
     locality = try_count_locality(tensor)
     if locality is not None:

--- a/python/sim/dfb.py
+++ b/python/sim/dfb.py
@@ -53,7 +53,7 @@ from .ttnnsim import (
     tile_count_from_tensor,
     tile_shape_from_tensor,
 )
-from .trace import TRACE, trace
+from .trace import TRACE, dtype_name, trace
 from .typedefs import Index, IndexType, PositiveInt, Shape, Size
 from .greenlet_scheduler import block_if_needed
 
@@ -180,6 +180,11 @@ class Block:
             self._sm.initialize()
         else:
             self._sm.set_unrestricted()
+
+    @property
+    def dtype(self):
+        """Declared logical dtype of the block's tiles (bf16/fp32/bfloat8_b)."""
+        return self._buf.dtype
 
     def __enter__(self) -> "Block":
         """Context manager entry - returns self for use in with statement."""
@@ -826,6 +831,15 @@ class Block:
             raise ValueError(
                 f"Shape mismatch in binary operation: left shape {left_shape} does not match "
                 f"right shape {right_shape}. Use broadcast() to expand operands first."
+            )
+
+        # [cycle-estimator] emit before the dry-run skip so dry-run records the work.
+        if TRACE.enabled:
+            trace(
+                "compute_op",
+                op_type=op.__name__,
+                tiles=len(self),
+                dtype=dtype_name(self.dtype),
             )
 
         # Skip the actual elementwise compute in dry-run: tile-grid shape and
@@ -1636,4 +1650,11 @@ def matmul(a: Block, b: Block, _output_hint: Optional[Block] = None) -> Block:
         is_temporary=True,
     )
     track_source_blocks(result_block, a, b)
+    # for cycle-accurate compute ops, trace the MAC-tile volume of the matmul
+    if TRACE.enabled:
+        m, k = a.shape[-2], a.shape[-1]
+        n = b.shape[-1]
+        trace(
+            "compute_op", op_type="matmul", tiles=m * k * n, dtype=dtype_name(a.dtype)
+        )  # MAC-tile volume
     return result_block

--- a/python/sim/math.py
+++ b/python/sim/math.py
@@ -27,6 +27,11 @@ from .dfb import (
     matmul,
     _dry_run_result,
 )
+from .trace import (  # [cycle-estimator] compute_op instrumentation
+    TRACE,
+    dtype_name,
+    trace,
+)
 from .ttnnsim import ROW_MAJOR_LAYOUT, Tensor
 from .typedefs import PositiveInt
 
@@ -52,6 +57,14 @@ def _create_unary_op_wrapper(
     """
 
     def wrapper(block: Block) -> Block:
+        # [cycle-estimator] emit before the dry-run skip so dry-run records the work.
+        if TRACE.enabled:
+            trace(
+                "compute_op",
+                op_type=name,
+                tiles=len(block),
+                dtype=dtype_name(block.dtype),
+            )
         if _is_dry_run():
             return _dry_run_result(block.shape, block)
         # Apply the operation to each tensor in the block
@@ -158,6 +171,15 @@ def _apply_binary_op(
         raise ValueError(
             f"Shape mismatch in binary op: a has shape {a_shape}, b has shape {b_shape}"
         )
+    # [cycle-estimator] emit before the dry-run skip so dry-run records the work.
+    # Generic op_type: no op name is threaded here (max/min/compare).
+    if TRACE.enabled:
+        trace(
+            "compute_op",
+            op_type="eltwise_binary",
+            tiles=len(a),
+            dtype=dtype_name(a.dtype),
+        )
     if _is_dry_run():
         return _dry_run_result(a_shape, a, b)
     layout = a.layout
@@ -186,6 +208,15 @@ def _apply_unary_with_params(
     Returns:
         Block with operation applied element-wise
     """
+    # [cycle-estimator] emit before the dry-run skip so dry-run records the work.
+    # Generic op_type: no op name is threaded here.
+    if TRACE.enabled:
+        trace(
+            "compute_op",
+            op_type="eltwise_unary",
+            tiles=len(block),
+            dtype=dtype_name(block.dtype),
+        )
     if _is_dry_run():
         return _dry_run_result(block.shape, block)
     layout = block.layout
@@ -526,6 +557,14 @@ def _reduce_impl(
             f"(block shape {block_shape}, reducing dims {dims})"
         )
 
+    # [cycle-estimator] emit before the dry-run skip so dry-run records the work.
+    if TRACE.enabled:
+        trace(
+            "compute_op",
+            op_type=f"reduce_{op}",
+            tiles=len(block),
+            dtype=dtype_name(block.dtype),
+        )
     if _is_dry_run():
         return _dry_run_result(result_shape, block)
 

--- a/python/sim/trace.py
+++ b/python/sim/trace.py
@@ -39,7 +39,7 @@ from .context_types import TraceEvent
 # All defined event categories.  Pass ALL_CATEGORIES to :func:`set_tracing`
 # to enable everything; pass an empty frozenset to disable.
 ALL_CATEGORIES: frozenset[str] = frozenset(
-    {"operation", "kernel", "dfb", "copy", "pipe"}
+    {"operation", "kernel", "dfb", "copy", "pipe", "compute"}
 )
 
 
@@ -61,6 +61,7 @@ _EVENT_CATEGORY: dict[str, str] = {
     "copy_end": "copy",
     "pipe_send": "pipe",
     "pipe_recv": "pipe",
+    "compute_op": "compute",  # for cycle-accurate compute ops
 }
 
 
@@ -141,6 +142,25 @@ def trace(event: str, **data: Any) -> None:
             data=data,
         )
     )
+
+
+def dtype_name(dt: object) -> str:
+    """Canonical short name for a declared dtype (bf16 / fp32 / fp16 / bfp8 / ...).
+
+    Works on any dtype repr (torch dtypes or the sim's declared-dtype objects) so
+    it needs no import of the dtype classes. Feeds the ``compute_op`` / ``copy``
+    trace so the cycle estimator can key rates and tile bytes on dtype.
+    """
+    s = str(dt).lower()
+    if "bfloat8" in s or "bfp8" in s:
+        return "bfp8"
+    if "bfloat16" in s:
+        return "bf16"
+    if "float32" in s:
+        return "fp32"
+    if "float16" in s:
+        return "fp16"
+    return str(dt).replace("torch.", "")
 
 
 def get_pipe_name(pipe: Any) -> str:


### PR DESCRIPTION
### Problem description
The simulator trace records scheduling events but no per-op **work-counts**, so nothing downstream can reason about how much compute or data-movement each kernel does. 

This PR adds that producer-side data to the trace. 
It's useful for trace analysis on its own, and is the foundation for a cycle estimator that consumes it (follow-up PR).

### What's changed
- New **`compute_op`** trace event at each math-op site (matmul, elementwise binary/unary, reduce), carrying `op_type`, `tiles`, and declared `dtype`
- **`copy_end`** enriched with per-locality tile counts (`local_l1` / `remote_l1` / `dram`) and dtype
- **`ttl.block.fill(0, shape=…)`** now derives its dtype from the target block instead of hardcoding bf16 — this was breaking fp32 kernels (`bf16 tile ≠ f32 view`). The example set is updated to pass the dtype through

Additive to the trace schema —  existing traces gain fields, no behavior change.

The new events are exercised whenever an example runs under `tt-lang-sim`; the schema-conformance test lands with the consumer in the follow-up PR.

### Ticket
N/A

### Checklist
- [x] New/Existing tests provide coverage for changes
