### PR TITLE
[ttl][fix][refactor] Resolve tile strategies and shared compute-kernel configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,17 @@
 - **Python lit tests**: `llvm-lit test/python/` (hardware execution tests)
 - **Simulation tests**: `pytest test/sim/` (software simulation of runtime behavior); add `--run-slow` to include slow tests (hardware CI always passes this flag; GitHub-hosted CI does not)
 
+## Docker
+
+- Run Docker commands directly. Never use `sudo docker`; the user has Docker
+  daemon access through group membership.
+
 ## Code Style Guidelines
 - **C++ Style**: LLVM style (see .clang-format, .clang-tidy)
 - **Naming**: UpperCamelCase for types, lowerCamelCase for variables/functions
 - **Includes**: Absolute paths from tt-lang root, sorted: main header → local →
   LLVM → system
-- **Comments**: Full sentences, explain why not what. Code TODOs use an issue
-  number without an issue URL.
+- **Comments**: See [Comments](#comments) below.
 - **Python**: PEP 8 with black formatter (v23.x), Python 3.10+ only
 - **Functions**: Bottom-up order, helpers before callers, static/anonymous
   namespace for .cpp
@@ -35,6 +39,39 @@
 - **Unicode**: Avoid Unicode characters in code and documentation. Use ASCII
   equivalents instead (e.g., `->` instead of `→`). This ensures compatibility
   across different editors, terminals, and build environments.
+
+### Comments
+
+A comment exists for one reason: to let the next reader understand the code.
+Comments occupy space and must be maintained, so write one only when the code
+itself cannot carry the information.
+
+- **Follow LLVM commenting conventions** in substance, location, and style:
+  https://llvm.org/docs/CodingStandards.html#commenting. Use `///` doxygen
+  comments on declarations in headers, `//` for implementation notes in `.cpp`
+  files, and write full sentences with capitalization and a period. Do not
+  repeat a header's doc comment above the definition.
+- **Default to writing no comment.** The function name, signature, and body
+  usually suffice. A comment is justified only when it states one of:
+  1. Contract or role -- what callers can rely on, not the steps taken.
+  2. Why this and not the obvious alternative -- the constraint, prior bug, or
+     framework quirk that motivated the choice.
+  3. An invariant the type system cannot express.
+- **Do not narrate the code.** Reject comments that restate the function name,
+  paraphrase the body in English, explain the *absence* of code, or hedge
+  informally ("we just", "basically", "the trick is"). One line beats three.
+- **Do not repeat a comment.** State a fact in exactly one place -- the
+  declaration, the TableGen `description`, or a design document -- and nowhere
+  else. Detailed op and pass documentation lives in the `.td`, not the `.cpp`;
+  `.cpp` comments explain non-obvious implementation only.
+- **Rationale belongs in the PR, not the source.** Design decisions,
+  alternatives considered, performance measurements, and why a block of code
+  sits in one location rather than another go in the PR description. When a
+  decision must be recorded in the repository, write it up under `docs/`.
+- **Prose rules match [Documentation Style](#documentation-style)**: no
+  metaphorical verbs (write "execute", not "fire"; "delete", not "blow away"),
+  no invented jargon, ASCII only.
+- **TODOs** reference an issue number without an issue URL.
 
 ## MLIR implementation
 - Follow the conventions in llvm-project for directory organization and naming

--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -11,14 +11,14 @@ impose different requirements on those shared settings.
 `ttl-set-compute-kernel-config` resolves these decisions before DST assignment:
 
 ```text
-TTCore target attributes ---> KernelTargetEnvironment --+
+TTCore target attributes ---> KernelTargetEnvironment ---+
 pass options and attrs -----> KernelConfigPolicy --------+--> resolver
 TTL tile operations --------> KernelRequirements --------+       |
-                                                               v
-                                                       KernelConfigPlan
-                                                               |
-                                                               v
-                                               explicit IR attributes
+                                                                 v
+                                                         KernelConfigPlan
+                                                                 |
+                                                                 v
+                                                   explicit IR attributes
 ```
 
 The resolver separates target capabilities, compilation policy, and kernel

--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -58,10 +58,15 @@ existing TTCore system and device descriptions. If both sources are present,
 their architectures must agree. A device selecting chips with different
 architectures is invalid.
 
+When neither source is present, target-specific restrictions are not applied.
+Device compilation attaches an architecture before this pass; the unspecified
+environment supports target-neutral compiler testing.
+
 Capability queries contain architecture and backend restrictions. They consume
 only target-independent execution categories, not operations. For example,
 Blackhole row reduction and Wormhole reduction restrict full-fp32 accumulation,
-and Wormhole bf16 row broadcast restricts f32 DST mode.
+and Wormhole and Blackhole broadcasts with non-f32 inputs restrict f32 DST
+mode.
 
 ### Policy
 

--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -59,8 +59,8 @@ their architectures must agree. A device selecting chips with different
 architectures is invalid.
 
 When neither source is present, target-specific restrictions are not applied.
-Device compilation attaches an architecture before this pass; the unspecified
-environment supports target-neutral compiler testing.
+This environment is limited to target-neutral compiler testing. Pipelines that
+emit device kernels must attach an architecture before this pass.
 
 Capability queries contain architecture and backend restrictions. They consume
 only target-independent execution categories, not operations. For example,
@@ -140,9 +140,9 @@ Resolution returns a `KernelConfigPlan` containing:
 - one DST synchronization mode;
 - the sorted set of DFB indices using unpack-to-DST-f32.
 
-Plan application validates all recorded operations before mutation. It then
-writes operation strategy attributes and function configuration attributes
-without additional failure points. The input-only
+Only the resolver can construct a plan. Plan application writes operation
+strategy attributes and function configuration attributes without re-deriving
+policy or introducing additional failure points. The input-only
 `ttl.enable_fpu_binary_ops` policy attribute is removed. Application derives no
 additional policy.
 

--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -91,6 +91,11 @@ kernel-wide DST and synchronization settings use three-state selections:
 Full-fp32 reduce and matmul settings are preferences. The FPU binary setting
 controls whether the FPU strategy is available.
 
+The operation-level `math_fidelity` selection is forwarded to every generated
+TTNN compute descriptor. It does not participate in joint resolution because
+it does not change the current tile-strategy, DST, or DFB compatibility
+relations.
+
 An explicit `ttl.unpack_to_dest_fp32` attribute specifies the exact set of
 dataflow buffer indices using `ComputeConfigDescriptor::unpack_to_dest_mode`.
 It is validated by intersecting the selected setting with every consumer's
@@ -217,7 +222,8 @@ extend the typed target queries with an allowed configuration relation. A new
 architecture adds its own query implementation and runtime translation; it
 does not inherit Gen1 behavior by default. Runtime names such as
 `fp32_dest_acc_en` and `ttl.unpack_to_dest_fp32` remain at the IR/runtime
-translation boundary.
+translation boundary. Operation-only settings without compiler compatibility
+relations, such as `math_fidelity`, remain runtime descriptor inputs.
 
 ### Adding an Architecture or Configuration API
 

--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -1,0 +1,182 @@
+# Compute Kernel Configuration
+
+## Overview
+
+Compute kernels share hardware configuration across all tile operations in a
+`func.func`. DST element format and synchronization are kernel-wide. Each
+dataflow buffer also has one unpack mode for the complete kernel. Tile
+operations may support more than one execution strategy, and each strategy can
+impose different requirements on those shared settings.
+
+`ttl-set-compute-kernel-config` resolves these decisions before DST assignment:
+
+```text
+TTCore target attributes ---> KernelTargetEnvironment --+
+pass options and attrs -----> KernelConfigPolicy --------+--> resolver
+TTL tile operations --------> KernelRequirements --------+       |
+                                                               v
+                                                       KernelConfigPlan
+                                                               |
+                                                               v
+                                               explicit IR attributes
+```
+
+The resolver separates target capabilities, compilation policy, and kernel
+requirements. No component infers facts owned by another component.
+
+## Tile Execution Semantics
+
+Tile operations implement `TileExecutionOpInterface`. The interface reports:
+
+- the hardware primitive;
+- legal execution strategies;
+- the route for each operand: dataflow buffer, DST, or no tile-data route;
+- whether the result is resident in DST;
+- the full-fp32 accumulation category, when configurable;
+- whether repeated operations accumulate into an existing DST slot.
+
+These facts are independent of the target. Target support is queried through
+`KernelTargetEnvironment`.
+
+Add, subtract, and multiply can use FPU or SFPU execution. FPU requires both
+operands to address the same tile coordinates and resolve to dataflow buffers.
+The selected strategy is written as `ttl.tile_execution_strategy` before DST
+assignment. Later passes consume that attribute and do not recompute the
+decision after copy insertion changes SSA operands.
+
+An operation with no legal strategy alternatives provides fixed execution
+semantics. A new tile operation participates by implementing the interface; the
+kernel analysis does not maintain an operation-name list.
+
+## Inputs
+
+### Target Environment
+
+`KernelTargetEnvironment` reads the typed `ttl.target_arch` attribute and the
+existing TTCore system and device descriptions. If both sources are present,
+their architectures must agree. A device selecting chips with different
+architectures is invalid.
+
+Capability queries contain architecture and backend restrictions. They consume
+only target-independent execution categories, not operations. For example,
+Blackhole row reduction and Wormhole reduction restrict full-fp32 accumulation,
+and bf16 broadcast and transpose restrict f32 DST mode.
+
+### Policy
+
+`KernelConfigPolicy` normalizes pass options and function attributes. The
+kernel-wide DST and synchronization settings use three-state selections:
+`auto`, `enabled`, and `disabled`. Function attributes are hard constraints.
+Full-fp32 reduce and matmul settings are preferences. The FPU binary setting
+controls whether the FPU strategy is available.
+
+An explicit `ttl.unpack_to_dest_fp32` attribute specifies the exact set of
+dataflow buffer indices using that mode. It is validated against every
+consumer.
+
+### Requirements
+
+The pass walks all nested regions without modifying IR. Fixed tile operations
+contribute their requirements immediately. Operations with strategy
+alternatives retain every legal option and its complete DFB and DST
+requirements for joint resolution. The resolver does not re-query operations.
+
+Each requirement records its operation and operand number for diagnostics. The
+dataflow buffer resolver handles both `ttl.compute` block arguments and direct
+tile operands derived from `tensor.extract` and `ttl.attach_cb`. A required
+dataflow-buffer operand without a finalized DFB index is invalid.
+
+## Resolution
+
+The resolver maintains finite configuration domains:
+
+```text
+DST mode:             {default, fp32}
+DFB N unpack mode:    {default, unpack-to-DST-fp32}
+```
+
+Hard policy constraints restrict the initial domains. Fixed operation
+requirements are then intersected with the target-supported values. Each
+strategy option is represented by the same requirement types as a fixed
+operation.
+
+Strategy selection and configuration selection are solved together. The
+search chooses the unresolved operation with the fewest compatible options,
+applies one option to a copy of the current domains, and continues until every
+operation has a strategy. The resolver tries FPU before SFPU after hard
+constraints are satisfied, preserving the default FPU preference without
+depending on interface result order.
+
+Joint resolution is required for correctness. A fixed SFPU consumer can require
+unpack-to-DST-f32 for a DFB that is also read by an eligible binary operation.
+Selecting FPU for the binary operation would require default unpack mode and
+create a conflict. Selecting SFPU for the binary operation is valid. Resolving
+the strategy before the shared DFB constraint would reject this valid kernel.
+
+After all hard constraints are satisfied, reduce and matmul preferences select
+f32 DST mode when it remains supported. Preferences never make a valid domain
+empty.
+
+DST synchronization currently has no operation-specific compatibility
+constraints. `enabled` selects full synchronization; `auto` and `disabled`
+select double-buffered synchronization.
+
+An empty domain produces a diagnostic identifying both incompatible
+requirements. The resolver retains typed conflict evidence rather than
+reconstructing a cause from mutated IR.
+
+## Application
+
+Resolution returns a `KernelConfigPlan` containing:
+
+- one selected strategy for each operation with alternatives;
+- one DST mode;
+- one DST synchronization mode;
+- the sorted set of DFB indices using unpack-to-DST-f32.
+
+Plan application validates all recorded operations before mutation. It then
+writes operation strategy attributes and function configuration attributes
+without additional failure points. The input-only
+`ttl.enable_fpu_binary_ops` policy attribute is removed. Application derives no
+additional policy.
+
+## Correctness Invariants
+
+- Target capabilities do not depend on kernel operations.
+- Kernel requirements contain no architecture checks.
+- Policy contains no inferred operation facts.
+- Every DFB-consuming operand has an explicit route.
+- One concrete unpack mode applies to each DFB for the complete kernel.
+- One concrete DST mode and synchronization mode apply to the complete kernel.
+- Strategy selection is stable across later IR rewrites.
+- Failure before plan application leaves IR unchanged.
+- Unknown execution semantics and unresolved DFB identities are errors.
+
+## Pipeline Placement
+
+The relevant ordering is:
+
+```text
+ttl-finalize-dfb-indices
+ttl-set-compute-kernel-config
+ttl-assign-dst
+...
+convert-ttl-to-ttkernel
+```
+
+DFB finalization must run first because the plan writes physical DFB indices to
+`ttl.unpack_to_dest_fp32`. DST assignment must run after strategy selection
+because operand routes determine copy insertion and register allocation.
+TTKernel conversion consumes the same selected strategies.
+
+Passes between strategy selection and conversion must preserve the selected
+operand routes. A pass that cannot preserve them must reject the operation
+before mutation.
+
+## Extension
+
+New tile operations add execution semantics through
+`TileExecutionOpInterface`. Operations that introduce a new target restriction
+also add a typed `KernelTargetEnvironment` query. This keeps operation
+requirements independent from hardware capabilities and avoids adding another
+whole-function classification scan.

--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -3,10 +3,10 @@
 ## Overview
 
 Compute kernels share hardware configuration across all tile operations in a
-`func.func`. DST element format and synchronization are kernel-wide. Each
-dataflow buffer also has one unpack mode for the complete kernel. Tile
-operations may support more than one execution strategy, and each strategy can
-impose different requirements on those shared settings.
+`func.func`. Destination element width and synchronization are kernel-wide.
+Each dataflow buffer also has one target-defined unpack setting for the complete
+kernel. Tile operations may support more than one execution strategy, and each
+strategy can impose different requirements on those shared settings.
 
 `ttl-set-compute-kernel-config` resolves these decisions before DST assignment:
 
@@ -58,15 +58,30 @@ existing TTCore system and device descriptions. If both sources are present,
 their architectures must agree. A device selecting chips with different
 architectures is invalid.
 
-When neither source is present, target-specific restrictions are not applied.
-This environment is limited to target-neutral compiler testing. Pipelines that
+When neither source is present, the compiler uses the current shared Wormhole
+B0/Blackhole configuration relations without architecture-specific
+restrictions. This environment is limited to compiler testing. Pipelines that
 emit device kernels must attach an architecture before this pass.
 
 Capability queries contain architecture and backend restrictions. They consume
-only target-independent execution categories, not operations. For example,
-Blackhole row reduction and Wormhole reduction restrict full-fp32 accumulation,
-and Wormhole and Blackhole broadcasts with non-f32 inputs restrict f32 DST
-mode.
+only target-independent execution categories, element types, and operand
+routes, not operation classes. The target returns allowed combinations of
+destination element width and DFB unpack mode. It does not return a preferred
+singleton. Target lookup constructs a target-specific implementation of the
+query interface; architecture dispatch does not occur inside individual
+queries. Adding an architecture therefore requires an explicit implementation
+rather than inheriting another target's behavior.
+
+The current TT-Lang runtime launches Wormhole B0 and Blackhole through
+`ttnn.ComputeConfigDescriptor`. Both expose 16-bit and 32-bit destination
+elements. Their current broadcast LLKs restrict non-32-bit broadcast inputs to
+16-bit destination elements. Blackhole row reduction and Wormhole reduction
+also restrict full-fp32 accumulation.
+
+Quasar requires the Gen2 configuration descriptor, global unpack routing, and
+Quasar kernel launch mechanism. The current TT-Lang runtime does not implement
+those interfaces, so this pass rejects Quasar. Recognizing a TTCore architecture
+enum is not sufficient to compile or launch a kernel for that target.
 
 ### Policy
 
@@ -77,8 +92,10 @@ Full-fp32 reduce and matmul settings are preferences. The FPU binary setting
 controls whether the FPU strategy is available.
 
 An explicit `ttl.unpack_to_dest_fp32` attribute specifies the exact set of
-dataflow buffer indices using that mode. It is validated against every
-consumer.
+dataflow buffer indices using `ComputeConfigDescriptor::unpack_to_dest_mode`.
+It is validated by intersecting the selected setting with every consumer's
+allowed target configurations. The current runtime accepts entries for
+non-f32 DFBs as inert, so the analysis does not reject those entries.
 
 ### Requirements
 
@@ -89,22 +106,33 @@ requirements for joint resolution. The resolver does not re-query operations.
 
 Each requirement records its operation and operand number for diagnostics. The
 dataflow buffer resolver handles both `ttl.compute` block arguments and direct
-tile operands derived from `tensor.extract` and `ttl.attach_cb`. A required
-dataflow-buffer operand without a finalized DFB index is invalid.
+tile operands derived from `tensor.extract` and `ttl.attach_cb`. Tile operands
+and tensors of tiles use the same element-type query, including the tensor form
+produced for matmul after loop lowering. A required dataflow-buffer operand
+without a finalized DFB index is invalid.
+
+Destination requirements use the result or resident operand type, not only DFB
+input storage width. The width query uses the TTCore tile element type, so a
+supported operation with 32-bit integer destination elements requires 32-bit
+destination registers without an integer-type exception in this analysis.
 
 ## Resolution
 
-The resolver maintains finite configuration domains:
+The resolver maintains a finite set of complete target configurations:
 
 ```text
-DST mode:             {default, fp32}
-DFB N unpack mode:    {default, unpack-to-DST-fp32}
+destination element width:     {Bits16, Bits32}
+DFB N unpack mode:              {Default, UnpackToDestination}
 ```
 
-Hard policy constraints restrict the initial domains. Fixed operation
-requirements are then intersected with the target-supported values. Each
-strategy option is represented by the same requirement types as a fixed
-operation.
+Not every Cartesian-product combination is legal. Each target query returns
+the allowed width-and-mode relation for a primitive, element type, and operand
+route. `TileOperandRoute` separately records the primitive's physical operand
+route; the unpack mode does not describe that route for formats where the
+setting is inert. Hard policy constraints restrict the initial candidates.
+Fixed operation requirements are then intersected with the target-supported
+relations. Each strategy option is represented by the same requirement types
+as a fixed operation.
 
 Strategy selection and configuration selection are solved together. The
 search chooses the unresolved operation with the fewest compatible options,
@@ -120,8 +148,8 @@ create a conflict. Selecting SFPU for the binary operation is valid. Resolving
 the strategy before the shared DFB constraint would reject this valid kernel.
 
 After all hard constraints are satisfied, reduce and matmul preferences select
-f32 DST mode when it remains supported. Preferences never make a valid domain
-empty.
+32-bit destination elements when they remain supported. Preferences never make
+a valid domain empty.
 
 DST synchronization currently has no operation-specific compatibility
 constraints. `enabled` selects full synchronization; `auto` and `disabled`
@@ -136,7 +164,7 @@ reconstructing a cause from mutated IR.
 Resolution returns a `KernelConfigPlan` containing:
 
 - one selected strategy for each operation with alternatives;
-- one DST mode;
+- one destination element width;
 - one DST synchronization mode;
 - the sorted set of DFB indices using unpack-to-DST-f32.
 
@@ -148,12 +176,14 @@ additional policy.
 
 ## Correctness Invariants
 
-- Target capabilities do not depend on kernel operations.
+- Target capabilities do not depend on kernel operation classes.
 - Kernel requirements contain no architecture checks.
 - Policy contains no inferred operation facts.
 - Every DFB-consuming operand has an explicit route.
-- One concrete unpack mode applies to each DFB for the complete kernel.
-- One concrete DST mode and synchronization mode apply to the complete kernel.
+- One target-supported unpack setting applies to each DFB for the complete
+  kernel.
+- One concrete destination width and synchronization mode apply to the complete
+  kernel.
 - Strategy selection is stable across later IR rewrites.
 - Failure before plan application leaves IR unchanged.
 - Unknown execution semantics and unresolved DFB identities are errors.
@@ -183,6 +213,51 @@ before mutation.
 
 New tile operations add execution semantics through
 `TileExecutionOpInterface`. Operations that introduce a new target restriction
-also add a typed `KernelTargetEnvironment` query. This keeps operation
-requirements independent from hardware capabilities and avoids adding another
-whole-function classification scan.
+extend the typed target queries with an allowed configuration relation. A new
+architecture adds its own query implementation and runtime translation; it
+does not inherit Gen1 behavior by default. Runtime names such as
+`fp32_dest_acc_en` and `ttl.unpack_to_dest_fp32` remain at the IR/runtime
+translation boundary.
+
+### Adding an Architecture or Configuration API
+
+Architecture support requires all of the following changes:
+
+1. Add a `KernelTargetEnvironment` implementation that defines every
+   destination-width, per-DFB routing, and full-precision accumulation query
+   for the architecture and configuration API used by the compiler pipeline.
+   Reuse a base class only when the lower-level configuration and LLK contracts
+   are identical for every inherited query.
+2. Register that implementation in `KernelTargetEnvironment::get`. This is the
+   only architecture switch in configuration analysis. An architecture without
+   an implementation must produce a diagnostic during target construction.
+3. Add the corresponding compiler-to-runtime configuration translation and
+   kernel launch mechanism. Target recognition alone is not runtime support.
+4. Map runtime device discovery to the typed TTCore architecture attribute.
+   Unknown runtime architectures must fail instead of selecting another
+   target's implementation.
+5. Add compiler tests for every target-specific query difference, invalid
+   configuration diagnostics, and architecture/device disagreement. Add device
+   tests that verify the emitted configuration through the target's actual
+   runtime descriptor and launch mechanism.
+
+The implementation must be derived from the pinned tt-metal contract for that
+architecture. New fields remain target-neutral inside requirements and the
+plan when they represent shared hardware concepts. Generation-specific runtime
+spellings remain in the translation layer.
+
+Changing the configuration or launch API for an existing architecture also
+requires reviewing every target query. Architecture identity alone is not a
+compatibility proof. For example, the pinned experimental Metal 2.0
+`ComputeGen1Config` validates some inert `unpack_to_dest_mode` entries more
+strictly than the `ComputeConfigDescriptor` used by the current TT-Lang
+runtime. If a Wormhole B0 or Blackhole pipeline changes to `ComputeGen1Config`,
+target construction must select a `KernelTargetEnvironment` for that API. It
+must not select the existing `ComputeConfigDescriptor` environment solely from
+the unchanged architecture enum. Shared query implementations require a
+query-by-query compatibility review of validation and lowering semantics.
+
+Configuration analysis is independent of physical tile height and width. The
+same requirements are collected for every tile dimension supported by a
+primitive. This does not expand primitive support: the lowering and LLK must
+still support the selected physical tile dimensions.

--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -31,6 +31,7 @@ Tile operations implement `TileExecutionOpInterface`. The interface reports:
 - the hardware primitive;
 - legal execution strategies;
 - the route for each operand: dataflow buffer, DST, or no tile-data route;
+- which DST operands the operation lowering initializes itself;
 - whether the result is resident in DST;
 - the full-fp32 accumulation category, when configurable;
 - whether repeated operations accumulate into an existing DST slot.
@@ -60,7 +61,7 @@ architectures is invalid.
 Capability queries contain architecture and backend restrictions. They consume
 only target-independent execution categories, not operations. For example,
 Blackhole row reduction and Wormhole reduction restrict full-fp32 accumulation,
-and bf16 broadcast and transpose restrict f32 DST mode.
+and Wormhole bf16 row broadcast restricts f32 DST mode.
 
 ### Policy
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -82,7 +82,7 @@ ttl-verify-pipenet-guards      (Module)   Verify PipeNet launch-node domains
 ttl-verify-pipenet-schedule    (Module)   Verify PipeNet event ordering
 ttl-coalesce-dfb-acquires      (FuncOp)   Coalesce adjacent DFB acquisitions
 ttl-finalize-dfb-indices       (Module)   Finalize identities and allocations
-ttl-set-compute-kernel-config  (FuncOp)   Set per-kernel configuration
+ttl-set-compute-kernel-config  (FuncOp)   Resolve per-kernel configuration
   ... DST assignment, loop lowering, scheduling ...
 ttl-annotate-cb-associations   (FuncOp)   Copy CB indices to tile ops
 ttl-verify-dfb-spsc            (Module)   Reject DFBs shared across threads

--- a/docs/development/DST_Allocation.md
+++ b/docs/development/DST_Allocation.md
@@ -223,17 +223,13 @@ tt-metal patterns documented for future implementation.
 | Transpose (CB) | | x | | | — |
 | Transpose (DST) | x | | x | | — |
 
-Notes on FPU binary: `add`, `sub`, `mul` carry
-`TTLStrategyDependentBinaryOpTrait` instead of `DSTInputsTrait`. Whether
-they lower to the FPU or SFPU form is derived on demand from operand
-provenance by `isFPUEligibleBinaryOp` (TTLOpsUtils.h): both operands
-must trace to the same indexing source — input block args of one
-`ttl.compute` with matching indexing maps, or (post-lowering) `tensor.extract`
-with identical indices — and the func-level attribute
-`ttl.enable_fpu_binary_ops` must not be disabled. Eligible ops bypass
-`copy_tile` and read directly from CBs. `isCBInputOp` delegates to this
-helper for strategy-dependent ops, so the allocator's existing trait
-queries continue to work without modification.
+Notes on FPU binary: `add`, `sub`, and `mul` carry
+`TTLStrategyDependentBinaryOpTrait`. `TTLSetComputeKernelConfig` selects one
+strategy from the operation's `TileExecutionOpInterface` before DST assignment.
+The FPU strategy requires matching tile coordinates and consumes both operands
+from DFBs. The SFPU strategy consumes both operands from DST. The selected
+`ttl.tile_execution_strategy` attribute remains unchanged through allocation
+and lowering.
 
 Notes on in-place binary (max, min): These binary ops carry both
 `DSTInputsTrait` (from the `TTL_TileBinaryOp` base class) and
@@ -242,10 +238,9 @@ unary ops for interval merging: input and output share the same DST
 slot. The second operand occupies a separate DST slot (it is not
 overwritten).
 
-The allocator queries these traits compositionally:
-- `hasTrait<TTLCBInputTileOpTrait>()` -> operand stays in CB (no DST
-  slot needed for that operand)
-- `hasTrait<TTLDSTInputsTrait>()` -> operand needs a DST slot
+The allocator queries `TileExecutionOpInterface` operand routes to determine
+whether each operand remains in its DFB or requires a DST slot. It uses the
+following traits for behavior independent of execution strategy:
 - `hasTrait<TTLInPlaceOpTrait>()` -> merge input/output intervals
   (Phase 2)
 - `hasTrait<TTLAccumulatingOpTrait>()` -> DST slot must remain live
@@ -298,26 +293,20 @@ References:
 - Christian Wimmer and Michael Franz. 2010. Linear scan register allocation on SSA form. In Proceedings of CGO '10. https://doi.org/10.1145/1772954.1772979
 - P. S. Rawat et al. 2019. Associative instruction reordering to alleviate register pressure. In Proceedings of SC '18. https://doi.org/10.1109/SC.2018.00049
 
-### FPU/SFPU eligibility (derived, no separate phase)
+### FPU/SFPU strategy selection
 
-FPU eligibility for `add`/`sub`/`mul` is derived on demand by
-`isFPUEligibleBinaryOp` (TTLOpsUtils.h). An op qualifies when both
-operands are input block arguments of the same `ttl.compute` with
-identical indexing maps (or, post-`ttl-lower-to-loops`,
-`tensor.extract` ops with identical indices). The check is gated by
-the func-level attribute `ttl.enable_fpu_binary_ops`, which
-`TTLSetComputeKernelConfig` sets from the `enable-fpu-binary-ops`
-pipeline option (default: true); when disabled, every strategy-dependent
-binary op uses the SFPU path.
+`TTLSetComputeKernelConfig` selects FPU or SFPU before allocation. Structural
+legality requires both operands to address the same tile coordinates. Kernel
+policy may disable FPU. The configuration resolver also considers shared DFB
+unpack requirements, so an otherwise eligible binary operation selects SFPU
+when FPU would conflict with another consumer of the same DFB.
 
-Eligible ops bypass `copy_tile` during lowering and read operands
-directly from CBs via the SrcA/SrcB unpackers, reducing per-iteration
-DST pressure from 3 slots (2 copies + 1 output) to 1 slot (output
-only). The allocator queries `isCBInputOp` in Phase 1 and Phase 2; that
-helper delegates to `isFPUEligibleBinaryOp` for strategy-dependent ops,
-so DST slot counting reflects the eventual lowering without a separate
-marker pass. The same predicate feeds the `unroll_factor` computation
-at the end of allocation.
+FPU operations bypass `copy_tile` and read operands through SrcA/SrcB,
+reducing per-iteration DST pressure from three slots to one. SFPU operations
+require both inputs in DST. `TTLAssignDST` reads the selected operand routes
+through `TileExecutionOpInterface` for copy insertion, interval construction,
+and `unroll_factor` computation. It does not re-evaluate strategy after
+changing the operands.
 
 ### Future: Operation Scheduling for Register Pressure
 
@@ -586,11 +575,11 @@ Build live intervals for each tile value. For in-place operations
 (those with `TTLInPlaceOpTrait`), merge the input and output intervals
 since they must share the same DST register (hardware constraint).
 
-CB-only values: Block arguments consumed exclusively by CB-reading
-operations (`isCBInputOp` — FPU binary, copy_tile, broadcast) never
-enter DST and receive no interval. The implementation achieves this by
-skipping the operand loop for `isCBInputOp` operations: their operands
-are never recorded in the interval map.
+DFB-only values: Block arguments consumed exclusively through dataflow-buffer
+operand routes never enter DST and receive no interval. Operand routes come
+from the execution strategy selected before allocation. An operation may have
+both DFB and DST operands, so interval construction checks each operand rather
+than classifying the complete operation.
 
 ```
 intervals = {}
@@ -601,24 +590,21 @@ for i, op in enumerate(operations):
   op.index = i
 
 # Process operations in forward order to build intervals.
-# Operands of CB-input ops (isCBInputOp) are SKIPPED — they stay in
-# CBs and never enter DST. This implicitly identifies CB-only block
-# arguments: if a block arg is only consumed by CB-input ops, it
-# never appears in the interval map.
+# DFB-routed operands are skipped because they never enter DST.
 for each operation op:
-  if not isCBInputOp(op):
-    # Extend input intervals to this use
-    for each input_val in op.inputs:
-      if input_val not in intervals:
-        # Block argument: start at (op.index - 1) so the input
-        # expires just before the consuming op's output is defined.
-        # This enables the output to reuse the input's DST register.
-        intervals[input_val] = Interval(op.index - 1, op.index)
-      else:
-        intervals[input_val].end = max(intervals[input_val].end, op.index)
+  for each input operand in op.inputs:
+    if operand.route != DST:
+      continue
+    input_val = operand.value
+    if input_val not in intervals:
+      # Block argument: start at (op.index - 1) so the input
+      # expires just before the consuming op's output is defined.
+      # This enables the output to reuse the input's DST register.
+      intervals[input_val] = Interval(op.index - 1, op.index)
+    else:
+      intervals[input_val].end = max(intervals[input_val].end, op.index)
 
-  # Create interval for results (all ops, including CB-input ops,
-  # produce DST results that need intervals)
+  # Create intervals for results resident in DST.
   for each output_val in op.results:
     intervals[output_val] = Interval(op.index, op.index)
 

--- a/docs/development/DST_Allocation.md
+++ b/docs/development/DST_Allocation.md
@@ -223,7 +223,7 @@ tt-metal patterns documented for future implementation.
 | Transpose (CB) | | x | | | — |
 | Transpose (DST) | x | | x | | — |
 
-Notes on FPU binary: `add`, `sub`, and `mul` carry
+Notes on FPU binary: `add`, `sub`, and `mul` have
 `TTLStrategyDependentBinaryOpTrait`. `TTLSetComputeKernelConfig` selects one
 strategy from the operation's `TileExecutionOpInterface` before DST assignment.
 The FPU strategy requires matching tile coordinates and consumes both operands
@@ -231,7 +231,7 @@ from DFBs. The SFPU strategy consumes both operands from DST. The selected
 `ttl.tile_execution_strategy` attribute remains unchanged through allocation
 and lowering.
 
-Notes on in-place binary (max, min): These binary ops carry both
+Notes on in-place binary (max, min): These binary ops have both
 `DSTInputsTrait` (from the `TTL_TileBinaryOp` base class) and
 `TTLInPlaceOpTrait` (extra trait). The allocator treats them the same as
 unary ops for interval merging: input and output share the same DST

--- a/docs/development/DST_Utilization.md
+++ b/docs/development/DST_Utilization.md
@@ -705,6 +705,7 @@ pipeline option to gate the optimization passes.
 | `subblock-sync` | false | Refine DFB reserve/push to per-subblock granularity; when disabled, user-placed reserve/push is preserved |
 | `combine-pack-tiles` | true | Combine consecutive `pack_tile` ops into `pack_tile_block` |
 | `reduce-full-fp32` | true | Prefer full-fp32 reduce accumulation when supported |
+| `matmul-full-fp32` | true | Prefer full-fp32 matmul accumulation when supported |
 | `lower-to-emitc` | false | Lower TTKernel to EmitC (for C++ translation) |
 
 Python API equivalents (`CompilerOptions` in
@@ -718,6 +719,7 @@ Python API equivalents (`CompilerOptions` in
 | `subblock_sync` | `--ttl-subblock-sync` / `--no-ttl-subblock-sync` | `subblock-sync` |
 | `combine_pack_tiles` | `--ttl-combine-pack-tiles` / `--no-ttl-combine-pack-tiles` | `combine-pack-tiles` |
 | `reduce_full_fp32` | `--ttl-reduce-full-fp32` / `--no-ttl-reduce-full-fp32` | `reduce-full-fp32` |
+| `matmul_full_fp32` | `--ttl-matmul-full-fp32` / `--no-ttl-matmul-full-fp32` | `matmul-full-fp32` |
 
 Environment variable: `TTLANG_COMPILER_OPTIONS` (space-separated flags).
 

--- a/docs/development/DST_Utilization.md
+++ b/docs/development/DST_Utilization.md
@@ -107,20 +107,19 @@ $$N = \min\!\left(\left\lfloor \frac{C}{D} \right\rfloor,\; \texttt{totalTiles}\
 where $C$ is DST capacity, $D$ is `dstPerIteration`, and $N$ is the
 `unroll_factor` attached as `ttl.unroll_factor` on the ComputeOp.
 
-FPU-aware execution (component 8) reduces $D$ for FPU-eligible binary
-ops. An FPU binary uses 0 DST input slots (operands come from CBs), so
-`tile_add %a, %b` where both are block args costs 1 DST slot (output
-only) instead of 3 (2 copies + output). Eligibility is derived on demand
-by `isFPUEligibleBinaryOp` (TTLOpsUtils.h) from operand provenance and
-the func-level attribute `ttl.enable_fpu_binary_ops` (set by
-`TTLSetComputeKernelConfig` from the `enable-fpu-binary-ops` option,
-default true). When the flag is disabled, every binary op uses the SFPU
-lowering with `copy_tile`.
+FPU-aware execution (component 8) reduces $D$ for binary operations whose
+selected strategy is FPU. An FPU binary uses no DST input slots because its
+operands remain in DFBs, so `tile_add %a, %b` costs one DST slot instead of
+three. `TTLSetComputeKernelConfig` selects the strategy before allocation from
+structural legality, kernel policy, and shared configuration requirements.
+`TTLAssignDST` consumes the selected operand routes through
+`TileExecutionOpInterface`.
 
-FPU/accumulating DST register reuse prevention: When multiple
-FPU binary ops or `tile_matmul_block` ops appear in the same compute
-body, their output DST registers must be distinct within a single
-`tile_regs_acquire`/`tile_regs_release` region.
+DST accumulator reuse prevention: Operations whose result depends on residual
+contents in the destination slot require distinct output slots within one
+`tile_regs_acquire`/`tile_regs_release` region. FPU binary and
+`tile_matmul_block` operations report this requirement through
+`TileExecutionOpInterface`.
 The tt-metal API provides an
 [`acc_to_dest` parameter](https://github.com/tenstorrent/tt-metal/blob/0aa689f1b1b8/tt_metal/hw/inc/api/compute/eltwise_binary.h#L57)
 on FPU binary init functions (`add_tiles_init`, `sub_tiles_init`,
@@ -141,9 +140,8 @@ binary op's result included residual from the first). Across separate
 sync regions (`tile_regs_release` between ops), DST is cleared and no
 accumulation occurs (`examples/fpu_dst_reuse_test.py` passed).
 
-`TTLAssignDST` prevents this by extending result intervals for
-FPU-accumulating ops in Phase 2 so the linear scan allocator assigns
-distinct registers
+`TTLAssignDST` prevents this by extending the affected result intervals so the
+linear scan allocator assigns distinct registers
 ([source](https://github.com/tenstorrent/tt-lang/blob/main/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp#L387-L438)).
 The same extension applies to `TileMatmulBlockOp`, which also
 accumulates into DST. The interval end is set to
@@ -641,16 +639,12 @@ The full DST maximization pipeline is operational. The pipeline computes
 the correct subblock size (with FPU-aware DST pressure), partitions the
 iteration space via TilingInterface, emits unrolled subblock bodies with
 one sync region per subblock, groups operations by kind, and consolidates
-init ops. FPU binary detection (component 8) for
-`tile_add`/`tile_sub`/`tile_mul` with both block-arg operands is derived
-on demand by `isFPUEligibleBinaryOp`, reducing per-iteration DST
-pressure (0 input slots instead of 2). The allocator prevents DST register reuse between FPU
-binary ops via an interval extension (see component 1-2 details);
-hardware testing confirmed this is necessary — FPU ops accumulate
-within a single sync region despite the `acc_to_dest=false` default
-(#343). The allocator uses trait queries (`isInPlaceOp`,
-etc.) instead of type-specific checks, so new operations only need the
-correct trait annotations.
+init ops. The selected FPU strategy for
+`tile_add`/`tile_sub`/`tile_mul` reduces per-iteration DST pressure to no input
+slots instead of two. The allocator prevents reuse when execution semantics
+report that residual destination contents affect the result (see component 1-2
+details). In-place behavior that is independent of execution strategy remains
+encoded by operation traits.
 
 Not yet implemented (component 14):
 
@@ -706,10 +700,11 @@ pipeline option to gate the optimization passes.
 | Option | Default | Description |
 |--------|---------|-------------|
 | `maximize-dst` | true | Enable subblock partitioning and operation scheduling |
-| `enable-fpu-binary-ops` | true | Use FPU execution for binary add/sub/mul when both operands are CB-backed |
+| `enable-fpu-binary-ops` | true | Allow FPU strategy selection for binary add/sub/mul |
 | `use-block-matmul` | true | Lower matmul to block-level hardware calls (`matmul_block`) instead of per-tile loops |
 | `subblock-sync` | false | Refine DFB reserve/push to per-subblock granularity; when disabled, user-placed reserve/push is preserved |
 | `combine-pack-tiles` | true | Combine consecutive `pack_tile` ops into `pack_tile_block` |
+| `reduce-full-fp32` | true | Prefer full-fp32 reduce accumulation when supported |
 | `lower-to-emitc` | false | Lower TTKernel to EmitC (for C++ translation) |
 
 Python API equivalents (`CompilerOptions` in
@@ -722,6 +717,7 @@ Python API equivalents (`CompilerOptions` in
 | `use_block_matmul` | `--ttl-block-matmul` / `--no-ttl-block-matmul` | `use-block-matmul` |
 | `subblock_sync` | `--ttl-subblock-sync` / `--no-ttl-subblock-sync` | `subblock-sync` |
 | `combine_pack_tiles` | `--ttl-combine-pack-tiles` / `--no-ttl-combine-pack-tiles` | `combine-pack-tiles` |
+| `reduce_full_fp32` | `--ttl-reduce-full-fp32` / `--no-ttl-reduce-full-fp32` | `reduce-full-fp32` |
 
 Environment variable: `TTLANG_COMPILER_OPTIONS` (space-separated flags).
 
@@ -758,12 +754,11 @@ operands are needed by all compute lowering.
 
 With `--no-ttl-fpu-binary-ops`:
 
-`TTLSetComputeKernelConfig` writes `ttl.enable_fpu_binary_ops = false`
-on the func. `isFPUEligibleBinaryOp` then returns false for every
-strategy-dependent binary, so add/sub/mul take the SFPU path (copy_tile
-for both operands; `add_binary_tile`/`sub_binary_tile`/`mul_binary_tile`
-instead of `add_tiles`/`sub_tiles`/`mul_tiles`). The consolidation pass
-emits `init_sfpu` instead of `binary_op_init_common`.
+`TTLSetComputeKernelConfig` selects SFPU for tile add, subtract, and multiply.
+DST assignment inserts the required input copies, and TTKernel
+lowering emits `add_binary_tile`, `sub_binary_tile`, or `mul_binary_tile`
+instead of the FPU operations. Init consolidation emits `init_sfpu` instead of
+`binary_op_init_common`.
 
 With `--no-ttl-block-matmul`:
 

--- a/docs/sphinx/implementation.md
+++ b/docs/sphinx/implementation.md
@@ -7,6 +7,7 @@ This section collects design documents and pipeline traces that describe how TT-
 - [Static Execution Analysis](https://github.com/tenstorrent/tt-lang/blob/main/docs/development/StaticExecutionAnalysis.md) - exact operation cardinality in structured control flow
 - [Value Origin Analysis](https://github.com/tenstorrent/tt-lang/blob/main/docs/development/ValueOriginAnalysis.md) - conservative SSA value origins through control flow and tensor updates
 - [`ComputeOp` Creation and Fusion](https://github.com/tenstorrent/tt-lang/blob/main/docs/development/ComputeOpCreation.md) - immutable planning for `ttl.compute` creation, fusion, DFB publication, and intermediate materialization
+- [Compute Kernel Configuration](https://github.com/tenstorrent/tt-lang/blob/main/docs/development/ComputeKernelConfiguration.md) - joint tile-strategy and kernel-configuration resolution
 - [DST Register Allocation](https://github.com/tenstorrent/tt-lang/blob/main/docs/development/DST_Allocation.md) — how the `TTLAssignDST` pass assigns destination registers to tile operations
 - [DST Register Utilization](https://github.com/tenstorrent/tt-lang/blob/main/docs/development/DST_Utilization.md) — maximizing tile throughput per DST synchronization cycle
 

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -122,6 +122,7 @@ ttlang-opt input.mlir -p 'ttl-to-ttkernel-pipeline{maximize-dst=true lower-to-em
 | `subblock-sync` | bool | `false` | Refine DFB reserve/push to per-subblock granularity. |
 | `combine-pack-tiles` | bool | `true` | Combine consecutive `pack_tile` ops into `pack_tile_block`. |
 | `reduce-full-fp32` | bool | `true` | Prefer full-fp32 reduce accumulation when supported. |
+| `matmul-full-fp32` | bool | `true` | Prefer full-fp32 matmul accumulation when supported. |
 | `strict-f32-acc` | bool | `false` | Error if a `+=` accumulation loop's output block exceeds f32 DST capacity. |
 | `compiler-dfbs` | bool | `true` | Insert compiler-allocated intermediate DFBs for DFB-only operands, source-lifetime preservation, and computed values stored by operations in multiple MLIR basic blocks. Error if disabled and any operation requires one. |
 | `pipe-computed-addresses` | bool | `true` | Use computed receiver DFB addresses for eligible PipeNet transfers. When disabled, transfers use receiver-published destination addresses; multicast still requires proven equal runtime receiver addresses. |
@@ -220,6 +221,7 @@ merging.
 |---|---|---|---|
 | `dst-capacity` | uint32_t | `0` (auto) | Override DST register capacity. Auto-computed from `fp32_dest_acc_en` and `dst_full_sync_en` by default. Single-buffering (`dst_full_sync_en=true`): f32=8, f16/bf16=16. Double-buffering (default): f32=4, f16/bf16=8. |
 | `separate-output-region` | bool | `false` | Allocate outputs in a separate DST region (needed for reductions and some loop optimizations). |
+
 ```bash
 ttlang-opt input.mlir -p 'func.func(ttl-assign-dst{dst-capacity=16})'
 ```

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -196,7 +196,7 @@ ttlang-opt input.mlir -p 'builtin.module(ttl-finalize-dfb-indices{reuse-user-dfb
 #### `ttl-set-compute-kernel-config`
 
 Resolve tile execution strategies and shared compute-kernel configuration. See
-[Compute Kernel Configuration](../../development/ComputeKernelConfiguration.md)
+[Compute Kernel Configuration](https://github.com/tenstorrent/tt-lang/blob/main/docs/development/ComputeKernelConfiguration.md)
 for the algorithm and invariants.
 
 | Option | Type | Default | Description |

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -13,10 +13,12 @@ python my_kernel.py --no-ttl-maximize-dst
 | Flag | Default | Description |
 |---|---|---|
 | `--ttl-maximize-dst` / `--no-ttl-maximize-dst` | enabled | Partition compute iteration spaces into subblocks that maximize DST register utilization, and reorder tile operations within sync regions to group by kind. Disabling falls back to per-tile synchronization. |
-| `--ttl-fpu-binary-ops` / `--no-ttl-fpu-binary-ops` | enabled | Emit FPU binary elementwise ops (`add_tiles`, `sub_tiles`, `mul_tiles`) when both operands come from dataflow buffers. When disabled, binary ops use the SFPU path. |
+| `--ttl-fpu-binary-ops` / `--no-ttl-fpu-binary-ops` | enabled | Allow FPU strategy selection for binary add, subtract, and multiply when their operands permit it. Disabling selects SFPU. |
 | `--ttl-block-matmul` / `--no-ttl-block-matmul` | enabled | Emit `matmul_block` (processes the full tile block atomically) instead of per-tile matmul loops. Disabling this option is not yet supported. |
 | `--ttl-subblock-sync` / `--no-ttl-subblock-sync` | disabled | Refine DFB reserve/push to per-subblock granularity, enabling `pack_tile_block` for contiguous subblocks. When disabled, user-placed reserve/push is preserved as written. |
 | `--ttl-combine-pack-tiles` / `--no-ttl-combine-pack-tiles` | enabled | Combine consecutive `pack_tile` ops on the same DFB with contiguous DST and DFB indices into a single `pack_tile_block` call. |
+| `--ttl-reduce-full-fp32` / `--no-ttl-reduce-full-fp32` | enabled | Prefer full-fp32 accumulation for reduce operations when supported by the target and the complete kernel configuration. |
+| `--ttl-matmul-full-fp32` / `--no-ttl-matmul-full-fp32` | enabled | Prefer full-fp32 accumulation for matmul operations when supported by the target and the complete kernel configuration. |
 | `--ttl-strict-f32-acc` / `--no-ttl-strict-f32-acc` | disabled | Error at compile time if a `+=` accumulation loop's output block exceeds f32 DST capacity (4 tiles with double-buffering). When enabled, guarantees each accumulation step fits in a single DST section without subblocking. |
 | `--ttl-compiler-dfbs` / `--no-ttl-compiler-dfbs` | enabled | Insert compiler-allocated intermediate DFBs when an operation requires DFB-attached inputs, fusion would read a source after its DFB is released, or a computed value is stored by operations in multiple MLIR basic blocks. When disabled, the compiler emits an error if materialization is required. |
 | `--ttl-pipe-computed-addresses` / `--no-ttl-pipe-computed-addresses` | enabled | Use computed receiver DFB addresses for eligible PipeNet transfers. When disabled, transfers use receiver-published destination addresses; multicast still requires proven equal runtime receiver addresses. |
@@ -53,7 +55,7 @@ flags) and control the TTNN compute kernel hardware configuration:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `fp32_dest_acc_en` | `bool` or `None` | `None` | Enable f32 accumulation in the DST register file. When `None`, auto-detected from input tensor dtypes (enabled when any input is f32). |
+| `fp32_dest_acc_en` | `bool` or `None` | `None` | Constrain the DST register file to f32 mode. When `None`, resolve the mode from target capabilities and tile-operation requirements. |
 | `dst_full_sync_en` | `bool` or `None` | `None` | Enable full DST synchronization (single-buffering mode). Doubles DST capacity (f32: 8, f16/bf16: 16) at the cost of a full sync between math and pack threads. |
 
 ```python
@@ -115,10 +117,11 @@ ttlang-opt input.mlir -p 'ttl-to-ttkernel-pipeline{maximize-dst=true lower-to-em
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `maximize-dst` | bool | `true` | Enable DST maximization via subblock compute and scheduling. |
-| `enable-fpu-binary-ops` | bool | `true` | Use FPU for binary add/sub/mul. |
+| `enable-fpu-binary-ops` | bool | `true` | Allow FPU strategy selection for binary add/sub/mul. |
 | `use-block-matmul` | bool | `true` | Lower matmul to block-level hardware calls (`matmul_block`). |
 | `subblock-sync` | bool | `false` | Refine DFB reserve/push to per-subblock granularity. |
 | `combine-pack-tiles` | bool | `true` | Combine consecutive `pack_tile` ops into `pack_tile_block`. |
+| `reduce-full-fp32` | bool | `true` | Prefer full-fp32 reduce accumulation when supported. |
 | `strict-f32-acc` | bool | `false` | Error if a `+=` accumulation loop's output block exceeds f32 DST capacity. |
 | `compiler-dfbs` | bool | `true` | Insert compiler-allocated intermediate DFBs for DFB-only operands, source-lifetime preservation, and computed values stored by operations in multiple MLIR basic blocks. Error if disabled and any operation requires one. |
 | `pipe-computed-addresses` | bool | `true` | Use computed receiver DFB addresses for eligible PipeNet transfers. When disabled, transfers use receiver-published destination addresses; multicast still requires proven equal runtime receiver addresses. |
@@ -141,7 +144,7 @@ The pipeline runs these passes in order:
 - `ttl-verify-pipenet-guards`, then `ttl-verify-pipenet-schedule` -- verify PipeNet launch domains and event ordering while logical DFB identities remain distinct and before physical DFB allocation
 - `ttl-coalesce-dfb-acquires` -- coalesce compatible DFB acquires
 - `ttl-finalize-dfb-indices` -- assign logical DFBs to physical indices, validate capacity, and emit runtime metadata; `reuse-user-dfbs` controls user-DFB reuse and `exact-coloring-search-limit` bounds exhaustive fixed-limit and minimum physical-index-count queries
-- `ttl-set-compute-kernel-config` -- set `fp32_dest_acc_en` / `dst_full_sync_en` defaults
+- `ttl-set-compute-kernel-config` -- select tile execution strategies and resolve kernel-wide DST and per-DFB unpack configuration
 - `ttl-assign-dst` -- DST register allocation (linear scan with copy insertion)
 - `ttl-subblock-compute-for-dst` -- tile `ttl.compute` into DST-sized subblocks *(only if `maximize-dst=true`)*; optionally refine reserve/push to per-subblock granularity *(only if `subblock-sync=true`)*
 - `ttl-lower-to-loops` -- lower `ttl.compute` to `scf.for` loops; matmul computes are expanded inline via `generateMatmulCompute`
@@ -192,15 +195,20 @@ ttlang-opt input.mlir -p 'builtin.module(ttl-finalize-dfb-indices{reuse-user-dfb
 
 #### `ttl-set-compute-kernel-config`
 
-Set default compute kernel configuration attributes on `ttl.compute` ops.
+Resolve tile execution strategies and shared compute-kernel configuration. See
+[Compute Kernel Configuration](../../development/ComputeKernelConfiguration.md)
+for the algorithm and invariants.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `fp32-dest-acc-en` | bool | `false` | Default `fp32_dest_acc_en` when not already configured. |
-| `dst-full-sync-en` | bool | `false` | Default `dst_full_sync_en` when not already configured. |
+| `fp32-dest-acc-en` | string | `auto` | Select f32 DST mode: `auto`, `enabled`, or `disabled`. |
+| `dst-full-sync-en` | string | `auto` | Select full DST synchronization: `auto`, `enabled`, or `disabled`. |
+| `reduce-full-fp32` | bool | `true` | Prefer full-fp32 reduce accumulation when supported. |
+| `matmul-full-fp32` | bool | `true` | Prefer full-fp32 matmul accumulation when supported. |
+| `enable-fpu-binary-ops` | bool | `true` | Allow eligible add/sub/mul operations to select FPU. |
 
 ```bash
-ttlang-opt input.mlir -p 'func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=1})'
+ttlang-opt input.mlir -p 'func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled})'
 ```
 
 #### `ttl-assign-dst`
@@ -212,10 +220,8 @@ merging.
 |---|---|---|---|
 | `dst-capacity` | uint32_t | `0` (auto) | Override DST register capacity. Auto-computed from `fp32_dest_acc_en` and `dst_full_sync_en` by default. Single-buffering (`dst_full_sync_en=true`): f32=8, f16/bf16=16. Double-buffering (default): f32=4, f16/bf16=8. |
 | `separate-output-region` | bool | `false` | Allocate outputs in a separate DST region (needed for reductions and some loop optimizations). |
-| `enable-fpu-binary-ops` | bool | `true` | Use FPU for binary add/sub/mul when both operands come from DFBs. When disabled, binary ops use the SFPU path. |
-
 ```bash
-ttlang-opt input.mlir -p 'func.func(ttl-assign-dst{dst-capacity=16 enable-fpu-binary-ops=0})'
+ttlang-opt input.mlir -p 'func.func(ttl-assign-dst{dst-capacity=16})'
 ```
 
 #### `ttl-subblock-compute-for-dst`

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -50,16 +50,22 @@ my_kernel(tensor_a, tensor_b, options="--no-ttl-fpu-binary-ops")
 
 ## Compute Configuration
 
-These two parameters are set on the `@ttl.operation` decorator (not via command-line
+These parameters are set on the `@ttl.operation` decorator (not via command-line
 flags) and control the TTNN compute kernel hardware configuration:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `fp32_dest_acc_en` | `bool` or `None` | `None` | Constrain the Wormhole B0/Blackhole DST register-file element width: `true` selects 32-bit elements and `false` selects 16-bit elements. When `None`, resolve the width from target capabilities and tile-operation requirements. |
 | `dst_full_sync_en` | `bool` or `None` | `None` | Enable full DST synchronization (single-buffering mode). Doubles DST capacity (32-bit elements: 8, 16-bit elements: 16) at the cost of a full sync between math and pack threads. |
+| `math_fidelity` | `str` or `None` | `None` | Set the compute math fidelity to `LoFi`, `HiFi2`, `HiFi3`, or `HiFi4`. When `None`, retain the TTNN default. |
 
 ```python
-@ttl.operation(grid=(2, 2), fp32_dest_acc_en=True, dst_full_sync_en=False)
+@ttl.operation(
+    grid=(2, 2),
+    fp32_dest_acc_en=True,
+    dst_full_sync_en=False,
+    math_fidelity="HiFi4",
+)
 def my_kernel(a, b): ...
 ```
 

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -55,8 +55,8 @@ flags) and control the TTNN compute kernel hardware configuration:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `fp32_dest_acc_en` | `bool` or `None` | `None` | Constrain the DST register file to f32 mode. When `None`, resolve the mode from target capabilities and tile-operation requirements. |
-| `dst_full_sync_en` | `bool` or `None` | `None` | Enable full DST synchronization (single-buffering mode). Doubles DST capacity (f32: 8, f16/bf16: 16) at the cost of a full sync between math and pack threads. |
+| `fp32_dest_acc_en` | `bool` or `None` | `None` | Constrain the Wormhole B0/Blackhole DST register-file element width: `true` selects 32-bit elements and `false` selects 16-bit elements. When `None`, resolve the width from target capabilities and tile-operation requirements. |
+| `dst_full_sync_en` | `bool` or `None` | `None` | Enable full DST synchronization (single-buffering mode). Doubles DST capacity (32-bit elements: 8, 16-bit elements: 16) at the cost of a full sync between math and pack threads. |
 
 ```python
 @ttl.operation(grid=(2, 2), fp32_dest_acc_en=True, dst_full_sync_en=False)
@@ -202,7 +202,7 @@ for the algorithm and invariants.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `fp32-dest-acc-en` | string | `auto` | Select f32 DST mode: `auto`, `enabled`, or `disabled`. |
+| `fp32-dest-acc-en` | string | `auto` | Select 32-bit destination elements through the Wormhole B0/Blackhole `fp32_dest_acc_en` setting: `auto`, `enabled`, or `disabled`. |
 | `dst-full-sync-en` | string | `auto` | Select full DST synchronization: `auto`, `enabled`, or `disabled`. |
 | `reduce-full-fp32` | bool | `true` | Prefer full-fp32 reduce accumulation when supported. |
 | `matmul-full-fp32` | bool | `true` | Prefer full-fp32 matmul accumulation when supported. |
@@ -219,7 +219,7 @@ merging.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `dst-capacity` | uint32_t | `0` (auto) | Override DST register capacity. Auto-computed from `fp32_dest_acc_en` and `dst_full_sync_en` by default. Single-buffering (`dst_full_sync_en=true`): f32=8, f16/bf16=16. Double-buffering (default): f32=4, f16/bf16=8. |
+| `dst-capacity` | uint32_t | `0` (auto) | Override DST register capacity. Auto-computed from `fp32_dest_acc_en` and `dst_full_sync_en` by default. Single-buffering (`dst_full_sync_en=true`): 32-bit elements=8, 16-bit elements=16. Double-buffering (default): 32-bit elements=4, 16-bit elements=8. |
 | `separate-output-region` | bool | `false` | Allocate outputs in a separate DST region (needed for reductions and some loop optimizations). |
 
 ```bash

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -44,27 +44,9 @@ constexpr llvm::StringLiteral kDstFullSyncEnAttrName("dst_full_sync_en");
 constexpr llvm::StringLiteral
     kUnpackToDestFp32AttrName("ttl.unpack_to_dest_fp32");
 
-/// Canonical target_arch values. Mirrored in python/ttl/ttl_api.py.
-constexpr llvm::StringLiteral kBlackholeArchName("blackhole");
-constexpr llvm::StringLiteral kWormholeB0ArchName("wormhole_b0");
-
-inline bool hasTargetArch(Operation *op, llvm::StringRef archName) {
-  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
-  if (!moduleOp) {
-    return false;
-  }
-
-  auto targetArch = moduleOp->getAttrOfType<StringAttr>(kTargetArchAttrName);
-  return targetArch && targetArch.getValue() == archName;
-}
-
-inline bool isBlackholeTarget(Operation *op) {
-  return hasTargetArch(op, kBlackholeArchName);
-}
-
-inline bool isWormholeB0Target(Operation *op) {
-  return hasTargetArch(op, kWormholeB0ArchName);
-}
+/// Selected strategy on tile operations with execution alternatives.
+constexpr llvm::StringLiteral
+    kTileExecutionStrategyAttrName("ttl.tile_execution_strategy");
 
 /// PipeNet role exposed by `is_src` / `is_dst` / `is_active` predicate ops
 /// and by `pipenet_scope` declarations.
@@ -87,8 +69,7 @@ getDefaultDstWriteFootprints(mlir::Operation *op);
 mlir::FailureOr<DstFootprint> getDefaultResultDstFootprint(mlir::Operation *op,
                                                            mlir::Value result);
 
-/// Func-level: enable FPU lowering for eligible tile add/sub/mul.
-/// Set by TTLSetComputeKernelConfig, read via getKernelBoolAttr.
+/// Function-level policy for selecting FPU add, subtract, and multiply.
 constexpr llvm::StringLiteral
     kEnableFPUBinaryOpsAttrName("ttl.enable_fpu_binary_ops");
 
@@ -206,9 +187,7 @@ template <typename ConcreteType>
 class TTLDSTInputsTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, TTLDSTInputsTrait> {};
 
-/// Participation marker for binary tile ops (add/sub/mul) whose input source
-/// is decided by operand provenance rather than op identity. The eligibility
-/// answer is computed by isFPUEligibleBinaryOp() in TTLOpsUtils.h.
+/// Marks binary tile ops that support both FPU and SFPU execution strategies.
 template <typename ConcreteType>
 class TTLStrategyDependentBinaryOpTrait
     : public mlir::OpTrait::TraitBase<ConcreteType,

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -62,7 +62,7 @@ struct DstFootprint {
   int64_t tileCount = 1;
 };
 
-llvm::SmallVector<DstFootprint, 2>
+mlir::FailureOr<llvm::SmallVector<DstFootprint, 2>>
 getDefaultDstReadFootprints(mlir::Operation *op);
 llvm::SmallVector<DstFootprint, 2>
 getDefaultDstWriteFootprints(mlir::Operation *op);

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -111,7 +111,7 @@ def TTL_DstAccessOpInterface : OpInterface<"DstAccessOpInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/"Return DST slots read by this operation after tile execution semantics and DST residency are resolved.",
-      /*retTy=*/"::llvm::SmallVector<::mlir::tt::ttl::DstFootprint, 2>",
+      /*retTy=*/"::mlir::FailureOr<::llvm::SmallVector<::mlir::tt::ttl::DstFootprint, 2>>",
       /*methodName=*/"getDstReadFootprints",
       /*args=*/(ins),
       /*methodBody=*/"",

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -110,7 +110,7 @@ def TTL_DstAccessOpInterface : OpInterface<"DstAccessOpInterface"> {
 
   let methods = [
     InterfaceMethod<
-      /*desc=*/"Return DST slots read by this operation.",
+      /*desc=*/"Return DST slots read by this operation after tile execution semantics and DST residency are resolved.",
       /*retTy=*/"::llvm::SmallVector<::mlir::tt::ttl::DstFootprint, 2>",
       /*methodName=*/"getDstReadFootprints",
       /*args=*/(ins),

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -143,4 +143,37 @@ def TTL_DstAccessOpInterface : OpInterface<"DstAccessOpInterface"> {
   ];
 }
 
+def TTL_TileExecutionOpInterface : OpInterface<"TileExecutionOpInterface"> {
+  let description = [{
+    Tile operations expose target-independent execution semantics through this
+    interface. An execution strategy determines operand routes and DST
+    behavior independently of target capabilities.
+  }];
+
+  let cppNamespace = "::mlir::tt::ttl";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/"Return execution strategies structurally permitted by the current operands.",
+      /*retTy=*/"::llvm::SmallVector<::mlir::tt::ttl::TileExecutionStrategy, 2>",
+      /*methodName=*/"getLegalExecutionStrategies",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::mlir::tt::ttl::getDefaultLegalTileExecutionStrategies(
+            $_op.getOperation());
+      }]>,
+    InterfaceMethod<
+      /*desc=*/"Return execution semantics for the supplied strategy.",
+      /*retTy=*/"::mlir::FailureOr<::mlir::tt::ttl::TileExecutionInfo>",
+      /*methodName=*/"getTileExecutionInfo",
+      /*args=*/(ins "::std::optional<::mlir::tt::ttl::TileExecutionStrategy>":$strategy),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::mlir::tt::ttl::getDefaultTileExecutionInfo(
+            $_op.getOperation(), strategy);
+      }]>
+  ];
+}
+
 #endif // TTLANG_DIALECT_TTL_IR_TTLINTERFACES_TD

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.h
@@ -19,6 +19,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsAttrs.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsEnums.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
+#include "ttlang/Dialect/TTL/IR/TileExecution.h"
 
 #include "ttlang/Dialect/TTL/IR/TTLInterfaces.h.inc"
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -863,7 +863,8 @@ def TTL_DPrintOp
 // Note: These ops are NOT Pure because they write to DST registers.
 class TTL_TileOp<string mnemonic, list<Trait> traits = []>
     : TTL_Op<mnemonic, !listconcat(traits, [TTL_TileComputeOpTrait,
-                                             TTL_DstAccessOpInterface])>;
+                                             TTL_DstAccessOpInterface,
+                                             TTL_TileExecutionOpInterface])>;
 
 def TTL_TileType : Type<
     CPred<"llvm::isa<mlir::tt::ttcore::TileType>($_self)">,
@@ -917,7 +918,8 @@ def TTL_CopyTileOp : TTL_Op<"copy_tile",
                              TTL_CBInputTileOpTrait,
                              TTL_DataMovementOpTrait,
                              TTL_DstResultOpTrait,
-                             TTL_DstAccessOpInterface]> {
+                             TTL_DstAccessOpInterface,
+                             TTL_TileExecutionOpInterface]> {
   let summary = "Copy a tile from a circular buffer into a DST register";
   let description = [{
     Performs a CB -> DST copy, matching `copy_tile_init` + `copy_tile` in the
@@ -962,7 +964,8 @@ def TTL_CopyDstOp : TTL_Op<"copy_dst",
                             MemoryEffects<[MemRead, MemWrite]>,
                             TTL_DSTInputsTrait,
                             TTL_DataMovementOpTrait,
-                            TTL_DstAccessOpInterface]> {
+                            TTL_DstAccessOpInterface,
+                            TTL_TileExecutionOpInterface]> {
   let summary = "Copy a tile from one DST register to another";
   let description = [{
     Performs DST -> DST copy for multi-consumer value preservation. Used when
@@ -990,7 +993,8 @@ def TTL_CopyDstOp : TTL_Op<"copy_dst",
 }
 
 def TTL_DstIndexOp : TTL_Op<"dst_index",
-    [Pure, TTL_DstAccessOpInterface, AllTypesMatch<["source", "result"]>]> {
+    [Pure, TTL_DstAccessOpInterface, TTL_TileExecutionOpInterface,
+     AllTypesMatch<["source", "result"]>]> {
   let summary = "Index a tile value resident in a specific DST slot";
   let description = [{
     `ttl.dst_index` names an existing DST-resident tile at `dst_index` while
@@ -1022,9 +1026,8 @@ class TTL_TileBinaryOpBase<string mnemonic, list<Trait> traits = []>
 class TTL_TileSfpuBinaryOp<string mnemonic, list<Trait> traits = []>
     : TTL_TileBinaryOpBase<mnemonic, !listconcat(traits, [TTL_DSTInputsTrait])>;
 
-// Strategy-dependent binary tile op: input source is determined by operand
-// provenance at lowering time. add/sub/mul live here; isFPUEligibleBinaryOp
-// resolves the choice from the current IR.
+// The selected FPU/SFPU strategy determines whether operands are consumed from
+// dataflow buffers or DST.
 class TTL_TileStrategyDepBinaryOp<string mnemonic, list<Trait> traits = []>
     : TTL_TileBinaryOpBase<mnemonic,
                            !listconcat(traits,
@@ -1045,9 +1048,9 @@ class TTL_TileUnaryOp<string mnemonic, list<Trait> traits = []>
 // Binary Elementwise Operations (Tensor + Tile Ops)
 //===----------------------------------------------------------------------===//
 
-// Multiclass for paired tensor + strategy-dependent tile binary ops.
-// Used by add/sub/mul, where the tile op may lower to either an FPU or
-// SFPU TTKernel form depending on operand provenance.
+// Multiclass for tensor operations paired with FPU/SFPU tile operations.
+// Add, subtract, and multiply select one tile execution strategy before DST
+// assignment.
 multiclass TTL_BinaryStrategyDepElementwisePair<string mnemonic,
                                                 string kernelOp,
                                                 list<Trait> opTraits = []> {
@@ -1768,7 +1771,7 @@ def TTL_GetDfbIdOp : TTL_Op<"get_dfb_id", [Pure]> {
 
 def TTL_TileStoreOp : TTL_Op<"tile_store",
     [MemoryEffects<[MemWrite]>, TTL_DstResultOpTrait,
-     TTL_DstAccessOpInterface]> {
+     TTL_DstAccessOpInterface, TTL_TileExecutionOpInterface]> {
   let summary = "Store a tile into a circular buffer view";
   let description = [{
     `ttl.tile_store` packs a single tile from the DST register into a circular

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -61,6 +61,17 @@ def TTL_PipeTransferKindAttr : TTL_Attr<"PipeTransferKind",
   let assemblyFormat = "`<` $value `>`";
 }
 
+def TTL_TileExecutionStrategyAttr
+    : TTL_Attr<"TileExecutionStrategy", "tile_execution_strategy"> {
+  let summary = "Selected tile execution strategy";
+  let description = [{
+    Identifies the execution strategy that defines operand routing and DST
+    behavior for a tile operation with execution-strategy alternatives.
+  }];
+  let parameters = (ins "TileExecutionStrategy":$value);
+  let assemblyFormat = "`<` $value `>`";
+}
+
 def TTL_LayoutAttr : TTL_Attr<"Layout", "layout"> {
   let summary = "Tensor layout encoding for grid distribution and memory placement";
   let description = [{

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
@@ -119,4 +119,16 @@ def TTL_TensorMemoryLayout : I32EnumAttr<
   let cppNamespace = "::mlir::tt::ttl";
 }
 
+def TTL_TileExecutionStrategy_FPU :
+    I32EnumAttrCase<"FPU", 0, "fpu">;
+def TTL_TileExecutionStrategy_SFPU :
+    I32EnumAttrCase<"SFPU", 1, "sfpu">;
+
+def TTL_TileExecutionStrategy : I32EnumAttr<
+    "TileExecutionStrategy", "tile execution strategy",
+    [TTL_TileExecutionStrategy_FPU, TTL_TileExecutionStrategy_SFPU]> {
+  let cppNamespace = "::mlir::tt::ttl";
+  let genSpecializedAttr = 0;
+}
+
 #endif // TTLANG_DIALECT_TTL_IR_TTLOPSENUMS_TD

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -310,25 +310,6 @@ inline bool isBinaryElementwiseOp(mlir::Operation *op) {
   return op->hasTrait<TTLBinaryElementwiseOpTrait>();
 }
 
-/// Return whether a reduce op supports full-fp32 accumulation on its target.
-inline bool isFullFp32ReduceSupported(TileReduceOp reduceOp) {
-  // Wormhole full_fp32 requires FP32 DST and changes existing reduce results.
-  if (isWormholeB0Target(reduceOp)) {
-    return false;
-  }
-
-  // Blackhole cannot write the low 16 bits while the 32-bit dest is enabled, so
-  // the row-reduce LLK disables fp32 accumulation internally (tt-metal #47311).
-  // Report unsupported so DST_ACCUM_MODE is not enabled for it.
-  return !isBlackholeTarget(reduceOp) ||
-         reduceOp.getReduceDim() != mlir::tt::ttkernel::ReduceDim::Row;
-}
-
-/// Apply the user request and target restrictions for reduce full-fp32.
-inline bool shouldUseFullFp32Reduce(TileReduceOp reduceOp, bool requested) {
-  return requested && isFullFp32ReduceSupported(reduceOp);
-}
-
 /// Check if an operation is a tile-level unary op (executes in-place on DST).
 inline bool isTileUnaryOp(mlir::Operation *op) {
   return op->hasTrait<TTLTileUnaryOpTrait>();
@@ -360,66 +341,6 @@ inline int64_t getNocIndex(mlir::Operation *op) {
     return attr.getInt();
   }
   return 0;
-}
-
-/// Return true when an add/sub/mul tile op is eligible to lower to its FPU
-/// form. Eligibility requires all of:
-///   1. op carries TTLStrategyDependentBinaryOpTrait;
-///   2. the enclosing func.func has ttl.enable_fpu_binary_ops = true
-///      (absent or false ⇒ not eligible);
-///   3. both operands trace to the same CB-backed indexing source — either
-///      input block args of one ttl.compute with equal indexing maps
-///      (pre-ttl-lower-to-loops), or tensor.extract ops with equal index
-///      lists (post-ttl-lower-to-loops).
-///
-/// This is a structural predicate over the IR; resolving a usable CB handle
-/// for the operands is the conversion pattern's responsibility.
-inline bool isFPUEligibleBinaryOp(mlir::Operation *op) {
-  if (!op->hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
-    return false;
-  }
-  if (!getKernelBoolAttr(op, kEnableFPUBinaryOpsAttrName)) {
-    return false;
-  }
-  mlir::Value lhs = op->getOperand(0);
-  mlir::Value rhs = op->getOperand(1);
-
-  // Pre-lower-to-loops: input block args of one ttl.compute with equal maps.
-  if (auto lhsArg = mlir::dyn_cast<mlir::BlockArgument>(lhs)) {
-    auto rhsArg = mlir::dyn_cast<mlir::BlockArgument>(rhs);
-    if (!rhsArg || lhsArg.getOwner() != rhsArg.getOwner()) {
-      return false;
-    }
-    auto computeOp =
-        mlir::dyn_cast_or_null<ComputeOp>(lhsArg.getOwner()->getParentOp());
-    if (!computeOp) {
-      return false;
-    }
-    unsigned numInputs = computeOp.getNumInputs();
-    if (lhsArg.getArgNumber() >= numInputs ||
-        rhsArg.getArgNumber() >= numInputs) {
-      return false;
-    }
-    auto indexingMaps = computeOp.getIndexingMapsArray();
-    return indexingMaps[lhsArg.getArgNumber()] ==
-           indexingMaps[rhsArg.getArgNumber()];
-  }
-
-  // Post-lower-to-loops: tensor.extract ops with identical indices. CB
-  // attachment is guaranteed by loop lowering and re-verified by the FPU
-  // conversion pattern's CB lookup, so no getAttachedCB check is needed here.
-  auto lhsExtract = lhs.getDefiningOp<mlir::tensor::ExtractOp>();
-  auto rhsExtract = rhs.getDefiningOp<mlir::tensor::ExtractOp>();
-  return lhsExtract && rhsExtract &&
-         lhsExtract.getIndices() == rhsExtract.getIndices();
-}
-
-/// True if op reads inputs from CB at runtime. Unconditional for trait-bearing
-/// ops (bcast/transpose/reduce/...); conditional for strategy-dep add/sub/mul
-/// (delegated to isFPUEligibleBinaryOp). The strategy-dep answer can flip
-/// across TTLAssignDST copy insertion — re-query, do not cache.
-inline bool isCBInputOp(mlir::Operation *op) {
-  return op->hasTrait<TTLCBInputTileOpTrait>() || isFPUEligibleBinaryOp(op);
 }
 
 /// Check if an operation is any elementwise tensor op (unary or binary).

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -429,7 +429,7 @@ enum class TileOpCategory : uint8_t {
   Unknown = 255
 };
 
-/// Classify a TTL tile op into its category.
+/// Classify a TTL tile op into its category after strategy resolution.
 /// Uses TTL traits and attributes for O(1) per-call classification.
 TileOpCategory classifyTileOp(mlir::Operation *op);
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -193,6 +193,16 @@ inline std::optional<mlir::Type> getTileElementType(mlir::Type type) {
   return std::nullopt;
 }
 
+/// Return the tensor's tile type without discarding physical tile dimensions.
+/// Scalar-element tensors use the target-independent default tile dimensions.
+inline ttcore::TileType getTensorTileType(mlir::RankedTensorType tensorType) {
+  if (auto tileType =
+          mlir::dyn_cast<ttcore::TileType>(tensorType.getElementType())) {
+    return tileType;
+  }
+  return ttcore::TileType::get(tensorType.getElementType());
+}
+
 /// Check tilization consistency between two element types.
 /// - Both non-tile: success (no tilization to compare).
 /// - Exactly one side tiled: error (mixed tile/scalar is invalid).

--- a/include/ttlang/Dialect/TTL/IR/TileExecution.h
+++ b/include/ttlang/Dialect/TTL/IR/TileExecution.h
@@ -81,6 +81,11 @@ getSelectedTileExecutionStrategy(mlir::Operation *operation);
 mlir::FailureOr<TileExecutionInfo>
 getSelectedTileExecutionInfo(mlir::Operation *operation);
 
+/// Verify the strategy attribute against the operation's legal alternatives.
+mlir::LogicalResult verifyTileExecutionStrategy(
+    mlir::Operation *operation,
+    llvm::ArrayRef<TileExecutionStrategy> legalStrategies);
+
 /// Return whether `operand` must be resident in DST when consumed.
 /// Tile execution semantics must be verified before calling this function.
 bool isDstInput(mlir::OpOperand &operand);

--- a/include/ttlang/Dialect/TTL/IR/TileExecution.h
+++ b/include/ttlang/Dialect/TTL/IR/TileExecution.h
@@ -81,9 +81,11 @@ mlir::FailureOr<TileExecutionInfo>
 getSelectedTileExecutionInfo(mlir::Operation *operation);
 
 /// Return whether `operand` must be resident in DST when consumed.
+/// Tile execution semantics must be verified before calling this function.
 bool isDstInput(mlir::OpOperand &operand);
 
 /// Return whether the operation lowering initializes DST from `operand`.
+/// Tile execution semantics must be verified before calling this function.
 bool isDstInputMaterializedByOperation(mlir::OpOperand &operand);
 
 /// Verify that every tile operation has complete execution semantics.

--- a/include/ttlang/Dialect/TTL/IR/TileExecution.h
+++ b/include/ttlang/Dialect/TTL/IR/TileExecution.h
@@ -18,6 +18,7 @@ namespace mlir::tt::ttl {
 
 /// Tile operation category used by configuration capability queries.
 enum class TilePrimitive {
+  Unknown,
   Copy,
   ElementwiseBinary,
   ElementwiseUnary,
@@ -49,7 +50,7 @@ enum class FullFp32AccumulationKind {
 
 /// Target-independent execution semantics for one tile operation.
 struct TileExecutionInfo {
-  TilePrimitive primitive;
+  TilePrimitive primitive = TilePrimitive::Unknown;
   llvm::SmallVector<TileOperandRoute, 4> operandRoutes;
   /// DST operands initialized by the operation's lowering.
   llvm::SmallBitVector dstOperandsMaterializedByOperation;

--- a/include/ttlang/Dialect/TTL/IR/TileExecution.h
+++ b/include/ttlang/Dialect/TTL/IR/TileExecution.h
@@ -9,6 +9,7 @@
 
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <optional>
@@ -20,7 +21,9 @@ enum class TilePrimitive {
   Copy,
   ElementwiseBinary,
   ElementwiseUnary,
-  Broadcast,
+  BroadcastColumn,
+  BroadcastRow,
+  BroadcastScalar,
   Reduce,
   Transpose,
   Fill,
@@ -48,6 +51,8 @@ enum class FullFp32AccumulationKind {
 struct TileExecutionInfo {
   TilePrimitive primitive;
   llvm::SmallVector<TileOperandRoute, 4> operandRoutes;
+  /// DST operands initialized by the operation's lowering.
+  llvm::SmallBitVector dstOperandsMaterializedByOperation;
   bool resultInDst = false;
   std::optional<FullFp32AccumulationKind> fullFp32Accumulation;
   /// Residual contents in a reused destination slot affect the result.
@@ -77,6 +82,9 @@ getSelectedTileExecutionInfo(mlir::Operation *operation);
 
 /// Return whether `operand` must be resident in DST when consumed.
 bool isDstInput(mlir::OpOperand &operand);
+
+/// Return whether the operation lowering initializes DST from `operand`.
+bool isDstInputMaterializedByOperation(mlir::OpOperand &operand);
 
 /// Verify that every tile operation has complete execution semantics.
 mlir::LogicalResult verifyTileExecutionSemantics(mlir::Operation *root);

--- a/include/ttlang/Dialect/TTL/IR/TileExecution.h
+++ b/include/ttlang/Dialect/TTL/IR/TileExecution.h
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_IR_TILEEXECUTION_H
+#define TTLANG_DIALECT_TTL_IR_TILEEXECUTION_H
+
+#include "ttlang/Dialect/TTL/IR/TTLOpsEnums.h"
+
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace mlir::tt::ttl {
+
+/// Tile operation category used by configuration capability queries.
+enum class TilePrimitive {
+  Copy,
+  ElementwiseBinary,
+  ElementwiseUnary,
+  Broadcast,
+  Reduce,
+  Transpose,
+  Fill,
+  Matmul,
+  Store,
+  DstIndex,
+};
+
+/// Hardware location from which a tile operand is consumed.
+enum class TileOperandRoute {
+  None,
+  DataflowBuffer,
+  Dst,
+};
+
+/// Target-independent category for optional full-fp32 accumulation.
+enum class FullFp32AccumulationKind {
+  Matmul,
+  ReduceRow,
+  ReduceColumn,
+  ReduceScalar,
+};
+
+/// Target-independent execution semantics for one tile operation.
+struct TileExecutionInfo {
+  TilePrimitive primitive;
+  llvm::SmallVector<TileOperandRoute, 4> operandRoutes;
+  bool resultInDst = false;
+  std::optional<FullFp32AccumulationKind> fullFp32Accumulation;
+  /// Residual contents in a reused destination slot affect the result.
+  bool accumulatesIntoDst = false;
+};
+
+/// Return strategies structurally permitted by the operation's SSA operands.
+llvm::SmallVector<TileExecutionStrategy, 2>
+getDefaultLegalTileExecutionStrategies(mlir::Operation *operation);
+
+/// Return execution semantics for `operation` under `strategy`.
+mlir::FailureOr<TileExecutionInfo> getDefaultTileExecutionInfo(
+    mlir::Operation *operation,
+    std::optional<TileExecutionStrategy> strategy = std::nullopt);
+
+/// Verify that execution semantics define one route for every operand.
+mlir::LogicalResult verifyTileExecutionInfo(mlir::Operation *operation,
+                                            const TileExecutionInfo &info);
+
+/// Return the strategy recorded on an operation with strategy alternatives.
+mlir::FailureOr<TileExecutionStrategy>
+getSelectedTileExecutionStrategy(mlir::Operation *operation);
+
+/// Return execution semantics using the strategy recorded on the operation.
+mlir::FailureOr<TileExecutionInfo>
+getSelectedTileExecutionInfo(mlir::Operation *operation);
+
+/// Return whether `operand` must be resident in DST when consumed.
+bool isDstInput(mlir::OpOperand &operand);
+
+/// Verify that every tile operation has complete execution semantics.
+mlir::LogicalResult verifyTileExecutionSemantics(mlir::Operation *root);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_IR_TILEEXECUTION_H

--- a/include/ttlang/Dialect/TTL/Passes.h
+++ b/include/ttlang/Dialect/TTL/Passes.h
@@ -29,8 +29,7 @@ namespace mlir::tt::ttl {
 
 /// Populate patterns for lowering ttl.tile_* ops to TTKernel.
 void populateTTLTileOpsToTTKernelPatterns(mlir::TypeConverter *typeConverter,
-                                          RewritePatternSet &patterns,
-                                          bool reduceFullFp32 = true);
+                                          RewritePatternSet &patterns);
 
 } // namespace mlir::tt::ttl
 

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -420,6 +420,9 @@ def TTLAssignDST
     - Inserts ttl.copy_tile for block arguments
     - Assigns dst_index SSA operands to tile math operations
     - Checks capacity and emits diagnostics on overflow
+
+    DST operations must be directly contained in the `ttl.compute` body. The
+    pass diagnoses nested DST operations before modifying IR.
   }];
 
   let options = [

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -439,29 +439,28 @@ def TTLAssignDST
 
 def TTLSetComputeKernelConfig
     : Pass<"ttl-set-compute-kernel-config", "::mlir::func::FuncOp"> {
-  let summary = "Set ttl.compute kernel configuration attributes";
+  let summary = "Resolve compute-kernel configuration";
   let description = [{
-    Sets fp32_dest_acc_en, dst_full_sync_en, and ttl.enable_fpu_binary_ops
-    attributes on the enclosing func.func when they are not already
-    configured. These are per-kernel compile-time settings; any op in the
-    function can read them via getKernelBoolAttr().
+    Selects tile execution strategies and resolves kernel-wide DST mode,
+    synchronization mode, and per-dataflow-buffer unpack mode. Target
+    capabilities, user policy, and target-independent kernel requirements are
+    analyzed separately. The pass validates a complete configuration before
+    writing operation or function attributes.
   }];
 
   let options = [
-    Option<"fp32DestAccEn", "fp32-dest-acc-en", "bool", "false",
-           "Set default fp32_dest_acc_en when not already configured.">,
-    Option<"dstFullSyncEn", "dst-full-sync-en", "bool", "false",
-           "Set default dst_full_sync_en when not already configured.">,
+    Option<"fp32DestAccEn", "fp32-dest-acc-en", "std::string", "\"auto\"",
+           "Select fp32 destination accumulation: auto, enabled, or disabled.">,
+    Option<"dstFullSyncEn", "dst-full-sync-en", "std::string", "\"auto\"",
+           "Select full DST synchronization: auto, enabled, or disabled.">,
     Option<"reduceFullFp32", "reduce-full-fp32", "bool", "true",
-           "Enable FP32 accumulation for reduce operations. "
-           "Sets fp32_dest_acc_en on the kernel when any compute op contains reduce.">,
+           "Prefer FP32 accumulation for reduce operations when supported.">,
     Option<"matmulFullFp32", "matmul-full-fp32", "bool", "true",
-           "Enable FP32 accumulation for matmul operations. "
-           "Sets fp32_dest_acc_en on the kernel when any compute op contains matmul_block.">,
+           "Prefer FP32 accumulation for matmul operations when supported.">,
     Option<"enableFPUBinaryOps", "enable-fpu-binary-ops", "bool", "true",
-           "Allow lowering eligible tile add/sub/mul to FPU binary form. "
-           "Written as the ttl.enable_fpu_binary_ops attribute on the func and "
-           "consumed by isFPUEligibleBinaryOp(). Disable to force the SFPU path.">
+           "Allow tile add/sub/mul with matching operand coordinates and "
+           "DFB-backed operands to select the FPU strategy. "
+           "Disable to select the SFPU strategy.">
   ];
 
   let dependentDialects = [
@@ -588,6 +587,9 @@ def TTLScheduleOperations
     : Pass<"ttl-schedule-operations", "::mlir::func::FuncOp"> {
   let summary = "Group tile operations by kind within sync regions";
   let description = [{
+    Requires `ttl-set-compute-kernel-config` to select execution strategies for
+    tile operations that support alternatives.
+
     Reorders tile operations within sync regions (`tile_regs_acquire` to
     `tile_regs_commit`) to group by operation kind. After `ttl-lower-to-loops`
     unrolls a subblocked compute, tile ops from different iterations are

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -421,8 +421,9 @@ def TTLAssignDST
     - Assigns dst_index SSA operands to tile math operations
     - Checks capacity and emits diagnostics on overflow
 
-    DST operations must be directly contained in the `ttl.compute` body. The
-    pass diagnoses nested DST operations before modifying IR.
+    Nested DST operations are preserved when their destination and source
+    indices are resolved and they do not require copy insertion. The pass
+    diagnoses unsupported nested operations before modifying IR.
   }];
 
   let options = [

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -441,11 +441,11 @@ def TTLSetComputeKernelConfig
     : Pass<"ttl-set-compute-kernel-config", "::mlir::func::FuncOp"> {
   let summary = "Resolve compute-kernel configuration";
   let description = [{
-    Selects tile execution strategies and resolves kernel-wide DST mode,
-    synchronization mode, and per-dataflow-buffer unpack mode. Target
-    capabilities, user policy, and target-independent kernel requirements are
-    analyzed separately. The pass validates a complete configuration before
-    writing operation or function attributes.
+    Selects tile execution strategies and resolves kernel-wide destination
+    element width, synchronization mode, and per-dataflow-buffer unpack mode.
+    Target capabilities, user policy, and target-independent kernel
+    requirements are analyzed separately. The pass validates a complete
+    configuration before writing operation or function attributes.
   }];
 
   let options = [

--- a/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
+++ b/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
@@ -47,6 +47,10 @@ struct TTLToTTKernelPipelineOptions
       *this, "reduce-full-fp32",
       llvm::cl::desc("Prefer FP32 accumulation for reduce operations."),
       llvm::cl::init(true)};
+  Option<bool> matmulFullFp32{
+      *this, "matmul-full-fp32",
+      llvm::cl::desc("Prefer FP32 accumulation for matmul operations."),
+      llvm::cl::init(true)};
   Option<bool> strictF32Acc{
       *this, "strict-f32-acc",
       llvm::cl::desc("Error if accumulation output exceeds f32 DST capacity."),

--- a/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
+++ b/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
@@ -26,7 +26,8 @@ struct TTLToTTKernelPipelineOptions
       llvm::cl::init(true)};
   Option<bool> enableFPUBinaryOps{
       *this, "enable-fpu-binary-ops",
-      llvm::cl::desc("Use FPU for binary add/sub/mul."), llvm::cl::init(true)};
+      llvm::cl::desc("Allow FPU strategy selection for binary add/sub/mul."),
+      llvm::cl::init(true)};
   Option<bool> useBlockMatmul{
       *this, "use-block-matmul",
       llvm::cl::desc("Lower matmul to block-level hardware calls "
@@ -44,7 +45,7 @@ struct TTLToTTKernelPipelineOptions
       llvm::cl::init(true)};
   Option<bool> reduceFullFp32{
       *this, "reduce-full-fp32",
-      llvm::cl::desc("Enable FP32 accumulation for reduce operations."),
+      llvm::cl::desc("Prefer FP32 accumulation for reduce operations."),
       llvm::cl::init(true)};
   Option<bool> strictF32Acc{
       *this, "strict-f32-acc",

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -5,7 +5,6 @@
 #ifndef TTLANG_DIALECT_TTL_TRANSFORMS_COMPUTEKERNELCONFIGANALYSIS_H
 #define TTLANG_DIALECT_TTL_TRANSFORMS_COMPUTEKERNELCONFIGANALYSIS_H
 
-#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TileExecution.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -66,7 +65,6 @@ public:
   static FailureOr<std::unique_ptr<KernelTargetEnvironment>>
   get(func::FuncOp function);
 
-  virtual std::optional<ttcore::Arch> getArch() const = 0;
   virtual bool supportsDestinationElementWidth(
       TilePrimitive primitive, Type elementType,
       DestinationElementWidth destinationElementWidth) const = 0;

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_COMPUTEKERNELCONFIGANALYSIS_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_COMPUTEKERNELCONFIGANALYSIS_H
+
+#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttlang/Dialect/TTL/IR/TileExecution.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace mlir::tt::ttl {
+
+/// User policy for a configuration value that may otherwise be inferred.
+enum class ConfigSelection {
+  Auto,
+  Enabled,
+  Disabled,
+};
+
+/// Element format used by the kernel's DST register file.
+enum class DstMode {
+  Default,
+  Fp32,
+};
+
+/// Synchronization protocol used for the kernel's DST register file.
+enum class DstSyncMode {
+  DoubleBuffered,
+  Full,
+};
+
+/// Unpack mode assigned to one dataflow buffer for the complete kernel.
+enum class DFBUnpackMode {
+  Default,
+  UnpackToDestFp32,
+};
+
+/// Immutable hardware and backend capabilities for one kernel target.
+class KernelTargetEnvironment {
+public:
+  static FailureOr<KernelTargetEnvironment> get(func::FuncOp function);
+
+  std::optional<ttcore::Arch> getArch() const { return arch; }
+  bool supportsDstMode(TilePrimitive primitive, Type elementType,
+                       DstMode mode) const;
+  bool supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const;
+  DFBUnpackMode getRequiredUnpackMode(TilePrimitive primitive,
+                                      TileOperandRoute route,
+                                      Type elementType) const;
+
+private:
+  explicit KernelTargetEnvironment(std::optional<ttcore::Arch> arch)
+      : arch(arch) {}
+
+  std::optional<ttcore::Arch> arch;
+};
+
+/// Explicit configuration constraints normalized without inspecting tile ops.
+struct KernelConfigPolicy {
+  ConfigSelection fp32DestAccumulation = ConfigSelection::Auto;
+  ConfigSelection dstSynchronization = ConfigSelection::Auto;
+  bool preferFullFp32Reduce = true;
+  bool preferFullFp32Matmul = true;
+  bool allowFPUBinary = true;
+  std::optional<llvm::SmallVector<int32_t>> unpackToDestFp32;
+
+  static FailureOr<KernelConfigPolicy>
+  get(func::FuncOp function, StringRef fp32DestAccumulation,
+      StringRef dstSynchronization, bool preferFullFp32Reduce,
+      bool preferFullFp32Matmul, bool allowFPUBinary);
+};
+
+/// Strategy selected for one tile operation with alternatives.
+struct TileExecutionDecision {
+  Operation *operation;
+  TileExecutionStrategy strategy;
+};
+
+/// One dataflow-buffer operand and the facts used to determine unpack mode.
+struct DFBInputUse {
+  int64_t dfbIndex;
+  Operation *consumer;
+  unsigned operandIndex;
+  TilePrimitive primitive;
+  TileOperandRoute route;
+  Type elementType;
+};
+
+/// One operand or result that requires a kernel-wide DST mode.
+struct DstModeUse {
+  Operation *operation;
+  TilePrimitive primitive;
+  Type elementType;
+};
+
+/// Requirements imposed by one legal execution strategy.
+struct TileExecutionOption {
+  TileExecutionStrategy strategy;
+  llvm::SmallVector<DFBInputUse> dfbInputUses;
+  llvm::SmallVector<DstModeUse> dstModeUses;
+};
+
+/// Legal strategy alternatives retained for kernel-wide resolution.
+struct TileExecutionChoice {
+  Operation *operation;
+  llvm::SmallVector<TileExecutionOption, 2> options;
+  bool hasExplicitStrategy = false;
+};
+
+/// One operation eligible for optional full-fp32 accumulation.
+struct FullFp32AccumulationUse {
+  Operation *operation;
+  FullFp32AccumulationKind kind;
+};
+
+/// Target-independent requirements collected from immutable TTL IR.
+struct KernelRequirements {
+  llvm::SmallVector<DFBInputUse> dfbInputUses;
+  llvm::SmallVector<DstModeUse> dstModeUses;
+  llvm::SmallVector<FullFp32AccumulationUse> fullFp32AccumulationUses;
+  llvm::SmallVector<TileExecutionChoice, 0> tileStrategyChoices;
+};
+
+/// Complete configuration selected before any IR mutation.
+struct KernelConfigPlan {
+  DstMode dstMode;
+  DstSyncMode dstSyncMode;
+  llvm::SmallVector<int32_t> unpackToDestFp32;
+  llvm::SmallVector<TileExecutionDecision> tileStrategies;
+};
+
+/// Collect target-independent requirements and legal tile strategies.
+FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function);
+
+/// Resolve one complete configuration from target, policy, and requirements.
+FailureOr<KernelConfigPlan> resolveKernelConfig(
+    func::FuncOp function, const KernelTargetEnvironment &target,
+    const KernelConfigPolicy &policy, const KernelRequirements &requirements);
+
+/// Apply a validated plan without deriving additional configuration policy.
+LogicalResult applyKernelConfigPlan(func::FuncOp function,
+                                    const KernelConfigPlan &plan);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_COMPUTEKERNELCONFIGANALYSIS_H

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -45,6 +45,12 @@ enum class DFBUnpackMode {
   UnpackToDestination,
 };
 
+/// Target support and fallback warning for a preferred accumulation mode.
+struct FullFp32AccumulationSupport {
+  bool supported;
+  std::optional<StringRef> fallbackWarning;
+};
+
 /// One target-supported combination of shared destination width and per-DFB
 /// unpack selection.
 struct DFBHardwareConfiguration {
@@ -64,8 +70,8 @@ public:
   virtual bool supportsDestinationElementWidth(
       TilePrimitive primitive, Type elementType,
       DestinationElementWidth destinationElementWidth) const = 0;
-  virtual bool
-  supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const = 0;
+  virtual FullFp32AccumulationSupport
+  getFullFp32AccumulationSupport(FullFp32AccumulationKind kind) const = 0;
   virtual llvm::SmallVector<DFBHardwareConfiguration, 4>
   getSupportedDFBConfigurations(TilePrimitive primitive, TileOperandRoute route,
                                 Type elementType) const = 0;

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <memory>
 #include <optional>
 #include <utility>
 
@@ -24,10 +25,11 @@ enum class ConfigSelection {
   Disabled,
 };
 
-/// Element format used by the kernel's DST register file.
-enum class DstMode {
-  Default,
-  Fp32,
+/// Physical element width used by the kernel's destination register file.
+/// Tensix exposes only 16-bit and 32-bit destination element configurations.
+enum class DestinationElementWidth {
+  Bits16,
+  Bits32,
 };
 
 /// Synchronization protocol used for the kernel's DST register file.
@@ -36,30 +38,40 @@ enum class DstSyncMode {
   Full,
 };
 
-/// Unpack mode assigned to one dataflow buffer for the complete kernel.
+/// Per-DFB unpack selection shared by the complete kernel. A target defines
+/// when each selection changes the primitive's physical operand route.
 enum class DFBUnpackMode {
   Default,
-  UnpackToDestFp32,
+  UnpackToDestination,
+};
+
+/// One target-supported combination of shared destination width and per-DFB
+/// unpack selection.
+struct DFBHardwareConfiguration {
+  DestinationElementWidth destinationElementWidth;
+  DFBUnpackMode unpackMode;
 };
 
 /// Immutable hardware and backend capabilities for one kernel target.
 class KernelTargetEnvironment {
 public:
-  static FailureOr<KernelTargetEnvironment> get(func::FuncOp function);
+  virtual ~KernelTargetEnvironment() = default;
 
-  std::optional<ttcore::Arch> getArch() const { return arch; }
-  bool supportsDstMode(TilePrimitive primitive, Type elementType,
-                       DstMode mode) const;
-  bool supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const;
-  DFBUnpackMode getRequiredUnpackMode(TilePrimitive primitive,
-                                      TileOperandRoute route,
-                                      Type elementType) const;
+  static FailureOr<std::unique_ptr<KernelTargetEnvironment>>
+  get(func::FuncOp function);
 
-private:
-  explicit KernelTargetEnvironment(std::optional<ttcore::Arch> arch)
-      : arch(arch) {}
+  virtual std::optional<ttcore::Arch> getArch() const = 0;
+  virtual bool supportsDestinationElementWidth(
+      TilePrimitive primitive, Type elementType,
+      DestinationElementWidth destinationElementWidth) const = 0;
+  virtual bool
+  supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const = 0;
+  virtual llvm::SmallVector<DFBHardwareConfiguration, 4>
+  getSupportedDFBConfigurations(TilePrimitive primitive, TileOperandRoute route,
+                                Type elementType) const = 0;
 
-  std::optional<ttcore::Arch> arch;
+protected:
+  KernelTargetEnvironment() = default;
 };
 
 /// Explicit configuration constraints normalized without inspecting tile ops.
@@ -93,8 +105,8 @@ struct DFBInputUse {
   Type elementType;
 };
 
-/// One operand or result that requires a kernel-wide DST mode.
-struct DstModeUse {
+/// One operand or result that constrains the shared destination width.
+struct DestinationUse {
   Operation *operation;
   TilePrimitive primitive;
   Type elementType;
@@ -104,7 +116,7 @@ struct DstModeUse {
 struct TileExecutionOption {
   TileExecutionStrategy strategy;
   llvm::SmallVector<DFBInputUse> dfbInputUses;
-  llvm::SmallVector<DstModeUse> dstModeUses;
+  llvm::SmallVector<DestinationUse> destinationUses;
 };
 
 /// Legal strategy alternatives retained for kernel-wide resolution.
@@ -123,7 +135,7 @@ struct FullFp32AccumulationUse {
 /// Target-independent requirements collected from immutable TTL IR.
 struct KernelRequirements {
   llvm::SmallVector<DFBInputUse> dfbInputUses;
-  llvm::SmallVector<DstModeUse> dstModeUses;
+  llvm::SmallVector<DestinationUse> destinationUses;
   llvm::SmallVector<FullFp32AccumulationUse> fullFp32AccumulationUses;
   llvm::SmallVector<TileExecutionChoice, 0> tileStrategyChoices;
 };
@@ -132,7 +144,9 @@ struct KernelRequirements {
 /// before mutating IR because its decisions contain operation pointers.
 class KernelConfigPlan {
 public:
-  DstMode getDstMode() const { return dstMode; }
+  DestinationElementWidth getDestinationElementWidth() const {
+    return destinationElementWidth;
+  }
   DstSyncMode getDstSyncMode() const { return dstSyncMode; }
   llvm::ArrayRef<int32_t> getUnpackToDestFp32() const {
     return unpackToDestFp32;
@@ -146,14 +160,15 @@ private:
       func::FuncOp function, const KernelTargetEnvironment &target,
       const KernelConfigPolicy &policy, const KernelRequirements &requirements);
 
-  KernelConfigPlan(DstMode dstMode, DstSyncMode dstSyncMode,
+  KernelConfigPlan(DestinationElementWidth destinationElementWidth,
+                   DstSyncMode dstSyncMode,
                    llvm::SmallVector<int32_t> unpackToDestFp32,
                    llvm::SmallVector<TileExecutionDecision> tileStrategies)
-      : dstMode(dstMode), dstSyncMode(dstSyncMode),
-        unpackToDestFp32(std::move(unpackToDestFp32)),
+      : destinationElementWidth(destinationElementWidth),
+        dstSyncMode(dstSyncMode), unpackToDestFp32(std::move(unpackToDestFp32)),
         tileStrategies(std::move(tileStrategies)) {}
 
-  DstMode dstMode;
+  DestinationElementWidth destinationElementWidth;
   DstSyncMode dstSyncMode;
   llvm::SmallVector<int32_t> unpackToDestFp32;
   llvm::SmallVector<TileExecutionDecision> tileStrategies;

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -9,9 +9,11 @@
 #include "ttlang/Dialect/TTL/IR/TileExecution.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <optional>
+#include <utility>
 
 namespace mlir::tt::ttl {
 
@@ -126,8 +128,31 @@ struct KernelRequirements {
   llvm::SmallVector<TileExecutionChoice, 0> tileStrategyChoices;
 };
 
-/// Complete configuration selected before any IR mutation.
-struct KernelConfigPlan {
+/// Complete configuration selected before any IR mutation. Apply the plan
+/// before mutating IR because its decisions contain operation pointers.
+class KernelConfigPlan {
+public:
+  DstMode getDstMode() const { return dstMode; }
+  DstSyncMode getDstSyncMode() const { return dstSyncMode; }
+  llvm::ArrayRef<int32_t> getUnpackToDestFp32() const {
+    return unpackToDestFp32;
+  }
+  llvm::ArrayRef<TileExecutionDecision> getTileStrategies() const {
+    return tileStrategies;
+  }
+
+private:
+  friend FailureOr<KernelConfigPlan> resolveKernelConfig(
+      func::FuncOp function, const KernelTargetEnvironment &target,
+      const KernelConfigPolicy &policy, const KernelRequirements &requirements);
+
+  KernelConfigPlan(DstMode dstMode, DstSyncMode dstSyncMode,
+                   llvm::SmallVector<int32_t> unpackToDestFp32,
+                   llvm::SmallVector<TileExecutionDecision> tileStrategies)
+      : dstMode(dstMode), dstSyncMode(dstSyncMode),
+        unpackToDestFp32(std::move(unpackToDestFp32)),
+        tileStrategies(std::move(tileStrategies)) {}
+
   DstMode dstMode;
   DstSyncMode dstSyncMode;
   llvm::SmallVector<int32_t> unpackToDestFp32;
@@ -142,9 +167,8 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
     func::FuncOp function, const KernelTargetEnvironment &target,
     const KernelConfigPolicy &policy, const KernelRequirements &requirements);
 
-/// Apply a validated plan without deriving additional configuration policy.
-LogicalResult applyKernelConfigPlan(func::FuncOp function,
-                                    const KernelConfigPlan &plan);
+/// Apply a resolved plan without deriving additional configuration policy.
+void applyKernelConfigPlan(func::FuncOp function, const KernelConfigPlan &plan);
 
 } // namespace mlir::tt::ttl
 

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -189,11 +189,11 @@ getDefaultTileExecutionInfo(Operation *operation,
     info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
     return info;
   }
-  if (isa<TileReduceOp>(operation)) {
+  if (auto reduce = dyn_cast<TileReduceOp>(operation)) {
     info.primitive = TilePrimitive::Reduce;
     info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
     info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
-    switch (cast<TileReduceOp>(operation).getReduceDim()) {
+    switch (reduce.getReduceDim()) {
     case ttkernel::ReduceDim::Row:
       info.fullFp32Accumulation = FullFp32AccumulationKind::ReduceRow;
       break;

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -257,6 +257,10 @@ getDefaultTileExecutionInfo(Operation *operation,
 
 LogicalResult verifyTileExecutionInfo(Operation *operation,
                                       const TileExecutionInfo &info) {
+  if (info.primitive == TilePrimitive::Unknown) {
+    operation->emitOpError("does not define a tile execution primitive");
+    return failure();
+  }
   if (info.operandRoutes.size() != operation->getNumOperands()) {
     operation->emitOpError() << "defines " << info.operandRoutes.size()
                              << " tile operand routes for "
@@ -368,22 +372,20 @@ LogicalResult verifyTileExecutionSemantics(Operation *root) {
       return WalkResult::interrupt();
     }
     FailureOr<TileExecutionInfo> info = getSelectedTileExecutionInfo(operation);
-    if (succeeded(info) &&
-        succeeded(verifyTileExecutionInfo(operation, *info))) {
-      return WalkResult::advance();
-    }
-    if (succeeded(info)) {
+    if (failed(info)) {
+      if (!legalStrategies.empty()) {
+        operation->emitOpError()
+            << "requires a selected " << kTileExecutionStrategyAttrName
+            << " attribute; run ttl-set-compute-kernel-config before DST "
+               "assignment, scheduling, or lowering";
+      } else {
+        operation->emitOpError("has no tile execution semantics");
+      }
       return WalkResult::interrupt();
     }
-    if (!legalStrategies.empty()) {
-      operation->emitOpError()
-          << "requires a selected " << kTileExecutionStrategyAttrName
-          << " attribute; run ttl-set-compute-kernel-config before DST "
-             "assignment, scheduling, or lowering";
-    } else {
-      operation->emitOpError("has no tile execution semantics");
-    }
-    return WalkResult::interrupt();
+    return failed(verifyTileExecutionInfo(operation, *info))
+               ? WalkResult::interrupt()
+               : WalkResult::advance();
   });
   return failure(walkResult.wasInterrupted());
 }

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -6,7 +6,6 @@
 
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir::tt::ttl {
 
@@ -305,23 +304,46 @@ getSelectedTileExecutionInfo(Operation *operation) {
   return executionOp.getTileExecutionInfo(*strategy);
 }
 
+LogicalResult
+verifyTileExecutionStrategy(Operation *operation,
+                            ArrayRef<TileExecutionStrategy> legalStrategies) {
+  Attribute rawStrategy = operation->getAttr(kTileExecutionStrategyAttrName);
+  auto strategyAttr = dyn_cast_or_null<TileExecutionStrategyAttr>(rawStrategy);
+  if (rawStrategy && !strategyAttr) {
+    operation->emitOpError()
+        << kTileExecutionStrategyAttrName
+        << " must be a #ttl.tile_execution_strategy attribute";
+    return failure();
+  }
+  if (legalStrategies.empty() && strategyAttr) {
+    operation->emitOpError()
+        << kTileExecutionStrategyAttrName
+        << " is only valid on tile operations with execution-strategy "
+           "alternatives";
+    return failure();
+  }
+  if (strategyAttr &&
+      !llvm::is_contained(legalStrategies, strategyAttr.getValue())) {
+    operation->emitOpError() << "explicit " << kTileExecutionStrategyAttrName
+                             << " is not legal for its operands";
+    return failure();
+  }
+  return success();
+}
+
 /// Return an operand route after all required strategies have been selected.
 static TileOperandRoute getRequiredOperandRoute(OpOperand &operand) {
-  if (!isa<TileExecutionOpInterface>(operand.getOwner())) {
-    if (isTileComputeOp(operand.getOwner())) {
-      llvm::report_fatal_error(
-          "tile operation does not implement TileExecutionOpInterface");
-    }
+  auto executionOp = dyn_cast<TileExecutionOpInterface>(operand.getOwner());
+  if (!executionOp) {
+    assert(!isTileComputeOp(operand.getOwner()) &&
+           "tile operation must implement TileExecutionOpInterface");
     return TileOperandRoute::None;
   }
   FailureOr<TileExecutionInfo> info =
       getSelectedTileExecutionInfo(operand.getOwner());
-  if (failed(info)) {
-    llvm::report_fatal_error("tile execution strategy is unresolved");
-  }
-  if (operand.getOperandNumber() >= info->operandRoutes.size()) {
-    llvm::report_fatal_error("tile execution operand route is missing");
-  }
+  assert(succeeded(info) && "tile execution strategy must be resolved");
+  assert(operand.getOperandNumber() < info->operandRoutes.size() &&
+         "tile execution semantics must define every operand route");
   return info->operandRoutes[operand.getOperandNumber()];
 }
 
@@ -332,43 +354,27 @@ bool isDstInput(OpOperand &operand) {
 bool isDstInputMaterializedByOperation(OpOperand &operand) {
   FailureOr<TileExecutionInfo> info =
       getSelectedTileExecutionInfo(operand.getOwner());
-  if (failed(info)) {
-    llvm::report_fatal_error("tile execution strategy is unresolved");
-  }
-  if (operand.getOperandNumber() >=
-      info->dstOperandsMaterializedByOperation.size()) {
-    llvm::report_fatal_error(
-        "tile execution DST materialization entry is missing");
-  }
+  assert(succeeded(info) && "tile execution strategy must be resolved");
+  assert(operand.getOperandNumber() <
+             info->dstOperandsMaterializedByOperation.size() &&
+         "tile execution semantics must define every DST materialization bit");
   return info->dstOperandsMaterializedByOperation.test(
       operand.getOperandNumber());
 }
 
 LogicalResult verifyTileExecutionSemantics(Operation *root) {
-  WalkResult walkResult = root->walk([&](TileExecutionOpInterface executionOp) {
-    Operation *operation = executionOp.getOperation();
+  WalkResult walkResult = root->walk([&](Operation *operation) {
+    auto executionOp = dyn_cast<TileExecutionOpInterface>(operation);
+    if (!executionOp) {
+      if (isTileComputeOp(operation)) {
+        operation->emitOpError("does not implement TileExecutionOpInterface");
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    }
     SmallVector<TileExecutionStrategy, 2> legalStrategies =
         executionOp.getLegalExecutionStrategies();
-    Attribute rawStrategy = operation->getAttr(kTileExecutionStrategyAttrName);
-    auto strategyAttr =
-        dyn_cast_or_null<TileExecutionStrategyAttr>(rawStrategy);
-    if (rawStrategy && !strategyAttr) {
-      operation->emitOpError()
-          << kTileExecutionStrategyAttrName
-          << " must be a #ttl.tile_execution_strategy attribute";
-      return WalkResult::interrupt();
-    }
-    if (legalStrategies.empty() && strategyAttr) {
-      operation->emitOpError()
-          << kTileExecutionStrategyAttrName
-          << " is only valid on tile operations with execution-strategy "
-             "alternatives";
-      return WalkResult::interrupt();
-    }
-    if (strategyAttr &&
-        !llvm::is_contained(legalStrategies, strategyAttr.getValue())) {
-      operation->emitOpError() << kTileExecutionStrategyAttrName
-                               << " is not legal for the operation operands";
+    if (failed(verifyTileExecutionStrategy(operation, legalStrategies))) {
       return WalkResult::interrupt();
     }
     FailureOr<TileExecutionInfo> info = getSelectedTileExecutionInfo(operation);
@@ -452,30 +458,35 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
 
 /// Interface defaults require resolved DST operands because callers use this
 /// after DST assignment, where unresolved tile residency is invalid IR.
-static void appendDstOperandFootprint(SmallVectorImpl<DstFootprint> &footprints,
-                                      Value operand) {
+static LogicalResult
+appendDstOperandFootprint(SmallVectorImpl<DstFootprint> &footprints,
+                          Value operand) {
   if (!isTileValue(operand)) {
-    return;
+    return success();
   }
   FailureOr<DstFootprint> footprint = getDstFootprint(operand);
   if (failed(footprint)) {
-    llvm::report_fatal_error("DST operand has no DST footprint");
+    return failure();
   }
   footprints.push_back(*footprint);
+  return success();
 }
 
-SmallVector<DstFootprint, 2> getDefaultDstReadFootprints(Operation *op) {
+FailureOr<SmallVector<DstFootprint, 2>>
+getDefaultDstReadFootprints(Operation *op) {
   SmallVector<DstFootprint, 2> footprints;
   FailureOr<TileExecutionInfo> info = getSelectedTileExecutionInfo(op);
   if (failed(info)) {
-    llvm::report_fatal_error("tile execution semantics are unresolved");
+    return failure();
   }
   for (OpOperand &operand : op->getOpOperands()) {
     if (info->operandRoutes[operand.getOperandNumber()] !=
         TileOperandRoute::Dst) {
       continue;
     }
-    appendDstOperandFootprint(footprints, operand.get());
+    if (failed(appendDstOperandFootprint(footprints, operand.get()))) {
+      return failure();
+    }
   }
   return footprints;
 }
@@ -574,7 +585,12 @@ FailureOr<SmallVector<int64_t>> getConstantDstReadIndices(Operation *op) {
   if (!dstAccess) {
     return SmallVector<int64_t>{};
   }
-  return getConstantDstIndices(dstAccess.getDstReadFootprints());
+  FailureOr<SmallVector<DstFootprint, 2>> footprints =
+      dstAccess.getDstReadFootprints();
+  if (failed(footprints)) {
+    return failure();
+  }
+  return getConstantDstIndices(*footprints);
 }
 
 FailureOr<SmallVector<int64_t>> getConstantDstWriteIndices(Operation *op) {
@@ -605,14 +621,14 @@ TileOpCategory classifyTileOp(Operation *op) {
   if (isa<TileMatmulBlockOp>(op)) {
     return TileOpCategory::FPUBinary;
   }
-  // TODO: add TileOpCategory::Transpose case when TTL transpose op is added.
+  if (isa<TileTransposeOp>(op)) {
+    return TileOpCategory::Transpose;
+  }
 
   if (op->hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
     FailureOr<TileExecutionStrategy> strategy =
         getSelectedTileExecutionStrategy(op);
-    if (failed(strategy)) {
-      llvm::report_fatal_error("tile execution strategy is unresolved");
-    }
+    assert(succeeded(strategy) && "tile execution strategy must be resolved");
     return *strategy == TileExecutionStrategy::FPU ? TileOpCategory::FPUBinary
                                                    : TileOpCategory::SFPUBinary;
   }

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir::tt::ttl {
 
@@ -303,14 +304,20 @@ getSelectedTileExecutionInfo(Operation *operation) {
 /// Return an operand route after all required strategies have been selected.
 static TileOperandRoute getRequiredOperandRoute(OpOperand &operand) {
   if (!isa<TileExecutionOpInterface>(operand.getOwner())) {
-    assert(!isTileComputeOp(operand.getOwner()) &&
-           "tile operation does not implement TileExecutionOpInterface");
+    if (isTileComputeOp(operand.getOwner())) {
+      llvm::report_fatal_error(
+          "tile operation does not implement TileExecutionOpInterface");
+    }
     return TileOperandRoute::None;
   }
   FailureOr<TileExecutionInfo> info =
       getSelectedTileExecutionInfo(operand.getOwner());
-  assert(succeeded(info) && "tile execution strategy is unresolved");
-  assert(operand.getOperandNumber() < info->operandRoutes.size());
+  if (failed(info)) {
+    llvm::report_fatal_error("tile execution strategy is unresolved");
+  }
+  if (operand.getOperandNumber() >= info->operandRoutes.size()) {
+    llvm::report_fatal_error("tile execution operand route is missing");
+  }
   return info->operandRoutes[operand.getOperandNumber()];
 }
 
@@ -321,9 +328,14 @@ bool isDstInput(OpOperand &operand) {
 bool isDstInputMaterializedByOperation(OpOperand &operand) {
   FailureOr<TileExecutionInfo> info =
       getSelectedTileExecutionInfo(operand.getOwner());
-  assert(succeeded(info) && "tile execution strategy is unresolved");
-  assert(operand.getOperandNumber() <
-         info->dstOperandsMaterializedByOperation.size());
+  if (failed(info)) {
+    llvm::report_fatal_error("tile execution strategy is unresolved");
+  }
+  if (operand.getOperandNumber() >=
+      info->dstOperandsMaterializedByOperation.size()) {
+    llvm::report_fatal_error(
+        "tile execution DST materialization entry is missing");
+  }
   return info->dstOperandsMaterializedByOperation.test(
       operand.getOperandNumber());
 }
@@ -436,7 +448,7 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
   return lhsType.getDimSize(0) * rhsType.getDimSize(1);
 }
 
-/// Interface defaults assert for missing DST operands because callers use this
+/// Interface defaults require resolved DST operands because callers use this
 /// after DST assignment, where unresolved tile residency is invalid IR.
 static void appendDstOperandFootprint(SmallVectorImpl<DstFootprint> &footprints,
                                       Value operand) {
@@ -444,14 +456,18 @@ static void appendDstOperandFootprint(SmallVectorImpl<DstFootprint> &footprints,
     return;
   }
   FailureOr<DstFootprint> footprint = getDstFootprint(operand);
-  assert(succeeded(footprint) && "DST operand has no DST footprint");
+  if (failed(footprint)) {
+    llvm::report_fatal_error("DST operand has no DST footprint");
+  }
   footprints.push_back(*footprint);
 }
 
 SmallVector<DstFootprint, 2> getDefaultDstReadFootprints(Operation *op) {
   SmallVector<DstFootprint, 2> footprints;
   FailureOr<TileExecutionInfo> info = getSelectedTileExecutionInfo(op);
-  assert(succeeded(info) && "tile execution semantics are unresolved");
+  if (failed(info)) {
+    llvm::report_fatal_error("tile execution semantics are unresolved");
+  }
   for (OpOperand &operand : op->getOpOperands()) {
     if (info->operandRoutes[operand.getOperandNumber()] !=
         TileOperandRoute::Dst) {
@@ -592,7 +608,9 @@ TileOpCategory classifyTileOp(Operation *op) {
   if (op->hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
     FailureOr<TileExecutionStrategy> strategy =
         getSelectedTileExecutionStrategy(op);
-    assert(succeeded(strategy) && "tile execution strategy is unresolved");
+    if (failed(strategy)) {
+      llvm::report_fatal_error("tile execution strategy is unresolved");
+    }
     return *strategy == TileExecutionStrategy::FPU ? TileOpCategory::FPUBinary
                                                    : TileOpCategory::SFPUBinary;
   }

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -152,6 +152,7 @@ getDefaultTileExecutionInfo(Operation *operation,
   TileExecutionInfo info;
   info.operandRoutes.assign(operation->getNumOperands(),
                             TileOperandRoute::None);
+  info.dstOperandsMaterializedByOperation.resize(operation->getNumOperands());
   info.resultInDst = operation->hasTrait<TTLDstResultOpTrait>();
 
   if (isa<CopyTileOp>(operation)) {
@@ -173,8 +174,18 @@ getDefaultTileExecutionInfo(Operation *operation,
     info.operandRoutes[0] = TileOperandRoute::Dst;
     return info;
   }
-  if (isa<TileBcastOp>(operation)) {
-    info.primitive = TilePrimitive::Broadcast;
+  if (auto broadcast = dyn_cast<TileBcastOp>(operation)) {
+    switch (broadcast.getBcastType()) {
+    case BcastType::Col:
+      info.primitive = TilePrimitive::BroadcastColumn;
+      break;
+    case BcastType::Row:
+      info.primitive = TilePrimitive::BroadcastRow;
+      break;
+    case BcastType::Scalar:
+      info.primitive = TilePrimitive::BroadcastScalar;
+      break;
+    }
     info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
     return info;
   }
@@ -210,6 +221,7 @@ getDefaultTileExecutionInfo(Operation *operation,
     info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
     if (matmul.getAccumulator()) {
       info.operandRoutes[2] = TileOperandRoute::Dst;
+      info.dstOperandsMaterializedByOperation.set(2);
     }
     info.fullFp32Accumulation = FullFp32AccumulationKind::Matmul;
     info.accumulatesIntoDst = true;
@@ -244,13 +256,21 @@ getDefaultTileExecutionInfo(Operation *operation,
 
 LogicalResult verifyTileExecutionInfo(Operation *operation,
                                       const TileExecutionInfo &info) {
-  if (info.operandRoutes.size() == operation->getNumOperands()) {
-    return success();
+  if (info.operandRoutes.size() != operation->getNumOperands()) {
+    operation->emitOpError() << "defines " << info.operandRoutes.size()
+                             << " tile operand routes for "
+                             << operation->getNumOperands() << " operands";
+    return failure();
   }
-  operation->emitOpError() << "defines " << info.operandRoutes.size()
-                           << " tile operand routes for "
-                           << operation->getNumOperands() << " operands";
-  return failure();
+  if (info.dstOperandsMaterializedByOperation.size() !=
+      operation->getNumOperands()) {
+    operation->emitOpError()
+        << "defines " << info.dstOperandsMaterializedByOperation.size()
+        << " DST operand materialization entries for "
+        << operation->getNumOperands() << " operands";
+    return failure();
+  }
+  return success();
 }
 
 FailureOr<TileExecutionStrategy>
@@ -296,6 +316,16 @@ static TileOperandRoute getRequiredOperandRoute(OpOperand &operand) {
 
 bool isDstInput(OpOperand &operand) {
   return getRequiredOperandRoute(operand) == TileOperandRoute::Dst;
+}
+
+bool isDstInputMaterializedByOperation(OpOperand &operand) {
+  FailureOr<TileExecutionInfo> info =
+      getSelectedTileExecutionInfo(operand.getOwner());
+  assert(succeeded(info) && "tile execution strategy is unresolved");
+  assert(operand.getOperandNumber() <
+         info->dstOperandsMaterializedByOperation.size());
+  return info->dstOperandsMaterializedByOperation.test(
+      operand.getOperandNumber());
 }
 
 LogicalResult verifyTileExecutionSemantics(Operation *root) {

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -98,6 +98,254 @@ LogicalResult verifyResolvedDFBIdentities(ModuleOp moduleOp,
       getDFBId, "DFB lifecycle", DFBIdentityRequirement::Finalized);
 }
 
+/// FPU binary execution requires both operands to address the same tile
+/// coordinates.
+static bool hasMatchingFPUInputIndices(Operation *operation) {
+  assert(operation->getNumOperands() >= 2 &&
+         "binary tile op with execution alternatives must have two data "
+         "operands");
+  Value lhs = operation->getOperand(0);
+  Value rhs = operation->getOperand(1);
+
+  if (auto lhsArgument = dyn_cast<BlockArgument>(lhs)) {
+    auto rhsArgument = dyn_cast<BlockArgument>(rhs);
+    if (!rhsArgument || lhsArgument.getOwner() != rhsArgument.getOwner()) {
+      return false;
+    }
+    auto computeOp =
+        dyn_cast_or_null<ComputeOp>(lhsArgument.getOwner()->getParentOp());
+    if (!computeOp) {
+      return false;
+    }
+    unsigned numInputs = computeOp.getNumInputs();
+    if (lhsArgument.getArgNumber() >= numInputs ||
+        rhsArgument.getArgNumber() >= numInputs) {
+      return false;
+    }
+    auto indexingMaps = computeOp.getIndexingMapsArray();
+    return indexingMaps[lhsArgument.getArgNumber()] ==
+           indexingMaps[rhsArgument.getArgNumber()];
+  }
+
+  auto lhsExtract = lhs.getDefiningOp<tensor::ExtractOp>();
+  auto rhsExtract = rhs.getDefiningOp<tensor::ExtractOp>();
+  return lhsExtract && rhsExtract &&
+         lhsExtract.getIndices() == rhsExtract.getIndices();
+}
+
+SmallVector<TileExecutionStrategy, 2>
+getDefaultLegalTileExecutionStrategies(Operation *operation) {
+  if (!operation->hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
+    return {};
+  }
+
+  SmallVector<TileExecutionStrategy, 2> strategies{TileExecutionStrategy::SFPU};
+  if (hasMatchingFPUInputIndices(operation)) {
+    strategies.insert(strategies.begin(), TileExecutionStrategy::FPU);
+  }
+  return strategies;
+}
+
+FailureOr<TileExecutionInfo>
+getDefaultTileExecutionInfo(Operation *operation,
+                            std::optional<TileExecutionStrategy> strategy) {
+  TileExecutionInfo info;
+  info.operandRoutes.assign(operation->getNumOperands(),
+                            TileOperandRoute::None);
+  info.resultInDst = operation->hasTrait<TTLDstResultOpTrait>();
+
+  if (isa<CopyTileOp>(operation)) {
+    info.primitive = TilePrimitive::Copy;
+    info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
+    return info;
+  }
+  if (isa<CopyDstOp>(operation)) {
+    info.primitive = TilePrimitive::Copy;
+    info.operandRoutes[0] = TileOperandRoute::Dst;
+    return info;
+  }
+  if (isa<DstIndexOp>(operation)) {
+    info.primitive = TilePrimitive::DstIndex;
+    return info;
+  }
+  if (isa<TileStoreOp>(operation)) {
+    info.primitive = TilePrimitive::Store;
+    info.operandRoutes[0] = TileOperandRoute::Dst;
+    return info;
+  }
+  if (isa<TileBcastOp>(operation)) {
+    info.primitive = TilePrimitive::Broadcast;
+    info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
+    return info;
+  }
+  if (isa<TileReduceOp>(operation)) {
+    info.primitive = TilePrimitive::Reduce;
+    info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
+    info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
+    switch (cast<TileReduceOp>(operation).getReduceDim()) {
+    case ttkernel::ReduceDim::Row:
+      info.fullFp32Accumulation = FullFp32AccumulationKind::ReduceRow;
+      break;
+    case ttkernel::ReduceDim::Col:
+      info.fullFp32Accumulation = FullFp32AccumulationKind::ReduceColumn;
+      break;
+    case ttkernel::ReduceDim::Scalar:
+      info.fullFp32Accumulation = FullFp32AccumulationKind::ReduceScalar;
+      break;
+    }
+    return info;
+  }
+  if (isa<TileTransposeOp>(operation)) {
+    info.primitive = TilePrimitive::Transpose;
+    info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
+    return info;
+  }
+  if (isa<TileFillOp>(operation)) {
+    info.primitive = TilePrimitive::Fill;
+    return info;
+  }
+  if (auto matmul = dyn_cast<TileMatmulBlockOp>(operation)) {
+    info.primitive = TilePrimitive::Matmul;
+    info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
+    info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
+    if (matmul.getAccumulator()) {
+      info.operandRoutes[2] = TileOperandRoute::Dst;
+    }
+    info.fullFp32Accumulation = FullFp32AccumulationKind::Matmul;
+    info.accumulatesIntoDst = true;
+    return info;
+  }
+  if (operation->hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
+    if (!strategy) {
+      return failure();
+    }
+    info.primitive = TilePrimitive::ElementwiseBinary;
+    TileOperandRoute route = *strategy == TileExecutionStrategy::FPU
+                                 ? TileOperandRoute::DataflowBuffer
+                                 : TileOperandRoute::Dst;
+    info.operandRoutes[0] = route;
+    info.operandRoutes[1] = route;
+    info.accumulatesIntoDst = *strategy == TileExecutionStrategy::FPU;
+    return info;
+  }
+  if (operation->hasTrait<TTLTileBinaryOpTrait>()) {
+    info.primitive = TilePrimitive::ElementwiseBinary;
+    info.operandRoutes[0] = TileOperandRoute::Dst;
+    info.operandRoutes[1] = TileOperandRoute::Dst;
+    return info;
+  }
+  if (operation->hasTrait<TTLTileUnaryOpTrait>()) {
+    info.primitive = TilePrimitive::ElementwiseUnary;
+    info.operandRoutes[0] = TileOperandRoute::Dst;
+    return info;
+  }
+  return failure();
+}
+
+LogicalResult verifyTileExecutionInfo(Operation *operation,
+                                      const TileExecutionInfo &info) {
+  if (info.operandRoutes.size() == operation->getNumOperands()) {
+    return success();
+  }
+  operation->emitOpError() << "defines " << info.operandRoutes.size()
+                           << " tile operand routes for "
+                           << operation->getNumOperands() << " operands";
+  return failure();
+}
+
+FailureOr<TileExecutionStrategy>
+getSelectedTileExecutionStrategy(Operation *operation) {
+  auto strategyAttr = operation->getAttrOfType<TileExecutionStrategyAttr>(
+      kTileExecutionStrategyAttrName);
+  if (!strategyAttr) {
+    return failure();
+  }
+  return strategyAttr.getValue();
+}
+
+FailureOr<TileExecutionInfo>
+getSelectedTileExecutionInfo(Operation *operation) {
+  auto executionOp = dyn_cast<TileExecutionOpInterface>(operation);
+  if (!executionOp) {
+    return failure();
+  }
+  if (executionOp.getLegalExecutionStrategies().empty()) {
+    return executionOp.getTileExecutionInfo(std::nullopt);
+  }
+  FailureOr<TileExecutionStrategy> strategy =
+      getSelectedTileExecutionStrategy(operation);
+  if (failed(strategy)) {
+    return failure();
+  }
+  return executionOp.getTileExecutionInfo(*strategy);
+}
+
+/// Return an operand route after all required strategies have been selected.
+static TileOperandRoute getRequiredOperandRoute(OpOperand &operand) {
+  if (!isa<TileExecutionOpInterface>(operand.getOwner())) {
+    assert(!isTileComputeOp(operand.getOwner()) &&
+           "tile operation does not implement TileExecutionOpInterface");
+    return TileOperandRoute::None;
+  }
+  FailureOr<TileExecutionInfo> info =
+      getSelectedTileExecutionInfo(operand.getOwner());
+  assert(succeeded(info) && "tile execution strategy is unresolved");
+  assert(operand.getOperandNumber() < info->operandRoutes.size());
+  return info->operandRoutes[operand.getOperandNumber()];
+}
+
+bool isDstInput(OpOperand &operand) {
+  return getRequiredOperandRoute(operand) == TileOperandRoute::Dst;
+}
+
+LogicalResult verifyTileExecutionSemantics(Operation *root) {
+  WalkResult walkResult = root->walk([&](TileExecutionOpInterface executionOp) {
+    Operation *operation = executionOp.getOperation();
+    SmallVector<TileExecutionStrategy, 2> legalStrategies =
+        executionOp.getLegalExecutionStrategies();
+    Attribute rawStrategy = operation->getAttr(kTileExecutionStrategyAttrName);
+    auto strategyAttr =
+        dyn_cast_or_null<TileExecutionStrategyAttr>(rawStrategy);
+    if (rawStrategy && !strategyAttr) {
+      operation->emitOpError()
+          << kTileExecutionStrategyAttrName
+          << " must be a #ttl.tile_execution_strategy attribute";
+      return WalkResult::interrupt();
+    }
+    if (legalStrategies.empty() && strategyAttr) {
+      operation->emitOpError()
+          << kTileExecutionStrategyAttrName
+          << " is only valid on tile operations with execution-strategy "
+             "alternatives";
+      return WalkResult::interrupt();
+    }
+    if (strategyAttr &&
+        !llvm::is_contained(legalStrategies, strategyAttr.getValue())) {
+      operation->emitOpError() << kTileExecutionStrategyAttrName
+                               << " is not legal for the operation operands";
+      return WalkResult::interrupt();
+    }
+    FailureOr<TileExecutionInfo> info = getSelectedTileExecutionInfo(operation);
+    if (succeeded(info) &&
+        succeeded(verifyTileExecutionInfo(operation, *info))) {
+      return WalkResult::advance();
+    }
+    if (succeeded(info)) {
+      return WalkResult::interrupt();
+    }
+    if (!legalStrategies.empty()) {
+      operation->emitOpError()
+          << "requires a selected " << kTileExecutionStrategyAttrName
+          << " attribute; run ttl-set-compute-kernel-config before DST "
+             "assignment, scheduling, or lowering";
+    } else {
+      operation->emitOpError("has no tile execution semantics");
+    }
+    return WalkResult::interrupt();
+  });
+  return failure(walkResult.wasInterrupted());
+}
+
 std::optional<BcastType> getTileBroadcastType(ArrayRef<int64_t> dims,
                                               int64_t rank) {
   llvm::SmallDenseSet<int64_t> normalizedDims = normalizeDimsToSet(dims, rank);
@@ -170,23 +418,16 @@ static void appendDstOperandFootprint(SmallVectorImpl<DstFootprint> &footprints,
   footprints.push_back(*footprint);
 }
 
-/// Ordinary DST-input tile ops read tile operands from their producer slots.
-/// FPU-eligible strategy-dependent binary ops read from DFBs instead.
 SmallVector<DstFootprint, 2> getDefaultDstReadFootprints(Operation *op) {
   SmallVector<DstFootprint, 2> footprints;
-  if (isa<CopyTileOp, DstIndexOp>(op)) {
-    return footprints;
-  }
-  if (auto store = dyn_cast<TileStoreOp>(op)) {
-    appendDstOperandFootprint(footprints, store.getTile());
-    return footprints;
-  }
-  if (op->hasTrait<TTLDSTInputsTrait>() ||
-      (op->hasTrait<TTLStrategyDependentBinaryOpTrait>() &&
-       !isFPUEligibleBinaryOp(op))) {
-    for (Value operand : op->getOperands()) {
-      appendDstOperandFootprint(footprints, operand);
+  FailureOr<TileExecutionInfo> info = getSelectedTileExecutionInfo(op);
+  assert(succeeded(info) && "tile execution semantics are unresolved");
+  for (OpOperand &operand : op->getOpOperands()) {
+    if (info->operandRoutes[operand.getOperandNumber()] !=
+        TileOperandRoute::Dst) {
+      continue;
     }
+    appendDstOperandFootprint(footprints, operand.get());
   }
   return footprints;
 }
@@ -318,8 +559,12 @@ TileOpCategory classifyTileOp(Operation *op) {
   }
   // TODO: add TileOpCategory::Transpose case when TTL transpose op is added.
 
-  if (isFPUEligibleBinaryOp(op)) {
-    return TileOpCategory::FPUBinary;
+  if (op->hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
+    FailureOr<TileExecutionStrategy> strategy =
+        getSelectedTileExecutionStrategy(op);
+    assert(succeeded(strategy) && "tile execution strategy is unresolved");
+    return *strategy == TileExecutionStrategy::FPU ? TileOpCategory::FPUBinary
+                                                   : TileOpCategory::SFPUBinary;
   }
   // SFPU unary: tile unary ops that operate in-place on DST.
   if (op->hasTrait<TTLTileUnaryOpTrait>()) {

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -43,6 +43,7 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
   {
     TTLSetComputeKernelConfigOptions configOpts;
     configOpts.reduceFullFp32 = options.reduceFullFp32;
+    configOpts.matmulFullFp32 = options.matmulFullFp32;
     configOpts.enableFPUBinaryOps = options.enableFPUBinaryOps;
     pm.addNestedPass<func::FuncOp>(createTTLSetComputeKernelConfig(configOpts));
   }

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(TTLangTTLTransforms
   ComputeOpCreationPlanning.cpp
+  ComputeKernelConfigAnalysis.cpp
   IntermediateDFBPlanning.cpp
   ConvertTTLToTTKernel.cpp
   DFBAcquireReleaseAnalysis.cpp

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -16,8 +16,8 @@
 #include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/Support/ErrorHandling.h"
 
 #include <algorithm>
 #include <limits>
@@ -133,14 +133,13 @@ resolveDataflowBufferIndex(Value value, Operation *consumer) {
 }
 
 /// Return the element type required by configuration queries.
-FailureOr<Type> getRequiredTileElementType(Value value, Operation *operation) {
-  std::optional<Type> elementType = getTileElementType(value.getType());
-  if (!elementType) {
-    operation->emitOpError()
-        << "expected a tile operand or result, got " << value.getType();
-    return failure();
+Type getRequiredTileElementType(Value value) {
+  auto tileType = dyn_cast<ttcore::TileType>(value.getType());
+  if (!tileType) {
+    llvm::report_fatal_error(
+        "kernel configuration requires verified tile execution semantics");
   }
-  return *elementType;
+  return tileType.getElementType();
 }
 
 /// Return a dataflow-buffer operand that the strategy cannot address.
@@ -174,11 +173,10 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     if (route == TileOperandRoute::None) {
       continue;
     }
-    FailureOr<Type> elementType =
-        getRequiredTileElementType(operand.get(), operation);
+    Type elementType = getRequiredTileElementType(operand.get());
     FailureOr<std::optional<int64_t>> dataflowBufferIndex =
         resolveDataflowBufferIndex(operand.get(), operation);
-    if (failed(elementType) || failed(dataflowBufferIndex)) {
+    if (failed(dataflowBufferIndex)) {
       return failure();
     }
     if (route == TileOperandRoute::DataflowBuffer && !*dataflowBufferIndex) {
@@ -190,10 +188,10 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     if (*dataflowBufferIndex) {
       dfbInputUses.push_back({**dataflowBufferIndex, operation,
                               operand.getOperandNumber(), info.primitive, route,
-                              *elementType});
+                              elementType});
     }
     if (route == TileOperandRoute::Dst) {
-      dstModeUses.push_back({operation, info.primitive, *elementType});
+      dstModeUses.push_back({operation, info.primitive, elementType});
     }
   }
 
@@ -204,11 +202,8 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     if (!isa<ttcore::TileType>(result.getType())) {
       continue;
     }
-    FailureOr<Type> elementType = getRequiredTileElementType(result, operation);
-    if (failed(elementType)) {
-      return failure();
-    }
-    dstModeUses.push_back({operation, info.primitive, *elementType});
+    Type elementType = getRequiredTileElementType(result);
+    dstModeUses.push_back({operation, info.primitive, elementType});
   }
   return success();
 }
@@ -309,7 +304,9 @@ void emitDstModeConflict(func::FuncOp function, DstModeEvidence requiresFp32,
   diagnostic.attachNote(requiresDefault.operation->getLoc())
       << "the target does not support f32 DST mode for "
       << requiresDefault.operation->getName() << " with "
-      << requiresDefault.use->elementType << " elements";
+      << requiresDefault.use->elementType
+      << " elements; use an f32 broadcast input or place the broadcast in a "
+         "separate kernel";
 }
 
 struct DstModeConflict {
@@ -824,8 +821,8 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
                              : DstSyncMode::DoubleBuffered;
 
   if (policy.unpackToDestFp32) {
-    return KernelConfigPlan{dstMode, syncMode, *policy.unpackToDestFp32,
-                            std::move(tileStrategies)};
+    return KernelConfigPlan(dstMode, syncMode, *policy.unpackToDestFp32,
+                            std::move(tileStrategies));
   }
 
   SmallVector<int32_t> unpackToDestFp32;
@@ -835,90 +832,27 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
     }
   }
   llvm::sort(unpackToDestFp32);
-  return KernelConfigPlan{dstMode, syncMode, std::move(unpackToDestFp32),
-                          std::move(tileStrategies)};
+  return KernelConfigPlan(dstMode, syncMode, std::move(unpackToDestFp32),
+                          std::move(tileStrategies));
 }
 
-LogicalResult applyKernelConfigPlan(func::FuncOp function,
-                                    const KernelConfigPlan &plan) {
-  if (!std::is_sorted(plan.unpackToDestFp32.begin(),
-                      plan.unpackToDestFp32.end()) ||
-      std::adjacent_find(plan.unpackToDestFp32.begin(),
-                         plan.unpackToDestFp32.end()) !=
-          plan.unpackToDestFp32.end() ||
-      llvm::any_of(plan.unpackToDestFp32, [](int32_t index) {
-        return index < 0 || index >= kMaxCircularBuffers;
-      })) {
-    function.emitOpError(
-        "kernel configuration plan contains invalid dataflow buffer indices");
-    return failure();
-  }
-
-  llvm::SmallPtrSet<Operation *, 8> plannedOperations;
-  for (const TileExecutionDecision &decision : plan.tileStrategies) {
-    if (!decision.operation || !function->isAncestor(decision.operation)) {
-      function.emitOpError(
-          "tile execution plan refers to an operation outside the kernel");
-      return failure();
-    }
-    if (!plannedOperations.insert(decision.operation).second) {
-      decision.operation->emitOpError(
-          "tile execution plan contains duplicate strategy decisions");
-      return failure();
-    }
-    auto executionOp = dyn_cast<TileExecutionOpInterface>(decision.operation);
-    if (!executionOp) {
-      decision.operation->emitOpError(
-          "tile execution plan records a strategy for an unsupported op");
-      return failure();
-    }
-    if (!llvm::is_contained(executionOp.getLegalExecutionStrategies(),
-                            decision.strategy)) {
-      decision.operation->emitOpError(
-          "tile execution plan is inconsistent with the operation operands");
-      return failure();
-    }
-    FailureOr<TileExecutionInfo> info =
-        executionOp.getTileExecutionInfo(decision.strategy);
-    if (failed(info)) {
-      decision.operation->emitOpError(
-          "tile execution plan selects incomplete execution semantics");
-      return failure();
-    }
-    if (failed(verifyTileExecutionInfo(decision.operation, *info))) {
-      return failure();
-    }
-  }
-
-  WalkResult completeness =
-      function.walk([&](TileExecutionOpInterface executionOp) {
-        if (executionOp.getLegalExecutionStrategies().empty() ||
-            plannedOperations.contains(executionOp.getOperation())) {
-          return WalkResult::advance();
-        }
-        executionOp->emitOpError(
-            "tile execution plan does not select an execution strategy");
-        return WalkResult::interrupt();
-      });
-  if (completeness.wasInterrupted()) {
-    return failure();
-  }
-
+void applyKernelConfigPlan(func::FuncOp function,
+                           const KernelConfigPlan &plan) {
   MLIRContext *context = function.getContext();
-  for (const TileExecutionDecision &decision : plan.tileStrategies) {
+  for (const TileExecutionDecision &decision : plan.getTileStrategies()) {
     decision.operation->setAttr(
         kTileExecutionStrategyAttrName,
         TileExecutionStrategyAttr::get(context, decision.strategy));
   }
   function->setAttr(kFp32DestAccEnAttrName,
-                    BoolAttr::get(context, plan.dstMode == DstMode::Fp32));
+                    BoolAttr::get(context, plan.getDstMode() == DstMode::Fp32));
   function->setAttr(
       kDstFullSyncEnAttrName,
-      BoolAttr::get(context, plan.dstSyncMode == DstSyncMode::Full));
-  function->setAttr(kUnpackToDestFp32AttrName,
-                    DenseI32ArrayAttr::get(context, plan.unpackToDestFp32));
+      BoolAttr::get(context, plan.getDstSyncMode() == DstSyncMode::Full));
+  function->setAttr(
+      kUnpackToDestFp32AttrName,
+      DenseI32ArrayAttr::get(context, plan.getUnpackToDestFp32()));
   function->removeAttr(kEnableFPUBinaryOpsAttrName);
-  return success();
 }
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -623,11 +623,10 @@ bool KernelTargetEnvironment::supportsDstMode(TilePrimitive primitive,
   if (mode == DstMode::Default) {
     return true;
   }
-  if ((primitive == TilePrimitive::Broadcast ||
-       primitive == TilePrimitive::Transpose) &&
-      !elementType.isF32()) {
-    // tt-llk #1338: bf16 broadcast and transpose are incorrect when the
-    // kernel configures DST for f32 values.
+  if (primitive == TilePrimitive::BroadcastRow && !elementType.isF32() &&
+      (!arch || *arch == ttcore::Arch::WormholeB0)) {
+    // tt-llk #1338: Wormhole row broadcast is incorrect for bf16 input when
+    // DST stores f32 values.
     return false;
   }
   return true;

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -1014,7 +1014,7 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
       hasDestinationWidth(DestinationElementWidth::Bits32)) {
     destinationElementWidth = DestinationElementWidth::Bits32;
   }
-  if (preferFp32 &&
+  if (preferFp32 && policy.fp32DestAccumulation != ConfigSelection::Disabled &&
       destinationElementWidth == DestinationElementWidth::Bits16) {
     for (Operation *operation : supportedFullFp32Preferences) {
       operation->emitWarning()

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -300,9 +300,9 @@ struct DestinationWidthEvidence {
 };
 
 /// Diagnose the two constraints that eliminated every destination width.
-void emitDestinationWidthConflict(func::FuncOp function,
-                                  DestinationWidthEvidence requires32Bits,
-                                  DestinationWidthEvidence requires16Bits) {
+void emitDestinationWidthConflict(
+    func::FuncOp function, const DestinationWidthEvidence &requires32Bits,
+    const DestinationWidthEvidence &requires16Bits) {
   if (!requires16Bits.use) {
     requires32Bits.operation->emitOpError(
         "requires 32-bit destination elements, but fp32 destination "
@@ -685,8 +685,9 @@ public:
            !requires32BitDestination(elementType);
   }
 
-  bool supportsFullFp32Accumulation(FullFp32AccumulationKind) const override {
-    return true;
+  FullFp32AccumulationSupport
+  getFullFp32AccumulationSupport(FullFp32AccumulationKind) const override {
+    return {true, std::nullopt};
   }
 
   SmallVector<DFBHardwareConfiguration, 4>
@@ -743,9 +744,9 @@ public:
   WormholeKernelTargetEnvironment()
       : WormholeBlackholeKernelTargetEnvironment(ttcore::Arch::WormholeB0) {}
 
-  bool
-  supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const override {
-    return kind == FullFp32AccumulationKind::Matmul;
+  FullFp32AccumulationSupport
+  getFullFp32AccumulationSupport(FullFp32AccumulationKind kind) const override {
+    return {kind == FullFp32AccumulationKind::Matmul, std::nullopt};
   }
 };
 
@@ -755,9 +756,14 @@ public:
   BlackholeKernelTargetEnvironment()
       : WormholeBlackholeKernelTargetEnvironment(ttcore::Arch::Blackhole) {}
 
-  bool
-  supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const override {
-    return kind != FullFp32AccumulationKind::ReduceRow;
+  FullFp32AccumulationSupport
+  getFullFp32AccumulationSupport(FullFp32AccumulationKind kind) const override {
+    if (kind == FullFp32AccumulationKind::ReduceRow) {
+      return {false,
+              "full-fp32 row reduce is unavailable on Blackhole (tt-metal "
+              "#47311); using non-full-fp32 reduce lowering"};
+    }
+    return {true, std::nullopt};
   }
 };
 
@@ -1001,15 +1007,14 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
     if (!preferred) {
       continue;
     }
-    if (target.supportsFullFp32Accumulation(use.kind)) {
+    FullFp32AccumulationSupport support =
+        target.getFullFp32AccumulationSupport(use.kind);
+    if (support.supported) {
       preferFp32 = true;
       continue;
     }
-    if (target.getArch() == ttcore::Arch::Blackhole &&
-        use.kind == FullFp32AccumulationKind::ReduceRow) {
-      use.operation->emitWarning()
-          << "full-fp32 row reduce is unavailable on Blackhole (tt-metal "
-             "#47311); using non-full-fp32 reduce lowering";
+    if (support.fallbackWarning) {
+      use.operation->emitWarning() << *support.fallbackWarning;
     }
   }
   auto hasDestinationWidth = [&](DestinationElementWidth width) {

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -17,7 +17,6 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
-#include "llvm/Support/ErrorHandling.h"
 
 #include <algorithm>
 #include <limits>
@@ -132,14 +131,29 @@ resolveDataflowBufferIndex(Value value, Operation *consumer) {
   return std::optional<int64_t>();
 }
 
-/// Return the element type required by configuration queries.
-Type getRequiredTileElementType(Value value) {
-  auto tileType = dyn_cast<ttcore::TileType>(value.getType());
+/// Return the scalar element type of a tile or tensor of tiles.
+FailureOr<Type> getRequiredTileElementType(Value value,
+                                           Operation *diagnosticOp) {
+  Type valueType = value.getType();
+  auto tileType = dyn_cast<ttcore::TileType>(valueType);
   if (!tileType) {
-    llvm::report_fatal_error(
-        "kernel configuration requires verified tile execution semantics");
+    if (auto tensorType = dyn_cast<TensorType>(valueType)) {
+      tileType = dyn_cast<ttcore::TileType>(tensorType.getElementType());
+    }
+  }
+  if (!tileType) {
+    diagnosticOp->emitOpError()
+        << "expected a tile or tensor-of-tiles operand, got "
+        << value.getType();
+    return failure();
   }
   return tileType.getElementType();
+}
+
+/// Return whether a tile element occupies a full 32-bit DST slot.
+bool requires32BitDestination(Type elementType) {
+  return ttcore::getNumberOfBits(ttcore::elementTypeToDataType(elementType)) ==
+         32;
 }
 
 /// Return a dataflow-buffer operand that the strategy cannot address.
@@ -167,13 +181,17 @@ findUnavailableDataflowBufferOperand(Operation *operation,
 LogicalResult
 appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
                             SmallVectorImpl<DFBInputUse> &dfbInputUses,
-                            SmallVectorImpl<DstModeUse> &dstModeUses) {
+                            SmallVectorImpl<DestinationUse> &destinationUses) {
   for (OpOperand &operand : operation->getOpOperands()) {
     TileOperandRoute route = info.operandRoutes[operand.getOperandNumber()];
     if (route == TileOperandRoute::None) {
       continue;
     }
-    Type elementType = getRequiredTileElementType(operand.get());
+    FailureOr<Type> elementType =
+        getRequiredTileElementType(operand.get(), operation);
+    if (failed(elementType)) {
+      return failure();
+    }
     FailureOr<std::optional<int64_t>> dataflowBufferIndex =
         resolveDataflowBufferIndex(operand.get(), operation);
     if (failed(dataflowBufferIndex)) {
@@ -188,10 +206,10 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     if (*dataflowBufferIndex) {
       dfbInputUses.push_back({**dataflowBufferIndex, operation,
                               operand.getOperandNumber(), info.primitive, route,
-                              elementType});
+                              *elementType});
     }
     if (route == TileOperandRoute::Dst) {
-      dstModeUses.push_back({operation, info.primitive, elementType});
+      destinationUses.push_back({operation, info.primitive, *elementType});
     }
   }
 
@@ -199,11 +217,18 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     return success();
   }
   for (Value result : operation->getResults()) {
-    if (!isa<ttcore::TileType>(result.getType())) {
+    Type resultType = result.getType();
+    auto tileType = dyn_cast<ttcore::TileType>(resultType);
+    if (!tileType) {
+      if (auto tensorType = dyn_cast<TensorType>(resultType)) {
+        tileType = dyn_cast<ttcore::TileType>(tensorType.getElementType());
+      }
+    }
+    if (!tileType) {
       continue;
     }
-    Type elementType = getRequiredTileElementType(result);
-    dstModeUses.push_back({operation, info.primitive, elementType});
+    destinationUses.push_back(
+        {operation, info.primitive, tileType.getElementType()});
   }
   return success();
 }
@@ -217,20 +242,11 @@ getTileExecutionChoice(TileExecutionOpInterface executionOp) {
   assert(!legalStrategies.empty() &&
          "strategy choice requires at least one legal alternative");
 
-  Attribute rawStrategy = operation->getAttr(kTileExecutionStrategyAttrName);
-  auto selectedAttr = dyn_cast_or_null<TileExecutionStrategyAttr>(rawStrategy);
-  if (rawStrategy && !selectedAttr) {
-    operation->emitOpError()
-        << kTileExecutionStrategyAttrName
-        << " must be a #ttl.tile_execution_strategy attribute";
+  if (failed(verifyTileExecutionStrategy(operation, legalStrategies))) {
     return failure();
   }
-  if (selectedAttr &&
-      !llvm::is_contained(legalStrategies, selectedAttr.getValue())) {
-    operation->emitOpError() << "explicit " << kTileExecutionStrategyAttrName
-                             << " is not legal for its operands";
-    return failure();
-  }
+  auto selectedAttr = operation->getAttrOfType<TileExecutionStrategyAttr>(
+      kTileExecutionStrategyAttrName);
 
   if (selectedAttr) {
     legalStrategies.assign(1, selectedAttr.getValue());
@@ -265,7 +281,7 @@ getTileExecutionChoice(TileExecutionOpInterface executionOp) {
 
     TileExecutionOption option{strategy, {}, {}};
     if (failed(appendExecutionRequirements(
-            operation, *info, option.dfbInputUses, option.dstModeUses))) {
+            operation, *info, option.dfbInputUses, option.destinationUses))) {
       return failure();
     }
     options.push_back(std::move(option));
@@ -278,46 +294,44 @@ getTileExecutionChoice(TileExecutionOpInterface executionOp) {
                              static_cast<bool>(selectedAttr)};
 }
 
-struct DstModeEvidence {
+struct DestinationWidthEvidence {
   Operation *operation;
-  std::optional<DstModeUse> use;
+  std::optional<DestinationUse> use;
 };
 
-/// Diagnose the two constraints that emptied the kernel-wide DST domain.
-void emitDstModeConflict(func::FuncOp function, DstModeEvidence requiresFp32,
-                         DstModeEvidence requiresDefault) {
-  if (!requiresDefault.use) {
-    requiresFp32.operation->emitOpError(
-        "requires f32 DST mode, but fp32 destination accumulation is "
-        "explicitly disabled");
+/// Diagnose the two constraints that eliminated every destination width.
+void emitDestinationWidthConflict(func::FuncOp function,
+                                  DestinationWidthEvidence requires32Bits,
+                                  DestinationWidthEvidence requires16Bits) {
+  if (!requires16Bits.use) {
+    requires32Bits.operation->emitOpError(
+        "requires 32-bit destination elements, but fp32 destination "
+        "accumulation is explicitly disabled");
     return;
   }
 
   InFlightDiagnostic diagnostic =
-      requiresFp32.use
-          ? requiresFp32.operation->emitOpError(
-                "requires f32 DST mode, but no kernel-wide DST mode supports "
-                "all tile operations")
+      requires32Bits.use
+          ? requires32Bits.operation->emitOpError(
+                "requires 32-bit destination elements, but no kernel-wide "
+                "destination width supports all tile operations")
           : function.emitOpError(
-                "explicit f32 destination accumulation is unsupported by "
-                "the kernel's tile operations");
-  diagnostic.attachNote(requiresDefault.operation->getLoc())
-      << "the target does not support f32 DST mode for "
-      << requiresDefault.operation->getName() << " with "
-      << requiresDefault.use->elementType
-      << " elements; use an f32 broadcast input or place the broadcast in a "
-         "separate kernel";
+                "explicit 32-bit destination elements are unsupported by the "
+                "kernel's tile operations");
+  diagnostic.attachNote(requires16Bits.operation->getLoc())
+      << "the target does not support 32-bit destination elements for "
+      << requires16Bits.operation->getName() << " with "
+      << requires16Bits.use->elementType << " elements";
 }
 
-struct DstModeConflict {
-  DstModeEvidence requiresFp32;
-  DstModeEvidence requiresDefault;
+struct DestinationWidthConflict {
+  DestinationWidthEvidence requires32Bits;
+  DestinationWidthEvidence requires16Bits;
 };
 
 struct ExplicitUnpackConflict {
   DFBInputUse use;
-  DFBUnpackMode configuredMode;
-  DFBUnpackMode requiredMode;
+  bool configuresUnpackToDestination;
 };
 
 struct DFBUnpackConflict {
@@ -325,15 +339,37 @@ struct DFBUnpackConflict {
   DFBInputUse secondUse;
 };
 
+struct UnsupportedDFBConfiguration {
+  DFBInputUse use;
+};
+
+struct UnsupportedDestinationConfiguration {
+  DestinationUse use;
+};
+
 using ConfigConstraintConflict =
-    std::variant<DstModeConflict, ExplicitUnpackConflict, DFBUnpackConflict>;
+    std::variant<DestinationWidthConflict, ExplicitUnpackConflict,
+                 DFBUnpackConflict, UnsupportedDFBConfiguration,
+                 UnsupportedDestinationConfiguration>;
+
+struct ConfigurationCandidate {
+  explicit ConfigurationCandidate(DestinationElementWidth width)
+      : destinationElementWidth(width) {}
+
+  DestinationElementWidth destinationElementWidth;
+  llvm::MapVector<int64_t, llvm::SmallSet<DFBUnpackMode, 2>> unpackModes;
+  llvm::DenseMap<int64_t, DFBInputUse> firstUnpackUses;
+};
 
 struct ConfigConstraintState {
-  llvm::SmallSet<DstMode, 2> dstModes{DstMode::Default, DstMode::Fp32};
-  DstModeEvidence requiresFp32{nullptr, std::nullopt};
-  DstModeEvidence requiresDefault{nullptr, std::nullopt};
-  llvm::MapVector<int64_t, DFBUnpackMode> unpackModes;
-  llvm::DenseMap<int64_t, DFBInputUse> firstUnpackUses;
+  ConfigConstraintState() {
+    candidates.emplace_back(DestinationElementWidth::Bits16);
+    candidates.emplace_back(DestinationElementWidth::Bits32);
+  }
+
+  llvm::SmallVector<ConfigurationCandidate, 2> candidates;
+  DestinationWidthEvidence requires32Bits{nullptr, std::nullopt};
+  DestinationWidthEvidence requires16Bits{nullptr, std::nullopt};
 };
 
 using ConfigConstraintResult =
@@ -343,52 +379,115 @@ using ConfigConstraintResult =
 ConfigConstraintResult applyConfigConstraints(
     ConfigConstraintState state, const KernelTargetEnvironment &target,
     const KernelConfigPolicy &policy, ArrayRef<DFBInputUse> dfbInputUses,
-    ArrayRef<DstModeUse> dstModeUses) {
-  for (const DstModeUse &use : dstModeUses) {
-    if (use.elementType.isF32()) {
-      state.dstModes.erase(DstMode::Default);
-      if (!state.requiresFp32.operation) {
-        state.requiresFp32 = {use.operation, use};
+    ArrayRef<DestinationUse> destinationUses) {
+  for (const DestinationUse &use : destinationUses) {
+    bool supportsBits16 = target.supportsDestinationElementWidth(
+        use.primitive, use.elementType, DestinationElementWidth::Bits16);
+    bool supportsBits32 = target.supportsDestinationElementWidth(
+        use.primitive, use.elementType, DestinationElementWidth::Bits32);
+    if (!supportsBits16 && !supportsBits32) {
+      return ConfigConstraintConflict(UnsupportedDestinationConfiguration{use});
+    }
+    if (requires32BitDestination(use.elementType)) {
+      if (!state.requires32Bits.operation) {
+        state.requires32Bits = {use.operation, use};
       }
     }
-    if (!target.supportsDstMode(use.primitive, use.elementType,
-                                DstMode::Fp32)) {
-      state.dstModes.erase(DstMode::Fp32);
-      if (!state.requiresDefault.operation) {
-        state.requiresDefault = {use.operation, use};
+    if (!supportsBits32) {
+      if (!state.requires16Bits.operation) {
+        state.requires16Bits = {use.operation, use};
       }
     }
-    if (state.dstModes.empty()) {
+    llvm::erase_if(state.candidates,
+                   [&](const ConfigurationCandidate &candidate) {
+                     return (requires32BitDestination(use.elementType) &&
+                             candidate.destinationElementWidth ==
+                                 DestinationElementWidth::Bits16) ||
+                            (candidate.destinationElementWidth ==
+                                     DestinationElementWidth::Bits16
+                                 ? !supportsBits16
+                                 : !supportsBits32);
+                   });
+    if (state.candidates.empty()) {
       return ConfigConstraintConflict(
-          DstModeConflict{state.requiresFp32, state.requiresDefault});
+          DestinationWidthConflict{state.requires32Bits, state.requires16Bits});
     }
   }
 
   for (const DFBInputUse &use : dfbInputUses) {
-    DFBUnpackMode requiredMode =
-        target.getRequiredUnpackMode(use.primitive, use.route, use.elementType);
-    if (policy.unpackToDestFp32) {
-      bool configuresFp32 =
-          llvm::is_contained(*policy.unpackToDestFp32, use.dfbIndex);
-      DFBUnpackMode configuredMode = configuresFp32
-                                         ? DFBUnpackMode::UnpackToDestFp32
-                                         : DFBUnpackMode::Default;
-      if (configuredMode != requiredMode) {
-        return ConfigConstraintConflict(
-            ExplicitUnpackConflict{use, configuredMode, requiredMode});
+    llvm::SmallVector<DFBHardwareConfiguration, 4> supportedConfigurations =
+        target.getSupportedDFBConfigurations(use.primitive, use.route,
+                                             use.elementType);
+    bool hasExplicitConfiguration = policy.unpackToDestFp32.has_value();
+    bool configuresUnpackToDestination =
+        hasExplicitConfiguration &&
+        llvm::is_contained(*policy.unpackToDestFp32, use.dfbIndex);
+    std::optional<ConfigConstraintConflict> firstConflict;
+
+    for (auto candidateIterator = state.candidates.begin();
+         candidateIterator != state.candidates.end();) {
+      ConfigurationCandidate &candidate = *candidateIterator;
+      llvm::SmallSet<DFBUnpackMode, 2> allowedModes;
+      for (const DFBHardwareConfiguration &configuration :
+           supportedConfigurations) {
+        if (configuration.destinationElementWidth ==
+            candidate.destinationElementWidth) {
+          allowedModes.insert(configuration.unpackMode);
+        }
       }
-      continue;
+
+      // ComputeConfigDescriptor::unpack_to_dest_mode changes the route only
+      // for f32. For other formats, tt-metal ignores an enabled entry.
+      if (hasExplicitConfiguration && use.elementType.isF32()) {
+        DFBUnpackMode configuredMode = configuresUnpackToDestination
+                                           ? DFBUnpackMode::UnpackToDestination
+                                           : DFBUnpackMode::Default;
+        bool supportsConfiguredMode = allowedModes.contains(configuredMode);
+        allowedModes.clear();
+        if (supportsConfiguredMode) {
+          allowedModes.insert(configuredMode);
+        }
+      }
+
+      auto modeIterator = candidate.unpackModes.find(use.dfbIndex);
+      if (modeIterator != candidate.unpackModes.end()) {
+        llvm::SmallSet<DFBUnpackMode, 2> intersection;
+        for (DFBUnpackMode mode : modeIterator->second) {
+          if (allowedModes.contains(mode)) {
+            intersection.insert(mode);
+          }
+        }
+        allowedModes = std::move(intersection);
+      }
+
+      if (allowedModes.empty()) {
+        if (!firstConflict) {
+          if (hasExplicitConfiguration && use.elementType.isF32()) {
+            firstConflict =
+                ExplicitUnpackConflict{use, configuresUnpackToDestination};
+          } else if (modeIterator != candidate.unpackModes.end()) {
+            firstConflict = DFBUnpackConflict{
+                candidate.firstUnpackUses.lookup(use.dfbIndex), use};
+          } else {
+            firstConflict = UnsupportedDFBConfiguration{use};
+          }
+        }
+        candidateIterator = state.candidates.erase(candidateIterator);
+        continue;
+      }
+
+      if (modeIterator == candidate.unpackModes.end()) {
+        candidate.unpackModes.insert({use.dfbIndex, std::move(allowedModes)});
+        candidate.firstUnpackUses.insert({use.dfbIndex, use});
+      } else {
+        modeIterator->second = std::move(allowedModes);
+      }
+      ++candidateIterator;
     }
 
-    auto [iterator, inserted] =
-        state.unpackModes.insert({use.dfbIndex, requiredMode});
-    if (inserted) {
-      state.firstUnpackUses.insert({use.dfbIndex, use});
-      continue;
-    }
-    if (iterator->second != requiredMode) {
-      return ConfigConstraintConflict(
-          DFBUnpackConflict{state.firstUnpackUses.lookup(use.dfbIndex), use});
+    if (state.candidates.empty()) {
+      assert(firstConflict && "an eliminated candidate must retain evidence");
+      return *firstConflict;
     }
   }
   return state;
@@ -400,23 +499,22 @@ void emitConfigConstraintConflict(func::FuncOp function,
   std::visit(
       [&](const auto &typedConflict) {
         using ConflictType = std::decay_t<decltype(typedConflict)>;
-        if constexpr (std::is_same_v<ConflictType, DstModeConflict>) {
-          emitDstModeConflict(function, typedConflict.requiresFp32,
-                              typedConflict.requiresDefault);
+        if constexpr (std::is_same_v<ConflictType, DestinationWidthConflict>) {
+          emitDestinationWidthConflict(function, typedConflict.requires32Bits,
+                                       typedConflict.requires16Bits);
         } else if constexpr (std::is_same_v<ConflictType,
                                             ExplicitUnpackConflict>) {
           const DFBInputUse &use = typedConflict.use;
           use.consumer->emitOpError()
               << "dataflow buffer " << use.dfbIndex << " requires "
-              << (typedConflict.requiredMode == DFBUnpackMode::UnpackToDestFp32
-                      ? "unpack-to-DST-f32 mode, but "
-                      : "default unpack mode, but ")
+              << (typedConflict.configuresUnpackToDestination
+                      ? "default unpack mode, but "
+                      : "unpack-to-DST-f32 mode, but ")
               << kUnpackToDestFp32AttrName
-              << (typedConflict.configuredMode ==
-                          DFBUnpackMode::UnpackToDestFp32
+              << (typedConflict.configuresUnpackToDestination
                       ? " includes this index"
                       : " excludes this index");
-        } else {
+        } else if constexpr (std::is_same_v<ConflictType, DFBUnpackConflict>) {
           InFlightDiagnostic diagnostic =
               typedConflict.secondUse.consumer->emitOpError()
               << "dataflow buffer " << typedConflict.secondUse.dfbIndex
@@ -424,6 +522,16 @@ void emitConfigConstraintConflict(func::FuncOp function,
           diagnostic.attachNote(typedConflict.firstUse.consumer->getLoc())
               << "operand " << typedConflict.firstUse.operandIndex
               << " establishes the conflicting unpack mode";
+        } else if constexpr (std::is_same_v<ConflictType,
+                                            UnsupportedDFBConfiguration>) {
+          typedConflict.use.consumer->emitOpError()
+              << "dataflow buffer " << typedConflict.use.dfbIndex
+              << " has no target-supported destination-width and unpack-route "
+                 "configuration";
+        } else {
+          typedConflict.use.operation->emitOpError()
+              << "has no target-supported destination element width for "
+              << typedConflict.use.elementType << " elements";
         }
       },
       conflict);
@@ -493,7 +601,7 @@ resolveTileStrategies(ArrayRef<TileStrategyOptions> allOptions,
     for (const TileExecutionOption &option : options) {
       ConfigConstraintResult result =
           applyConfigConstraints(state.constraints, target, policy,
-                                 option.dfbInputUses, option.dstModeUses);
+                                 option.dfbInputUses, option.destinationUses);
       if (std::holds_alternative<ConfigConstraintState>(result)) {
         ++compatibleOptions;
       } else if (!choiceConflict) {
@@ -521,7 +629,7 @@ resolveTileStrategies(ArrayRef<TileStrategyOptions> allOptions,
   for (const TileExecutionOption &option : allOptions[*selectedChoice]) {
     ConfigConstraintResult result =
         applyConfigConstraints(state.constraints, target, policy,
-                               option.dfbInputUses, option.dstModeUses);
+                               option.dfbInputUses, option.destinationUses);
     if (std::holds_alternative<ConfigConstraintConflict>(result)) {
       if (!immediateConflict) {
         immediateConflict =
@@ -550,9 +658,112 @@ resolveTileStrategies(ArrayRef<TileStrategyOptions> allOptions,
   return *immediateConflict;
 }
 
+SmallVector<DFBHardwareConfiguration, 4>
+getWormholeBlackholeSupportedDFBConfigurations(TilePrimitive primitive,
+                                               TileOperandRoute route,
+                                               Type elementType) {
+  bool requiresDestinationRoute =
+      elementType.isF32() &&
+      (route == TileOperandRoute::Dst || primitive == TilePrimitive::Copy);
+  if (requiresDestinationRoute) {
+    return {
+        {DestinationElementWidth::Bits32, DFBUnpackMode::UnpackToDestination}};
+  }
+  return {{DestinationElementWidth::Bits16, DFBUnpackMode::Default},
+          {DestinationElementWidth::Bits32, DFBUnpackMode::Default}};
+}
+
+class UnspecifiedKernelTargetEnvironment final
+    : public KernelTargetEnvironment {
+public:
+  std::optional<ttcore::Arch> getArch() const override { return std::nullopt; }
+
+  bool supportsDestinationElementWidth(
+      TilePrimitive, Type elementType,
+      DestinationElementWidth destinationElementWidth) const override {
+    return destinationElementWidth == DestinationElementWidth::Bits32 ||
+           !requires32BitDestination(elementType);
+  }
+
+  bool supportsFullFp32Accumulation(FullFp32AccumulationKind) const override {
+    return true;
+  }
+
+  SmallVector<DFBHardwareConfiguration, 4>
+  getSupportedDFBConfigurations(TilePrimitive primitive, TileOperandRoute route,
+                                Type elementType) const override {
+    return getWormholeBlackholeSupportedDFBConfigurations(primitive, route,
+                                                          elementType);
+  }
+};
+
+class WormholeBlackholeKernelTargetEnvironment
+    : public KernelTargetEnvironment {
+public:
+  std::optional<ttcore::Arch> getArch() const final { return arch; }
+
+  bool supportsDestinationElementWidth(
+      TilePrimitive primitive, Type elementType,
+      DestinationElementWidth destinationElementWidth) const final {
+    if (destinationElementWidth == DestinationElementWidth::Bits16) {
+      return !requires32BitDestination(elementType);
+    }
+    if (requires32BitDestination(elementType)) {
+      return true;
+    }
+    switch (primitive) {
+    case TilePrimitive::BroadcastColumn:
+    case TilePrimitive::BroadcastRow:
+    case TilePrimitive::BroadcastScalar:
+      // These LLKs interpret non-32-bit inputs using the default DST format.
+      return false;
+    default:
+      return true;
+    }
+  }
+
+  SmallVector<DFBHardwareConfiguration, 4>
+  getSupportedDFBConfigurations(TilePrimitive primitive, TileOperandRoute route,
+                                Type elementType) const final {
+    return getWormholeBlackholeSupportedDFBConfigurations(primitive, route,
+                                                          elementType);
+  }
+
+protected:
+  explicit WormholeBlackholeKernelTargetEnvironment(ttcore::Arch arch)
+      : arch(arch) {}
+
+private:
+  ttcore::Arch arch;
+};
+
+class WormholeKernelTargetEnvironment final
+    : public WormholeBlackholeKernelTargetEnvironment {
+public:
+  WormholeKernelTargetEnvironment()
+      : WormholeBlackholeKernelTargetEnvironment(ttcore::Arch::WormholeB0) {}
+
+  bool
+  supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const override {
+    return kind == FullFp32AccumulationKind::Matmul;
+  }
+};
+
+class BlackholeKernelTargetEnvironment final
+    : public WormholeBlackholeKernelTargetEnvironment {
+public:
+  BlackholeKernelTargetEnvironment()
+      : WormholeBlackholeKernelTargetEnvironment(ttcore::Arch::Blackhole) {}
+
+  bool
+  supportsFullFp32Accumulation(FullFp32AccumulationKind kind) const override {
+    return kind != FullFp32AccumulationKind::ReduceRow;
+  }
+};
+
 } // namespace
 
-FailureOr<KernelTargetEnvironment>
+FailureOr<std::unique_ptr<KernelTargetEnvironment>>
 KernelTargetEnvironment::get(func::FuncOp function) {
   ModuleOp module = function->getParentOfType<ModuleOp>();
   if (!module) {
@@ -607,47 +818,29 @@ KernelTargetEnvironment::get(func::FuncOp function) {
     targetArch = deviceArch;
   }
 
-  return KernelTargetEnvironment(targetArch);
-}
-
-bool KernelTargetEnvironment::supportsDstMode(TilePrimitive primitive,
-                                              Type elementType,
-                                              DstMode mode) const {
-  if (mode == DstMode::Default || elementType.isF32() || !arch) {
-    return true;
+  if (!targetArch) {
+    return std::unique_ptr<KernelTargetEnvironment>(
+        std::make_unique<UnspecifiedKernelTargetEnvironment>());
   }
 
-  switch (primitive) {
-  case TilePrimitive::BroadcastColumn:
-  case TilePrimitive::BroadcastRow:
-  case TilePrimitive::BroadcastScalar:
-    // Broadcast LLKs interpret non-f32 inputs using the default DST format.
-    return *arch != ttcore::Arch::WormholeB0 &&
-           *arch != ttcore::Arch::Blackhole;
-  default:
-    return true;
+  switch (*targetArch) {
+  case ttcore::Arch::WormholeB0:
+    return std::unique_ptr<KernelTargetEnvironment>(
+        std::make_unique<WormholeKernelTargetEnvironment>());
+  case ttcore::Arch::Blackhole:
+    return std::unique_ptr<KernelTargetEnvironment>(
+        std::make_unique<BlackholeKernelTargetEnvironment>());
+  case ttcore::Arch::Quasar:
+    module.emitOpError(
+        "Quasar compute kernels require the Gen2 configuration and launch "
+        "APIs, which are not supported by the current TT-Lang runtime");
+    return failure();
   }
-}
-
-bool KernelTargetEnvironment::supportsFullFp32Accumulation(
-    FullFp32AccumulationKind kind) const {
-  if (kind == FullFp32AccumulationKind::Matmul) {
-    return true;
-  }
-  if (arch == ttcore::Arch::WormholeB0) {
-    return false;
-  }
-  return arch != ttcore::Arch::Blackhole ||
-         kind != FullFp32AccumulationKind::ReduceRow;
-}
-
-DFBUnpackMode KernelTargetEnvironment::getRequiredUnpackMode(
-    TilePrimitive primitive, TileOperandRoute route, Type elementType) const {
-  if (elementType.isF32() &&
-      (route == TileOperandRoute::Dst || primitive == TilePrimitive::Copy)) {
-    return DFBUnpackMode::UnpackToDestFp32;
-  }
-  return DFBUnpackMode::Default;
+  module.emitOpError()
+      << "compute-kernel configuration is not implemented for target "
+         "architecture "
+      << ttcore::ArchAttr::get(module.getContext(), *targetArch);
+  return failure();
 }
 
 FailureOr<KernelConfigPolicy>
@@ -698,8 +891,15 @@ KernelConfigPolicy::get(func::FuncOp function, StringRef fp32Selection,
 
 FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
   KernelRequirements requirements;
-  WalkResult result = function.walk([&](TileExecutionOpInterface executionOp) {
-    Operation *operation = executionOp.getOperation();
+  WalkResult result = function.walk([&](Operation *operation) {
+    auto executionOp = dyn_cast<TileExecutionOpInterface>(operation);
+    if (!executionOp) {
+      if (isTileComputeOp(operation)) {
+        operation->emitOpError("does not implement TileExecutionOpInterface");
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    }
     if (!executionOp.getLegalExecutionStrategies().empty()) {
       FailureOr<TileExecutionChoice> choice =
           getTileExecutionChoice(executionOp);
@@ -710,11 +910,7 @@ FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
       return WalkResult::advance();
     }
 
-    if (operation->hasAttr(kTileExecutionStrategyAttrName)) {
-      operation->emitOpError()
-          << kTileExecutionStrategyAttrName
-          << " is only valid on tile operations with execution-strategy "
-             "alternatives";
+    if (failed(verifyTileExecutionStrategy(operation, {}))) {
       return WalkResult::interrupt();
     }
     FailureOr<TileExecutionInfo> info =
@@ -726,7 +922,7 @@ FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
     if (failed(verifyTileExecutionInfo(operation, *info)) ||
         failed(appendExecutionRequirements(operation, *info,
                                            requirements.dfbInputUses,
-                                           requirements.dstModeUses))) {
+                                           requirements.destinationUses))) {
       return WalkResult::interrupt();
     }
     if (info->fullFp32Accumulation) {
@@ -746,16 +942,23 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
     const KernelConfigPolicy &policy, const KernelRequirements &requirements) {
   ConfigConstraintState initialState;
   if (policy.fp32DestAccumulation == ConfigSelection::Enabled) {
-    initialState.dstModes.erase(DstMode::Default);
-    initialState.requiresFp32 = {function.getOperation(), std::nullopt};
+    llvm::erase_if(initialState.candidates,
+                   [](const ConfigurationCandidate &candidate) {
+                     return candidate.destinationElementWidth ==
+                            DestinationElementWidth::Bits16;
+                   });
+    initialState.requires32Bits = {function.getOperation(), std::nullopt};
   } else if (policy.fp32DestAccumulation == ConfigSelection::Disabled) {
-    initialState.dstModes.erase(DstMode::Fp32);
-    initialState.requiresDefault = {function.getOperation(), std::nullopt};
+    llvm::erase_if(initialState.candidates,
+                   [](const ConfigurationCandidate &candidate) {
+                     return candidate.destinationElementWidth ==
+                            DestinationElementWidth::Bits32;
+                   });
+    initialState.requires16Bits = {function.getOperation(), std::nullopt};
   }
-
   ConfigConstraintResult fixedResult = applyConfigConstraints(
       initialState, target, policy, requirements.dfbInputUses,
-      requirements.dstModeUses);
+      requirements.destinationUses);
   if (std::holds_alternative<ConfigConstraintConflict>(fixedResult)) {
     emitConfigConstraintConflict(
         function, std::get<ConfigConstraintConflict>(std::move(fixedResult)));
@@ -809,30 +1012,46 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
              "#47311); using non-full-fp32 reduce lowering";
     }
   }
-  DstMode dstMode = DstMode::Default;
-  if ((preferFp32 ||
-       !resolvedState.constraints.dstModes.contains(DstMode::Default)) &&
-      resolvedState.constraints.dstModes.contains(DstMode::Fp32)) {
-    dstMode = DstMode::Fp32;
+  auto hasDestinationWidth = [&](DestinationElementWidth width) {
+    return llvm::any_of(resolvedState.constraints.candidates,
+                        [&](const ConfigurationCandidate &candidate) {
+                          return candidate.destinationElementWidth == width;
+                        });
+  };
+  DestinationElementWidth destinationElementWidth =
+      DestinationElementWidth::Bits16;
+  if ((preferFp32 || !hasDestinationWidth(DestinationElementWidth::Bits16)) &&
+      hasDestinationWidth(DestinationElementWidth::Bits32)) {
+    destinationElementWidth = DestinationElementWidth::Bits32;
   }
+  auto selectedCandidate = llvm::find_if(
+      resolvedState.constraints.candidates,
+      [&](const ConfigurationCandidate &candidate) {
+        return candidate.destinationElementWidth == destinationElementWidth;
+      });
+  assert(selectedCandidate != resolvedState.constraints.candidates.end() &&
+         "resolved destination width must have a candidate");
 
   DstSyncMode syncMode = policy.dstSynchronization == ConfigSelection::Enabled
                              ? DstSyncMode::Full
                              : DstSyncMode::DoubleBuffered;
 
   if (policy.unpackToDestFp32) {
-    return KernelConfigPlan(dstMode, syncMode, *policy.unpackToDestFp32,
+    return KernelConfigPlan(destinationElementWidth, syncMode,
+                            *policy.unpackToDestFp32,
                             std::move(tileStrategies));
   }
 
   SmallVector<int32_t> unpackToDestFp32;
-  for (auto [dfbIndex, mode] : resolvedState.constraints.unpackModes) {
-    if (mode == DFBUnpackMode::UnpackToDestFp32) {
+  for (const auto &[dfbIndex, modes] : selectedCandidate->unpackModes) {
+    if (!modes.contains(DFBUnpackMode::Default) &&
+        modes.contains(DFBUnpackMode::UnpackToDestination)) {
       unpackToDestFp32.push_back(static_cast<int32_t>(dfbIndex));
     }
   }
   llvm::sort(unpackToDestFp32);
-  return KernelConfigPlan(dstMode, syncMode, std::move(unpackToDestFp32),
+  return KernelConfigPlan(destinationElementWidth, syncMode,
+                          std::move(unpackToDestFp32),
                           std::move(tileStrategies));
 }
 
@@ -844,8 +1063,10 @@ void applyKernelConfigPlan(func::FuncOp function,
         kTileExecutionStrategyAttrName,
         TileExecutionStrategyAttr::get(context, decision.strategy));
   }
-  function->setAttr(kFp32DestAccEnAttrName,
-                    BoolAttr::get(context, plan.getDstMode() == DstMode::Fp32));
+  function->setAttr(
+      kFp32DestAccEnAttrName,
+      BoolAttr::get(context, plan.getDestinationElementWidth() ==
+                                 DestinationElementWidth::Bits32));
   function->setAttr(
       kDstFullSyncEnAttrName,
       BoolAttr::get(context, plan.getDstSyncMode() == DstSyncMode::Full));

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -676,8 +676,6 @@ getWormholeBlackholeSupportedDFBConfigurations(TilePrimitive primitive,
 class UnspecifiedKernelTargetEnvironment final
     : public KernelTargetEnvironment {
 public:
-  std::optional<ttcore::Arch> getArch() const override { return std::nullopt; }
-
   bool supportsDestinationElementWidth(
       TilePrimitive, Type elementType,
       DestinationElementWidth destinationElementWidth) const override {
@@ -701,8 +699,6 @@ public:
 class WormholeBlackholeKernelTargetEnvironment
     : public KernelTargetEnvironment {
 public:
-  std::optional<ttcore::Arch> getArch() const final { return arch; }
-
   bool supportsDestinationElementWidth(
       TilePrimitive primitive, Type elementType,
       DestinationElementWidth destinationElementWidth) const final {
@@ -729,21 +725,11 @@ public:
     return getWormholeBlackholeSupportedDFBConfigurations(primitive, route,
                                                           elementType);
   }
-
-protected:
-  explicit WormholeBlackholeKernelTargetEnvironment(ttcore::Arch arch)
-      : arch(arch) {}
-
-private:
-  ttcore::Arch arch;
 };
 
 class WormholeKernelTargetEnvironment final
     : public WormholeBlackholeKernelTargetEnvironment {
 public:
-  WormholeKernelTargetEnvironment()
-      : WormholeBlackholeKernelTargetEnvironment(ttcore::Arch::WormholeB0) {}
-
   FullFp32AccumulationSupport
   getFullFp32AccumulationSupport(FullFp32AccumulationKind kind) const override {
     return {kind == FullFp32AccumulationKind::Matmul, std::nullopt};
@@ -753,9 +739,6 @@ public:
 class BlackholeKernelTargetEnvironment final
     : public WormholeBlackholeKernelTargetEnvironment {
 public:
-  BlackholeKernelTargetEnvironment()
-      : WormholeBlackholeKernelTargetEnvironment(ttcore::Arch::Blackhole) {}
-
   FullFp32AccumulationSupport
   getFullFp32AccumulationSupport(FullFp32AccumulationKind kind) const override {
     if (kind == FullFp32AccumulationKind::ReduceRow) {
@@ -999,6 +982,7 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
   }
 
   bool preferFp32 = false;
+  SmallVector<Operation *> supportedFullFp32Preferences;
   for (const FullFp32AccumulationUse &use :
        requirements.fullFp32AccumulationUses) {
     bool isMatmul = use.kind == FullFp32AccumulationKind::Matmul;
@@ -1011,6 +995,7 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
         target.getFullFp32AccumulationSupport(use.kind);
     if (support.supported) {
       preferFp32 = true;
+      supportedFullFp32Preferences.push_back(use.operation);
       continue;
     }
     if (support.fallbackWarning) {
@@ -1028,6 +1013,14 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
   if ((preferFp32 || !hasDestinationWidth(DestinationElementWidth::Bits16)) &&
       hasDestinationWidth(DestinationElementWidth::Bits32)) {
     destinationElementWidth = DestinationElementWidth::Bits32;
+  }
+  if (preferFp32 &&
+      destinationElementWidth == DestinationElementWidth::Bits16) {
+    for (Operation *operation : supportedFullFp32Preferences) {
+      operation->emitWarning()
+          << "preferred full-fp32 accumulation is unavailable in the resolved "
+             "kernel configuration; using non-full-fp32 lowering";
+    }
   }
   auto selectedCandidate = llvm::find_if(
       resolvedState.constraints.candidates,

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -1,0 +1,925 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h"
+
+#include "ttlang/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttlang/Dialect/TTCore/IR/Utils.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallSet.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <variant>
+
+namespace mlir::tt::ttl {
+namespace {
+
+/// Parse a three-state pass option and its accepted boolean spellings.
+FailureOr<ConfigSelection> parseConfigSelection(Operation *diagnosticOp,
+                                                StringRef optionName,
+                                                StringRef value) {
+  if (value == "auto") {
+    return ConfigSelection::Auto;
+  }
+  if (value == "enabled" || value == "true" || value == "1") {
+    return ConfigSelection::Enabled;
+  }
+  if (value == "disabled" || value == "false" || value == "0") {
+    return ConfigSelection::Disabled;
+  }
+  diagnosticOp->emitError() << "invalid " << optionName << " value '" << value
+                            << "'; expected auto, enabled, or disabled";
+  return failure();
+}
+
+/// Read and type-check an optional function-level boolean constraint.
+FailureOr<std::optional<bool>>
+getOptionalBoolConstraint(func::FuncOp function, StringRef attributeName) {
+  Attribute rawAttribute = function->getAttr(attributeName);
+  if (!rawAttribute) {
+    return std::optional<bool>();
+  }
+  auto boolAttribute = dyn_cast<BoolAttr>(rawAttribute);
+  if (!boolAttribute) {
+    function.emitOpError() << attributeName << " must be a boolean attribute";
+    return failure();
+  }
+  return std::optional<bool>(boolAttribute.getValue());
+}
+
+/// Read an exact per-DFB unpack configuration from the function.
+FailureOr<std::optional<SmallVector<int32_t>>>
+getOptionalUnpackConstraint(func::FuncOp function) {
+  Attribute rawAttribute = function->getAttr(kUnpackToDestFp32AttrName);
+  if (!rawAttribute) {
+    return std::optional<SmallVector<int32_t>>();
+  }
+  auto unpackAttribute = dyn_cast<DenseI32ArrayAttr>(rawAttribute);
+  if (!unpackAttribute) {
+    function.emitOpError() << kUnpackToDestFp32AttrName
+                           << " must be a dense i32 array attribute";
+    return failure();
+  }
+
+  SmallVector<int32_t> dataflowBufferIndices(unpackAttribute.asArrayRef());
+  if (llvm::any_of(dataflowBufferIndices, [](int32_t index) {
+        return index < 0 || index >= kMaxCircularBuffers;
+      })) {
+    function.emitOpError()
+        << kUnpackToDestFp32AttrName
+        << " must contain dataflow buffer indices in range [0, "
+        << kMaxCircularBuffers - 1 << "]";
+    return failure();
+  }
+  llvm::sort(dataflowBufferIndices);
+  dataflowBufferIndices.erase(
+      std::unique(dataflowBufferIndices.begin(), dataflowBufferIndices.end()),
+      dataflowBufferIndices.end());
+  return std::optional<SmallVector<int32_t>>(std::move(dataflowBufferIndices));
+}
+
+/// Return the attached DFB index, or `std::nullopt` when no DFB is attached.
+FailureOr<std::optional<int64_t>>
+resolveDataflowBufferIndex(Value value, Operation *consumer) {
+  if (auto blockArgument = dyn_cast<BlockArgument>(value)) {
+    auto computeOp =
+        dyn_cast_or_null<ComputeOp>(blockArgument.getOwner()->getParentOp());
+    if (!computeOp) {
+      return std::optional<int64_t>();
+    }
+    unsigned argumentNumber = blockArgument.getArgNumber();
+    if (argumentNumber < computeOp.getNumInputs()) {
+      value = computeOp.getInputs()[argumentNumber];
+    } else {
+      unsigned outputNumber = argumentNumber - computeOp.getNumInputs();
+      if (outputNumber >= computeOp.getNumOutputs()) {
+        return std::optional<int64_t>();
+      }
+      value = computeOp.getOutputs()[outputNumber];
+    }
+  }
+
+  Value dfb = getAttachedCB(value);
+  if (dfb) {
+    std::optional<int64_t> dfbIndex = getCBIndex(dfb);
+    if (!dfbIndex) {
+      consumer->emitOpError("uses a dataflow buffer without a finalized index");
+      return failure();
+    }
+    if (*dfbIndex < 0 || *dfbIndex >= kMaxCircularBuffers) {
+      consumer->emitOpError() << "uses dataflow buffer index " << *dfbIndex
+                              << " outside the supported range [0, "
+                              << kMaxCircularBuffers - 1 << "]";
+      return failure();
+    }
+    return dfbIndex;
+  }
+
+  if (value.getDefiningOp() || isa<BlockArgument>(value)) {
+    return std::optional<int64_t>();
+  }
+  consumer->emitOpError("has an unresolved tile operand");
+  return failure();
+}
+
+/// Return the element type required by configuration queries.
+FailureOr<Type> getRequiredTileElementType(Value value, Operation *operation) {
+  std::optional<Type> elementType = getTileElementType(value.getType());
+  if (!elementType) {
+    operation->emitOpError()
+        << "expected a tile operand or result, got " << value.getType();
+    return failure();
+  }
+  return *elementType;
+}
+
+/// Return a dataflow-buffer operand that the strategy cannot address.
+FailureOr<std::optional<unsigned>>
+findUnavailableDataflowBufferOperand(Operation *operation,
+                                     const TileExecutionInfo &info) {
+  for (OpOperand &operand : operation->getOpOperands()) {
+    if (info.operandRoutes[operand.getOperandNumber()] !=
+        TileOperandRoute::DataflowBuffer) {
+      continue;
+    }
+    FailureOr<std::optional<int64_t>> dataflowBufferIndex =
+        resolveDataflowBufferIndex(operand.get(), operation);
+    if (failed(dataflowBufferIndex)) {
+      return failure();
+    }
+    if (!*dataflowBufferIndex) {
+      return std::optional<unsigned>(operand.getOperandNumber());
+    }
+  }
+  return std::optional<unsigned>();
+}
+
+/// Append the configuration requirements imposed by one execution option.
+LogicalResult
+appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
+                            SmallVectorImpl<DFBInputUse> &dfbInputUses,
+                            SmallVectorImpl<DstModeUse> &dstModeUses) {
+  for (OpOperand &operand : operation->getOpOperands()) {
+    TileOperandRoute route = info.operandRoutes[operand.getOperandNumber()];
+    if (route == TileOperandRoute::None) {
+      continue;
+    }
+    FailureOr<Type> elementType =
+        getRequiredTileElementType(operand.get(), operation);
+    FailureOr<std::optional<int64_t>> dataflowBufferIndex =
+        resolveDataflowBufferIndex(operand.get(), operation);
+    if (failed(elementType) || failed(dataflowBufferIndex)) {
+      return failure();
+    }
+    if (route == TileOperandRoute::DataflowBuffer && !*dataflowBufferIndex) {
+      operation->emitOpError()
+          << "operand " << operand.getOperandNumber()
+          << " must resolve to a dataflow buffer for the selected strategy";
+      return failure();
+    }
+    if (*dataflowBufferIndex) {
+      dfbInputUses.push_back({**dataflowBufferIndex, operation,
+                              operand.getOperandNumber(), info.primitive, route,
+                              *elementType});
+    }
+    if (route == TileOperandRoute::Dst) {
+      dstModeUses.push_back({operation, info.primitive, *elementType});
+    }
+  }
+
+  if (!info.resultInDst) {
+    return success();
+  }
+  for (Value result : operation->getResults()) {
+    if (!isa<ttcore::TileType>(result.getType())) {
+      continue;
+    }
+    FailureOr<Type> elementType = getRequiredTileElementType(result, operation);
+    if (failed(elementType)) {
+      return failure();
+    }
+    dstModeUses.push_back({operation, info.primitive, *elementType});
+  }
+  return success();
+}
+
+/// Return strategy alternatives and their complete configuration requirements.
+FailureOr<TileExecutionChoice>
+getTileExecutionChoice(TileExecutionOpInterface executionOp) {
+  Operation *operation = executionOp.getOperation();
+  SmallVector<TileExecutionStrategy, 2> legalStrategies =
+      executionOp.getLegalExecutionStrategies();
+  assert(!legalStrategies.empty() &&
+         "strategy choice requires at least one legal alternative");
+
+  Attribute rawStrategy = operation->getAttr(kTileExecutionStrategyAttrName);
+  auto selectedAttr = dyn_cast_or_null<TileExecutionStrategyAttr>(rawStrategy);
+  if (rawStrategy && !selectedAttr) {
+    operation->emitOpError()
+        << kTileExecutionStrategyAttrName
+        << " must be a #ttl.tile_execution_strategy attribute";
+    return failure();
+  }
+  if (selectedAttr &&
+      !llvm::is_contained(legalStrategies, selectedAttr.getValue())) {
+    operation->emitOpError() << "explicit " << kTileExecutionStrategyAttrName
+                             << " is not legal for its operands";
+    return failure();
+  }
+
+  if (selectedAttr) {
+    legalStrategies.assign(1, selectedAttr.getValue());
+  }
+
+  SmallVector<TileExecutionOption, 2> options;
+  for (TileExecutionStrategy strategy : legalStrategies) {
+    FailureOr<TileExecutionInfo> info =
+        executionOp.getTileExecutionInfo(strategy);
+    if (failed(info)) {
+      operation->emitOpError("has no semantics for a legal tile strategy");
+      return failure();
+    }
+    if (failed(verifyTileExecutionInfo(operation, *info))) {
+      return failure();
+    }
+    FailureOr<std::optional<unsigned>> unavailableOperand =
+        findUnavailableDataflowBufferOperand(operation, *info);
+    if (failed(unavailableOperand)) {
+      return failure();
+    }
+    if (*unavailableOperand) {
+      if (selectedAttr) {
+        operation->emitOpError()
+            << "operand " << **unavailableOperand
+            << " does not resolve to a dataflow buffer required by explicit "
+            << kTileExecutionStrategyAttrName;
+        return failure();
+      }
+      continue;
+    }
+
+    TileExecutionOption option{strategy, {}, {}};
+    if (failed(appendExecutionRequirements(
+            operation, *info, option.dfbInputUses, option.dstModeUses))) {
+      return failure();
+    }
+    options.push_back(std::move(option));
+  }
+  if (options.empty()) {
+    operation->emitOpError("has no legal tile execution strategy");
+    return failure();
+  }
+  return TileExecutionChoice{operation, std::move(options),
+                             static_cast<bool>(selectedAttr)};
+}
+
+struct DstModeEvidence {
+  Operation *operation;
+  std::optional<DstModeUse> use;
+};
+
+/// Diagnose the two constraints that emptied the kernel-wide DST domain.
+void emitDstModeConflict(func::FuncOp function, DstModeEvidence requiresFp32,
+                         DstModeEvidence requiresDefault) {
+  if (!requiresDefault.use) {
+    requiresFp32.operation->emitOpError(
+        "requires f32 DST mode, but fp32 destination accumulation is "
+        "explicitly disabled");
+    return;
+  }
+
+  InFlightDiagnostic diagnostic =
+      requiresFp32.use
+          ? requiresFp32.operation->emitOpError(
+                "requires f32 DST mode, but no kernel-wide DST mode supports "
+                "all tile operations")
+          : function.emitOpError(
+                "explicit f32 destination accumulation is unsupported by "
+                "the kernel's tile operations");
+  diagnostic.attachNote(requiresDefault.operation->getLoc())
+      << "the target does not support f32 DST mode for "
+      << requiresDefault.operation->getName() << " with "
+      << requiresDefault.use->elementType << " elements";
+}
+
+struct DstModeConflict {
+  DstModeEvidence requiresFp32;
+  DstModeEvidence requiresDefault;
+};
+
+struct ExplicitUnpackConflict {
+  DFBInputUse use;
+  DFBUnpackMode configuredMode;
+  DFBUnpackMode requiredMode;
+};
+
+struct DFBUnpackConflict {
+  DFBInputUse firstUse;
+  DFBInputUse secondUse;
+};
+
+using ConfigConstraintConflict =
+    std::variant<DstModeConflict, ExplicitUnpackConflict, DFBUnpackConflict>;
+
+struct ConfigConstraintState {
+  llvm::SmallSet<DstMode, 2> dstModes{DstMode::Default, DstMode::Fp32};
+  DstModeEvidence requiresFp32{nullptr, std::nullopt};
+  DstModeEvidence requiresDefault{nullptr, std::nullopt};
+  llvm::MapVector<int64_t, DFBUnpackMode> unpackModes;
+  llvm::DenseMap<int64_t, DFBInputUse> firstUnpackUses;
+};
+
+using ConfigConstraintResult =
+    std::variant<ConfigConstraintState, ConfigConstraintConflict>;
+
+/// Intersect one execution option's requirements with the current domains.
+ConfigConstraintResult applyConfigConstraints(
+    ConfigConstraintState state, const KernelTargetEnvironment &target,
+    const KernelConfigPolicy &policy, ArrayRef<DFBInputUse> dfbInputUses,
+    ArrayRef<DstModeUse> dstModeUses) {
+  for (const DstModeUse &use : dstModeUses) {
+    if (use.elementType.isF32()) {
+      state.dstModes.erase(DstMode::Default);
+      if (!state.requiresFp32.operation) {
+        state.requiresFp32 = {use.operation, use};
+      }
+    }
+    if (!target.supportsDstMode(use.primitive, use.elementType,
+                                DstMode::Fp32)) {
+      state.dstModes.erase(DstMode::Fp32);
+      if (!state.requiresDefault.operation) {
+        state.requiresDefault = {use.operation, use};
+      }
+    }
+    if (state.dstModes.empty()) {
+      return ConfigConstraintConflict(
+          DstModeConflict{state.requiresFp32, state.requiresDefault});
+    }
+  }
+
+  for (const DFBInputUse &use : dfbInputUses) {
+    DFBUnpackMode requiredMode =
+        target.getRequiredUnpackMode(use.primitive, use.route, use.elementType);
+    if (policy.unpackToDestFp32) {
+      bool configuresFp32 =
+          llvm::is_contained(*policy.unpackToDestFp32, use.dfbIndex);
+      DFBUnpackMode configuredMode = configuresFp32
+                                         ? DFBUnpackMode::UnpackToDestFp32
+                                         : DFBUnpackMode::Default;
+      if (configuredMode != requiredMode) {
+        return ConfigConstraintConflict(
+            ExplicitUnpackConflict{use, configuredMode, requiredMode});
+      }
+      continue;
+    }
+
+    auto [iterator, inserted] =
+        state.unpackModes.insert({use.dfbIndex, requiredMode});
+    if (inserted) {
+      state.firstUnpackUses.insert({use.dfbIndex, use});
+      continue;
+    }
+    if (iterator->second != requiredMode) {
+      return ConfigConstraintConflict(
+          DFBUnpackConflict{state.firstUnpackUses.lookup(use.dfbIndex), use});
+    }
+  }
+  return state;
+}
+
+/// Emit the constraint evidence retained by an unsuccessful resolution.
+void emitConfigConstraintConflict(func::FuncOp function,
+                                  const ConfigConstraintConflict &conflict) {
+  std::visit(
+      [&](const auto &typedConflict) {
+        using ConflictType = std::decay_t<decltype(typedConflict)>;
+        if constexpr (std::is_same_v<ConflictType, DstModeConflict>) {
+          emitDstModeConflict(function, typedConflict.requiresFp32,
+                              typedConflict.requiresDefault);
+        } else if constexpr (std::is_same_v<ConflictType,
+                                            ExplicitUnpackConflict>) {
+          const DFBInputUse &use = typedConflict.use;
+          use.consumer->emitOpError()
+              << "dataflow buffer " << use.dfbIndex << " requires "
+              << (typedConflict.requiredMode == DFBUnpackMode::UnpackToDestFp32
+                      ? "unpack-to-DST-f32 mode, but "
+                      : "default unpack mode, but ")
+              << kUnpackToDestFp32AttrName
+              << (typedConflict.configuredMode ==
+                          DFBUnpackMode::UnpackToDestFp32
+                      ? " includes this index"
+                      : " excludes this index");
+        } else {
+          InFlightDiagnostic diagnostic =
+              typedConflict.secondUse.consumer->emitOpError()
+              << "dataflow buffer " << typedConflict.secondUse.dfbIndex
+              << " requires incompatible unpack modes in one kernel";
+          diagnostic.attachNote(typedConflict.firstUse.consumer->getLoc())
+              << "operand " << typedConflict.firstUse.operandIndex
+              << " establishes the conflicting unpack mode";
+        }
+      },
+      conflict);
+}
+
+using TileStrategyOptions = SmallVector<TileExecutionOption, 2>;
+using KernelTileStrategyOptions = SmallVector<TileStrategyOptions, 0>;
+
+/// Apply strategy policy without changing the collected requirements.
+FailureOr<KernelTileStrategyOptions>
+getTileStrategyOptions(const KernelRequirements &requirements,
+                       const KernelConfigPolicy &policy) {
+  KernelTileStrategyOptions allOptions;
+  allOptions.reserve(requirements.tileStrategyChoices.size());
+  for (const TileExecutionChoice &choice : requirements.tileStrategyChoices) {
+    TileStrategyOptions choiceOptions;
+    for (const TileExecutionOption &option : choice.options) {
+      if (option.strategy == TileExecutionStrategy::FPU &&
+          !policy.allowFPUBinary) {
+        continue;
+      }
+      choiceOptions.push_back(option);
+    }
+    if (choiceOptions.empty()) {
+      if (choice.hasExplicitStrategy) {
+        choice.operation->emitOpError(
+            "explicit FPU strategy conflicts with disabled FPU binary policy");
+      } else {
+        choice.operation->emitOpError(
+            "has no tile execution strategy allowed by kernel policy");
+      }
+      return failure();
+    }
+    llvm::stable_sort(choiceOptions, [](const TileExecutionOption &lhs,
+                                        const TileExecutionOption &rhs) {
+      return lhs.strategy == TileExecutionStrategy::FPU &&
+             rhs.strategy != TileExecutionStrategy::FPU;
+    });
+    allOptions.push_back(std::move(choiceOptions));
+  }
+  return allOptions;
+}
+
+struct StrategySearchState {
+  ConfigConstraintState constraints;
+  SmallVector<std::optional<TileExecutionStrategy>> selections;
+};
+
+using StrategySearchResult =
+    std::variant<StrategySearchState, ConfigConstraintConflict>;
+
+/// Select strategies jointly with shared per-DFB unpack constraints.
+StrategySearchResult
+resolveTileStrategies(ArrayRef<TileStrategyOptions> allOptions,
+                      const KernelTargetEnvironment &target,
+                      const KernelConfigPolicy &policy,
+                      StrategySearchState state) {
+  std::optional<size_t> selectedChoice;
+  size_t fewestCompatibleOptions = std::numeric_limits<size_t>::max();
+
+  for (auto [choiceIndex, options] : llvm::enumerate(allOptions)) {
+    if (state.selections[choiceIndex]) {
+      continue;
+    }
+    size_t compatibleOptions = 0;
+    std::optional<ConfigConstraintConflict> choiceConflict;
+    for (const TileExecutionOption &option : options) {
+      ConfigConstraintResult result =
+          applyConfigConstraints(state.constraints, target, policy,
+                                 option.dfbInputUses, option.dstModeUses);
+      if (std::holds_alternative<ConfigConstraintState>(result)) {
+        ++compatibleOptions;
+      } else if (!choiceConflict) {
+        choiceConflict = std::get<ConfigConstraintConflict>(std::move(result));
+      }
+    }
+    if (compatibleOptions == 0) {
+      assert(choiceConflict && "an incompatible option must retain evidence");
+      return *choiceConflict;
+    }
+    if (compatibleOptions < fewestCompatibleOptions) {
+      selectedChoice = choiceIndex;
+      fewestCompatibleOptions = compatibleOptions;
+    }
+  }
+
+  if (!selectedChoice) {
+    return state;
+  }
+
+  // Option order preserves the FPU preference after shared constraints are
+  // satisfied. Resolving the most constrained operation limits backtracking.
+  std::optional<ConfigConstraintConflict> immediateConflict;
+  std::optional<ConfigConstraintConflict> branchConflict;
+  for (const TileExecutionOption &option : allOptions[*selectedChoice]) {
+    ConfigConstraintResult result =
+        applyConfigConstraints(state.constraints, target, policy,
+                               option.dfbInputUses, option.dstModeUses);
+    if (std::holds_alternative<ConfigConstraintConflict>(result)) {
+      if (!immediateConflict) {
+        immediateConflict =
+            std::get<ConfigConstraintConflict>(std::move(result));
+      }
+      continue;
+    }
+    StrategySearchState nextState = state;
+    nextState.constraints = std::get<ConfigConstraintState>(std::move(result));
+    nextState.selections[*selectedChoice] = option.strategy;
+    StrategySearchResult searchResult =
+        resolveTileStrategies(allOptions, target, policy, std::move(nextState));
+    if (std::holds_alternative<StrategySearchState>(searchResult)) {
+      return searchResult;
+    }
+    if (!branchConflict) {
+      branchConflict =
+          std::get<ConfigConstraintConflict>(std::move(searchResult));
+    }
+  }
+
+  if (branchConflict) {
+    return *branchConflict;
+  }
+  assert(immediateConflict && "failed strategy search must retain evidence");
+  return *immediateConflict;
+}
+
+} // namespace
+
+FailureOr<KernelTargetEnvironment>
+KernelTargetEnvironment::get(func::FuncOp function) {
+  ModuleOp module = function->getParentOfType<ModuleOp>();
+  if (!module) {
+    function.emitOpError("is not nested in a module");
+    return failure();
+  }
+
+  Attribute rawTarget = module->getAttr(kTargetArchAttrName);
+  auto targetAttr = dyn_cast_or_null<ttcore::ArchAttr>(rawTarget);
+  if (rawTarget && !targetAttr) {
+    module.emitOpError() << kTargetArchAttrName
+                         << " must be a #ttcore.arch attribute";
+    return failure();
+  }
+  std::optional<ttcore::Arch> targetArch;
+  if (targetAttr) {
+    targetArch = targetAttr.getValue();
+  }
+
+  auto systemDesc = module->getAttrOfType<ttcore::SystemDescAttr>(
+      ttcore::SystemDescAttr::name);
+  auto device =
+      module.lookupSymbol<ttcore::DeviceOp>(ttcore::getDefaultDeviceName());
+  if (systemDesc && device) {
+    ArrayRef<unsigned> chipIds = device.getDeviceAttr().getChipIds();
+    if (chipIds.empty()) {
+      device.emitOpError("has no selected chip");
+      return failure();
+    }
+    auto invalidChip = llvm::find_if(chipIds, [&](unsigned chipId) {
+      return chipId >= systemDesc.getChipDescIndices().size();
+    });
+    if (invalidChip != chipIds.end()) {
+      device.emitOpError() << "selects chip " << *invalidChip
+                           << " outside the system description";
+      return failure();
+    }
+    ttcore::Arch deviceArch =
+        systemDesc.getChipDesc(chipIds.front()).getArch().getValue();
+    if (llvm::any_of(llvm::drop_begin(chipIds), [&](unsigned chipId) {
+          return systemDesc.getChipDesc(chipId).getArch().getValue() !=
+                 deviceArch;
+        })) {
+      device.emitOpError("selects chips with different architectures");
+      return failure();
+    }
+    if (targetArch && *targetArch != deviceArch) {
+      module.emitOpError() << kTargetArchAttrName
+                           << " does not match the selected device arch";
+      return failure();
+    }
+    targetArch = deviceArch;
+  }
+
+  return KernelTargetEnvironment(targetArch);
+}
+
+bool KernelTargetEnvironment::supportsDstMode(TilePrimitive primitive,
+                                              Type elementType,
+                                              DstMode mode) const {
+  if (mode == DstMode::Default) {
+    return true;
+  }
+  if ((primitive == TilePrimitive::Broadcast ||
+       primitive == TilePrimitive::Transpose) &&
+      !elementType.isF32()) {
+    // tt-llk #1338: bf16 broadcast and transpose are incorrect when the
+    // kernel configures DST for f32 values.
+    return false;
+  }
+  return true;
+}
+
+bool KernelTargetEnvironment::supportsFullFp32Accumulation(
+    FullFp32AccumulationKind kind) const {
+  if (kind == FullFp32AccumulationKind::Matmul) {
+    return true;
+  }
+  if (arch == ttcore::Arch::WormholeB0) {
+    return false;
+  }
+  return arch != ttcore::Arch::Blackhole ||
+         kind != FullFp32AccumulationKind::ReduceRow;
+}
+
+DFBUnpackMode KernelTargetEnvironment::getRequiredUnpackMode(
+    TilePrimitive primitive, TileOperandRoute route, Type elementType) const {
+  if (elementType.isF32() &&
+      (route == TileOperandRoute::Dst || primitive == TilePrimitive::Copy)) {
+    return DFBUnpackMode::UnpackToDestFp32;
+  }
+  return DFBUnpackMode::Default;
+}
+
+FailureOr<KernelConfigPolicy>
+KernelConfigPolicy::get(func::FuncOp function, StringRef fp32Selection,
+                        StringRef syncSelection, bool reduceFullFp32,
+                        bool matmulFullFp32, bool enableFPUBinary) {
+  FailureOr<ConfigSelection> fp32 =
+      parseConfigSelection(function, "fp32-dest-acc-en", fp32Selection);
+  FailureOr<ConfigSelection> sync =
+      parseConfigSelection(function, "dst-full-sync-en", syncSelection);
+  if (failed(fp32) || failed(sync)) {
+    return failure();
+  }
+
+  FailureOr<std::optional<bool>> fp32Constraint =
+      getOptionalBoolConstraint(function, kFp32DestAccEnAttrName);
+  FailureOr<std::optional<bool>> syncConstraint =
+      getOptionalBoolConstraint(function, kDstFullSyncEnAttrName);
+  FailureOr<std::optional<bool>> fpuConstraint =
+      getOptionalBoolConstraint(function, kEnableFPUBinaryOpsAttrName);
+  FailureOr<std::optional<SmallVector<int32_t>>> unpackConstraint =
+      getOptionalUnpackConstraint(function);
+  if (failed(fp32Constraint) || failed(syncConstraint) ||
+      failed(fpuConstraint) || failed(unpackConstraint)) {
+    return failure();
+  }
+
+  KernelConfigPolicy policy;
+  policy.fp32DestAccumulation = *fp32;
+  policy.dstSynchronization = *sync;
+  policy.preferFullFp32Reduce = reduceFullFp32;
+  policy.preferFullFp32Matmul = matmulFullFp32;
+  policy.allowFPUBinary = enableFPUBinary;
+  policy.unpackToDestFp32 = std::move(*unpackConstraint);
+  if (*fp32Constraint) {
+    policy.fp32DestAccumulation =
+        **fp32Constraint ? ConfigSelection::Enabled : ConfigSelection::Disabled;
+  }
+  if (*syncConstraint) {
+    policy.dstSynchronization =
+        **syncConstraint ? ConfigSelection::Enabled : ConfigSelection::Disabled;
+  }
+  if (*fpuConstraint) {
+    policy.allowFPUBinary = **fpuConstraint;
+  }
+  return policy;
+}
+
+FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
+  KernelRequirements requirements;
+  WalkResult result = function.walk([&](TileExecutionOpInterface executionOp) {
+    Operation *operation = executionOp.getOperation();
+    if (!executionOp.getLegalExecutionStrategies().empty()) {
+      FailureOr<TileExecutionChoice> choice =
+          getTileExecutionChoice(executionOp);
+      if (failed(choice)) {
+        return WalkResult::interrupt();
+      }
+      requirements.tileStrategyChoices.push_back(std::move(*choice));
+      return WalkResult::advance();
+    }
+
+    if (operation->hasAttr(kTileExecutionStrategyAttrName)) {
+      operation->emitOpError()
+          << kTileExecutionStrategyAttrName
+          << " is only valid on tile operations with execution-strategy "
+             "alternatives";
+      return WalkResult::interrupt();
+    }
+    FailureOr<TileExecutionInfo> info =
+        executionOp.getTileExecutionInfo(std::nullopt);
+    if (failed(info)) {
+      operation->emitOpError("has no tile execution semantics");
+      return WalkResult::interrupt();
+    }
+    if (failed(verifyTileExecutionInfo(operation, *info)) ||
+        failed(appendExecutionRequirements(operation, *info,
+                                           requirements.dfbInputUses,
+                                           requirements.dstModeUses))) {
+      return WalkResult::interrupt();
+    }
+    if (info->fullFp32Accumulation) {
+      requirements.fullFp32AccumulationUses.push_back(
+          {operation, *info->fullFp32Accumulation});
+    }
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted()) {
+    return failure();
+  }
+  return requirements;
+}
+
+FailureOr<KernelConfigPlan> resolveKernelConfig(
+    func::FuncOp function, const KernelTargetEnvironment &target,
+    const KernelConfigPolicy &policy, const KernelRequirements &requirements) {
+  ConfigConstraintState initialState;
+  if (policy.fp32DestAccumulation == ConfigSelection::Enabled) {
+    initialState.dstModes.erase(DstMode::Default);
+    initialState.requiresFp32 = {function.getOperation(), std::nullopt};
+  } else if (policy.fp32DestAccumulation == ConfigSelection::Disabled) {
+    initialState.dstModes.erase(DstMode::Fp32);
+    initialState.requiresDefault = {function.getOperation(), std::nullopt};
+  }
+
+  ConfigConstraintResult fixedResult = applyConfigConstraints(
+      initialState, target, policy, requirements.dfbInputUses,
+      requirements.dstModeUses);
+  if (std::holds_alternative<ConfigConstraintConflict>(fixedResult)) {
+    emitConfigConstraintConflict(
+        function, std::get<ConfigConstraintConflict>(std::move(fixedResult)));
+    return failure();
+  }
+
+  FailureOr<KernelTileStrategyOptions> allOptions =
+      getTileStrategyOptions(requirements, policy);
+  if (failed(allOptions)) {
+    return failure();
+  }
+  StrategySearchState searchState{
+      std::get<ConfigConstraintState>(std::move(fixedResult)),
+      SmallVector<std::optional<TileExecutionStrategy>>(
+          requirements.tileStrategyChoices.size())};
+  StrategySearchResult searchResult = resolveTileStrategies(
+      *allOptions, target, policy, std::move(searchState));
+  if (std::holds_alternative<ConfigConstraintConflict>(searchResult)) {
+    emitConfigConstraintConflict(
+        function, std::get<ConfigConstraintConflict>(std::move(searchResult)));
+    return failure();
+  }
+  StrategySearchState resolvedState =
+      std::get<StrategySearchState>(std::move(searchResult));
+
+  SmallVector<TileExecutionDecision> tileStrategies;
+  tileStrategies.reserve(requirements.tileStrategyChoices.size());
+  for (auto [choice, strategy] : llvm::zip_equal(
+           requirements.tileStrategyChoices, resolvedState.selections)) {
+    assert(strategy && "successful strategy search must select every op");
+    tileStrategies.push_back({choice.operation, *strategy});
+  }
+
+  bool preferFp32 = false;
+  for (const FullFp32AccumulationUse &use :
+       requirements.fullFp32AccumulationUses) {
+    bool isMatmul = use.kind == FullFp32AccumulationKind::Matmul;
+    bool preferred =
+        isMatmul ? policy.preferFullFp32Matmul : policy.preferFullFp32Reduce;
+    if (!preferred) {
+      continue;
+    }
+    if (target.supportsFullFp32Accumulation(use.kind)) {
+      preferFp32 = true;
+      continue;
+    }
+    if (target.getArch() == ttcore::Arch::Blackhole &&
+        use.kind == FullFp32AccumulationKind::ReduceRow) {
+      use.operation->emitWarning()
+          << "full-fp32 row reduce is unavailable on Blackhole (tt-metal "
+             "#47311); using non-full-fp32 reduce lowering";
+    }
+  }
+  DstMode dstMode = DstMode::Default;
+  if ((preferFp32 ||
+       !resolvedState.constraints.dstModes.contains(DstMode::Default)) &&
+      resolvedState.constraints.dstModes.contains(DstMode::Fp32)) {
+    dstMode = DstMode::Fp32;
+  }
+
+  DstSyncMode syncMode = policy.dstSynchronization == ConfigSelection::Enabled
+                             ? DstSyncMode::Full
+                             : DstSyncMode::DoubleBuffered;
+
+  if (policy.unpackToDestFp32) {
+    return KernelConfigPlan{dstMode, syncMode, *policy.unpackToDestFp32,
+                            std::move(tileStrategies)};
+  }
+
+  SmallVector<int32_t> unpackToDestFp32;
+  for (auto [dfbIndex, mode] : resolvedState.constraints.unpackModes) {
+    if (mode == DFBUnpackMode::UnpackToDestFp32) {
+      unpackToDestFp32.push_back(static_cast<int32_t>(dfbIndex));
+    }
+  }
+  llvm::sort(unpackToDestFp32);
+  return KernelConfigPlan{dstMode, syncMode, std::move(unpackToDestFp32),
+                          std::move(tileStrategies)};
+}
+
+LogicalResult applyKernelConfigPlan(func::FuncOp function,
+                                    const KernelConfigPlan &plan) {
+  if (!std::is_sorted(plan.unpackToDestFp32.begin(),
+                      plan.unpackToDestFp32.end()) ||
+      std::adjacent_find(plan.unpackToDestFp32.begin(),
+                         plan.unpackToDestFp32.end()) !=
+          plan.unpackToDestFp32.end() ||
+      llvm::any_of(plan.unpackToDestFp32, [](int32_t index) {
+        return index < 0 || index >= kMaxCircularBuffers;
+      })) {
+    function.emitOpError(
+        "kernel configuration plan contains invalid dataflow buffer indices");
+    return failure();
+  }
+
+  llvm::SmallPtrSet<Operation *, 8> plannedOperations;
+  for (const TileExecutionDecision &decision : plan.tileStrategies) {
+    if (!decision.operation || !function->isAncestor(decision.operation)) {
+      function.emitOpError(
+          "tile execution plan refers to an operation outside the kernel");
+      return failure();
+    }
+    if (!plannedOperations.insert(decision.operation).second) {
+      decision.operation->emitOpError(
+          "tile execution plan contains duplicate strategy decisions");
+      return failure();
+    }
+    auto executionOp = dyn_cast<TileExecutionOpInterface>(decision.operation);
+    if (!executionOp) {
+      decision.operation->emitOpError(
+          "tile execution plan records a strategy for an unsupported op");
+      return failure();
+    }
+    if (!llvm::is_contained(executionOp.getLegalExecutionStrategies(),
+                            decision.strategy)) {
+      decision.operation->emitOpError(
+          "tile execution plan is inconsistent with the operation operands");
+      return failure();
+    }
+    FailureOr<TileExecutionInfo> info =
+        executionOp.getTileExecutionInfo(decision.strategy);
+    if (failed(info)) {
+      decision.operation->emitOpError(
+          "tile execution plan selects incomplete execution semantics");
+      return failure();
+    }
+    if (failed(verifyTileExecutionInfo(decision.operation, *info))) {
+      return failure();
+    }
+  }
+
+  WalkResult completeness =
+      function.walk([&](TileExecutionOpInterface executionOp) {
+        if (executionOp.getLegalExecutionStrategies().empty() ||
+            plannedOperations.contains(executionOp.getOperation())) {
+          return WalkResult::advance();
+        }
+        executionOp->emitOpError(
+            "tile execution plan does not select an execution strategy");
+        return WalkResult::interrupt();
+      });
+  if (completeness.wasInterrupted()) {
+    return failure();
+  }
+
+  MLIRContext *context = function.getContext();
+  for (const TileExecutionDecision &decision : plan.tileStrategies) {
+    decision.operation->setAttr(
+        kTileExecutionStrategyAttrName,
+        TileExecutionStrategyAttr::get(context, decision.strategy));
+  }
+  function->setAttr(kFp32DestAccEnAttrName,
+                    BoolAttr::get(context, plan.dstMode == DstMode::Fp32));
+  function->setAttr(
+      kDstFullSyncEnAttrName,
+      BoolAttr::get(context, plan.dstSyncMode == DstSyncMode::Full));
+  function->setAttr(kUnpackToDestFp32AttrName,
+                    DenseI32ArrayAttr::get(context, plan.unpackToDestFp32));
+  function->removeAttr(kEnableFPUBinaryOpsAttrName);
+  return success();
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -129,11 +129,7 @@ resolveDataflowBufferIndex(Value value, Operation *consumer) {
     return dfbIndex;
   }
 
-  if (value.getDefiningOp() || isa<BlockArgument>(value)) {
-    return std::optional<int64_t>();
-  }
-  consumer->emitOpError("has an unresolved tile operand");
-  return failure();
+  return std::optional<int64_t>();
 }
 
 /// Return the element type required by configuration queries.
@@ -620,16 +616,20 @@ KernelTargetEnvironment::get(func::FuncOp function) {
 bool KernelTargetEnvironment::supportsDstMode(TilePrimitive primitive,
                                               Type elementType,
                                               DstMode mode) const {
-  if (mode == DstMode::Default) {
+  if (mode == DstMode::Default || elementType.isF32() || !arch) {
     return true;
   }
-  if (primitive == TilePrimitive::BroadcastRow && !elementType.isF32() &&
-      (!arch || *arch == ttcore::Arch::WormholeB0)) {
-    // tt-llk #1338: Wormhole row broadcast is incorrect for bf16 input when
-    // DST stores f32 values.
-    return false;
+
+  switch (primitive) {
+  case TilePrimitive::BroadcastColumn:
+  case TilePrimitive::BroadcastRow:
+  case TilePrimitive::BroadcastScalar:
+    // Broadcast LLKs interpret non-f32 inputs using the default DST format.
+    return *arch != ttcore::Arch::WormholeB0 &&
+           *arch != ttcore::Arch::Blackhole;
+  default:
+    return true;
   }
-  return true;
 }
 
 bool KernelTargetEnvironment::supportsFullFp32Accumulation(

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -389,7 +389,7 @@ static FailureOr<Type> getResultTileType(Operation *source) {
   if (!tensorType) {
     return failure();
   }
-  return ttcore::TileType::get(tensorType.getElementType());
+  return getTensorTileType(tensorType);
 }
 
 static ExpFlagsPlan buildExpFlagsPlan(ExpOp exp,

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -367,9 +367,6 @@ static FailureOr<Value> getSrcDstIndex(Value operand, Location loc,
 ///
 /// Source DST indices are resolved from the operand-defining ops' dst_index.
 /// The output index comes from this op's dst_index operand.
-/// The FPU variant (TTLTileBinaryFPUToTTKernel) is registered with higher
-/// benefit so it is tried first; this SFPU pattern is the unconditional
-/// fallback.
 template <typename SourceOp, typename InitOp, typename TTKernelComputeOp>
 struct TTLTileBinaryToTTKernel : OpConversionPattern<SourceOp> {
   TTLTileBinaryToTTKernel(MLIRContext *ctx)
@@ -378,6 +375,13 @@ struct TTLTileBinaryToTTKernel : OpConversionPattern<SourceOp> {
   LogicalResult
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (op->template hasTrait<TTLStrategyDependentBinaryOpTrait>()) {
+      FailureOr<TileExecutionStrategy> strategy =
+          getSelectedTileExecutionStrategy(op);
+      if (failed(strategy) || *strategy != TileExecutionStrategy::SFPU) {
+        return rewriter.notifyMatchFailure(op, "SFPU strategy is not selected");
+      }
+    }
     Location loc = op.getLoc();
 
     auto src0 = getSrcDstIndex(op.getLhs(), loc, rewriter);
@@ -432,9 +436,7 @@ struct TTLTileMaxToTTKernel : OpConversionPattern<SourceOp> {
 /// FPU binary ops: read both operands from CBs, write result to DST.
 /// add_tiles(in0_cb, in1_cb, in0_tile_index, in1_tile_index, dst_index)
 ///
-/// Only matches strategy-dependent binary ops (add/sub/mul) that are
-/// currently FPU-eligible per isFPUEligibleBinaryOp. Registered with higher
-/// benefit than the SFPU pattern so this predicate is tried first.
+/// Only matches binary tile ops whose selected strategy is FPU.
 template <typename SourceOp, typename InitOp, typename TTKernelComputeOp>
 struct TTLTileBinaryFPUToTTKernel : OpConversionPattern<SourceOp> {
   TTLTileBinaryFPUToTTKernel(const TypeConverter &typeConverter,
@@ -444,8 +446,10 @@ struct TTLTileBinaryFPUToTTKernel : OpConversionPattern<SourceOp> {
   LogicalResult
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!isFPUEligibleBinaryOp(op)) {
-      return rewriter.notifyMatchFailure(op, "not FPU-eligible");
+    FailureOr<TileExecutionStrategy> strategy =
+        getSelectedTileExecutionStrategy(op);
+    if (failed(strategy) || *strategy != TileExecutionStrategy::FPU) {
+      return rewriter.notifyMatchFailure(op, "FPU strategy is not selected");
     }
 
     Location loc = op.getLoc();
@@ -488,9 +492,8 @@ struct TTLTileBinaryFPUToTTKernel : OpConversionPattern<SourceOp> {
               llvm::Twine(rhsTensorTy.getNumElements()));
     }
 
-    // CB tile index: both operands share the same index because
-    // isFPUEligibleBinaryOp only matches when the two tensor.extract ops use
-    // identical induction indices (the lowered form of matching maps).
+    // FPU strategy selection proves that both extracts use the same tile
+    // coordinates before DST assignment can change operand provenance.
     auto cbIdx = computeCBTileIndex(op.getLhs(), rewriter, loc);
     if (failed(cbIdx)) {
       return rewriter.notifyMatchFailure(
@@ -753,11 +756,7 @@ struct CBInputTileOpSetup {
 
 /// Lower ttl.tile_reduce to ttkernel.reduce_tile.
 struct TTLTileReduceToTTKernel : OpConversionPattern<TileReduceOp> {
-  bool fullFp32;
-
-  TTLTileReduceToTTKernel(TypeConverter &converter, MLIRContext *ctx,
-                          bool fullFp32)
-      : OpConversionPattern<TileReduceOp>(converter, ctx), fullFp32(fullFp32) {}
+  using OpConversionPattern<TileReduceOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(TileReduceOp op, TileReduceOp::Adaptor adaptor,
@@ -795,12 +794,6 @@ struct TTLTileReduceToTTKernel : OpConversionPattern<TileReduceOp> {
         ttk::ReduceTypeAttr::get(op.getContext(), ttkReduceType),
         ttk::ReduceDimAttr::get(op.getContext(), op.getReduceDim()));
 
-    if (fullFp32 && isBlackholeTarget(op) &&
-        op.getReduceDim() == ttk::ReduceDim::Row) {
-      op.emitWarning()
-          << "full-fp32 row reduce is unavailable on Blackhole (tt-metal "
-             "#47311); using non-full-fp32 reduce lowering";
-    }
     // Propagate output CB index for per-op init insertion.
     if (auto cbIdxAttr =
             op->getAttrOfType<IntegerAttr>(kReduceOutputCBIndexAttrName)) {
@@ -1076,8 +1069,7 @@ struct TTLTileMulUnaryConstToTTKernel
 //===----------------------------------------------------------------------===//
 
 void populateTTLTileOpsToTTKernelPatterns(TypeConverter *typeConverter,
-                                          RewritePatternSet &patterns,
-                                          bool reduceFullFp32) {
+                                          RewritePatternSet &patterns) {
   MLIRContext *ctx = patterns.getContext();
 
   // DST lifecycle ops (1:1 conversion, no operands/results).
@@ -1119,7 +1111,7 @@ void populateTTLTileOpsToTTKernelPatterns(TypeConverter *typeConverter,
   patterns.add<TTLTileBcastToTTKernel>(*typeConverter, ctx);
 
   // Reduce and transpose ops need the type converter for CB lookup.
-  patterns.add<TTLTileReduceToTTKernel>(*typeConverter, ctx, reduceFullFp32);
+  patterns.add<TTLTileReduceToTTKernel>(*typeConverter, ctx);
   patterns.add<TTLTileTransposeToTTKernel>(*typeConverter, ctx);
 
   // Matmul block needs the type converter for CB lookup.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -461,10 +461,10 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   // tensor's element type so mixed-dtype fusion (e.g., bf16 input + f32
   // intermediate produced by a fused `ttl.typecast`) preserves per-value
   // precision. The output block arg type matches the sink tensor.
-  Type outputTileType = ttcore::TileType::get(type.getElementType());
+  Type outputTileType = getTensorTileType(type);
   auto getInputTileType = [&](Value root) -> Type {
     auto inputTensor = cast<RankedTensorType>(root.getType());
-    return ttcore::TileType::get(inputTensor.getElementType());
+    return getTensorTileType(inputTensor);
   };
 
   for (Value root : creation.inputs) {
@@ -621,9 +621,9 @@ static LogicalResult buildComputeFromInputs(
     if (!inputType) {
       return rewriter.notifyMatchFailure(op, "input is not a ranked tensor");
     }
-    inputTileTypes.push_back(ttcore::TileType::get(inputType.getElementType()));
+    inputTileTypes.push_back(getTensorTileType(inputType));
   }
-  Type outputTileType = ttcore::TileType::get(outputType.getElementType());
+  Type outputTileType = getTensorTileType(outputType);
 
   SmallVector<Attribute> maps;
   for (AffineMap inputMap : creation->iteration.inputMaps) {
@@ -1066,8 +1066,7 @@ struct LowerStoreToCompute : OpRewritePattern<StoreOp> {
         rewriter.getArrayAttr(iteratorTypes));
 
     Block *body = rewriter.createBlock(&computeOp.getBody());
-    Type scalarType = inputType.getElementType();
-    Type tileType = ttcore::TileType::get(scalarType);
+    Type tileType = getTensorTileType(inputType);
     body->addArgument(tileType, loc);
     body->addArgument(tileType, loc);
 

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1850,8 +1850,7 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
 /// (ttl-lower-to-loops).
 static LogicalResult
 lowerTileOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
-                       TTLToTTKernelTypeConverter &typeConverter,
-                       bool reduceFullFp32) {
+                       TTLToTTKernelTypeConverter &typeConverter) {
   ConversionTarget computeTarget(ctx);
   computeTarget.addLegalDialect<ttkernel::TTKernelDialect>();
   computeTarget.addLegalDialect<affine::AffineDialect, arith::ArithDialect>();
@@ -1884,8 +1883,7 @@ lowerTileOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
       });
 
   RewritePatternSet computePatterns(&ctx);
-  populateTTLTileOpsToTTKernelPatterns(&typeConverter, computePatterns,
-                                       reduceFullFp32);
+  populateTTLTileOpsToTTKernelPatterns(&typeConverter, computePatterns);
   return applyPartialConversion(mod, computeTarget, std::move(computePatterns));
 }
 
@@ -2054,6 +2052,11 @@ struct TTLConvertTTLToTTKernelPass
     ModuleOp mod = getOperation();
     TTLToTTKernelTypeConverter typeConverter;
 
+    if (failed(verifyTileExecutionSemantics(mod))) {
+      signalPassFailure();
+      return;
+    }
+
     // Phase 0: Expand DstSectionOp into four TTL sync ops. This inlines the
     // DstSectionOp body and inserts acquire/commit/wait/release around it,
     // with stores reordered to the pack phase (after wait).
@@ -2068,8 +2071,7 @@ struct TTLConvertTTLToTTKernelPass
     }
 
     // Phase 2: Lower tile compute ops to TTKernel (tile_add, tile_mul, ...)
-    if (failed(
-            lowerTileOpsToTTKernel(mod, ctx, typeConverter, reduceFullFp32))) {
+    if (failed(lowerTileOpsToTTKernel(mod, ctx, typeConverter))) {
       signalPassFailure();
       return;
     }

--- a/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
@@ -126,21 +126,19 @@ static FailureOr<CopyTileOp> createCopyTileForArg(
 // Phase 1: Copy Insertion
 //===----------------------------------------------------------------------===//
 
-/// Get consumers of a value sorted by their position in the block.
-/// Excludes CB-reading ops (bcast, etc.) since they don't use DST for input.
+/// Return distinct DST consumers of `value` in block order.
 static SmallVector<Operation *> getSortedConsumers(Value v) {
-  SmallVector<Operation *> consumers;
-  for (Operation *user : v.getUsers()) {
-    // Skip CB-input ops (bcast, reduce, transpose, FPU binary, etc.)
-    if (isCBInputOp(user)) {
+  llvm::SmallSetVector<Operation *, 4> consumers;
+  for (OpOperand &use : v.getUses()) {
+    if (!isDstInput(use)) {
       continue;
     }
-    consumers.push_back(user);
+    consumers.insert(use.getOwner());
   }
-  // Sort by block position
-  llvm::sort(consumers,
+  SmallVector<Operation *> sortedConsumers(consumers.begin(), consumers.end());
+  llvm::sort(sortedConsumers,
              [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
-  return consumers;
+  return sortedConsumers;
 }
 
 /// Check if any consumer is an in-place operation (overwrites DST input).
@@ -259,20 +257,17 @@ static void buildLiveIntervals(
   for (Operation &op : *body) {
     int64_t currentIdx = opIndex[&op];
 
-    // Extend input intervals to this use (skipping ops with CB inputs)
-    if (!isCBInputOp(&op)) {
-      for (Value operand : op.getOperands()) {
-        if (!isTileValue(operand)) {
-          continue;
-        }
-        if (!intervals.count(operand)) {
-          // Block argument: start at (first_use - 1) to enable register reuse.
-          // Args consumed at position N get allocated before outputs produced
-          // at N, allowing outputs to reuse the consumed args' registers.
-          intervals[operand] = {currentIdx - 1, currentIdx, operand};
-        } else {
-          intervals[operand].end = std::max(intervals[operand].end, currentIdx);
-        }
+    for (OpOperand &operandUse : op.getOpOperands()) {
+      Value operand = operandUse.get();
+      if (!isDstInput(operandUse) || !isTileValue(operand)) {
+        continue;
+      }
+      if (!intervals.count(operand)) {
+        // Block arguments begin immediately before their first DST use so an
+        // output produced by that use may reuse the consumed register.
+        intervals[operand] = {currentIdx - 1, currentIdx, operand};
+      } else {
+        intervals[operand].end = std::max(intervals[operand].end, currentIdx);
       }
     }
 
@@ -377,56 +372,52 @@ static void buildLiveIntervals(
     });
   }
 
-  // Prevent DST register reuse between FPU binary ops.
-  // FPU binary ops (add_tiles, mul_tiles, sub_tiles) accumulate into their
-  // output DST register: result = old_DST_value + computed_value. If two FPU
-  // binary ops share the same DST output index, the second reads the first's
-  // residual and produces a corrupted result. We prevent this by extending
-  // FPU binary result intervals so the linear scan allocator assigns distinct
-  // registers.
+  // Operations that accumulate into DST cannot reuse a prior accumulator slot
+  // within the same acquire because its residual value changes the result.
+  // Keep their result intervals live through the last accumulating operation.
   //
-  // TODO(#343): This wastes DST capacity. The proper fix is to pass
-  // acc_to_dest=false to add_tiles_init/sub_tiles_init/mul_tiles_init in
-  // TTKernel (currently a FIXME in TTKernelOps.td). With explicit overwrite
-  // mode, DST reuse between FPU binary ops would be safe and this interval
-  // extension could be removed.
+  // TODO(#343): Set acc_to_dest=false for FPU binary init operations so they
+  // no longer require this extension.
   {
-    // Include TileMatmulBlockOp alongside FPU binary ops: matmul_block also
-    // accumulates into DST and its slot must not be reused by another
-    // accumulating op within the same sync region.
-    auto isFPUAccumulatingOp = [](Operation &op) {
-      return isFPUEligibleBinaryOp(&op) || isa<TileMatmulBlockOp>(&op);
+    auto isDstAccumulatingOp = [](Operation &op) {
+      auto executionOp = dyn_cast<TileExecutionOpInterface>(&op);
+      if (!executionOp) {
+        return false;
+      }
+      FailureOr<TileExecutionInfo> info = getSelectedTileExecutionInfo(&op);
+      assert(succeeded(info) && "tile execution semantics are unresolved");
+      return info->accumulatesIntoDst;
     };
 
-    SmallVector<int64_t> fpuBinaryStarts;
+    SmallVector<int64_t> accumulatingOpStarts;
     for (Operation &op : *body) {
-      if (isFPUAccumulatingOp(op)) {
-        fpuBinaryStarts.push_back(opIndex[&op]);
+      if (isDstAccumulatingOp(op)) {
+        accumulatingOpStarts.push_back(opIndex[&op]);
       }
     }
 
-    if (fpuBinaryStarts.size() > 1) {
-      int64_t lastFPUStart = *llvm::max_element(fpuBinaryStarts);
+    if (accumulatingOpStarts.size() > 1) {
+      int64_t lastAccumulatingStart = *llvm::max_element(accumulatingOpStarts);
       for (Operation &op : *body) {
-        if (!isFPUAccumulatingOp(op)) {
+        if (!isDstAccumulatingOp(op)) {
           continue;
         }
         for (Value result : op.getResults()) {
           if (!isTileValue(result) || !intervals.count(result)) {
             continue;
           }
-          // Use lastFPUStart + 1 because the linear scan expires intervals
-          // with end <= start, so end must be strictly greater than the last
-          // FPU binary op's start index to remain active during allocation.
-          if (intervals[result].end <= lastFPUStart) {
+          // The allocator expires intervals with end <= start, so the end must
+          // exceed the final accumulating operation's start.
+          if (intervals[result].end <= lastAccumulatingStart) {
             LLVM_DEBUG({
-              llvm::dbgs() << "Phase 2: Extended FPU binary interval from ["
+              llvm::dbgs() << "Phase 2: Extended accumulating interval from ["
                            << intervals[result].start << ", "
                            << intervals[result].end << "] to ["
                            << intervals[result].start << ", "
-                           << (lastFPUStart + 1) << "] to prevent DST reuse\n";
+                           << (lastAccumulatingStart + 1)
+                           << "] to prevent DST reuse\n";
             });
-            intervals[result].end = lastFPUStart + 1;
+            intervals[result].end = lastAccumulatingStart + 1;
           }
         }
       }
@@ -553,6 +544,11 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
 
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
+
+    if (failed(verifyTileExecutionSemantics(funcOp))) {
+      signalPassFailure();
+      return;
+    }
 
     funcOp.walk([&](ComputeOp computeOp) {
       Block *body = &computeOp.getRegion().front();
@@ -724,10 +720,13 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
       // Copies must be inserted at first use (not block start) to match the
       // liveness intervals that DST allocation was computed against.
       for (Operation &op : *body) {
-        if (isCBInputOp(&op) || isa<CopyTileOp>(&op)) {
+        if (isa<CopyTileOp>(&op)) {
           continue;
         }
         for (OpOperand &operand : op.getOpOperands()) {
+          if (!isDstInput(operand)) {
+            continue;
+          }
           auto arg = dyn_cast<BlockArgument>(operand.get());
           if (!arg || !isTileValue(arg) || dstIndexForValue.count(arg)) {
             continue;
@@ -743,8 +742,7 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
 
           arg.replaceUsesWithIf(copy->getDstTile(), [&](OpOperand &use) {
             return use.getOwner() != copy->getOperation() &&
-                   !isa<CopyTileOp>(use.getOwner()) &&
-                   !isCBInputOp(use.getOwner());
+                   !isa<CopyTileOp>(use.getOwner()) && isDstInput(use);
           });
         }
       }

--- a/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
@@ -71,6 +71,22 @@ constexpr int64_t kPlaceholderIndex = std::numeric_limits<int64_t>::max();
 
 static bool isTileValue(Value v) { return isa<ttcore::TileType>(v.getType()); }
 
+static LogicalResult verifyDSTOperationPlacement(ComputeOp computeOp) {
+  Block *body = &computeOp.getRegion().front();
+  WalkResult result = computeOp.getRegion().walk([&](Operation *operation) {
+    if (operation->getBlock() == body ||
+        !dyn_cast<DstAccessOpInterface>(operation)) {
+      return WalkResult::advance();
+    }
+
+    operation->emitOpError()
+        << "nested DST operations are not supported by ttl-assign-dst; "
+           "expected the operation directly in the ttl.compute body";
+    return WalkResult::interrupt();
+  });
+  return success(!result.wasInterrupted());
+}
+
 //===----------------------------------------------------------------------===//
 // Equivalence Classes for Merged Intervals
 //===----------------------------------------------------------------------===//
@@ -544,6 +560,16 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
 
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
+
+    WalkResult placementResult = funcOp.walk([&](ComputeOp computeOp) {
+      return failed(verifyDSTOperationPlacement(computeOp))
+                 ? WalkResult::interrupt()
+                 : WalkResult::advance();
+    });
+    if (placementResult.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
 
     if (failed(verifyTileExecutionSemantics(funcOp))) {
       signalPassFailure();

--- a/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
@@ -71,22 +71,6 @@ constexpr int64_t kPlaceholderIndex = std::numeric_limits<int64_t>::max();
 
 static bool isTileValue(Value v) { return isa<ttcore::TileType>(v.getType()); }
 
-static LogicalResult verifyDSTOperationPlacement(ComputeOp computeOp) {
-  Block *body = &computeOp.getRegion().front();
-  WalkResult result = computeOp.getRegion().walk([&](Operation *operation) {
-    if (operation->getBlock() == body ||
-        !dyn_cast<DstAccessOpInterface>(operation)) {
-      return WalkResult::advance();
-    }
-
-    operation->emitOpError()
-        << "nested DST operations are not supported by ttl-assign-dst; "
-           "expected the operation directly in the ttl.compute body";
-    return WalkResult::interrupt();
-  });
-  return success(!result.wasInterrupted());
-}
-
 //===----------------------------------------------------------------------===//
 // Equivalence Classes for Merged Intervals
 //===----------------------------------------------------------------------===//
@@ -142,19 +126,16 @@ static FailureOr<CopyTileOp> createCopyTileForArg(
 // Phase 1: Copy Insertion
 //===----------------------------------------------------------------------===//
 
-/// Return distinct DST consumers of `value` in block order.
-static SmallVector<Operation *> getSortedConsumers(Value v) {
+/// Return distinct DST consumers of `value`.
+static SmallVector<Operation *> getDSTConsumers(Value value) {
   llvm::SmallSetVector<Operation *, 4> consumers;
-  for (OpOperand &use : v.getUses()) {
+  for (OpOperand &use : value.getUses()) {
     if (!isDstInput(use) || isDstInputMaterializedByOperation(use)) {
       continue;
     }
     consumers.insert(use.getOwner());
   }
-  SmallVector<Operation *> sortedConsumers = llvm::to_vector(consumers);
-  llvm::sort(sortedConsumers,
-             [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
-  return sortedConsumers;
+  return llvm::to_vector(consumers);
 }
 
 /// Check if any consumer is an in-place operation (overwrites DST input).
@@ -162,6 +143,93 @@ static bool hasInPlaceConsumer(ArrayRef<Operation *> consumers) {
   return llvm::any_of(consumers, [](Operation *op) {
     return op->hasTrait<TTLInPlaceOpTrait>();
   });
+}
+
+static LogicalResult verifyNestedDSTRequirements(ComputeOp computeOp) {
+  Block *body = &computeOp.getRegion().front();
+  WalkResult result = computeOp.getRegion().walk([&](Operation *operation) {
+    if (operation->getBlock() == body ||
+        !isa<DstAccessOpInterface>(operation)) {
+      return WalkResult::advance();
+    }
+
+    auto emitUnsupported = [&](StringRef requirement) {
+      operation->emitOpError()
+          << "nested DST operation requires " << requirement
+          << " by ttl-assign-dst; expected the operation directly in the "
+             "ttl.compute body";
+      return WalkResult::interrupt();
+    };
+
+    if (operation->hasAttr(kDstPlaceholderAttrName)) {
+      return emitUnsupported("destination assignment");
+    }
+    if (std::optional<Value> dstIndex = getTileOpDstIndex(operation)) {
+      std::optional<int64_t> constantIndex = getConstantIntValue(*dstIndex);
+      if (constantIndex && *constantIndex == kUnassignedDstIndex) {
+        return emitUnsupported("destination assignment");
+      }
+    }
+    if (auto copyTile = dyn_cast<CopyTileOp>(operation);
+        copyTile && copyTile.getSrcIndices().empty()) {
+      return emitUnsupported("source-index materialization");
+    }
+    if (auto tileStore = dyn_cast<TileStoreOp>(operation);
+        tileStore && tileStore.getIndices().empty()) {
+      return emitUnsupported("store-index materialization");
+    }
+
+    for (OpOperand &operand : operation->getOpOperands()) {
+      if (!isDstInput(operand) || isDstInputMaterializedByOperation(operand)) {
+        continue;
+      }
+      bool usesDestinationAsFirstInput =
+          operation->hasTrait<TTLInPlaceOpTrait>() &&
+          operand.getOperandNumber() == 0;
+      if (!usesDestinationAsFirstInput &&
+          failed(getDstFootprint(operand.get()))) {
+        return emitUnsupported("source DST index resolution");
+      }
+    }
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted()) {
+    return failure();
+  }
+
+  auto verifyValue = [&](Value value) -> LogicalResult {
+    if (!isTileValue(value)) {
+      return success();
+    }
+    SmallVector<Operation *> consumers = getDSTConsumers(value);
+    if (consumers.size() <= 1 || !hasInPlaceConsumer(consumers)) {
+      return success();
+    }
+    auto nestedConsumer = llvm::find_if(consumers, [&](Operation *consumer) {
+      return consumer->getBlock() != body;
+    });
+    if (nestedConsumer == consumers.end()) {
+      return success();
+    }
+    (*nestedConsumer)->emitOpError()
+        << "nested DST consumer requires copy insertion by ttl-assign-dst; "
+           "expected the operation directly in the ttl.compute body";
+    return failure();
+  };
+
+  for (Value blockArgument : body->getArguments()) {
+    if (failed(verifyValue(blockArgument))) {
+      return failure();
+    }
+  }
+  for (Operation &operation : *body) {
+    for (Value result : operation.getResults()) {
+      if (failed(verifyValue(result))) {
+        return failure();
+      }
+    }
+  }
+  return success();
 }
 
 /// Phase 1: Insert copy operations for multi-consumer values where any
@@ -184,7 +252,7 @@ static void insertCopiesForMultiConsumerValues(ComputeOp computeOp,
       return;
     }
 
-    auto consumers = getSortedConsumers(v);
+    auto consumers = getDSTConsumers(v);
     if (consumers.size() <= 1) {
       return; // No multi-consumer
     }
@@ -193,6 +261,15 @@ static void insertCopiesForMultiConsumerValues(ComputeOp computeOp,
     if (!hasInPlaceConsumer(consumers)) {
       return; // No in-place consumers - no copies needed
     }
+
+    assert(llvm::all_of(consumers,
+                        [&](Operation *consumer) {
+                          return consumer->getBlock() == body;
+                        }) &&
+           "nested consumer requiring copy insertion passed preflight");
+    llvm::sort(consumers, [](Operation *lhs, Operation *rhs) {
+      return lhs->isBeforeInBlock(rhs);
+    });
 
     valuesToCopy.push_back({v, consumers});
   };
@@ -561,17 +638,17 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
 
-    WalkResult placementResult = funcOp.walk([&](ComputeOp computeOp) {
-      return failed(verifyDSTOperationPlacement(computeOp))
-                 ? WalkResult::interrupt()
-                 : WalkResult::advance();
-    });
-    if (placementResult.wasInterrupted()) {
+    if (failed(verifyTileExecutionSemantics(funcOp))) {
       signalPassFailure();
       return;
     }
 
-    if (failed(verifyTileExecutionSemantics(funcOp))) {
+    WalkResult requirementsResult = funcOp.walk([&](ComputeOp computeOp) {
+      return failed(verifyNestedDSTRequirements(computeOp))
+                 ? WalkResult::interrupt()
+                 : WalkResult::advance();
+    });
+    if (requirementsResult.wasInterrupted()) {
       signalPassFailure();
       return;
     }

--- a/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
@@ -130,7 +130,7 @@ static FailureOr<CopyTileOp> createCopyTileForArg(
 static SmallVector<Operation *> getSortedConsumers(Value v) {
   llvm::SmallSetVector<Operation *, 4> consumers;
   for (OpOperand &use : v.getUses()) {
-    if (!isDstInput(use)) {
+    if (!isDstInput(use) || isDstInputMaterializedByOperation(use)) {
       continue;
     }
     consumers.insert(use.getOwner());
@@ -724,7 +724,8 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
           continue;
         }
         for (OpOperand &operand : op.getOpOperands()) {
-          if (!isDstInput(operand)) {
+          if (!isDstInput(operand) ||
+              isDstInputMaterializedByOperation(operand)) {
             continue;
           }
           auto arg = dyn_cast<BlockArgument>(operand.get());
@@ -742,7 +743,8 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
 
           arg.replaceUsesWithIf(copy->getDstTile(), [&](OpOperand &use) {
             return use.getOwner() != copy->getOperation() &&
-                   !isa<CopyTileOp>(use.getOwner()) && isDstInput(use);
+                   !isa<CopyTileOp>(use.getOwner()) && isDstInput(use) &&
+                   !isDstInputMaterializedByOperation(use);
           });
         }
       }

--- a/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
@@ -135,7 +135,7 @@ static SmallVector<Operation *> getSortedConsumers(Value v) {
     }
     consumers.insert(use.getOwner());
   }
-  SmallVector<Operation *> sortedConsumers(consumers.begin(), consumers.end());
+  SmallVector<Operation *> sortedConsumers = llvm::to_vector(consumers);
   llvm::sort(sortedConsumers,
              [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
   return sortedConsumers;

--- a/lib/Dialect/TTL/Transforms/TTLScheduleOperations.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLScheduleOperations.cpp
@@ -257,6 +257,11 @@ struct TTLScheduleOperationsPass
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
 
+    if (failed(verifyTileExecutionSemantics(funcOp))) {
+      signalPassFailure();
+      return;
+    }
+
     WalkResult result = funcOp.walk([&](DstSectionOp dstSection) {
       SmallVector<Operation *, 16> pendingTileOps;
       auto schedulePendingTileOps = [&]() -> LogicalResult {

--- a/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
@@ -27,7 +27,7 @@ struct TTLSetComputeKernelConfigPass
 
   void runOnOperation() override {
     func::FuncOp function = getOperation();
-    FailureOr<KernelTargetEnvironment> target =
+    FailureOr<std::unique_ptr<KernelTargetEnvironment>> target =
         KernelTargetEnvironment::get(function);
     FailureOr<KernelConfigPolicy> policy = KernelConfigPolicy::get(
         function, fp32DestAccEn, dstFullSyncEn, reduceFullFp32, matmulFullFp32,
@@ -45,7 +45,7 @@ struct TTLSetComputeKernelConfigPass
     }
 
     FailureOr<KernelConfigPlan> plan =
-        resolveKernelConfig(function, *target, *policy, *requirements);
+        resolveKernelConfig(function, **target, *policy, *requirements);
     if (failed(plan)) {
       signalPassFailure();
       return;

--- a/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
@@ -5,19 +5,11 @@
 //===----------------------------------------------------------------------===//
 // TTL Set Compute Kernel Config Pass
 //===----------------------------------------------------------------------===//
-//
-// Sets compute configuration attributes on ttl.compute operations so
-// downstream passes can consume stable, explicit settings.
-//
-//===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/IR/BuiltinAttributes.h"
-#include "ttlang/Dialect/TTL/IR/TTL.h"
-#include "ttlang/Dialect/TTL/IR/TTLOps.h"
-#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
-#include "llvm/ADT/STLExtras.h"
+
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h"
 
 namespace mlir::tt::ttl {
 
@@ -25,129 +17,6 @@ namespace mlir::tt::ttl {
 #include "ttlang/Dialect/TTL/Passes.h.inc"
 
 namespace {
-
-// TODO(#264): This function returns true if ANY arg is f32, enabling
-// fp32_dest_acc_en for the entire compute op. Consider emitting a diagnostic
-// when mixed dtypes are detected, or allowing per-operation fp32 control.
-static bool hasF32TileArgs(ComputeOp computeOp) {
-  Block *body = &computeOp.getRegion().front();
-  if (!body) {
-    return false;
-  }
-
-  return llvm::any_of(body->getArguments(), [](BlockArgument arg) {
-    std::optional<mlir::Type> elementType = getTileElementType(arg.getType());
-    return elementType && elementType->isF32();
-  });
-}
-
-/// Resolve the CB index of `value` when it is an f32 input block argument of
-/// `computeOp` that is consumed directly from a circular buffer.
-static std::optional<int64_t>
-getF32InputCBIndexForBlockArg(Value value, ComputeOp computeOp) {
-  auto arg = dyn_cast<BlockArgument>(value);
-  if (!arg || arg.getOwner() != &computeOp.getRegion().front()) {
-    return std::nullopt;
-  }
-  unsigned argNumber = arg.getArgNumber();
-  if (argNumber >= computeOp.getNumInputs()) {
-    return std::nullopt;
-  }
-  std::optional<mlir::Type> elementType = getTileElementType(arg.getType());
-  if (!elementType || !elementType->isF32()) {
-    return std::nullopt;
-  }
-  Value cb = getAttachedCB(computeOp.getInputs()[argNumber]);
-  if (!cb) {
-    return std::nullopt;
-  }
-  return getCBIndex(cb);
-}
-
-// TODO: Add TTLFPUOp and TTLSFPUOp traits to distinguish FPU and SFPU tile ops.
-// Then stop relying on the list of ops in "if (isa<TileReduceOp,
-// TileMatmulBlockOp>(op), ...) "
-static bool isDstInputTileComputeOp(Operation *op) {
-  if (!isTileComputeOp(op)) {
-    return false;
-  }
-  if (isa<TileReduceOp, TileMatmulBlockOp>(op)) {
-    return false;
-  }
-  if (isFPUEligibleBinaryOp(op)) {
-    return false;
-  }
-
-  return op->hasTrait<TTLStrategyDependentBinaryOpTrait>() ||
-         op->hasTrait<TTLDSTInputsTrait>() ||
-         isa<TileBcastOp, TileTransposeOp>(op);
-}
-
-/// Return true if `op` benefits from `UnpackToDestFp32` when its input is an
-/// f32 tile fed directly from a CB. This is the SFPU subset of
-/// `isDstInputTileComputeOp`: tile_bcast and tile_transpose are also
-/// DST-input ops, but their LLK paths (unary_bcast, transpose_dest) do not
-/// support `UnpackToDestFp32` mode and produce incorrect results when it is
-/// enabled on their source CB (see tt-llk #1338). They are therefore
-/// excluded here so the CB stays in the default unpack mode.
-static inline bool wantsUnpackToDestFp32(Operation *op) {
-  return isDstInputTileComputeOp(op) && !isa<TileBcastOp, TileTransposeOp>(op);
-}
-
-/// Return the CB index when `value` is an f32 input block argument of
-/// `computeOp` consumed by a tile op that must keep its source CB in `Default`
-/// unpack mode. FPU-style ops (reduce, matmul, FPU-eligible add/sub/mul) route
-/// the operand through SRCA/SRCB; `tile_bcast`/`tile_transpose` lower to
-/// `unary_bcast`/`transpose_dest`, which produce incorrect results under
-/// `UnpackToDestFp32` on their source CB (tt-llk #1338). Both are incompatible
-/// with the mode.
-static std::optional<int64_t>
-getF32DefaultUnpackCBIndex(Operation *op, Value operand, ComputeOp computeOp) {
-  if (!isa<TileReduceOp, TileMatmulBlockOp, TileBcastOp, TileTransposeOp>(op) &&
-      !isFPUEligibleBinaryOp(op)) {
-    return std::nullopt;
-  }
-  return getF32InputCBIndexForBlockArg(operand, computeOp);
-}
-
-static constexpr unsigned kMaxUnpackFp32CBs = 4;
-
-struct F32InputCBUsage {
-  llvm::SmallSetVector<int64_t, kMaxUnpackFp32CBs> sfpuCBs;
-  llvm::MapVector<int64_t, Operation *> fpuCBConsumers;
-};
-
-/// Collect f32 input CB usage in one compute body.
-///
-/// FPU consumers (reduce, matmul, and FPU-eligible add/sub/mul) read via
-/// SRCA/SRCB and must remain in `Default` unpack mode. SFPU consumers that read
-/// f32 directly into DST require `UnpackToDestFp32`. These modes are configured
-/// per kernel on the function, so conflicts must be diagnosed after aggregating
-/// usage across every ttl.compute in the func.func.
-static F32InputCBUsage collectF32InputCBUsage(ComputeOp computeOp) {
-  F32InputCBUsage usage;
-
-  Block &body = computeOp.getRegion().front();
-  for (Operation &op : body.without_terminator()) {
-    for (Value operand : op.getOperands()) {
-      if (std::optional<int64_t> fpuIdx =
-              getF32DefaultUnpackCBIndex(&op, operand, computeOp)) {
-        usage.fpuCBConsumers.insert({*fpuIdx, &op});
-      }
-    }
-    if (!wantsUnpackToDestFp32(&op)) {
-      continue;
-    }
-    for (Value operand : op.getOperands()) {
-      if (std::optional<int64_t> cbIdx =
-              getF32InputCBIndexForBlockArg(operand, computeOp)) {
-        usage.sfpuCBs.insert(*cbIdx);
-      }
-    }
-  }
-
-  return usage;
-}
 
 struct TTLSetComputeKernelConfigPass
     : public impl::TTLSetComputeKernelConfigBase<
@@ -157,124 +26,28 @@ struct TTLSetComputeKernelConfigPass
   using Base::Base;
 
   void runOnOperation() override {
-    func::FuncOp funcOp = getOperation();
-
-    // fp32_dest_acc_en and dst_full_sync_en are per-kernel compile-time
-    // settings. Set them on the function so all compute ops inherit the
-    // same value via getKernelBoolAttr().
-    bool needsFp32 = fp32DestAccEn;
-    bool fp32FromMatmul = false;
-    bool fp32FromReduce = false;
-    if (!needsFp32) {
-      funcOp->walk([&](ComputeOp computeOp) {
-        if (needsFp32) {
-          return WalkResult::interrupt();
-        }
-        if (hasF32TileArgs(computeOp)) {
-          needsFp32 = true;
-          return WalkResult::interrupt();
-        }
-        if (reduceFullFp32) {
-          bool hasFullFp32Reduce = false;
-          computeOp->walk([&](TileReduceOp reduceOp) -> WalkResult {
-            if (shouldUseFullFp32Reduce(reduceOp, reduceFullFp32)) {
-              hasFullFp32Reduce = true;
-              return WalkResult::interrupt();
-            }
-            return WalkResult::advance();
-          });
-          if (hasFullFp32Reduce) {
-            needsFp32 = true;
-            fp32FromReduce = true;
-            return WalkResult::interrupt();
-          }
-        }
-        if (matmulFullFp32) {
-          bool hasMatmul = false;
-          computeOp->walk([&](TileMatmulBlockOp) -> WalkResult {
-            hasMatmul = true;
-            return WalkResult::interrupt();
-          });
-          if (hasMatmul) {
-            needsFp32 = true;
-            fp32FromMatmul = true;
-            return WalkResult::interrupt();
-          }
-        }
-        return WalkResult::advance();
-      });
-    }
-
-    // TODO(#454): Remove once tt-llk #1338 is fixed. unary_bcast produces
-    // incorrect results with fp32_dest_acc_en and bf16 CBs. The same failure
-    // mode appears when full-fp32 reduce enables fp32_dest_acc_en and the
-    // fused body still feeds a bf16 unary_bcast (e.g. reduce then broadcast).
-    if (fp32FromMatmul || fp32FromReduce) {
-      bool hasBf16Bcast = false;
-      funcOp->walk([&](TileBcastOp bcastOp) -> WalkResult {
-        auto elemType = getTileElementType(bcastOp.getInput().getType());
-        if (elemType && !elemType->isF32()) {
-          hasBf16Bcast = true;
-          return WalkResult::interrupt();
-        }
-        return WalkResult::advance();
-      });
-      if (hasBf16Bcast) {
-        needsFp32 = false;
-      }
-    }
-
-    if (needsFp32 && !funcOp->hasAttr(kFp32DestAccEnAttrName)) {
-      funcOp->setAttr(kFp32DestAccEnAttrName,
-                      BoolAttr::get(funcOp.getContext(), true));
-    }
-    if (dstFullSyncEn && !funcOp->hasAttr(kDstFullSyncEnAttrName)) {
-      funcOp->setAttr(kDstFullSyncEnAttrName,
-                      BoolAttr::get(funcOp.getContext(), true));
-    }
-    funcOp->setAttr(kEnableFPUBinaryOpsAttrName,
-                    BoolAttr::get(funcOp.getContext(), enableFPUBinaryOps));
-
-    llvm::SmallSetVector<int64_t, kMaxUnpackFp32CBs> kernelSFPUCBs;
-    llvm::SmallDenseMap<int64_t, Operation *> kernelFPUCBConsumers;
-    funcOp->walk([&](ComputeOp computeOp) {
-      const F32InputCBUsage usage = collectF32InputCBUsage(computeOp);
-      kernelSFPUCBs.insert_range(usage.sfpuCBs);
-      for (auto [cb, consumer] : usage.fpuCBConsumers) {
-        // Keep the first FPU consumer for stable diagnostics when multiple
-        // compute regions consume the same CB through the FPU path.
-        kernelFPUCBConsumers.insert({cb, consumer});
-      }
-    });
-
-    bool hasConflict = false;
-    for (int64_t cb : kernelSFPUCBs) {
-      Operation *fpuConsumer = kernelFPUCBConsumers.lookup(cb);
-      if (!fpuConsumer) {
-        continue;
-      }
-      fpuConsumer->emitOpError()
-          << "f32 input from CB " << cb
-          << " is consumed by both FPU and SFPU strategies in the same "
-             "kernel; the FPU consumer requires default unpack mode while "
-             "the SFPU consumer needs UnpackToDestFp32, and the two modes "
-             "are mutually exclusive on a given CB. Split the source into "
-             "separate CBs (one per strategy) so the SFPU consumer keeps "
-             "full f32 precision";
-      hasConflict = true;
-    }
-    if (hasConflict) {
+    func::FuncOp function = getOperation();
+    FailureOr<KernelTargetEnvironment> target =
+        KernelTargetEnvironment::get(function);
+    FailureOr<KernelConfigPolicy> policy = KernelConfigPolicy::get(
+        function, fp32DestAccEn, dstFullSyncEn, reduceFullFp32, matmulFullFp32,
+        enableFPUBinaryOps);
+    if (failed(target) || failed(policy)) {
       signalPassFailure();
       return;
     }
 
-    if (!kernelSFPUCBs.empty() && !funcOp->hasAttr(kUnpackToDestFp32AttrName)) {
-      SmallVector<int64_t> sortedCBs(kernelSFPUCBs.begin(),
-                                     kernelSFPUCBs.end());
-      llvm::sort(sortedCBs);
-      SmallVector<int32_t> sortedCBs32(sortedCBs.begin(), sortedCBs.end());
-      funcOp->setAttr(kUnpackToDestFp32AttrName,
-                      DenseI32ArrayAttr::get(funcOp.getContext(), sortedCBs32));
+    FailureOr<KernelRequirements> requirements =
+        collectKernelRequirements(function);
+    if (failed(requirements)) {
+      signalPassFailure();
+      return;
+    }
+
+    FailureOr<KernelConfigPlan> plan =
+        resolveKernelConfig(function, *target, *policy, *requirements);
+    if (failed(plan) || failed(applyKernelConfigPlan(function, *plan))) {
+      signalPassFailure();
     }
   }
 };

--- a/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
@@ -46,9 +46,11 @@ struct TTLSetComputeKernelConfigPass
 
     FailureOr<KernelConfigPlan> plan =
         resolveKernelConfig(function, *target, *policy, *requirements);
-    if (failed(plan) || failed(applyKernelConfigPlan(function, *plan))) {
+    if (failed(plan)) {
       signalPassFailure();
+      return;
     }
+    applyKernelConfigPlan(function, *plan);
   }
 };
 

--- a/python/sim/operation.py
+++ b/python/sim/operation.py
@@ -11,7 +11,7 @@ specified grid configurations.
 import types
 from typing import Any, Callable, Optional, Union, cast
 
-from ttl.constants import SUPPORTED_MATH_FIDELITIES
+from ttl.constants import validate_math_fidelity
 
 from .blockstate import KernelType
 from .typedefs import Shape
@@ -76,9 +76,7 @@ def operation(
             f"{', '.join(sorted(unknown))}"
         )
 
-    if math_fidelity is not None and math_fidelity not in SUPPORTED_MATH_FIDELITIES:
-        supported = ", ".join(repr(value) for value in SUPPORTED_MATH_FIDELITIES)
-        raise ValueError(f"math_fidelity must be one of {supported}")
+    validate_math_fidelity(math_fidelity)
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         # Set grid to default if 'auto' or 'full'

--- a/python/sim/operation.py
+++ b/python/sim/operation.py
@@ -11,6 +11,8 @@ specified grid configurations.
 import types
 from typing import Any, Callable, Optional, Union, cast
 
+from ttl.constants import SUPPORTED_MATH_FIDELITIES
+
 from .blockstate import KernelType
 from .typedefs import Shape
 from .context import get_context, cleanup_run_context
@@ -41,13 +43,14 @@ def operation(
     grid: Union[str, Shape] = "full",
     fp32_dest_acc_en: Optional[bool] = None,
     dst_full_sync_en: Optional[bool] = None,
+    math_fidelity: Optional[str] = None,
     **unknown: Any,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     Decorator that generates a kernel with specified grid.
 
-    fp32_dest_acc_en and dst_full_sync_en are accepted for compatibility with
-    compiler-side code but have no effect in the simulator.  Any other
+    Compute configuration arguments are accepted for compatibility with
+    compiler-side code but have no effect in the simulator. Any other
     unrecognised keyword argument raises TypeError to catch user errors early.
 
     Args:
@@ -55,6 +58,7 @@ def operation(
             (configurable via set_default_grid()).
         fp32_dest_acc_en: Ignored; accepted for compiler compatibility.
         dst_full_sync_en: Ignored; accepted for compiler compatibility.
+        math_fidelity: Ignored; accepted for compiler compatibility.
 
     Returns:
         Decorated function with grid configuration
@@ -71,6 +75,10 @@ def operation(
             f"ttl.operation() received unexpected keyword argument(s): "
             f"{', '.join(sorted(unknown))}"
         )
+
+    if math_fidelity is not None and math_fidelity not in SUPPORTED_MATH_FIDELITIES:
+        supported = ", ".join(repr(value) for value in SUPPORTED_MATH_FIDELITIES)
+        raise ValueError(f"math_fidelity must be one of {supported}")
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         # Set grid to default if 'auto' or 'full'

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -538,6 +538,7 @@ def _compile_atom(
     program_hash: int,
     fp32_dest_acc_en: Optional[bool],
     dst_full_sync_en: Optional[bool],
+    math_fidelity: Optional[str],
     target_arch: Optional[str],
     compiler_options: CompilerOptions,
 ):
@@ -650,6 +651,7 @@ def _compile_atom(
         target_arch=target_arch,
         fp32_dest_acc_en=fp32_dest_acc_en,
         dst_full_sync_en=dst_full_sync_en,
+        math_fidelity=math_fidelity,
         compiler_options=compiler_options,
         program_hash=program_hash,
         l1_budget_override=l1_budget_override,
@@ -679,6 +681,7 @@ def _compile_unified_operation(
         program_hash,
         fp32_dest_acc_en=decorator_options["fp32_dest_acc_en"],
         dst_full_sync_en=decorator_options["dst_full_sync_en"],
+        math_fidelity=decorator_options["math_fidelity"],
         target_arch=target_arch,
         compiler_options=compiler_options,
     )
@@ -709,6 +712,7 @@ class Atom:
             grid=decorator_options["grid"],
             fp32_dest_acc_en=decorator_options["fp32_dest_acc_en"],
             dst_full_sync_en=decorator_options["dst_full_sync_en"],
+            math_fidelity=decorator_options["math_fidelity"],
             options=decorator_options["options"],
             prepare_call=prepare_call,
         )
@@ -734,6 +738,7 @@ def _unified_operation(
     tiled: bool = True,
     fp32_dest_acc_en: Optional[bool] = None,
     dst_full_sync_en: Optional[bool] = None,
+    math_fidelity: Optional[str] = None,
     options: Optional[str] = None,
 ) -> Callable:
     """Build the unified-body form selected by ``@ttl.operation``.
@@ -742,7 +747,7 @@ def _unified_operation(
     / dst-sync overrides, compiler options). A grid is required for a
     top-level operation; a composed operation used only for expansion needs none.
     """
-    _validate_operation_options(num_outs, memory_space, tiled)
+    _validate_operation_options(num_outs, memory_space, tiled, math_fidelity)
 
     def _decorator(f):
         spec = _build_atom_spec(f)
@@ -755,6 +760,7 @@ def _unified_operation(
                 "tiled": tiled,
                 "fp32_dest_acc_en": fp32_dest_acc_en,
                 "dst_full_sync_en": dst_full_sync_en,
+                "math_fidelity": math_fidelity,
                 "options": options,
             },
         )
@@ -771,6 +777,7 @@ def operation(
     tiled: bool = True,
     fp32_dest_acc_en: Optional[bool] = None,
     dst_full_sync_en: Optional[bool] = None,
+    math_fidelity: Optional[str] = None,
     options: Optional[str] = None,
 ) -> Callable:
     """Define a unified-body or explicit multi-kernel operation."""
@@ -789,6 +796,7 @@ def operation(
                 tiled=tiled,
                 fp32_dest_acc_en=fp32_dest_acc_en,
                 dst_full_sync_en=dst_full_sync_en,
+                math_fidelity=math_fidelity,
                 options=options,
                 _prepare_call=prepare_call,
             )(fn)
@@ -802,6 +810,7 @@ def operation(
             tiled=tiled,
             fp32_dest_acc_en=fp32_dest_acc_en,
             dst_full_sync_en=dst_full_sync_en,
+            math_fidelity=math_fidelity,
             options=options,
         )(fn)
 

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -46,7 +46,7 @@ def _make_parser() -> argparse.ArgumentParser:
         default=None,
         dest="enable_fpu_binary_ops",
         action=argparse.BooleanOptionalAction,
-        help="Use FPU for binary add/sub/mul (default: enabled).",
+        help="Allow FPU strategy selection for binary add/sub/mul (default: enabled).",
     )
     p.add_argument(
         "--ttl-block-matmul",
@@ -74,14 +74,14 @@ def _make_parser() -> argparse.ArgumentParser:
         default=None,
         dest="reduce_full_fp32",
         action=argparse.BooleanOptionalAction,
-        help="Enable FP32 accumulation for reduce operations (default: enabled).",
+        help="Prefer FP32 accumulation for reduce operations (default: enabled).",
     )
     p.add_argument(
         "--ttl-matmul-full-fp32",
         default=None,
         dest="matmul_full_fp32",
         action=argparse.BooleanOptionalAction,
-        help="Enable FP32 accumulation for matmul operations (default: enabled).",
+        help="Prefer FP32 accumulation for matmul operations (default: enabled).",
     )
     p.add_argument(
         "--ttl-strict-f32-acc",

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -189,7 +189,8 @@ class CompilerOptions:
     """Compiler pipeline options for kernel compilation.
 
     Frozen so it's hashable and usable directly as a cache key component.
-    Does NOT include TTNN compute config (fp32_dest_acc_en, dst_full_sync_en).
+    Does NOT include TTNN compute config (fp32_dest_acc_en, dst_full_sync_en,
+    math_fidelity).
 
     Priority ordering (highest wins)::
 

--- a/python/ttl/constants.py
+++ b/python/ttl/constants.py
@@ -8,6 +8,14 @@ DEFAULT_TILE_SIZE = 32
 SUPPORTED_MEMORY_SPACES = frozenset(["L1", "DRAM"])
 SUPPORTED_MATH_FIDELITIES = ("LoFi", "HiFi2", "HiFi3", "HiFi4")
 
+
+def validate_math_fidelity(math_fidelity: str | None) -> None:
+    if math_fidelity is None or math_fidelity in SUPPORTED_MATH_FIDELITIES:
+        return
+    supported = ", ".join(repr(value) for value in SUPPORTED_MATH_FIDELITIES)
+    raise ValueError(f"math_fidelity must be one of {supported}")
+
+
 # Per-core static CB region budget (bytes) when IR has no system descriptor:
 # Wormhole and Blackhole total L1 (1464 KiB) minus reserved kernel space (128 KiB)
 # per tt-metal dev_mem_map. Matches ChipDesc usable L1 for those architectures

--- a/python/ttl/constants.py
+++ b/python/ttl/constants.py
@@ -6,6 +6,7 @@
 
 DEFAULT_TILE_SIZE = 32
 SUPPORTED_MEMORY_SPACES = frozenset(["L1", "DRAM"])
+SUPPORTED_MATH_FIDELITIES = ("LoFi", "HiFi2", "HiFi3", "HiFi4")
 
 # Per-core static CB region budget (bytes) when IR has no system descriptor:
 # Wormhole and Blackhole total L1 (1464 KiB) minus reserved kernel space (128 KiB)

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -86,7 +86,7 @@ from .dataflow_buffer import (
     get_cb_count,
 )
 from .pipe import Pipe, PipeNet
-from .constants import SUPPORTED_MATH_FIDELITIES, SUPPORTED_MEMORY_SPACES
+from .constants import SUPPORTED_MEMORY_SPACES, validate_math_fidelity
 from .diagnostics import (
     TTLangCompileError,
     find_variable_assignment,
@@ -2353,9 +2353,7 @@ def _validate_operation_options(
         )
     if not isinstance(tiled, bool):
         raise TypeError(f"tiled must be a boolean, got {type(tiled).__name__}")
-    if math_fidelity is not None and math_fidelity not in SUPPORTED_MATH_FIDELITIES:
-        supported = ", ".join(repr(value) for value in SUPPORTED_MATH_FIDELITIES)
-        raise ValueError(f"math_fidelity must be one of {supported}")
+    validate_math_fidelity(math_fidelity)
 
 
 def pykernel_gen(

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -56,6 +56,7 @@ from ttl.passes import (
     get_ttkernel_names,
     ttkernel_to_cpp_by_name,
 )
+
 from ttl.passmanager import PassManager
 
 
@@ -105,6 +106,12 @@ from .kernel_runner import (
 from .operators import CopyTransferHandler, TensorBlock, copy
 from .compiler_options import CompilerOptions
 from .ttl_utils import get_thread_type_string
+
+_TTCORE_ARCH_BY_DEVICE_NAME = {
+    "blackhole": ttcore.Arch.Blackhole,
+    "wormhole_b0": ttcore.Arch.WormholeB0,
+    "quasar": ttcore.Arch.Quasar,
+}
 
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
@@ -492,6 +499,8 @@ def _device_target_arch(args) -> Optional[str]:
         arch = _detect_device_arch(device)
         if arch is None:
             continue
+        if arch not in _TTCORE_ARCH_BY_DEVICE_NAME:
+            raise ValueError(f"Unsupported TT device architecture: {arch}")
         return arch
     return None
 
@@ -1892,7 +1901,9 @@ def _lower_program_to_kernel(
             ctx,
         )
         if target_arch is not None:
-            module.operation.attributes["ttl.target_arch"] = StringAttr.get(target_arch)
+            module.operation.attributes["ttl.target_arch"] = ttcore.ir.ArchAttr.get(
+                ctx, int(_TTCORE_ARCH_BY_DEVICE_NAME[target_arch])
+            )
 
         # Insert standalone thread functions directly into module
         with InsertionPoint(module.body):
@@ -1917,11 +1928,13 @@ def _lower_program_to_kernel(
         config_options = []
         if fp32_dest_acc_en is not None:
             config_options.append(
-                f"fp32-dest-acc-en={1 if fp32_dest_acc_en else 0}"
+                "fp32-dest-acc-en="
+                + ("enabled" if fp32_dest_acc_en else "disabled")
             )
         if dst_full_sync_en is not None:
             config_options.append(
-                f"dst-full-sync-en={1 if dst_full_sync_en else 0}"
+                "dst-full-sync-en="
+                + ("enabled" if dst_full_sync_en else "disabled")
             )
         config_options.append(
             f"reduce-full-fp32={int(compiler_options.reduce_full_fp32)}"

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -813,6 +813,20 @@ def _get_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
     return list(attr)
 
 
+def _get_optional_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
+    """Read an optional `DenseI32ArrayAttr` kernel attribute."""
+    operation = _lookup_kernel_func_op(module, kernel_name)
+    attr = operation.attributes.get(attr_name, None)
+    if attr is None:
+        return []
+    if not isinstance(attr, DenseI32ArrayAttr):
+        raise ValueError(
+            f"Expected DenseI32ArrayAttr for '{attr_name}' on kernel "
+            f"'{kernel_name}', got {attr}"
+        )
+    return list(attr)
+
+
 def _get_kernel_core_coords(module, kernel_name: str):
     """Read the `ttl.core_coord` attribute set by `ttkernel-specialize-cores`.
 
@@ -1036,7 +1050,7 @@ def _compile_ttnn_kernel(
         kernel_path = _write_kernel_to_tmp(name, cpp_source)
         kernel_paths.append((kernel_path, thread_type))
         kernel_pipe_computed_address_dfb_indices.append(
-            _get_kernel_i32_array_attr(
+            _get_optional_kernel_i32_array_attr(
                 module, name, _ttl_ir.PIPE_COMPUTED_ADDRESS_DFB_INDICES_ATTR
             )
         )

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -110,7 +110,6 @@ from .ttl_utils import get_thread_type_string
 _TTCORE_ARCH_BY_DEVICE_NAME = {
     "blackhole": ttcore.Arch.Blackhole,
     "wormhole_b0": ttcore.Arch.WormholeB0,
-    "quasar": ttcore.Arch.Quasar,
 }
 
 # Thread registry for automatic collection of @compute and @datamovement threads
@@ -489,20 +488,32 @@ def _detect_device_arch(device) -> Optional[str]:
 
 
 def _device_target_arch(args) -> Optional[str]:
-    """Return the first detected tensor device architecture, or None."""
+    """Return the common tensor device architecture, or None for host inputs."""
+    target_arch = None
     for arg in args:
-        if not is_ttnn_tensor(arg) or not hasattr(arg, "device"):
+        if not is_ttnn_tensor(arg):
             continue
-        device = arg.device()
+        try:
+            device = arg.device()
+        except Exception as error:
+            raise ValueError(
+                "Unsupported or undetectable TT device architecture"
+            ) from error
         if device is None:
             continue
         arch = _detect_device_arch(device)
         if arch is None:
-            continue
+            raise ValueError("Unsupported or undetectable TT device architecture")
         if arch not in _TTCORE_ARCH_BY_DEVICE_NAME:
             raise ValueError(f"Unsupported TT device architecture: {arch}")
-        return arch
-    return None
+        if target_arch is None:
+            target_arch = arch
+        elif target_arch != arch:
+            raise ValueError(
+                "Tensor arguments use different TT device architectures: "
+                f"{target_arch} and {arch}"
+            )
+    return target_arch
 
 
 def _resolve_grid(grid, args, kwargs):
@@ -770,7 +781,10 @@ def _get_kernel_bool_attr(module, kernel_name: str, attr_name: str) -> bool:
     operation = _lookup_kernel_func_op(module, kernel_name)
     attr = operation.attributes.get(attr_name, None)
     if attr is None:
-        return False
+        raise ValueError(
+            f"Required compiler-generated attribute '{attr_name}' is missing "
+            f"from compute kernel '{kernel_name}'"
+        )
     attr_text = str(attr).strip()
     if attr_text == "true":
         return True
@@ -783,14 +797,14 @@ def _get_kernel_bool_attr(module, kernel_name: str, attr_name: str) -> bool:
 
 
 def _get_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
-    """Read a `DenseI32ArrayAttr` func.func attribute as a list of ints.
-
-    Returns an empty list when the attribute is missing.
-    """
+    """Read a required `DenseI32ArrayAttr` kernel attribute."""
     operation = _lookup_kernel_func_op(module, kernel_name)
     attr = operation.attributes.get(attr_name, None)
     if attr is None:
-        return []
+        raise ValueError(
+            f"Required compiler-generated attribute '{attr_name}' is missing "
+            f"from compute kernel '{kernel_name}'"
+        )
     if not isinstance(attr, DenseI32ArrayAttr):
         raise ValueError(
             f"Expected DenseI32ArrayAttr for '{attr_name}' on kernel "
@@ -1009,7 +1023,8 @@ def _compile_ttnn_kernel(
                 module, name, "ttl.unpack_to_dest_fp32"
             ),
         }
-        for name, _ in kernel_info
+        for name, thread_type in kernel_info
+        if thread_type == "compute"
     }
 
     # Build thread-to-kernel mapping for profiling

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -86,7 +86,7 @@ from .dataflow_buffer import (
     get_cb_count,
 )
 from .pipe import Pipe, PipeNet
-from .constants import SUPPORTED_MEMORY_SPACES
+from .constants import SUPPORTED_MATH_FIDELITIES, SUPPORTED_MEMORY_SPACES
 from .diagnostics import (
     TTLangCompileError,
     find_variable_assignment,
@@ -161,6 +161,7 @@ def _make_cache_key(
     resolved_grid: Union[tuple, List[int]],
     fp32_dest_acc_en: Optional[bool],
     dst_full_sync_en: Optional[bool],
+    math_fidelity: Optional[str],
     target_arch: Optional[str],
     compiler_options: CompilerOptions = CompilerOptions(),
 ) -> tuple:
@@ -188,6 +189,7 @@ def _make_cache_key(
         grid_key,
         fp32_dest_acc_en,
         dst_full_sync_en,
+        math_fidelity,
         target_arch,
         compiler_options,
     )
@@ -776,6 +778,15 @@ def _set_unpack_to_dest_fp32(config, ttnn_mod, cb_indices) -> None:
         )
 
 
+def _set_math_fidelity(config, ttnn_mod, math_fidelity: str) -> None:
+    try:
+        config.math_fidelity = getattr(ttnn_mod.MathFidelity, math_fidelity)
+    except AttributeError as error:
+        raise RuntimeError(
+            f"TTNN does not provide MathFidelity.{math_fidelity}"
+        ) from error
+
+
 def _get_kernel_bool_attr(module, kernel_name: str, attr_name: str) -> bool:
     """Read a boolean func.func attribute from a compiled kernel."""
     operation = _lookup_kernel_func_op(module, kernel_name)
@@ -902,6 +913,7 @@ def _compile_ttnn_kernel(
     program_hash=None,
     fp32_dest_acc_en: Optional[bool] = None,
     dst_full_sync_en: Optional[bool] = None,
+    math_fidelity: Optional[str] = None,
     verbose=True,
     source_lines=None,
     all_source_lines=None,
@@ -1061,6 +1073,8 @@ def _compile_ttnn_kernel(
 
         if thread_type == "compute":
             config = ttnn.ComputeConfigDescriptor()
+            if math_fidelity is not None:
+                _set_math_fidelity(config, ttnn, math_fidelity)
             if fp32_dest_acc_en is not None:
                 config.fp32_dest_acc_en = fp32_dest_acc_en
             elif kernel_config_attrs[name]["fp32_dest_acc_en"]:
@@ -1713,6 +1727,7 @@ def _compile_kernel(
     program_hash: int,
     fp32_dest_acc_en: Optional[bool] = None,
     dst_full_sync_en: Optional[bool] = None,
+    math_fidelity: Optional[str] = None,
     target_arch: Optional[str] = None,
     compiler_options: CompilerOptions = CompilerOptions(),
 ) -> Optional[CompiledTTNNKernel]:
@@ -1732,6 +1747,7 @@ def _compile_kernel(
         program_hash: Hash for tt-metal program cache
         fp32_dest_acc_en: Optional override for fp32_dest_acc_en
         dst_full_sync_en: Optional override for dst_full_sync_en
+        math_fidelity: Optional TTNN compute math fidelity
         target_arch: Optional TT device architecture for target-specific lowering
         compiler_options: Compiler pipeline options
 
@@ -1837,6 +1853,7 @@ def _compile_kernel(
         target_arch=target_arch,
         fp32_dest_acc_en=fp32_dest_acc_en,
         dst_full_sync_en=dst_full_sync_en,
+        math_fidelity=math_fidelity,
         compiler_options=compiler_options,
         program_hash=program_hash,
         l1_budget_override=l1_budget_override,
@@ -1855,6 +1872,7 @@ def _lower_program_to_kernel(
     target_arch,
     fp32_dest_acc_en,
     dst_full_sync_en,
+    math_fidelity,
     compiler_options,
     program_hash,
     l1_budget_override,
@@ -2188,6 +2206,7 @@ def _lower_program_to_kernel(
             program_hash=program_hash,
             fp32_dest_acc_en=fp32_dest_acc_en,
             dst_full_sync_en=dst_full_sync_en,
+            math_fidelity=math_fidelity,
             source_lines=profile_source_lines,
             all_source_lines=all_source_lines,
             kernel_line_offsets=kernel_line_offsets,
@@ -2233,6 +2252,7 @@ def _make_operation_wrapper(
     grid,
     fp32_dest_acc_en: Optional[bool],
     dst_full_sync_en: Optional[bool],
+    math_fidelity: Optional[str],
     options: Optional[str],
     prepare_call: Optional[Callable] = None,
 ) -> Callable:
@@ -2264,6 +2284,7 @@ def _make_operation_wrapper(
             resolved_grid=resolved_grid,
             fp32_dest_acc_en=fp32_dest_acc_en,
             dst_full_sync_en=dst_full_sync_en,
+            math_fidelity=math_fidelity,
             target_arch=target_arch,
             compiler_options=compiler_options,
         )
@@ -2320,7 +2341,9 @@ def _make_operation_wrapper(
     return _wrapper
 
 
-def _validate_operation_options(num_outs, memory_space, tiled) -> None:
+def _validate_operation_options(
+    num_outs, memory_space, tiled, math_fidelity: Optional[str]
+) -> None:
     if num_outs != 1:
         raise ValueError(f"num_outs must be 1, got {num_outs}")
     if memory_space not in SUPPORTED_MEMORY_SPACES:
@@ -2330,6 +2353,9 @@ def _validate_operation_options(num_outs, memory_space, tiled) -> None:
         )
     if not isinstance(tiled, bool):
         raise TypeError(f"tiled must be a boolean, got {type(tiled).__name__}")
+    if math_fidelity is not None and math_fidelity not in SUPPORTED_MATH_FIDELITIES:
+        supported = ", ".join(repr(value) for value in SUPPORTED_MATH_FIDELITIES)
+        raise ValueError(f"math_fidelity must be one of {supported}")
 
 
 def pykernel_gen(
@@ -2341,6 +2367,7 @@ def pykernel_gen(
     tiled: bool = True,
     fp32_dest_acc_en: Optional[bool] = None,
     dst_full_sync_en: Optional[bool] = None,
+    math_fidelity: Optional[str] = None,
     options: Optional[str] = None,
     _prepare_call: Optional[Callable] = None,
 ) -> Callable:
@@ -2360,17 +2387,18 @@ def pykernel_gen(
         tiled: Whether to use tiled layout
         fp32_dest_acc_en: Optional override for fp32_dest_acc_en
         dst_full_sync_en: Optional override for dst_full_sync_en
+        math_fidelity: Optional TTNN compute math fidelity
         options: Compiler option string (e.g., "--no-ttl-maximize-dst")
 
     Returns:
         Decorated function that compiles and executes the kernel
 
     Raises:
-        AssertionError: If required parameters are missing or invalid
+        ValueError: If required parameters or compute configuration are invalid
     """
     if grid is None:
         raise ValueError("grid parameter is required")
-    _validate_operation_options(num_outs, memory_space, tiled)
+    _validate_operation_options(num_outs, memory_space, tiled, math_fidelity)
     if iterator_types is not None and indexing_maps is None:
         raise ValueError("indexing_maps must be set when iterator_types is set")
 
@@ -2414,6 +2442,7 @@ def pykernel_gen(
                 program_hash,
                 fp32_dest_acc_en=fp32_dest_acc_en,
                 dst_full_sync_en=dst_full_sync_en,
+                math_fidelity=math_fidelity,
                 target_arch=target_arch,
                 compiler_options=compiler_options,
             )
@@ -2424,6 +2453,7 @@ def pykernel_gen(
             grid=grid,
             fp32_dest_acc_en=fp32_dest_acc_en,
             dst_full_sync_en=dst_full_sync_en,
+            math_fidelity=math_fidelity,
             options=options,
             prepare_call=_prepare_call,
         )

--- a/test/me2e/base.py
+++ b/test/me2e/base.py
@@ -163,11 +163,29 @@ class ME2ETestBase:
             # Determine thread type from metadata or name fallback.
             thread_type_str = kernel_meta.get("thread_type", "")
             if thread_type_str == "compute" or "compute" in name.lower():
+                required_config_fields = (
+                    "fp32_dest_acc_en",
+                    "dst_full_sync_en",
+                    "unpack_to_dest_fp32",
+                )
+                missing_config_fields = [
+                    field
+                    for field in required_config_fields
+                    if field not in kernel_meta
+                ]
+                if missing_config_fields:
+                    raise ValueError(
+                        f"Compute kernel '{name}' metadata is missing required "
+                        f"configuration fields: {', '.join(missing_config_fields)}"
+                    )
                 compute_kernel = KernelSpec(
                     name=name,
                     thread_type=ThreadType.COMPUTE,
                     source=source,
                     tensor_indices=tensor_indices,
+                    fp32_dest_acc_en=kernel_meta["fp32_dest_acc_en"],
+                    dst_full_sync_en=kernel_meta["dst_full_sync_en"],
+                    unpack_to_dest_fp32=kernel_meta["unpack_to_dest_fp32"],
                 )
             else:
                 noc_kernels.append(
@@ -183,7 +201,6 @@ class ME2ETestBase:
             pytest.skip("No compute kernel found in kernel files.")
 
         # Run based on arity.
-        fp32_accum = inputs[0].dtype == torch.float32
         if len(inputs) == 2:
             result = run_binary_op(
                 device=device,
@@ -192,7 +209,6 @@ class ME2ETestBase:
                 input_a=inputs[0],
                 input_b=inputs[1],
                 kernel_dir=kernel_dir,
-                enable_fp32_accumulation=fp32_accum,
             )
         else:
             result = run_unary_op(
@@ -201,7 +217,6 @@ class ME2ETestBase:
                 compute_kernel=compute_kernel,
                 input_a=inputs[0],
                 kernel_dir=kernel_dir,
-                enable_fp32_accumulation=fp32_accum,
             )
 
         # Save result for validation.

--- a/test/me2e/builder/device_arch.py
+++ b/test/me2e/builder/device_arch.py
@@ -27,8 +27,6 @@ def get_mock_arch_from_device(device) -> str:
     if device is None:
         return "wormhole_b0"
 
-    # Try to detect architecture from device.
-    # Common attributes to check (may vary by ttnn version):
     arch_attrs = [
         "arch",
         "architecture",
@@ -39,22 +37,24 @@ def get_mock_arch_from_device(device) -> str:
     ]
 
     for attr in arch_attrs:
-        if hasattr(device, attr):
+        try:
             arch_value = getattr(device, attr)
-            # Try calling if it's a method/function.
-            if callable(arch_value):
-                try:
-                    arch_value = arch_value()
-                except Exception:
-                    continue
-            # Convert to string for comparison (handles enums, strings, etc.)
-            arch_str = str(arch_value)
-            arch_lower = arch_str.lower()
-            if "wormhole" in arch_lower:
-                return "wormhole_b0"
-            if "blackhole" in arch_lower:
-                return "blackhole"
-            if "quasar" in arch_lower:
-                return "quasar"
+        except Exception:
+            continue
+        if callable(arch_value):
+            try:
+                arch_value = arch_value()
+            except Exception:
+                continue
+        arch = str(arch_value).lower().rsplit(".", maxsplit=1)[-1]
+        if arch == "wormhole_b0":
+            return arch
+        if arch == "blackhole":
+            return arch
+        if arch == "quasar":
+            raise ValueError(
+                "Quasar compute kernels require unsupported Gen2 runtime APIs"
+            )
+        raise ValueError(f"Unsupported TT device architecture: {arch}")
 
     raise ValueError("Unsupported or undetectable TT device architecture")

--- a/test/me2e/builder/device_arch.py
+++ b/test/me2e/builder/device_arch.py
@@ -18,7 +18,11 @@ def get_mock_arch_from_device(device) -> str:
 
     Returns:
         Architecture string (e.g., "wormhole_b0", "blackhole") for mock system desc.
-        Defaults to "wormhole_b0" if device is None or detection fails.
+        Defaults to "wormhole_b0" for compiler-only tests without a device.
+
+    Raises:
+        ValueError: If a device is present but its architecture is unsupported
+            or cannot be detected.
     """
     if device is None:
         return "wormhole_b0"
@@ -46,12 +50,11 @@ def get_mock_arch_from_device(device) -> str:
             # Convert to string for comparison (handles enums, strings, etc.)
             arch_str = str(arch_value)
             arch_lower = arch_str.lower()
-            if "wormhole" in arch_lower or "wh" in arch_lower:
+            if "wormhole" in arch_lower:
                 return "wormhole_b0"
-            elif "blackhole" in arch_lower or "bh" in arch_lower:
+            if "blackhole" in arch_lower:
                 return "blackhole"
-            elif "grayskull" in arch_lower or "gs" in arch_lower:
-                return "wormhole_b0"  # Fallback to wormhole_b0 for grayskull
+            if "quasar" in arch_lower:
+                return "quasar"
 
-    # Default to wormhole_b0 if detection fails.
-    return "wormhole_b0"
+    raise ValueError("Unsupported or undetectable TT device architecture")

--- a/test/me2e/builder/kernels.py
+++ b/test/me2e/builder/kernels.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Tuple
 
-from ttl.ir import Module, ArrayAttr, IntegerAttr
+from ttl.ir import Module, ArrayAttr, DenseI32ArrayAttr, IntegerAttr
 from ttl.passes import ttkernel_to_cpp_by_name, get_ttkernel_names
 from ttl.dialects import func
 
@@ -36,6 +36,17 @@ class KernelSpec:
     tensor_indices: List[int] = field(default_factory=list)  # Global tensor indices
     compile_args: List[int] = field(default_factory=list)
     runtime_args: List[int] = field(default_factory=list)
+    fp32_dest_acc_en: bool = False
+    dst_full_sync_en: bool = False
+    unpack_to_dest_fp32: List[int] = field(default_factory=list)
+
+
+def _get_kernel_func(module: Module, kernel_name: str) -> func.FuncOp:
+    """Return the compiled function for a kernel symbol."""
+    for operation in module.body.operations:
+        if isinstance(operation, func.FuncOp) and operation.name.value == kernel_name:
+            return operation
+    raise ValueError(f"Kernel function '{kernel_name}' not found")
 
 
 def _get_kernel_tensor_indices(module: Module, kernel_name: str) -> List[int]:
@@ -52,16 +63,51 @@ def _get_kernel_tensor_indices(module: Module, kernel_name: str) -> List[int]:
     Returns:
         List of global tensor indices accessed by the kernel.
     """
-    # Find the function in the module.
-    for op in module.body.operations:
-        if isinstance(op, func.FuncOp) and op.name.value == kernel_name:
-            # Check for ttl.crta_indices attribute.
-            if "ttl.crta_indices" in op.attributes:
-                crta_attr = op.attributes["ttl.crta_indices"]
-                if isinstance(crta_attr, ArrayAttr):
-                    return [int(IntegerAttr(idx).value) for idx in crta_attr]
-            return []
+    operation = _get_kernel_func(module, kernel_name)
+    if "ttl.crta_indices" in operation.attributes:
+        crta_attr = operation.attributes["ttl.crta_indices"]
+        if isinstance(crta_attr, ArrayAttr):
+            return [int(IntegerAttr(index).value) for index in crta_attr]
     return []
+
+
+def _get_kernel_bool_attr(module: Module, kernel_name: str, attr_name: str) -> bool:
+    """Return a required compiler-generated boolean kernel attribute."""
+    operation = _get_kernel_func(module, kernel_name)
+    attribute = operation.attributes.get(attr_name)
+    if attribute is None:
+        raise ValueError(
+            f"Required compiler-generated attribute '{attr_name}' is missing "
+            f"from compute kernel '{kernel_name}'"
+        )
+    attribute_text = str(attribute).strip()
+    if attribute_text == "true":
+        return True
+    if attribute_text == "false":
+        return False
+    raise ValueError(
+        f"Expected boolean attribute '{attr_name}' on kernel '{kernel_name}', "
+        f"got {attribute_text!r}"
+    )
+
+
+def _get_kernel_i32_array_attr(
+    module: Module, kernel_name: str, attr_name: str
+) -> List[int]:
+    """Return a compiler-generated dense i32 array kernel attribute."""
+    operation = _get_kernel_func(module, kernel_name)
+    attribute = operation.attributes.get(attr_name)
+    if attribute is None:
+        raise ValueError(
+            f"Required compiler-generated attribute '{attr_name}' is missing "
+            f"from compute kernel '{kernel_name}'"
+        )
+    if not isinstance(attribute, DenseI32ArrayAttr):
+        raise ValueError(
+            f"Expected dense i32 array attribute '{attr_name}' on kernel "
+            f"'{kernel_name}', got {attribute}"
+        )
+    return list(attribute)
 
 
 def translate_module_to_kernels(
@@ -109,6 +155,15 @@ def translate_module_to_kernels(
         if thread_type == ThreadType.COMPUTE:
             if compute_kernel is not None:
                 raise ValueError("Multiple compute kernels found")
+            spec.fp32_dest_acc_en = _get_kernel_bool_attr(
+                module, name, "fp32_dest_acc_en"
+            )
+            spec.dst_full_sync_en = _get_kernel_bool_attr(
+                module, name, "dst_full_sync_en"
+            )
+            spec.unpack_to_dest_fp32 = _get_kernel_i32_array_attr(
+                module, name, "ttl.unpack_to_dest_fp32"
+            )
             compute_kernel = spec
         else:
             noc_kernels.append(spec)
@@ -159,6 +214,9 @@ def write_kernels(
         metadata[kernel.name] = {
             "thread_type": kernel.thread_type.value,
             "tensor_indices": kernel.tensor_indices,
+            "fp32_dest_acc_en": kernel.fp32_dest_acc_en,
+            "dst_full_sync_en": kernel.dst_full_sync_en,
+            "unpack_to_dest_fp32": kernel.unpack_to_dest_fp32,
         }
 
     # Write metadata file.

--- a/test/me2e/builder/pipeline.py
+++ b/test/me2e/builder/pipeline.py
@@ -31,7 +31,7 @@ def compile_ttl_to_ttkernel(
         module: TTL MLIR module to compile.
         device: Optional TTNN device (unused, kept for API compat).
         maximize_dst: Enable DST maximization (subblocking + scheduling).
-        enable_fpu_binary_ops: Enable FPU binary op detection (add_tiles, etc).
+        enable_fpu_binary_ops: Allow FPU strategy selection for add/sub/mul.
         specialize_cores: Clone kernels that branch on a core coordinate
             once per launch coordinate (ttkernel-specialize-cores).
 

--- a/test/me2e/builder/pipeline.py
+++ b/test/me2e/builder/pipeline.py
@@ -21,7 +21,6 @@ from .device_arch import get_mock_arch_from_device
 _TTCORE_ARCH_BY_DEVICE_NAME = {
     "blackhole": ttcore.Arch.Blackhole,
     "wormhole_b0": ttcore.Arch.WormholeB0,
-    "quasar": ttcore.Arch.Quasar,
 }
 
 

--- a/test/me2e/builder/pipeline.py
+++ b/test/me2e/builder/pipeline.py
@@ -11,8 +11,18 @@ Provides compilation from TTL dialect to TTKernel dialect.
 import os
 from typing import Any, Optional
 
+from ttl.dialects import ttcore
 from ttl.ir import Module
 from ttl.passmanager import PassManager
+
+from .device_arch import get_mock_arch_from_device
+
+
+_TTCORE_ARCH_BY_DEVICE_NAME = {
+    "blackhole": ttcore.Arch.Blackhole,
+    "wormhole_b0": ttcore.Arch.WormholeB0,
+    "quasar": ttcore.Arch.Quasar,
+}
 
 
 def compile_ttl_to_ttkernel(
@@ -29,7 +39,8 @@ def compile_ttl_to_ttkernel(
 
     Args:
         module: TTL MLIR module to compile.
-        device: Optional TTNN device (unused, kept for API compat).
+        device: Optional TTNN device used to select target capabilities. A
+            compiler-only invocation without a device uses a Wormhole mock.
         maximize_dst: Enable DST maximization (subblocking + scheduling).
         enable_fpu_binary_ops: Allow FPU strategy selection for add/sub/mul.
         specialize_cores: Clone kernels that branch on a core coordinate
@@ -38,6 +49,11 @@ def compile_ttl_to_ttkernel(
     Returns:
         Compiled module with TTKernel/EmitC ops.
     """
+    target_arch = get_mock_arch_from_device(device)
+    module.operation.attributes["ttl.target_arch"] = ttcore.ir.ArchAttr.get(
+        module.context, int(_TTCORE_ARCH_BY_DEVICE_NAME[target_arch])
+    )
+
     pipeline_options = " ".join(
         [
             f"maximize-dst={str(maximize_dst).lower()}",

--- a/test/me2e/builder/ttnn_runner.py
+++ b/test/me2e/builder/ttnn_runner.py
@@ -54,7 +54,6 @@ def run_binary_op(
     input_a: torch.Tensor,
     input_b: torch.Tensor,
     kernel_dir: Path,
-    enable_fp32_accumulation: bool = False,
 ) -> torch.Tensor:
     """
     Run a binary operation on device.
@@ -66,8 +65,6 @@ def run_binary_op(
         input_a: First input tensor.
         input_b: Second input tensor.
         kernel_dir: Directory containing kernel C++ files.
-        enable_fp32_accumulation: If True, enable fp32 dest accumulation on compute.
-
     Returns:
         Output tensor as torch tensor.
     """
@@ -77,7 +74,6 @@ def run_binary_op(
         compute_kernel=compute_kernel,
         inputs=[input_a, input_b],
         kernel_dir=kernel_dir,
-        enable_fp32_accumulation=enable_fp32_accumulation,
     )
 
 
@@ -87,7 +83,6 @@ def run_unary_op(
     compute_kernel: KernelSpec,
     input_a: torch.Tensor,
     kernel_dir: Path,
-    enable_fp32_accumulation: bool = False,
 ) -> torch.Tensor:
     """
     Run a unary operation on device.
@@ -98,8 +93,6 @@ def run_unary_op(
         compute_kernel: Compute kernel spec.
         input_a: Input tensor.
         kernel_dir: Directory containing kernel C++ files.
-        enable_fp32_accumulation: If True, enable fp32 dest accumulation on compute.
-
     Returns:
         Output tensor as torch tensor.
     """
@@ -109,8 +102,23 @@ def run_unary_op(
         compute_kernel=compute_kernel,
         inputs=[input_a],
         kernel_dir=kernel_dir,
-        enable_fp32_accumulation=enable_fp32_accumulation,
     )
+
+
+def _get_compute_config(compute_kernel: KernelSpec):
+    """Translate compiler-selected kernel configuration to TTNN."""
+    config = ttnn.ComputeConfigDescriptor()
+    config.fp32_dest_acc_en = compute_kernel.fp32_dest_acc_en
+    config.dst_full_sync_en = compute_kernel.dst_full_sync_en
+    if compute_kernel.unpack_to_dest_fp32:
+        configured_indices = set(compute_kernel.unpack_to_dest_fp32)
+        for dfb_index in range(64):
+            config.unpack_to_dest_mode.append(
+                ttnn.UnpackToDestMode.UnpackToDestFp32
+                if dfb_index in configured_indices
+                else ttnn.UnpackToDestMode.Default
+            )
+    return config
 
 
 def _run_op(
@@ -119,7 +127,6 @@ def _run_op(
     compute_kernel: KernelSpec,
     inputs: List[torch.Tensor],
     kernel_dir: Path,
-    enable_fp32_accumulation: bool = False,
 ) -> torch.Tensor:
     """
     Run an operation on device using shared kernel_runner infrastructure.
@@ -133,8 +140,6 @@ def _run_op(
         compute_kernel: Compute kernel spec.
         inputs: List of input tensors.
         kernel_dir: Directory containing kernel C++ files.
-        enable_fp32_accumulation: If True, enable fp32 dest accumulation on compute.
-
     Returns:
         Output tensor as torch tensor.
     """
@@ -192,9 +197,7 @@ def _run_op(
             path=str(kernel_dir / f"{compute_kernel.name}.cpp"),
             thread_type="compute",
             tensor_indices=[],  # Compute kernels don't access tensors directly.
-            config=ttnn.ComputeConfigDescriptor(
-                fp32_dest_acc_en=enable_fp32_accumulation,
-            ),
+            config=_get_compute_config(compute_kernel),
         ),
     ]
 

--- a/test/me2e/config_specs.py
+++ b/test/me2e/config_specs.py
@@ -84,7 +84,7 @@ class TestConfig:
         maximize_dst: Enable DST subblocking and operation scheduling passes.
             When False, uses basic loop lowering without subblocking. Default is True.
 
-        enable_fpu_binary_ops: Enable FPU binary op detection for add/sub/mul.
+        enable_fpu_binary_ops: Allow FPU strategy selection for add/sub/mul.
             When False, all binary ops use the copy_tile + SFPU path. Default is True.
 
     Examples:
@@ -177,7 +177,7 @@ CONFIGS = [
     TestConfig(num_tiles=4, block_h=2, block_w=2),  # 2x2 grid (4 tiles)
     # Maximize-DST disabled: no subblocking or scheduling (basic loop lowering).
     TestConfig(num_tiles=4, block_h=2, block_w=2, maximize_dst=False),
-    # SFPU path: FPU binary detection disabled (all binary ops use copy_tile + SFPU).
+    # SFPU execution: FPU selection disabled, so binary inputs use copy_tile.
     TestConfig(num_tiles=4, block_h=2, block_w=2, enable_fpu_binary_ops=False),
     # Both disabled: basic loop lowering with SFPU binary path.
     TestConfig(

--- a/test/me2e/runner.py
+++ b/test/me2e/runner.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional
 import torch
 from ttlang_test_utils import make_compare_inputs
 
+from .builder.device_arch import get_mock_arch_from_device
 from .builder.kernels import (
     KernelSpec,
     ThreadType,
@@ -50,6 +51,7 @@ def get_compute_kernel(
     cache_key = (
         f"{op.name}_{op.ttl_op}_{config.block_h}x{config.block_w}_{config.dtype}"
         f"_dst{config.maximize_dst}_fpu{config.enable_fpu_binary_ops}"
+        f"_arch{get_mock_arch_from_device(device)}"
     )
     if cache_key in _kernel_cache:
         return _kernel_cache[cache_key]

--- a/test/me2e/runner.py
+++ b/test/me2e/runner.py
@@ -145,6 +145,9 @@ def run_compute_test(
         name=compute_kernel_spec.name,
         thread_type=ThreadType.COMPUTE,
         source=compute_cpp,
+        fp32_dest_acc_en=compute_kernel_spec.fp32_dest_acc_en,
+        dst_full_sync_en=compute_kernel_spec.dst_full_sync_en,
+        unpack_to_dest_fp32=compute_kernel_spec.unpack_to_dest_fp32,
     )
 
     # 4. Write kernels to temporary directory.
@@ -157,7 +160,6 @@ def run_compute_test(
     from .builder.ttnn_runner import run_binary_op, run_unary_op
 
     try:
-        fp32_accum = config.dtype == torch.float32
         if op.arity == 2:
             result = run_binary_op(
                 device=device,
@@ -166,7 +168,6 @@ def run_compute_test(
                 input_a=torch_inputs[0],
                 input_b=torch_inputs[1],
                 kernel_dir=kernel_dir,
-                enable_fp32_accumulation=fp32_accum,
             )
         else:
             result = run_unary_op(
@@ -175,7 +176,6 @@ def run_compute_test(
                 compute_kernel=compute_kernel_spec,
                 input_a=torch_inputs[0],
                 kernel_dir=kernel_dir,
-                enable_fp32_accumulation=fp32_accum,
             )
 
         # 6. Validate against golden.

--- a/test/me2e/test_device_arch.py
+++ b/test/me2e/test_device_arch.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ME2E target architecture detection and propagation."""
+
+import pytest
+
+import ttl.dialects.ttl as ttl
+from ttl.ir import Context, Module
+
+from .builder.device_arch import get_mock_arch_from_device
+from .builder.pipeline import compile_ttl_to_ttkernel
+
+
+class FakeDevice:
+    def __init__(self, architecture: str):
+        self.architecture = architecture
+
+
+@pytest.mark.parametrize(
+    "architecture, expected",
+    [
+        ("Arch.WORMHOLE_B0", "wormhole_b0"),
+        ("Arch.BLACKHOLE", "blackhole"),
+        ("Arch.QUASAR", "quasar"),
+    ],
+)
+def test_detect_supported_device_architecture(architecture, expected):
+    assert get_mock_arch_from_device(FakeDevice(architecture)) == expected
+
+
+def test_compiler_only_architecture_defaults_to_wormhole():
+    assert get_mock_arch_from_device(None) == "wormhole_b0"
+
+
+def test_unknown_device_architecture_is_rejected():
+    with pytest.raises(
+        ValueError, match="Unsupported or undetectable TT device architecture"
+    ):
+        get_mock_arch_from_device(FakeDevice("Arch.UNKNOWN"))
+
+
+def test_pipeline_attaches_typed_target_architecture():
+    context = Context()
+    ttl.ensure_dialects_registered(context)
+
+    with context:
+        module = Module.parse("module {}", context)
+        compile_ttl_to_ttkernel(
+            module, FakeDevice("Arch.BLACKHOLE"), maximize_dst=False
+        )
+
+        assert (
+            str(module.operation.attributes["ttl.target_arch"])
+            == "#ttcore.arch<blackhole>"
+        )

--- a/test/me2e/test_device_arch.py
+++ b/test/me2e/test_device_arch.py
@@ -18,12 +18,17 @@ class FakeDevice:
         self.architecture = architecture
 
 
+class DeviceWithRaisingArch:
+    @property
+    def arch(self):
+        raise RuntimeError("device handle closed")
+
+
 @pytest.mark.parametrize(
     "architecture, expected",
     [
         ("Arch.WORMHOLE_B0", "wormhole_b0"),
         ("Arch.BLACKHOLE", "blackhole"),
-        ("Arch.QUASAR", "quasar"),
     ],
 )
 def test_detect_supported_device_architecture(architecture, expected):
@@ -35,10 +40,20 @@ def test_compiler_only_architecture_defaults_to_wormhole():
 
 
 def test_unknown_device_architecture_is_rejected():
+    with pytest.raises(ValueError, match="Unsupported TT device architecture"):
+        get_mock_arch_from_device(FakeDevice("Arch.UNKNOWN"))
+
+
+def test_undetectable_device_architecture_is_rejected():
     with pytest.raises(
         ValueError, match="Unsupported or undetectable TT device architecture"
     ):
-        get_mock_arch_from_device(FakeDevice("Arch.UNKNOWN"))
+        get_mock_arch_from_device(DeviceWithRaisingArch())
+
+
+def test_quasar_device_architecture_is_rejected():
+    with pytest.raises(ValueError, match="unsupported Gen2 runtime APIs"):
+        get_mock_arch_from_device(FakeDevice("Arch.QUASAR"))
 
 
 def test_pipeline_attaches_typed_target_architecture():

--- a/test/me2e/test_kernel_config.py
+++ b/test/me2e/test_kernel_config.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for compiler-selected compute configuration propagation."""
+
+import pytest
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl.dialects.ttl as ttl  # noqa: E402
+from ttl.ir import Context, Module  # noqa: E402
+
+from .builder import kernels as kernel_builder  # noqa: E402
+from .builder.kernels import KernelSpec, ThreadType  # noqa: E402
+from .builder.ttnn_runner import _get_compute_config  # noqa: E402
+
+
+def test_compiled_kernel_configuration_is_extracted(monkeypatch):
+    context = Context()
+    ttl.ensure_dialects_registered(context)
+
+    with context:
+        module = Module.parse(
+            """
+            module {
+              func.func @compute_kernel() attributes {
+                dst_full_sync_en = true,
+                fp32_dest_acc_en = true,
+                ttl.unpack_to_dest_fp32 = array<i32: 3, 17>
+              } {
+                return
+              }
+            }
+            """,
+            context,
+        )
+        monkeypatch.setattr(
+            kernel_builder,
+            "get_ttkernel_names",
+            lambda compiled_module: [("compute_kernel", "compute")],
+        )
+        monkeypatch.setattr(
+            kernel_builder,
+            "ttkernel_to_cpp_by_name",
+            lambda compiled_module, kernel_name: "void kernel_main() {}",
+        )
+
+        noc_kernels, compute_kernel = kernel_builder.translate_module_to_kernels(module)
+
+    assert noc_kernels == []
+    assert compute_kernel.fp32_dest_acc_en
+    assert compute_kernel.dst_full_sync_en
+    assert compute_kernel.unpack_to_dest_fp32 == [3, 17]
+
+
+def test_missing_compiler_configuration_is_rejected(monkeypatch):
+    context = Context()
+    ttl.ensure_dialects_registered(context)
+
+    with context:
+        module = Module.parse(
+            """
+            module {
+              func.func @compute_kernel() attributes {
+                dst_full_sync_en = false,
+                fp32_dest_acc_en = false
+              } {
+                return
+              }
+            }
+            """,
+            context,
+        )
+        monkeypatch.setattr(
+            kernel_builder,
+            "get_ttkernel_names",
+            lambda compiled_module: [("compute_kernel", "compute")],
+        )
+        monkeypatch.setattr(
+            kernel_builder,
+            "ttkernel_to_cpp_by_name",
+            lambda compiled_module, kernel_name: "void kernel_main() {}",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Required compiler-generated attribute "
+            "'ttl.unpack_to_dest_fp32' is missing",
+        ):
+            kernel_builder.translate_module_to_kernels(module)
+
+
+def test_noc_kernel_does_not_require_compute_configuration(monkeypatch):
+    context = Context()
+    ttl.ensure_dialects_registered(context)
+
+    with context:
+        module = Module.parse(
+            """
+            module {
+              func.func @reader() {
+                return
+              }
+              func.func @compute_kernel() attributes {
+                dst_full_sync_en = false,
+                fp32_dest_acc_en = false,
+                ttl.unpack_to_dest_fp32 = array<i32>
+              } {
+                return
+              }
+            }
+            """,
+            context,
+        )
+        monkeypatch.setattr(
+            kernel_builder,
+            "get_ttkernel_names",
+            lambda compiled_module: [
+                ("reader", "noc"),
+                ("compute_kernel", "compute"),
+            ],
+        )
+        monkeypatch.setattr(
+            kernel_builder,
+            "ttkernel_to_cpp_by_name",
+            lambda compiled_module, kernel_name: "void kernel_main() {}",
+        )
+
+        noc_kernels, compute_kernel = kernel_builder.translate_module_to_kernels(module)
+
+    assert len(noc_kernels) == 1
+    assert noc_kernels[0].name == "reader"
+    assert compute_kernel.name == "compute_kernel"
+
+
+def test_compiled_kernel_configuration_is_translated_to_ttnn():
+    compute_kernel = KernelSpec(
+        name="compute_kernel",
+        thread_type=ThreadType.COMPUTE,
+        source="void kernel_main() {}",
+        fp32_dest_acc_en=True,
+        dst_full_sync_en=True,
+        unpack_to_dest_fp32=[3, 17],
+    )
+
+    config = _get_compute_config(compute_kernel)
+
+    assert config.fp32_dest_acc_en
+    assert config.dst_full_sync_en
+    assert len(config.unpack_to_dest_mode) == 64
+    assert config.unpack_to_dest_mode[3] == ttnn.UnpackToDestMode.UnpackToDestFp32
+    assert config.unpack_to_dest_mode[17] == ttnn.UnpackToDestMode.UnpackToDestFp32
+    assert config.unpack_to_dest_mode[0] == ttnn.UnpackToDestMode.Default

--- a/test/python/atom/test_atom_tensor_add.py
+++ b/test/python/atom/test_atom_tensor_add.py
@@ -20,7 +20,7 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 from ttlang_test_utils import assert_allclose, to_l1
 
 
-@ttl.operation(grid=(1, 1))
+@ttl.operation(grid=(1, 1), math_fidelity="LoFi")
 def atom_tensor_add(a, b, out):
     a_cb = ttl.make_dataflow_buffer_like(a, shape=(1, 1), block_count=2)
     b_cb = ttl.make_dataflow_buffer_like(b, shape=(1, 1), block_count=2)

--- a/test/python/simple_add_f32.py
+++ b/test/python/simple_add_f32.py
@@ -26,6 +26,7 @@ except ImportError:
     grid=(1, 1),
     fp32_dest_acc_en=True,
     dst_full_sync_en=False,
+    math_fidelity="HiFi4",
 )
 def add_kernel_f32(lhs, rhs, out):
     lhs_dfb = ttl.make_dataflow_buffer_like(lhs, shape=(1, 1), block_count=2)

--- a/test/python/test_recurrence_multi_output_dfb.py
+++ b/test/python/test_recurrence_multi_output_dfb.py
@@ -588,8 +588,6 @@ def test_multi_output_out_of_order_consumers(dtype, device):
 
 @pytest.mark.requires_device
 def test_published_value_mixed_consumers(device):
-    # One f32 DFB cannot feed both FPU and SFPU consumers because their unpack
-    # modes conflict. Existing f32 kernels publish separate strategy inputs.
     dtype = torch.bfloat16
     torch.manual_seed(5)
     lhs_torch = torch.randn(TILE, TILE, dtype=dtype)

--- a/test/python/test_recurrence_multi_output_dfb.py
+++ b/test/python/test_recurrence_multi_output_dfb.py
@@ -277,6 +277,34 @@ def published_value_mixed_consumers(lhs, rhs, out):
             ttl.copy(scaled, out[0:1, 1:2]).wait()
 
 
+@ttl.operation(grid=(1, 1))
+def shared_dfb_fixed_and_strategy_consumers(lhs, rhs, out):
+    lhs_dfb = ttl.make_dataflow_buffer_like(lhs, shape=(1, 1), block_count=1)
+    rhs_dfb = ttl.make_dataflow_buffer_like(rhs, shape=(1, 1), block_count=1)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=1)
+
+    @ttl.compute()
+    def compute():
+        lhs_block = lhs_dfb.wait()
+        rhs_block = rhs_dfb.wait()
+        exponential = ttl.exp(lhs_block)
+        summed = lhs_block + rhs_block
+        with out_dfb.reserve() as out_block:
+            out_block.store(exponential + summed)
+
+    @ttl.datamovement()
+    def dm_read():
+        with lhs_dfb.reserve() as lhs_block:
+            ttl.copy(lhs[0:1, 0:1], lhs_block).wait()
+        with rhs_dfb.reserve() as rhs_block:
+            ttl.copy(rhs[0:1, 0:1], rhs_block).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with out_dfb.wait() as out_block:
+            ttl.copy(out_block, out[0:1, 0:1]).wait()
+
+
 @ttl.operation(grid=(N_BRANCH_NODES, 1))
 def branch_intermediate_consumers(lhs, rhs, out):
     a_dfb = ttl.make_dataflow_buffer_like(lhs, shape=(1, 1), block_count=2)
@@ -603,6 +631,25 @@ def test_published_value_mixed_consumers(device):
     result = ttnn.to_torch(out).float()
     summed = lhs_torch.float() + rhs_torch.float()
     expected = torch.cat((summed, summed * summed.sum(dim=1, keepdim=True)), dim=1)
+    assert_pcc(expected, result, threshold=_pcc_threshold(dtype))
+
+
+@pytest.mark.parametrize("dtype", DTYPES, ids=["bf16", "f32"])
+@pytest.mark.requires_device
+def test_shared_dfb_fixed_and_strategy_consumers(dtype, device):
+    torch.manual_seed(6)
+    lhs_torch = torch.randn(TILE, TILE, dtype=dtype)
+    rhs_torch = torch.randn(TILE, TILE, dtype=dtype)
+    out_torch = torch.zeros(TILE, TILE, dtype=dtype)
+
+    lhs = to_dram(lhs_torch, device)
+    rhs = to_dram(rhs_torch, device)
+    out = to_dram(out_torch, device)
+
+    shared_dfb_fixed_and_strategy_consumers(lhs, rhs, out)
+
+    result = ttnn.to_torch(out).float()
+    expected = torch.exp(lhs_torch.float()) + lhs_torch.float() + rhs_torch.float()
     assert_pcc(expected, result, threshold=_pcc_threshold(dtype))
 
 

--- a/test/python/test_recurrence_multi_output_dfb.py
+++ b/test/python/test_recurrence_multi_output_dfb.py
@@ -21,6 +21,7 @@ M_TILES = 2
 N_BRANCH_NODES = 2
 N_MULTI_OUTPUT_USES = 3
 DTYPES = [torch.bfloat16, torch.float32]
+COMPUTE_TILE_SIZES = [(16, 16), (16, 32), (32, 16), (32, 32)]
 
 
 @ttl.operation(grid=(1, 1))
@@ -635,16 +636,22 @@ def test_published_value_mixed_consumers(device):
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    "tile_hw",
+    COMPUTE_TILE_SIZES,
+    ids=[f"{height}x{width}" for height, width in COMPUTE_TILE_SIZES],
+)
 @pytest.mark.requires_device
-def test_shared_dfb_fixed_and_strategy_consumers(dtype, device):
+def test_shared_dfb_fixed_and_strategy_consumers(dtype, tile_hw, device):
     torch.manual_seed(6)
-    lhs_torch = torch.randn(TILE, TILE, dtype=dtype)
-    rhs_torch = torch.randn(TILE, TILE, dtype=dtype)
-    out_torch = torch.zeros(TILE, TILE, dtype=dtype)
+    tile_height, tile_width = tile_hw
+    lhs_torch = torch.randn(tile_height, tile_width, dtype=dtype)
+    rhs_torch = torch.randn(tile_height, tile_width, dtype=dtype)
+    out_torch = torch.zeros(tile_height, tile_width, dtype=dtype)
 
-    lhs = to_dram(lhs_torch, device)
-    rhs = to_dram(rhs_torch, device)
-    out = to_dram(out_torch, device)
+    lhs = to_dram(lhs_torch, device, tile_hw=tile_hw)
+    rhs = to_dram(rhs_torch, device, tile_hw=tile_hw)
+    out = to_dram(out_torch, device, tile_hw=tile_hw)
 
     shared_dfb_fixed_and_strategy_consumers(lhs, rhs, out)
 

--- a/test/python/test_reduce.py
+++ b/test/python/test_reduce.py
@@ -1479,7 +1479,7 @@ def test_matmul_then_reduce(device, dtype):
 REDUCE_BCAST_MATMUL_TEMPLATE = """
 import ttl
 
-@ttl.operation(grid=(1, 1), fp32_dest_acc_en=True)
+@ttl.operation(grid=(1, 1))
 def reduce_bcast_matmul_kernel(reduce_in, mat_b, out):
     reduce_dfb = ttl.make_dataflow_buffer_like(reduce_in, shape=({mt}, {kt}), block_count=2)
     red_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)

--- a/test/python/test_ttl_api_device_options.py
+++ b/test/python/test_ttl_api_device_options.py
@@ -10,6 +10,7 @@ import pytest
 
 import ttl.dialects.ttl as ttl
 import ttl.ttl_api as ttl_api
+from ttl.constants import SUPPORTED_MATH_FIDELITIES
 from ttl.ir import Context, Module
 
 
@@ -179,7 +180,7 @@ class TestKernelI32ArrayAttr:
 
 
 class TestMathFidelity:
-    @pytest.mark.parametrize("math_fidelity", ttl_api.SUPPORTED_MATH_FIDELITIES)
+    @pytest.mark.parametrize("math_fidelity", SUPPORTED_MATH_FIDELITIES)
     def test_maps_supported_value(self, math_fidelity):
         fidelity_value = object()
         ttnn_module = mock.Mock()

--- a/test/python/test_ttl_api_device_options.py
+++ b/test/python/test_ttl_api_device_options.py
@@ -176,3 +176,23 @@ class TestKernelI32ArrayAttr:
                 ttl_api._get_kernel_i32_array_attr(
                     module, "compute_kernel", "ttl.unpack_to_dest_fp32"
                 )
+
+
+class TestMathFidelity:
+    @pytest.mark.parametrize("math_fidelity", ttl_api.SUPPORTED_MATH_FIDELITIES)
+    def test_maps_supported_value(self, math_fidelity):
+        fidelity_value = object()
+        ttnn_module = mock.Mock()
+        setattr(ttnn_module.MathFidelity, math_fidelity, fidelity_value)
+        config = mock.Mock()
+
+        ttl_api._set_math_fidelity(config, ttnn_module, math_fidelity)
+
+        assert config.math_fidelity is fidelity_value
+
+    def test_missing_ttnn_value_is_rejected(self):
+        ttnn_module = mock.Mock()
+        del ttnn_module.MathFidelity.HiFi4
+
+        with pytest.raises(RuntimeError, match="does not provide MathFidelity.HiFi4"):
+            ttl_api._set_math_fidelity(mock.Mock(), ttnn_module, "HiFi4")

--- a/test/python/test_ttl_api_device_options.py
+++ b/test/python/test_ttl_api_device_options.py
@@ -60,23 +60,35 @@ class TestDeviceTargetArch:
         device = _DeviceWithArchAttribute("BLACKHOLE")
         assert ttl_api._device_target_arch((_TensorWithDevice(device),)) == "blackhole"
 
-    def test_quasar_arch(self):
+    def test_quasar_arch_is_rejected(self):
         device = _DeviceWithArchMethod("Arch.QUASAR")
-        assert ttl_api._device_target_arch((_TensorWithDevice(device),)) == "quasar"
+        with pytest.raises(ValueError, match="Unsupported TT device architecture"):
+            ttl_api._device_target_arch((_TensorWithDevice(device),))
 
     def test_unknown_arch_is_rejected(self):
         device = _DeviceWithArchAttribute("future_arch")
         with pytest.raises(ValueError, match="Unsupported TT device architecture"):
             ttl_api._device_target_arch((_TensorWithDevice(device),))
 
-    def test_no_recognized_arch_attribute_returns_none(self):
-        assert ttl_api._device_target_arch((_TensorWithDevice(object()),)) is None
+    def test_no_recognized_arch_attribute_is_rejected(self):
+        with pytest.raises(
+            ValueError, match="Unsupported or undetectable TT device architecture"
+        ):
+            ttl_api._device_target_arch((_TensorWithDevice(object()),))
 
     def test_no_tensor_args_returns_none(self):
         assert ttl_api._device_target_arch(()) is None
 
-    def test_raising_arch_attribute_returns_none(self):
-        assert (
+    def test_raising_arch_attribute_is_rejected(self):
+        with pytest.raises(
+            ValueError, match="Unsupported or undetectable TT device architecture"
+        ):
             ttl_api._device_target_arch((_TensorWithDevice(_DeviceWithRaisingArch()),))
-            is None
+
+    def test_different_device_architectures_are_rejected(self):
+        args = (
+            _TensorWithDevice(_DeviceWithArchAttribute("Arch.WORMHOLE_B0")),
+            _TensorWithDevice(_DeviceWithArchAttribute("Arch.BLACKHOLE")),
         )
+        with pytest.raises(ValueError, match="different TT device architectures"):
+            ttl_api._device_target_arch(args)

--- a/test/python/test_ttl_api_device_options.py
+++ b/test/python/test_ttl_api_device_options.py
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for device target-arch detection used by the TTL Python wrapper."""
+"""Unit tests for TT device options used by the TTL Python wrapper."""
 
 from unittest import mock
 
 import pytest
 
+import ttl.dialects.ttl as ttl
 import ttl.ttl_api as ttl_api
+from ttl.ir import Context, Module
 
 
 class _TensorWithDevice:
@@ -92,3 +94,85 @@ class TestDeviceTargetArch:
         )
         with pytest.raises(ValueError, match="different TT device architectures"):
             ttl_api._device_target_arch(args)
+
+
+class TestKernelI32ArrayAttr:
+    def test_optional_attribute_may_be_absent(self):
+        context = Context()
+        ttl.ensure_dialects_registered(context)
+
+        with context:
+            module = Module.parse("module { func.func @reader() { return } }")
+            assert (
+                ttl_api._get_optional_kernel_i32_array_attr(
+                    module, "reader", "ttl.pipe_computed_address_dfb_indices"
+                )
+                == []
+            )
+
+    def test_optional_attribute_is_read_when_present(self):
+        context = Context()
+        ttl.ensure_dialects_registered(context)
+
+        with context:
+            module = Module.parse(
+                """
+                module {
+                  func.func @reader() attributes {
+                    ttl.pipe_computed_address_dfb_indices = array<i32: 2, 5>
+                  } {
+                    return
+                  }
+                }
+                """
+            )
+            assert ttl_api._get_optional_kernel_i32_array_attr(
+                module, "reader", "ttl.pipe_computed_address_dfb_indices"
+            ) == [2, 5]
+
+    def test_optional_attribute_is_validated_when_present(self):
+        context = Context()
+        ttl.ensure_dialects_registered(context)
+
+        with context:
+            module = Module.parse(
+                """
+                module {
+                  func.func @reader() attributes {
+                    ttl.pipe_computed_address_dfb_indices = 2 : i32
+                  } {
+                    return
+                  }
+                }
+                """
+            )
+            with pytest.raises(ValueError, match="Expected DenseI32ArrayAttr"):
+                ttl_api._get_optional_kernel_i32_array_attr(
+                    module, "reader", "ttl.pipe_computed_address_dfb_indices"
+                )
+
+    def test_required_attribute_must_be_present(self):
+        context = Context()
+        ttl.ensure_dialects_registered(context)
+
+        with context:
+            module = Module.parse(
+                """
+                module {
+                  func.func @compute_kernel() attributes {
+                    dst_full_sync_en = false,
+                    fp32_dest_acc_en = false
+                  } {
+                    return
+                  }
+                }
+                """
+            )
+            with pytest.raises(
+                ValueError,
+                match="Required compiler-generated attribute "
+                "'ttl.unpack_to_dest_fp32' is missing",
+            ):
+                ttl_api._get_kernel_i32_array_attr(
+                    module, "compute_kernel", "ttl.unpack_to_dest_fp32"
+                )

--- a/test/python/test_ttl_api_device_options.py
+++ b/test/python/test_ttl_api_device_options.py
@@ -60,11 +60,14 @@ class TestDeviceTargetArch:
         device = _DeviceWithArchAttribute("BLACKHOLE")
         assert ttl_api._device_target_arch((_TensorWithDevice(device),)) == "blackhole"
 
-    def test_unknown_arch_returns_normalized_string(self):
+    def test_quasar_arch(self):
+        device = _DeviceWithArchMethod("Arch.QUASAR")
+        assert ttl_api._device_target_arch((_TensorWithDevice(device),)) == "quasar"
+
+    def test_unknown_arch_is_rejected(self):
         device = _DeviceWithArchAttribute("future_arch")
-        assert (
-            ttl_api._device_target_arch((_TensorWithDevice(device),)) == "future_arch"
-        )
+        with pytest.raises(ValueError, match="Unsupported TT device architecture"):
+            ttl_api._device_target_arch((_TensorWithDevice(device),))
 
     def test_no_recognized_arch_attribute_returns_none(self):
         assert ttl_api._device_target_arch((_TensorWithDevice(object()),)) is None
@@ -73,9 +76,6 @@ class TestDeviceTargetArch:
         assert ttl_api._device_target_arch(()) is None
 
     def test_raising_arch_attribute_returns_none(self):
-        # hasattr() swallows the AttributeError-or-otherwise; detection
-        # falls through to the next attribute and ultimately returns None
-        # when none resolve.
         assert (
             ttl_api._device_target_arch((_TensorWithDevice(_DeviceWithRaisingArch()),))
             is None

--- a/test/python/test_ttl_api_kernel_cache.py
+++ b/test/python/test_ttl_api_kernel_cache.py
@@ -6,6 +6,8 @@
 
 import itertools
 
+import pytest
+
 import ttl.ttl_api as ttl_api
 
 
@@ -130,6 +132,23 @@ def test_operation_cache_reuses_compiled_kernel_for_same_tensor_config(monkeypat
         (first_input, first_output),
         (second_input, second_output),
     ]
+
+
+def test_operation_propagates_math_fidelity(monkeypatch):
+    compile_calls = _install_recording_compile(monkeypatch)
+
+    @ttl_api.operation(grid=(1, 1), math_fidelity="HiFi3")
+    def copy_kernel(input_tensor, output_tensor):
+        pass
+
+    copy_kernel(_FakeTensor(), _FakeTensor())
+
+    assert compile_calls[0]["compile_options"]["math_fidelity"] == "HiFi3"
+
+
+def test_operation_rejects_invalid_math_fidelity():
+    with pytest.raises(ValueError, match="math_fidelity must be one of"):
+        ttl_api.operation(grid=(1, 1), math_fidelity="HiFi5")
 
 
 def test_operation_cache_reuses_kernel_across_allocation_capacities(monkeypatch):

--- a/test/python/test_ttl_api_kernel_cache.py
+++ b/test/python/test_ttl_api_kernel_cache.py
@@ -146,6 +146,25 @@ def test_operation_propagates_math_fidelity(monkeypatch):
     assert compile_calls[0]["compile_options"]["math_fidelity"] == "HiFi3"
 
 
+def test_cache_key_separates_math_fidelity(monkeypatch):
+    monkeypatch.setattr(
+        ttl_api, "is_ttnn_tensor", lambda arg: isinstance(arg, _FakeTensor)
+    )
+    tensors = (_FakeTensor(), _FakeTensor())
+    common_options = {
+        "args": tensors,
+        "resolved_grid": (1, 1),
+        "fp32_dest_acc_en": False,
+        "dst_full_sync_en": False,
+        "target_arch": "blackhole",
+    }
+
+    hifi2_key = ttl_api._make_cache_key(math_fidelity="HiFi2", **common_options)
+    hifi4_key = ttl_api._make_cache_key(math_fidelity="HiFi4", **common_options)
+
+    assert hifi2_key != hifi4_key
+
+
 def test_operation_rejects_invalid_math_fidelity():
     with pytest.raises(ValueError, match="math_fidelity must be one of"):
         ttl_api.operation(grid=(1, 1), math_fidelity="HiFi5")

--- a/test/sim/test_operation.py
+++ b/test/sim/test_operation.py
@@ -1194,6 +1194,21 @@ class TestHardwareKeywordsIgnored:
         )
         kernel(a, b)
 
+    @pytest.mark.parametrize("math_fidelity", ["LoFi", "HiFi2", "HiFi3", "HiFi4"])
+    def test_math_fidelity_accepted(self, math_fidelity: str) -> None:
+        """Supported math fidelities do not raise."""
+        a = ttnn.from_torch(torch.zeros(32, 32))
+        b = ttnn.from_torch(torch.zeros(32, 32))
+        kernel = _make_passthrough_kernel(
+            ttl.operation(grid=(1, 1), math_fidelity=math_fidelity)
+        )
+        kernel(a, b)
+
+    def test_invalid_math_fidelity_rejected(self) -> None:
+        """Unsupported math fidelity raises before execution."""
+        with pytest.raises(ValueError, match="math_fidelity must be one of"):
+            ttl.operation(grid=(1, 1), math_fidelity="HiFi5")
+
     def test_multiple_hardware_kwargs_accepted(self) -> None:
         """Multiple hardware kwargs together do not raise."""
         a = ttnn.from_torch(torch.zeros(32, 32))
@@ -1203,6 +1218,7 @@ class TestHardwareKeywordsIgnored:
                 grid=(1, 1),
                 fp32_dest_acc_en=True,
                 dst_full_sync_en=False,
+                math_fidelity="HiFi4",
             )
         )
         kernel(a, b)

--- a/test/ttlang/Conversion/TTLToCompute/dst_assignment.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/dst_assignment.mlir
@@ -1,7 +1,7 @@
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst),canonicalize)' | FileCheck %s
 
 // Test: token-based lowering with dst_idx annotations on math ops.
-// Note: enable-fpu-binary-ops=0 keeps SFPU lowering path (not testing FPU detection).
+// Disabling FPU selection makes binary operands use DST.
 
 func.func @ok(%a: tensor<2x2x!ttcore.tile<32x32, f32>>, %b: tensor<2x2x!ttcore.tile<32x32, f32>>) -> tensor<2x2x!ttcore.tile<32x32, f32>> {
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>

--- a/test/ttlang/Conversion/TTLToCompute/elementwise_basic.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/elementwise_basic.mlir
@@ -1,7 +1,7 @@
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst),cse,canonicalize)' | FileCheck %s
 
 // Basic elementwise operations lowered to ttl.compute with tile ops and DST assignment.
-// Note: enable-fpu-binary-ops=0 keeps SFPU lowering path (not testing FPU detection).
+// Disabling FPU selection makes binary operands use DST.
 // Input provides explicit bind_cb and attach_cb ops; pass creates compute.
 
 #map = affine_map<(d0, d1) -> (d0, d1)>

--- a/test/ttlang/Conversion/TTLToCompute/elementwise_coverage.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/elementwise_coverage.mlir
@@ -1,6 +1,6 @@
 // RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst),cse,canonicalize)' | FileCheck %s
 
-// Note: enable-fpu-binary-ops=0 keeps SFPU lowering path (not testing FPU detection).
+// Disabling FPU selection makes binary operands use DST.
 // Test: Binary elementwise operations lower to ttl.compute with tile ops
 // Input provides explicit bind_cb and attach_cb ops.
 // This test verifies the full CB attachment pattern for all arguments.
@@ -21,7 +21,7 @@ func.func @binary_add(%arg0: tensor<2x2x!ttcore.tile<32x32, f32>>, %arg1: tensor
   // CHECK-NEXT: ^bb0(%[[IN0:.+]]: !ttcore.tile<32x32, f32>, %[[IN1:.+]]: !ttcore.tile<32x32, f32>, %[[OUT:.+]]: !ttcore.tile<32x32, f32>):
   // CHECK:        %[[DTOK0:.*]], %[[DTILE0:.*]] = ttl.copy_tile %[[IN0]]
   // CHECK:        %[[DTOK1:.*]], %[[DTILE1:.*]] = ttl.copy_tile %[[IN1]]
-  // CHECK-NEXT:   %[[ADD:.+]] = ttl.tile_add %[[DTILE0]], %[[DTILE1]] into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  // CHECK-NEXT:   %[[ADD:.+]] = ttl.tile_add %[[DTILE0]], %[[DTILE1]] into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   // CHECK:        ttl.tile_store
   // CHECK-NEXT:   ttl.yield
   // CHECK-NEXT: } -> tensor<2x2x!ttcore.tile<32x32, f32>>
@@ -483,7 +483,7 @@ func.func @chained_ops(%arg0: tensor<2x2x!ttcore.tile<32x32, f32>>, %arg1: tenso
   // CHECK-NEXT: ^bb0(%[[IN0:.+]]: !ttcore.tile<32x32, f32>, %[[IN1:.+]]: !ttcore.tile<32x32, f32>, %[[OUT0:.+]]: !ttcore.tile<32x32, f32>):
   // CHECK:        %[[DTOK0:.*]], %[[DTILE0:.*]] = ttl.copy_tile %[[IN0]]
   // CHECK:        %[[DTOK1:.*]], %[[DTILE1:.*]] = ttl.copy_tile %[[IN1]]
-  // CHECK-NEXT:   %[[TILE_ADD:.+]] = ttl.tile_add %[[DTILE0]], %[[DTILE1]] into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  // CHECK-NEXT:   %[[TILE_ADD:.+]] = ttl.tile_add %[[DTILE0]], %[[DTILE1]] into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   // CHECK:        ttl.tile_store
   // CHECK-NEXT:   ttl.yield
   // CHECK-NEXT: } -> tensor<2x2x!ttcore.tile<32x32, f32>>

--- a/test/ttlang/Conversion/TTLToCompute/subtile.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/subtile.mlir
@@ -1,0 +1,114 @@
+// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),canonicalize)' | FileCheck %s
+
+// Verifies that conversion preserves physical tile dimensions for direct,
+// fused, and passthrough compute operations.
+
+// Direct elementwise lowering must use the tensor element tile type for every
+// compute block argument and tile result.
+// CHECK-LABEL: func.func @direct_subtile
+// CHECK:       %[[RESULT:.*]] = ttl.compute
+// CHECK-NEXT:  ^bb0(%[[INPUT:.*]]: !ttcore.tile<16x32, bf16>, %[[OUTPUT:.*]]: !ttcore.tile<16x32, bf16>):
+// CHECK-NEXT:    %[[ROW:.*]] = ttl.iter_index 0
+// CHECK-NEXT:    %[[COL:.*]] = ttl.iter_index 1
+// CHECK-NEXT:    %[[EXP:.*]] = ttl.tile_exp %[[INPUT]]{{.*}} -> !ttcore.tile<16x32, bf16>
+// CHECK-NEXT:    ttl.tile_store %[[EXP]], %{{.*}}[%[[ROW]], %[[COL]]]
+// CHECK:       } -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+func.func @direct_subtile(%arg: tensor<1x1x!ttcore.tile<16x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<16x32, bf16>> {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 2>
+  %input = ttl.attach_cb %arg, %input_dfb
+      : (tensor<1x1x!ttcore.tile<16x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+  %result = ttl.exp %input
+      : tensor<1x1x!ttcore.tile<16x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+  ttl.store %result, %output
+      : tensor<1x1x!ttcore.tile<16x32, bf16>>,
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
+  return %result : tensor<1x1x!ttcore.tile<16x32, bf16>>
+}
+
+// -----
+
+// Fused lowering must preserve physical tile dimensions through intermediate
+// tile operations and the output store.
+// CHECK-LABEL: func.func @fused_subtile
+// CHECK:       %[[RESULT:.*]] = ttl.compute
+// CHECK-NEXT:  ^bb0(%[[LHS:.*]]: !ttcore.tile<32x16, f32>, %[[RHS:.*]]: !ttcore.tile<32x16, f32>, %[[OUTPUT:.*]]: !ttcore.tile<32x16, f32>):
+// CHECK-NEXT:    %[[ROW:.*]] = ttl.iter_index 0
+// CHECK-NEXT:    %[[COL:.*]] = ttl.iter_index 1
+// CHECK-NEXT:    %[[EXP:.*]] = ttl.tile_exp %[[LHS]]{{.*}} -> !ttcore.tile<32x16, f32>
+// CHECK-NEXT:    %[[SUM:.*]] = ttl.tile_add %[[EXP]], %[[RHS]]{{.*}} -> !ttcore.tile<32x16, f32>
+// CHECK-NEXT:    ttl.tile_store %[[SUM]], %{{.*}}[%[[ROW]], %[[COL]]]
+// CHECK:       } -> tensor<1x1x!ttcore.tile<32x16, f32>>
+func.func @fused_subtile(
+    %lhs_arg: tensor<1x1x!ttcore.tile<32x16, f32>>,
+    %rhs_arg: tensor<1x1x!ttcore.tile<32x16, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x16, f32>> {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>
+  %lhs = ttl.attach_cb %lhs_arg, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x16, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %rhs = ttl.attach_cb %rhs_arg, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x16, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x16, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %exp = ttl.exp %lhs
+      : tensor<1x1x!ttcore.tile<32x16, f32>>
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %result = ttl.add %exp, %rhs
+      : tensor<1x1x!ttcore.tile<32x16, f32>>,
+        tensor<1x1x!ttcore.tile<32x16, f32>>
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  ttl.store %result, %output
+      : tensor<1x1x!ttcore.tile<32x16, f32>>,
+        tensor<1x1x!ttcore.tile<32x16, f32>>
+  return %result : tensor<1x1x!ttcore.tile<32x16, f32>>
+}
+
+// -----
+
+// Passthrough-store lowering must preserve physical tile dimensions when it
+// constructs the compute block arguments.
+// CHECK-LABEL: func.func @passthrough_subtile
+// CHECK:       %[[RESULT:.*]] = ttl.compute
+// CHECK-NEXT:  ^bb0(%[[INPUT:.*]]: !ttcore.tile<16x16, bf16>, %[[OUTPUT:.*]]: !ttcore.tile<16x16, bf16>):
+// CHECK-NEXT:    %[[ROW:.*]] = ttl.iter_index 0
+// CHECK-NEXT:    %[[COL:.*]] = ttl.iter_index 1
+// CHECK-NEXT:    ttl.tile_store %[[INPUT]], %{{.*}}[%[[ROW]], %[[COL]]]
+// CHECK-NEXT:    ttl.yield
+// CHECK-NEXT:  } -> tensor<1x1x!ttcore.tile<16x16, bf16>>
+func.func @passthrough_subtile(%arg: tensor<1x1x!ttcore.tile<16x16, bf16>>)
+    -> tensor<1x1x!ttcore.tile<16x16, bf16>> {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x16, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x16, bf16>, 2>
+  %input = ttl.attach_cb %arg, %input_dfb
+      : (tensor<1x1x!ttcore.tile<16x16, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<16x16, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<16x16, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<16x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<16x16, bf16>>
+  ttl.store %input, %output
+      : tensor<1x1x!ttcore.tile<16x16, bf16>>,
+        tensor<1x1x!ttcore.tile<16x16, bf16>>
+  return %input : tensor<1x1x!ttcore.tile<16x16, bf16>>
+}

--- a/test/ttlang/Conversion/TTLToTTKernel/fpu_binary_cb_mismatch_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/fpu_binary_cb_mismatch_invalid.mlir
@@ -2,9 +2,8 @@
 
 // FPU binary op where lhs and rhs CBs have different tile counts.
 // The lhs CB is [2, 2] (4 tiles) while the rhs CB is [1, 2] (2 tiles). Both
-// tensor.extract ops use identical indices so isFPUEligibleBinaryOp picks the
-// FPU pattern, which rejects the mismatched per-block shape; the SFPU pattern
-// also rejects (predicate is true), so the op fails to legalize.
+// tensor.extract ops use identical indices, but the selected FPU strategy
+// rejects the mismatched per-block DFB dimensions.
 func.func @fpu_add_cb_shape_mismatch()
     attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [],
                 ttl.kernel_thread = #ttkernel.thread<compute>} {
@@ -23,7 +22,10 @@ func.func @fpu_add_cb_shape_mismatch()
   %rhs_tile = tensor.extract %rhs[%c0, %c0] : tensor<1x2x!ttcore.tile<32x32, bf16>>
 
   // expected-error @+1 {{failed to legalize operation 'ttl.tile_add' that was explicitly marked illegal}}
-  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%c0]
+      {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>}
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
 
   %out_view = ttl.cb_reserve %cb1 : <[2, 2], !ttcore.tile<32x32, bf16>, 2> -> tensor<2x2x!ttcore.tile<32x32, bf16>>
   %out = tensor.insert %sum into %out_view[%c0, %c0] : tensor<2x2x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Conversion/TTLToTTKernel/init_consolidation.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/init_consolidation.mlir
@@ -108,9 +108,9 @@ func.func @mixed_binary(
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %m0 = ttl.tile_mul %a, %b into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %m1 = ttl.tile_mul %a, %b into dst[%c1] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %s0 = ttl.tile_add %m0, %m1 into dst[%c2] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %m0 = ttl.tile_mul %a, %b into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %m1 = ttl.tile_mul %a, %b into dst[%c1] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %s0 = ttl.tile_add %m0, %m1 into dst[%c2] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %s0 : !ttcore.tile<32x32, f32>
 }

--- a/test/ttlang/Conversion/TTLToTTKernel/reduce_lowering_warning.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/reduce_lowering_warning.mlir
@@ -1,10 +1,10 @@
-// Summary: Tests diagnostics for reduce tile op lowering to TTKernel.
-
+// Verify configuration reports unavailable full-fp32 reduction before
+// TTKernel conversion.
 // RUN: ttlang-opt %s --verify-diagnostics \
-// RUN:   -pass-pipeline='builtin.module(convert-ttl-to-ttkernel{reduce-full-fp32=true})'
+// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config),convert-ttl-to-ttkernel)'
 
-// Blackhole REDUCE_ROW disables full-fp32 lowering because of issue #533.
-module attributes {ttl.target_arch = "blackhole"} {
+// Blackhole row reduction cannot use full-fp32 accumulation (tt-metal #47311).
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @blackhole_reduce_sum_dim1_warning() attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>} {
     %c0 = arith.constant 0 : index
     %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>

--- a/test/ttlang/Conversion/TTLToTTKernel/tile_execution_strategy_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/tile_execution_strategy_invalid.mlir
@@ -1,0 +1,14 @@
+// Verify conversion rejects tile operations with alternatives when no
+// execution strategy has been selected.
+// RUN: ttlang-opt %s --convert-ttl-to-ttkernel --verify-diagnostics
+
+func.func @missing_tile_execution_strategy(
+    %lhs: !ttcore.tile<32x32, bf16>,
+    %rhs: !ttcore.tile<32x32, bf16>) {
+  %zero = arith.constant 0 : index
+  // expected-error @below {{'ttl.tile_add' op requires a selected ttl.tile_execution_strategy attribute; run ttl-set-compute-kernel-config before DST assignment, scheduling, or lowering}}
+  %sum = ttl.tile_add %lhs, %rhs into dst[%zero]
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
+  return
+}

--- a/test/ttlang/Conversion/TTLToTTKernel/tile_ops_to_ttkernel.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/tile_ops_to_ttkernel.mlir
@@ -58,7 +58,7 @@ func.func @tile_sqrt(%a: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
 func.func @tile_add(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %sum = ttl.tile_add %a, %b into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %sum = ttl.tile_add %a, %b into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %sum : !ttcore.tile<32x32, f32>
 }
@@ -71,7 +71,7 @@ func.func @tile_add(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32x32, f32>) 
 func.func @tile_sub(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %diff = ttl.tile_sub %a, %b into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %diff = ttl.tile_sub %a, %b into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %diff : !ttcore.tile<32x32, f32>
 }
@@ -84,7 +84,7 @@ func.func @tile_sub(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32x32, f32>) 
 func.func @tile_mul(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %prod = ttl.tile_mul %a, %b into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %prod = ttl.tile_mul %a, %b into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %prod : !ttcore.tile<32x32, f32>
 }
@@ -138,7 +138,7 @@ func.func @tile_compare_ops(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32x32
 func.func @tile_chain(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %sum = ttl.tile_add %a, %b into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %sum = ttl.tile_add %a, %b into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   %exp = ttl.tile_exp %sum into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %exp : !ttcore.tile<32x32, f32>
@@ -164,8 +164,8 @@ func.func @tile_add_block_args(%a: !ttcore.tile<32x32, f32>, %b: !ttcore.tile<32
   %c2 = arith.constant 2 : index
   %c3 = arith.constant 3 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %sum = ttl.tile_add %a, %b into dst[%c2] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %result = ttl.tile_add %sum, %a into dst[%c3] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %sum = ttl.tile_add %a, %b into dst[%c2] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %result = ttl.tile_add %sum, %a into dst[%c3] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %result : !ttcore.tile<32x32, f32>
 }
@@ -198,9 +198,9 @@ func.func @tile_axby_pattern(%a: !ttcore.tile<32x32, f32>, %x: !ttcore.tile<32x3
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %term1 = ttl.tile_mul %a, %x into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %term2 = ttl.tile_mul %b, %y into dst[%c1] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %result = ttl.tile_add %term1, %term2 into dst[%c2] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %term1 = ttl.tile_mul %a, %x into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %term2 = ttl.tile_mul %b, %y into dst[%c1] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %result = ttl.tile_add %term1, %term2 into dst[%c2] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %result : !ttcore.tile<32x32, f32>
 }

--- a/test/ttlang/Conversion/TTLToTTKernel/tile_ops_to_ttkernel_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/tile_ops_to_ttkernel_invalid.mlir
@@ -14,7 +14,7 @@ func.func @tile_mul_lhs_missing_dst_idx(%idx: index) -> !ttcore.tile<32x32, f32>
   %a_tile = builtin.unrealized_conversion_cast %a : tensor<32x32xf32> to !ttcore.tile<32x32, f32>
 
   // expected-error @+1 {{failed to legalize operation 'ttl.tile_mul' that was explicitly marked illegal}}
-  %prod = ttl.tile_mul %a_tile, %b_with_idx into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %prod = ttl.tile_mul %a_tile, %b_with_idx into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   func.return %prod : !ttcore.tile<32x32, f32>
 }
 
@@ -32,7 +32,7 @@ func.func @tile_mul_rhs_missing_dst_idx(%idx: index) -> !ttcore.tile<32x32, f32>
   %b_tile = builtin.unrealized_conversion_cast %b : tensor<32x32xf32> to !ttcore.tile<32x32, f32>
 
   // expected-error @+1 {{failed to legalize operation 'ttl.tile_mul' that was explicitly marked illegal}}
-  %prod = ttl.tile_mul %a_with_idx, %b_tile into dst[%c1] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %prod = ttl.tile_mul %a_with_idx, %b_tile into dst[%c1] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   func.return %prod : !ttcore.tile<32x32, f32>
 }
 

--- a/test/ttlang/Conversion/TTLToTTKernel/tile_regs_acquire.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/tile_regs_acquire.mlir
@@ -33,14 +33,14 @@ func.func @acquire_two_compute_lowers(%t0: !ttcore.tile<32x32, f32>, %t1: !ttcor
   // First region
   ttl.tile_regs_acquire
   %c0 = arith.constant 0 : index
-  %a = ttl.tile_add %t0, %t1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %a = ttl.tile_add %t0, %t1 into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttl.tile_regs_commit
   ttl.tile_regs_wait
   ttl.tile_regs_release
 
   // Second region
   ttl.tile_regs_acquire
-  %b = ttl.tile_mul %a, %t1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %b = ttl.tile_mul %a, %t1 into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttl.tile_regs_commit
   ttl.tile_regs_wait
   ttl.tile_regs_release
@@ -60,8 +60,8 @@ func.func @acquire_chain_lowers(%t0: !ttcore.tile<32x32, f32>,
                                 %t2: !ttcore.tile<32x32, f32>) {
   ttl.tile_regs_acquire
   %c0 = arith.constant 0 : index
-  %a = ttl.tile_add %t0, %t1 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %b = ttl.tile_mul %a, %t2 into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %a = ttl.tile_add %t0, %t1 into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %b = ttl.tile_mul %a, %t2 into dst[%c0] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   %c = ttl.tile_exp %b into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttl.tile_regs_commit
   ttl.tile_regs_wait

--- a/test/ttlang/Dialect/TTL/Pipelines/pipe_verifier_order.mlir
+++ b/test/ttlang/Dialect/TTL/Pipelines/pipe_verifier_order.mlir
@@ -1,5 +1,7 @@
 // RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline --dump-pass-pipeline 2>&1 | FileCheck %s
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-verify-pipenet)' --dump-pass-pipeline 2>&1 | FileCheck %s --check-prefix=SUBPIPELINE
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-to-ttkernel-pipeline{matmul-full-fp32=false})' --dump-pass-pipeline 2>&1 | FileCheck %s --check-prefix=MATMUL-DISABLED
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-to-ttkernel-pipeline{matmul-full-fp32=true})' --dump-pass-pipeline 2>&1 | FileCheck %s --check-prefix=MATMUL-ENABLED
 
 // Verify PipeNet schedule semantics before later transformations modify the
 // high-level pipe and DFB operations or reuse provisional DFB indices.
@@ -39,5 +41,10 @@
 // SUBPIPELINE-NEXT: ttl-verify-pipenet-schedule
 // SUBPIPELINE-NOT:  ttl-verify-pipenet-guards
 // SUBPIPELINE-NOT:  ttl-verify-pipenet-schedule
+
+// Verify the public pipeline option reaches kernel configuration resolution.
+
+// MATMUL-DISABLED: ttl-set-compute-kernel-config{{.*}}matmul-full-fp32=false
+// MATMUL-ENABLED: ttl-set-compute-kernel-config{{.*}}matmul-full-fp32=true
 
 module {}

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_add_mul_exp_chain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_add_mul_exp_chain.mlir
@@ -28,9 +28,9 @@
 // CHECK-NEXT: ^bb0(%[[A:.*]]: !ttcore.tile<32x32, f32>, %[[B:.*]]: !ttcore.tile<32x32, f32>, %[[C:.*]]: !ttcore.tile<32x32, f32>, %[[OUT:.*]]: !ttcore.tile<32x32, f32>):
 // CHECK-NEXT:   %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:   %[[I1:.*]] = ttl.iter_index 1 : index
-// CHECK-NEXT:   %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK-NEXT:   %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%c0] {{.*}} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK-NEXT:   %{{.*}}, %[[DTILE:.*]] = ttl.copy_tile %[[C]][%[[I0]], %[[I1]]] into dst[%[[C1]]]
-// CHECK-NEXT:   %[[MUL:.*]] = ttl.tile_mul %[[ADD]], %[[DTILE]] into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK-NEXT:   %[[MUL:.*]] = ttl.tile_mul %[[ADD]], %[[DTILE]] into dst[%c0] {{.*}} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK-NEXT:   %[[EXP:.*]] = ttl.tile_exp %[[MUL]] into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK-NEXT:   ttl.tile_store %[[EXP]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:   ttl.yield

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_binary_inplace.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_binary_inplace.mlir
@@ -109,3 +109,59 @@ func.func @single_max(%a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
   } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   func.return %result : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
+
+// -----
+
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+
+// Test that two uses by one in-place operation count as one consumer. The
+// allocator materializes the input once and routes both operands to that tile.
+
+// CHECK-LABEL: func.func @repeated_operand_one_consumer
+// CHECK:           ttl.compute
+// CHECK-NEXT:      ^bb0(%[[INPUT:[^:]*]]: !ttcore.tile<32x32, bf16>, %[[OUT:[^:]*]]: !ttcore.tile<32x32, bf16>):
+// CHECK:           %{{.*}}, %[[INPUT_TILE:.*]] = ttl.copy_tile %[[INPUT]]
+// CHECK-NOT:       ttl.copy_tile %[[INPUT]]
+// CHECK:           %[[MAX:.*]] = ttl.tile_max %[[INPUT_TILE]], %[[INPUT_TILE]]
+// CHECK:           ttl.tile_store %[[MAX]]
+// CHECK-NEXT:      ttl.yield
+
+func.func @repeated_operand_one_consumer(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_attached = ttl.attach_cb %init, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_view = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %result = ttl.compute
+      ins(%input_attached : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      outs(%output_attached : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      {indexing_maps = [#map2, #map2],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+       %output_tile: !ttcore.tile<32x32, bf16>):
+    %row = ttl.iter_index 0 : index
+    %column = ttl.iter_index 1 : index
+    %zero = arith.constant 0 : index
+    %maximum = ttl.tile_max %input_tile, %input_tile into dst[%zero]
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+          -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %maximum, %output_view[%row, %column] from dst[%zero]
+        : !ttcore.tile<32x32, bf16>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  func.return %result : tensor<1x1x!ttcore.tile<32x32, bf16>>
+}

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_copy_dst_intermediate.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_copy_dst_intermediate.mlir
@@ -23,7 +23,7 @@
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary mul: both operands are block args -> DST[0]
-// CHECK-NEXT:      %[[X:.*]] = ttl.tile_mul %[[A]], %[[B]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+// CHECK-NEXT:      %[[X:.*]] = ttl.tile_mul %[[A]], %[[B]] into dst[%c0] {{.*}} : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // copy_dst preserves x in DST[1] before destructive abs
 // CHECK-NEXT:      %[[COPY:.*]] = ttl.copy_dst %[[X]] into dst[%c1] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // abs overwrites DST[1] in-place
@@ -31,7 +31,7 @@
 // rsqrt overwrites DST[1] in-place
 // CHECK-NEXT:      %[[RSQRT:.*]] = ttl.tile_rsqrt %[[ABS]] into dst[%c1] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // SFPU binary mul: x at DST[0], rsqrt at DST[1] -> DST[0]
-// CHECK-NEXT:      %[[RESULT:.*]] = ttl.tile_mul %[[X]], %[[RSQRT]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+// CHECK-NEXT:      %[[RESULT:.*]] = ttl.tile_mul %[[X]], %[[RSQRT]] into dst[%c0] {{.*}} : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // CHECK:           ttl.tile_store %[[RESULT]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_corner_cases.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_corner_cases.mlir
@@ -246,7 +246,7 @@ func.func @single_input_multiple_outputs(%a: tensor<2x2x!ttcore.tile<32x32, f32>
 // CHECK:      %[[EXP:.*]] = ttl.tile_exp %[[ABSCOPY]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // B copied at first use (tile_add)
 // CHECK:           %{{.*}}, %[[BTILE:.*]] = ttl.copy_tile %[[B]][%[[I0]], %[[I1]]] into dst[%c2]
-// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[ABS]], %[[BTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[ABS]], %[[BTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[EXP]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK:           ttl.tile_store %[[ADD]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
@@ -321,7 +321,7 @@ func.func @unary_chain_with_branch(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK:      %[[SIG:.*]] = ttl.tile_sigmoid %[[RELU]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // B copied at first use (tile_add)
 // CHECK:           %{{.*}}, %[[BTILE:.*]] = ttl.copy_tile %[[B]][%[[I0]], %[[I1]]] into dst[%c1]
-// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[SIG]], %[[BTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[SIG]], %[[BTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[ADD]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 
@@ -383,7 +383,7 @@ func.func @deep_unary_then_binary(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK-NEXT:      %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary: both operands are the same block arg, no copy needed.
 // CHECK-NOT:       ttl.copy_tile
-// CHECK:           %[[SQ:.*]] = ttl.tile_mul %[[A]], %[[A]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[SQ:.*]] = ttl.tile_mul %[[A]], %[[A]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[SQ]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 
@@ -441,12 +441,12 @@ func.func @square_pattern(%a: tensor<2x2x!ttcore.tile<32x32, f32>>)
 // CHECK:           %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:      %[[I1:.*]] = ttl.iter_index 1 : index
 // First add is FPU binary (no copies for A, B). C copied for SFPU mul.
-// CHECK:           %[[ADD0:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[ADD0:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           %{{.*}}, %[[CTILE:.*]] = ttl.copy_tile %[[C]][%[[I0]], %[[I1]]] into dst[%[[C1]]]
-// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[ADD0]], %[[CTILE]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[ADD0]], %[[CTILE]] into dst[%[[C1]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:      %[[EXP:.*]] = ttl.tile_exp %[[MUL]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // ADD0 is reused here - it was kept live across mul and exp
-// CHECK:      %[[ADD1:.*]] = ttl.tile_add %[[EXP]], %[[ADD0]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[ADD1:.*]] = ttl.tile_add %[[EXP]], %[[ADD0]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[ADD1]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 
@@ -525,11 +525,11 @@ func.func @intermediate_reuse_late(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK:           %{{.*}}, %[[XCOPY_ABS:.*]] = ttl.copy_tile %[[X_SFPU]][%[[I0]], %[[I1]]] into dst[%[[C0]]]
 // CHECK:      %[[ABS:.*]] = ttl.tile_abs %[[XCOPY_ABS]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // Both add and mul are FPU binary on x_fpu/y (both block args)
-// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[X_FPU]], %[[Y]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[X_FPU]], %[[Y]] into dst[%[[C2]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[X_FPU]], %[[Y]] into dst[%[[C1]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[X_FPU]], %[[Y]] into dst[%[[C2]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // Combine results (SFPU, operands from DST)
-// CHECK:      %[[TMP:.*]] = ttl.tile_add %[[ABS]], %[[ADD]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-// CHECK:      %[[RESULT:.*]] = ttl.tile_add %[[TMP]], %[[MUL]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[TMP:.*]] = ttl.tile_add %[[ABS]], %[[ADD]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[RESULT:.*]] = ttl.tile_add %[[TMP]], %[[MUL]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[RESULT]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_fpu_binary.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_fpu_binary.mlir
@@ -1,7 +1,6 @@
-// Summary: Tests for FPU binary detection in DST allocation. Binary tile ops
-// (add, sub, mul) with BOTH operands as block arguments use the FPU execution
-// engine which reads from CB, consuming 0 DST input slots. This doubles the
-// achievable unroll_factor for simple binary patterns.
+// Summary: Tests FPU and SFPU strategy effects on DST allocation. FPU binary
+// operations read both operands from DFBs and consume no DST input slots,
+// increasing the available unroll factor for simple binary computations.
 
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' --split-input-file | FileCheck %s
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
@@ -34,7 +33,7 @@
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // No copy_tile - FPU reads from CB
 // CHECK-NOT:       ttl.copy_tile
-// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[ADD]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 // SEPARATE-LABEL:  func.func @simple_fpu_add
@@ -53,7 +52,7 @@
 // SFPU-NEXT:        %[[SI1:.*]] = ttl.iter_index 1 : index
 // SFPU:           %{{.*}}, %[[ATILE:.*]] = ttl.copy_tile %[[A]][%[[SI0]], %[[SI1]]] into dst[%[[C0]]]
 // SFPU:           %{{.*}}, %[[BTILE:.*]] = ttl.copy_tile %[[B]][%[[SI0]], %[[SI1]]] into dst[%c1]
-// SFPU:      %[[ADD:.*]] = ttl.tile_add %[[ATILE]], %[[BTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// SFPU:      %[[ADD:.*]] = ttl.tile_add %[[ATILE]], %[[BTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // SFPU:           ttl.tile_store %[[ADD]], %{{.*}}[%[[SI0]], %[[SI1]]]
 // SFPU-NEXT:      ttl.yield
 
@@ -102,11 +101,11 @@ func.func @simple_fpu_add(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary add: both block args, reads from CB
-// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // C copied for SFPU mul
 // CHECK:           %{{.*}}, %[[CTILE:.*]] = ttl.copy_tile %[[C]][%[[I0]], %[[I1]]] into dst[%c1]
 // SFPU mul: one operand from DST (add result), one from copy_tile
-// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[ADD]], %[[CTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[ADD]], %[[CTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[MUL]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 // SEPARATE-LABEL:  func.func @mixed_fpu_sfpu
@@ -126,10 +125,10 @@ func.func @simple_fpu_add(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // copy A and B for SFPU add
 // SFPU:           %{{.*}}, %[[ATILE:.*]] = ttl.copy_tile %[[A]][%[[SI0]], %[[SI1]]] into dst[%[[C0]]]
 // SFPU:           %{{.*}}, %[[BTILE:.*]] = ttl.copy_tile %[[B]][%[[SI0]], %[[SI1]]] into dst[%c1]
-// SFPU:      %[[ADD:.*]] = ttl.tile_add %[[ATILE]], %[[BTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// SFPU:      %[[ADD:.*]] = ttl.tile_add %[[ATILE]], %[[BTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // copy C for SFPU mul
 // SFPU:           %{{.*}}, %[[CTILE:.*]] = ttl.copy_tile %[[C]][%[[SI0]], %[[SI1]]] into dst[%c1]
-// SFPU:      %[[MUL:.*]] = ttl.tile_mul %[[ADD]], %[[CTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// SFPU:      %[[MUL:.*]] = ttl.tile_mul %[[ADD]], %[[CTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // SFPU:           ttl.tile_store %[[MUL]], %{{.*}}[%[[SI0]], %[[SI1]]]
 // SFPU-NEXT:      ttl.yield
 
@@ -187,7 +186,7 @@ func.func @mixed_fpu_sfpu(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // B needs copy_tile for SFPU add
 // CHECK:           %{{.*}}, %[[BTILE:.*]] = ttl.copy_tile %[[B]][%[[I0]], %[[I1]]] into dst[%c1]
 // tile_add is SFPU (one operand computed)
-// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[EXP]], %[[BTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[EXP]], %[[BTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[ADD]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 //
@@ -251,9 +250,9 @@ func.func @not_fpu_computed_operand(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK-NEXT:      %[[I1:.*]] = ttl.iter_index 1 : index
 // No copy_tile for any op - all FPU
 // CHECK-NOT:       ttl.copy_tile
-// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-// CHECK:      %[[SUB:.*]] = ttl.tile_sub %[[A]], %[[B]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[A]], %[[B]] into dst[%[[C2]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[SUB:.*]] = ttl.tile_sub %[[A]], %[[B]] into dst[%[[C1]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[A]], %[[B]] into dst[%[[C2]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[ADD]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK:           ttl.tile_store %[[SUB]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK:           ttl.tile_store %[[MUL]], %{{.*}}[%[[I0]], %[[I1]]]
@@ -269,9 +268,9 @@ func.func @not_fpu_computed_operand(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // copy A and B for SFPU ops
 // SFPU:           %{{.*}}, %[[ATILE:.*]] = ttl.copy_tile {{.*}}
 // SFPU:           %{{.*}}, %[[BTILE:.*]] = ttl.copy_tile {{.*}}
-// SFPU:           %[[ADD:.*]] = ttl.tile_add %[[ATILE]], %[[BTILE]] into dst[%[[C2]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-// SFPU:      %[[SUB:.*]] = ttl.tile_sub %[[ATILE]], %[[BTILE]] into dst[%[[C3]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-// SFPU:      %[[MUL:.*]] = ttl.tile_mul %[[ATILE]], %[[BTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// SFPU:           %[[ADD:.*]] = ttl.tile_add %[[ATILE]], %[[BTILE]] into dst[%[[C2]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// SFPU:      %[[SUB:.*]] = ttl.tile_sub %[[ATILE]], %[[BTILE]] into dst[%[[C3]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// SFPU:      %[[MUL:.*]] = ttl.tile_mul %[[ATILE]], %[[BTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // SFPU:            ttl.tile_store
 // SFPU:            ttl.tile_store
 // SFPU:            ttl.tile_store
@@ -339,7 +338,7 @@ func.func @all_fpu_ops(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK:           %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:      %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary: reads a_fpu and B from CB
-// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A_FPU]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A_FPU]], %[[B]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // copy_tile a_sfpu for SFPU exp
 // CHECK:           %{{.*}}, %[[ATILE:.*]] = ttl.copy_tile %[[A_SFPU]][%[[I0]], %[[I1]]] into dst[%[[C1]]]
 // CHECK:      %[[EXP:.*]] = ttl.tile_exp %[[ATILE]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
@@ -357,7 +356,7 @@ func.func @all_fpu_ops(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // copy a_fpu and B for SFPU add
 // SFPU:           %{{.*}}, %[[ATILE1:.*]] = ttl.copy_tile %{{.*}}[%{{.*}}, %{{.*}}] into dst[%[[C0]]]
 // SFPU:           %{{.*}}, %[[BTILE:.*]] = ttl.copy_tile %{{.*}}[%{{.*}}, %{{.*}}] into dst[%[[C1]]]
-// SFPU:      %[[ADD:.*]] = ttl.tile_add %[[ATILE1]], %[[BTILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// SFPU:      %[[ADD:.*]] = ttl.tile_add %[[ATILE1]], %[[BTILE]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // copy a_sfpu for exp
 // SFPU:           %{{.*}}, %[[ATILE2:.*]] = ttl.copy_tile %{{.*}}[%{{.*}}, %{{.*}}] into dst[%[[C1]]]
 // SFPU:      %[[EXP:.*]] = ttl.tile_exp %[[ATILE2]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
@@ -434,13 +433,13 @@ func.func @block_arg_fpu_and_sfpu(%a: tensor<2x2x!ttcore.tile<32x32, f32>>,
 // CHECK:           %{{.*}}, %[[ATILE:.*]] = ttl.copy_tile %[[A_SFPU]][%[[I0]], %[[I1]]] into dst[%[[C0]]]
 // CHECK:      %[[ABS:.*]] = ttl.tile_abs %[[ATILE]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // FPU add: reads a_fpu and B from CB, gets DST[1]
-// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[A_FPU]], %[[B]] into dst[%[[C1]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[ADD:.*]] = ttl.tile_add %[[A_FPU]], %[[B]] into dst[%[[C1]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // SFPU binary: abs + add -> DST[0]
-// CHECK:      %[[SUM1:.*]] = ttl.tile_add %[[ABS]], %[[ADD]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[SUM1:.*]] = ttl.tile_add %[[ABS]], %[[ADD]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // FPU mul: reads a_fpu and B from CB, gets DST[2] (NOT DST[1] - no reuse!)
-// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[A_FPU]], %[[B]] into dst[%[[C2]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[MUL:.*]] = ttl.tile_mul %[[A_FPU]], %[[B]] into dst[%[[C2]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // SFPU binary: sum1 + mul -> DST[0]
-// CHECK:      %[[SUM2:.*]] = ttl.tile_add %[[SUM1]], %[[MUL]] into dst[%[[C0]]] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK:      %[[SUM2:.*]] = ttl.tile_add %[[SUM1]], %[[MUL]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>} : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 // CHECK:           ttl.tile_store %[[SUM2]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
 //

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_matmul_accumulator.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_matmul_accumulator.mlir
@@ -1,16 +1,14 @@
-// Summary: Matmul accumulator and output share the same DST register.
-// The 3-operand tile_matmul_block(lhs, rhs, accumulator) has its accumulator
-// and output intervals merged so they receive the same dst_idx. The actual
-// copy_tile to pre-load the accumulator into DST is emitted during TTKernel
-// lowering, not here; this test verifies the interval merge only.
+// Verify matmul accumulates in the DST register initialized from its third
+// operand and preserves that register for subsequent in-place operations.
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @matmul_with_accumulator
-// Accumulator and output merged to dst_idx = 0. Three operands preserved.
+// The accumulator copy and matmul result use the same DST register.
 // CHECK: ^bb0(%[[A:.*]]: !ttcore.tile<32x32, bf16>, %[[B:.*]]: !ttcore.tile<32x32, bf16>, %[[C:.*]]: !ttcore.tile<32x32, bf16>, %{{.*}}: !ttcore.tile<32x32, bf16>):
-// CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[A]], %[[B]], %[[C]] into dst[%c0]
+// CHECK: %{{.*}}, %[[C_DST:.*]] = ttl.copy_tile %[[C]]{{.*}} into dst[%c0]
+// CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[A]], %[[B]], %[[C_DST]] into dst[%c0]
 func.func @matmul_with_accumulator(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %b: tensor<1x1x!ttcore.tile<32x32, bf16>>,
@@ -55,7 +53,8 @@ func.func @matmul_with_accumulator(
 
 // CHECK-LABEL: func.func @matmul_accumulator_relu
 // CHECK: ^bb0(%[[A2:.*]]: !ttcore.tile<32x32, bf16>, %[[B2:.*]]: !ttcore.tile<32x32, bf16>, %[[C2:.*]]: !ttcore.tile<32x32, bf16>, %{{.*}}: !ttcore.tile<32x32, bf16>):
-// CHECK: %[[MM2:.*]] = ttl.tile_matmul_block %[[A2]], %[[B2]], %[[C2]] into dst[%c0]
+// CHECK: %{{.*}}, %[[C2_DST:.*]] = ttl.copy_tile %[[C2]]{{.*}} into dst[%c0]
+// CHECK: %[[MM2:.*]] = ttl.tile_matmul_block %[[A2]], %[[B2]], %[[C2_DST]] into dst[%c0]
 // CHECK: ttl.tile_relu %[[MM2]] into dst[%c0]
 func.func @matmul_accumulator_relu(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_matmul_accumulator.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_matmul_accumulator.mlir
@@ -1,14 +1,14 @@
-// Verify matmul accumulates in the DST register initialized from its third
-// operand and preserves that register for subsequent in-place operations.
+// Verify the matmul accumulator and result share a DST register. Matmul
+// lowering initializes that register from the accumulator tensor.
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @matmul_with_accumulator
-// The accumulator copy and matmul result use the same DST register.
+// The accumulator and result use the same DST register without a generic copy.
 // CHECK: ^bb0(%[[A:.*]]: !ttcore.tile<32x32, bf16>, %[[B:.*]]: !ttcore.tile<32x32, bf16>, %[[C:.*]]: !ttcore.tile<32x32, bf16>, %{{.*}}: !ttcore.tile<32x32, bf16>):
-// CHECK: %{{.*}}, %[[C_DST:.*]] = ttl.copy_tile %[[C]]{{.*}} into dst[%c0]
-// CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[A]], %[[B]], %[[C_DST]] into dst[%c0]
+// CHECK-NOT: ttl.copy_tile
+// CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[A]], %[[B]], %[[C]] into dst[%c0]
 func.func @matmul_with_accumulator(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %b: tensor<1x1x!ttcore.tile<32x32, bf16>>,
@@ -53,8 +53,8 @@ func.func @matmul_with_accumulator(
 
 // CHECK-LABEL: func.func @matmul_accumulator_relu
 // CHECK: ^bb0(%[[A2:.*]]: !ttcore.tile<32x32, bf16>, %[[B2:.*]]: !ttcore.tile<32x32, bf16>, %[[C2:.*]]: !ttcore.tile<32x32, bf16>, %{{.*}}: !ttcore.tile<32x32, bf16>):
-// CHECK: %{{.*}}, %[[C2_DST:.*]] = ttl.copy_tile %[[C2]]{{.*}} into dst[%c0]
-// CHECK: %[[MM2:.*]] = ttl.tile_matmul_block %[[A2]], %[[B2]], %[[C2_DST]] into dst[%c0]
+// CHECK-NOT: ttl.copy_tile
+// CHECK: %[[MM2:.*]] = ttl.tile_matmul_block %[[A2]], %[[B2]], %[[C2]] into dst[%c0]
 // CHECK: ttl.tile_relu %[[MM2]] into dst[%c0]
 func.func @matmul_accumulator_relu(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_multi_use_patterns.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_multi_use_patterns.mlir
@@ -28,14 +28,14 @@
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary add: both operands are block args, no copy_tile needed
-// CHECK:           %[[SUM:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+// CHECK:           %[[SUM:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%c0] {{.*}} : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // Copy C before sub (SFPU operand needs copy_tile)
 // CHECK:           %{{.*}}, %[[TC:.*]] = ttl.copy_tile %[[C]][%[[I0]], %[[I1]]] into dst[%c1]
 // CHECK-NEXT:      %[[DIFF:.*]] = ttl.tile_sub %[[SUM]], %[[TC]] into dst[%c1]
 // Copy D before mul (SFPU operand needs copy_tile)
 // CHECK:           %{{.*}}, %[[TD:.*]] = ttl.copy_tile %[[D]][%[[I0]], %[[I1]]] into dst[%c2]
 // CHECK-NEXT:      %[[PROD:.*]] = ttl.tile_mul %[[SUM]], %[[TD]] into dst[%c0]
-// CHECK-NEXT:      %[[COMBO:.*]] = ttl.tile_add %[[DIFF]], %[[PROD]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+// CHECK-NEXT:      %[[COMBO:.*]] = ttl.tile_add %[[DIFF]], %[[PROD]] into dst[%c0] {{.*}} : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // SEPARATE:        ttl.tile_add {{.*}} into dst[%c3]
 // CHECK:           ttl.tile_store %[[COMBO]], %{{.*}}[%[[I0]], %[[I1]]]
 // CHECK-NEXT:      ttl.yield
@@ -105,7 +105,7 @@ func.func @diamond_intermediate_reuse(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // FPU binary add: both operands are block args, no copy_tile needed
-// CHECK:           %[[INTERMEDIATE:.*]] = ttl.tile_add %[[ARG0]], %[[ARG1]] into dst[%c0] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+// CHECK:           %[[INTERMEDIATE:.*]] = ttl.tile_add %[[ARG0]], %[[ARG1]] into dst[%c0] {{.*}} : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // copy_dst preserves intermediate for mul (fan-out use)
 // CHECK-NEXT:      %[[COPY_DST1:.*]] = ttl.copy_dst %[[INTERMEDIATE]] into dst[%c1]
 // Copy ARG2 before mul (SFPU operand needs copy_tile)

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_register_reuse.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_register_reuse.mlir
@@ -7,8 +7,8 @@
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: verify FPU binary detection for simple add (both operands are block
-// args). No copy_tile needed since FPU reads from CB, not DST.
+// A simple add selects FPU because both block arguments have matching indexing
+// maps. FPU reads from DFBs, so no copy_tile is required.
 // DEBUG: Max DST usage: 1 / 4 registers
 // CHECK-LABEL: func.func @simple_add
 func.func @simple_add(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
@@ -33,7 +33,7 @@ func.func @simple_add(%a: tensor<2x2x!ttcore.tile<32x32, bf16>>,
 // CHECK-NEXT:        %[[I0:.*]] = ttl.iter_index 0 : index
 // CHECK-NEXT:        %[[I1:.*]] = ttl.iter_index 1 : index
 // CHECK-NOT:       ttl.copy_tile
-// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+// CHECK:           %[[ADD:.*]] = ttl.tile_add %[[A]], %[[B]] into dst[%[[C0]]] {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>} : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
 // CHECK:           ttl.tile_store %[[ADD]], %{{.*}}[%[[I0]], %[[I1]]] from dst[%[[C0]]]
 // CHECK-NEXT:      ttl.yield
 // SEPARATE-DAG:    %[[SC0:.*]] = arith.constant 0 : index

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/invalid_placeholder_copy.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/invalid_placeholder_copy.mlir
@@ -1,4 +1,4 @@
-// Summary: Test that the pass detects unreplaced placeholder copy_tile operations.
+// Verify DST assignment rejects an unreplaced placeholder copy operation.
 // The sentinel value 9223372036854775807 (int64_t max) indicates a placeholder
 // copy_tile that was not properly replaced during DST assignment.
 //
@@ -6,7 +6,7 @@
 // block argument (it's the result of another operation), so the pass cannot
 // replace it with a proper copy. This should trigger the post-pass verification.
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}))' --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-assign-dst{dst-capacity=8}))' --verify-diagnostics
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
@@ -33,7 +33,10 @@ func.func @invalid_placeholder_copy(%i0: tensor<1x1x!ttcore.tile<32x32, f32>>,
     %j = ttl.iter_index 1 : index
     // First compute an intermediate result
     %c0 = arith.constant 0 : index
-    %add = ttl.tile_add %x, %y into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    %add = ttl.tile_add %x, %y into dst[%c0]
+        {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>}
+        : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+          -> !ttcore.tile<32x32, f32>
     // Pre-existing copy_tile with placeholder sentinel indices
     // The src is NOT a block argument (it's %add), so the pass cannot replace it
     %placeholder_dst = arith.constant 9223372036854775807 : index

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/nested_regions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/nested_regions.mlir
@@ -1,0 +1,103 @@
+// Verifies ttl-assign-dst preserves resolved nested DST operations that do not
+// require compute-body allocation or materialization.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-assign-dst))' | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// Preserve resolved nested DFB readers and destination writes in conditionals
+// and loops.
+// CHECK-LABEL: func.func @resolved_nested_dst_operations
+// CHECK: scf.if
+// CHECK-NEXT: %[[FILL:.*]] = ttl.tile_fill
+// CHECK-NEXT: ttl.tile_store %[[FILL]],
+// CHECK-NEXT: %[[BCAST:.*]] = ttl.tile_bcast
+// CHECK-NEXT: ttl.tile_store %[[BCAST]],
+// CHECK-NEXT: %{{.*}}, %[[COPY:.*]] = ttl.copy_tile
+// CHECK-NEXT: ttl.tile_store %[[COPY]],
+// CHECK-NEXT: %[[REDUCE:.*]] = ttl.tile_reduce
+// CHECK-NEXT: ttl.tile_store %[[REDUCE]],
+// CHECK-NEXT: %[[EXP:.*]] = ttl.tile_exp
+// CHECK-NEXT: ttl.tile_store %[[EXP]],
+// CHECK-NEXT: }
+// CHECK: scf.for
+// CHECK-NEXT: %[[LOOP_FILL:.*]] = ttl.tile_fill
+// CHECK-NEXT: ttl.tile_store %[[LOOP_FILL]],
+// CHECK-NEXT: }
+func.func @resolved_nested_dst_operations(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %output: tensor<1x1x!ttcore.tile<32x32, bf16>>, %condition: i1)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %empty = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %attached_input = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %attached_output = ttl.attach_cb %empty, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %reserved_output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %result = ttl.compute
+      ins(%attached_input : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      outs(%attached_output : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      {indexing_maps = [#map, #map],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+       %output_tile: !ttcore.tile<32x32, bf16>):
+    %row = ttl.iter_index 0 : index
+    %column = ttl.iter_index 1 : index
+    %pad = ttl.tile_fill 0.0 into dst[%c0] : !ttcore.tile<32x32, bf16>
+    ttl.tile_store %pad, %reserved_output[%row, %column] from dst[%c0]
+        : !ttcore.tile<32x32, bf16>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.if %condition {
+      %filled = ttl.tile_fill 1.0 into dst[%c0]
+          : !ttcore.tile<32x32, bf16>
+      ttl.tile_store %filled, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %broadcast = ttl.tile_bcast %input_tile, %input_tile 1 : i32
+          into dst[%c0] : (!ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+      ttl.tile_store %broadcast, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %token, %copied = ttl.copy_tile %input_tile[%row, %column] into dst[%c0]
+          : !ttcore.tile<32x32, bf16>
+          -> !ttl.dst, !ttcore.tile<32x32, bf16>
+      ttl.tile_store %copied, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %reduced = ttl.tile_reduce %input_tile, %input_tile, %input_tile 0 : i32
+          <reduce_dim_row> into dst[%c0] : (!ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+      ttl.tile_store %reduced, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %exponential = ttl.tile_exp %input_tile into dst[%c0]
+          : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+      ttl.tile_store %exponential, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      scf.yield
+    }
+    scf.for %iteration = %c0 to %c1 step %c1 {
+      %loop_fill = ttl.tile_fill 2.0 into dst[%c0]
+          : !ttcore.tile<32x32, bf16>
+      ttl.tile_store %loop_fill, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return %result : tensor<1x1x!ttcore.tile<32x32, bf16>>
+}

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/nested_regions_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/nested_regions_invalid.mlir
@@ -1,0 +1,106 @@
+// Verifies ttl-assign-dst diagnoses nested DST operations before allocation.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-assign-dst))' --verify-diagnostics --split-input-file
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  // Reject a DST operation nested in a conditional before modifying IR.
+  func.func @nested_dst_operation(
+      %input: tensor<1x1x!ttcore.tile<32x32, f32>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, f32>>, %condition: i1)
+      -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %empty = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %attached_input = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %attached_output = ttl.attach_cb %empty, %output_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %reserved_output = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %result = ttl.compute
+        ins(%attached_input : tensor<1x1x!ttcore.tile<32x32, f32>>)
+        outs(%attached_output : tensor<1x1x!ttcore.tile<32x32, f32>>)
+        {indexing_maps = [#map, #map],
+         iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%input_tile: !ttcore.tile<32x32, f32>,
+         %output_tile: !ttcore.tile<32x32, f32>):
+      %row = ttl.iter_index 0 : index
+      %column = ttl.iter_index 1 : index
+      ttl.tile_store %output_tile, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+      scf.if %condition {
+        // expected-error @below {{'ttl.tile_exp' op nested DST operations are not supported by ttl-assign-dst; expected the operation directly in the ttl.compute body}}
+        %nested = ttl.tile_exp %input_tile into dst[%c0]
+            : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+        ttl.tile_store %nested, %reserved_output[%row, %column] from dst[%c0]
+            : !ttcore.tile<32x32, f32>,
+              tensor<1x1x!ttcore.tile<32x32, f32>>
+        scf.yield
+      }
+      ttl.yield
+    } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    return %result : tensor<1x1x!ttcore.tile<32x32, f32>>
+  }
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  // Reject a DST operation nested in a loop before modifying IR.
+  func.func @nested_dst_operation_in_loop(
+      %input: tensor<1x1x!ttcore.tile<32x32, f32>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, f32>>)
+      -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %empty = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %attached_input = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %attached_output = ttl.attach_cb %empty, %output_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %reserved_output = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %result = ttl.compute
+        ins(%attached_input : tensor<1x1x!ttcore.tile<32x32, f32>>)
+        outs(%attached_output : tensor<1x1x!ttcore.tile<32x32, f32>>)
+        {indexing_maps = [#map, #map],
+         iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%input_tile: !ttcore.tile<32x32, f32>,
+         %output_tile: !ttcore.tile<32x32, f32>):
+      %row = ttl.iter_index 0 : index
+      %column = ttl.iter_index 1 : index
+      ttl.tile_store %output_tile, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+      scf.for %iteration = %c0 to %c1 step %c1 {
+        // expected-error @below {{'ttl.tile_exp' op nested DST operations are not supported by ttl-assign-dst; expected the operation directly in the ttl.compute body}}
+        %nested = ttl.tile_exp %input_tile into dst[%c0]
+            : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+        ttl.tile_store %nested, %reserved_output[%row, %column] from dst[%c0]
+            : !ttcore.tile<32x32, f32>,
+              tensor<1x1x!ttcore.tile<32x32, f32>>
+      }
+      ttl.yield
+    } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    return %result : tensor<1x1x!ttcore.tile<32x32, f32>>
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/nested_regions_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/nested_regions_invalid.mlir
@@ -3,8 +3,9 @@
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module {
-  // Reject a DST operation nested in a conditional before modifying IR.
-  func.func @nested_dst_operation(
+  // Reject copy insertion whose consumers span the compute body and a nested
+  // region before sorting operations from different blocks.
+  func.func @cross_region_copy_insertion(
       %input: tensor<1x1x!ttcore.tile<32x32, f32>>,
       %output: tensor<1x1x!ttcore.tile<32x32, f32>>, %condition: i1)
       -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -37,8 +38,13 @@ module {
       %column = ttl.iter_index 1 : index
       ttl.tile_store %output_tile, %reserved_output[%row, %column] from dst[%c0]
           : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+      %direct = ttl.tile_exp %input_tile into dst[%c0]
+          : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+      ttl.tile_store %direct, %reserved_output[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, f32>,
+            tensor<1x1x!ttcore.tile<32x32, f32>>
       scf.if %condition {
-        // expected-error @below {{'ttl.tile_exp' op nested DST operations are not supported by ttl-assign-dst; expected the operation directly in the ttl.compute body}}
+        // expected-error @below {{'ttl.tile_exp' op nested DST consumer requires copy insertion by ttl-assign-dst; expected the operation directly in the ttl.compute body}}
         %nested = ttl.tile_exp %input_tile into dst[%c0]
             : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
         ttl.tile_store %nested, %reserved_output[%row, %column] from dst[%c0]
@@ -56,8 +62,9 @@ module {
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module {
-  // Reject a DST operation nested in a loop before modifying IR.
-  func.func @nested_dst_operation_in_loop(
+  // Reject a nested non-in-place operation whose source DST indices are not
+  // represented by its operands.
+  func.func @nested_unresolved_source_dst_indices(
       %input: tensor<1x1x!ttcore.tile<32x32, f32>>,
       %output: tensor<1x1x!ttcore.tile<32x32, f32>>)
       -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -92,9 +99,11 @@ module {
       ttl.tile_store %output_tile, %reserved_output[%row, %column] from dst[%c0]
           : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
       scf.for %iteration = %c0 to %c1 step %c1 {
-        // expected-error @below {{'ttl.tile_exp' op nested DST operations are not supported by ttl-assign-dst; expected the operation directly in the ttl.compute body}}
-        %nested = ttl.tile_exp %input_tile into dst[%c0]
-            : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+        // expected-error @below {{'ttl.tile_add' op nested DST operation requires source DST index resolution by ttl-assign-dst; expected the operation directly in the ttl.compute body}}
+        %nested = ttl.tile_add %input_tile, %output_tile into dst[%c0]
+            {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>}
+            : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+            -> !ttcore.tile<32x32, f32>
         ttl.tile_store %nested, %reserved_output[%row, %column] from dst[%c0]
             : !ttcore.tile<32x32, f32>,
               tensor<1x1x!ttcore.tile<32x32, f32>>

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/unary_chain_merging.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/unary_chain_merging.mlir
@@ -14,8 +14,7 @@
 // - Block arg and all unary results should have the same interval [0, 3]
 // - All values get allocated to the same DST register
 
-// Phase 1 directly: copy insertion only (FPU eligibility is no longer
-// stamped as an attribute; isFPUEligibleBinaryOp resolves on demand).
+// Copy insertion consumes the strategy selected by kernel configuration.
 // CHECK: === Phase 1: Copy Insertion ===
 
 // Verify Phase 2 merging happens

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_operations_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_operations_invalid.mlir
@@ -1,0 +1,14 @@
+// Verify scheduling rejects tile operations whose execution strategy has not
+// been selected.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-schedule-operations))' --verify-diagnostics
+
+func.func @missing_tile_execution_strategy(
+    %lhs: !ttcore.tile<32x32, bf16>,
+    %rhs: !ttcore.tile<32x32, bf16>) {
+  %zero = arith.constant 0 : index
+  // expected-error @below {{'ttl.tile_add' op requires a selected ttl.tile_execution_strategy attribute; run ttl-set-compute-kernel-config before DST assignment, scheduling, or lowering}}
+  %sum = ttl.tile_add %lhs, %rhs into dst[%zero]
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_ordering_boundaries.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_ordering_boundaries.mlir
@@ -133,3 +133,26 @@ func.func @preserve_nested_pure_consumer_order(
   }
   return
 }
+
+// A transpose is a modeled DFB-to-DST operation and sorts before independent
+// DST operations so its full initialization executes first.
+
+// CHECK-LABEL: func.func @schedule_transpose_before_dst_operations
+// CHECK:       ttl.dst_section {
+// CHECK-NEXT:    %[[TRANSPOSE:.*]] = ttl.tile_transpose
+// CHECK-NEXT:    %[[DST:.*]] = ttl.dst_index
+// CHECK-NEXT:    %[[EXP:.*]] = ttl.tile_exp %[[DST]]
+// CHECK-NEXT:  }
+func.func @schedule_transpose_before_dst_operations(
+    %input: !ttcore.tile<32x32, bf16>,
+    %output: !ttcore.tile<32x32, bf16>) {
+  %dst0 = arith.constant 0 : index
+  %dst1 = arith.constant 1 : index
+  ttl.dst_section {
+    %dst = ttl.dst_index %input[%dst0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %exp = ttl.tile_exp %dst into dst[%dst0] : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    %transpose = ttl.tile_transpose %input, %output into dst[%dst1] : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+    ttl.yield
+  }
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
@@ -4,7 +4,7 @@
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file --verify-diagnostics
 
 module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
-  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  // expected-error @below {{'func.func' op explicit 32-bit destination elements are unsupported by the kernel's tile operations}}
   func.func @wormhole_column(
       %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -20,7 +20,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     %output_tile = tensor.extract %output[%zero, %zero]
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    // expected-note @below {{the target does not support 32-bit destination elements for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %input_tile, %output_tile 1 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
@@ -32,7 +32,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
 // -----
 
 module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
-  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  // expected-error @below {{'func.func' op explicit 32-bit destination elements are unsupported by the kernel's tile operations}}
   func.func @wormhole_row(
       %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -48,7 +48,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     %output_tile = tensor.extract %output[%zero, %zero]
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    // expected-note @below {{the target does not support 32-bit destination elements for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %input_tile, %output_tile 2 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
@@ -60,7 +60,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
 // -----
 
 module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
-  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  // expected-error @below {{'func.func' op explicit 32-bit destination elements are unsupported by the kernel's tile operations}}
   func.func @wormhole_scalar(
       %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -76,7 +76,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     %output_tile = tensor.extract %output[%zero, %zero]
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    // expected-note @below {{the target does not support 32-bit destination elements for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %input_tile, %output_tile 3 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
@@ -88,7 +88,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
 // -----
 
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
-  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  // expected-error @below {{'func.func' op explicit 32-bit destination elements are unsupported by the kernel's tile operations}}
   func.func @blackhole_column(
       %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -104,7 +104,7 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     %output_tile = tensor.extract %output[%zero, %zero]
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    // expected-note @below {{the target does not support 32-bit destination elements for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %input_tile, %output_tile 1 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
@@ -141,10 +141,10 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     %bf16_output_tile = tensor.extract %bf16_output[%zero, %zero]
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-error @below {{'ttl.tile_exp' op requires f32 DST mode, but no kernel-wide DST mode supports all tile operations}}
+    // expected-error @below {{'ttl.tile_exp' op requires 32-bit destination elements, but no kernel-wide destination width supports all tile operations}}
     %exp = ttl.tile_exp %f32_tile into dst[%zero]
         : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements; use an f32 broadcast input or place the broadcast in a separate kernel}}
+    // expected-note @below {{the target does not support 32-bit destination elements for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %bf16_tile, %bf16_output_tile 1 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
@@ -156,7 +156,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
 // -----
 
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
-  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  // expected-error @below {{'func.func' op explicit 32-bit destination elements are unsupported by the kernel's tile operations}}
   func.func @blackhole_row(
       %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -172,7 +172,7 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     %output_tile = tensor.extract %output[%zero, %zero]
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    // expected-note @below {{the target does not support 32-bit destination elements for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %input_tile, %output_tile 2 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
@@ -184,7 +184,7 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
 // -----
 
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
-  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  // expected-error @below {{'func.func' op explicit 32-bit destination elements are unsupported by the kernel's tile operations}}
   func.func @blackhole_scalar(
       %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -200,7 +200,7 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     %output_tile = tensor.extract %output[%zero, %zero]
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    // expected-note @below {{the target does not support 32-bit destination elements for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %input_tile, %output_tile 3 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
@@ -1,0 +1,169 @@
+// Verify that non-f32 broadcasts reject f32 DST mode on every architecture
+// and broadcast dimension whose LLK ignores that configuration.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file --verify-diagnostics
+
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
+  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  func.func @wormhole_column(
+      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      attributes {fp32_dest_acc_en = true} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_tile = tensor.extract %output[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    %broadcast = ttl.tile_bcast %input_tile, %output_tile 1 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
+  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  func.func @wormhole_row(
+      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      attributes {fp32_dest_acc_en = true} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_tile = tensor.extract %output[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    %broadcast = ttl.tile_bcast %input_tile, %output_tile 2 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
+  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  func.func @wormhole_scalar(
+      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      attributes {fp32_dest_acc_en = true} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_tile = tensor.extract %output[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    %broadcast = ttl.tile_bcast %input_tile, %output_tile 3 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  func.func @blackhole_column(
+      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      attributes {fp32_dest_acc_en = true} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_tile = tensor.extract %output[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    %broadcast = ttl.tile_bcast %input_tile, %output_tile 1 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  func.func @blackhole_row(
+      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      attributes {fp32_dest_acc_en = true} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_tile = tensor.extract %output[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    %broadcast = ttl.tile_bcast %input_tile, %output_tile 2 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  func.func @blackhole_scalar(
+      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      attributes {fp32_dest_acc_en = true} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_tile = tensor.extract %output[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    %broadcast = ttl.tile_bcast %input_tile, %output_tile 3 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
@@ -1,5 +1,6 @@
 // Verify that non-f32 broadcasts reject f32 DST mode on every architecture
-// and broadcast dimension whose LLK ignores that configuration.
+// and broadcast dimension whose LLK ignores that configuration, including an
+// automatic conflict with an f32 SFPU operation.
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file --verify-diagnostics
 
 module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
@@ -105,6 +106,46 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
         : tensor<1x1x!ttcore.tile<32x32, bf16>>
     // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
     %broadcast = ttl.tile_bcast %input_tile, %output_tile 1 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+// Verify the default policy reports both requirements when an f32 SFPU
+// operation and a non-f32 broadcast require incompatible kernel-wide modes.
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
+  func.func @automatic_mixed_dst_mode_conflict(
+      %f32_input: tensor<1x1x!ttcore.tile<32x32, f32>>,
+      %bf16_input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %bf16_output: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+    %f32_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %bf16_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %f32_attached = ttl.attach_cb %f32_input, %f32_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %bf16_attached = ttl.attach_cb %bf16_input, %bf16_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %f32_tile = tensor.extract %f32_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, f32>>
+    %bf16_tile = tensor.extract %bf16_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %bf16_output_tile = tensor.extract %bf16_output[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-error @below {{'ttl.tile_exp' op requires f32 DST mode, but no kernel-wide DST mode supports all tile operations}}
+    %exp = ttl.tile_exp %f32_tile into dst[%zero]
+        : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements; use an f32 broadcast input or place the broadcast in a separate kernel}}
+    %broadcast = ttl.tile_bcast %bf16_tile, %bf16_output_tile 1 : i32
         into dst[%zero]
         : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
           -> !ttcore.tile<32x32, bf16>

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/direct_tile_execution.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/direct_tile_execution.mlir
@@ -1,0 +1,173 @@
+// Verify direct tile operations in nested regions use the same strategy and
+// dataflow-buffer resolution as operations in ttl.compute.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s
+
+// CHECK-LABEL: func.func @nested_direct_tile_ops
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// CHECK: scf.if
+// CHECK: ttl.tile_abs
+// CHECK: scf.for
+// CHECK: ttl.tile_add {{.*}}ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>
+func.func @nested_direct_tile_ops(
+    %input: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>, %condition: i1) {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %lhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %one = arith.constant 1 : index
+  %input_tile = tensor.extract %input_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  scf.if %condition {
+    %absolute = ttl.tile_abs %input_tile into dst[%zero]
+        : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    scf.yield
+  }
+  scf.for %iteration = %zero to %one step %one {
+    %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+        : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+          -> !ttcore.tile<32x32, f32>
+    scf.yield
+  }
+  return
+}
+
+// -----
+
+// A resultless DST consumer contributes both DST and unpack requirements for a
+// DFB-backed compute input.
+// CHECK-LABEL: func.func @f32_store_of_compute_input
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 3>
+func.func @f32_store_of_compute_input(
+    %input: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %output: tensor<1x1x!ttcore.tile<32x32, f32>>) {
+  %input_dfb = ttl.bind_cb {cb_index = 3, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_attached = ttl.attach_cb %output, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_view = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %result = ttl.compute
+      ins(%input_attached : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%output_attached : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%input_tile: !ttcore.tile<32x32, f32>,
+       %output_tile: !ttcore.tile<32x32, f32>):
+    ttl.tile_store %input_tile, %output_view[%zero, %zero] from dst[%zero]
+        : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  return
+}
+
+// -----
+
+// A compute output block argument retains the DFB identity of its output
+// operand when consumed through DST.
+// CHECK-LABEL: func.func @f32_compute_output_argument
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 5>
+func.func @f32_compute_output_argument(
+    %output: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  %output_dfb = ttl.bind_cb {cb_index = 5, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %output_attached = ttl.attach_cb %output, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_view = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %result = ttl.compute
+      ins()
+      outs(%output_attached : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%output_tile: !ttcore.tile<32x32, f32>):
+    %absolute = ttl.tile_abs %output_tile into dst[%zero]
+        : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    ttl.tile_store %absolute, %output_view[%zero, %zero] from dst[%zero]
+        : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  return %result : tensor<1x1x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// An explicit DFB-to-DST copy requires f32 unpack mode for its source DFB.
+// CHECK-LABEL: func.func @explicit_f32_copy
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 4>
+func.func @explicit_f32_copy(
+    %input: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  %input_dfb = ttl.bind_cb {cb_index = 4, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_attached = ttl.attach_cb %output, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_view = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %result = ttl.compute
+      ins(%input_attached : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%output_attached : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%input_tile: !ttcore.tile<32x32, f32>,
+       %output_tile: !ttcore.tile<32x32, f32>):
+    %token, %tile = ttl.copy_tile %input_tile[%zero, %zero] into dst[%zero]
+        : !ttcore.tile<32x32, f32> -> !ttl.dst, !ttcore.tile<32x32, f32>
+    ttl.tile_store %tile, %output_view[%zero, %zero] from dst[%zero]
+        : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  return %result : tensor<1x1x!ttcore.tile<32x32, f32>>
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options.mlir
@@ -1,0 +1,15 @@
+// Verify explicit pass policy selects one complete kernel configuration.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=enabled}))' | FileCheck %s --check-prefix=ENABLED
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=disabled dst-full-sync-en=disabled}))' | FileCheck %s --check-prefix=DISABLED
+
+// ENABLED-LABEL: func.func @policy_options
+// ENABLED-SAME: dst_full_sync_en = true
+// ENABLED-SAME: fp32_dest_acc_en = true
+// ENABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32>
+// DISABLED-LABEL: func.func @policy_options
+// DISABLED-SAME: dst_full_sync_en = false
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32>
+func.func @policy_options() {
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options_invalid.mlir
@@ -1,0 +1,7 @@
+// Verify an invalid three-state policy value is rejected.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=invalid}))' --verify-diagnostics
+
+// expected-error @below {{invalid fp32-dest-acc-en value 'invalid'; expected auto, enabled, or disabled}}
+func.func @invalid_policy_option() {
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/post_lower_to_loops.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/post_lower_to_loops.mlir
@@ -1,0 +1,61 @@
+// Verify configuration analysis accepts tensor-of-tile operands produced by
+// ttl-lower-to-loops when a pipeline re-runs configuration analysis.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0},ttl-assign-dst,ttl-lower-to-loops,ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s
+
+#identity = affine_map<(tileRow, tileColumn) -> (tileRow, tileColumn)>
+
+// CHECK-LABEL: func.func @matmul_tensor_operands_after_loop_lowering
+// CHECK-SAME: fp32_dest_acc_en = false
+// CHECK: ttl.tile_matmul_block %{{.*}}, %{{.*}} into dst[%{{.*}}]
+// CHECK-SAME: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+// CHECK-SAME: tensor<1x1x!ttcore.tile<32x32, bf16>>
+func.func @matmul_tensor_operands_after_loop_lowering(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %lhsDfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %rhsDfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %outputDfb = ttl.bind_cb {cb_index = 16, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %lhsAttached = ttl.attach_cb %lhs, %lhsDfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %rhsAttached = ttl.attach_cb %rhs, %rhsDfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %outputAttached = ttl.attach_cb %output, %outputDfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %outputReserve = ttl.cb_reserve %outputDfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %result = ttl.compute
+      ins(%lhsAttached, %rhsAttached
+          : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      outs(%outputAttached : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      {indexing_maps = [#identity, #identity, #identity],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%lhsTile: !ttcore.tile<32x32, bf16>,
+       %rhsTile: !ttcore.tile<32x32, bf16>,
+       %outputTile: !ttcore.tile<32x32, bf16>):
+    %zero = arith.constant 0 : index
+    %product = ttl.tile_matmul_block %lhsTile, %rhsTile into dst[%zero]
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+          -> !ttcore.tile<32x32, bf16>
+    %tileRow = ttl.iter_index 0 : index
+    %tileColumn = ttl.iter_index 1 : index
+    ttl.tile_store %product, %outputReserve[%tileRow, %tileColumn]
+        from dst[%zero]
+        : !ttcore.tile<32x32, bf16>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_explicit_disabled.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_explicit_disabled.mlir
@@ -1,0 +1,65 @@
+// Verify an explicit 16-bit DST constraint overrides a supported full-fp32
+// preference without warning about the requested fallback.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --verify-diagnostics | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @bf16_reduce_explicit_16bit
+// CHECK-SAME: fp32_dest_acc_en = false
+func.func @bf16_reduce_explicit_16bit(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    attributes {fp32_dest_acc_en = false,
+                ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dst_index = arith.constant 0 : index
+  %output = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %scaler_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %scaler_attached = ttl.attach_cb %scaler, %scaler_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_attached = ttl.attach_cb %output, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+
+  %output_view = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %result = ttl.compute
+      ins(%input_attached, %scaler_attached
+          : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      outs(%output_attached : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      {indexing_maps = [#map, #map, #map],
+       iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+         %scaler_tile: !ttcore.tile<32x32, bf16>,
+         %output_tile: !ttcore.tile<32x32, bf16>):
+      %row = ttl.iter_index 0 : index
+      %column = ttl.iter_index 1 : index
+      %reduced = ttl.tile_reduce %input_tile, %scaler_tile, %output_tile
+          0 : i32 <reduce_dim_col> into dst[%dst_index]
+          : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+             !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+      ttl.tile_store %reduced, %output_view[%row, %column]
+          from dst[%dst_index]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+
+  return %result : tensor<1x1x!ttcore.tile<32x32, bf16>>
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_fallback.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_fallback.mlir
@@ -1,0 +1,79 @@
+// Verifies a supported full-fp32 preference emits a warning when another
+// kernel requirement forces 16-bit destination elements.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// A Blackhole bf16 column broadcast forces 16-bit destination elements, so a
+// supported matmul full-fp32 preference falls back with a diagnostic.
+// CHECK-LABEL: func.func @matmul_broadcast_fallback
+// CHECK-SAME: fp32_dest_acc_en = false
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @matmul_broadcast_fallback(
+      %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %bias: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %bias_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 3, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %bias_attached = ttl.attach_cb %bias, %bias_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_attached = ttl.attach_cb %output, %output_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_view = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %result = ttl.compute
+        ins(%lhs_attached, %rhs_attached, %bias_attached
+            : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+              tensor<1x1x!ttcore.tile<32x32, bf16>>,
+              tensor<1x1x!ttcore.tile<32x32, bf16>>)
+        outs(%output_attached : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+        {indexing_maps = [#map, #map, #map, #map],
+         iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%lhs_tile: !ttcore.tile<32x32, bf16>,
+         %rhs_tile: !ttcore.tile<32x32, bf16>,
+         %bias_tile: !ttcore.tile<32x32, bf16>,
+         %output_tile: !ttcore.tile<32x32, bf16>):
+      // expected-warning @below {{preferred full-fp32 accumulation is unavailable in the resolved kernel configuration; using non-full-fp32 lowering}}
+      %product = ttl.tile_matmul_block %lhs_tile, %rhs_tile into dst[%c0]
+          : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+          -> !ttcore.tile<32x32, bf16>
+      %broadcast = ttl.tile_bcast %bias_tile, %output_tile 1 : i32
+          into dst[%c0] : (!ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+      %sum = ttl.tile_add %product, %broadcast into dst[%c0]
+          : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+          -> !ttcore.tile<32x32, bf16>
+      %row = ttl.iter_index 0 : index
+      %column = ttl.iter_index 1 : index
+      ttl.tile_store %sum, %output_view[%row, %column] from dst[%c0]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.yield
+    } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return %result : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
@@ -163,6 +163,55 @@ func.func @bf16_reduce_col_auto_fp32(
 
 // -----
 
+#map_reduce_col = affine_map<(d0, d1) -> (d0, d1)>
+
+// An explicit 16-bit destination constraint overrides the supported full-fp32
+// reduce preference.
+// DEFAULT-LABEL: func.func @bf16_reduce_col_explicit_16bit
+// DEFAULT-SAME: fp32_dest_acc_en = false
+func.func @bf16_reduce_col_explicit_16bit(
+    %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    attributes {fp32_dest_acc_en = false,
+                ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+
+  %a_cb = ttl.attach_cb %a, %cb0
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %scaler_cb = ttl.attach_cb %scaler, %cb1
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %init_cb = ttl.attach_cb %init, %cb2
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+
+  %out_view = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %res = ttl.compute
+      ins(%a_cb, %scaler_cb : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+                              tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      outs(%init_cb : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      {indexing_maps = [#map_reduce_col, #map_reduce_col, #map_reduce_col],
+       iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%a_tile: !ttcore.tile<32x32, bf16>, %scaler_tile: !ttcore.tile<32x32, bf16>, %out_tile: !ttcore.tile<32x32, bf16>):
+      %i = ttl.iter_index 0 : index
+      %j = ttl.iter_index 1 : index
+      %red = ttl.tile_reduce %a_tile, %scaler_tile, %out_tile 0 : i32 <reduce_dim_col> into dst[%c0] : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+      ttl.tile_store %red, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+
+  return %res : tensor<1x1x!ttcore.tile<32x32, bf16>>
+}
+
+// -----
+
 #map_reduce_row = affine_map<(d0, d1) -> (d0, d1)>
 
 // A row reduce on an unspecified target retains the supported f32 preference.

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
@@ -469,15 +469,15 @@ func.func @bf16_matmul_auto_fp32(
 
 #map4 = affine_map<(d0, d1) -> (d0, d1)>
 
-// A bf16 broadcast removes the unsupported f32 mode, so the matmul preference
-// selects the remaining default mode.
-// DEFAULT-LABEL: func.func @bf16_matmul_bcast_no_fp32
-// DEFAULT-SAME: fp32_dest_acc_en = false
-// NO-MATMUL-FP32-LABEL: func.func @bf16_matmul_bcast_no_fp32
+// A column broadcast supports f32 DST mode, so the matmul preference remains
+// effective. Disabling that preference selects default DST mode.
+// DEFAULT-LABEL: func.func @bf16_matmul_column_bcast
+// DEFAULT-SAME: fp32_dest_acc_en = true
+// NO-MATMUL-FP32-LABEL: func.func @bf16_matmul_column_bcast
 // NO-MATMUL-FP32-SAME: fp32_dest_acc_en = false
-// NO-REDUCE-FP32-LABEL: func.func @bf16_matmul_bcast_no_fp32
-// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = false
-func.func @bf16_matmul_bcast_no_fp32(
+// NO-REDUCE-FP32-LABEL: func.func @bf16_matmul_column_bcast
+// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = true
+func.func @bf16_matmul_column_bcast(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %b: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %bias: tensor<1x1x!ttcore.tile<32x32, bf16>>)

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
@@ -1,7 +1,6 @@
-// Summary: Verify ttl-set-compute-kernel-config sets kernel config on func.func.
-// Attributes are per-kernel (set on the function, not individual compute ops).
+// Verify kernel configuration resolution from operation requirements, target
+// capabilities, and pass policy.
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s --check-prefix=DEFAULT
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=1 dst-full-sync-en=1}))' --split-input-file | FileCheck %s --check-prefix=OVERRIDE
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0}))' --split-input-file | FileCheck %s --check-prefix=NO-MATMUL-FP32
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{reduce-full-fp32=0}))' --split-input-file | FileCheck %s --check-prefix=NO-REDUCE-FP32
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0}))' --split-input-file | FileCheck %s --check-prefix=FPUOFF
@@ -10,23 +9,19 @@
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: f32 tile args enable fp32_dest_acc_en on the function.
-// ttl.enable_fpu_binary_ops is written from the pass option (default true,
-// override =0 via FPUOFF) regardless of dtype.
+// f32 DST values require f32 destination accumulation. The resolver selects an
+// FPU binary strategy compatible with the complete kernel configuration.
 // DEFAULT-LABEL: func.func @f32_auto_enable
+// DEFAULT-SAME: dst_full_sync_en = false
 // DEFAULT-SAME: fp32_dest_acc_en = true
-// DEFAULT-SAME: ttl.enable_fpu_binary_ops = true
-// DEFAULT-NOT: dst_full_sync_en
-// OVERRIDE-LABEL: func.func @f32_auto_enable
-// OVERRIDE-SAME: dst_full_sync_en = true
-// OVERRIDE-SAME: fp32_dest_acc_en = true
-// OVERRIDE-SAME: ttl.enable_fpu_binary_ops = true
-// f32 tile args still trigger fp32 even with matmul-full-fp32=0.
+// DEFAULT-SAME: ttl.unpack_to_dest_fp32 = array<i32>
+// DEFAULT-NOT: ttl.enable_fpu_binary_ops
+// DEFAULT: ttl.tile_add {{.*}}ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>
+// Disabling a matmul preference does not alter the f32 semantic requirement.
 // NO-MATMUL-FP32-LABEL: func.func @f32_auto_enable
 // NO-MATMUL-FP32-SAME: fp32_dest_acc_en = true
-// NO-MATMUL-FP32-SAME: ttl.enable_fpu_binary_ops = true
 // FPUOFF-LABEL: func.func @f32_auto_enable
-// FPUOFF-SAME: ttl.enable_fpu_binary_ops = false
+// FPUOFF: ttl.tile_add {{.*}}ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
 func.func @f32_auto_enable(%a: tensor<1x1x!ttcore.tile<32x32, f32>>,
                            %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
     -> tensor<1x1x!ttcore.tile<32x32, f32>> {
@@ -69,19 +64,15 @@ func.func @f32_auto_enable(%a: tensor<1x1x!ttcore.tile<32x32, f32>>,
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: bf16 with no special ops -- no fp32_dest_acc_en by default,
-// but override enables both.
+// A bf16 kernel without an accumulation preference selects default DST mode.
 // DEFAULT-LABEL: func.func @bf16_no_special_ops
-// DEFAULT-NOT: fp32_dest_acc_en
-// DEFAULT-NOT: dst_full_sync_en
-// OVERRIDE-LABEL: func.func @bf16_no_special_ops
-// OVERRIDE-SAME: dst_full_sync_en = true
-// OVERRIDE-SAME: fp32_dest_acc_en = true
+// DEFAULT-SAME: dst_full_sync_en = false
+// DEFAULT-SAME: fp32_dest_acc_en = false
 // NO-MATMUL-FP32-LABEL: func.func @bf16_no_special_ops
-// NO-MATMUL-FP32-NOT: fp32_dest_acc_en
-// NO-MATMUL-FP32-NOT: dst_full_sync_en
+// NO-MATMUL-FP32-SAME: dst_full_sync_en = false
+// NO-MATMUL-FP32-SAME: fp32_dest_acc_en = false
 // NO-REDUCE-FP32-LABEL: func.func @bf16_no_special_ops
-// NO-REDUCE-FP32-NOT: fp32_dest_acc_en
+// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = false
 func.func @bf16_no_special_ops(%a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
                                %b: tensor<1x1x!ttcore.tile<32x32, bf16>>)
     -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
@@ -123,15 +114,13 @@ func.func @bf16_no_special_ops(%a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
 
 #map_reduce_col = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: bf16 non-ROW reduce triggers fp32_dest_acc_en through reduce-full-fp32.
+// A supported reduce preference selects f32 DST mode.
 // DEFAULT-LABEL: func.func @bf16_reduce_col_auto_fp32
 // DEFAULT-SAME: fp32_dest_acc_en = true
-// OVERRIDE-LABEL: func.func @bf16_reduce_col_auto_fp32
-// OVERRIDE-SAME: fp32_dest_acc_en = true
 // NO-MATMUL-FP32-LABEL: func.func @bf16_reduce_col_auto_fp32
 // NO-MATMUL-FP32-SAME: fp32_dest_acc_en = true
 // NO-REDUCE-FP32-LABEL: func.func @bf16_reduce_col_auto_fp32
-// NO-REDUCE-FP32-NOT: fp32_dest_acc_en
+// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = false
 func.func @bf16_reduce_col_auto_fp32(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -176,16 +165,13 @@ func.func @bf16_reduce_col_auto_fp32(
 
 #map_reduce_row = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: bf16 ROW reduce triggers fp32_dest_acc_en when no target_arch is
-// set (the issue #533 workaround applies only on Blackhole).
+// A row reduce on an unspecified target retains the supported f32 preference.
 // DEFAULT-LABEL: func.func @bf16_reduce_row_auto_fp32
 // DEFAULT-SAME: fp32_dest_acc_en = true
-// OVERRIDE-LABEL: func.func @bf16_reduce_row_auto_fp32
-// OVERRIDE-SAME: fp32_dest_acc_en = true
 // NO-MATMUL-FP32-LABEL: func.func @bf16_reduce_row_auto_fp32
 // NO-MATMUL-FP32-SAME: fp32_dest_acc_en = true
 // NO-REDUCE-FP32-LABEL: func.func @bf16_reduce_row_auto_fp32
-// NO-REDUCE-FP32-NOT: fp32_dest_acc_en
+// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = false
 func.func @bf16_reduce_row_auto_fp32(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -230,11 +216,11 @@ func.func @bf16_reduce_row_auto_fp32(
 
 #map_reduce_row = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: Blackhole ROW reduce does not trigger fp32_dest_acc_en, because
-// tt-metal disables fp32 accumulation in the row-reduce LLK (tt-metal #47311).
+// Blackhole row reduce does not support full-fp32 accumulation.
 // BLACKHOLE-LABEL: func.func @blackhole_bf16_reduce_row_no_auto_fp32
+// BLACKHOLE-SAME: fp32_dest_acc_en = false
 // BLACKHOLE-SAME: ttl.kernel_thread = #ttkernel.thread<compute>
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @blackhole_bf16_reduce_row_no_auto_fp32(
       %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -280,12 +266,11 @@ module attributes {ttl.target_arch = "blackhole"} {
 
 #map_mixed_reduce = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: A Blackhole compute op containing both a ROW and a COL reduce
-// must still enable fp32_dest_acc_en — the workaround only suppresses the
-// auto-enable when the *only* fp32-justifying reduces are ROW reduces.
+// A supported column reduce selects f32 mode even when another reduce cannot
+// use full-fp32 accumulation.
 // BLACKHOLE-LABEL: func.func @blackhole_bf16_reduce_row_and_col_auto_fp32
 // BLACKHOLE-SAME: fp32_dest_acc_en = true
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @blackhole_bf16_reduce_row_and_col_auto_fp32(
       %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -333,12 +318,11 @@ module attributes {ttl.target_arch = "blackhole"} {
 
 #map_reduce_row = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: Wormhole reduce does not trigger fp32_dest_acc_en from
-// reduce-full-fp32.
+// Wormhole does not support full-fp32 reduction.
 // WORMHOLE-LABEL: func.func @wormhole_bf16_reduce_row_no_auto_fp32
-// WORMHOLE-NOT: fp32_dest_acc_en
+// WORMHOLE-SAME: fp32_dest_acc_en = false
 // WORMHOLE-SAME: ttl.kernel_thread = #ttkernel.thread<compute>
-module attributes {ttl.target_arch = "wormhole_b0"} {
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
   func.func @wormhole_bf16_reduce_row_no_auto_fp32(
       %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
@@ -384,22 +368,19 @@ module attributes {ttl.target_arch = "wormhole_b0"} {
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: Existing func-level attributes are preserved (not overwritten).
+// Function attributes are hard constraints and override pass preferences.
 // DEFAULT-LABEL: func.func @preserve_existing
 // DEFAULT-SAME: dst_full_sync_en = false
-// DEFAULT-SAME: fp32_dest_acc_en = false
-// OVERRIDE-LABEL: func.func @preserve_existing
-// OVERRIDE-SAME: dst_full_sync_en = false
-// OVERRIDE-SAME: fp32_dest_acc_en = false
+// DEFAULT-SAME: fp32_dest_acc_en = true
 // NO-MATMUL-FP32-LABEL: func.func @preserve_existing
 // NO-MATMUL-FP32-SAME: dst_full_sync_en = false
-// NO-MATMUL-FP32-SAME: fp32_dest_acc_en = false
+// NO-MATMUL-FP32-SAME: fp32_dest_acc_en = true
 // NO-REDUCE-FP32-LABEL: func.func @preserve_existing
-// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = false
+// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = true
 func.func @preserve_existing(%a: tensor<1x1x!ttcore.tile<32x32, f32>>,
                              %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
     -> tensor<1x1x!ttcore.tile<32x32, f32>>
-    attributes {dst_full_sync_en = false, fp32_dest_acc_en = false} {
+    attributes {dst_full_sync_en = false, fp32_dest_acc_en = true} {
   %c0 = arith.constant 0 : index
   %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
 
@@ -438,15 +419,11 @@ func.func @preserve_existing(%a: tensor<1x1x!ttcore.tile<32x32, f32>>,
 
 #map3 = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: bf16 matmul triggers fp32_dest_acc_en via matmul-full-fp32 (default).
-// With matmul-full-fp32=0, bf16 matmul does not trigger fp32_dest_acc_en.
+// Matmul policy prefers f32 DST mode when supported.
 // DEFAULT-LABEL: func.func @bf16_matmul_auto_fp32
 // DEFAULT-SAME: fp32_dest_acc_en = true
-// OVERRIDE-LABEL: func.func @bf16_matmul_auto_fp32
-// OVERRIDE-SAME: dst_full_sync_en = true
-// OVERRIDE-SAME: fp32_dest_acc_en = true
 // NO-MATMUL-FP32-LABEL: func.func @bf16_matmul_auto_fp32
-// NO-MATMUL-FP32-NOT: fp32_dest_acc_en
+// NO-MATMUL-FP32-SAME: fp32_dest_acc_en = false
 // NO-REDUCE-FP32-LABEL: func.func @bf16_matmul_auto_fp32
 // NO-REDUCE-FP32-SAME: fp32_dest_acc_en = true
 func.func @bf16_matmul_auto_fp32(
@@ -492,18 +469,14 @@ func.func @bf16_matmul_auto_fp32(
 
 #map4 = affine_map<(d0, d1) -> (d0, d1)>
 
-// Purpose: bf16 matmul + bcast in the same kernel suppresses matmul-triggered
-// fp32_dest_acc_en. unary_bcast produces incorrect results under fp32 DST
-// format with bf16 CBs, so the kernel must stay in bf16 mode.
+// A bf16 broadcast removes the unsupported f32 mode, so the matmul preference
+// selects the remaining default mode.
 // DEFAULT-LABEL: func.func @bf16_matmul_bcast_no_fp32
-// DEFAULT-NOT: fp32_dest_acc_en
-// OVERRIDE-LABEL: func.func @bf16_matmul_bcast_no_fp32
-// OVERRIDE-SAME: dst_full_sync_en = true
-// OVERRIDE-SAME: fp32_dest_acc_en = true
+// DEFAULT-SAME: fp32_dest_acc_en = false
 // NO-MATMUL-FP32-LABEL: func.func @bf16_matmul_bcast_no_fp32
-// NO-MATMUL-FP32-NOT: fp32_dest_acc_en
+// NO-MATMUL-FP32-SAME: fp32_dest_acc_en = false
 // NO-REDUCE-FP32-LABEL: func.func @bf16_matmul_bcast_no_fp32
-// NO-REDUCE-FP32-NOT: fp32_dest_acc_en
+// NO-REDUCE-FP32-SAME: fp32_dest_acc_en = false
 func.func @bf16_matmul_bcast_no_fp32(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %b: tensor<1x1x!ttcore.tile<32x32, bf16>>,

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
@@ -525,3 +525,42 @@ func.func @bf16_matmul_column_bcast(
 
   return %res2 : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
+
+// -----
+
+// An unspecified target applies no architecture-specific broadcast
+// restriction while still resolving target-independent f32 requirements.
+// DEFAULT-LABEL: func.func @unspecified_target_row_broadcast
+// DEFAULT-SAME: fp32_dest_acc_en = true
+// DEFAULT-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @unspecified_target_row_broadcast(
+    %f32_input: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %bf16_input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %output: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %f32_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %bf16_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %f32_attached = ttl.attach_cb %f32_input, %f32_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %bf16_attached = ttl.attach_cb %bf16_input, %bf16_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %f32_tile = tensor.extract %f32_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %bf16_tile = tensor.extract %bf16_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_tile = tensor.extract %output[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %exponential = ttl.tile_exp %f32_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %broadcast = ttl.tile_bcast %bf16_tile, %output_tile 2 : i32
+      into dst[%zero]
+      : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+        -> !ttcore.tile<32x32, bf16>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
@@ -163,55 +163,6 @@ func.func @bf16_reduce_col_auto_fp32(
 
 // -----
 
-#map_reduce_col = affine_map<(d0, d1) -> (d0, d1)>
-
-// An explicit 16-bit destination constraint overrides the supported full-fp32
-// reduce preference.
-// DEFAULT-LABEL: func.func @bf16_reduce_col_explicit_16bit
-// DEFAULT-SAME: fp32_dest_acc_en = false
-func.func @bf16_reduce_col_explicit_16bit(
-    %a: tensor<1x1x!ttcore.tile<32x32, bf16>>,
-    %scaler: tensor<1x1x!ttcore.tile<32x32, bf16>>)
-    -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    attributes {fp32_dest_acc_en = false,
-                ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %c0 = arith.constant 0 : index
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
-
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-
-  %a_cb = ttl.attach_cb %a, %cb0
-      : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %scaler_cb = ttl.attach_cb %scaler, %cb1
-      : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %init_cb = ttl.attach_cb %init, %cb2
-      : (tensor<1x1x!ttcore.tile<32x32, bf16>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-
-  %out_view = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %res = ttl.compute
-      ins(%a_cb, %scaler_cb : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-                              tensor<1x1x!ttcore.tile<32x32, bf16>>)
-      outs(%init_cb : tensor<1x1x!ttcore.tile<32x32, bf16>>)
-      {indexing_maps = [#map_reduce_col, #map_reduce_col, #map_reduce_col],
-       iterator_types = ["parallel", "parallel"]} {
-    ^bb0(%a_tile: !ttcore.tile<32x32, bf16>, %scaler_tile: !ttcore.tile<32x32, bf16>, %out_tile: !ttcore.tile<32x32, bf16>):
-      %i = ttl.iter_index 0 : index
-      %j = ttl.iter_index 1 : index
-      %red = ttl.tile_reduce %a_tile, %scaler_tile, %out_tile 0 : i32 <reduce_dim_col> into dst[%c0] : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-      ttl.tile_store %red, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, bf16>, tensor<1x1x!ttcore.tile<32x32, bf16>>
-      ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-
-  return %res : tensor<1x1x!ttcore.tile<32x32, bf16>>
-}
-
-// -----
-
 #map_reduce_row = affine_map<(d0, d1) -> (d0, d1)>
 
 // A row reduce on an unspecified target retains the supported f32 preference.

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
@@ -151,6 +151,77 @@ module attributes {
 
 // -----
 
+// An explicit FPU strategy requires operands that address the same tile.
+func.func @explicit_strategy_illegal_for_operands(
+    %lhs: tensor<1x2x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x2x!ttcore.tile<32x32, bf16>>) {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %one = arith.constant 1 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %one]
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.tile_add' op explicit ttl.tile_execution_strategy is not legal for its operands}}
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+      {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>}
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+// Attached DFB handles must resolve to a physical index before analysis.
+func.func @dataflow_buffer_without_finalized_index(
+    %input: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %input_dfb: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) {
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %input_tile = tensor.extract %input_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{'ttl.tile_exp' op uses a dataflow buffer without a finalized index}}
+  %exp = ttl.tile_exp %input_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// Physical DFB indices outside the kernel configuration domain are invalid.
+func.func @dataflow_buffer_index_out_of_range(
+    %input: tensor<1x1x!ttcore.tile<32x32, f32>>) {
+  %input_dfb = ttl.bind_cb {cb_index = 32, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %input_tile = tensor.extract %input_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{'ttl.tile_exp' op uses dataflow buffer index 32 outside the supported range [0, 31]}}
+  %exp = ttl.tile_exp %input_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
 // Device chip IDs must refer to entries in the system description.
 module attributes {
   ttcore.system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 204800, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 0, erisc_l1_unreserved_base = 0, dram_unreserved_base = 0, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>], supported_tile_sizes = [32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(0, 0)], dram_bank_to_logical_worker_noc1 = [(0, 0)]}], [0], [1 : i32], [ 0x0x0x0]>

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
@@ -21,34 +21,36 @@ func.func @disabled_required_f32() attributes {fp32_dest_acc_en = false} {
 
 // -----
 
-// expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
-func.func @enabled_unsupported_bcast(
-    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
-    %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
-    attributes {fp32_dest_acc_en = true} {
-  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
-      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
-      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %input_attached = ttl.attach_cb %input, %input_dfb
-      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
-         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %output_attached = ttl.attach_cb %output, %output_dfb
-      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
-         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %zero = arith.constant 0 : index
-  %input_tile = tensor.extract %input_attached[%zero, %zero]
-      : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %output_tile = tensor.extract %output_attached[%zero, %zero]
-      : tensor<1x1x!ttcore.tile<32x32, bf16>>
-  // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
-  %broadcast = ttl.tile_bcast %input_tile, %output_tile 1 : i32
-      into dst[%zero]
-      : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
-        -> !ttcore.tile<32x32, bf16>
-  return
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
+  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+  func.func @enabled_unsupported_wormhole_row_bcast(
+      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      attributes {fp32_dest_acc_en = true} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_attached = ttl.attach_cb %output, %output_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_tile = tensor.extract %output_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+    %broadcast = ttl.tile_bcast %input_tile, %output_tile 2 : i32
+        into dst[%zero]
+        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+          -> !ttcore.tile<32x32, bf16>
+    return
+  }
 }
 
 // -----

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
@@ -1,0 +1,195 @@
+// Verify invalid targets, policy constraints, and execution strategies are
+// diagnosed before kernel configuration mutates the IR.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' --split-input-file --verify-diagnostics
+
+// expected-error @below {{'builtin.module' op ttl.target_arch must be a #ttcore.arch attribute}}
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @malformed_target() {
+    return
+  }
+}
+
+// -----
+
+func.func @disabled_required_f32() attributes {fp32_dest_acc_en = false} {
+  %zero = arith.constant 0 : index
+  // expected-error @below {{'ttl.tile_fill' op requires f32 DST mode, but fp32 destination accumulation is explicitly disabled}}
+  %value = ttl.tile_fill 1.0 into dst[%zero]
+      : !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
+func.func @enabled_unsupported_bcast(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    attributes {fp32_dest_acc_en = true} {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_attached = ttl.attach_cb %output, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %input_tile = tensor.extract %input_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_tile = tensor.extract %output_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
+  %broadcast = ttl.tile_bcast %input_tile, %output_tile 1 : i32
+      into dst[%zero]
+      : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+        -> !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+// expected-error @below {{'func.func' op fp32_dest_acc_en must be a boolean attribute}}
+func.func @malformed_boolean_policy() attributes {fp32_dest_acc_en = "true"} {
+  return
+}
+
+// -----
+
+// expected-error @below {{'func.func' op ttl.unpack_to_dest_fp32 must be a dense i32 array attribute}}
+func.func @malformed_unpack_policy()
+    attributes {ttl.unpack_to_dest_fp32 = [0 : i32]} {
+  return
+}
+
+// -----
+
+// expected-error @below {{'func.func' op ttl.unpack_to_dest_fp32 must contain dataflow buffer indices in range [0, 31]}}
+func.func @out_of_range_unpack_policy()
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 32>} {
+  return
+}
+
+// -----
+
+func.func @explicit_unpack_excludes_required_dfb(
+    %input: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32>} {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %input_tile = tensor.extract %input_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{'ttl.tile_abs' op dataflow buffer 0 requires unpack-to-DST-f32 mode, but ttl.unpack_to_dest_fp32 excludes this index}}
+  %absolute = ttl.tile_abs %input_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+func.func @strategy_on_fixed_operation() {
+  %zero = arith.constant 0 : index
+  // expected-error @below {{'ttl.tile_fill' op ttl.tile_execution_strategy is only valid on tile operations with execution-strategy alternatives}}
+  %value = ttl.tile_fill 1.0 into dst[%zero]
+      {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>}
+      : !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+func.func @malformed_strategy(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.tile_add' op ttl.tile_execution_strategy must be a #ttl.tile_execution_strategy attribute}}
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+      {ttl.tile_execution_strategy = "fpu"}
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+func.func @explicit_fpu_conflicts_with_policy(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    attributes {ttl.enable_fpu_binary_ops = false} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttl.tile_add' op explicit FPU strategy conflicts with disabled FPU binary policy}}
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+      {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>}
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+// The requested target must agree with the device selected from the system
+// description.
+// expected-error @below {{'builtin.module' op ttl.target_arch does not match the selected device arch}}
+module attributes {
+  ttl.target_arch = #ttcore.arch<blackhole>,
+  ttcore.system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 204800, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 0, erisc_l1_unreserved_base = 0, dram_unreserved_base = 0, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>], supported_tile_sizes = [32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(0, 0)], dram_bank_to_logical_worker_noc1 = [(0, 0)]}], [0], [1 : i32], [ 0x0x0x0]>
+} {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  func.func @target_mismatch() {
+    return
+  }
+}
+
+// -----
+
+// Device chip IDs must refer to entries in the system description.
+module attributes {
+  ttcore.system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 204800, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 0, erisc_l1_unreserved_base = 0, dram_unreserved_base = 0, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>], supported_tile_sizes = [32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(0, 0)], dram_bank_to_logical_worker_noc1 = [(0, 0)]}], [0], [1 : i32], [ 0x0x0x0]>
+} {
+  // expected-error @below {{'ttcore.device' op selects chip 1 outside the system description}}
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [1]>
+  func.func @invalid_device_chip() {
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
@@ -11,9 +11,19 @@ module attributes {ttl.target_arch = "blackhole"} {
 
 // -----
 
+// Quasar requires a Gen2 configuration descriptor and kernel launch API.
+// expected-error @below {{'builtin.module' op Quasar compute kernels require the Gen2 configuration and launch APIs, which are not supported by the current TT-Lang runtime}}
+module attributes {ttl.target_arch = #ttcore.arch<quasar>} {
+  func.func @unsupported_quasar_target() {
+    return
+  }
+}
+
+// -----
+
 func.func @disabled_required_f32() attributes {fp32_dest_acc_en = false} {
   %zero = arith.constant 0 : index
-  // expected-error @below {{'ttl.tile_fill' op requires f32 DST mode, but fp32 destination accumulation is explicitly disabled}}
+  // expected-error @below {{'ttl.tile_fill' op requires 32-bit destination elements, but fp32 destination accumulation is explicitly disabled}}
   %value = ttl.tile_fill 1.0 into dst[%zero]
       : !ttcore.tile<32x32, f32>
   return
@@ -217,6 +227,18 @@ func.func @dataflow_buffer_index_out_of_range(
   // expected-error @below {{'ttl.tile_exp' op uses dataflow buffer index 32 outside the supported range [0, 31]}}
   %exp = ttl.tile_exp %input_tile into dst[%zero]
       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// Kernel configuration rejects malformed tile-operation operands without
+// aborting the compiler.
+func.func @non_tile_operand(%input: f32, %output: f32) {
+  %zero = arith.constant 0 : index
+  // expected-error @below {{'ttl.tile_bcast' op expected a tile or tensor-of-tiles operand, got 'f32'}}
+  %broadcast = ttl.tile_bcast %input, %output 2 : i32 into dst[%zero]
+      : (f32, f32) -> f32
   return
 }
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
@@ -21,40 +21,6 @@ func.func @disabled_required_f32() attributes {fp32_dest_acc_en = false} {
 
 // -----
 
-module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
-  // expected-error @below {{'func.func' op explicit f32 destination accumulation is unsupported by the kernel's tile operations}}
-  func.func @enabled_unsupported_wormhole_row_bcast(
-      %input: tensor<1x1x!ttcore.tile<32x32, bf16>>,
-      %output: tensor<1x1x!ttcore.tile<32x32, bf16>>)
-      attributes {fp32_dest_acc_en = true} {
-    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %input_attached = ttl.attach_cb %input, %input_dfb
-        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
-           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    %output_attached = ttl.attach_cb %output, %output_dfb
-        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
-           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    %zero = arith.constant 0 : index
-    %input_tile = tensor.extract %input_attached[%zero, %zero]
-        : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    %output_tile = tensor.extract %output_attached[%zero, %zero]
-        : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    // expected-note @below {{the target does not support f32 DST mode for ttl.tile_bcast with 'bf16' elements}}
-    %broadcast = ttl.tile_bcast %input_tile, %output_tile 2 : i32
-        into dst[%zero]
-        : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
-          -> !ttcore.tile<32x32, bf16>
-    return
-  }
-}
-
-// -----
-
 // expected-error @below {{'func.func' op fp32_dest_acc_en must be a boolean attribute}}
 func.func @malformed_boolean_policy() attributes {fp32_dest_acc_en = "true"} {
   return

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_conflict_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_conflict_invalid.mlir
@@ -1,237 +1,29 @@
-// Summary: Diagnose CB conflicts when an f32 input is consumed by both FPU
-// and SFPU strategies in the same kernel. Default and UnpackToDestFp32 modes
-// are mutually exclusive on a given CB, so silently dropping one strategy's
-// request would lose f32 precision. The pass instead emits a hard error so the
-// kernel author can split the source into per-strategy CBs.
-//
+// Verify that fixed execution requirements using one f32 dataflow buffer are
+// rejected when they require incompatible unpack modes.
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file --verify-diagnostics
 
-#map = affine_map<(d0, d1) -> (d0, d1)>
-
-func.func @f32_cb1_used_by_both_fpu_and_sfpu(
-    %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
-    %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
-    -> tensor<1x1x!ttcore.tile<32x32, f32>>
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                ttl.enable_fpu_binary_ops = true} {
-  %c0 = arith.constant 0 : index
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-
-  %a_cb = ttl.attach_cb %a, %cb0
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+// SFPU operations consume f32 input through DST, while tile_bcast requires the
+// default unpack mode. Neither operation has an alternative execution strategy.
+func.func @f32_dfb_used_by_bcast_and_sfpu(
+    %input: tensor<1x1x!ttcore.tile<32x32, f32>>) {
+  %input_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %input_attached = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
         -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  // Both %b_cb and %b_cb_again attach to CB1 so the two block args inside
-  // the compute body both read their unpacks from CB1; one is consumed by an
-  // FPU tile_add and the other by an SFPU tile_exp.
-  %b_cb = ttl.attach_cb %b, %cb1
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %b_cb_again = ttl.attach_cb %b, %cb1
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %init_cb = ttl.attach_cb %init, %cb2
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  %out_view = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %res = ttl.compute
-      ins(%a_cb, %b_cb, %b_cb_again : tensor<1x1x!ttcore.tile<32x32, f32>>,
-                                       tensor<1x1x!ttcore.tile<32x32, f32>>,
-                                       tensor<1x1x!ttcore.tile<32x32, f32>>)
-      outs(%init_cb : tensor<1x1x!ttcore.tile<32x32, f32>>)
-      {indexing_maps = [#map, #map, #map, #map],
-       iterator_types = ["parallel", "parallel"]} {
-    ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-         %b_tile_fpu: !ttcore.tile<32x32, f32>,
-         %b_tile_sfpu: !ttcore.tile<32x32, f32>,
-         %out_tile: !ttcore.tile<32x32, f32>):
-      %i = ttl.iter_index 0 : index
-      %j = ttl.iter_index 1 : index
-      // FPU path: CB0 + CB1 through SRCA/SRCB.
-      // expected-error @below {{f32 input from CB 1 is consumed by both FPU and SFPU strategies in the same kernel}}
-      %sum = ttl.tile_add %a_tile, %b_tile_fpu into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-      // SFPU path: same b on CB1 read straight to DST via tile_exp.
-      %ex = ttl.tile_exp %b_tile_sfpu into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-      ttl.tile_store %sum, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
-      ttl.tile_store %ex, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
-      ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
-}
-
-// -----
-
-#map = affine_map<(d0, d1) -> (d0, d1)>
-
-// Purpose: Conflicts are diagnosed at kernel scope, not only within a single
-// ttl.compute body. CB1 is consumed by an FPU tile_add in the first compute and
-// by an SFPU tile_exp in the second compute, which would otherwise set
-// ttl.unpack_to_dest_fp32 = array<i32: 1> for the whole func.func.
-func.func @f32_cb1_used_by_fpu_and_sfpu_in_separate_computes(
-    %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
-    %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
-    -> tensor<1x1x!ttcore.tile<32x32, f32>>
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                ttl.enable_fpu_binary_ops = true} {
-  %c0 = arith.constant 0 : index
-  %init0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
-  %init1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb3 = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-
-  %a_cb = ttl.attach_cb %a, %cb0
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %b_cb = ttl.attach_cb %b, %cb1
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %init0_cb = ttl.attach_cb %init0, %cb2
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %init1_cb = ttl.attach_cb %init1, %cb3
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  %out0 = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %res0 = ttl.compute
-      ins(%a_cb, %b_cb : tensor<1x1x!ttcore.tile<32x32, f32>>,
-                         tensor<1x1x!ttcore.tile<32x32, f32>>)
-      outs(%init0_cb : tensor<1x1x!ttcore.tile<32x32, f32>>)
-      {indexing_maps = [#map, #map, #map],
-       iterator_types = ["parallel", "parallel"]} {
-    ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-         %b_tile_fpu: !ttcore.tile<32x32, f32>,
-         %out_tile: !ttcore.tile<32x32, f32>):
-      %i = ttl.iter_index 0 : index
-      %j = ttl.iter_index 1 : index
-      // expected-error @below {{f32 input from CB 1 is consumed by both FPU and SFPU strategies in the same kernel}}
-      %sum = ttl.tile_add %a_tile, %b_tile_fpu into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-      ttl.tile_store %sum, %out0[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
-      ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  %out1 = ttl.cb_reserve %cb3 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %res1 = ttl.compute
-      ins(%b_cb : tensor<1x1x!ttcore.tile<32x32, f32>>)
-      outs(%init1_cb : tensor<1x1x!ttcore.tile<32x32, f32>>)
-      {indexing_maps = [#map, #map],
-       iterator_types = ["parallel", "parallel"]} {
-    ^bb0(%b_tile_sfpu: !ttcore.tile<32x32, f32>,
-         %out_tile: !ttcore.tile<32x32, f32>):
-      %i = ttl.iter_index 0 : index
-      %j = ttl.iter_index 1 : index
-      %ex = ttl.tile_exp %b_tile_sfpu into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-      ttl.tile_store %ex, %out1[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
-      ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  return %res1 : tensor<1x1x!ttcore.tile<32x32, f32>>
-}
-
-// -----
-
-#map = affine_map<(d0, d1) -> (d0, d1)>
-
-// Purpose: tile_bcast / tile_transpose must keep their source CB in Default
-// unpack mode (tt-llk #1338). When an f32 CB feeds both an SFPU DST op
-// (tile_exp) and a tile_bcast, the conflict is diagnosed rather than silently
-// configuring UnpackToDestFp32 and corrupting the bcast.
-func.func @f32_cb1_used_by_bcast_and_sfpu(
-    %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
-    %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
-    -> tensor<1x1x!ttcore.tile<32x32, f32>>
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %c0 = arith.constant 0 : index
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %a_cb = ttl.attach_cb %a, %cb0 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %b_cb_sfpu = ttl.attach_cb %b, %cb1 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %b_cb_bcast = ttl.attach_cb %b, %cb1 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %init_cb = ttl.attach_cb %init, %cb2 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %out_view = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %res = ttl.compute
-      ins(%a_cb, %b_cb_sfpu, %b_cb_bcast : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>)
-      outs(%init_cb : tensor<1x1x!ttcore.tile<32x32, f32>>)
-      {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} {
-    ^bb0(%a_tile: !ttcore.tile<32x32, f32>, %b_sfpu: !ttcore.tile<32x32, f32>, %b_bcast: !ttcore.tile<32x32, f32>, %out_tile: !ttcore.tile<32x32, f32>):
-      %i = ttl.iter_index 0 : index
-      %j = ttl.iter_index 1 : index
-      %ex = ttl.tile_exp %b_sfpu into dst[%c0] : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-      // expected-error @below {{f32 input from CB 1 is consumed by both FPU and SFPU strategies in the same kernel}}
-      %bc = ttl.tile_bcast %b_bcast, %out_tile 2 : i32 into dst[%c0] : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-      ttl.tile_store %ex, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
-      ttl.tile_store %bc, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
-      ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
-}
-
-// -----
-
-#map = affine_map<(d0, d1) -> (d0, d1)>
-
-// Purpose: Non-FPU-eligible strategy-dependent binary ops lower through the
-// SFPU DST path and therefore require UnpackToDestFp32 for f32 CB inputs. This
-// conflicts when the same CB also feeds an FPU-eligible binary op.
-func.func @f32_cb1_used_by_fpu_and_strategy_dependent_sfpu_binary(
-    %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
-    %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
-    -> tensor<1x1x!ttcore.tile<32x32, f32>>
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                ttl.enable_fpu_binary_ops = true} {
-  %c0 = arith.constant 0 : index
-  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
-
-  %a_cb = ttl.attach_cb %a, %cb0
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %b_cb_fpu = ttl.attach_cb %b, %cb1
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %b_cb_sfpu = ttl.attach_cb %b, %cb1
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %init_cb = ttl.attach_cb %init, %cb2
-      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  %out_view = ttl.cb_reserve %cb2 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
-  %res = ttl.compute
-      ins(%a_cb, %b_cb_fpu, %b_cb_sfpu : tensor<1x1x!ttcore.tile<32x32, f32>>,
-                                            tensor<1x1x!ttcore.tile<32x32, f32>>,
-                                            tensor<1x1x!ttcore.tile<32x32, f32>>)
-      outs(%init_cb : tensor<1x1x!ttcore.tile<32x32, f32>>)
-      {indexing_maps = [#map, #map, #map, #map],
-       iterator_types = ["parallel", "parallel"]} {
-    ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-         %b_tile_fpu: !ttcore.tile<32x32, f32>,
-         %b_tile_sfpu: !ttcore.tile<32x32, f32>,
-         %out_tile: !ttcore.tile<32x32, f32>):
-      %i = ttl.iter_index 0 : index
-      %j = ttl.iter_index 1 : index
-      // FPU path: both operands are block args with the same indexing map.
-      // expected-error @below {{f32 input from CB 1 is consumed by both FPU and SFPU strategies in the same kernel}}
-      %sum = ttl.tile_add %a_tile, %b_tile_fpu into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-      // SFPU path: lhs is an intermediate DST value, so this strategy-dependent
-      // binary op is not FPU-eligible and must copy %b_tile_sfpu through DST.
-      %mul = ttl.tile_mul %sum, %b_tile_sfpu into dst[%c0] : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-      ttl.tile_store %mul, %out_view[%i, %j] from dst[%c0] : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
-      ttl.yield
-  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
-
-  return %res : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %input_tile = tensor.extract %input_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_tile = tensor.extract %output[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-note @below {{operand 0 establishes the conflicting unpack mode}}
+  %exponential = ttl.tile_exp %input_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  // expected-error @below {{'ttl.tile_bcast' op dataflow buffer 1 requires incompatible unpack modes in one kernel}}
+  %broadcast = ttl.tile_bcast %input_tile, %output_tile 2 : i32 into dst[%zero]
+      : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>)
+        -> !ttcore.tile<32x32, f32>
+  return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_inert.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_inert.mlir
@@ -1,0 +1,222 @@
+// Verify explicit unpack-to-DST-f32 entries for non-f32 dataflow buffers do not
+// require 32-bit destination elements.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s --check-prefix=AUTO
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=disabled matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s --check-prefix=DISABLED
+
+// A fixed SFPU consumer ignores the f32 route entry for bf16.
+// AUTO-LABEL: func.func @bf16_sfpu_unary
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @bf16_sfpu_unary
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @bf16_sfpu_unary(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %absolute = ttl.tile_abs %tile into dst[%zero]
+      : !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+// A fixed source-register consumer ignores the f32 route entry for
+// bf16.
+// AUTO-LABEL: func.func @bf16_broadcast
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @bf16_broadcast
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @bf16_broadcast(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %broadcast = ttl.tile_bcast %tile, %tile 2 : i32 into dst[%zero]
+      : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>)
+        -> !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+// A strategy-dependent binary consumer ignores the f32 route entry for
+// bf16.
+// AUTO-LABEL: func.func @bf16_strategy_binary
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @bf16_strategy_binary
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @bf16_strategy_binary(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %sum = ttl.tile_add %tile, %tile into dst[%zero]
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+// An explicit DFB-to-destination copy ignores the f32 route entry for
+// bf16.
+// AUTO-LABEL: func.func @bf16_copy
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @bf16_copy
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @bf16_copy(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %token, %copy = ttl.copy_tile %tile[%zero, %zero] into dst[%zero]
+      : !ttcore.tile<32x32, bf16>
+        -> !ttl.dst, !ttcore.tile<32x32, bf16>
+  return
+}
+
+// -----
+
+// A fixed SFPU consumer ignores the f32 route entry for f16.
+// AUTO-LABEL: func.func @f16_sfpu_unary
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @f16_sfpu_unary
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @f16_sfpu_unary(
+    %input: tensor<1x1x!ttcore.tile<32x32, f16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f16>>
+  %absolute = ttl.tile_abs %tile into dst[%zero]
+      : !ttcore.tile<32x32, f16> -> !ttcore.tile<32x32, f16>
+  return
+}
+
+// -----
+
+// A fixed source-register consumer ignores the f32 route entry for
+// f16.
+// AUTO-LABEL: func.func @f16_broadcast
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @f16_broadcast
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @f16_broadcast(
+    %input: tensor<1x1x!ttcore.tile<32x32, f16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f16>>
+  %broadcast = ttl.tile_bcast %tile, %tile 2 : i32 into dst[%zero]
+      : (!ttcore.tile<32x32, f16>, !ttcore.tile<32x32, f16>)
+        -> !ttcore.tile<32x32, f16>
+  return
+}
+
+// -----
+
+// A strategy-dependent binary consumer ignores the f32 route entry for
+// f16.
+// AUTO-LABEL: func.func @f16_strategy_binary
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @f16_strategy_binary
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @f16_strategy_binary(
+    %input: tensor<1x1x!ttcore.tile<32x32, f16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f16>>
+  %sum = ttl.tile_add %tile, %tile into dst[%zero]
+      : !ttcore.tile<32x32, f16>, !ttcore.tile<32x32, f16>
+        -> !ttcore.tile<32x32, f16>
+  return
+}
+
+// -----
+
+// An explicit DFB-to-destination copy ignores the f32 route entry for
+// f16.
+// AUTO-LABEL: func.func @f16_copy
+// AUTO-SAME: fp32_dest_acc_en = false
+// AUTO-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+// DISABLED-LABEL: func.func @f16_copy
+// DISABLED-SAME: fp32_dest_acc_en = false
+// DISABLED-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0>
+func.func @f16_copy(
+    %input: tensor<1x1x!ttcore.tile<32x32, f16>>)
+    attributes {ttl.unpack_to_dest_fp32 = array<i32: 0>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>
+  %attached = ttl.attach_cb %input, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f16>>
+  %zero = arith.constant 0 : index
+  %tile = tensor.extract %attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f16>>
+  %token, %copy = ttl.copy_tile %tile[%zero, %zero] into dst[%zero]
+      : !ttcore.tile<32x32, f16>
+        -> !ttl.dst, !ttcore.tile<32x32, f16>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_negative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_negative.mlir
@@ -1,12 +1,12 @@
-// Summary: Verify ttl.unpack_to_dest_fp32 is not set for FPU/SRCA-SRCB input.
-//
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s --implicit-check-not=ttl.unpack_to_dest_fp32
+// Verify DFB inputs that do not unpack through DST retain default mode.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 // Purpose: tile_reduce consumes f32 input through SRCA/SRCB, so it must not
 // request unpack-to-DST mode for the input CB.
 // CHECK-LABEL: func.func @f32_reduce_does_not_set_unpack
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32>
 func.func @f32_reduce_does_not_set_unpack(
     %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
     %scaler: tensor<1x1x!ttcore.tile<32x32, f32>>)
@@ -54,6 +54,7 @@ func.func @f32_reduce_does_not_set_unpack(
 // Purpose: An SFPU op consuming an upstream FPU result reads from DST, not from
 // a CB, so no unpack-to-DST mode is needed for the original f32 block args.
 // CHECK-LABEL: func.func @f32_fpu_result_to_sfpu_does_not_set_unpack
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32>
 func.func @f32_fpu_result_to_sfpu_does_not_set_unpack(
     %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
     %b: tensor<1x1x!ttcore.tile<32x32, f32>>)
@@ -101,6 +102,7 @@ func.func @f32_fpu_result_to_sfpu_does_not_set_unpack(
 // Purpose: bf16 -> f32 typecast from CB0 does not need f32 unpack-to-DST mode
 // because the CB0 input itself is not f32.
 // CHECK-LABEL: func.func @bf16_to_f32_typecast_does_not_set_unpack
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32>
 func.func @bf16_to_f32_typecast_does_not_set_unpack(
     %a: tensor<1x1x!ttcore.tile<32x32, bf16>>)
     -> tensor<1x1x!ttcore.tile<32x32, f32>> {
@@ -141,6 +143,7 @@ func.func @bf16_to_f32_typecast_does_not_set_unpack(
 // Purpose: tile_bcast consuming an f32 CB must NOT enable UnpackToDestFp32
 // (tt-llk #1338); with no SFPU consumer on that CB there is also no conflict.
 // CHECK-LABEL: func.func @bcast_only_f32_does_not_set_unpack
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32>
 func.func @bcast_only_f32_does_not_set_unpack(
     %a: tensor<1x1x!ttcore.tile<32x32, f32>>)
     -> tensor<1x1x!ttcore.tile<32x32, f32>>

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_positive.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_positive.mlir
@@ -1,5 +1,4 @@
-// Summary: Verify ttl.unpack_to_dest_fp32 lists the SFPU f32 CB-to-DST inputs.
-//
+// Verify f32 DFB inputs consumed through DST select unpack-to-DST-f32 mode.
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
@@ -1,0 +1,122 @@
+// Verify that execution strategy selection and f32 unpack configuration are
+// resolved together across the complete compute kernel.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s
+
+// A binary operation with FPU/SFPU alternatives selects SFPU when a fixed
+// SFPU consumer requires unpack-to-DST mode for the same dataflow buffer.
+// CHECK-LABEL: func.func @shared_dfb_selects_compatible_strategy
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0, 1>
+// CHECK: ttl.tile_exp
+// CHECK-NEXT: ttl.tile_add
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+func.func @shared_dfb_selects_compatible_strategy(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    attributes {ttl.enable_fpu_binary_ops = true} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %exponential = ttl.tile_exp %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// Requirements in nested regions constrain strategy decisions elsewhere in
+// the same compute kernel.
+// CHECK-LABEL: func.func @strategy_resolution_spans_regions
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0, 1>
+// CHECK: scf.if
+// CHECK: ttl.tile_exp
+// CHECK: ttl.tile_add
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+func.func @strategy_resolution_spans_regions(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>, %condition: i1)
+    attributes {ttl.enable_fpu_binary_ops = true} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  scf.if %condition {
+    %exponential = ttl.tile_exp %rhs_tile into dst[%zero]
+        : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    scf.yield
+  }
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// Binary operations with execution alternatives are selected as one compatible
+// assignment rather than independently by operation order.
+// CHECK-LABEL: func.func @dependent_strategy_decisions_are_resolved_together
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0, 1>
+// CHECK: ttl.tile_add
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+// CHECK-NEXT: ttl.tile_mul
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+func.func @dependent_strategy_decisions_are_resolved_together(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    attributes {ttl.enable_fpu_binary_ops = true} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  %product = ttl.tile_mul %sum, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
@@ -119,6 +119,49 @@ func.func @shared_dfb_mul_selects_compatible_strategy(
 
 // -----
 
+// A fixed requirement constrains strategy-dependent binary operations both
+// before and after it in operation order.
+// CHECK-LABEL: func.func @shared_dfb_selection_is_order_independent
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0, 1>
+// CHECK: ttl.tile_sub
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+// CHECK-NEXT: ttl.tile_exp
+// CHECK-NEXT: ttl.tile_mul
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+func.func @shared_dfb_selection_is_order_independent(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    attributes {ttl.enable_fpu_binary_ops = true} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %difference = ttl.tile_sub %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  %exponential = ttl.tile_exp %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %product = ttl.tile_mul %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
 // Requirements in nested regions constrain strategy decisions elsewhere in
 // the same compute kernel.
 // CHECK-LABEL: func.func @strategy_resolution_spans_regions
@@ -196,5 +239,44 @@ func.func @dependent_strategy_decisions_are_resolved_together(
   %product = ttl.tile_mul %sum, %rhs_tile into dst[%zero]
       : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
         -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// Physical subtile dimensions do not change the shared configuration or
+// strategy constraints.
+// CHECK-LABEL: func.func @subtile_shared_dfb_selects_compatible_strategy
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0, 1>
+// CHECK: ttl.tile_exp
+// CHECK-NEXT: ttl.tile_add
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+func.func @subtile_shared_dfb_selects_compatible_strategy(
+    %lhs: tensor<1x1x!ttcore.tile<16x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<16x32, f32>>)
+    attributes {ttl.enable_fpu_binary_ops = true} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, f32>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<16x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<16x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<16x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<16x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<16x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<16x32, f32>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<16x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<16x32, f32>>
+  %exponential = ttl.tile_exp %rhs_tile into dst[%zero]
+      : !ttcore.tile<16x32, f32> -> !ttcore.tile<16x32, f32>
+  %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<16x32, f32>, !ttcore.tile<16x32, f32>
+        -> !ttcore.tile<16x32, f32>
   return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
@@ -41,6 +41,84 @@ func.func @shared_dfb_selects_compatible_strategy(
 
 // -----
 
+// A flexible operation visited before the fixed SFPU consumer still selects
+// the strategy compatible with the complete kernel requirements.
+// CHECK-LABEL: func.func @reverse_order_sub_selects_compatible_strategy
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0, 1>
+// CHECK: ttl.tile_sub
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+// CHECK-NEXT: ttl.tile_exp
+func.func @reverse_order_sub_selects_compatible_strategy(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    attributes {ttl.enable_fpu_binary_ops = true} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %difference = ttl.tile_sub %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  %exponential = ttl.tile_exp %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// Multiply selects SFPU when a fixed SFPU consumer requires unpack-to-DST mode
+// for the same dataflow buffer.
+// CHECK-LABEL: func.func @shared_dfb_mul_selects_compatible_strategy
+// CHECK-SAME: fp32_dest_acc_en = true
+// CHECK-SAME: ttl.unpack_to_dest_fp32 = array<i32: 0, 1>
+// CHECK: ttl.tile_exp
+// CHECK-NEXT: ttl.tile_mul
+// CHECK-SAME: ttl.tile_execution_strategy = #ttl.tile_execution_strategy<sfpu>
+func.func @shared_dfb_mul_selects_compatible_strategy(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    attributes {ttl.enable_fpu_binary_ops = true} {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %zero = arith.constant 0 : index
+  %lhs_tile = tensor.extract %lhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %rhs_tile = tensor.extract %rhs_attached[%zero, %zero]
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %exponential = ttl.tile_exp %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  %product = ttl.tile_mul %lhs_tile, %rhs_tile into dst[%zero]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+        -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
 // Requirements in nested regions constrain strategy decisions elsewhere in
 // the same compute kernel.
 // CHECK-LABEL: func.func @strategy_resolution_spans_regions

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_compute_edge_cases.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_compute_edge_cases.mlir
@@ -148,8 +148,8 @@ func.func @consecutive_computes(
 // Exercises mapOffsetsAndSizes where the FIRST result is a constant (0) and
 // the second is a dim expression. The col broadcast test in the main file
 // covers the reverse case (first dim, second constant).
-// Inputs have different indexing maps (identity vs row broadcast), so FPU
-// binary detection is skipped. SFPU path: dstPerIteration=2.
+// Different indexing maps make the FPU strategy illegal, so configuration
+// selects SFPU with dstPerIteration=2.
 // DST capacity=4 (f32), dstPerIteration=2, totalTiles=36.
 // unroll_factor = min(4/2, 36) = 2. subblock = [1,2].
 // Both dims tiled: dim0 0..6 step 1, dim1 0..6 step 2.
@@ -214,8 +214,8 @@ func.func @subblock_row_broadcast(
 // broadcast input (1x1) should always extract the full tensor regardless
 // of loop IVs. With 2D subblocking, neither outer loop variable appears
 // in the broadcast input's extract_slice.
-// Inputs have different indexing maps (identity vs scalar broadcast), so FPU
-// binary detection is skipped. SFPU path: dstPerIteration=2.
+// Different indexing maps make the FPU strategy illegal, so configuration
+// selects SFPU with dstPerIteration=2.
 // DST capacity=4 (f32), dstPerIteration=2. subblock=[1,2].
 
 // TILED-LABEL: func.func @subblock_scalar_broadcast

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_compute_for_dst.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_compute_for_dst.mlir
@@ -5,7 +5,7 @@
 
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}))' --split-input-file | FileCheck %s --check-prefix=ASSIGN
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8},ttl-subblock-compute-for-dst,canonicalize,cse))' --split-input-file | FileCheck %s --check-prefix=TILED
-// Actual DST capacity (no override) for broadcast tests where FPU detection matters:
+// Actual DST capacity (no override) for tests where strategy selection matters:
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))' --split-input-file | FileCheck %s --check-prefix=BCAST-ASSIGN
 // RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst,ttl-subblock-compute-for-dst,canonicalize,cse))' --split-input-file | FileCheck %s --check-prefix=BCAST-TILED
 
@@ -384,9 +384,8 @@ func.func @tile_multidim_remainder_3x3(%a: tensor<3x3x!ttcore.tile<32x32, f32>>)
 // expression for the column dimension. Verifies that the broadcast dim
 // retains its original size (1) in extract_slice rather than being
 // incorrectly set to the iteration-domain size (4).
-// The two inputs have different indexing maps (identity vs broadcast), so
-// FPU binary detection is skipped and the op uses the SFPU path with
-// dstPerIteration=2 (copy_tile for both operands).
+// Different input indexing maps make the FPU strategy illegal, so the
+// operation selects SFPU with dstPerIteration=2 (copy_tile for both operands).
 // DST capacity=4 (f32, actual), dstPerIteration=2, totalTiles=16.
 // unroll_factor = min(4/2, 16) = 2.
 // Multi-dim tiling: tileSizes=[1,2], product=2.

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_strict_f32_acc_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_strict_f32_acc_invalid.mlir
@@ -15,7 +15,8 @@
 func.func @strict_f32_subblock_bf16_error(
     %arg0: tensor<3x2x!ttcore.tile<32x32, bf16>>,
     %arg1: tensor<2x3x!ttcore.tile<32x32, bf16>>) -> tensor<3x3x!ttcore.tile<32x32, bf16>>
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, fp32_dest_acc_en} {
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                fp32_dest_acc_en = true} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -42,7 +43,8 @@ func.func @strict_f32_subblock_bf16_error(
 func.func @strict_f32_fits_in_dst_ok(
     %arg0: tensor<2x2x!ttcore.tile<32x32, bf16>>,
     %arg1: tensor<2x2x!ttcore.tile<32x32, bf16>>) -> tensor<2x2x!ttcore.tile<32x32, bf16>>
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>, fp32_dest_acc_en} {
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                fp32_dest_acc_en = true} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index

--- a/test/ttlang/Dialect/TTL/Transforms/tile_execution_strategy_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/tile_execution_strategy_invalid.mlir
@@ -1,0 +1,16 @@
+// Verify that passes consuming selected tile execution semantics reject a
+// strategy that is no longer legal for the operation's operands.
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-assign-dst))' --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-schedule-operations))' --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(convert-ttl-to-ttkernel)' --verify-diagnostics
+
+func.func @stale_fpu_strategy(%lhs: !ttcore.tile<32x32, bf16>,
+                              %rhs: !ttcore.tile<32x32, bf16>) {
+  %zero = arith.constant 0 : index
+  // expected-error @below {{'ttl.tile_add' op explicit ttl.tile_execution_strategy is not legal for its operands}}
+  %sum = ttl.tile_add %lhs, %rhs into dst[%zero]
+      {ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>}
+      : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+        -> !ttcore.tile<32x32, bf16>
+  return
+}

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -214,12 +214,13 @@ def torch_dtype_from_env(var_name: str, default: str = "bf16"):
     return torch_dtype_from_name(os.environ.get(var_name, default))
 
 
-def to_dram(torch_tensor, device):
+def to_dram(torch_tensor, device, tile_hw=None):
     """Create a TTNN tensor in DRAM from a torch tensor.
 
     Args:
         torch_tensor: Source torch tensor
         device: TTNN device handle
+        tile_hw: Optional physical tile dimensions.
 
     Returns:
         TTNN tensor in DRAM with TILE_LAYOUT
@@ -229,13 +230,15 @@ def to_dram(torch_tensor, device):
     ttnn = _get_ttnn()
     if ttnn is None:
         raise RuntimeError("TTNN not available")
-    return ttnn.from_torch(
-        torch_tensor,
+    options = dict(
         dtype=torch_dtype_to_ttnn_datatype(torch_tensor.dtype),
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
+    if tile_hw is not None:
+        options["tile"] = ttnn.Tile(tile_hw)
+    return ttnn.from_torch(torch_tensor, **options)
 
 
 def to_l1(torch_tensor, device):


### PR DESCRIPTION
### Problem description

Compute-kernel configuration is derived through several independent mutable-IR heuristics. Configuration, DST assignment, scheduling, and lowering classify tile operations separately, and DST copy insertion changes the SSA provenance those classifications inspect.

The configuration pass also selects add, subtract, and multiply execution before it knows the complete per-DFB unpack requirements. When one f32 dataflow buffer feeds both a fixed SFPU consumer and a flexible binary operation, the fixed consumer requires unpack-to-DST-f32 while the preferred FPU strategy requires default unpack mode. The pass rejects the kernel even though selecting SFPU for the binary operation is valid. This also prevents f32 composition kernels such as reduce-broadcast-matmul from reaching device execution.

Current Kimi operation sources also select math fidelity at operation construction, but current main rejects the option and cannot propagate it to TTNN compute descriptors.

Fixes #799.

PR #803 is merged into the base and this branch; its preserved physical tile dimensions provide the prerequisite for the shared-DFB subtile coverage.

Subsequent accumulation changes require the same configuration contract. Their accumulator remains in DST while each contribution is read from a dataflow buffer, so execution semantics cannot depend on whether a copy operation is present at a particular pipeline point.

### What's changed

This PR separates target capabilities, compilation policy, target-independent operation requirements, and the resolved kernel plan.

- Add `TileExecutionOpInterface` and explicit `ttl.tile_execution_strategy` selection.
- Analyze the complete kernel before mutation and jointly resolve operation strategies, kernel-wide DST mode, and per-DFB unpack modes.
- Select SFPU when FPU conflicts with another consumer of the same DFB while retaining diagnostics for incompatible fixed requirements.
- Make DST assignment, subblocking, scheduling, and TTL-to-TTKernel lowering consume the recorded strategy instead of re-deriving it.
- Distinguish DST residency from whether DST assignment or operation lowering initializes an operand.
- Replace the `ttl.target_arch` string with `#ttcore.arch`, validate module/device agreement, and attach the detected architecture in the ME2E device pipeline.
- Forward `matmul-full-fp32` through the public TTL-to-TTKernel pipeline and document the configuration contract and pipeline ordering.
- Expose validated `math_fidelity` on unified and explicit operations, include it in compilation identity, apply it to every TTNN compute descriptor, and accept it in simulator builds.

Hardware coverage validates bf16 and f32 shared-DFB consumers. The f32 kernel selects SFPU for the binary operation when FPU would conflict with the fixed consumer's unpack mode. Existing f32 reduce-broadcast-matmul coverage now selects a valid configuration. Additional device coverage executes a unified bf16 operation with `LoFi` and an explicit f32 operation with `HiFi4`; focused unit coverage validates all four fidelity values, invalid input, runtime mapping, cache propagation, and simulator compatibility. MLIR coverage includes nested control flow, reverse operation order, exact add/subtract/multiply conflicts, incompatible fixed consumers, and preservation through DST assignment, compute subblocking, loop lowering, and scheduling.

### Checklist

- [x] New/Existing tests provide coverage for changes
