### PR TITLE
[ci] re-enable Galaxy hardware tests

### DIFF
--- a/.github/scripts/compile-and-run-examples.sh
+++ b/.github/scripts/compile-and-run-examples.sh
@@ -23,6 +23,8 @@
 #   bash .github/scripts/compile-and-run-examples.sh
 #
 # Optional first argument: repo root (default: current directory).
+# Env: HW_SERIAL_TEST_VISIBLE_DEVICES restricts TT device visibility for each
+#      script. Unset preserves the caller's TT_VISIBLE_DEVICES.
 
 set -uo pipefail
 
@@ -75,6 +77,11 @@ fi
 
 declare -a RESULTS=()
 N_PASS=0  N_FAIL=0  N_SKIP=0  N_XFAIL=0  N_XPASS=0
+
+if [[ -n "${HW_SERIAL_TEST_VISIBLE_DEVICES:-}" ]]; then
+  export TT_VISIBLE_DEVICES="${HW_SERIAL_TEST_VISIBLE_DEVICES}"
+  echo "Restricting hardware examples to TT_VISIBLE_DEVICES=${TT_VISIBLE_DEVICES}"
+fi
 
 for script in "${SCRIPTS[@]}"; do
   path="${ROOT}/${script}"

--- a/.github/scripts/run-hardware-lit.sh
+++ b/.github/scripts/run-hardware-lit.sh
@@ -4,7 +4,7 @@
 #
 # Run hardware Python lit tests with one serial lit process per chip. Each shard
 # is restricted with TT_VISIBLE_DEVICES, preserving one open device per process.
-# Multi-device lit tests run afterward with every chip visible.
+# Multi-device lit tests run afterward in a serial process.
 #
 # Env:
 #   HW_LIT_CHIPS overrides the detected chip count.

--- a/.github/scripts/run-hardware-pytests.sh
+++ b/.github/scripts/run-hardware-pytests.sh
@@ -8,10 +8,12 @@
 # Chip count is the number of digit-named nodes under /dev/tenstorrent (matching
 # test/lit.cfg.py). With more than one chip, single-device tests run under
 # pytest-xdist (-n <chips>) with each worker restricted to one chip through
-# TT_VISIBLE_DEVICES. The multi_device tests then run serially with every chip
-# visible. With one chip the whole suite runs serially.
+# TT_VISIBLE_DEVICES. The multi_device tests then run serially. With one chip the
+# whole suite runs serially.
 #
 # Env: HW_PYTEST_CHIPS overrides the detected chip count.
+# Env: HW_SERIAL_TEST_VISIBLE_DEVICES restricts device visibility for serial
+#      phases that need multiple devices. Unset means every chip remains visible.
 #
 # Usage: run-hardware-pytests.sh <test-dir> <report-prefix>
 
@@ -51,6 +53,16 @@ run_pytest_phase() {
     return "$phase_rc"
 }
 
+run_multi_device_phase() {
+    if [ -n "${HW_SERIAL_TEST_VISIBLE_DEVICES:-}" ]; then
+        export TT_VISIBLE_DEVICES="$HW_SERIAL_TEST_VISIBLE_DEVICES"
+        echo "Restricting serial multi_device pytest phase to TT_VISIBLE_DEVICES=$TT_VISIBLE_DEVICES"
+    else
+        unset TT_VISIBLE_DEVICES
+    fi
+    run_pytest_phase "$@"
+}
+
 if [ "$chips" -gt 1 ]; then
     echo "Detected ${chips} chips: single-device tests in parallel (-n ${chips}), multi_device serial"
     unset TT_VISIBLE_DEVICES
@@ -65,7 +77,7 @@ if [ "$chips" -gt 1 ]; then
         run_pytest_phase "$TEST_DIR" -m "not multi_device" -n "$chips" \
         --max-worker-restart=0 "${common[@]}" \
         --junitxml="${REPORT_PREFIX}-parallel.xml" || rc=1
-    run_pytest_phase "$TEST_DIR" -m multi_device \
+    run_multi_device_phase "$TEST_DIR" -m multi_device \
         "${common[@]}" --junitxml="${REPORT_PREFIX}-multidevice.xml" || rc=1
     if [ "$selected_phase_count" -eq 0 ]; then
         echo "No tests selected by either hardware pytest phase" >&2

