### PR TITLE
[ttl] Preserve subtile dimensions through compute lowering

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -116,16 +116,6 @@ inline std::optional<mlir::Type> getTileElementType(mlir::Type type) {
   return std::nullopt;
 }
 
-/// Return the tensor's tile type without discarding physical tile dimensions.
-/// Scalar-element tensors use the target-independent default tile dimensions.
-inline ttcore::TileType getTensorTileType(mlir::RankedTensorType tensorType) {
-  if (auto tileType =
-          mlir::dyn_cast<ttcore::TileType>(tensorType.getElementType())) {
-    return tileType;
-  }
-  return ttcore::TileType::get(tensorType.getElementType());
-}
-
 /// Check tilization consistency between two element types.
 /// - Both non-tile: success (no tilization to compare).
 /// - Exactly one side tiled: error (mixed tile/scalar is invalid).

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -116,6 +116,16 @@ inline std::optional<mlir::Type> getTileElementType(mlir::Type type) {
   return std::nullopt;
 }
 
+/// Return the tensor's tile type without discarding physical tile dimensions.
+/// Scalar-element tensors use the target-independent default tile dimensions.
+inline ttcore::TileType getTensorTileType(mlir::RankedTensorType tensorType) {
+  if (auto tileType =
+          mlir::dyn_cast<ttcore::TileType>(tensorType.getElementType())) {
+    return tileType;
+  }
+  return ttcore::TileType::get(tensorType.getElementType());
+}
+
 /// Check tilization consistency between two element types.
 /// - Both non-tile: success (no tilization to compare).
 /// - Exactly one side tiled: error (mixed tile/scalar is invalid).

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <functional>
 
@@ -381,7 +382,7 @@ static LogicalResult collectComputeInstrumentation(
                                 placements, failureReason);
 }
 
