### PR TITLE
[ttl][nfc] Extract PipeTransportEmitter for PipeNet NoC lowering [pipes-4]

### DIFF
--- a/.github/scripts/run-hardware-lit.sh
+++ b/.github/scripts/run-hardware-lit.sh
@@ -28,10 +28,13 @@ chips="$(resolve_tt_chip_count "${HW_LIT_CHIPS:-}")" || {
 lit_common=(-j1 --verbose)
 multi_device_filter="${HW_LIT_MULTI_DEVICE_FILTER:-mesh_tensor}"
 cache_root="$(absolute_path "${TT_METAL_CACHE:-${REPORT_PREFIX}-tt-metal-cache}")"
+lit_exec_root="$(absolute_path "${REPORT_PREFIX}-lit-exec")"
 
 if [ "$chips" -le 1 ]; then
     echo "Detected ${chips} chip(s): running Python lit serially"
-    llvm-lit "$TEST_DIR" "${lit_common[@]}" --xunit-xml-output="${REPORT_PREFIX}.xml"
+    TTLANG_LIT_TEST_EXEC_ROOT="${lit_exec_root}/serial" \
+        llvm-lit "$TEST_DIR" "${lit_common[@]}" \
+        --xunit-xml-output="${REPORT_PREFIX}.xml"
     exit $?
 fi
 
@@ -44,6 +47,7 @@ for ((chip_index = 0; chip_index < chips; chip_index++)); do
     (
         export TT_VISIBLE_DEVICES="${chip_index}"
         export TT_METAL_CACHE="${cache_root}/shard-${shard_number}"
+        export TTLANG_LIT_TEST_EXEC_ROOT="${lit_exec_root}/shard-${shard_number}"
         mkdir -p "$TT_METAL_CACHE"
         llvm-lit "$TEST_DIR" \
             --num-shards "$chips" \
@@ -62,7 +66,10 @@ done
 
 multi_device_cache="${cache_root}/multidevice"
 mkdir -p "$multi_device_cache"
-env -u TT_VISIBLE_DEVICES TT_METAL_CACHE="$multi_device_cache" llvm-lit "$TEST_DIR" \
+env -u TT_VISIBLE_DEVICES \
+    TT_METAL_CACHE="$multi_device_cache" \
+    TTLANG_LIT_TEST_EXEC_ROOT="${lit_exec_root}/multidevice" \
+    llvm-lit "$TEST_DIR" \
     --filter "$multi_device_filter" \
     --allow-empty-runs \
     "${lit_common[@]}" \

--- a/.github/scripts/tests/test_run_hardware_lit.bats
+++ b/.github/scripts/tests/test_run_hardware_lit.bats
@@ -22,7 +22,11 @@ write_fake_lit() {
     local exit_code="${1:-0}"
     cat > "$BIN/llvm-lit" <<EOF
 #!/usr/bin/env bash
-printf 'env:%s cache:%s args:%s\n' "\${TT_VISIBLE_DEVICES:-}" "\${TT_METAL_CACHE:-}" "\$*" >> "$CALLS"
+printf 'env:%s cache:%s exec_root:%s args:%s\n' \
+    "\${TT_VISIBLE_DEVICES:-}" \
+    "\${TT_METAL_CACHE:-}" \
+    "\${TTLANG_LIT_TEST_EXEC_ROOT:-}" \
+    "\$*" >> "$CALLS"
 exit $exit_code
 EOF
     chmod +x "$BIN/llvm-lit"
@@ -35,10 +39,10 @@ EOF
 
     assert_success
     run cat "$CALLS"
-    assert_line --partial "env:0 cache:$PWD/build/test/python-lit-report-tt-metal-cache/shard-1 args:build/test/python --num-shards 3 --run-shard 1"
-    assert_line --partial "env:1 cache:$PWD/build/test/python-lit-report-tt-metal-cache/shard-2 args:build/test/python --num-shards 3 --run-shard 2"
-    assert_line --partial "env:2 cache:$PWD/build/test/python-lit-report-tt-metal-cache/shard-3 args:build/test/python --num-shards 3 --run-shard 3"
-    assert_line --partial "env: cache:$PWD/build/test/python-lit-report-tt-metal-cache/multidevice args:build/test/python --filter mesh_tensor"
+    assert_line --partial "env:0 cache:$PWD/build/test/python-lit-report-tt-metal-cache/shard-1 exec_root:$PWD/build/test/python-lit-report-lit-exec/shard-1 args:build/test/python --num-shards 3 --run-shard 1"
+    assert_line --partial "env:1 cache:$PWD/build/test/python-lit-report-tt-metal-cache/shard-2 exec_root:$PWD/build/test/python-lit-report-lit-exec/shard-2 args:build/test/python --num-shards 3 --run-shard 2"
+    assert_line --partial "env:2 cache:$PWD/build/test/python-lit-report-tt-metal-cache/shard-3 exec_root:$PWD/build/test/python-lit-report-lit-exec/shard-3 args:build/test/python --num-shards 3 --run-shard 3"
+    assert_line --partial "env: cache:$PWD/build/test/python-lit-report-tt-metal-cache/multidevice exec_root:$PWD/build/test/python-lit-report-lit-exec/multidevice args:build/test/python --filter mesh_tensor"
     assert_line --partial "python-lit-report-shard-1.xml"
     assert_line --partial "python-lit-report-multidevice.xml"
     [ "${#lines[@]}" -eq 4 ]
@@ -51,6 +55,7 @@ EOF
 
     assert_success
     run cat "$CALLS"
+    assert_output --partial "exec_root:$PWD/build/test/python-lit-report-lit-exec/serial"
     assert_output --partial "args:build/test/python -j1 --verbose"
     assert_output --partial "python-lit-report.xml"
     refute_output --partial "--num-shards"

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -541,8 +541,7 @@ public:
     ttk::NocAsyncWriteBarrierOp::create(rewriter, loc, nocVal);
   }
 
-  LogicalResult
-  emitReceiverCompletionIncrement(
+  LogicalResult emitReceiverCompletionIncrement(
       Value receiverCompletionCounterAddr) override {
     auto completionIncrement = arith::ConstantIndexOp::create(rewriter, loc, 1);
 

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -400,74 +400,275 @@ buildReceiverPublishedAddress(Value dst, Location loc,
       .getResult();
 }
 
-static void
-emitLocalReceiverAddressPublish(Location loc, Value tableAddress,
-                                Value publishedAddress,
-                                ConversionPatternRewriter &rewriter) {
-  auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
-  Value tablePtr =
-      ttk::CastToL1PtrOp::create(rewriter, loc, l1PtrTy, tableAddress);
-  Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
-  ttk::StoreToL1Op::create(rewriter, loc, publishedAddress, tablePtr, zero);
-}
+class PipeTransportEmitter {
+public:
+  virtual ~PipeTransportEmitter() = default;
 
-static void emitRemoteReceiverAddressPublish(
-    Location loc, Value sourceX, Value sourceY, Value tableAddress,
-    Value publishedAddress, Value nocVal, ConversionPatternRewriter &rewriter) {
-  auto byteEnableAll = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI8Type(), rewriter.getI8IntegerAttr(0xF));
-  ttk::NocInlineDwWriteOp::create(rewriter, loc, sourceX, sourceY, tableAddress,
-                                  publishedAddress, byteEnableAll, nocVal);
-}
+  virtual LogicalResult emitReceiverAddressPublish(Value senderTableAddress,
+                                                   Value publishedAddress) = 0;
+  virtual void emitAddressPublishBarrier() = 0;
+  virtual LogicalResult
+  emitSenderReadyIncrement(Value senderReadyCounterAddr) = 0;
+  virtual void preparePayloadWrite() = 0;
+  virtual LogicalResult emitPayloadWrite(Value srcAddr, Value dstAddr,
+                                         Value totalSizeBytes) = 0;
+  virtual void emitPayloadWriteBarrier() = 0;
+  virtual LogicalResult
+  emitReceiverCompletionIncrement(Value receiverCompletionCounterAddr) = 0;
+  virtual void emitCompletionSignalBarrier() = 0;
+};
 
-/// Publish locally when the receiver is the source because inline NoC writes do
-/// not update their issuing core's SRAM.
-static void emitReceiverAddressPublish(Location loc, PipeType pipeType,
-                                       Value sourceXTranslated,
-                                       Value sourceYTranslated,
-                                       Value tableAddress,
-                                       Value publishedAddress, Value nocVal,
-                                       ConversionPatternRewriter &rewriter) {
-  if (!pipeType.srcInDstRange()) {
-    emitRemoteReceiverAddressPublish(loc, sourceXTranslated, sourceYTranslated,
-                                     tableAddress, publishedAddress, nocVal,
-                                     rewriter);
-    return;
-  }
-  if (pipeType.hasSingleReceiver()) {
-    emitLocalReceiverAddressPublish(loc, tableAddress, publishedAddress,
-                                    rewriter);
-    return;
+class NocPipeTransportEmitter final : public PipeTransportEmitter {
+  struct LogicalCore {
+    Value x;
+    Value y;
+  };
+
+  struct TranslatedCore {
+    Value x;
+    Value y;
+  };
+
+  struct DestinationRange {
+    Value startX;
+    Value startY;
+    Value endX;
+    Value endY;
+  };
+
+public:
+  NocPipeTransportEmitter(Operation *op, PipeType pipeType,
+                          ConversionPatternRewriter &rewriter)
+      : loc(op->getLoc()), pipeType(pipeType), rewriter(rewriter),
+        nocIdx(getNocIndex(op)),
+        nocVal(arith::ConstantOp::create(rewriter, loc, rewriter.getI8Type(),
+                                         rewriter.getI8IntegerAttr(nocIdx))) {}
+
+  LogicalResult emitReceiverAddressPublish(Value senderTableAddress,
+                                           Value publishedAddress) override {
+    TranslatedCore sourceCore = getSourceCore();
+    if (!pipeType.srcInDstRange()) {
+      emitRemoteReceiverAddressPublish(senderTableAddress, publishedAddress,
+                                       sourceCore);
+      return success();
+    }
+    if (pipeType.hasSingleReceiver()) {
+      emitLocalReceiverAddressPublish(senderTableAddress, publishedAddress);
+      return success();
+    }
+
+    LogicalCore logicalSourceCore = getSourceLogicalCore();
+    Value currentX =
+        ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+    Value currentY =
+        ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+    Value xMatches = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, currentX, logicalSourceCore.x);
+    Value yMatches = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, currentY, logicalSourceCore.y);
+    Value receiverIsSource =
+        arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
+    auto localPublish = scf::IfOp::create(
+        rewriter, loc, receiverIsSource, /*withElseRegion=*/true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&localPublish.getThenRegion().front());
+      emitLocalReceiverAddressPublish(senderTableAddress, publishedAddress);
+      rewriter.setInsertionPointToStart(&localPublish.getElseRegion().front());
+      emitRemoteReceiverAddressPublish(senderTableAddress, publishedAddress,
+                                       sourceCore);
+    }
+    rewriter.setInsertionPointAfter(localPublish);
+    return success();
   }
 
-  Value currentX =
-      ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
-  Value currentY =
-      ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
-  Value sourceX =
-      arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcX());
-  Value sourceY =
-      arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcY());
-  Value xMatches = arith::CmpIOp::create(
-      rewriter, loc, arith::CmpIPredicate::eq, currentX, sourceX);
-  Value yMatches = arith::CmpIOp::create(
-      rewriter, loc, arith::CmpIPredicate::eq, currentY, sourceY);
-  Value receiverIsSource =
-      arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
-  auto localPublish = scf::IfOp::create(rewriter, loc, receiverIsSource,
-                                        /*withElseRegion=*/true);
-  {
-    OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPointToStart(&localPublish.getThenRegion().front());
-    emitLocalReceiverAddressPublish(loc, tableAddress, publishedAddress,
-                                    rewriter);
-    rewriter.setInsertionPointToStart(&localPublish.getElseRegion().front());
-    emitRemoteReceiverAddressPublish(loc, sourceXTranslated, sourceYTranslated,
-                                     tableAddress, publishedAddress, nocVal,
-                                     rewriter);
+  void emitAddressPublishBarrier() override {
+    ttk::NocAsyncWriteBarrierOp::create(rewriter, loc, nocVal);
   }
-  rewriter.setInsertionPointAfter(localPublish);
-}
+
+  LogicalResult
+  emitSenderReadyIncrement(Value senderReadyCounterAddr) override {
+    TranslatedCore sourceCore = getSourceCore();
+    auto senderReadyCounterNocAddr =
+        ttk::GetNocAddrOp::create(rewriter, loc, sourceCore.x, sourceCore.y,
+                                  senderReadyCounterAddr, nocVal);
+    auto readyCounterIncrement =
+        arith::ConstantIndexOp::create(rewriter, loc, 1);
+    ttk::NocSemaphoreIncOp::create(
+        rewriter, loc, senderReadyCounterNocAddr.getResult(),
+        readyCounterIncrement, nocVal, /*posted=*/BoolAttr());
+    return success();
+  }
+
+  void preparePayloadWrite() override {
+    if (pipeType.hasSingleReceiver()) {
+      getDstStartCore();
+      return;
+    }
+    getDestinationRange();
+  }
+
+  LogicalResult emitPayloadWrite(Value srcAddr, Value dstAddr,
+                                 Value totalSizeBytes) override {
+    if (pipeType.hasSingleReceiver()) {
+      TranslatedCore dstStartCore = getDstStartCore();
+      ttk::NocAsyncWriteOp::create(
+          rewriter, loc, srcAddr, ValueRange{dstStartCore.x, dstStartCore.y},
+          ValueRange{}, dstAddr, totalSizeBytes, nocVal);
+      return success();
+    }
+
+    DestinationRange destinationRange = getDestinationRange();
+    auto numDests = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32Type(),
+        rewriter.getI32IntegerAttr(pipeType.getNumDests()));
+    if (pipeType.srcInDstRange()) {
+      ttk::NocAsyncWriteMulticastLoopbackSrcOp::create(
+          rewriter, loc, srcAddr, totalSizeBytes, numDests,
+          destinationRange.startX, destinationRange.startY,
+          destinationRange.endX, destinationRange.endY, dstAddr, nocVal,
+          /*linked=*/nullptr);
+      return success();
+    }
+    ttk::NocAsyncWriteMulticastOp::create(
+        rewriter, loc, srcAddr, totalSizeBytes, numDests,
+        destinationRange.startX, destinationRange.startY, destinationRange.endX,
+        destinationRange.endY, dstAddr, nocVal, /*linked=*/nullptr);
+    return success();
+  }
+
+  void emitPayloadWriteBarrier() override {
+    ttk::NocAsyncWriteBarrierOp::create(rewriter, loc, nocVal);
+  }
+
+  LogicalResult
+  emitReceiverCompletionIncrement(
+      Value receiverCompletionCounterAddr) override {
+    auto completionIncrement = arith::ConstantIndexOp::create(rewriter, loc, 1);
+
+    if (pipeType.hasSingleReceiver()) {
+      TranslatedCore dstStartCore = getDstStartCore();
+      auto receiverCompletionNocAddr = ttk::GetNocAddrOp::create(
+          rewriter, loc, dstStartCore.x, dstStartCore.y,
+          receiverCompletionCounterAddr, nocVal);
+      ttk::NocSemaphoreIncOp::create(
+          rewriter, loc, receiverCompletionNocAddr.getResult(),
+          completionIncrement, nocVal, /*posted=*/BoolAttr());
+      return success();
+    }
+
+    DestinationRange destinationRange = getDestinationRange();
+    int64_t numRemoteDests = pipeType.srcInDstRange()
+                                 ? pipeType.getNumDests() - 1
+                                 : pipeType.getNumDests();
+    auto remoteReceiverCount =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                  rewriter.getI32IntegerAttr(numRemoteDests));
+    auto remoteReceiverCompletionMcastNocAddr =
+        ttk::GetNocMulticastAddrOp::create(
+            rewriter, loc, destinationRange.startX, destinationRange.startY,
+            destinationRange.endX, destinationRange.endY,
+            receiverCompletionCounterAddr, nocVal);
+    ttk::NocSemaphoreIncMulticastOp::create(
+        rewriter, loc, remoteReceiverCompletionMcastNocAddr.getResult(),
+        completionIncrement, remoteReceiverCount, nocVal,
+        /*posted=*/BoolAttr());
+
+    if (pipeType.srcInDstRange()) {
+      TranslatedCore sourceCore = getSourceCore();
+      auto localReceiverCompletionNocAddr =
+          ttk::GetNocAddrOp::create(rewriter, loc, sourceCore.x, sourceCore.y,
+                                    receiverCompletionCounterAddr, nocVal);
+      ttk::NocSemaphoreIncOp::create(
+          rewriter, loc, localReceiverCompletionNocAddr.getResult(),
+          completionIncrement, nocVal, /*posted=*/BoolAttr());
+    }
+    return success();
+  }
+
+  void emitCompletionSignalBarrier() override {
+    ttk::NocAsyncAtomicBarrierOp::create(rewriter, loc, nocVal);
+  }
+
+private:
+  void emitLocalReceiverAddressPublish(Value senderTableAddress,
+                                       Value publishedAddress) {
+    auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
+    Value tablePtr = ttk::CastToL1PtrOp::create(
+        rewriter, loc, l1PtrTy, senderTableAddress);
+    Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+    ttk::StoreToL1Op::create(rewriter, loc, publishedAddress, tablePtr, zero);
+  }
+
+  void emitRemoteReceiverAddressPublish(Value senderTableAddress,
+                                        Value publishedAddress,
+                                        TranslatedCore sourceCore) {
+    auto byteEnableAll = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI8Type(), rewriter.getI8IntegerAttr(0xF));
+    // Inline NoC writes do not update the sender's local SRAM when the sender
+    // is also this receiver, so that case uses a direct L1 store.
+    ttk::NocInlineDwWriteOp::create(rewriter, loc, sourceCore.x, sourceCore.y,
+                                    senderTableAddress, publishedAddress,
+                                    byteEnableAll, nocVal);
+  }
+
+  LogicalCore getSourceLogicalCore() {
+    return {arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcX()),
+            arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcY())};
+  }
+
+  TranslatedCore buildTranslatedCore(int64_t logicalX, int64_t logicalY) {
+    auto logicalXValue =
+        arith::ConstantIndexOp::create(rewriter, loc, logicalX);
+    auto logicalYValue =
+        arith::ConstantIndexOp::create(rewriter, loc, logicalY);
+    auto translatedX = ttk::ConvertLogicalXToTranslatedOp::create(
+        rewriter, loc, rewriter.getIndexType(), logicalXValue);
+    auto translatedY = ttk::ConvertLogicalYToTranslatedOp::create(
+        rewriter, loc, rewriter.getIndexType(), logicalYValue);
+    return {translatedX, translatedY};
+  }
+
+  TranslatedCore getSourceCore() {
+    if (!sourceCore) {
+      sourceCore = buildTranslatedCore(pipeType.getSrcX(), pipeType.getSrcY());
+    }
+    return *sourceCore;
+  }
+
+  TranslatedCore getDstStartCore() {
+    if (!dstStartCore) {
+      dstStartCore =
+          buildTranslatedCore(pipeType.getDstStartX(), pipeType.getDstStartY());
+    }
+    return *dstStartCore;
+  }
+
+  DestinationRange getDestinationRange() {
+    if (destinationRange) {
+      return *destinationRange;
+    }
+    TranslatedCore dstStartTranslatedCore = getDstStartCore();
+    auto [dstStartX, dstStartY] = dstStartTranslatedCore;
+    auto [dstEndX, dstEndY] =
+        buildTranslatedCore(pipeType.getDstEndX(), pipeType.getDstEndY());
+    if (nocIdx == 1) {
+      std::swap(dstStartX, dstEndX);
+      std::swap(dstStartY, dstEndY);
+    }
+    destinationRange = DestinationRange{dstStartX, dstStartY, dstEndX, dstEndY};
+    return *destinationRange;
+  }
+
+  Location loc;
+  PipeType pipeType;
+  ConversionPatternRewriter &rewriter;
+  int64_t nocIdx;
+  Value nocVal;
+  std::optional<TranslatedCore> sourceCore;
+  std::optional<TranslatedCore> dstStartCore;
+  std::optional<DestinationRange> destinationRange;
+};
 
 //===----------------------------------------------------------------------===//
 // Receiver post sequence counter initialization