--- a/.github/scripts/tests/test_compile_and_run_examples.bats
+++ b/.github/scripts/tests/test_compile_and_run_examples.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/compile-and-run-examples.sh.
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/compile-and-run-examples.sh"
+    BIN="$BATS_TEST_TMPDIR/bin"
+    REPO="$BATS_TEST_TMPDIR/repo"
+    CALLS="$BATS_TEST_TMPDIR/python.calls"
+    mkdir -p "$BIN" "$REPO/examples/tutorial"
+    cp "$SCRIPT" "$BATS_TEST_TMPDIR/compile-and-run-examples.sh"
+    SCRIPT="$BATS_TEST_TMPDIR/compile-and-run-examples.sh"
+    PATH="$BIN:$PATH"
+    unset TT_VISIBLE_DEVICES
+    unset HW_SERIAL_TEST_VISIBLE_DEVICES
+}
+
+write_fake_python() {
+    cat > "$BIN/python3" <<EOF
+#!/usr/bin/env bash
+printf 'args:%s vis:%s\n' "\$*" "\${TT_VISIBLE_DEVICES:-}" >> "$CALLS"
+exit 0
+EOF
+    chmod +x "$BIN/python3"
+}
+
+write_example() {
+    local path="$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path" <<'EOF'
+import ttl
+
+@ttl.operation
+def add(in0, in1, out):
+    pass
+EOF
+}
+
+@test "serial visibility override applies to each example subprocess" {
+    write_fake_python
+    write_example "$REPO/examples/eltwise_add.py"
+    write_example "$REPO/examples/tutorial/broadcast.py"
+
+    HW_SERIAL_TEST_VISIBLE_DEVICES=0,1 run bash "$SCRIPT" "$REPO"
+
+    assert_success
+    assert_output --partial "Restricting hardware examples to TT_VISIBLE_DEVICES=0,1"
+    run cat "$CALLS"
+    assert_line --partial "args:examples/eltwise_add.py vis:0,1"
+    assert_line --partial "args:examples/tutorial/broadcast.py vis:0,1"
+    [ "${#lines[@]}" -eq 2 ]
+}

--- a/.github/scripts/tests/test_run_hardware_pytests.bats
+++ b/.github/scripts/tests/test_run_hardware_pytests.bats
@@ -80,6 +80,21 @@ EOF
     [ "${#lines[@]}" -eq 2 ]
 }
 
+@test "multi-chip: serial test visibility override applies to multi_device phase" {
+    write_fake_python 0
+
+    HW_PYTEST_CHIPS=4 HW_SERIAL_TEST_VISIBLE_DEVICES=0,1 run "$SCRIPT" test/python build/test/pytest-report
+
+    assert_success
+    assert_output --partial "Restricting serial multi_device pytest phase to TT_VISIBLE_DEVICES=0,1"
+    run cat "$CALLS"
+    assert_line --partial "pytest test/python -m not multi_device"
+    assert_line --partial "vis:"
+    assert_line --partial "pytest test/python -m multi_device"
+    assert_line --partial "vis:0,1"
+    [ "${#lines[@]}" -eq 2 ]
+}
+
 @test "single chip: one serial run over the whole suite" {
     write_fake_python 0
 

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -77,6 +77,7 @@ jobs:
       RUNS_ON: ${{ inputs.runs-on }}
       PYTHONDONTWRITEBYTECODE: 1
       TTLANG_TEST_SEED: 42
+      HW_SERIAL_TEST_VISIBLE_DEVICES: ${{ inputs.runs-on == 'galaxy-bh' && '0,1' || '' }}
 
     steps:
       - name: Checkout tt-lang
@@ -117,6 +118,15 @@ jobs:
           python3 test/python/smoketest.py
 
       - name: Single test (just python)
+        if: inputs.runs-on != 'galaxy-bh'
+        run: |
+          source build/env/activate
+          python test/python/simple_add.py
+
+      - name: Single test (just python, Galaxy one chip)
+        if: inputs.runs-on == 'galaxy-bh'
+        env:
+          TT_VISIBLE_DEVICES: "0"
         run: |
           source build/env/activate
           python test/python/simple_add.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
     secrets: inherit
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
+      run_galaxy_tests: true
 
   build-docs:
     name: Build documentation

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -179,16 +179,14 @@ if _ttnn_check.returncode == 0:
 if getattr(config, "ttlang_has_device", False) or os.environ.get("TT_METAL_SIMULATOR"):
     config.available_features.add("tt-device")
 
-# Add multi-device feature when >= 4 Tenstorrent chips are physically present.
+# Add multi-device feature when at least two Tenstorrent chips are physically present.
 # Count /dev/tenstorrent device nodes (cheap, no cluster open) instead of probing
-# ttnn, which would open the device at config time for every lit run. Tests that
-# need a fabric mesh expose all chips via `env -u TT_VISIBLE_DEVICES`, so the
-# physical chip count is what they will see.
+# ttnn, which would open the device at config time for every lit run.
 try:
     _tt_chip_count = sum(
         1 for entry in os.listdir("/dev/tenstorrent") if entry.isdigit()
     )
 except OSError:
     _tt_chip_count = 0
-if _tt_chip_count >= 4:
+if _tt_chip_count >= 2:
     config.available_features.add("multi-device")

--- a/test/me2e/conftest.py
+++ b/test/me2e/conftest.py
@@ -47,7 +47,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "multi_device: needs all chips; excluded from per-chip parallel runs",
+        "multi_device: needs a fabric mesh; excluded from per-chip parallel runs",
     )
 
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -80,7 +80,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "multi_device: needs all chips (a fabric mesh); excluded from the "
+        "multi_device: needs a fabric mesh; excluded from the "
         "per-chip parallel run and executed serially",
     )
 