-static FailureOr<Type> getResultTileType(Operation *source) {
+static FailureOr<ttcore::TileType> getResultTileType(Operation *source) {
   if (source->getNumResults() != 1) {
     return failure();
   }
@@ -389,7 +390,11 @@ static FailureOr<Type> getResultTileType(Operation *source) {
   if (!tensorType) {
     return failure();
   }
-  return getTensorTileType(tensorType);
+  auto tileType = dyn_cast<ttcore::TileType>(tensorType.getElementType());
+  if (!tileType) {
+    return failure();
+  }
+  return tileType;
 }
 
 static FailureOr<unsigned> findFusedRootInput(const ComputeOpCreationPlan &plan,
@@ -464,9 +469,10 @@ static LogicalResult buildFusedOperationPlans(ComputeOpCreationPlan &plan,
       operationPlan.operands.push_back({value, rootInputIndex});
       return success();
     };
-    FailureOr<Type> resultTileType = getResultTileType(operation);
+    FailureOr<ttcore::TileType> resultTileType = getResultTileType(operation);
     if (failed(resultTileType)) {
-      failureReason = "fused operation result is not a ranked tensor";
+      failureReason =
+          "fused operation result must be a tensor of ttcore.tile elements";
       return failure();
     }
     operationPlan.resultTileType = *resultTileType;
@@ -997,6 +1003,41 @@ bool isComputeOpCreationElision(Operation *source) {
          typecast.getInput().getType() == typecast.getResult().getType();
 }
 
+static std::string formatTensorOfTilesDiagnostic(StringRef role, Type type) {
+  std::string message;
+  llvm::raw_string_ostream stream(message);
+  stream << role << " must be a tensor of ttcore.tile elements, got " << type;
+  return stream.str();
+}
+
+static std::optional<PlanningDiagnostic>
+recordComputeTileTypes(ComputeOpCreationPlan &plan) {
+  auto resultTileType =
+      dyn_cast<ttcore::TileType>(plan.resultType.getElementType());
+  if (!resultTileType) {
+    return PlanningDiagnostic{
+        plan.source,
+        formatTensorOfTilesDiagnostic("compute result", plan.resultType)};
+  }
+  plan.resultTileType = resultTileType;
+
+  for (auto [inputIndex, input] : llvm::enumerate(plan.inputs)) {
+    RankedTensorType inputType = getTensorType(input);
+    auto inputTileType =
+        inputType ? dyn_cast<ttcore::TileType>(inputType.getElementType())
+                  : ttcore::TileType{};
+    if (!inputTileType) {
+      std::string role = "compute input " + std::to_string(inputIndex);
+      return PlanningDiagnostic{
+          plan.source,
+          formatTensorOfTilesDiagnostic(role, inputType ? Type(inputType)
+                                                        : input.getType())};
+    }
+    plan.inputTileTypes.push_back(inputTileType);
+  }
+  return std::nullopt;
+}
+
 bool hasStandaloneComputeOpCreationRecipe(Operation *source) {
   if (source->getNumResults() != 1) {
     return false;
@@ -1018,7 +1059,11 @@ bool hasStandaloneComputeOpCreationRecipe(Operation *source) {
     plan.inputs.push_back(source->getOperand(operandIndex));
   }
   std::string failureReason;
-  return succeeded(buildOperationSpecificPlan(plan, failureReason));
+  if (failed(buildOperationSpecificPlan(plan, failureReason))) {
+    return false;
+  }
+  return plan.kind == ComputeOpCreationKind::Elide ||
+         !recordComputeTileTypes(plan);
 }
 
 PlanningResult<OutputPublicationPlan>
@@ -1251,6 +1296,14 @@ buildComputeOpCreationPlan(Operation *source,
         std::move(failureReason));
   }
 
+  if (plan.kind != ComputeOpCreationKind::Elide) {
+    if (std::optional<PlanningDiagnostic> invalidIR =
+            recordComputeTileTypes(plan)) {
+      return PlanningResult<ComputeOpCreationPlan, ComputeOpCreationRejection>::
+          invalidIR(invalidIR->operation, std::move(invalidIR->message));
+    }
+  }
+
   // Identity typecasts preserve position and storage. They neither form a
   // compute nor alter output publication, so requiring a store would make
   // their legality depend on a later mutation. Record the final input expected
@@ -1374,6 +1427,12 @@ buildPassthroughStorePlan(StoreOp store,
     failureReason = "store input is not a ranked tensor";
     return failure();
   }
+  auto tileType = dyn_cast<ttcore::TileType>(tensorType.getElementType());
+  if (!tileType) {
+    failureReason =
+        formatTensorOfTilesDiagnostic("passthrough store input", tensorType);
+    return failure();
+  }
   if (lifetimes.getAvailability(input, store) ==
       DFBValueAvailability::MayBeReleased) {
     failureReason =
@@ -1389,6 +1448,7 @@ buildPassthroughStorePlan(StoreOp store,
   plan.outputView = store.getView();
   plan.outputDFB = reserve.getCb();
   plan.tensorType = tensorType;
+  plan.tileType = tileType;
   AffineMap identity = AffineMap::getMultiDimIdentityMap(tensorType.getRank(),
                                                          store->getContext());
   plan.iteration.inputMaps = {identity};

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -389,7 +389,7 @@ static FailureOr<Type> getResultTileType(Operation *source) {
   if (!tensorType) {
     return failure();
   }
-  return ttcore::TileType::get(tensorType.getElementType());
+  return getTensorTileType(tensorType);
 }
 
 static FailureOr<unsigned> findFusedRootInput(const ComputeOpCreationPlan &plan,

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -29,6 +29,7 @@
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LogicalResult.h"
 #include "ttlang/Analysis/PlanningResult.h"
+#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
@@ -232,8 +233,8 @@ struct FusedOperationPlan {
   /// Tensor dependencies and their external compute input slots.
   SmallVector<FusedOperationOperand> operands;
 
-  /// Tile result type derived from the source result.
-  Type resultTileType;
+  /// Exact tile result type recorded from the source result.
+  ttcore::TileType resultTileType;
 
   /// Hardware broadcast kind for a tile-broadcast recipe.
   std::optional<BcastType> tileBroadcast;
@@ -462,6 +463,11 @@ struct ComputeOpCreationPlan {
   /// Complete ordered tensor inputs read by the created `ComputeOp`.
   SmallVector<Value> inputs;
 
+  /// Exact tile type for each entry in `inputs`.
+  ///
+  /// Empty for an identity elision, which creates no `ComputeOp`.
+  SmallVector<ttcore::TileType> inputTileTypes;
+
   /// Indexing role for each fused input. A value appears more than once when
   /// distinct uses require different affine maps. Empty for direct creation.
   SmallVector<FusedInputRole> fusedInputRoles;
@@ -474,6 +480,11 @@ struct ComputeOpCreationPlan {
 
   /// Result tensor type used by the created `ComputeOp`.
   RankedTensorType resultType;
+
+  /// Exact result tile type recorded during planning.
+  ///
+  /// Null for an identity elision, which creates no `ComputeOp`.
+  ttcore::TileType resultTileType;
 
   /// Precomputed indexing maps and iterator types.
   ComputeIterationPlan iteration;
@@ -583,6 +594,9 @@ struct PassthroughStorePlan {
 
   /// Tensor type shared by the passthrough input and result.
   RankedTensorType tensorType;
+
+  /// Exact tile type shared by the passthrough input and result.
+  ttcore::TileType tileType;
 
   /// Identity iteration used by the passthrough compute.
   ComputeIterationPlan iteration;

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -430,10 +430,10 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   // tensor's element type so mixed-dtype fusion (e.g., bf16 input + f32
   // intermediate produced by a fused `ttl.typecast`) preserves per-value
   // precision. The output block arg type matches the sink tensor.
-  Type outputTileType = ttcore::TileType::get(type.getElementType());
+  Type outputTileType = getTensorTileType(type);
   auto getInputTileType = [&](Value root) -> Type {
     auto inputTensor = cast<RankedTensorType>(root.getType());
-    return ttcore::TileType::get(inputTensor.getElementType());
+    return getTensorTileType(inputTensor);
   };
 
   for (Value root : creation.inputs) {
@@ -587,9 +587,9 @@ static LogicalResult buildComputeFromInputs(
     if (!inputType) {
       return rewriter.notifyMatchFailure(op, "input is not a ranked tensor");
     }
-    inputTileTypes.push_back(ttcore::TileType::get(inputType.getElementType()));
+    inputTileTypes.push_back(getTensorTileType(inputType));
   }
-  Type outputTileType = ttcore::TileType::get(outputType.getElementType());
+  Type outputTileType = getTensorTileType(outputType);
 
   SmallVector<Attribute> maps;
   for (AffineMap inputMap : creation->iteration.inputMaps) {
@@ -1008,8 +1008,7 @@ struct LowerStoreToCompute : OpRewritePattern<StoreOp> {
         rewriter.getArrayAttr(iteratorTypes));
 
     Block *body = rewriter.createBlock(&computeOp.getBody());
-    Type scalarType = inputType.getElementType();
-    Type tileType = ttcore::TileType::get(scalarType);
+    Type tileType = getTensorTileType(inputType);
     body->addArgument(tileType, loc);
     body->addArgument(tileType, loc);
 

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -426,21 +426,11 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   // Build the body region
   Block *body = rewriter.createBlock(&computeOp.getBody());
 
-  // Each block argument's tile type is derived from its corresponding
-  // tensor's element type so mixed-dtype fusion (e.g., bf16 input + f32
-  // intermediate produced by a fused `ttl.typecast`) preserves per-value
-  // precision. The output block arg type matches the sink tensor.
-  Type outputTileType = getTensorTileType(type);
-  auto getInputTileType = [&](Value root) -> Type {
-    auto inputTensor = cast<RankedTensorType>(root.getType());
-    return getTensorTileType(inputTensor);
-  };
-
-  for (Value root : creation.inputs) {
-    body->addArgument(getInputTileType(root), loc);
+  for (ttcore::TileType inputTileType : creation.inputTileTypes) {
+    body->addArgument(inputTileType, loc);
   }
   for (size_t i = 0; i < outputs.dfbs.size(); ++i) {
-    body->addArgument(outputTileType, loc);
+    body->addArgument(creation.resultTileType, loc);
   }
 
   rewriter.setInsertionPointToStart(body);
@@ -581,16 +571,6 @@ static LogicalResult buildComputeFromInputs(
   ValueRange inputs(creation->inputs);
   RankedTensorType outputType = creation->resultType;
 
-  SmallVector<Type> inputTileTypes;
-  for (Value input : inputs) {
-    auto inputType = getTensorType(input);
-    if (!inputType) {
-      return rewriter.notifyMatchFailure(op, "input is not a ranked tensor");
-    }
-    inputTileTypes.push_back(getTensorTileType(inputType));
-  }
-  Type outputTileType = getTensorTileType(outputType);
-
   SmallVector<Attribute> maps;
   for (AffineMap inputMap : creation->iteration.inputMaps) {
     maps.push_back(AffineMapAttr::get(inputMap));
@@ -625,18 +605,19 @@ static LogicalResult buildComputeFromInputs(
                                      rewriter.getArrayAttr(iteratorTypes));
 
   Block *body = rewriter.createBlock(&computeOp.getBody());
-  for (Type inputTileType : inputTileTypes) {
+  for (ttcore::TileType inputTileType : creation->inputTileTypes) {
     body->addArgument(inputTileType, loc);
   }
   for (size_t i = 0; i < outputs.dfbs.size(); ++i) {
-    body->addArgument(outputTileType, loc);
+    body->addArgument(creation->resultTileType, loc);
   }
 
   rewriter.setInsertionPointToStart(body);
   ComputeInstrumentationEmitter instrumentationEmitter(
       rewriter, creation->instrumentation);
   instrumentationEmitter.emitLeading();
-  Value result = emitTileOp(rewriter, loc, outputTileType, body, *creation);
+  Value result =
+      emitTileOp(rewriter, loc, creation->resultTileType, body, *creation);
   instrumentationEmitter.emitAfter(op);
   for (StoreOp store : outputs.stores) {
     emitTileStore(rewriter, loc, result, computeOp, store, outputs);
@@ -1008,9 +989,8 @@ struct LowerStoreToCompute : OpRewritePattern<StoreOp> {
         rewriter.getArrayAttr(iteratorTypes));
 
     Block *body = rewriter.createBlock(&computeOp.getBody());
-    Type tileType = getTensorTileType(inputType);
-    body->addArgument(tileType, loc);
-    body->addArgument(tileType, loc);
+    body->addArgument(plan.tileType, loc);
+    body->addArgument(plan.tileType, loc);
 
     rewriter.setInsertionPointToEnd(body);
     SmallVector<Value> iterIndices =

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -10,6 +10,7 @@ from typing import Any, Tuple
 from ttl.ir import *
 
 from ._src.ttl_ast import syntax
+from .constants import DEFAULT_TILE_SIZE
 from ttl.dialects import ttl
 
 # Module-level counter for DFB index assignment in creation order
@@ -61,7 +62,7 @@ class DataflowBuffer:
         shape: Tuple[int, ...],
         block_count: int,
         dtype: Any = None,
-        tile: Tuple[int, int] = (32, 32),
+        tile: Tuple[int, int] = (DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE),
     ):
         if len(shape) < 2:
             raise ValueError(f"DFB shape must have at least 2 dimensions, got {shape}")
@@ -143,15 +144,15 @@ class CompilerAllocatedDFBConfig:
     """Configuration for a compiler-allocated dataflow buffer.
 
     Created by the Python runtime after reading the ttl.compiler_allocated_dfbs
-    module attribute produced by the ttl-finalize-dfb-indices pass. Carries
-    the same information as a user-declared DataflowBuffer but without a
-    backing tensor -- the data format comes directly from the MLIR attribute.
+    module attribute produced by the ttl-finalize-dfb-indices pass. Includes
+    the static storage configuration needed without a backing tensor.
     """
 
     dfb_index: int
     num_tiles: int
     data_format: str  # e.g., "bf16", "f32", "f16"
     block_count: int
+    tile: Tuple[int, int] = (DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE)
 
 
 def make_dataflow_buffer_like(
@@ -170,7 +171,7 @@ def make_dataflow_buffer_like(
     Returns:
         DataflowBuffer for use in thread function closures
     """
-    tile = (32, 32)
+    tile = (DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE)
     if hasattr(tensor, "get_tile"):
         tile = tuple(tensor.get_tile().tile_shape)
     return DataflowBuffer(tensor, shape, block_count, tile=tile)

--- a/python/ttl/dtype_utils.py
+++ b/python/ttl/dtype_utils.py
@@ -193,34 +193,54 @@ def format_name_to_ttnn_dtype(name: str):
             )
 
 
-def tile_bytes_from_dtype(dtype) -> int:
+def tile_bytes_from_dtype(dtype, tile=(32, 32)) -> int:
     """
     Calculate tile size in bytes from ttnn dtype.
 
-    For tiled tensors, each tile is 32x32 elements. The byte size depends on
-    the data type's element size plus any format-specific overhead.
+    The byte size matches ttcore::TileType::getSizeBytes(). Dense formats scale
+    with the physical tile dimensions. BFP formats currently support only the
+    default 32x32 tile dimensions.
 
     Args:
         dtype: ttnn.DataType enum value
+        tile: Physical tile dimensions as (height, width)
 
     Returns:
         Tile size in bytes
 
     Raises:
-        ValueError: If dtype is not supported
+        ValueError: If dtype or its tile dimensions are not supported
     """
-    dtype_int = dtype.value
-    # Map ttnn DataType enum values to tile sizes
-    # Reference: tt-metal/tt_metal/common/constants.hpp
-    if dtype_int in (0, 6):  # BFloat16, UInt16
-        return 32 * 32 * 2  # 2048
-    elif dtype_int in (1, 2, 7):  # Float32, Int32, UInt32
-        return 32 * 32 * 4  # 4096
-    elif dtype_int == 3:  # BFP8
+    if len(tile) != 2:
+        raise ValueError(f"Expected 2D tile dimensions, got {tile}")
+    tile_height, tile_width = tile
+    if tile_height <= 0 or tile_width <= 0:
+        raise ValueError(f"Tile dimensions must be positive, got {tile}")
+
+    _ensure_ttnn()
+    if ttnn is None:
+        raise RuntimeError("ttnn is not available")
+
+    tile_elements = tile_height * tile_width
+    # Keep this mapping synchronized with ttcore::TileType::getSizeBytes().
+    if dtype in (ttnn.DataType.BFLOAT16, ttnn.DataType.UINT16):
+        return tile_elements * 2
+    if dtype in (
+        ttnn.DataType.FLOAT32,
+        ttnn.DataType.INT32,
+        ttnn.DataType.UINT32,
+    ):
+        return tile_elements * 4
+    if dtype == ttnn.DataType.UINT8:
+        return tile_elements
+    bfp_dtypes = (
+        ttnn.DataType.BFLOAT8_B,
+        ttnn.DataType.BFLOAT4_B,
+    )
+    if dtype in bfp_dtypes and tuple(tile) != (32, 32):
+        raise ValueError(f"{dtype} supports only 32x32 tiles, got {tile}")
+    if dtype == ttnn.DataType.BFLOAT8_B:
         return 32 * 32 + 64  # 1088
-    elif dtype_int == 5:  # UInt8/Int8
-        return 32 * 32  # 1024
-    elif dtype_int == 4:  # BFP4
+    if dtype == ttnn.DataType.BFLOAT4_B:
         return 512 + 64  # 576
-    else:
-        raise ValueError(f"Unsupported dtype for tile size calculation: {dtype}")
+    raise ValueError(f"Unsupported dtype for tile size calculation: {dtype}")

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -38,6 +38,7 @@ from .dataflow_buffer import CompilerAllocatedDFBConfig
 from .constants import DEFAULT_L1_CB_BUDGET_BYTES
 from .dtype_utils import (
     format_name_to_ttnn_dtype,
+    tile_bytes_from_dtype,
     torch_dtype_to_ttnn_datatype,
 )
 
@@ -423,7 +424,7 @@ def build_cb_descriptors(
         data_format = _dfb_data_format(cb)
         tile = ttnn.Tile(cb.tile)
         tile_descriptor = ttnn.TileDescriptor(tile)
-        page_size = tile.get_tile_size(data_format)
+        page_size = tile_bytes_from_dtype(data_format, cb.tile)
         total_size = _dfb_capacity_tiles(cb) * page_size
         if isinstance(cb, CompilerAllocatedDFBConfig):
             description = (
@@ -754,8 +755,7 @@ def emit_runner_source(
             continue
         data_format = _dfb_data_format(cb)
         tile_hw = tuple(cb.tile)
-        tile = ttnn.Tile(tile_hw)
-        page_size = tile.get_tile_size(data_format)
+        page_size = tile_bytes_from_dtype(data_format, tile_hw)
         dtype_str = _dtype_to_ttnn_str(data_format)
         total_size = _dfb_capacity_tiles(cb) * page_size
         lines.append(

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -38,17 +38,25 @@ from .dataflow_buffer import CompilerAllocatedDFBConfig
 from .constants import DEFAULT_L1_CB_BUDGET_BYTES
 from .dtype_utils import (
     format_name_to_ttnn_dtype,
-    tile_bytes_from_dtype,
     torch_dtype_to_ttnn_datatype,
 )
 
 
-def _cb_data_format(cb):
-    """ttnn data format for a DataflowBuffer, from its (torch or ttnn) dtype."""
-    dtype = cb.dtype
+def _dfb_data_format(dfb):
+    """Return the ttnn data format for a user or compiler-allocated DFB."""
+    if isinstance(dfb, CompilerAllocatedDFBConfig):
+        return format_name_to_ttnn_dtype(dfb.data_format)
+    dtype = dfb.dtype
     if hasattr(dtype, "name"):  # already a ttnn.DataType enum
         return dtype
     return torch_dtype_to_ttnn_datatype(dtype)
+
+
+def _dfb_capacity_tiles(dfb) -> int:
+    """Return the DFB capacity using its declared tile-count representation."""
+    if isinstance(dfb, CompilerAllocatedDFBConfig):
+        return dfb.num_tiles * dfb.block_count
+    return dfb.shape[0] * dfb.shape[1] * dfb.block_count
 
 
 def get_min_remaining_l1_for_device(device):
@@ -412,36 +420,23 @@ def build_cb_descriptors(
                 f"All DFB indices must have associated DataflowBuffer configurations."
             )
 
+        data_format = _dfb_data_format(cb)
+        tile = ttnn.Tile(cb.tile)
+        tile_descriptor = ttnn.TileDescriptor(tile)
+        page_size = tile.get_tile_size(data_format)
+        total_size = _dfb_capacity_tiles(cb) * page_size
         if isinstance(cb, CompilerAllocatedDFBConfig):
-            data_format = format_name_to_ttnn_dtype(cb.data_format)
-            page_size = tile_bytes_from_dtype(data_format)
-            total_size = cb.num_tiles * cb.block_count * page_size
-            rows.append(
-                (
-                    data_format,
-                    page_size,
-                    total_size,
-                    None,
-                    f"  CB[{i}]: compiler-allocated num_tiles={cb.num_tiles} "
-                    f"block_count={cb.block_count} format={cb.data_format} -> {total_size} bytes",
-                )
+            description = (
+                f"  CB[{i}]: compiler-allocated num_tiles={cb.num_tiles} "
+                f"block_count={cb.block_count} format={cb.data_format} "
+                f"tile={cb.tile} -> {total_size} bytes"
             )
         else:
-            data_format = _cb_data_format(cb)
-            tile = ttnn.Tile(cb.tile)
-            tile_descriptor = ttnn.TileDescriptor(tile)
-            page_size = tile.get_tile_size(data_format)
-            num_tiles = cb.shape[0] * cb.shape[1] * cb.block_count
-            total_size = num_tiles * page_size
-            rows.append(
-                (
-                    data_format,
-                    page_size,
-                    total_size,
-                    tile_descriptor,
-                    f"  CB[{i}]: shape={cb.shape} block_count={cb.block_count} -> {total_size} bytes",
-                )
+            description = (
+                f"  CB[{i}]: shape={cb.shape} block_count={cb.block_count} "
+                f"tile={cb.tile} -> {total_size} bytes"
             )
+        rows.append((data_format, page_size, total_size, tile_descriptor, description))
 
         total_cb_bytes += total_size
 
@@ -454,8 +449,8 @@ def build_cb_descriptors(
             remaining_bytes = get_min_remaining_l1_for_device(device)
             break
 
-    # Must stay aligned with MLIR ttl-validate-cb-budget (TileType::getSizeBytes) and
-    # tile_bytes_from_dtype; see issue #511.
+    # Must stay aligned with MLIR ttl-validate-cb-budget
+    # (TileType::getSizeBytes()); see issue #511.
     if total_cb_bytes > remaining_bytes:
         breakdown = "\n".join(r[-1] for r in rows)
         raise ValueError(
@@ -757,13 +752,14 @@ def emit_runner_source(
         if cb is None:
             lines.append(f"    None,  # CB {i}")
             continue
-        data_format = _cb_data_format(cb)
-        page_size = tile_bytes_from_dtype(data_format)
+        data_format = _dfb_data_format(cb)
+        tile_hw = tuple(cb.tile)
+        tile = ttnn.Tile(tile_hw)
+        page_size = tile.get_tile_size(data_format)
         dtype_str = _dtype_to_ttnn_str(data_format)
-        num_tiles = cb.shape[0] * cb.shape[1] * cb.block_count
-        total_size = num_tiles * page_size
+        total_size = _dfb_capacity_tiles(cb) * page_size
         lines.append(
-            f"    ({cb.shape!r}, {cb.block_count}, {dtype_str}, {page_size}, {total_size}),  # CB {i}"
+            f"    ({tile_hw!r}, {dtype_str}, {page_size}, {total_size}),  # CB {i}"
         )
     lines.append("]")
     lines.append("")
@@ -797,12 +793,14 @@ def emit_runner_source(
 
     lines.append("    cb_descriptors = []")
     lines.append(
-        "    for i, (shape, block_count, dtype, page_size, total_size) in enumerate(CB_CONFIGS):"
+        "    for i, (tile_hw, dtype, page_size, total_size) in enumerate(CB_CONFIGS):"
     )
+    lines.append("        tile = ttnn.Tile(tile_hw)")
     lines.append("        cb_format = ttnn.CBFormatDescriptor(")
     lines.append("            buffer_index=i,")
     lines.append("            data_format=dtype,")
     lines.append("            page_size=page_size,")
+    lines.append("            tile=ttnn.TileDescriptor(tile),")
     lines.append("        )")
     lines.append("        cb_desc = ttnn.CBDescriptor(")
     lines.append("            total_size=total_size,")

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1240,8 +1240,11 @@ _MLIR_TYPE_TO_FORMAT = {
     "f16": "float16",
     "f32": "float32",
     "i32": "int32",
+    "si32": "int32",
     "ui32": "uint32",
+    "u32": "uint32",
     "ui16": "uint16",
+    "u16": "uint16",
 }
 
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -48,7 +48,7 @@ def _ensure_ttnn():
 import ttl._mlir_libs._ttlang  # Register tt-lang passes
 from ttl._mlir_libs._ttlang import ttl_ir as _ttl_ir
 from ttl.pykernel._src.utils import _cleanup_source_code
-from ttl.dialects import ttkernel
+from ttl.dialects import ttcore, ttkernel
 from ttl.ir import *
 from ttl.ir import DenseI32ArrayAttr
 from ttl.passes import (
@@ -84,7 +84,7 @@ from .dataflow_buffer import (
     get_cb_count,
 )
 from .pipe import Pipe, PipeNet
-from .constants import SUPPORTED_MEMORY_SPACES
+from .constants import DEFAULT_TILE_SIZE, SUPPORTED_MEMORY_SPACES
 from .diagnostics import (
     TTLangCompileError,
     find_variable_assignment,
@@ -93,7 +93,6 @@ from .diagnostics import (
 )
 from .dtype_utils import (
     is_ttnn_tensor,
-    tile_bytes_from_dtype,
     torch_dtype_to_ttnn_datatype,
 )
 from .kernel_runner import (
@@ -1246,21 +1245,32 @@ _MLIR_TYPE_TO_FORMAT = {
 }
 
 
-def _parse_mlir_element_type(type_str: str) -> str:
-    """Extract the base data format name from an MLIR TypeAttr string.
+def _parse_mlir_dfb_element_type(element_type_attr) -> tuple[str, tuple[int, int]]:
+    """Extract the data format and physical tile dimensions from a TypeAttr.
 
     The TypeAttr prints as e.g. "bf16" or "!ttcore.tile<32x32, bf16>".
-    This function extracts the trailing type mnemonic and maps it to a
-    ttnn-compatible format name.
+    Scalar elements use the default tile dimensions.
     """
-    # For compound types like "!ttcore.tile<32x32, bf16>", extract the
-    # type after the last comma. For bare types like "bf16", use as-is.
+    if not isinstance(element_type_attr, TypeAttr):
+        raise ValueError(
+            "Compiler-allocated DFB element_type metadata must be a TypeAttr, "
+            f"got {element_type_attr}"
+        )
+    element_type = element_type_attr.value
+    tile_type = ttcore.ir.TileType.maybe_downcast(element_type)
+    tile = (
+        tuple(tile_type.shape)
+        if tile_type is not None
+        else (DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE)
+    )
+
+    type_str = str(element_type)
     token = type_str.strip()
     if "," in token:
         token = token.rsplit(",", 1)[1].strip().rstrip(">").strip()
     fmt = _MLIR_TYPE_TO_FORMAT.get(token)
     if fmt is not None:
-        return fmt
+        return fmt, tile
     raise ValueError(
         f"Unrecognized MLIR element type '{token}' (from '{type_str}'). "
         f"Known types: {list(_MLIR_TYPE_TO_FORMAT.keys())}"
@@ -1283,7 +1293,7 @@ def _extract_compiler_allocated_dfbs(module):
         dfb_index = int(entry["dfb_index"])
         num_tiles = int(entry["num_tiles"])
         block_count = int(entry["block_count"])
-        data_format = _parse_mlir_element_type(str(entry["element_type"]))
+        data_format, tile = _parse_mlir_dfb_element_type(entry["element_type"])
 
         configs.append(
             CompilerAllocatedDFBConfig(
@@ -1291,6 +1301,7 @@ def _extract_compiler_allocated_dfbs(module):
                 num_tiles=num_tiles,
                 data_format=data_format,
                 block_count=block_count,
+                tile=tile,
             )
         )
     return configs

--- a/test/python/test_compiler_allocated_dfb_metadata.py
+++ b/test/python/test_compiler_allocated_dfb_metadata.py
@@ -10,24 +10,41 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 from ttl.dataflow_buffer import CompilerAllocatedDFBConfig
 from ttl.dialects import ttl
+from ttl.dtype_utils import tile_bytes_from_dtype
 from ttl.ir import Context, Module
 from ttl.kernel_runner import build_cb_descriptors, emit_runner_source
 from ttl.ttl_api import _extract_compiler_allocated_dfbs
 
 
-def test_extract_compiler_allocated_subtile_metadata():
+MLIR_FORMAT_CASES = [
+    ("bf16", "bfloat16", 2),
+    ("f16", "float16", 2),
+    ("f32", "float32", 4),
+    ("si32", "int32", 4),
+    ("u32", "uint32", 4),
+    ("u16", "uint16", 2),
+]
+COMPUTE_TILE_SIZES = [(16, 16), (16, 32), (32, 16), (32, 32)]
+
+
+@pytest.mark.parametrize(
+    "mlir_type,data_format",
+    [(case[0], case[1]) for case in MLIR_FORMAT_CASES],
+    ids=[case[0] for case in MLIR_FORMAT_CASES],
+)
+def test_extract_compiler_allocated_subtile_metadata(mlir_type, data_format):
     with Context() as context:
         ttl.ensure_dialects_registered(context)
         module = Module.parse(
-            """
-            module attributes {
-              ttl.compiler_allocated_dfbs = [{
+            f"""
+            module attributes {{
+              ttl.compiler_allocated_dfbs = [{{
                 block_count = 2 : i32,
                 dfb_index = 3 : i32,
-                element_type = !ttcore.tile<16x32, bf16>,
+                element_type = !ttcore.tile<16x32, {mlir_type}>,
                 num_tiles = 5 : i32
-              }]
-            } {}
+              }}]
+            }} {{}}
             """
         )
         configs = _extract_compiler_allocated_dfbs(module)
@@ -36,32 +53,61 @@ def test_extract_compiler_allocated_subtile_metadata():
         CompilerAllocatedDFBConfig(
             dfb_index=3,
             num_tiles=5,
-            data_format="bfloat16",
+            data_format=data_format,
             block_count=2,
             tile=(16, 32),
         )
     ]
 
 
-def test_compiler_allocated_subtile_descriptor():
+@pytest.mark.parametrize(
+    "data_format,bytes_per_element",
+    [(case[1], case[2]) for case in MLIR_FORMAT_CASES],
+    ids=[case[0] for case in MLIR_FORMAT_CASES],
+)
+@pytest.mark.parametrize(
+    "tile_hw", COMPUTE_TILE_SIZES, ids=lambda tile: f"{tile[0]}x{tile[1]}"
+)
+def test_compiler_allocated_subtile_descriptor(data_format, bytes_per_element, tile_hw):
     core_ranges = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}
     )
     config = CompilerAllocatedDFBConfig(
         dfb_index=0,
         num_tiles=3,
-        data_format="bfloat16",
+        data_format=data_format,
         block_count=2,
-        tile=(16, 32),
+        tile=tile_hw,
     )
 
     descriptor = build_cb_descriptors([None], [config], core_ranges)[0]
     format_descriptor = descriptor.format_descriptors[0]
+    tile_height, tile_width = tile_hw
+    page_size = tile_height * tile_width * bytes_per_element
 
-    assert descriptor.total_size == 6 * 16 * 32 * 2
-    assert format_descriptor.page_size == 16 * 32 * 2
-    assert format_descriptor.tile.height == 16
-    assert format_descriptor.tile.width == 32
+    assert descriptor.total_size == 6 * page_size
+    assert format_descriptor.page_size == page_size
+    assert format_descriptor.tile.height == tile_height
+    assert format_descriptor.tile.width == tile_width
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
+def test_bfp_subtile_size_is_rejected(dtype):
+    with pytest.raises(ValueError, match="supports only 32x32 tiles"):
+        tile_bytes_from_dtype(dtype, (16, 32))
+
+
+@pytest.mark.parametrize(
+    "dtype,tile_hw,expected_size",
+    [
+        (ttnn.uint8, (16, 32), 512),
+        (ttnn.bfloat8_b, (32, 32), 1088),
+        (ttnn.bfloat4_b, (32, 32), 576),
+    ],
+    ids=["uint8-subtile", "bfp8", "bfp4"],
+)
+def test_tile_size_for_remaining_ttnn_formats(dtype, tile_hw, expected_size):
+    assert tile_bytes_from_dtype(dtype, tile_hw) == expected_size
 
 
 def test_emitted_runner_preserves_compiler_allocated_subtile():

--- a/test/python/test_compiler_allocated_dfb_metadata.py
+++ b/test/python/test_compiler_allocated_dfb_metadata.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests compiler-allocated DFB tile metadata and runtime descriptors."""
+
+import pytest
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttl.dataflow_buffer import CompilerAllocatedDFBConfig
+from ttl.dialects import ttl
+from ttl.ir import Context, Module
+from ttl.kernel_runner import build_cb_descriptors, emit_runner_source
+from ttl.ttl_api import _extract_compiler_allocated_dfbs
+
+
+def test_extract_compiler_allocated_subtile_metadata():
+    with Context() as context:
+        ttl.ensure_dialects_registered(context)
+        module = Module.parse(
+            """
+            module attributes {
+              ttl.compiler_allocated_dfbs = [{
+                block_count = 2 : i32,
+                dfb_index = 3 : i32,
+                element_type = !ttcore.tile<16x32, bf16>,
+                num_tiles = 5 : i32
+              }]
+            } {}
+            """
+        )
+        configs = _extract_compiler_allocated_dfbs(module)
+
+    assert configs == [
+        CompilerAllocatedDFBConfig(
+            dfb_index=3,
+            num_tiles=5,
+            data_format="bfloat16",
+            block_count=2,
+            tile=(16, 32),
+        )
+    ]
+
+
+def test_compiler_allocated_subtile_descriptor():
+    core_ranges = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}
+    )
+    config = CompilerAllocatedDFBConfig(
+        dfb_index=0,
+        num_tiles=3,
+        data_format="bfloat16",
+        block_count=2,
+        tile=(16, 32),
+    )
+
+    descriptor = build_cb_descriptors([None], [config], core_ranges)[0]
+    format_descriptor = descriptor.format_descriptors[0]
+
+    assert descriptor.total_size == 6 * 16 * 32 * 2
+    assert format_descriptor.page_size == 16 * 32 * 2
+    assert format_descriptor.tile.height == 16
+    assert format_descriptor.tile.width == 32
+
+
+def test_emitted_runner_preserves_compiler_allocated_subtile():
+    config = CompilerAllocatedDFBConfig(
+        dfb_index=0,
+        num_tiles=3,
+        data_format="bfloat16",
+        block_count=2,
+        tile=(16, 32),
+    )
+
+    source = emit_runner_source(
+        kernel_specs=[],
+        cb_configs=[config],
+        grid_cols=1,
+        grid_rows=1,
+        num_tensors=0,
+    )
+
+    assert "((16, 32), ttnn.bfloat16, 1024, 6144)" in source
+    assert "tile=ttnn.TileDescriptor(tile)" in source

--- a/test/python/test_subtile_compute.py
+++ b/test/python/test_subtile_compute.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device coverage for compute operations using LLK-supported tile dimensions."""
+
+import pytest
+import torch
+
+import ttl
+from utils.correctness import assert_allclose
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+
+@ttl.operation(grid=(1, 1))
+def materialized_subtile_exp(inp, out):
+    input_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    output_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        input_block = input_dfb.wait()
+        result = ttl.math.exp(input_block)
+        input_block.pop()
+        output_block = output_dfb.reserve()
+        output_block.store(result)
+
+    @ttl.datamovement()
+    def reader():
+        ttl.copy(inp[0:1, 0:1], input_dfb.reserve())
+
+    @ttl.datamovement()
+    def writer():
+        ttl.copy(output_dfb.wait(), out[0:1, 0:1])
+
+
+COMPUTE_TILE_SIZES = [(16, 16), (16, 32), (32, 16), (32, 32)]
+DTYPES = [
+    (torch.bfloat16, ttnn.bfloat16, 5e-2, 1.0),
+    (torch.float32, ttnn.float32, 1e-3, 1e-3),
+]
+
+
+def _to_device(torch_tensor, device, tile_hw, dtype):
+    return ttnn.from_torch(
+        torch_tensor,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        tile=ttnn.Tile(tile_hw),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+@pytest.mark.parametrize(
+    "tile_hw", COMPUTE_TILE_SIZES, ids=lambda tile: f"{tile[0]}x{tile[1]}"
+)
+@pytest.mark.parametrize(
+    "torch_dtype,ttnn_dtype,rtol,atol",
+    DTYPES,
+    ids=["bf16", "fp32"],
+)
+def test_materialized_subtile_exp(device, tile_hw, torch_dtype, ttnn_dtype, rtol, atol):
+    tile_height, tile_width = tile_hw
+    source = torch.linspace(-0.5, 0.5, tile_height * tile_width).reshape(tile_hw)
+    source = source.to(torch_dtype)
+    expected = torch.exp(source.float())
+    input_tensor = _to_device(source, device, tile_hw, ttnn_dtype)
+    output_tensor = _to_device(
+        torch.zeros(tile_hw, dtype=torch_dtype), device, tile_hw, ttnn_dtype
+    )
+
+    materialized_subtile_exp(input_tensor, output_tensor)
+
+    actual = ttnn.to_torch(output_tensor).reshape(tile_hw).float()
+    assert_allclose(actual, expected.float(), rtol=rtol, atol=atol)

--- a/test/ttlang/Conversion/TTLToCompute/subtile.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/subtile.mlir
@@ -1,0 +1,114 @@
+// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),canonicalize)' | FileCheck %s
+
+// Verifies that conversion preserves physical tile dimensions for direct,
+// fused, and passthrough compute operations.
+
+// Direct elementwise lowering uses the tensor element tile type for every
+// compute block argument and tile result.
+// CHECK-LABEL: func.func @direct_subtile
+// CHECK:       %[[RESULT:.*]] = ttl.compute
+// CHECK-NEXT:  ^bb0(%[[INPUT:.*]]: !ttcore.tile<16x32, bf16>, %[[OUTPUT:.*]]: !ttcore.tile<16x32, bf16>):
+// CHECK-NEXT:    %[[ROW:.*]] = ttl.iter_index 0
+// CHECK-NEXT:    %[[COL:.*]] = ttl.iter_index 1
+// CHECK-NEXT:    %[[EXP:.*]] = ttl.tile_exp %[[INPUT]]{{.*}} -> !ttcore.tile<16x32, bf16>
+// CHECK-NEXT:    ttl.tile_store %[[EXP]], %{{.*}}[%[[ROW]], %[[COL]]]
+// CHECK:       } -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+func.func @direct_subtile(%arg: tensor<1x1x!ttcore.tile<16x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<16x32, bf16>> {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 2>
+  %input = ttl.attach_cb %arg, %input_dfb
+      : (tensor<1x1x!ttcore.tile<16x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+  %result = ttl.exp %input
+      : tensor<1x1x!ttcore.tile<16x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+  ttl.store %result, %output
+      : tensor<1x1x!ttcore.tile<16x32, bf16>>,
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
+  return %result : tensor<1x1x!ttcore.tile<16x32, bf16>>
+}
+
+// -----
+
+// Fused lowering preserves physical tile dimensions through intermediate tile
+// operations and the output store.
+// CHECK-LABEL: func.func @fused_subtile
+// CHECK:       %[[RESULT:.*]] = ttl.compute
+// CHECK-NEXT:  ^bb0(%[[LHS:.*]]: !ttcore.tile<32x16, f32>, %[[RHS:.*]]: !ttcore.tile<32x16, f32>, %[[OUTPUT:.*]]: !ttcore.tile<32x16, f32>):
+// CHECK-NEXT:    %[[ROW:.*]] = ttl.iter_index 0
+// CHECK-NEXT:    %[[COL:.*]] = ttl.iter_index 1
+// CHECK-NEXT:    %[[EXP:.*]] = ttl.tile_exp %[[LHS]]{{.*}} -> !ttcore.tile<32x16, f32>
+// CHECK-NEXT:    %[[SUM:.*]] = ttl.tile_add %[[EXP]], %[[RHS]]{{.*}} -> !ttcore.tile<32x16, f32>
+// CHECK-NEXT:    ttl.tile_store %[[SUM]], %{{.*}}[%[[ROW]], %[[COL]]]
+// CHECK:       } -> tensor<1x1x!ttcore.tile<32x16, f32>>
+func.func @fused_subtile(
+    %lhs_arg: tensor<1x1x!ttcore.tile<32x16, f32>>,
+    %rhs_arg: tensor<1x1x!ttcore.tile<32x16, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x16, f32>> {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>
+  %lhs = ttl.attach_cb %lhs_arg, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x16, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %rhs = ttl.attach_cb %rhs_arg, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x16, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x16, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x16, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %exp = ttl.exp %lhs
+      : tensor<1x1x!ttcore.tile<32x16, f32>>
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  %result = ttl.add %exp, %rhs
+      : tensor<1x1x!ttcore.tile<32x16, f32>>,
+        tensor<1x1x!ttcore.tile<32x16, f32>>
+        -> tensor<1x1x!ttcore.tile<32x16, f32>>
+  ttl.store %result, %output
+      : tensor<1x1x!ttcore.tile<32x16, f32>>,
+        tensor<1x1x!ttcore.tile<32x16, f32>>
+  return %result : tensor<1x1x!ttcore.tile<32x16, f32>>
+}
+
+// -----
+
+// Passthrough-store lowering preserves physical tile dimensions when it
+// constructs the compute block arguments.
+// CHECK-LABEL: func.func @passthrough_subtile
+// CHECK:       %[[RESULT:.*]] = ttl.compute
+// CHECK-NEXT:  ^bb0(%[[INPUT:.*]]: !ttcore.tile<16x16, bf16>, %[[OUTPUT:.*]]: !ttcore.tile<16x16, bf16>):
+// CHECK-NEXT:    %[[ROW:.*]] = ttl.iter_index 0
+// CHECK-NEXT:    %[[COL:.*]] = ttl.iter_index 1
+// CHECK-NEXT:    ttl.tile_store %[[INPUT]], %{{.*}}[%[[ROW]], %[[COL]]]
+// CHECK-NEXT:    ttl.yield
+// CHECK-NEXT:  } -> tensor<1x1x!ttcore.tile<16x16, bf16>>
+func.func @passthrough_subtile(%arg: tensor<1x1x!ttcore.tile<16x16, bf16>>)
+    -> tensor<1x1x!ttcore.tile<16x16, bf16>> {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x16, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x16, bf16>, 2>
+  %input = ttl.attach_cb %arg, %input_dfb
+      : (tensor<1x1x!ttcore.tile<16x16, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<16x16, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<16x16, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<16x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<16x16, bf16>>
+  ttl.store %input, %output
+      : tensor<1x1x!ttcore.tile<16x16, bf16>>,
+        tensor<1x1x!ttcore.tile<16x16, bf16>>
+  return %input : tensor<1x1x!ttcore.tile<16x16, bf16>>
+}

--- a/test/ttlang/Conversion/TTLToCompute/tensor_tile_types_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/tensor_tile_types_invalid.mlir
@@ -1,0 +1,78 @@
+// RUN: ttlang-opt --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute))' --verify-diagnostics --split-input-file %s
+
+// Verify that compute creation requires explicit physical tile types instead
+// of assigning default tile dimensions to scalar-element tensors.
+
+// A tensor operation cannot produce a scalar-element tensor because its
+// physical tile dimensions are unavailable.
+module {
+  func.func @scalar_result() {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], bf16, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], bf16, 2>
+    %wait = ttl.cb_wait %input_dfb
+        : <[1, 1], bf16, 2> -> tensor<1x1xbf16>
+    %input = ttl.attach_cb %wait, %input_dfb
+        : (tensor<1x1xbf16>, !ttl.cb<[1, 1], bf16, 2>)
+          -> tensor<1x1xbf16>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 1], bf16, 2> -> tensor<1x1xbf16>
+    // expected-error @below {{'ttl.exp' op compute result must be a tensor of ttcore.tile elements, got tensor<1x1xbf16>}}
+    %result = ttl.exp %input : tensor<1x1xbf16> -> tensor<1x1xbf16>
+    ttl.store %result, %output : tensor<1x1xbf16>, tensor<1x1xbf16>
+    func.return
+  }
+}
+
+// -----
+
+// A tensor operation cannot consume a scalar-element tensor when its result
+// has an explicit physical tile type.
+module {
+  func.func @scalar_input() {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], bf16, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %wait = ttl.cb_wait %input_dfb
+        : <[1, 1], bf16, 2> -> tensor<1x1xbf16>
+    %input = ttl.attach_cb %wait, %input_dfb
+        : (tensor<1x1xbf16>, !ttl.cb<[1, 1], bf16, 2>)
+          -> tensor<1x1xbf16>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    // expected-error @below {{'ttl.typecast' op compute input 0 must be a tensor of ttcore.tile elements, got tensor<1x1xbf16>}}
+    %result = ttl.typecast %input
+        : (tensor<1x1xbf16>)
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.store %result, %output
+        : tensor<1x1x!ttcore.tile<32x32, f32>>,
+          tensor<1x1x!ttcore.tile<32x32, f32>>
+    func.return
+  }
+}
+
+// -----
+
+// A passthrough store cannot create a compute operation without an explicit
+// physical tile type.
+module {
+  func.func @scalar_passthrough() {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], bf16, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], bf16, 2>
+    %wait = ttl.cb_wait %input_dfb
+        : <[1, 1], bf16, 2> -> tensor<1x1xbf16>
+    %input = ttl.attach_cb %wait, %input_dfb
+        : (tensor<1x1xbf16>, !ttl.cb<[1, 1], bf16, 2>)
+          -> tensor<1x1xbf16>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 1], bf16, 2> -> tensor<1x1xbf16>
+    // expected-error @below {{'ttl.store' op cannot lower tensor store to ttl.compute: passthrough store input must be a tensor of ttcore.tile elements, got tensor<1x1xbf16>}}
+    ttl.store %input, %output : tensor<1x1xbf16>, tensor<1x1xbf16>
+    func.return
+  }
+}


### PR DESCRIPTION
### Problem description

Compute lowering reconstructs tile types from their scalar element types, which replaces physical subtile dimensions with the default 32x32 dimensions. This produces invalid compute regions for subtile tensors. Compiler-allocated DFB metadata parsing also discards physical tile dimensions, so runtime descriptors use incorrect page sizes and omit the required tile descriptor.

Fixes #801.

### What's changed

- Preserve existing `ttcore.tile` dimensions in direct, fused, and passthrough compute lowering.
- Require compute tensors to specify `ttcore.tile` element types. Immutable creation plans record exact input and result tile types, and application consumes those recorded types without assigning default dimensions.
- Preserve compiler-allocated DFB tile dimensions in Python metadata and use them for page-size calculation, runtime descriptors, and emitted standalone runners.
- Calculate DFB page sizes from the compiler tile-size contract without initializing a device during compile-only validation.
- Accept the TTCore integer tile mnemonics `si32`, `u32`, and `u16` in compiler-allocated DFB metadata.
- Add MLIR coverage for direct, fused, and passthrough lowering.
- Add runtime metadata tests and Blackhole device coverage for bf16 and fp32 using every LLK-supported compute tile dimension: 16x16, 16x32, 32x16, and 32x32.

Validation:

- `pre-commit run --all-files`
- MLIR suite: 215 passed, 1 expected failure
- Runtime and metadata pytests: 52 passed
- Exact no-device Python lit regression: 1 passed
- Subtile device pytests: 8 passed on Blackhole

### Checklist

- [x] New/Existing tests provide coverage for changes