@@ -596,6 +797,8 @@ LogicalResult lowerPipeTransferSend(
   FuncOp senderFunc = op->getParentOfType<FuncOp>();
   assert(senderFunc && "pipe transfer send must be inside a function");
   auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
+  NocPipeTransportEmitter nocTransport(op, pipeType, rewriter);
+  PipeTransportEmitter &transport = nocTransport;
 
   auto cbType = getTTLCBType(srcCB);
   if (!cbType) {
@@ -657,37 +860,7 @@ LogicalResult lowerPipeTransferSend(
     auto srcWritePtr = ttk::GetWritePtrOp::create(rewriter, loc, *cbConverted);
     srcPtrIdx = arith::IndexCastOp::create(rewriter, loc, indexTy, srcWritePtr);
   }
-
-  // Hardware multicast destination coordinates use translated NOC coords.
-  auto dstStartXLogical =
-      arith::ConstantIndexOp::create(rewriter, loc, dstStartX);
-  auto dstStartYLogical =
-      arith::ConstantIndexOp::create(rewriter, loc, dstStartY);
-  auto dstEndXLogical = arith::ConstantIndexOp::create(rewriter, loc, dstEndX);
-  auto dstEndYLogical = arith::ConstantIndexOp::create(rewriter, loc, dstEndY);
-
-  // NoC operations require translated coordinates.
-  auto dstStartXVal = ttk::ConvertLogicalXToTranslatedOp::create(
-      rewriter, loc, indexTy, dstStartXLogical);
-  auto dstStartYVal = ttk::ConvertLogicalYToTranslatedOp::create(
-      rewriter, loc, indexTy, dstStartYLogical);
-  auto dstEndXVal = ttk::ConvertLogicalXToTranslatedOp::create(
-      rewriter, loc, indexTy, dstEndXLogical);
-  auto dstEndYVal = ttk::ConvertLogicalYToTranslatedOp::create(
-      rewriter, loc, indexTy, dstEndYLogical);
-  Value mcastStartXVal = dstStartXVal;
-  Value mcastStartYVal = dstStartYVal;
-  Value mcastEndXVal = dstEndXVal;
-  Value mcastEndYVal = dstEndYVal;
-  // TTKernel multicast ops follow tt-metal's NOC1 convention: callers pass
-  // the rectangle with start/end reversed after coordinate translation.
-  if (nocIdx == 1) {
-    std::swap(mcastStartXVal, mcastEndXVal);
-    std::swap(mcastStartYVal, mcastEndYVal);
-  }
-
-  auto numDestsVal = arith::ConstantOp::create(
-      rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(numDests));
+  transport.preparePayloadWrite();
 
   // Transfer the entire block in one NoC write. Tiles are contiguous in the
   // DFB, and destination DFB layout is uniform across nodes, so lowering sends
@@ -711,84 +884,24 @@ LogicalResult lowerPipeTransferSend(
         buildAddressTableDestinationAddress(loc, addressTableInfo, rewriter);
   }
 
-  // TODO(ttl): Select unicast or multicast from a compiler optimization over
-  // the transfer plan instead of directly preserving the user's tt-lang syntax.
-  if (pipeType.hasSingleReceiver()) {
-    ttk::NocAsyncWriteOp::create(rewriter, loc, srcAddr,
-                                 ValueRange{dstStartXVal, dstStartYVal},
-                                 ValueRange{}, dstAddr, totalSizeVal, nocVal);
-  } else {
-    if (pipeType.srcInDstRange()) {
-      ttk::NocAsyncWriteMulticastLoopbackSrcOp::create(
-          rewriter, loc, srcAddr, totalSizeVal, numDestsVal, mcastStartXVal,
-          mcastStartYVal, mcastEndXVal, mcastEndYVal, dstAddr, nocVal,
-          /*linked=*/nullptr);
-    } else {
-      ttk::NocAsyncWriteMulticastOp::create(
-          rewriter, loc, srcAddr, totalSizeVal, numDestsVal, mcastStartXVal,
-          mcastStartYVal, mcastEndXVal, mcastEndYVal, dstAddr, nocVal,
-          /*linked=*/nullptr);
-    }
+  if (failed(transport.emitPayloadWrite(srcAddr, dstAddr, totalSizeVal))) {
+    return failure();
   }
 
   // Wait for payload writes to complete before signaling receiver completion.
   // Without this barrier, the receiver may wake up before all data arrives.
-  ttk::NocAsyncWriteBarrierOp::create(rewriter, loc, nocVal);
   Value receiverCompletionCounterAddr = buildPipeCounterAddress(
       loc, senderFunc, completionInfo.counter, pipeResourcePlan, rewriter);
+  transport.emitPayloadWriteBarrier();
 
-  if (pipeType.hasSingleReceiver()) {
-    // Point-to-point increments the destination receiver-completion counter.
-    auto completionIncrement = arith::ConstantIndexOp::create(rewriter, loc, 1);
-    auto receiverCompletionNocAddr =
-        ttk::GetNocAddrOp::create(rewriter, loc, dstStartXVal, dstStartYVal,
-                                  receiverCompletionCounterAddr, nocVal);
-    ttk::NocSemaphoreIncOp::create(
-        rewriter, loc, receiverCompletionNocAddr.getResult(),
-        completionIncrement, nocVal, /*posted=*/BoolAttr());
-  } else {
-    // Collective increments every receiver-completion counter. The receiver
-    // pairs this with a cumulative wait_min threshold.
-    // Hardware multicast excludes the sender, so num_dests counts only remote
-    // receivers. TT-Metal has no multicast loopback increment, so a source that
-    // is also a receiver requires a separate local increment.
-    int64_t numRemoteDests = pipeType.srcInDstRange() ? numDests - 1 : numDests;
-    auto remoteReceiverCount = arith::ConstantOp::create(
-        rewriter, loc, i32Ty, rewriter.getI32IntegerAttr(numRemoteDests));
-
-    auto remoteReceiverCompletionMcastNocAddr =
-        ttk::GetNocMulticastAddrOp::create(
-            rewriter, loc, mcastStartXVal, mcastStartYVal, mcastEndXVal,
-            mcastEndYVal, receiverCompletionCounterAddr, nocVal);
-
-    auto completionIncrement = arith::ConstantIndexOp::create(rewriter, loc, 1);
-    ttk::NocSemaphoreIncMulticastOp::create(
-        rewriter, loc, remoteReceiverCompletionMcastNocAddr.getResult(),
-        completionIncrement, remoteReceiverCount, nocVal,
-        /*posted=*/BoolAttr());
-
-    if (pipeType.srcInDstRange()) {
-      auto srcXLogical =
-          arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcX());
-      auto srcYLogical =
-          arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcY());
-      auto srcXTranslated = ttk::ConvertLogicalXToTranslatedOp::create(
-          rewriter, loc, indexTy, srcXLogical);
-      auto srcYTranslated = ttk::ConvertLogicalYToTranslatedOp::create(
-          rewriter, loc, indexTy, srcYLogical);
-      auto localReceiverCompletionNocAddr = ttk::GetNocAddrOp::create(
-          rewriter, loc, srcXTranslated, srcYTranslated,
-          receiverCompletionCounterAddr, nocVal);
-      ttk::NocSemaphoreIncOp::create(
-          rewriter, loc, localReceiverCompletionNocAddr.getResult(),
-          completionIncrement, nocVal, /*posted=*/BoolAttr());
-    }
+  if (failed(transport.emitReceiverCompletionIncrement(
+          receiverCompletionCounterAddr))) {
+    return failure();
   }
 
-  // Point-to-point and collective completion signals use non-posted atomics.
-  // The send ttl.wait lowers to a no-op, so this barrier is the only flush
-  // before kernel exit; without it receivers can observe stale counts.
-  ttk::NocAsyncAtomicBarrierOp::create(rewriter, loc, nocVal);
+  // Completion signals use non-posted atomics. The send ttl.wait lowers to a
+  // no-op, so this barrier is the only flush before the kernel exits.
+  transport.emitCompletionSignalBarrier();
 
   rewriter.replaceOp(op, makeZeroI32(loc, rewriter));
   return success();
@@ -826,8 +939,8 @@ LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
   }
   Value sequenceCounter = *maybeSequenceCounter;
 
-  int64_t nocIdx = getNocIndex(op);
-  auto indexTy = rewriter.getIndexType();
+  NocPipeTransportEmitter nocTransport(op, pipeType, rewriter);
+  PipeTransportEmitter &transport = nocTransport;
 
   // Preflight the only fallible validation before emitting any ops, so a match
   // failure leaves no partially-built IR for the conversion driver to roll
@@ -844,40 +957,24 @@ LogicalResult lowerPipeTransferPost(PipeTransferPostOp op, Value dst,
     maybePublishedAddressInfo = *info;
   }
 
-  Value nocVal = arith::ConstantOp::create(rewriter, loc, rewriter.getI8Type(),
-                                           rewriter.getI8IntegerAttr(nocIdx));
-
-  auto srcXLogical =
-      arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcX());
-  auto srcYLogical =
-      arith::ConstantIndexOp::create(rewriter, loc, pipeType.getSrcY());
-  auto srcXTranslated = ttk::ConvertLogicalXToTranslatedOp::create(
-      rewriter, loc, indexTy, srcXLogical);
-  auto srcYTranslated = ttk::ConvertLogicalYToTranslatedOp::create(
-      rewriter, loc, indexTy, srcYLogical);
-
   if (!usesComputedReceiverDFB) {
     AddressTableInfo addressTableInfo = getAddressTableInfo(op, pipeResource);
     Value publishedAddress = buildReceiverPublishedAddress(
         dst, loc, *maybePublishedAddressInfo, rewriter);
     Value tableAddress =
         buildAddressTableAddress(loc, addressTableInfo, rewriter);
-    emitReceiverAddressPublish(loc, pipeType, srcXTranslated, srcYTranslated,
-                               tableAddress, publishedAddress, nocVal,
-                               rewriter);
-    ttk::NocAsyncWriteBarrierOp::create(rewriter, loc, nocVal);
+    if (failed(transport.emitReceiverAddressPublish(tableAddress,
+                                                    publishedAddress))) {
+      return failure();
+    }
+    transport.emitAddressPublishBarrier();
   }
 
   Value senderReadyCounterAddr = buildPipeCounterAddress(
       loc, func, pipeResource.readyCounter, pipeResourcePlan, rewriter);