--- a/test/python/mesh_tensor_spmd.py
+++ b/test/python/mesh_tensor_spmd.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # REQUIRES: ttnn, tt-device, multi-device
-# RUN: env -u TT_VISIBLE_DEVICES %python %s > %t.output.txt 2>&1
+# RUN: env TT_VISIBLE_DEVICES=0,1 %python %s > %t.output.txt 2>&1
 # RUN: FileCheck %s < %t.output.txt
 
 """
 Test SPMD mesh tensor compilation and execution.
 
-Logical shape: (32 * num_devices) x 32 -- one 32x32 tile per device.
+Logical shape: (32 * num_devices) x 32 -- one 32x32 tile per visible device.
 Shard shape:    32x32 (1x1 tile) -- dim-0 sharded across all mesh devices.
 
 The kernel processes a single tile (1x1). With the full logical shape the
@@ -17,9 +17,9 @@ kernel would only touch the first tile and produce incorrect results for the
 rest. Correct output for all elements proves the tensor was properly sharded
 so each device sees its own 32x32 slice.
 
-Requires multiple devices for real mesh sharding. The `multi-device` lit
-feature restricts the test so lit reports it unsupported on single-card hosts
-(single-device execution is covered by other tests).
+Requires multiple devices for real mesh sharding. The lit RUN line exposes two
+devices because this test validates SPMD sharding semantics, not full-system
+fabric scale.
 """
 
 import torch

--- a/test/python/pipe/test_pipenet_spmd.py
+++ b/test/python/pipe/test_pipenet_spmd.py
@@ -18,7 +18,7 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 from ttlang_test_utils import assert_allclose, open_fabric_mesh
 
-# Opens a fabric mesh across all chips; run serially, not in the per-chip pool.
+# Opens a fabric mesh across visible chips; run serially, not in the per-chip pool.
 pytestmark = pytest.mark.multi_device
 
 TILE = 32

--- a/test/python/test_matmul_with_bias_spmd.py
+++ b/test/python/test_matmul_with_bias_spmd.py
@@ -18,7 +18,7 @@ import ttl
 
 from ttlang_test_utils import open_fabric_mesh
 
-# Opens a fabric mesh across all chips; run serially, not in the per-chip pool.
+# Opens a fabric mesh across visible chips; run serially, not in the per-chip pool.
 pytestmark = pytest.mark.multi_device
 
 TILE_SIZE = 32

--- a/test/tutorial/conftest.py
+++ b/test/tutorial/conftest.py
@@ -24,5 +24,5 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "multi_device: opens a device mesh; excluded from the per-chip parallel "
-        "run and executed serially with every chip visible",
+        "run and executed serially",
     )

--- a/test/tutorial/test_tutorials.py
+++ b/test/tutorial/test_tutorials.py
@@ -14,9 +14,9 @@ that worker's pinned chip during the per-chip parallel phase.
 
 Scheduling reuses .github/scripts/run-hardware-pytests.sh. Single-device
 tutorials run sharded across chips; tutorials that open a device mesh carry the
-multi_device marker and run serially with every chip visible. Classification
-comes from the same "# TTLANG_TUTORIAL_CI:" file tags that
-.github/scripts/run-tutorials.sh reads, keeping the two runners consistent.
+multi_device marker and run serially. Classification comes from the same
+"# TTLANG_TUTORIAL_CI:" file tags that .github/scripts/run-tutorials.sh reads,
+keeping the two runners consistent.
 """
 
 import os
@@ -48,10 +48,10 @@ PYTEST_TIMEOUT_BACKSTOP_SECONDS = (
     SUBPROCESS_TIMEOUT_SECONDS + SIGTERM_GRACE_SECONDS + 60
 )
 
-# step_7's all_reduce over a Galaxy-scale mesh hangs on a known upstream fabric
+# step_7's all_reduce over a full Galaxy mesh hangs on a known upstream fabric
 # bug (tt-lang#585, tt-metal#43749 / #41794); the killed process leaves the
 # board's ethernet dispatch firmware wedged. It sorts last within its directory,
-# so nothing runs after it in the serial phase, and it is xfailed on Galaxy.
+# so nothing runs after it in the serial phase.
 ALL_REDUCE_TUTORIAL = "step_7_multidevice_shard_k_all_reduce.py"
 
 
@@ -76,6 +76,28 @@ def _host_chip_count() -> int:
 def _on_galaxy() -> bool:
     """True on a Galaxy runner, detected from the CI-provided RUNS_ON label."""
     return "galaxy" in os.environ.get("RUNS_ON", "").lower()
+
+
+def _visible_chip_count() -> int:
+    """Number of chips visible to the tutorial subprocess."""
+    visible_devices = os.environ.get("TT_VISIBLE_DEVICES")
+    if visible_devices is None:
+        return _host_chip_count()
+    if not visible_devices.strip():
+        return 0
+    return sum(
+        1 for visible_device in visible_devices.split(",") if visible_device.strip()
+    )
+
+
+def _uses_full_galaxy_mesh() -> bool:
+    """True when the full Galaxy host is visible to a mesh tutorial."""
+    host_chip_count = _host_chip_count()
+    return (
+        _on_galaxy()
+        and host_chip_count >= 32
+        and _visible_chip_count() >= host_chip_count
+    )
 
 
 def _ci_tags(script: Path) -> set:
@@ -111,13 +133,13 @@ def _tutorial_param(script: Path) -> "pytest.ParameterSet":
         marks.append(
             pytest.mark.skipif(_host_chip_count() < 2, reason="requires >= 2 devices")
         )
-    if script.name == ALL_REDUCE_TUTORIAL and _on_galaxy():
+    if script.name == ALL_REDUCE_TUTORIAL and _uses_full_galaxy_mesh():
         marks.append(
             pytest.mark.xfail(
                 reason=(
-                    "Galaxy all_reduce/reduce_scatter fabric hang: tt-lang#585, "
-                    "tt-metal#43749 / #41794; the killed run wedges ethernet "
-                    "dispatch firmware"
+                    "Full-Galaxy all_reduce/reduce_scatter fabric hang: "
+                    "tt-lang#585, tt-metal#43749 / #41794; the killed run "
+                    "wedges ethernet dispatch firmware"
                 ),
                 strict=True,
             )


### PR DESCRIPTION
Re-enable Galaxy hardware tests in normal CI. Galaxy is online, but full 32-chip TTNN discovery still fails for tests that only need one or two chips, so this keeps single-device smoke on `TT_VISIBLE_DEVICES=0` and the shared serial multi-device phases on `0,1`.

The examples runner uses the same `HW_SERIAL_TEST_VISIBLE_DEVICES` setting because it invokes standalone scripts that call `ttnn.open_device(0)`; without the restriction they hit the same full-Galaxy `unordered_map::at` failure. The full-Galaxy tutorial xfail still applies when all Galaxy chips are visible.

Validated by CI run `30500635280`, including Galaxy hardware on `g08blx04` and N150 hardware.