-  auto senderReadyCounterNocAddr =
-      ttk::GetNocAddrOp::create(rewriter, loc, srcXTranslated, srcYTranslated,
-                                senderReadyCounterAddr, nocVal);
-  auto readyCounterIncrement = arith::ConstantIndexOp::create(rewriter, loc, 1);
-  ttk::NocSemaphoreIncOp::create(rewriter, loc,
-                                 senderReadyCounterNocAddr.getResult(),
-                                 readyCounterIncrement, nocVal,
-                                 /*posted=*/BoolAttr());
+  if (failed(transport.emitSenderReadyIncrement(senderReadyCounterAddr))) {
+    return failure();
+  }
 
   auto zeroIndex = arith::ConstantIndexOp::create(rewriter, loc, 0);
   auto previousSequence = memref::LoadOp::create(rewriter, loc, sequenceCounter,

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -400,6 +400,10 @@ buildReceiverPublishedAddress(Value dst, Location loc,
       .getResult();
 }
 
+namespace {
+
+/// Emits transport-specific PipeNet synchronization and payload operations.
+/// A transport returns failure when it cannot implement a selected operation.
 class PipeTransportEmitter {
 public:
   virtual ~PipeTransportEmitter() = default;
@@ -468,8 +472,8 @@ public:
         rewriter, loc, arith::CmpIPredicate::eq, currentY, logicalSourceCore.y);
     Value receiverIsSource =
         arith::AndIOp::create(rewriter, loc, xMatches, yMatches);
-    auto localPublish = scf::IfOp::create(
-        rewriter, loc, receiverIsSource, /*withElseRegion=*/true);
+    auto localPublish = scf::IfOp::create(rewriter, loc, receiverIsSource,
+                                          /*withElseRegion=*/true);
     {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(&localPublish.getThenRegion().front());
@@ -501,6 +505,8 @@ public:
   }
 
   void preparePayloadWrite() override {
+    // Materialize destination coordinates before computing the payload address
+    // so address selection does not change emitted operation order.
     if (pipeType.hasSingleReceiver()) {
       getDstStartCore();
       return;
@@ -593,8 +599,8 @@ private:
   void emitLocalReceiverAddressPublish(Value senderTableAddress,
                                        Value publishedAddress) {
     auto l1PtrTy = ttk::L1AddrPtrType::get(rewriter.getContext(), 32);
-    Value tablePtr = ttk::CastToL1PtrOp::create(
-        rewriter, loc, l1PtrTy, senderTableAddress);
+    Value tablePtr =
+        ttk::CastToL1PtrOp::create(rewriter, loc, l1PtrTy, senderTableAddress);
     Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
     ttk::StoreToL1Op::create(rewriter, loc, publishedAddress, tablePtr, zero);
   }
@@ -648,6 +654,7 @@ private:
       return *destinationRange;
     }
     TranslatedCore dstStartTranslatedCore = getDstStartCore();
+    // Preserve the memoized start coordinate for unicast and completion uses.
     auto [dstStartX, dstStartY] = dstStartTranslatedCore;
     auto [dstEndX, dstEndY] =
         buildTranslatedCore(pipeType.getDstEndX(), pipeType.getDstEndY());
@@ -668,6 +675,8 @@ private:
   std::optional<TranslatedCore> dstStartCore;
   std::optional<DestinationRange> destinationRange;
 };
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Receiver post sequence counter initialization

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -821,10 +821,6 @@ LogicalResult lowerPipeTransferSend(
   }
   int64_t pageSizeBytes = tileType.getSizeBytes();
 
-  int64_t dstStartX = pipeType.getDstStartX();
-  int64_t dstStartY = pipeType.getDstStartY();
-  int64_t dstEndX = pipeType.getDstEndX();
-  int64_t dstEndY = pipeType.getDstEndY();
   int64_t numDests = pipeType.getNumDests();
 
   auto indexTy = rewriter.getIndexType();
@@ -833,10 +829,6 @@ LogicalResult lowerPipeTransferSend(
   auto cbConverted = utils::convertTTLCBToTTKernel(srcCB, rewriter, loc);
   assert(succeeded(cbConverted) &&
          "getTTLCBType guarantees a convertible source DFB");
-
-  int64_t nocIdx = getNocIndex(op);
-  Value nocVal = arith::ConstantOp::create(rewriter, loc, rewriter.getI8Type(),
-                                           rewriter.getI8IntegerAttr(nocIdx));
 
   int64_t expectedReceiverPosts =
       isCollectiveTransfer(pipeResource.transferContract) ? numDests : 1;

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -46,7 +46,10 @@ config.ttlang_source_dir = getattr(
 )
 config.python_executable = getattr(config, "python_executable", sys.executable)
 
-config.test_exec_root = os.path.join(config.ttlang_obj_root, "test")
+# Concurrent hardware shards require separate timing and temporary files.
+config.test_exec_root = os.environ.get(
+    "TTLANG_LIT_TEST_EXEC_ROOT", os.path.join(config.ttlang_obj_root, "test")
+)
 
 # Create Output directories for lit temp files (%t substitution).
 # This is needed when running from pre-built artifacts where the build

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_completion_resources.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_completion_resources.mlir
@@ -357,9 +357,9 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
 // CHECK: %[[READY1_PTR:.*]] = ttkernel.reinterpret_cast(%[[READY1_SEND]])
 // CHECK: ttkernel.experimental.semaphore_wait(%[[READY1_PTR]]
 // CHECK: ttkernel.noc_semaphore_set(%[[READY1_PTR]]
-// CHECK: ttkernel.noc_async_write
+// CHECK-DAG: ttkernel.noc_async_write
+// CHECK-DAG: %[[GLOBAL_COMPLETION_SEND:.*]] = ttkernel.get_common_arg_val(%[[GLOBAL_COMPLETION_INDEX]])
 // CHECK: ttkernel.noc_async_write_barrier
-// CHECK: %[[GLOBAL_COMPLETION_SEND:.*]] = ttkernel.get_common_arg_val(%[[GLOBAL_COMPLETION_INDEX]])
 // CHECK: %[[GLOBAL_COMPLETION_NOC:.*]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[GLOBAL_COMPLETION_SEND]], {{.*}})
 // CHECK: ttkernel.noc_semaphore_inc(%[[GLOBAL_COMPLETION_NOC]]
 // CHECK: return

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops.mlir
@@ -73,9 +73,9 @@ func.func @different_noc_write_barriers_survive() attributes { "ttl.kernel_threa
 // CHECK: %[[TABLE_PTR:.*]] = ttkernel.reinterpret_cast{{.*}}(%[[SCRATCH]])
 // CHECK: %[[DST_ADDR:.*]] = ttkernel.load_from_l1(%[[TABLE_PTR]]
 // CHECK-NOT: ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[DST_ADDR]])
-// CHECK: ttkernel.noc_async_write %[[SRC_ADDR]], core[%[[DST_X]], %[[DST_Y]]], %[[DST_ADDR]], {{.*}}, noc %[[NOC]] : (i32, index, index, i32, i32, i8) -> ()
+// CHECK-DAG: ttkernel.noc_async_write %[[SRC_ADDR]], core[%[[DST_X]], %[[DST_Y]]], %[[DST_ADDR]], {{.*}}, noc %[[NOC]] : (i32, index, index, i32, i32, i8) -> ()
+// CHECK-DAG: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: ttkernel.noc_async_write_barrier(%[[NOC]])
-// CHECK: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: %[[DONE_NOC:.*]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[DONE_SEM]], %[[NOC]])
 // CHECK: ttkernel.noc_semaphore_inc(%[[DONE_NOC]], {{.*}}, %[[NOC]])
 // CHECK: ttkernel.noc_async_atomic_barrier(%[[NOC]])
@@ -1167,9 +1167,9 @@ func.func @separate_pipe_values_share_ready_state() attributes { "ttl.kernel_thr
 // CHECK: %[[DST_Y_END:.*]] = ttkernel.experimental.convert_logical_y_to_translated
 // CHECK: %[[DST_ADDR:.*]] = ttkernel.get_common_arg_val
 // CHECK-NOT: ttkernel.load_from_l1
-// CHECK: ttkernel.noc_async_write_multicast(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: ttkernel.noc_async_write_multicast(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: ttkernel.noc_async_write_barrier(%[[NOC]])
-// CHECK: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: %[[DONE_NOC:.*]] = ttkernel.get_noc_multicast_addr(%[[DST_X_START]], %[[DST_Y_START]], %[[DST_X_END]], %[[DST_Y_END]], %[[DONE_SEM]], %[[NOC]])
 // CHECK: ttkernel.noc_semaphore_inc_multicast(%[[DONE_NOC]], {{.*}}, {{.*}}, %[[NOC]])
 // CHECK: ttkernel.noc_async_atomic_barrier(%[[NOC]])
@@ -1251,9 +1251,9 @@ func.func @copy_cb_to_pipe_multicast_noc1() attributes { "ttl.kernel_thread" = #
 // CHECK: %[[DST_Y_END:.*]] = ttkernel.experimental.convert_logical_y_to_translated
 // CHECK: %[[DST_ADDR:.*]] = ttkernel.get_common_arg_val
 // CHECK-NOT: ttkernel.load_from_l1
-// CHECK: ttkernel.noc_async_write_multicast_loopback_src(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: ttkernel.noc_async_write_multicast_loopback_src(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: ttkernel.noc_async_write_barrier(%[[NOC]])
-// CHECK: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: %[[REMOTE_DONE_NOC:.*]] = ttkernel.get_noc_multicast_addr(%[[DST_X_START]], %[[DST_Y_START]], %[[DST_X_END]], %[[DST_Y_END]], %[[DONE_SEM]], %[[NOC]])
 // CHECK: ttkernel.noc_semaphore_inc_multicast(%[[REMOTE_DONE_NOC]], {{.*}}, {{.*}}, %[[NOC]])
 // CHECK: %[[LOCAL_DONE_NOC:.*]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[DONE_SEM]], %[[NOC]])

--- a/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_overlap.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_pipe_ops_overlap.mlir
@@ -316,9 +316,9 @@ func.func @grouped_reserve_advances_following_slot() attributes { "ttl.kernel_th
 // CHECK: %[[DST_Y_END:.*]] = ttkernel.experimental.convert_logical_y_to_translated
 // CHECK: %[[DST_ADDR:.*]] = ttkernel.get_common_arg_val
 // CHECK-NOT: ttkernel.load_from_l1
-// CHECK: ttkernel.noc_async_write_multicast_loopback_src(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: ttkernel.noc_async_write_multicast_loopback_src(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: ttkernel.noc_async_write_barrier(%[[NOC]])
-// CHECK: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: %[[REMOTE_DONE_NOC:.*]] = ttkernel.get_noc_multicast_addr(%[[DST_X_START]], %[[DST_Y_START]], %[[DST_X_END]], %[[DST_Y_END]], %[[DONE_SEM]], %[[NOC]])
 // CHECK: ttkernel.noc_semaphore_inc_multicast(%[[REMOTE_DONE_NOC]], {{.*}}, {{.*}}, %[[NOC]])
 // CHECK: %[[LOCAL_DONE_NOC:.*]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[DONE_SEM]], %[[NOC]])

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_published_address_overlap.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_published_address_overlap.mlir
@@ -179,9 +179,9 @@ module attributes {ttl.launch_grid = array<i64: 3, 4>} {
 // CHECK: %[[DST_Y_END:.*]] = ttkernel.experimental.convert_logical_y_to_translated
 // CHECK: %[[DST_ADDR:.*]] = ttkernel.load_from_l1
 // CHECK-NOT: ttkernel.get_noc_multicast_addr({{.*}}, %[[DST_ADDR]]
-// CHECK: ttkernel.noc_async_write_multicast_loopback_src(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: ttkernel.noc_async_write_multicast_loopback_src(%[[SRC_ADDR]], {{.*}}, {{.*}}, start_xy[%[[DST_X_START]], %[[DST_Y_START]]], end_xy[%[[DST_X_END]], %[[DST_Y_END]]], %[[DST_ADDR]], noc %[[NOC]])
+// CHECK-DAG: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: ttkernel.noc_async_write_barrier(%[[NOC]])
-// CHECK: %[[DONE_SEM:.*]] = ttkernel.get_semaphore
 // CHECK: %[[REMOTE_DONE_NOC:.*]] = ttkernel.get_noc_multicast_addr(%[[DST_X_START]], %[[DST_Y_START]], %[[DST_X_END]], %[[DST_Y_END]], %[[DONE_SEM]], %[[NOC]])
 // CHECK: ttkernel.noc_semaphore_inc_multicast(%[[REMOTE_DONE_NOC]], {{.*}}, {{.*}}, %[[NOC]])
 // CHECK: %[[LOCAL_DONE_NOC:.*]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[DONE_SEM]], %[[NOC]])


### PR DESCRIPTION
PipeNet PR tree:

```text
main (includes #756, #768, #704, #782, #778, #775, and #783; all merged)
  -> [pipes-3] #765
    -> [pipes-4] this PR
      -> [pipes-5] planning PR
        -> [pipes-6] #700
          |-> [pipes-7] #780
          |-> [pipes-8] #754
          `-> [pipes-fabric] #734
```

This replaces #740 after its branch was reordered beneath #700 and GitHub marked the old PR as merged into the #700 branch. The implementation and reviewed diff are unchanged except for removing capacity-only locals that are introduced later by #700.

### Problem description

PipeNet protocol decisions and NoC emission were interleaved. Fabric transport needs to reuse protocol proofs and resource decisions without duplicating NoC-specific lowering.

### What's changed

- Add `PipeTransportEmitter` as the transport emission interface.
- Move existing NoC address publication, sender-ready signaling, payload writes, barriers, and completion signaling into `NocPipeTransportEmitter`.
- Keep protocol selection, address proofs, synchronization, and resource decisions transport-independent.

This is a refactoring: generated intra-device behavior is unchanged.

### Validation

Regressions verify unchanged payload writes, synchronization order, and completion increments across the emitter extraction.

### Checklist

- [x] New and existing tests provide coverage for the changes.
