### PR TITLE
[ttl] Add portable logical kernel selection

### DIFF
--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -60,6 +60,22 @@ unused.pop(kernel=ttl.KernelKind.DATA_MOVEMENT)
 acquired block's uses and release. The selector is consumed during unified-body
 splitting and does not alter the external-call IR or C++ interface.
 
+### Planning and identity invariants
+
+Unified-body splitting analyzes immutable source AST before cloning or pruning
+statements. Its immutable split plan records every statement selection, inferred
+and explicit DFB transaction ownership, required kernel counts, and target
+capacities. Split application consumes this plan without recomputing placement
+from mutated AST. Retaining the required counts and capacities makes the
+target-feasibility decision auditable after analysis.
+
+Operation registration binds each `Kernel` handle in place exactly once to its
+source name and owning operation. Equality and hashing require this binding and
+include the kernel kind and complete logical identity. Equality or hashing of an
+unbound handle is an error because Python object identity is not a stable logical
+kernel identity. The bound identity is retained as typed function metadata and
+remains available on `KernelSpec` after core specialization.
+
 ## Argument contract
 
 | Source argument | Generated C++ interface | Restrictions |

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -28,6 +28,16 @@ ttl.call_extern_func(
 )
 ```
 
+Canonical kernel kinds may be combined with `|`:
+
+```python
+ttl.call_extern_func(
+    HEADER,
+    "shared_entry",
+    kernel=ttl.KernelKind.COMPUTE | ttl.KernelKind.DATA_MOVEMENT,
+)
+```
+
 An operation-local `Kernel` distinguishes multiple logical kernels of the same
 kind. Its declaration is a static top-level operation resource:
 
@@ -42,11 +52,12 @@ ttl.call_extern_func(
 )
 ```
 
-An external call accepts one selector or a nonempty tuple of distinct
-selectors. A tuple emits the call once in every selected logical kernel. A call
-may omit `kernel=` when its enclosing callback already determines one logical
-kernel. Otherwise, omission is invalid because opaque code cannot be assigned
-by inspecting its implementation.
+An external call accepts one selector or multiple distinct selectors. The `|`
+syntax combines `KernelKind` values. A nonempty tuple supports selections that
+include operation-local `Kernel` handles. Multiple selectors emit the call once
+in every selected logical kernel. A call may omit `kernel=` when its enclosing
+callback already determines one logical kernel. Otherwise, omission is invalid
+because opaque code cannot be assigned by inspecting its implementation.
 
 `TensorBlock.push` and `TensorBlock.pop` also accept `kernel=`, but only one
 selector. An explicit selector assigns an otherwise-unused DFB transaction:

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -73,8 +73,17 @@ Operation registration binds each `Kernel` handle in place exactly once to its
 source name and owning operation. Equality and hashing require this binding and
 include the kernel kind and complete logical identity. Equality or hashing of an
 unbound handle is an error because Python object identity is not a stable logical
-kernel identity. The bound identity is retained as typed function metadata and
-remains available on `KernelSpec` after core specialization.
+kernel identity. A deterministic fingerprint of immutable nonlocal captures
+distinguishes factory-created operations whose generated code differs.
+Composition retains the callee-owned bound handle, and repeated sequential calls
+to the same callee share it. The bound identity is retained as typed function
+metadata and remains available on `KernelSpec` after composition and core
+specialization.
+
+One target-indexed backend slot table supplies logical capacity validation,
+logical-to-processor assignment, and final TTNN interop validation. Explicit and
+unified operations therefore report capacity failures with the same logical
+kernel kinds and identities.
 
 ## Argument contract
 

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -14,6 +14,52 @@ inside C++.
 
 The Python interface currently supports void calls.
 
+## Logical-kernel selection
+
+A `call_extern_func` in a unified `@ttl.operation` accepts a `kernel=` selector.
+`KernelKind.COMPUTE` and `KernelKind.DATA_MOVEMENT` select the compiler-owned
+canonical kernel of that kind:
+
+```python
+ttl.call_extern_func(
+    HEADER,
+    "compute_entry",
+    kernel=ttl.KernelKind.COMPUTE,
+)
+```
+
+An operation-local `Kernel` distinguishes multiple logical kernels of the same
+kind. Its declaration is a static top-level operation resource:
+
+```python
+reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+ttl.call_extern_func(HEADER, "reader_entry", kernel=reader)
+ttl.call_extern_func(
+    HEADER,
+    "shared_entry",
+    kernel=(ttl.KernelKind.COMPUTE, reader),
+)
+```
+
+An external call accepts one selector or a nonempty tuple of distinct
+selectors. A tuple emits the call once in every selected logical kernel. A call
+may omit `kernel=` when its enclosing callback already determines one logical
+kernel. Otherwise, omission is invalid because opaque code cannot be assigned
+by inspecting its implementation.
+
+`TensorBlock.push` and `TensorBlock.pop` also accept `kernel=`, but only one
+selector. An explicit selector assigns an otherwise-unused DFB transaction:
+
+```python
+unused = input_dfb.wait()
+unused.pop(kernel=ttl.KernelKind.DATA_MOVEMENT)
+```
+
+`reserve` and `wait` do not accept a selector. Their ownership comes from the
+acquired block's uses and release. The selector is consumed during unified-body
+splitting and does not alter the external-call IR or C++ interface.
+
 ## Argument contract
 
 | Source argument | Generated C++ interface | Restrictions |
@@ -44,6 +90,7 @@ ttl.call_extern_func(
         ttl.dfb_descriptor(source),
         ttl.dfb_descriptor(destination),
     ],
+    kernel=ttl.KernelKind.DATA_MOVEMENT,
 )
 ```
 
@@ -84,6 +131,7 @@ ttl.call_extern_func(
     "legacy_copy",
     template_args=[ttl.get_dfb_id(source)],
     func_args=[source],
+    kernel=ttl.KernelKind.DATA_MOVEMENT,
 )
 ```
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -22,6 +22,7 @@ TT-Lang Documentation
 
    TT-Lang Spec <specs/TTLangSpecification>
    reference/compiler-options
+   reference/external-functions
    reference/print-debugging
    reference/performance-tools
 

--- a/docs/sphinx/programming-guide.md
+++ b/docs/sphinx/programming-guide.md
@@ -16,6 +16,10 @@ python examples/elementwise-tutorial/step_4_multinode_grid_full.py --no-ttl-maxi
 
 See the [full compiler options reference](reference/compiler-options.md) for all decorator parameters, `CompilerOptions` flags with their MLIR pass mappings, environment variables, and `ttlang-opt` pass options.
 
+## External Functions
+
+`ttl.call_extern_func` invokes custom C++ from a selected compute or data-movement kernel. The [external functions reference](reference/external-functions.md) documents template arguments, runtime arguments, DFB descriptors, tensor addresses, include directories, and logical `kernel=` selectors.
+
 ## Print Debugging
 
 Use `print()` inside kernel code to emit device debug prints. Enable at runtime with `TT_METAL_DPRINT_CORES`:

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -93,6 +93,15 @@ Operation registration binds a captured thread selector before compilation.
 This permits the same handle to identify the compiled kernel in runtime
 configuration APIs.
 
+Composing a unified operation preserves each callee-owned handle, including
+its operation identity. Repeated sequential calls to the same composed
+operation share that logical kernel instead of consuming additional target
+kernel resources. The original handle therefore remains equal to the
+`KernelSpec.logical_kernel` value produced for the composed program.
+Factory-created operations with different immutable nonlocal captures receive
+different deterministic operation identities. Equal captures retain the same
+identity.
+
 An external call accepts one selector or a nonempty tuple of distinct
 selectors. A tuple emits the call once in every selected logical kernel. A
 call may omit `kernel=` when its enclosing callback already determines one
@@ -101,7 +110,8 @@ the compiler cannot infer placement from C++ code.
 
 The target backend assigns logical kernels to its supported kernel resources.
 Compilation fails when an operation requests more kernels of a kind than the
-target supports.
+target supports. Unified and explicit multi-kernel operations use the same
+target capacity table and diagnostic terms.
 
 ## Template arguments
 
@@ -184,4 +194,6 @@ derived from the acquired block's uses and release. An explicit release
 selector that conflicts with inferred ownership is invalid.
 
 The release selector affects unified-operation splitting only. Generated IR
-and C++ retain the ordinary argument-free DFB release operation.
+and C++ retain the ordinary argument-free DFB release operation. An explicit
+thread may use the same signature, but its thread decorator already determines
+ownership, so the release selector has no additional effect.

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -1,0 +1,153 @@
+# External Functions
+
+`ttl.call_extern_func` invokes a void C++ function declared in a custom header.
+It supports static template arguments, runtime function arguments, custom
+include directories, and portable logical-kernel selection.
+
+```python
+ttl.call_extern_func(
+    header,
+    callee,
+    *,
+    template_args=None,
+    func_args=None,
+    include_paths=None,
+    kernel=None,
+)
+```
+
+`header` and `callee` are compile-time strings. `template_args`, `func_args`,
+and `include_paths` preserve source order. External functions currently return
+no value, and the compiler does not validate the C++ signature.
+
+## Logical-kernel selection
+
+A unified `@ttl.operation` assigns an external call to one or more logical
+kernels with `kernel=`. `KernelKind.COMPUTE` and
+`KernelKind.DATA_MOVEMENT` select the compiler-owned canonical kernel of that
+kind.
+
+```python
+@ttl.operation(grid=(1, 1))
+def compute_external(inp):
+    ttl.call_extern_func(
+        HEADER,
+        "compute_entry",
+        func_args=[ttl.raw_addr(inp)],
+        kernel=ttl.KernelKind.COMPUTE,
+    )
+```
+
+An operation-local `Kernel` distinguishes multiple kernels with the same
+kind. A `Kernel` declaration is a static top-level operation resource.
+
+```python
+@ttl.operation(grid=(1, 1))
+def selected_external(inp):
+    reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    ttl.call_extern_func(
+        HEADER,
+        "reader_entry",
+        func_args=[inp],
+        kernel=reader,
+    )
+    ttl.call_extern_func(
+        HEADER,
+        "shared_entry",
+        kernel=(ttl.KernelKind.COMPUTE, reader),
+    )
+```
+
+An external call accepts one selector or a nonempty tuple of distinct
+selectors. A tuple emits the call once in every selected logical kernel. A
+call may omit `kernel=` when its enclosing callback already determines one
+logical kernel. A top-level opaque call without a selector is invalid because
+the compiler cannot infer placement from C++ code.
+
+The target backend assigns logical kernels to its supported kernel resources.
+Compilation fails when an operation requests more kernels of a kind than the
+target supports.
+
+## Template arguments
+
+`template_args` accepts compile-time values and explicit DFB wrappers.
+
+| Python argument | Generated C++ argument |
+| --- | --- |
+| `int` | Signed integer constant |
+| `bool` | Boolean constant |
+| `float` | Unsigned binary32 bit-pattern constant |
+| `ttl.dfb_descriptor(dfb)` | `ttlang::DFBDescriptor<index, pages_per_block, block_count, page_size>` type |
+| `ttl.get_dfb_id(dfb)` | Physical DFB index constant |
+
+A bare DFB is invalid in `template_args`. `ttl.dfb_descriptor` supplies typed
+allocation metadata. `ttl.get_dfb_id` supplies only an integer index.
+
+```python
+ttl.call_extern_func(
+    HEADER,
+    "external_copy",
+    template_args=[
+        ttl.dfb_descriptor(source_dfb),
+        ttl.dfb_descriptor(destination_dfb),
+        4,
+        False,
+    ],
+    kernel=ttl.KernelKind.DATA_MOVEMENT,
+)
+```
+
+## Function arguments
+
+`func_args` accepts lowered scalar values, DFBs, base tensors, and raw tensor
+addresses.
+
+| Python argument | Generated C++ argument | Restrictions |
+| --- | --- | --- |
+| Scalar value | Scalar parameter | Uses the kernel runtime-argument convention. |
+| DFB | Physical DFB index parameter | Declares a direct dependency on that DFB. |
+| Base tensor | `TensorAccessor` parameter | Supported in data-movement kernels for tiled BF16 and FP32 tensors. |
+| `ttl.raw_addr(tensor)` | `uint32_t` buffer address | Supported in compute and data-movement kernels. |
+
+Tensor slices, views, and computed tensor values are not valid external
+arguments. `ttl.raw_addr` provides no layout, view offset, page size, alignment,
+or bounds metadata.
+
+When `ttl.get_dfb_id(dfb)` identifies storage accessed by the external
+function, the same DFB must appear as a direct dependency through `func_args`
+or `ttl.dfb_descriptor(dfb)`.
+
+## Include directories
+
+`include_paths` contains compile-time directory strings added to external
+header lookup. The compiler emits the requested header before the call.
+
+```python
+ttl.call_extern_func(
+    "kernels/custom_entry.hpp",
+    "custom_entry",
+    include_paths=[PROJECT_INCLUDE_DIR],
+    kernel=ttl.KernelKind.COMPUTE,
+)
+```
+
+## DFB synchronization ownership
+
+External C++ must complete its resource accesses before returning. The compiler
+does not infer reserve, wait, push, or pop operations from the C++ body.
+
+`TensorBlock.push` and `TensorBlock.pop` accept one `kernel=` selector when a
+DFB transaction has no other use from which ownership can be inferred.
+
+```python
+unused = input_dfb.wait()
+unused.pop(kernel=ttl.KernelKind.DATA_MOVEMENT)
+```
+
+`reserve` and `wait` do not accept `kernel=`. Their logical-kernel ownership is
+derived from the acquired block's uses and release. An explicit release
+selector that conflicts with inferred ownership is invalid.
+
+The selector affects unified-operation splitting only. Generated IR and C++
+retain the ordinary external call and argument-free DFB release operations.

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -38,6 +38,16 @@ def compute_external(inp):
     )
 ```
 
+Combine canonical kernel kinds with `|` when one call executes in both:
+
+```python
+ttl.call_extern_func(
+    HEADER,
+    "shared_entry",
+    kernel=ttl.KernelKind.COMPUTE | ttl.KernelKind.DATA_MOVEMENT,
+)
+```
+
 An operation-local `Kernel` distinguishes multiple kernels with the same
 kind. An operation factory may create one handle and capture it in the
 operation and related factory callbacks. Operation registration binds the
@@ -102,11 +112,13 @@ Factory-created operations with different immutable nonlocal captures receive
 different deterministic operation identities. Equal captures retain the same
 identity.
 
-An external call accepts one selector or a nonempty tuple of distinct
-selectors. A tuple emits the call once in every selected logical kernel. A
-call may omit `kernel=` when its enclosing callback already determines one
-logical kernel. A top-level opaque call without a selector is invalid because
-the compiler cannot infer placement from C++ code.
+An external call accepts one selector or multiple distinct selectors. The `|`
+syntax combines `KernelKind` values. A nonempty tuple supports selections that
+include operation-local `Kernel` handles. Multiple selectors emit the call once
+in every selected logical kernel. A call may omit `kernel=` when its enclosing
+callback already determines one logical kernel. A top-level opaque call without
+a selector is invalid because the compiler cannot infer placement from C++
+code.
 
 The target backend assigns logical kernels to its supported kernel resources.
 Compilation fails when an operation requests more kernels of a kind than the

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -68,6 +68,31 @@ def make_selected_external():
 A handle used only by the operation may instead be declared as a static
 top-level assignment in the operation body.
 
+Explicit multi-kernel operations use the same selectors on thread decorators.
+Each decorator accepts one selector whose kind matches the thread type. An
+omitted selector denotes the canonical kernel of that kind.
+
+```python
+def make_explicit_operation():
+    reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(1, 1))
+    def explicit_operation(inp):
+        @ttl.compute(kernel=ttl.KernelKind.COMPUTE)
+        def compute_thread():
+            pass
+
+        @ttl.datamovement(kernel=reader)
+        def reader_thread():
+            pass
+
+    return explicit_operation
+```
+
+Operation registration binds a captured thread selector before compilation.
+This permits the same handle to identify the compiled kernel in runtime
+configuration APIs.
+
 An external call accepts one selector or a nonempty tuple of distinct
 selectors. A tuple emits the call once in every selected logical kernel. A
 call may omit `kernel=` when its enclosing callback already determines one
@@ -158,5 +183,5 @@ unused.pop(kernel=ttl.KernelKind.DATA_MOVEMENT)
 derived from the acquired block's uses and release. An explicit release
 selector that conflicts with inferred ownership is invalid.
 
-The selector affects unified-operation splitting only. Generated IR and C++
-retain the ordinary external call and argument-free DFB release operations.
+The release selector affects unified-operation splitting only. Generated IR
+and C++ retain the ordinary argument-free DFB release operation.

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -39,25 +39,34 @@ def compute_external(inp):
 ```
 
 An operation-local `Kernel` distinguishes multiple kernels with the same
-kind. A `Kernel` declaration is a static top-level operation resource.
+kind. An operation factory may create one handle and capture it in the
+operation and related factory callbacks. Operation registration binds the
+same handle in place using its capture name and deterministic operation
+identity.
 
 ```python
-@ttl.operation(grid=(1, 1))
-def selected_external(inp):
+def make_selected_external():
     reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
 
-    ttl.call_extern_func(
-        HEADER,
-        "reader_entry",
-        func_args=[inp],
-        kernel=reader,
-    )
-    ttl.call_extern_func(
-        HEADER,
-        "shared_entry",
-        kernel=(ttl.KernelKind.COMPUTE, reader),
-    )
+    @ttl.operation(grid=(1, 1))
+    def selected_external(inp):
+        ttl.call_extern_func(
+            HEADER,
+            "reader_entry",
+            func_args=[inp],
+            kernel=reader,
+        )
+        ttl.call_extern_func(
+            HEADER,
+            "shared_entry",
+            kernel=(ttl.KernelKind.COMPUTE, reader),
+        )
+
+    return selected_external
 ```
+
+A handle used only by the operation may instead be declared as a static
+top-level assignment in the operation body.
 
 An external call accepts one selector or a nonempty tuple of distinct
 selectors. A tuple emits the call once in every selected logical kernel. A

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -94,6 +94,9 @@ constexpr llvm::StringLiteral
 /// the attribute value is a `ttkernel.thread` enum.
 constexpr llvm::StringLiteral kKernelThreadAttrName("ttl.kernel_thread");
 
+/// Func-level target-independent logical-kernel identity.
+constexpr llvm::StringLiteral kLogicalKernelAttrName("ttl.logical_kernel");
+
 /// Number of tiles per DST sync region.
 constexpr llvm::StringLiteral kUnrollFactorAttrName("ttl.unroll_factor");
 

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -95,6 +95,9 @@ constexpr llvm::StringLiteral
 /// the attribute value is a `ttkernel.thread` enum.
 constexpr llvm::StringLiteral kKernelThreadAttrName("ttl.kernel_thread");
 
+/// Func-level target-independent logical-kernel identity.
+constexpr llvm::StringLiteral kLogicalKernelAttrName("ttl.logical_kernel");
+
 /// Number of tiles per DST sync region.
 constexpr llvm::StringLiteral kUnrollFactorAttrName("ttl.unroll_factor");
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -15,12 +15,10 @@ include "ttlang/Dialect/TTL/IR/TTLOpsEnums.td"
 def TTL_LogicalKernelAttr : TTL_Attr<"LogicalKernel", "logical_kernel"> {
   let summary = "Target-independent identity of one operation kernel";
   let description = [{
-    Records the logical kind and operation-local identity assigned before
-    backend kernel selection. A canonical kind selector omits its identity. An
-    explicit operation handle records its identity and owning operation.
-    Compiler-owned affinity kernels use `role` instead of an operation.
-    Kernel specialization preserves this function attribute on every clone so
-    runtime resources can select clones by logical identity.
+    Records the logical kind and operation-local identity of a kernel function.
+    A canonical kind selector omits its identity. An explicit operation handle
+    records its identity and owning operation. Compiler-owned affinity kernels
+    use `role` instead of an operation.
   }];
   let parameters = (ins
     "LogicalKernelKind":$kind,

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -12,6 +12,26 @@ include "ttlang/Dialect/TTL/IR/TTLOpsEnums.td"
 // TTL attribute definitions
 //===----------------------------------------------------------------------===//
 
+def TTL_LogicalKernelAttr : TTL_Attr<"LogicalKernel", "logical_kernel"> {
+  let summary = "Target-independent identity of one operation kernel";
+  let description = [{
+    Records the logical kind and operation-local identity assigned before
+    backend kernel selection. A canonical kind selector omits its identity. An
+    explicit operation handle records its identity and owning operation.
+    Compiler-owned affinity kernels use `role` instead of an operation.
+    Kernel specialization preserves this function attribute on every clone so
+    runtime resources can select clones by logical identity.
+  }];
+  let parameters = (ins
+    "LogicalKernelKind":$kind,
+    OptionalParameter<"StringAttr">:$identity,
+    OptionalParameter<"StringAttr">:$operation,
+    OptionalParameter<"StringAttr">:$role
+  );
+  let assemblyFormat = "`<` struct(params) `>`";
+  let genVerifyDecl = 1;
+}
+
 def TTL_SliceAttr : TTL_Attr<"Slice", "slice"> {
   let summary = "Slice specification for core range";
   let parameters = (ins

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -13,6 +13,26 @@ include "mlir/IR/AttrTypeBase.td"
 // TTL attribute definitions
 //===----------------------------------------------------------------------===//
 
+def TTL_LogicalKernelAttr : TTL_Attr<"LogicalKernel", "logical_kernel"> {
+  let summary = "Target-independent identity of one operation kernel";
+  let description = [{
+    Records the logical kind and operation-local identity assigned before
+    backend kernel selection. A canonical kind selector omits its identity. An
+    explicit operation handle records its identity and owning operation.
+    Compiler-owned affinity kernels use `role` instead of an operation.
+    Kernel specialization preserves this function attribute on every clone so
+    runtime resources can select clones by logical identity.
+  }];
+  let parameters = (ins
+    "LogicalKernelKind":$kind,
+    OptionalParameter<"StringAttr">:$identity,
+    OptionalParameter<"StringAttr">:$operation,
+    OptionalParameter<"StringAttr">:$role
+  );
+  let assemblyFormat = "`<` struct(params) `>`";
+  let genVerifyDecl = 1;
+}
+
 def TTL_SliceAttr : TTL_Attr<"Slice", "slice"> {
   let summary = "Slice specification for core range";
   let parameters = (ins

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -16,12 +16,10 @@ include "mlir/IR/AttrTypeBase.td"
 def TTL_LogicalKernelAttr : TTL_Attr<"LogicalKernel", "logical_kernel"> {
   let summary = "Target-independent identity of one operation kernel";
   let description = [{
-    Records the logical kind and operation-local identity assigned before
-    backend kernel selection. A canonical kind selector omits its identity. An
-    explicit operation handle records its identity and owning operation.
-    Compiler-owned affinity kernels use `role` instead of an operation.
-    Kernel specialization preserves this function attribute on every clone so
-    runtime resources can select clones by logical identity.
+    Records the logical kind and operation-local identity of a kernel function.
+    A canonical kind selector omits its identity. An explicit operation handle
+    records its identity and owning operation. Compiler-owned affinity kernels
+    use `role` instead of an operation.
   }];
   let parameters = (ins
     "LogicalKernelKind":$kind,

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
@@ -15,6 +15,18 @@ include "mlir/IR/EnumAttr.td"
 // Note: TTL uses TTKernel's ThreadType enum (#ttkernel.thread<noc>) for
 // kernel thread annotations on functions.
 
+def TTL_LogicalKernelKind_Compute :
+    I32EnumAttrCase<"Compute", 0, "compute">;
+def TTL_LogicalKernelKind_DataMovement :
+    I32EnumAttrCase<"DataMovement", 1, "data_movement">;
+
+def TTL_LogicalKernelKind : I32EnumAttr<
+    "LogicalKernelKind", "Target-independent logical kernel kind",
+    [TTL_LogicalKernelKind_Compute, TTL_LogicalKernelKind_DataMovement]> {
+  let cppNamespace = "::mlir::tt::ttl";
+  let genSpecializedAttr = 0;
+}
+
 def TTL_TransferKind : I32EnumAttr<
     "TransferKind", "TTL transfer kind",
     [

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -42,6 +42,35 @@
 
 namespace mlir::tt::ttl {
 
+llvm::LogicalResult LogicalKernelAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+    LogicalKernelKind kind, StringAttr identity, StringAttr operation,
+    StringAttr role) {
+  (void)kind;
+  if (identity && identity.getValue().empty()) {
+    return emitError() << "logical kernel identity must be nonempty";
+  }
+  if (operation && operation.getValue().empty()) {
+    return emitError() << "logical kernel operation must be nonempty";
+  }
+  if (role && role.getValue().empty()) {
+    return emitError() << "logical kernel role must be nonempty";
+  }
+
+  bool hasIdentity = static_cast<bool>(identity);
+  bool hasOperation = static_cast<bool>(operation);
+  bool hasRole = static_cast<bool>(role);
+  if (!hasIdentity && (hasOperation || hasRole)) {
+    return emitError()
+           << "canonical logical kernel cannot have an operation or role";
+  }
+  if (hasIdentity && hasOperation == hasRole) {
+    return emitError() << "named logical kernel requires exactly one of an "
+                          "operation or compiler-owned role";
+  }
+  return llvm::success();
+}
+
 void TTLDialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -43,10 +43,8 @@
 namespace mlir::tt::ttl {
 
 llvm::LogicalResult LogicalKernelAttr::verify(
-    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
-    LogicalKernelKind kind, StringAttr identity, StringAttr operation,
-    StringAttr role) {
-  (void)kind;
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError, LogicalKernelKind,
+    StringAttr identity, StringAttr operation, StringAttr role) {
   if (identity && identity.getValue().empty()) {
     return emitError() << "logical kernel identity must be nonempty";
   }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -161,6 +161,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Src
     _src/atom_split.py
     _src/atom_inline.py
     _src/auto_profile.py
+    _src/global_semaphore.py
     _src/perf_summary.py
     _src/perf_trace_server.py
     _src/signpost_profile.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -132,6 +132,7 @@ declare_mlir_python_sources(TTLangPythonCommon.Main
     constants.py
     diagnostics.py
     kernel_runner.py
+    kernel.py
     pipe.py
     ttl.py
     ttl_api.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -131,8 +131,8 @@ declare_mlir_python_sources(TTLangPythonCommon.Main
     compiler_options.py
     constants.py
     diagnostics.py
-    kernel_runner.py
     kernel.py
+    kernel_runner.py
     pipe.py
     ttl.py
     ttl_api.py

--- a/python/sim/__init__.py
+++ b/python/sim/__init__.py
@@ -17,6 +17,7 @@ from .dfb import DFBStats
 from .constants import TILE_SHAPE
 from .copy import CopyTransaction, GroupTransfer, copy
 from .decorators import compute, datamovement
+from .kernel import Kernel, KernelKind
 from .nodecontext import node
 from .operation import operation
 from .pipe import DstPipeIdentity, DstT, Pipe, PipeNet, SrcPipeIdentity
@@ -95,6 +96,7 @@ class _TTLNamespace:
         from .copy import copy
         from .decorators import compute, datamovement
         from .nodecontext import node, grid_size
+        from .kernel import Kernel, KernelKind
         from .operation import operation
         from .pipe import DstPipeIdentity, DstT, Pipe, PipeNet, SrcPipeIdentity
         from .program import Program
@@ -106,6 +108,8 @@ class _TTLNamespace:
         self.make_tensor_backed_dfb = self._make_tensor_backed_dfb
         self.compute = compute
         self.datamovement = datamovement
+        self.Kernel = Kernel
+        self.KernelKind = KernelKind
         self.node = node
         self.copy = copy
         self.GroupTransfer = GroupTransfer
@@ -141,6 +145,8 @@ ttl = _TTLNamespace()
 
 __all__ = [
     "DFBStats",
+    "Kernel",
+    "KernelKind",
     "NodeCoord",
     "NodeRange",
     "DstT",

--- a/python/sim/block.py
+++ b/python/sim/block.py
@@ -20,7 +20,8 @@ import torch
 from .constants import TILE_SHAPE
 from .context import get_context
 from .dfb import Block, check_same_layout, track_source_blocks, _dry_run_result
-from .blockstate import BlockAcquisition, KernelType
+from .blockstate import BlockAcquisition
+from .kernel import KernelKind
 from .ttnnsim import ROW_MAJOR_LAYOUT, Tensor
 
 
@@ -224,7 +225,7 @@ def broadcast(
         tensor=Tensor(result_elem),
         shape=shape,
         acquisition=BlockAcquisition.RESERVE,
-        kernel_type=KernelType.COMPUTE,
+        kernel_type=KernelKind.COMPUTE,
         is_temporary=True,
     )
     track_source_blocks(result_block, block)
@@ -277,7 +278,7 @@ def fill(
         tensor=Tensor(elem),
         shape=shape,
         acquisition=BlockAcquisition.RESERVE,
-        kernel_type=KernelType.COMPUTE,
+        kernel_type=KernelKind.COMPUTE,
         is_temporary=True,
     )
 

--- a/python/sim/blockstate.py
+++ b/python/sim/blockstate.py
@@ -12,6 +12,8 @@ transition table used by Block to validate correct usage patterns.
 from enum import IntEnum, auto
 from typing import AbstractSet, Callable, Dict, FrozenSet, Iterable, Optional, Tuple
 
+from .kernel import KernelKind
+
 # Type alias for the lazy callsite used in error messages.  Block-level access
 # transitions are on the simulator's hottest path; passing a callable instead
 # of an already-resolved ``(file, line)`` tuple lets ``validate()`` skip the
@@ -47,13 +49,6 @@ class AccessState(IntEnum):
     )  # Read-Only while Reading: block has N copies in flight; N is tracked separately
     NAW = auto()  # No Access while Writing: block is being asynchronously written to
     OS = auto()  # Out of Scope: block was pushed or popped
-
-
-class KernelType(IntEnum):
-    """Kernel role for block operations (compute vs datamovement)."""
-
-    DM = auto()  # Data Movement
-    COMPUTE = auto()  # Compute
 
 
 class BlockAcquisition(IntEnum):
@@ -118,7 +113,7 @@ def _validate_mismatch_hint(
     expected_ops: AbstractSet[ExpectedOp],
     access: AccessState,
     acquisition: BlockAcquisition,
-    kernel: KernelType,
+    kernel: KernelKind,
 ) -> Optional[str]:
     """What the mistake usually means; None selects the generic secondary sentence."""
     if attempted == ExpectedOp.PUSH and acquisition == BlockAcquisition.WAIT:
@@ -129,13 +124,13 @@ def _validate_mismatch_hint(
         AccessState.MR,
         AccessState.RW,
     ):
-        if kernel == KernelType.DM:
+        if kernel == KernelKind.DATA_MOVEMENT:
             if attempted == ExpectedOp.COPY_DST and ExpectedOp.COPY_SRC in expected_ops:
                 return (
                     "After wait(), data is already in the block: copy *from* it first, not into it (unless the "
                     "state machine already allows a destination copy)."
                 )
-        if kernel == KernelType.COMPUTE:
+        if kernel == KernelKind.COMPUTE:
             if attempted == ExpectedOp.STORE and ExpectedOp.STORE_SRC in expected_ops:
                 return (
                     "A wait() block is not written in place with store(...); pass this block as the source to "
@@ -163,7 +158,7 @@ def format_validate_mismatch(
     expected_ops: AbstractSet[ExpectedOp],
     access: AccessState,
     acquisition: BlockAcquisition,
-    kernel: KernelType,
+    kernel: KernelKind,
     pending_copy_location: Optional[Tuple[str, int]] = None,
 ) -> str:
     expected_names = _sorted_op_names(expected_ops)
@@ -342,14 +337,14 @@ _OPS_STORE_SRC_PUSH: FrozenSet[ExpectedOp] = frozenset(
 # Organized by (acquisition, kernel_type) -> {(operation, access_state): (new_access_state, new_expected_ops)}
 # This structure makes it easy to see all transitions for a particular acquisition/kernel-role combination
 STATE_TRANSITIONS: Dict[
-    Tuple[BlockAcquisition, KernelType],
+    Tuple[BlockAcquisition, KernelKind],
     Dict[
         Tuple[str, AccessState],
         Tuple[AccessState, FrozenSet[ExpectedOp]],
     ],
 ] = {
     # DM kernel, WAIT acquisition
-    (BlockAcquisition.WAIT, KernelType.DM): {
+    (BlockAcquisition.WAIT, KernelKind.DATA_MOVEMENT): {
         # Copy as source: MR/RW -> ROR; further copies and tx_wait both expected
         ("copy_src", AccessState.MR): (AccessState.ROR, _OPS_TX_AND_COPY_SRC),
         ("copy_src", AccessState.RW): (AccessState.ROR, _OPS_TX_AND_COPY_SRC),
@@ -361,7 +356,7 @@ STATE_TRANSITIONS: Dict[
         ("tx_wait", AccessState.NAW): (AccessState.MR, _OPS_COPY_SRC),
     },
     # DM kernel, RESERVE acquisition
-    (BlockAcquisition.RESERVE, KernelType.DM): {
+    (BlockAcquisition.RESERVE, KernelKind.DATA_MOVEMENT): {
         # Copy as source: MR/RW -> ROR; further copies and tx_wait both expected
         ("copy_src", AccessState.MR): (AccessState.ROR, _OPS_TX_AND_COPY_SRC),
         ("copy_src", AccessState.RW): (AccessState.ROR, _OPS_TX_AND_COPY_SRC),
@@ -374,7 +369,7 @@ STATE_TRANSITIONS: Dict[
         ("tx_wait", AccessState.ROR): (AccessState.RW, _OPS_COPY_DST_SRC_PUSH),
     },
     # COMPUTE kernel, WAIT acquisition
-    (BlockAcquisition.WAIT, KernelType.COMPUTE): {
+    (BlockAcquisition.WAIT, KernelKind.COMPUTE): {
         # Assign as arithmetic source: MR/RW -> RW; POP now allowed but store
         # confirmation is deferred and tracked until program termination.
         ("assign_src", AccessState.MR): (AccessState.RW, _OPS_STORE_RW_POP),
@@ -386,7 +381,7 @@ STATE_TRANSITIONS: Dict[
         ("store_dst", AccessState.RW): (AccessState.MR, _OPS_STORE_SRC),
     },
     # COMPUTE kernel, RESERVE acquisition
-    (BlockAcquisition.RESERVE, KernelType.COMPUTE): {
+    (BlockAcquisition.RESERVE, KernelKind.COMPUTE): {
         # Store read complete: MR/RW -> RW with store ops + push
         ("store_src", AccessState.MR): (AccessState.RW, _OPS_STORE_RW_PUSH),
         ("store_src", AccessState.RW): (AccessState.RW, _OPS_STORE_RW_PUSH),
@@ -430,9 +425,9 @@ class BlockStateMachine:
         "_ctx_transitions",
     )
 
-    def __init__(self, acquisition: BlockAcquisition, kernel_type: KernelType) -> None:
+    def __init__(self, acquisition: BlockAcquisition, kernel_type: KernelKind) -> None:
         self.acquisition: BlockAcquisition = acquisition
-        self.kernel_type: KernelType = kernel_type
+        self.kernel_type: KernelKind = kernel_type
         self.access_state: AccessState = AccessState.OS
         # Module-level shared frozenset; ``initialize()`` / transitions
         # overwrite this with another shared frozenset, so no per-instance
@@ -467,13 +462,13 @@ class BlockStateMachine:
         """Set the initial state based on acquisition method and kernel role."""
         if self.acquisition == BlockAcquisition.RESERVE:
             self.access_state = AccessState.MW
-            if self.kernel_type == KernelType.DM:
+            if self.kernel_type == KernelKind.DATA_MOVEMENT:
                 self.expected_ops = _INIT_RESERVE_DM
             else:
                 self.expected_ops = _INIT_RESERVE_COMPUTE
         elif self.acquisition == BlockAcquisition.WAIT:
             self.access_state = AccessState.MR
-            if self.kernel_type == KernelType.DM:
+            if self.kernel_type == KernelKind.DATA_MOVEMENT:
                 self.expected_ops = _INIT_WAIT_DM
             else:
                 self.expected_ops = _INIT_WAIT_COMPUTE

--- a/python/sim/context.py
+++ b/python/sim/context.py
@@ -27,7 +27,7 @@ import sys
 from typing import Optional
 
 from .context_types import SimulatorContext
-from .blockstate import KernelType
+from .kernel import KernelKind
 
 
 # Single per-process simulator context.  Created lazily by ``get_context()``
@@ -138,11 +138,11 @@ def set_dry_run(enabled: bool) -> None:
     get_context().config.dry_run = enabled
 
 
-def get_current_kernel_type() -> KernelType:
+def get_current_kernel_type() -> KernelKind:
     """Get the current kernel role (compute vs datamovement).
 
     Returns:
-        KernelType
+        KernelKind
 
     Raises:
         RuntimeError: If kernel role is not set (not within a running compute/DM kernel)
@@ -156,7 +156,7 @@ def get_current_kernel_type() -> KernelType:
     return current_kernel_type
 
 
-def set_current_kernel_type(kernel_type: Optional[KernelType]) -> None:
+def set_current_kernel_type(kernel_type: Optional[KernelKind]) -> None:
     """Set the current kernel role (compute vs datamovement).
 
     Args:

--- a/python/sim/context_types.py
+++ b/python/sim/context_types.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Deque, Dict, Optional, Set, Tuple, TypedDict
 from .pipe import AnyPipe
 from .typedefs import Count, Shape, BindableTemplate
-from .blockstate import KernelType
+from .kernel import KernelKind
 
 if TYPE_CHECKING:
     from .ttnnsim import Tensor
@@ -104,7 +104,7 @@ class SimulatorContext:
     copy_state: CopySystemState = field(default_factory=CopySystemState)
     warnings: WarningState = field(default_factory=WarningState)
     scheduler: Any = None  # Optional[GreenletScheduler] - avoid import cycle
-    current_kernel_type: Optional[KernelType] = None
+    current_kernel_type: Optional[KernelKind] = None
     kernel_registry: list[BindableTemplate] = field(
         default_factory=list[BindableTemplate]
     )  # pyright: ignore[reportUnknownVariableType]

--- a/python/sim/debug_print.py
+++ b/python/sim/debug_print.py
@@ -14,9 +14,10 @@ import builtins
 from .context import get_context
 from .ttnnsim import Tensor
 from .dfb import Block, DataflowBuffer
-from .blockstate import AccessState, BlockAcquisition, KernelType
+from .blockstate import AccessState, BlockAcquisition
 from .diagnostics import warn_once_per_location
 from .greenlet_scheduler import get_current_node_id
+from .kernel import KernelKind
 
 # Type alias for TT-Lang printable objects
 TTLangObject = Union[Tensor, Block, DataflowBuffer]
@@ -75,7 +76,7 @@ def _format_block(block: Block) -> str:
     # 1. DM kernel + reserve + (MW or NAW)
     # 2. DM kernel + wait + NAW
     if not block.is_temporary:
-        if block.kernel_type == KernelType.DM:
+        if block.kernel_type == KernelKind.DATA_MOVEMENT:
             if block.acquisition == BlockAcquisition.RESERVE:
                 if block.access_state in (AccessState.MW, AccessState.NAW):
                     warning_msg = (

--- a/python/sim/decorators.py
+++ b/python/sim/decorators.py
@@ -14,9 +14,8 @@ import types
 from types import CellType, FunctionType
 from typing import Any, Callable, Dict, List
 
-from .blockstate import KernelType
 from .context import get_context
-from .kernel import KernelSelector
+from .kernel import KernelKind, KernelSelector
 from .typedefs import BindableTemplate
 
 
@@ -98,7 +97,7 @@ def compute(
         class ComputeTemplate:
             __name__ = func.__name__
             __wrapped__ = func  # Standard convention from functools.wraps
-            kernel_type = KernelType.COMPUTE  # KernelType enum for type safety
+            kernel_type = KernelKind.COMPUTE
 
             def bind(self, ctx: Dict[str, Any]) -> Callable[[], Any]:
                 # rebuild function with per-node closure
@@ -131,7 +130,7 @@ def datamovement(
         class DMTemplate:
             __name__ = func.__name__
             __wrapped__ = func  # Standard convention from functools.wraps
-            kernel_type = KernelType.DM  # KernelType enum for type safety
+            kernel_type = KernelKind.DATA_MOVEMENT
 
             def bind(self, ctx: Dict[str, Any]) -> Callable[[], Any]:
                 bound_func = rebind_func_with_ctx(func, ctx)

--- a/python/sim/decorators.py
+++ b/python/sim/decorators.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, List
 
 from .blockstate import KernelType
 from .context import get_context
+from .kernel import KernelSelector
 from .typedefs import BindableTemplate
 
 
@@ -78,7 +79,9 @@ def get_registered_kernels() -> List[BindableTemplate]:
     return kernels
 
 
-def compute() -> Callable[[FunctionType], BindableTemplate]:
+def compute(
+    *, kernel: KernelSelector | None = None
+) -> Callable[[FunctionType], BindableTemplate]:
     """
     Decorator to mark a function as a compute operation.
 
@@ -88,6 +91,8 @@ def compute() -> Callable[[FunctionType], BindableTemplate]:
     Returns:
         A BindableTemplate that can be bound to specific execution contexts
     """
+
+    del kernel
 
     def decorator(func: FunctionType) -> BindableTemplate:
         class ComputeTemplate:
@@ -107,7 +112,9 @@ def compute() -> Callable[[FunctionType], BindableTemplate]:
     return decorator
 
 
-def datamovement() -> Callable[[FunctionType], BindableTemplate]:
+def datamovement(
+    *, kernel: KernelSelector | None = None
+) -> Callable[[FunctionType], BindableTemplate]:
     """
     Decorator to mark a function as a data movement operation.
 
@@ -117,6 +124,8 @@ def datamovement() -> Callable[[FunctionType], BindableTemplate]:
     Returns:
         A BindableTemplate that can be bound to specific execution contexts
     """
+
+    del kernel
 
     def decorator(func: FunctionType) -> BindableTemplate:
         class DMTemplate:

--- a/python/sim/dfb.py
+++ b/python/sim/dfb.py
@@ -36,7 +36,6 @@ from .blockstate import (
     BlockAcquisition,
     BlockStateMachine,
     ExpectedOp,
-    KernelType,
     format_cannot_read_block,
     format_cannot_write_block,
 )
@@ -45,7 +44,7 @@ from .diagnostics import find_user_code_location
 from .dfbstate import DFBState
 from .constants import TILE_SHAPE
 from .errors import DFBContractError
-from .kernel import KernelSelector
+from .kernel import KernelKind, KernelSelector
 from .ttnnsim import (
     ROW_MAJOR_LAYOUT,
     TILE_LAYOUT,
@@ -97,7 +96,7 @@ def _dry_run_result(shape: Shape, *sources: "Block") -> "Block":
         tensor=_dry_run_sentinel(layout),
         shape=shape,
         acquisition=BlockAcquisition.RESERVE,
-        kernel_type=KernelType.COMPUTE,
+        kernel_type=KernelKind.COMPUTE,
         is_temporary=True,
     )
     track_source_blocks(result_block, *sources)
@@ -150,7 +149,7 @@ class Block:
         tensor: Tensor,
         shape: Shape,
         acquisition: BlockAcquisition,
-        kernel_type: KernelType,
+        kernel_type: KernelKind,
         is_temporary: bool = False,
         dfb: Optional["DataflowBuffer"] = None,
         name: Optional[str] = None,
@@ -550,7 +549,7 @@ class Block:
                 tensor=Tensor(elem_tensor, ROW_MAJOR_LAYOUT),
                 shape=shape,
                 acquisition=BlockAcquisition.RESERVE,
-                kernel_type=KernelType.COMPUTE,
+                kernel_type=KernelKind.COMPUTE,
                 is_temporary=True,
             )
             return block
@@ -578,7 +577,7 @@ class Block:
             tensor=Tensor(elem_tensor),
             shape=shape,
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.COMPUTE,
+            kernel_type=KernelKind.COMPUTE,
             is_temporary=True,
         )
         return block
@@ -608,7 +607,7 @@ class Block:
                 tensor=t,
                 shape=t.shape,
                 acquisition=BlockAcquisition.RESERVE,
-                kernel_type=KernelType.COMPUTE,
+                kernel_type=KernelKind.COMPUTE,
                 is_temporary=True,
             )
 
@@ -633,7 +632,7 @@ class Block:
             tensor=t,
             shape=tile_shape,
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.COMPUTE,
+            kernel_type=KernelKind.COMPUTE,
             is_temporary=True,
         )
 
@@ -697,7 +696,7 @@ class Block:
         # Track wait() Compute source blocks for state machine
         if (
             items._sm.acquisition == BlockAcquisition.WAIT
-            and items._sm.kernel_type == KernelType.COMPUTE
+            and items._sm.kernel_type == KernelKind.COMPUTE
             and ExpectedOp.STORE_SRC in items._sm.expected_ops
         ):
             source_blocks_to_mark.append(items)
@@ -759,7 +758,7 @@ class Block:
             if (
                 not source._is_temporary
                 and source._sm.acquisition == BlockAcquisition.WAIT
-                and source._sm.kernel_type == KernelType.COMPUTE
+                and source._sm.kernel_type == KernelKind.COMPUTE
             ):
                 if result_block._source_blocks is None:
                     result_block._source_blocks = []
@@ -792,7 +791,7 @@ class Block:
             tensor=result_tensor,
             shape=shape,
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.COMPUTE,
+            kernel_type=KernelKind.COMPUTE,
             is_temporary=True,
         )
         # Track all source blocks (self + any additional)
@@ -924,7 +923,7 @@ class Block:
         return self._sm.acquisition
 
     @property
-    def kernel_type(self) -> KernelType:
+    def kernel_type(self) -> KernelKind:
         """Get the kernel role (DM or Compute) that acquired this block."""
         return self._sm.kernel_type
 
@@ -1537,7 +1536,7 @@ def track_source_blocks(result_block: Block, *input_blocks: Block) -> None:
         if (
             not is_temporary
             and getattr(block, "acquisition", None) == BlockAcquisition.WAIT
-            and getattr(block, "kernel_type", None) == KernelType.COMPUTE
+            and getattr(block, "kernel_type", None) == KernelKind.COMPUTE
         ):
             # ``_source_blocks`` is now lazy-init on Block (``None`` until
             # the first source append) to skip ~17M empty-list allocations
@@ -1648,7 +1647,7 @@ def matmul(a: Block, b: Block, _output_hint: Optional[Block] = None) -> Block:
         tensor=result_tensor,
         shape=result_shape,
         acquisition=BlockAcquisition.RESERVE,
-        kernel_type=KernelType.COMPUTE,
+        kernel_type=KernelKind.COMPUTE,
         is_temporary=True,
     )
     track_source_blocks(result_block, a, b)

--- a/python/sim/dfb.py
+++ b/python/sim/dfb.py
@@ -45,6 +45,7 @@ from .diagnostics import find_user_code_location
 from .dfbstate import DFBState
 from .constants import TILE_SHAPE
 from .errors import DFBContractError
+from .kernel import KernelSelector
 from .ttnnsim import (
     ROW_MAJOR_LAYOUT,
     TILE_LAYOUT,
@@ -220,14 +221,16 @@ class Block:
             f"expected={expected})"
         )
 
-    def pop(self) -> None:
+    def pop(self, *, kernel: Optional[KernelSelector] = None) -> None:
+        del kernel
         if self.dfb is None:
             raise RuntimeError(
                 "Block.pop() is only valid for blocks acquired from a DataflowBuffer."
             )
         self.dfb.pop_block()
 
-    def push(self) -> None:
+    def push(self, *, kernel: Optional[KernelSelector] = None) -> None:
+        del kernel
         if self.dfb is None:
             raise RuntimeError(
                 "Block.push() is only valid for blocks acquired from a DataflowBuffer."

--- a/python/sim/greenlet_scheduler.py
+++ b/python/sim/greenlet_scheduler.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from greenlet import greenlet
 
-from .blockstate import KernelType
+from .kernel import KernelKind
 from .context import get_context, set_current_kernel_type, clear_current_kernel_type
 from .diagnostics import (
     print_diagnostic_error,
@@ -38,7 +38,7 @@ class KernelId:
     """
 
     linear_node: int
-    kind: KernelType
+    kind: KernelKind
     func_name: str
     # Cached hash; populated in __post_init__ and returned by __hash__.  Declared
     # as a non-init, non-repr, non-compare, non-hash field so the dataclass
@@ -104,9 +104,9 @@ class _KernelState:
 
     __slots__ = ("g", "kernel_type", "blocking_obj", "operation")
 
-    def __init__(self, g: greenlet, kernel_type: KernelType) -> None:
+    def __init__(self, g: greenlet, kernel_type: KernelKind) -> None:
         self.g: greenlet = g
-        self.kernel_type: KernelType = kernel_type
+        self.kernel_type: KernelKind = kernel_type
         self.blocking_obj: Any = None
         self.operation: str = ""
 
@@ -166,7 +166,7 @@ class GreenletScheduler:
 
         Args:
             kernel_id: Stable kernel identity. Its ``kind`` field doubles as the
-                kernel role (COMPUTE or DM); two kernels with the same
+                kernel role (COMPUTE or DATA_MOVEMENT); two kernels with the same
                 ``(linear_node, kind, func_name)`` triple is rejected.
             func: Kernel entry function to execute.
 

--- a/python/sim/kernel.py
+++ b/python/sim/kernel.py
@@ -4,8 +4,11 @@
 
 """Inert logical-kernel selectors for simulator API compatibility."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum, auto
+from typing import Tuple
 
 
 class KernelKind(Enum):
@@ -18,6 +21,11 @@ class KernelKind(Enum):
 
     COMPUTE = auto()
     DATA_MOVEMENT = auto()
+
+    def __or__(self, other: object) -> Tuple[KernelKind, KernelKind]:
+        if not isinstance(other, KernelKind):
+            return NotImplemented
+        return (self, other)
 
 
 @dataclass(frozen=True)

--- a/python/sim/kernel.py
+++ b/python/sim/kernel.py
@@ -29,8 +29,7 @@ class Kernel:
     def __post_init__(self) -> None:
         if not isinstance(self.kind, KernelKind):
             raise TypeError(
-                "Kernel kind must be a KernelKind, got "
-                f"{type(self.kind).__name__}"
+                "Kernel kind must be a KernelKind, got " f"{type(self.kind).__name__}"
             )
 
 

--- a/python/sim/kernel.py
+++ b/python/sim/kernel.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inert logical-kernel selectors for simulator API compatibility."""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class KernelKind(Enum):
+    """A target-independent kernel class."""
+
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        del start, count, last_values
+        return name.lower()
+
+    COMPUTE = auto()
+    DATA_MOVEMENT = auto()
+
+
+@dataclass(frozen=True)
+class Kernel:
+    """A logical-kernel declaration ignored by simulator execution."""
+
+    kind: KernelKind
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, KernelKind):
+            raise TypeError(
+                "Kernel kind must be a KernelKind, got "
+                f"{type(self.kind).__name__}"
+            )
+
+
+KernelSelector = KernelKind | Kernel

--- a/python/sim/kernel.py
+++ b/python/sim/kernel.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Tuple
 
 
 class KernelKind(Enum):
@@ -22,7 +21,7 @@ class KernelKind(Enum):
     COMPUTE = auto()
     DATA_MOVEMENT = auto()
 
-    def __or__(self, other: object) -> Tuple[KernelKind, KernelKind]:
+    def __or__(self, other: object) -> tuple[KernelKind, KernelKind]:
         if not isinstance(other, KernelKind):
             return NotImplemented
         return (self, other)

--- a/python/sim/kernel.py
+++ b/python/sim/kernel.py
@@ -10,8 +10,12 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 
-class KernelKind(Enum):
-    """A target-independent kernel class."""
+class KernelKind(str, Enum):
+    """A target-independent kernel class used by simulator execution state.
+
+    String-backed members match the compiler API and retain C-level hashing for
+    simulator state dictionaries.
+    """
 
     @staticmethod
     def _generate_next_value_(name, start, count, last_values):

--- a/python/sim/operation.py
+++ b/python/sim/operation.py
@@ -13,9 +13,9 @@ from typing import Any, Callable, Optional, Union, cast
 
 from ttl.constants import validate_math_fidelity
 
-from .blockstate import KernelType
 from .typedefs import Shape
 from .context import get_context, cleanup_run_context
+from .kernel import KernelKind
 
 
 def set_default_grid(grid: Shape) -> None:
@@ -130,10 +130,12 @@ def operation(
             compute_kernels = [
                 t
                 for t in kernels
-                if getattr(t, "kernel_type", None) == KernelType.COMPUTE
+                if getattr(t, "kernel_type", None) == KernelKind.COMPUTE
             ]
             dm_kernels = [
-                t for t in kernels if getattr(t, "kernel_type", None) == KernelType.DM
+                t
+                for t in kernels
+                if getattr(t, "kernel_type", None) == KernelKind.DATA_MOVEMENT
             ]
 
             if len(compute_kernels) != 1:

--- a/python/sim/program.py
+++ b/python/sim/program.py
@@ -17,7 +17,7 @@ from greenlet import getcurrent
 
 from .dfb import DataflowBuffer
 from .typedefs import BindableTemplate, Shape
-from .blockstate import KernelType
+from .kernel import KernelKind
 from .context import get_context
 from .greenlet_scheduler import (
     GreenletScheduler,
@@ -289,15 +289,15 @@ def Program(*funcs: BindableTemplate, grid: Shape, pipenets: Any = None) -> Any:
                     # a node must have distinct __name__s -- the scheduler
                     # rejects duplicates with a user-facing error.
                     for tmpl in (compute_func_tmpl, dm0_tmpl, dm1_tmpl):
-                        # Get KernelType directly from template's kernel_type attribute
                         kernel_type = getattr(tmpl, "kernel_type", None)
                         match kernel_type:
-                            case KernelType.COMPUTE | KernelType.DM:
+                            case KernelKind.COMPUTE | KernelKind.DATA_MOVEMENT:
                                 pass
                             case _:
                                 raise RuntimeError(
                                     f"Template {tmpl} has invalid kernel_type '{kernel_type}'. "
-                                    f"Expected KernelType enum (COMPUTE or DM)."
+                                    "Expected KernelKind enum "
+                                    "(COMPUTE or DATA_MOVEMENT)."
                                 )
 
                         # Bind template to node context

--- a/python/ttl/__init__.py
+++ b/python/ttl/__init__.py
@@ -29,6 +29,8 @@ else:
     from ttl.ttl import (
         operation,
         DFB,
+        Kernel,
+        KernelKind,
         compute,
         datamovement,
         Program,
@@ -63,6 +65,8 @@ else:
         "build_info",
         "operation",
         "DFB",
+        "Kernel",
+        "KernelKind",
         "compute",
         "datamovement",
         "Program",

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 import ast
 import copy
+import hashlib
 import inspect
-import itertools
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
+from ttl.kernel import Kernel
 
-_inline_counter = itertools.count()
 _NESTED_SCOPES = (
     ast.FunctionDef,
     ast.AsyncFunctionDef,
@@ -124,17 +124,21 @@ def inline_atom_calls(
     fn_def: ast.FunctionDef,
     fn_globals: Dict[str, object],
     caller_name: str,
-) -> Dict[str, object]:
+) -> Tuple[Dict[str, object], Dict[str, Kernel]]:
     reserved_names = _identifier_names(fn_def)
     external_pipenets = {}
+    logical_kernels = {}
+    inline_discriminators = {}
     fn_def.body = _inline_statements(
         fn_def.body,
         fn_globals,
         caller_name,
         reserved_names,
         external_pipenets,
+        logical_kernels,
+        inline_discriminators,
     )
-    return external_pipenets
+    return external_pipenets, logical_kernels
 
 
 def _inline_statements(
@@ -143,6 +147,8 @@ def _inline_statements(
     caller_name: str,
     reserved_names: Set[str],
     external_pipenets: Dict[str, object],
+    logical_kernels: Dict[str, Kernel],
+    inline_discriminators: Dict[str, int],
 ) -> List[ast.stmt]:
     result: List[ast.stmt] = []
     for statement in statements:
@@ -152,6 +158,8 @@ def _inline_statements(
             caller_name,
             reserved_names,
             external_pipenets,
+            logical_kernels,
+            inline_discriminators,
         )
         match = _standalone_operation_call(statement, scope)
         if match is None:
@@ -167,6 +175,8 @@ def _inline_statements(
                 scope,
                 reserved_names,
                 external_pipenets,
+                logical_kernels,
+                inline_discriminators,
             )
         )
     return result
@@ -178,6 +188,8 @@ def _inline_compound_bodies(
     caller_name: str,
     reserved_names: Set[str],
     external_pipenets: Dict[str, object],
+    logical_kernels: Dict[str, Kernel],
+    inline_discriminators: Dict[str, int],
 ) -> None:
     for attribute in ("body", "orelse", "finalbody"):
         body = getattr(statement, attribute, None)
@@ -191,6 +203,8 @@ def _inline_compound_bodies(
             caller_name,
             reserved_names,
             external_pipenets,
+            logical_kernels,
+            inline_discriminators,
         )
         setattr(statement, attribute, inlined)
 
@@ -205,6 +219,8 @@ def _inline_compound_bodies(
                 caller_name,
                 reserved_names,
                 external_pipenets,
+                logical_kernels,
+                inline_discriminators,
             )
 
 
@@ -278,10 +294,12 @@ def _expand_call(
     scope: Dict[str, object],
     reserved_names: Set[str],
     external_pipenets: Dict[str, object],
+    logical_kernels: Dict[str, Kernel],
+    inline_discriminators: Dict[str, int],
 ) -> List[ast.stmt]:
     spec = callee._spec
     bindings = _bind_args_to_params(spec, call, caller_name)
-    suffix = f"__{spec.name}_inl{next(_inline_counter)}"
+    suffix = _inline_suffix(spec, call, inline_discriminators)
     _add_capture_bindings(spec, bindings)
     _add_external_pipenet_bindings(
         spec,
@@ -289,6 +307,14 @@ def _expand_call(
         scope,
         reserved_names,
         external_pipenets,
+        suffix,
+    )
+    _add_logical_kernel_bindings(
+        spec,
+        bindings,
+        scope,
+        reserved_names,
+        logical_kernels,
         suffix,
     )
 
@@ -318,6 +344,17 @@ def _expand_call(
     return result
 
 
+def _inline_suffix(spec, call: ast.Call, discriminators: Dict[str, int]) -> str:
+    """Return a deterministic, caller-local suffix for one composed call."""
+    call_text = ast.dump(call, annotate_fields=True, include_attributes=False)
+    digest = hashlib.sha256(
+        f"{spec.operation_identity}\0{call_text}".encode("utf-8")
+    ).hexdigest()[:12]
+    occurrence = discriminators.get(digest, 0)
+    discriminators[digest] = occurrence + 1
+    return f"__{spec.name}_inl_{digest}_{occurrence}"
+
+
 def _add_capture_bindings(spec, bindings: Dict[str, ast.expr]) -> None:
     loaded_names = _loaded_names(spec.fn_ast.body)
     for name, value in spec.compile_time_captures.items():
@@ -341,6 +378,25 @@ def _add_external_pipenet_bindings(
         bindings[name] = ast.Name(id=fresh_name, ctx=ast.Load())
         scope[fresh_name] = pipenet
         external_pipenets[fresh_name] = pipenet
+
+
+def _add_logical_kernel_bindings(
+    spec,
+    bindings: Dict[str, ast.expr],
+    scope: Dict[str, object],
+    reserved_names: Set[str],
+    logical_kernels: Dict[str, Kernel],
+    suffix: str,
+) -> None:
+    loaded_names = _loaded_names(spec.fn_ast.body)
+    for name, kernel in spec.logical_kernels.items():
+        if name not in loaded_names or name in bindings:
+            continue
+        fresh_name = _fresh_name(name, suffix, reserved_names)
+        bindings[name] = ast.Name(id=fresh_name, ctx=ast.Load())
+        inlined_kernel = Kernel(kernel.kind)
+        scope[fresh_name] = inlined_kernel
+        logical_kernels[fresh_name] = inlined_kernel
 
 
 def _literal_node(value: object) -> ast.expr:

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -315,7 +315,6 @@ def _expand_call(
         scope,
         reserved_names,
         logical_kernels,
-        suffix,
     )
 
     local_names = _collect_local_names(spec.fn_ast)
@@ -386,17 +385,24 @@ def _add_logical_kernel_bindings(
     scope: Dict[str, object],
     reserved_names: Set[str],
     logical_kernels: Dict[str, Kernel],
-    suffix: str,
 ) -> None:
     loaded_names = _loaded_names(spec.fn_ast.body)
     for name, kernel in spec.logical_kernels.items():
         if name not in loaded_names or name in bindings:
             continue
-        fresh_name = _fresh_name(name, suffix, reserved_names)
-        bindings[name] = ast.Name(id=fresh_name, ctx=ast.Load())
-        inlined_kernel = Kernel(kernel.kind)
-        scope[fresh_name] = inlined_kernel
-        logical_kernels[fresh_name] = inlined_kernel
+        existing_name = next(
+            (
+                candidate_name
+                for candidate_name, candidate in logical_kernels.items()
+                if candidate == kernel
+            ),
+            None,
+        )
+        if existing_name is None:
+            existing_name = _fresh_name(f"{spec.name}__{name}", "", reserved_names)
+            scope[existing_name] = kernel
+            logical_kernels[existing_name] = kernel
+        bindings[name] = ast.Name(id=existing_name, ctx=ast.Load())
 
 
 def _literal_node(value: object) -> ast.expr:

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import ast
 import copy
+import inspect
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Dict, FrozenSet, List, Mapping, Optional, Set, Tuple, Union
@@ -119,7 +120,7 @@ _DFB_DIRECT_METHODS: Dict[str, _Placement] = {"publish": _Placement.DATA_MOVEMEN
 
 
 def _materialize_kernels(
-    classification: object,
+    classification: Union[KernelKind, _Placement],
     data_movement_kernels: FrozenSet[KernelSelector],
 ) -> Optional[FrozenSet[KernelSelector]]:
     if classification is _Placement.DATA_MOVEMENT:
@@ -148,9 +149,22 @@ def _kernel_keyword(call: ast.Call) -> Optional[ast.expr]:
     return None
 
 
+class _DefaultTTLSelectorNamespace:
+    KernelKind = KernelKind
+
+
+_DEFAULT_TTL_SELECTOR_NAMESPACE = _DefaultTTLSelectorNamespace()
+_MISSING_SELECTOR_VALUE = object()
+
+
 class _KernelSelectorResolver:
-    def __init__(self, logical_kernels: Mapping[str, Kernel]):
+    def __init__(
+        self,
+        logical_kernels: Mapping[str, Kernel],
+        selector_scope: Mapping[str, object],
+    ):
         self.logical_kernels = dict(logical_kernels)
+        self.selector_scope = dict(selector_scope)
         for name, kernel in self.logical_kernels.items():
             if not isinstance(kernel, Kernel):
                 raise TypeError(
@@ -162,6 +176,7 @@ class _KernelSelectorResolver:
                     f"logical kernel mapping name {name!r} does not match "
                     f"its operation-local identity {kernel.identity!r}"
                 )
+            self.selector_scope[name] = kernel
 
     def resolve_external(
         self,
@@ -224,38 +239,47 @@ class _KernelSelectorResolver:
         return selected
 
     def _resolve_selector(self, node: ast.expr) -> KernelSelector:
-        kind = self._resolve_kind(node)
-        if kind is not None:
-            return kind
-        if isinstance(node, ast.Name) and node.id in self.logical_kernels:
-            return self.logical_kernels[node.id]
+        value = self._resolve_reference(node)
+        if isinstance(value, KernelKind):
+            return value
+        if isinstance(value, Kernel) and any(
+            value is kernel for kernel in self.logical_kernels.values()
+        ):
+            return value
+        if isinstance(node, ast.Attribute):
+            owner = self._resolve_reference(node.value)
+            if owner is KernelKind and value is _MISSING_SELECTOR_VALUE:
+                raise _split_error(
+                    node,
+                    f"unknown KernelKind member {node.attr!r}",
+                )
+        type_detail = ""
+        if value is not _MISSING_SELECTOR_VALUE:
+            type_detail = f", got {type(value).__name__}"
         raise _split_error(
             node,
             "kernel selector must be a KernelKind or Kernel declared as a "
-            "top-level operation resource",
+            f"top-level operation resource{type_detail}",
         )
 
-    @staticmethod
-    def _resolve_kind(node: ast.expr) -> Optional[KernelKind]:
+    def _resolve_reference(self, node: ast.expr):
+        if isinstance(node, ast.Name):
+            if node.id in self.selector_scope:
+                return self.selector_scope[node.id]
+            if node.id == "KernelKind":
+                return KernelKind
+            if node.id == "ttl":
+                return _DEFAULT_TTL_SELECTOR_NAMESPACE
+            return _MISSING_SELECTOR_VALUE
         if not isinstance(node, ast.Attribute):
-            return None
-        owner = node.value
-        is_kernel_kind = isinstance(owner, ast.Name) and owner.id == "KernelKind"
-        if isinstance(owner, ast.Attribute):
-            is_kernel_kind = (
-                owner.attr == "KernelKind"
-                and isinstance(owner.value, ast.Name)
-                and owner.value.id == "ttl"
-            )
-        if not is_kernel_kind:
-            return None
+            return _MISSING_SELECTOR_VALUE
+        owner = self._resolve_reference(node.value)
+        if owner is _MISSING_SELECTOR_VALUE:
+            return _MISSING_SELECTOR_VALUE
         try:
-            return KernelKind[node.attr]
-        except KeyError:
-            raise _split_error(
-                node,
-                f"unknown KernelKind member {node.attr!r}",
-            ) from None
+            return inspect.getattr_static(owner, node.attr)
+        except AttributeError:
+            return _MISSING_SELECTOR_VALUE
 
 
 def _classify_ttl_call(
@@ -350,10 +374,13 @@ class SplitResult:
 class _AnalysisState:
     def __init__(self):
         self.anchor_selections: Dict[int, FrozenSet[KernelSelector]] = {}
+        self.kernel_origins: Dict[KernelSelector, ast.stmt] = {}
         self.transactions: List[DFBTransactionPlan] = []
 
     def select(self, statement: ast.stmt, kernels: Set[KernelSelector]) -> None:
         self.anchor_selections[id(statement)] = frozenset(kernels)
+        for kernel in kernels:
+            self.kernel_origins.setdefault(kernel, statement)
 
 
 def split_function_body(
@@ -361,6 +388,7 @@ def split_function_body(
     dfb_param_names: Set[str],
     local_dfb_names: Optional[Set[str]] = None,
     logical_kernels: Optional[Mapping[str, Kernel]] = None,
+    selector_scope: Optional[Mapping[str, object]] = None,
     kernel_capacities: Optional[Mapping[KernelKind, int]] = None,
 ) -> SplitResult:
     """Split a unified operation body into target-independent logical kernels.
@@ -371,10 +399,13 @@ def split_function_body(
         local_dfb_names: names of DFBs declared inside the body via a DFB
             factory. Treated as DFB receivers for wait/reserve recognition.
         logical_kernels: lifted logical Kernel resources keyed by source name.
+        selector_scope: frozen operation scope used for selector references.
         kernel_capacities: target-provided maximum kernel counts by kind.
     """
     dfb_names = set(dfb_param_names) | (local_dfb_names or set())
-    selector_resolver = _KernelSelectorResolver(logical_kernels or {})
+    selector_resolver = _KernelSelectorResolver(
+        logical_kernels or {}, selector_scope or {}
+    )
     state = _AnalysisState()
     _AnchorPlanner(
         dfb_names=dfb_names,
@@ -386,7 +417,12 @@ def split_function_body(
     for selection in state.anchor_selections.values():
         selected_kernels.update(selection)
     ordered_kernels = tuple(sorted(selected_kernels, key=_selector_sort_key))
-    _validate_kernel_capacities(fn_def, ordered_kernels, kernel_capacities)
+    _validate_kernel_capacities(
+        fn_def,
+        ordered_kernels,
+        state.kernel_origins,
+        kernel_capacities,
+    )
 
     all_kernels = frozenset(ordered_kernels)
     statements = tuple(
@@ -474,6 +510,7 @@ class _AnchorPlanner:
     # --- entry ---
 
     def analyze(self, body: List[ast.stmt]) -> None:
+        _validate_dfb_acquire_keywords(body, self.dfb_names)
         self._discover_producers(body)
         self._discover_callback_kernels(body)
         inferred_users, explicit_releases = _collect_block_ownership(
@@ -602,6 +639,8 @@ class _AnchorPlanner:
                 self._state.select(stmt, kernels)
             for child in stmt.body:
                 self._annotate(child)
+            if kernels is not None:
+                self._validate_with_body_selection(stmt, kernels)
             return
         if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
             callback_kernels = frozenset(
@@ -667,6 +706,23 @@ class _AnchorPlanner:
             if owner is not None:
                 merged.add(owner)
         return merged if any_dfb else None
+
+    def _validate_with_body_selection(
+        self,
+        stmt: ast.With,
+        acquire_kernels: Set[KernelSelector],
+    ) -> None:
+        for nested_statement in _walk_statements(stmt.body):
+            nested_kernels = self._state.anchor_selections.get(id(nested_statement))
+            if nested_kernels is None or nested_kernels.issubset(acquire_kernels):
+                continue
+            raise _split_error(
+                nested_statement,
+                "statement selects logical kernels "
+                f"({_format_kernels(nested_kernels)}) outside its enclosing "
+                "DFB acquire owner "
+                f"({_format_kernels(acquire_kernels)})",
+            )
 
     def _block_kernel_set(self, block_name: str) -> Set[KernelSelector]:
         owner = self.block_owners.get(block_name)
@@ -735,10 +791,15 @@ class _AnchorPlanner:
 
 
 class _KernelKeywordStripper(ast.NodeTransformer):
+    def __init__(self, block_names: Set[str]):
+        self.block_names = block_names
+
     def visit_Call(self, node: ast.Call):
         node = self.generic_visit(node)
         is_release = (
             isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in self.block_names
             and node.func.attr in _BLOCK_RELEASE_METHODS
         )
         if _is_external_call(node) or is_release:
@@ -761,6 +822,7 @@ def _walk_statements(statements: List[ast.stmt]):
 def _validate_kernel_capacities(
     fn_def: ast.FunctionDef,
     kernels: Tuple[KernelSelector, ...],
+    kernel_origins: Mapping[KernelSelector, ast.stmt],
     kernel_capacities: Optional[Mapping[KernelKind, int]],
 ) -> None:
     if kernel_capacities is None:
@@ -771,12 +833,19 @@ def _validate_kernel_capacities(
             raise ValueError(
                 f"kernel capacity for {kind.value} must be a nonnegative integer"
             )
-        required = sum(_selector_kind(kernel) == kind for kernel in kernels)
+        selected = tuple(kernel for kernel in kernels if _selector_kind(kernel) == kind)
+        required = len(selected)
         if required > capacity:
+            diagnostic_node = max(
+                (kernel_origins[kernel] for kernel in selected),
+                key=lambda statement: getattr(statement, "lineno", 0),
+                default=fn_def,
+            )
             raise _split_error(
-                fn_def,
+                diagnostic_node,
                 f"operation requires {required} {kind.value} kernels, but the "
-                f"target supports {capacity}",
+                f"target supports {capacity}; selected kernels: "
+                f"{_format_kernels(selected)}",
             )
 
 
@@ -791,7 +860,9 @@ def _apply_split_plan(
         statement.statement_id: statement.kernels for statement in plan.statements
     }
     cloned = _prune_statement_list(body, kernel, selections, memo, insert_pass=True)
-    stripper = _KernelKeywordStripper()
+    stripper = _KernelKeywordStripper(
+        {transaction.block_name for transaction in plan.transactions}
+    )
     return [
         ast.fix_missing_locations(stripper.visit(statement)) for statement in cloned
     ]
@@ -859,6 +930,29 @@ def _assigned_copy_target(stmt: ast.stmt) -> Optional[str]:
     if func.attr != "copy":
         return None
     return stmt.targets[0].id
+
+
+def _validate_dfb_acquire_keywords(
+    statements: List[ast.stmt], dfb_names: Set[str]
+) -> None:
+    """Reject placement selectors on DFB acquisition operations."""
+    for statement in statements:
+        for node in _iter_skip_nested_fns(statement):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            if func.attr not in _DFB_PRODUCING_METHODS:
+                continue
+            if not isinstance(func.value, ast.Name) or func.value.id not in dfb_names:
+                continue
+            if _kernel_keyword(node) is not None:
+                raise _split_error(
+                    node,
+                    f"kernel= is not supported on DFB {func.attr}(); "
+                    "select release ownership on push() or pop()",
+                )
 
 
 def _bare_wait_assign_target(
@@ -1025,8 +1119,6 @@ def _collect_block_ownership(
             if root in visible:
                 inferred_users[root].update(kernels)
         for kw in node.keywords:
-            if kw.arg == _KERNEL_KEYWORD:
-                continue
             root = _expr_root_name(kw.value)
             if root in visible:
                 inferred_users[root].update(kernels)

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -15,30 +15,44 @@ from __future__ import annotations
 import ast
 import copy
 from dataclasses import dataclass
-from typing import Dict, FrozenSet, List, Mapping, Optional, Set, Tuple
+from enum import Enum, auto
+from typing import Dict, FrozenSet, List, Mapping, Optional, Set, Tuple, Union
 
 from ttl.kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _PIPE_SOURCE_KERNEL_ROLE,
     _format_selector,
     _selector_kind,
     _selector_sort_key,
 )
 
-_PIPE_SOURCE_KERNEL = Kernel._implicit(KernelKind.DATA_MOVEMENT, "pipe_source")
+_EXTERNAL_CALL_NAME = "call_extern_func"
+_KERNEL_KEYWORD = "kernel"
+_BLOCK_RELEASE_METHODS = frozenset(("push", "pop"))
+_PIPE_SOURCE_KERNEL = Kernel._implicit(
+    KernelKind.DATA_MOVEMENT,
+    _PIPE_SOURCE_KERNEL_ROLE,
+)
+
+
+class _Placement(Enum):
+    DATA_MOVEMENT = auto()
+    CONTROL = auto()
+    DEFERRED = auto()
 
 
 # ----- op registry ----------------------------------------------------------
 
 
-# ``"dm"`` resolves to the current callback's logical data-movement kernel.
-# ``"control"`` does not constrain placement.
-_TTL_OPS: Dict[str, object] = {
+# DATA_MOVEMENT resolves to the current callback's logical data-movement
+# kernel. CONTROL does not constrain placement.
+_TTL_OPS: Dict[str, Union[KernelKind, _Placement]] = {
     # Data movement
-    "copy": "dm",
-    "element_read": "dm",
-    "element_write": "dm",
+    "copy": _Placement.DATA_MOVEMENT,
+    "element_read": _Placement.DATA_MOVEMENT,
+    "element_write": _Placement.DATA_MOVEMENT,
     # Compute
     "fill": KernelKind.COMPUTE,
     "matmul": KernelKind.COMPUTE,
@@ -62,19 +76,19 @@ _TTL_OPS: Dict[str, object] = {
     "sigmoid": KernelKind.COMPUTE,
     "gelu": KernelKind.COMPUTE,
     # Compile-time / scalar producers: duplicated, not anchored.
-    "Pipe": "control",
-    "PipeNet": "control",
-    "make_dataflow_buffer_like": "control",
-    "make_tensor_backed_dfb": "control",
-    "node": "control",
-    "dfb_descriptor": "control",
-    "get_dfb_id": "control",
-    "raw_addr": "control",
-    "grid_size": "control",
-    "dims": "control",
-    "cores": "control",
-    "tile_index": "control",
-    "signpost": "control",
+    "Pipe": _Placement.CONTROL,
+    "PipeNet": _Placement.CONTROL,
+    "make_dataflow_buffer_like": _Placement.CONTROL,
+    "make_tensor_backed_dfb": _Placement.CONTROL,
+    "node": _Placement.CONTROL,
+    "dfb_descriptor": _Placement.CONTROL,
+    "get_dfb_id": _Placement.CONTROL,
+    "raw_addr": _Placement.CONTROL,
+    "grid_size": _Placement.CONTROL,
+    "dims": _Placement.CONTROL,
+    "cores": _Placement.CONTROL,
+    "tile_index": _Placement.CONTROL,
+    "signpost": _Placement.CONTROL,
 }
 
 # ttl.<ns>.<name>(...) -> logical kind for every name in the namespace.
@@ -90,15 +104,15 @@ _PIPENET_METHODS: Dict[str, KernelSelector] = {
 }
 
 # Block releases use the transaction owner computed before statement planning.
-_BLOCK_METHODS: Dict[str, str] = {
-    "store": "compute",
-    "pop": "deferred",
-    "push": "deferred",
+_BLOCK_METHODS: Dict[str, Union[KernelKind, _Placement]] = {
+    "store": KernelKind.COMPUTE,
+    "pop": _Placement.DEFERRED,
+    "push": _Placement.DEFERRED,
 }
 
 # Methods on a DFB name that produce a block.
 _DFB_PRODUCING_METHODS: Set[str] = {"wait", "reserve"}
-_DFB_DIRECT_METHODS: Dict[str, str] = {"publish": "dm"}
+_DFB_DIRECT_METHODS: Dict[str, _Placement] = {"publish": _Placement.DATA_MOVEMENT}
 
 
 # ----- shared call classification ------------------------------------------
@@ -108,7 +122,7 @@ def _materialize_kernels(
     classification: object,
     data_movement_kernels: FrozenSet[KernelSelector],
 ) -> Optional[FrozenSet[KernelSelector]]:
-    if classification == "dm":
+    if classification is _Placement.DATA_MOVEMENT:
         return data_movement_kernels
     if isinstance(classification, KernelKind):
         return frozenset({classification})
@@ -118,10 +132,10 @@ def _materialize_kernels(
 def _is_external_call(call: ast.Call) -> bool:
     func = call.func
     if isinstance(func, ast.Name):
-        return func.id == "call_extern_func"
+        return func.id == _EXTERNAL_CALL_NAME
     return (
         isinstance(func, ast.Attribute)
-        and func.attr == "call_extern_func"
+        and func.attr == _EXTERNAL_CALL_NAME
         and isinstance(func.value, ast.Name)
         and func.value.id == "ttl"
     )
@@ -129,7 +143,7 @@ def _is_external_call(call: ast.Call) -> bool:
 
 def _kernel_keyword(call: ast.Call) -> Optional[ast.expr]:
     for keyword in call.keywords:
-        if keyword.arg == "kernel":
+        if keyword.arg == _KERNEL_KEYWORD:
             return keyword.value
     return None
 
@@ -708,9 +722,9 @@ class _AnchorPlanner:
                     return _materialize_kernels(method, self._data_movement_kernels)
             if func.value.id in self._producers:
                 method = _BLOCK_METHODS.get(func.attr)
-                if method == "compute":
-                    return frozenset({KernelKind.COMPUTE})
-                if method == "deferred":
+                if isinstance(method, KernelKind):
+                    return frozenset({method})
+                if method is _Placement.DEFERRED:
                     owner = self.block_owners.get(func.value.id)
                     if owner is not None:
                         return frozenset({owner})
@@ -723,13 +737,13 @@ class _AnchorPlanner:
 class _KernelKeywordStripper(ast.NodeTransformer):
     def visit_Call(self, node: ast.Call):
         node = self.generic_visit(node)
-        is_release = isinstance(node.func, ast.Attribute) and node.func.attr in {
-            "push",
-            "pop",
-        }
+        is_release = (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in _BLOCK_RELEASE_METHODS
+        )
         if _is_external_call(node) or is_release:
             node.keywords = [
-                keyword for keyword in node.keywords if keyword.arg != "kernel"
+                keyword for keyword in node.keywords if keyword.arg != _KERNEL_KEYWORD
             ]
         return node
 
@@ -1011,7 +1025,7 @@ def _collect_block_ownership(
             if root in visible:
                 inferred_users[root].update(kernels)
         for kw in node.keywords:
-            if kw.arg == "kernel":
+            if kw.arg == _KERNEL_KEYWORD:
                 continue
             root = _expr_root_name(kw.value)
             if root in visible:
@@ -1031,7 +1045,7 @@ def _collect_block_ownership(
             if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
                 receiver = func.value.id
                 method = func.attr
-                if receiver in visible and method in {"push", "pop"}:
+                if receiver in visible and method in _BLOCK_RELEASE_METHODS:
                     explicit = selector_resolver.resolve_release(node)
                     if explicit is not None:
                         explicit_releases[receiver].append((node, explicit))

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -150,6 +150,19 @@ def _kernel_keyword(call: ast.Call) -> Optional[ast.expr]:
     return None
 
 
+def _is_kernel_kind_union(node: ast.AST) -> bool:
+    return isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr)
+
+
+def _flatten_kernel_kind_union(node: ast.expr) -> List[ast.expr]:
+    if not _is_kernel_kind_union(node):
+        return [node]
+    assert isinstance(node, ast.BinOp)
+    return _flatten_kernel_kind_union(node.left) + _flatten_kernel_kind_union(
+        node.right
+    )
+
+
 class _DefaultTTLSelectorNamespace:
     KernelKind = KernelKind
 
@@ -208,6 +221,11 @@ class _KernelSelectorResolver:
                 selector,
                 f"{ast.unparse(call.func)} accepts one kernel selector, not a tuple",
             )
+        if _is_kernel_kind_union(selector):
+            raise _split_error(
+                selector,
+                f"{ast.unparse(call.func)} accepts one kernel selector, not a kind union",
+            )
         selected = self._resolve_selector(selector)
         return selected
 
@@ -216,6 +234,18 @@ class _KernelSelectorResolver:
         node: ast.expr,
         allow_tuple: bool,
     ) -> FrozenSet[KernelSelector]:
+        if _is_kernel_kind_union(node):
+            selectors = [
+                self._resolve_selector(element)
+                for element in _flatten_kernel_kind_union(node)
+            ]
+            if not all(isinstance(selector, KernelKind) for selector in selectors):
+                raise _split_error(
+                    node,
+                    "kernel kind union operands must be KernelKind members; "
+                    "use a tuple to include operation-local Kernel handles",
+                )
+            return self._validate_multiple_selection(node, selectors)
         if not isinstance(node, ast.Tuple):
             return frozenset({self._resolve_selector(node)})
         if not allow_tuple:
@@ -226,6 +256,13 @@ class _KernelSelectorResolver:
                 "call_extern_func kernel selection requires a nonempty tuple",
             )
         selectors = [self._resolve_selector(element) for element in node.elts]
+        return self._validate_multiple_selection(node, selectors)
+
+    def _validate_multiple_selection(
+        self,
+        node: ast.expr,
+        selectors: List[KernelSelector],
+    ) -> FrozenSet[KernelSelector]:
         selected = frozenset(selectors)
         if len(selected) != len(selectors):
             raise _split_error(

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -23,7 +23,9 @@ from ttl.kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _DFB_RELEASE_METHODS,
     _PIPE_SOURCE_KERNEL_ROLE,
+    _format_kernel_capacity_error,
     _format_selector,
     _selector_kind,
     _selector_sort_key,
@@ -31,7 +33,6 @@ from ttl.kernel import (
 
 _EXTERNAL_CALL_NAME = "call_extern_func"
 _KERNEL_KEYWORD = "kernel"
-_BLOCK_RELEASE_METHODS = frozenset(("push", "pop"))
 _PIPE_SOURCE_KERNEL = Kernel._implicit(
     KernelKind.DATA_MOVEMENT,
     _PIPE_SOURCE_KERNEL_ROLE,
@@ -170,11 +171,6 @@ class _KernelSelectorResolver:
                 raise TypeError(
                     f"logical kernel {name!r} must be a Kernel, got "
                     f"{type(kernel).__name__}"
-                )
-            if kernel.identity != name:
-                raise ValueError(
-                    f"logical kernel mapping name {name!r} does not match "
-                    f"its operation-local identity {kernel.identity!r}"
                 )
             self.selector_scope[name] = kernel
 
@@ -800,7 +796,7 @@ class _KernelKeywordStripper(ast.NodeTransformer):
             isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id in self.block_names
-            and node.func.attr in _BLOCK_RELEASE_METHODS
+            and node.func.attr in _DFB_RELEASE_METHODS
         )
         if _is_external_call(node) or is_release:
             node.keywords = [
@@ -843,9 +839,7 @@ def _validate_kernel_capacities(
             )
             raise _split_error(
                 diagnostic_node,
-                f"operation requires {required} {kind.value} kernels, but the "
-                f"target supports {capacity}; selected kernels: "
-                f"{_format_kernels(selected)}",
+                _format_kernel_capacity_error(kind, selected, capacity),
             )
 
 
@@ -1137,7 +1131,7 @@ def _collect_block_ownership(
             if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
                 receiver = func.value.id
                 method = func.attr
-                if receiver in visible and method in _BLOCK_RELEASE_METHODS:
+                if receiver in visible and method in _DFB_RELEASE_METHODS:
                     explicit = selector_resolver.resolve_release(node)
                     if explicit is not None:
                         explicit_releases[receiver].append((node, explicit))

--- a/python/ttl/_src/atom_split.py
+++ b/python/ttl/_src/atom_split.py
@@ -2,44 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Duplicate-and-prune splitter for unified-body @ttl.operation kernels.
+"""Plan and apply logical-kernel splitting for unified operations.
 
-Walks the function body of a unified @ttl.operation kernel and produces
-three stripped function ASTs: one each for the TRISC (compute), NCRISC
-(default DM, receivers + non-pipe DM), and BRISC (pipe senders) threads.
-
-Algorithm:
-
-    trisc_body, ncrisc_body, brisc_body = three deepcopies of body
-
-    Pass A (anchor tagging):
-        Walk every Call/MatMult node and look it up in the op
-        registry. Anchor stmts get an ``_ttl_threads`` attribute
-        set to the frozenset of threads they belong on. Stmts that
-        produce a block via ``cb.wait()`` / ``cb.reserve()`` are
-        *deferred anchors*: their thread is the union of threads
-        observed on the produced block's downstream anchor uses.
-
-        DM ops are registered with the sentinel ``"dm"``; the tagger
-        materializes that to a concrete thread (``"ncrisc"`` outside
-        an if_src callback, ``"brisc"`` inside one). Pipe dispatch
-        methods bind directly: ``if_src`` -> brisc, ``if_dst`` -> ncrisc.
-
-    Pass B (per-side prune):
-        For each side, walk the duplicated body. If a stmt has
-        ``_ttl_threads`` and this side isn't in it, drop the stmt.
-        Non-anchor stmts (control flow, scalar arithmetic, ttl.node,
-        make_dataflow_buffer_like, make_tensor_backed_dfb, ...) stay on
-        every side; MLIR DCE removes dead code per-thread later.
-
-    Post-check:
-        A DFB producer (``blk = cb.wait()`` / ``cb.reserve()``) must have
-        users on exactly one thread. Splitting an acquire across threads
-        would issue the synchronization operation more than once against
-        the same DFB.
-
-Unknown ``ttl.<name>(...)`` calls are a hard error. To add an op,
-register it in ``_TTL_OPS`` with its thread.
+The analysis records statement placement and DFB transaction ownership on the
+unmodified AST. Application then clones and prunes the body once per selected
+logical kernel. Target-specific processor assignment occurs in ``ttl.atom``
+after this module returns the logical split.
 """
 
 from __future__ import annotations
@@ -47,57 +15,60 @@ from __future__ import annotations
 import ast
 import copy
 from dataclasses import dataclass
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, Mapping, Optional, Set, Tuple
 
+from ttl.kernel import (
+    Kernel,
+    KernelKind,
+    KernelSelector,
+    _format_selector,
+    _selector_kind,
+    _selector_sort_key,
+)
 
-# ----- threads --------------------------------------------------------------
-
-
-THREADS: Tuple[str, ...] = ("trisc", "ncrisc", "brisc")
-DM_THREADS: Tuple[str, ...] = ("ncrisc", "brisc")
+_PIPE_SOURCE_KERNEL = Kernel._implicit(KernelKind.DATA_MOVEMENT, "pipe_source")
 
 
 # ----- op registry ----------------------------------------------------------
 
 
-# ttl.<name>(...) -> "trisc" | "dm" | "control".
-#
-# ``"dm"`` is a sentinel: at tagging time it is materialized to either
-# "ncrisc" or "brisc" depending on whether the call sits inside an
-# ``if_src`` callback (-> brisc) or anywhere else (-> ncrisc).
-_TTL_OPS: Dict[str, str] = {
+# ``"dm"`` resolves to the current callback's logical data-movement kernel.
+# ``"control"`` does not constrain placement.
+_TTL_OPS: Dict[str, object] = {
     # Data movement
     "copy": "dm",
     "element_read": "dm",
     "element_write": "dm",
     # Compute
-    "fill": "trisc",
-    "matmul": "trisc",
-    "reduce_sum": "trisc",
-    "reduce_max": "trisc",
-    "broadcast": "trisc",
-    "transpose": "trisc",
-    "exp": "trisc",
-    "mul": "trisc",
-    "add": "trisc",
-    "sub": "trisc",
-    "div": "trisc",
-    "recip": "trisc",
-    "neg": "trisc",
-    "sqrt": "trisc",
-    "tanh": "trisc",
-    "log": "trisc",
-    "abs": "trisc",
-    "relu": "trisc",
-    "sign": "trisc",
-    "sigmoid": "trisc",
-    "gelu": "trisc",
+    "fill": KernelKind.COMPUTE,
+    "matmul": KernelKind.COMPUTE,
+    "reduce_sum": KernelKind.COMPUTE,
+    "reduce_max": KernelKind.COMPUTE,
+    "broadcast": KernelKind.COMPUTE,
+    "transpose": KernelKind.COMPUTE,
+    "exp": KernelKind.COMPUTE,
+    "mul": KernelKind.COMPUTE,
+    "add": KernelKind.COMPUTE,
+    "sub": KernelKind.COMPUTE,
+    "div": KernelKind.COMPUTE,
+    "recip": KernelKind.COMPUTE,
+    "neg": KernelKind.COMPUTE,
+    "sqrt": KernelKind.COMPUTE,
+    "tanh": KernelKind.COMPUTE,
+    "log": KernelKind.COMPUTE,
+    "abs": KernelKind.COMPUTE,
+    "relu": KernelKind.COMPUTE,
+    "sign": KernelKind.COMPUTE,
+    "sigmoid": KernelKind.COMPUTE,
+    "gelu": KernelKind.COMPUTE,
     # Compile-time / scalar producers: duplicated, not anchored.
     "Pipe": "control",
     "PipeNet": "control",
     "make_dataflow_buffer_like": "control",
     "make_tensor_backed_dfb": "control",
     "node": "control",
+    "dfb_descriptor": "control",
+    "get_dfb_id": "control",
     "raw_addr": "control",
     "grid_size": "control",
     "dims": "control",
@@ -106,24 +77,21 @@ _TTL_OPS: Dict[str, str] = {
     "signpost": "control",
 }
 
-# ttl.<ns>.<name>(...) -> thread, applies to every name in the namespace.
-_TTL_NAMESPACES: Dict[str, str] = {
-    "math": "trisc",
-    "block": "trisc",
+# ttl.<ns>.<name>(...) -> logical kind for every name in the namespace.
+_TTL_NAMESPACES: Dict[str, KernelKind] = {
+    "math": KernelKind.COMPUTE,
+    "block": KernelKind.COMPUTE,
 }
 
-# <pipenet>.<method>(...) -> thread. The receiver is any Name (PipeNet
-# object). ``if_src`` dispatches the sender side on BRISC; ``if_dst``
-# the receiver side on NCRISC (sender = BRISC, receiver = NCRISC).
-_PIPENET_METHODS: Dict[str, str] = {
-    "if_src": "brisc",
-    "if_dst": "ncrisc",
+# Pipe source and destination callbacks have distinct logical affinities.
+_PIPENET_METHODS: Dict[str, KernelSelector] = {
+    "if_src": _PIPE_SOURCE_KERNEL,
+    "if_dst": KernelKind.DATA_MOVEMENT,
 }
 
-# <block>.<method>(...) where <block> is a known block. "trisc" pins
-# the call; "deferred" pins it to the block's inferred thread.
+# Block releases use the transaction owner computed before statement planning.
 _BLOCK_METHODS: Dict[str, str] = {
-    "store": "trisc",
+    "store": "compute",
     "pop": "deferred",
     "push": "deferred",
 }
@@ -133,65 +101,188 @@ _DFB_PRODUCING_METHODS: Set[str] = {"wait", "reserve"}
 _DFB_DIRECT_METHODS: Dict[str, str] = {"publish": "dm"}
 
 
-# ----- shared call -> thread classification ---------------------------------
+# ----- shared call classification ------------------------------------------
 
 
-def _materialize_thread(op: Optional[str], dm_thread: str) -> Optional[str]:
-    """Resolve a registry value to a concrete thread tag.
-
-    ``"dm"`` becomes the scope's DM thread (ncrisc by default, brisc inside an
-    if_src callback). Anything that is not a concrete thread (``"control"`` and
-    compile-time producers) returns None, since it does not pin a thread.
-    """
-    if op == "dm":
-        return dm_thread
-    if op in THREADS:
-        return op
+def _materialize_kernels(
+    classification: object,
+    data_movement_kernels: FrozenSet[KernelSelector],
+) -> Optional[FrozenSet[KernelSelector]]:
+    if classification == "dm":
+        return data_movement_kernels
+    if isinstance(classification, KernelKind):
+        return frozenset({classification})
     return None
 
 
-def _classify_ttl_call(func: ast.expr, dm_thread: str) -> Optional[str]:
-    """Thread a registry-driven call pins to, or None when the call is not a
-    registry anchor (control op, bare-name call, block / DFB method, or a
-    chained call).
+def _is_external_call(call: ast.Call) -> bool:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id == "call_extern_func"
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "call_extern_func"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "ttl"
+    )
 
-    Handles ``ttl.<op>(...)``, ``ttl.<ns>.<name>(...)`` and
-    ``<recv>.if_src/if_dst(...)``, raising on an unknown ``ttl.<...>`` form so a
-    new op must be registered rather than silently mis-split. This is the
-    single source of the call->thread decision; both anchor tagging and
-    block-use collection route through it.
-    """
-    # ttl.<name>(...) or <recv>.if_src/if_dst(...)
+
+def _kernel_keyword(call: ast.Call) -> Optional[ast.expr]:
+    for keyword in call.keywords:
+        if keyword.arg == "kernel":
+            return keyword.value
+    return None
+
+
+class _KernelSelectorResolver:
+    def __init__(self, logical_kernels: Mapping[str, Kernel]):
+        self.logical_kernels = dict(logical_kernels)
+        for name, kernel in self.logical_kernels.items():
+            if not isinstance(kernel, Kernel):
+                raise TypeError(
+                    f"logical kernel {name!r} must be a Kernel, got "
+                    f"{type(kernel).__name__}"
+                )
+            if kernel.identity != name:
+                raise ValueError(
+                    f"logical kernel mapping name {name!r} does not match "
+                    f"its operation-local identity {kernel.identity!r}"
+                )
+
+    def resolve_external(
+        self,
+        call: ast.Call,
+        inferred_kernels: FrozenSet[KernelSelector],
+    ) -> FrozenSet[KernelSelector]:
+        selector = _kernel_keyword(call)
+        if selector is None:
+            if len(inferred_kernels) == 1:
+                return inferred_kernels
+            raise _split_error(
+                call,
+                "call_extern_func requires a kernel selector when its logical "
+                "kernel cannot be inferred",
+            )
+
+        selected = self._resolve_selection(selector, allow_tuple=True)
+        if inferred_kernels and selected != inferred_kernels:
+            raise _split_error(
+                selector,
+                "explicit external-call kernel selection "
+                f"({_format_kernels(selected)}) conflicts with inferred "
+                f"selection ({_format_kernels(inferred_kernels)})",
+            )
+        return selected
+
+    def resolve_release(self, call: ast.Call) -> Optional[KernelSelector]:
+        selector = _kernel_keyword(call)
+        if selector is None:
+            return None
+        if isinstance(selector, ast.Tuple):
+            raise _split_error(
+                selector,
+                f"{ast.unparse(call.func)} accepts one kernel selector, not a tuple",
+            )
+        selected = self._resolve_selector(selector)
+        return selected
+
+    def _resolve_selection(
+        self,
+        node: ast.expr,
+        allow_tuple: bool,
+    ) -> FrozenSet[KernelSelector]:
+        if not isinstance(node, ast.Tuple):
+            return frozenset({self._resolve_selector(node)})
+        if not allow_tuple:
+            raise _split_error(node, "expected one kernel selector, not a tuple")
+        if not node.elts:
+            raise _split_error(
+                node,
+                "call_extern_func kernel selection requires a nonempty tuple",
+            )
+        selectors = [self._resolve_selector(element) for element in node.elts]
+        selected = frozenset(selectors)
+        if len(selected) != len(selectors):
+            raise _split_error(
+                node,
+                "call_extern_func kernel selection contains a duplicate kernel selector",
+            )
+        return selected
+
+    def _resolve_selector(self, node: ast.expr) -> KernelSelector:
+        kind = self._resolve_kind(node)
+        if kind is not None:
+            return kind
+        if isinstance(node, ast.Name) and node.id in self.logical_kernels:
+            return self.logical_kernels[node.id]
+        raise _split_error(
+            node,
+            "kernel selector must be a KernelKind or Kernel declared as a "
+            "top-level operation resource",
+        )
+
+    @staticmethod
+    def _resolve_kind(node: ast.expr) -> Optional[KernelKind]:
+        if not isinstance(node, ast.Attribute):
+            return None
+        owner = node.value
+        is_kernel_kind = isinstance(owner, ast.Name) and owner.id == "KernelKind"
+        if isinstance(owner, ast.Attribute):
+            is_kernel_kind = (
+                owner.attr == "KernelKind"
+                and isinstance(owner.value, ast.Name)
+                and owner.value.id == "ttl"
+            )
+        if not is_kernel_kind:
+            return None
+        try:
+            return KernelKind[node.attr]
+        except KeyError:
+            raise _split_error(
+                node,
+                f"unknown KernelKind member {node.attr!r}",
+            ) from None
+
+
+def _classify_ttl_call(
+    call: ast.Call,
+    data_movement_kernels: FrozenSet[KernelSelector],
+    inferred_external_kernels: FrozenSet[KernelSelector],
+    selector_resolver: _KernelSelectorResolver,
+) -> Optional[FrozenSet[KernelSelector]]:
+    """Return a registry-driven call's logical-kernel selection."""
+    if _is_external_call(call):
+        return selector_resolver.resolve_external(call, inferred_external_kernels)
+
+    func = call.func
     if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-        recv = func.value.id
+        receiver = func.value.id
         name = func.attr
-        if recv == "ttl":
-            op = _TTL_OPS.get(name)
-            if op is None:
+        if receiver == "ttl":
+            classification = _TTL_OPS.get(name)
+            if classification is None:
                 raise _split_error(
                     func,
-                    f"unknown ttl.{name}(...) call; register it in "
-                    f"atom_split._TTL_OPS with its thread "
-                    f"('trisc', 'dm', or 'control')",
+                    f"unknown ttl.{name}(...) call; register its logical "
+                    "kernel classification in atom_split._TTL_OPS",
                 )
-            return _materialize_thread(op, dm_thread)
+            return _materialize_kernels(classification, data_movement_kernels)
         if name in _PIPENET_METHODS:
-            return _PIPENET_METHODS[name]
+            return frozenset({_PIPENET_METHODS[name]})
         return None
 
-    # ttl.<ns>.<name>(...)
     if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
         outer = func.value
         if isinstance(outer.value, ast.Name) and outer.value.id == "ttl":
-            ns = outer.attr
-            ns_thread = _TTL_NAMESPACES.get(ns)
-            if ns_thread is None:
+            namespace = outer.attr
+            kind = _TTL_NAMESPACES.get(namespace)
+            if kind is None:
                 raise _split_error(
                     func,
-                    f"unknown ttl.{ns}.{func.attr}(...) call; register "
-                    f"namespace 'ttl.{ns}' in atom_split._TTL_NAMESPACES",
+                    f"unknown ttl.{namespace}.{func.attr}(...) call; register "
+                    f"namespace 'ttl.{namespace}' in atom_split._TTL_NAMESPACES",
                 )
-            return _materialize_thread(ns_thread, dm_thread)
+            return frozenset({kind})
 
     return None
 
@@ -199,53 +290,134 @@ def _classify_ttl_call(func: ast.expr, dm_thread: str) -> Optional[str]:
 # ----- public API -----------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class StatementSelection:
+    statement_id: int
+    kernels: FrozenSet[KernelSelector]
+    source_line: int
+
+
+@dataclass(frozen=True)
+class DFBTransactionPlan:
+    block_name: str
+    inferred_kernels: FrozenSet[KernelSelector]
+    explicit_kernels: FrozenSet[KernelSelector]
+    owner: KernelSelector
+    source_line: int
+
+
+@dataclass(frozen=True)
+class SplitPlan:
+    kernels: Tuple[KernelSelector, ...]
+    statements: Tuple[StatementSelection, ...]
+    transactions: Tuple[DFBTransactionPlan, ...]
+    kernel_requirements: Tuple[Tuple[KernelKind, int], ...]
+    target_capacities: Tuple[Tuple[KernelKind, int], ...]
+
+
 @dataclass
 class SplitResult:
-    trisc_body: List[ast.stmt]
-    ncrisc_body: List[ast.stmt]
-    brisc_body: List[ast.stmt]
+    plan: SplitPlan
+    _bodies: Dict[KernelSelector, List[ast.stmt]]
 
-    def body_for(self, thread: str) -> List[ast.stmt]:
-        return getattr(self, f"{thread}_body")
+    @property
+    def kernels(self) -> Tuple[KernelSelector, ...]:
+        return self.plan.kernels
+
+    def body_for(self, kernel: KernelSelector) -> List[ast.stmt]:
+        if not isinstance(kernel, (KernelKind, Kernel)):
+            raise TypeError(
+                "body_for() requires a KernelKind or Kernel, got "
+                f"{type(kernel).__name__}"
+            )
+        return self._bodies.get(kernel, [ast.Pass()])
+
+
+class _AnalysisState:
+    def __init__(self):
+        self.anchor_selections: Dict[int, FrozenSet[KernelSelector]] = {}
+        self.transactions: List[DFBTransactionPlan] = []
+
+    def select(self, statement: ast.stmt, kernels: Set[KernelSelector]) -> None:
+        self.anchor_selections[id(statement)] = frozenset(kernels)
 
 
 def split_function_body(
     fn_def: ast.FunctionDef,
     dfb_param_names: Set[str],
     local_dfb_names: Optional[Set[str]] = None,
+    logical_kernels: Optional[Mapping[str, Kernel]] = None,
+    kernel_capacities: Optional[Mapping[KernelKind, int]] = None,
 ) -> SplitResult:
-    """Split a unified @ttl.operation body into trisc / ncrisc / brisc bodies.
+    """Split a unified operation body into target-independent logical kernels.
 
     Args:
         fn_def: AST FunctionDef of the user's @ttl.operation function.
         dfb_param_names: parameter names annotated as ttl.DFB / ttl.DFB.Output.
         local_dfb_names: names of DFBs declared inside the body via a DFB
             factory. Treated as DFB receivers for wait/reserve recognition.
+        logical_kernels: lifted logical Kernel resources keyed by source name.
+        kernel_capacities: target-provided maximum kernel counts by kind.
     """
     dfb_names = set(dfb_param_names) | (local_dfb_names or set())
+    selector_resolver = _KernelSelectorResolver(logical_kernels or {})
+    state = _AnalysisState()
+    _AnchorPlanner(
+        dfb_names=dfb_names,
+        selector_resolver=selector_resolver,
+        state=state,
+    ).analyze(fn_def.body)
 
-    # Pass A: tag anchor stmts in-place on the original body.
-    _AnchorTagger(dfb_names=dfb_names).tag(fn_def.body)
+    selected_kernels: Set[KernelSelector] = set()
+    for selection in state.anchor_selections.values():
+        selected_kernels.update(selection)
+    ordered_kernels = tuple(sorted(selected_kernels, key=_selector_sort_key))
+    _validate_kernel_capacities(fn_def, ordered_kernels, kernel_capacities)
 
-    # Pass B: deep-copy the body once per side; prune anchors that
-    # don't apply on this side. Tag attributes survive deep-copy.
+    all_kernels = frozenset(ordered_kernels)
+    statements = tuple(
+        StatementSelection(
+            statement_id=id(statement),
+            kernels=state.anchor_selections.get(id(statement), all_kernels),
+            source_line=getattr(statement, "lineno", 0),
+        )
+        for statement in _walk_statements(fn_def.body)
+    )
+    requirements = tuple(
+        (
+            kind,
+            sum(_selector_kind(kernel) == kind for kernel in ordered_kernels),
+        )
+        for kind in KernelKind
+    )
+    target_capacities = tuple(
+        sorted(
+            (kernel_capacities or {}).items(),
+            key=lambda item: _selector_sort_key(item[0]),
+        )
+    )
+    plan = SplitPlan(
+        kernels=ordered_kernels,
+        statements=statements,
+        transactions=tuple(state.transactions),
+        kernel_requirements=requirements,
+        target_capacities=target_capacities,
+    )
     bodies = {
-        thread: _prune_body([copy.deepcopy(s) for s in fn_def.body], thread)
-        for thread in THREADS
+        kernel: _apply_split_plan(fn_def.body, kernel, plan)
+        for kernel in ordered_kernels
     }
-
     return SplitResult(
-        trisc_body=bodies["trisc"],
-        ncrisc_body=bodies["ncrisc"],
-        brisc_body=bodies["brisc"],
+        plan=plan,
+        _bodies=bodies,
     )
 
 
-# ----- Pass A: anchor tagging ----------------------------------------------
+# ----- logical-kernel analysis ---------------------------------------------
 
 
-class _AnchorTagger:
-    """Walks the body and annotates anchor stmts with ``_ttl_threads``.
+class _AnchorPlanner:
+    """Analyze statement placement and DFB transactions without AST mutation.
 
     Anchors fall into three categories:
 
@@ -253,53 +425,55 @@ class _AnchorTagger:
        ``ttl.<op>(...)`` call, a ``<pipenet>.if_src/if_dst(...)`` call,
        a DFB direct-method call (``dfb.publish()``), a block-method call
        (``blk.store(...)``), or a ``@`` MatMult.
-       Thread = union of anchor threads found.
+       Selection is the union of logical kernels found.
 
     2. Deferred producer anchors: ``name = cb.wait()/.reserve()`` (or
-       ``with cb.<m>() as name:``). The producer stmt's thread is the
-       block's inferred thread (from the produced block's downstream
+       ``with cb.<m>() as name:``). The producer statement uses the
+       block's resolved owner (from the produced block's downstream
        uses).
 
-    3. Block-method anchors with deferred thread: ``blk.pop()`` /
-       ``blk.push()`` resolve to the block's inferred thread.
+    3. Block-method anchors with deferred ownership: ``blk.pop()`` /
+       ``blk.push()`` resolve to the block's planned logical kernel.
 
-    ``dm_thread`` is the concrete thread used for DM-classified ops in
-    the current scope: ``"ncrisc"`` by default and ``"brisc"`` for the
-    body of an ``if_src`` callback. The outer scope's Phase 1 detects
-    which top-level FunctionDef names are passed as ``if_src(<name>)``;
-    those FunctionDefs get an inner tagger with ``dm_thread="brisc"``.
+    Data-movement operations use the current callback's logical affinity.
     """
 
-    def __init__(self, dfb_names: Set[str], dm_thread: str = "ncrisc"):
+    def __init__(
+        self,
+        dfb_names: Set[str],
+        selector_resolver: _KernelSelectorResolver,
+        state: _AnalysisState,
+        data_movement_kernels: FrozenSet[KernelSelector] = frozenset(
+            {KernelKind.DATA_MOVEMENT}
+        ),
+        inferred_external_kernels: FrozenSet[KernelSelector] = frozenset(),
+    ):
         self.dfb_names = dfb_names
-        self._dm_thread = dm_thread
-        # block_name -> frozenset of threads the block is used on.
-        self.block_threads: Dict[str, FrozenSet[str]] = {}
-        # block_name -> list of producer stmts (Assign / With) in this scope.
+        self._selector_resolver = selector_resolver
+        self._state = state
+        self._data_movement_kernels = data_movement_kernels
+        self._inferred_external_kernels = inferred_external_kernels
+        self.block_owners: Dict[str, KernelSelector] = {}
         self._producers: Dict[str, List[ast.stmt]] = {}
-        # FunctionDef names in this scope used as the callback argument
-        # to a ``<recv>.if_src(<Name>)`` call. Their inner bodies are
-        # tagged with dm_thread="brisc".
-        self._brisc_callbacks: Set[str] = set()
+        self._callback_kernels: Dict[str, Set[KernelSelector]] = {}
 
     # --- entry ---
 
-    def tag(self, body: List[ast.stmt]) -> None:
+    def analyze(self, body: List[ast.stmt]) -> None:
         self._discover_producers(body)
-        self._discover_brisc_callbacks(body)
-        block_users = _collect_block_users(
+        self._discover_callback_kernels(body)
+        inferred_users, explicit_releases = _collect_block_ownership(
             body,
             set(self._producers.keys()),
             self.dfb_names,
-            dm_thread=self._dm_thread,
-            brisc_callbacks=self._brisc_callbacks,
+            data_movement_kernels=self._data_movement_kernels,
+            callback_kernels=self._callback_kernels,
+            selector_resolver=self._selector_resolver,
+            inferred_external_kernels=self._inferred_external_kernels,
         )
-        for name, threads in block_users.items():
-            if threads:
-                self.block_threads[name] = frozenset(threads)
+        self._resolve_transactions(inferred_users, explicit_releases)
         for stmt in body:
             self._annotate(stmt)
-        self._check_producer_threads()
 
     # --- phase 1a: producer discovery (this scope only) ---
 
@@ -329,21 +503,72 @@ class _AnchorTagger:
         # Do NOT descend into FunctionDef / AsyncFunctionDef: they are
         # their own scope and get their own tagger in Phase 3.
 
-    # --- phase 1b: if_src callback discovery (this scope only) ---
+    # --- callback affinity discovery (this scope only) ---
 
-    def _discover_brisc_callbacks(self, stmts: List[ast.stmt]) -> None:
+    def _discover_callback_kernels(self, stmts: List[ast.stmt]) -> None:
         for node in _walk_skip_nested_fns_iter(stmts):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
             if not isinstance(func, ast.Attribute):
                 continue
-            if func.attr != "if_src":
+            kernel = _PIPENET_METHODS.get(func.attr)
+            if kernel is None:
                 continue
             if node.args and isinstance(node.args[0], ast.Name):
-                self._brisc_callbacks.add(node.args[0].id)
+                self._callback_kernels.setdefault(node.args[0].id, set()).add(kernel)
 
-    # --- phase 2: annotate every stmt with anchor threads ---
+    def _resolve_transactions(
+        self,
+        inferred_users: Dict[str, Set[KernelSelector]],
+        explicit_releases: Dict[str, List[Tuple[ast.Call, KernelSelector]]],
+    ) -> None:
+        for block_name, producers in self._producers.items():
+            inferred = frozenset(inferred_users.get(block_name, set()))
+            explicit = frozenset(
+                selector for _, selector in explicit_releases.get(block_name, [])
+            )
+            if len(inferred) > 1:
+                raise _split_error(
+                    producers[0],
+                    f"DFB block {block_name!r} is used by multiple logical "
+                    f"kernels ({_format_kernels(inferred)}); each "
+                    ".reserve()/.wait() must resolve to exactly one kernel",
+                )
+            if len(explicit) > 1:
+                raise _split_error(
+                    producers[0],
+                    f"DFB block {block_name!r} has releases assigned to "
+                    f"multiple logical kernels ({_format_kernels(explicit)})",
+                )
+            if inferred and explicit and inferred != explicit:
+                raise _split_error(
+                    explicit_releases[block_name][0][0],
+                    f"explicit {_format_kernels(explicit)} release ownership "
+                    f"conflicts with inferred {_format_kernels(inferred)} "
+                    f"ownership for DFB block {block_name!r}",
+                )
+            owners = inferred or explicit
+            if not owners:
+                raise _split_error(
+                    producers[0],
+                    f"result of a DFB wait/reserve bound to {block_name!r} has "
+                    "no uses; the splitter cannot infer a logical kernel and "
+                    "the release has no explicit kernel selector",
+                )
+            owner = next(iter(owners))
+            self.block_owners[block_name] = owner
+            self._state.transactions.append(
+                DFBTransactionPlan(
+                    block_name=block_name,
+                    inferred_kernels=inferred,
+                    explicit_kernels=explicit,
+                    owner=owner,
+                    source_line=getattr(producers[0], "lineno", 0),
+                )
+            )
+
+    # --- statement selection ---
 
     def _annotate(self, stmt: ast.stmt) -> None:
         if isinstance(stmt, (ast.For, ast.While, ast.If)):
@@ -351,55 +576,49 @@ class _AnchorTagger:
                 self._annotate(child)
             return
         if isinstance(stmt, ast.With):
-            threads = self._with_threads(stmt)
-            if threads is not None:
-                if not threads:
-                    names = [
-                        _with_item_block_name(item, self.dfb_names)
-                        for item in stmt.items
-                    ]
-                    names = [n for n in names if n]
+            kernels = self._with_kernels(stmt)
+            if kernels is not None:
+                if len(kernels) != 1:
                     raise _split_error(
                         stmt,
-                        f"result of `with <dfb>.wait()/.reserve() as ...` "
-                        f"({', '.join(names)}) has no uses; the splitter "
-                        f"cannot pick a thread for the wait/reserve. "
-                        f"Add a use inside the with-body or remove it.",
+                        "DFB acquire statement resolves to multiple logical "
+                        f"kernels ({_format_kernels(kernels)}); each "
+                        ".reserve()/.wait() must resolve to exactly one kernel",
                     )
-                if len(threads) != 1:
-                    raise _split_error(
-                        stmt,
-                        "DFB acquire statement resolves to multiple threads "
-                        f"({_format_threads(threads)}); each .reserve()/.wait() "
-                        "must resolve to exactly one thread",
-                    )
-                _tag(stmt, threads)
+                self._state.select(stmt, kernels)
             for child in stmt.body:
                 self._annotate(child)
             return
         if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            inner_dm = (
-                "brisc" if stmt.name in self._brisc_callbacks else self._dm_thread
+            callback_kernels = frozenset(
+                self._callback_kernels.get(stmt.name, self._data_movement_kernels)
             )
-            inner = _AnchorTagger(dfb_names=self.dfb_names, dm_thread=inner_dm)
-            inner.tag(stmt.body)
+            inferred_external_kernels = (
+                callback_kernels
+                if stmt.name in self._callback_kernels
+                else self._inferred_external_kernels
+            )
+            inner = _AnchorPlanner(
+                dfb_names=self.dfb_names,
+                selector_resolver=self._selector_resolver,
+                state=self._state,
+                data_movement_kernels=callback_kernels,
+                inferred_external_kernels=inferred_external_kernels,
+            )
+            inner.analyze(stmt.body)
             return
 
-        # Producer Assign: thread = block's inferred thread.
         prod = _bare_wait_assign_target(stmt, self.dfb_names)
         if prod is not None:
             block_name, dfb_name = prod
-            threads = self._block_thread_set(block_name)
-            if not threads:
+            owner = self.block_owners.get(block_name)
+            if owner is None:
                 raise _split_error(
                     stmt,
                     f"result of {dfb_name}.wait()/.reserve() bound to "
-                    f"'{block_name}' has no uses; the splitter cannot pick "
-                    f"a thread for the wait/reserve. Add a use of "
-                    f"'{block_name}' (e.g. a no-op store into another CB) "
-                    f"or remove the producer.",
+                    f"{block_name!r} has no logical-kernel owner",
                 )
-            _tag(stmt, threads)
+            self._state.select(stmt, {owner})
             return
 
         copy_target = _assigned_copy_target(stmt)
@@ -411,170 +630,202 @@ class _AnchorTagger:
                 "instead",
             )
 
-        threads = self._stmt_anchor_threads(stmt)
-        if threads is not None:
-            if len(threads) != 1:
+        kernels = self._stmt_anchor_kernels(stmt)
+        if kernels is not None:
+            if len(kernels) != 1 and not _is_external_call_statement(stmt):
                 raise _split_error(
                     stmt,
-                    "executable statement is pinned to multiple threads "
-                    f"({_format_threads(threads)}); split the compute and "
-                    "data movement work into separate statements",
+                    "executable statement is assigned to multiple logical "
+                    f"kernels ({_format_kernels(kernels)}); split the work "
+                    "into separate statements",
                 )
-            _tag(stmt, threads)
+            self._state.select(stmt, kernels)
 
-    def _with_threads(self, stmt: ast.With) -> Optional[Set[str]]:
-        """Thread set for a ``with cb.<wait|reserve>() as blk:`` form,
-        unioned across all DFB-sync withitems. ``None`` if the With has
-        no DFB-sync items (it's then a plain control-flow With).
-        """
-        merged: Set[str] = set()
+    def _with_kernels(self, stmt: ast.With) -> Optional[Set[KernelSelector]]:
+        merged: Set[KernelSelector] = set()
         any_dfb = False
         for item in stmt.items:
             name = _with_item_block_name(item, self.dfb_names)
             if name is None:
                 continue
             any_dfb = True
-            merged |= self._block_thread_set(name)
+            owner = self.block_owners.get(name)
+            if owner is not None:
+                merged.add(owner)
         return merged if any_dfb else None
 
-    def _block_thread_set(self, block_name: str) -> Set[str]:
-        return set(self.block_threads.get(block_name, frozenset()))
+    def _block_kernel_set(self, block_name: str) -> Set[KernelSelector]:
+        owner = self.block_owners.get(block_name)
+        return {owner} if owner is not None else set()
 
-    def _anchor_threads_in(self, root: ast.AST) -> Set[str]:
-        """Return all concrete thread anchors in ``root``."""
-        threads: Set[str] = set()
+    def _anchor_kernels_in(self, root: ast.AST) -> Set[KernelSelector]:
+        kernels: Set[KernelSelector] = set()
         for node in _iter_skip_nested_fns(root):
             if isinstance(node, ast.Call):
-                thread = self._classify_call(node)
-                if thread in THREADS:
-                    threads.add(thread)
+                selection = self._classify_call(node)
+                if selection is not None:
+                    kernels.update(selection)
             elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.MatMult):
-                threads.add("trisc")
-        return threads
+                kernels.add(KernelKind.COMPUTE)
+        return kernels
 
-    def _stmt_anchor_threads(self, stmt: ast.stmt) -> Optional[Set[str]]:
-        """Union of anchor threads found in the stmt's subtree. ``None``
-        if the stmt has no thread-pinning anchor (control / scalar /
-        registered compile-time op); those stay duplicated on all sides.
+    def _stmt_anchor_kernels(self, stmt: ast.stmt) -> Optional[Set[KernelSelector]]:
+        """Union of logical-kernel anchors found in a statement subtree.
 
-        Lambdas inside the stmt are deliberately skipped: their body's
-        DM ops are dispatched by the enclosing ``<recv>.if_src/if_dst``
-        call, whose own classification already pins the stmt to the
-        right thread. Including the lambda body would double-count an
-        ``if_src(lambda: ttl.copy(...))`` as both brisc (from if_src)
-        and ncrisc (from ttl.copy), forcing duplication.
+        ``None`` means the statement is control or scalar code and is cloned
+        into every selected logical kernel.
 
-        AugAssign on a known block is still a compute anchor even when
-        the RHS has no Call / MatMult (e.g. ``blk += scalar``).
+        Lambdas are skipped because their data-movement operations inherit the
+        enclosing PipeNet callback affinity.
+
+        AugAssign on a known block remains a compute anchor even when the RHS
+        has no call or matrix multiplication.
+
+        The result is ``None`` if the stmt has no kernel-pinning anchor.
         """
-        threads = self._anchor_threads_in(stmt)
-        if threads:
-            return threads
+        kernels = self._anchor_kernels_in(stmt)
+        if kernels:
+            return kernels
         if isinstance(stmt, ast.AugAssign) and isinstance(stmt.target, ast.Name):
-            return self._block_thread_set(stmt.target.id) or None
+            return self._block_kernel_set(stmt.target.id) or None
         return None
 
-    def _classify_call(self, call: ast.Call) -> Optional[str]:
-        """Return the thread of a Call ("trisc"/"ncrisc"/"brisc"), or None if
-        it isn't an anchor at all (e.g. ``range(...)``, ``int(...)``,
-        ``.wait()`` on a call result). Raises on a ``ttl.<unknown>(...)`` form.
+    def _classify_call(self, call: ast.Call) -> Optional[FrozenSet[KernelSelector]]:
+        selection = _classify_ttl_call(
+            call,
+            self._data_movement_kernels,
+            self._inferred_external_kernels,
+            self._selector_resolver,
+        )
+        if selection is not None:
+            return selection
 
-        Delegates the registry decision (ttl ops, namespaces, pipe dispatch)
-        to ``_classify_ttl_call``; resolves ``<block>.store/pop/push`` here,
-        since deferred block methods need this scope's inferred block threads.
-        """
-        thread = _classify_ttl_call(call.func, self._dm_thread)
-        if thread is not None:
-            return thread
-
-        # <block>.<method>(...) where <block> is a producer in this scope.
         func = call.func
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
             if func.value.id in self.dfb_names:
                 method = _DFB_DIRECT_METHODS.get(func.attr)
                 if method is not None:
-                    return _materialize_thread(method, self._dm_thread)
+                    return _materialize_kernels(method, self._data_movement_kernels)
             if func.value.id in self._producers:
                 method = _BLOCK_METHODS.get(func.attr)
-                if method == "trisc":
-                    return "trisc"
+                if method == "compute":
+                    return frozenset({KernelKind.COMPUTE})
                 if method == "deferred":
-                    bt = self.block_threads.get(func.value.id)
-                    if bt and len(bt) == 1:
-                        return next(iter(bt))
+                    owner = self.block_owners.get(func.value.id)
+                    if owner is not None:
+                        return frozenset({owner})
         return None
 
-    # --- post-check: every DFB acquire belongs to exactly one thread ---
 
-    def _check_producer_threads(self) -> None:
-        for name, stmts in self._producers.items():
-            threads = self.block_threads.get(name, frozenset())
-            if len(threads) > 1:
-                raise _split_error(
-                    stmts[0],
-                    f"DFB block '{name}' is used on multiple threads "
-                    f"({_format_threads(threads)}). Its .reserve()/.wait() "
-                    f"acquire must resolve to exactly one thread; use a "
-                    f"separate acquired block for each thread.",
-                )
+# ----- split-plan application ---------------------------------------------
 
 
-# ----- Pass B: prune --------------------------------------------------------
+class _KernelKeywordStripper(ast.NodeTransformer):
+    def visit_Call(self, node: ast.Call):
+        node = self.generic_visit(node)
+        is_release = isinstance(node.func, ast.Attribute) and node.func.attr in {
+            "push",
+            "pop",
+        }
+        if _is_external_call(node) or is_release:
+            node.keywords = [
+                keyword for keyword in node.keywords if keyword.arg != "kernel"
+            ]
+        return node
 
 
-def _prune_body(body: List[ast.stmt], side: str) -> List[ast.stmt]:
-    """Walk a deep-copied body and drop anchor stmts not for ``side``.
-    Empty control-flow bodies are filled with ``pass`` (AST well-formedness).
-    """
-    result: List[ast.stmt] = []
-    for stmt in body:
-        kept = _prune_stmt(stmt, side)
-        if kept is not None:
-            result.append(kept)
-    return result if result else [ast.Pass()]
+def _walk_statements(statements: List[ast.stmt]):
+    for statement in statements:
+        yield statement
+        for child in ast.iter_child_nodes(statement):
+            if isinstance(child, ast.stmt):
+                yield from _walk_statements([child])
+            elif isinstance(child, ast.ExceptHandler):
+                yield from _walk_statements(child.body)
 
 
-def _prune_stmt(stmt: ast.stmt, side: str) -> Optional[ast.stmt]:
-    threads = getattr(stmt, "_ttl_threads", None)
-    if threads is not None and side not in threads:
-        return None
-    if isinstance(stmt, ast.For):
-        stmt.body = _prune_body(stmt.body, side)
-        stmt.orelse = _prune_orelse(stmt.orelse, side)
-    elif isinstance(stmt, ast.While):
-        stmt.body = _prune_body(stmt.body, side)
-        stmt.orelse = _prune_orelse(stmt.orelse, side)
-    elif isinstance(stmt, ast.If):
-        stmt.body = _prune_body(stmt.body, side)
-        stmt.orelse = _prune_orelse(stmt.orelse, side)
-    elif isinstance(stmt, ast.With):
-        stmt.body = _prune_body(stmt.body, side)
-    elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        stmt.body = _prune_body(stmt.body, side)
-    return stmt
+def _validate_kernel_capacities(
+    fn_def: ast.FunctionDef,
+    kernels: Tuple[KernelSelector, ...],
+    kernel_capacities: Optional[Mapping[KernelKind, int]],
+) -> None:
+    if kernel_capacities is None:
+        return
+    for kind in KernelKind:
+        capacity = kernel_capacities.get(kind)
+        if isinstance(capacity, bool) or not isinstance(capacity, int) or capacity < 0:
+            raise ValueError(
+                f"kernel capacity for {kind.value} must be a nonnegative integer"
+            )
+        required = sum(_selector_kind(kernel) == kind for kernel in kernels)
+        if required > capacity:
+            raise _split_error(
+                fn_def,
+                f"operation requires {required} {kind.value} kernels, but the "
+                f"target supports {capacity}",
+            )
 
 
-def _prune_orelse(body: List[ast.stmt], side: str) -> List[ast.stmt]:
-    """Prune an orelse body without inserting a placeholder ``pass``.
+def _apply_split_plan(
+    body: List[ast.stmt],
+    kernel: KernelSelector,
+    plan: SplitPlan,
+) -> List[ast.stmt]:
+    memo: Dict[int, object] = {}
+    copy.deepcopy(body, memo)
+    selections = {
+        statement.statement_id: statement.kernels for statement in plan.statements
+    }
+    cloned = _prune_statement_list(body, kernel, selections, memo, insert_pass=True)
+    stripper = _KernelKeywordStripper()
+    return [
+        ast.fix_missing_locations(stripper.visit(statement)) for statement in cloned
+    ]
 
-    Python treats an empty orelse as 'no else clause'.
-    """
-    result: List[ast.stmt] = []
-    for stmt in body:
-        kept = _prune_stmt(stmt, side)
-        if kept is not None:
-            result.append(kept)
+
+def _prune_statement_list(
+    originals: List[ast.stmt],
+    kernel: KernelSelector,
+    selections: Dict[int, FrozenSet[KernelSelector]],
+    memo: Dict[int, object],
+    insert_pass: bool,
+) -> List[ast.stmt]:
+    result = []
+    for original in originals:
+        if kernel not in selections[id(original)]:
+            continue
+        clone = memo[id(original)]
+        assert isinstance(clone, ast.stmt)
+        if isinstance(original, (ast.For, ast.While, ast.If)):
+            clone.body = _prune_statement_list(
+                original.body, kernel, selections, memo, insert_pass=True
+            )
+            clone.orelse = _prune_statement_list(
+                original.orelse, kernel, selections, memo, insert_pass=False
+            )
+        elif isinstance(original, ast.With):
+            clone.body = _prune_statement_list(
+                original.body, kernel, selections, memo, insert_pass=True
+            )
+        elif isinstance(original, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            clone.body = _prune_statement_list(
+                original.body, kernel, selections, memo, insert_pass=True
+            )
+        result.append(clone)
+    if not result and insert_pass:
+        return [ast.Pass()]
     return result
 
 
 # ----- helpers --------------------------------------------------------------
 
 
-def _tag(stmt: ast.stmt, threads: Set[str]) -> None:
-    """Annotate a stmt with its anchor thread set. ``frozenset()`` means
-    'drop on every side'.
-    """
-    stmt._ttl_threads = frozenset(threads)
+def _is_external_call_statement(statement: ast.stmt) -> bool:
+    return (
+        isinstance(statement, ast.Expr)
+        and isinstance(statement.value, ast.Call)
+        and _is_external_call(statement.value)
+    )
 
 
 def _assigned_copy_target(stmt: ast.stmt) -> Optional[str]:
@@ -656,9 +907,10 @@ def _expr_root_name(node) -> Optional[str]:
         return None
 
 
-def _format_threads(threads) -> str:
-    """Stable, user-facing rendering of a concrete thread collection."""
-    return ", ".join(thread.upper() for thread in THREADS if thread in threads)
+def _format_kernels(kernels) -> str:
+    return ", ".join(
+        _format_selector(kernel) for kernel in sorted(kernels, key=_selector_sort_key)
+    )
 
 
 def _split_error(node, msg: str) -> ValueError:
@@ -729,103 +981,173 @@ def _local_bindings(fn_node) -> Set[str]:
     return locals_
 
 
-def _collect_block_users(
+def _collect_block_ownership(
     stmts: List[ast.stmt],
     block_names: Set[str],
     dfb_names: Set[str],
-    dm_thread: str = "ncrisc",
-    brisc_callbacks: Optional[Set[str]] = None,
-) -> Dict[str, Set[str]]:
-    """For each block name, the set of threads ("trisc"/"ncrisc"/"brisc")
-    on which it has an anchor-relevant use. Walks nested functions and
-    lambdas with shadow awareness: a re-bound name inside a callback
-    hides the outer name.
+    data_movement_kernels: FrozenSet[KernelSelector],
+    callback_kernels: Mapping[str, Set[KernelSelector]],
+    selector_resolver: _KernelSelectorResolver,
+    inferred_external_kernels: FrozenSet[KernelSelector],
+) -> Tuple[
+    Dict[str, Set[KernelSelector]],
+    Dict[str, List[Tuple[ast.Call, KernelSelector]]],
+]:
+    """Collect inferred block uses and explicit release ownership separately."""
+    inferred_users: Dict[str, Set[KernelSelector]] = {
+        name: set() for name in block_names
+    }
+    explicit_releases: Dict[str, List[Tuple[ast.Call, KernelSelector]]] = {
+        name: [] for name in block_names
+    }
 
-    ``dm_thread`` is the concrete thread for DM-classified ops in the
-    current scope (default "ncrisc"). When the walker descends into a
-    callback recognized as an if_src dispatch target (a FunctionDef whose
-    name is in ``brisc_callbacks``, or the lambda/named-arg of an
-    ``<recv>.if_src(...)`` call), it switches to "brisc". Descent into
-    ``<recv>.if_dst(...)`` arguments forces "ncrisc".
-
-    An anchor-relevant use:
-      - argument to a ttl.* / pipenet method call -> that call's thread
-      - receiver of ``.store(...)`` -> trisc
-      - receiver of ``.pop()``/``.push()`` -> does not pin (sync helper)
-      - operand of MatMult ``@`` or any other BinOp -> trisc
-      - target of an AugAssign -> trisc
-    """
-    brisc_callbacks = brisc_callbacks or set()
-    users: Dict[str, Set[str]] = {n: set() for n in block_names}
-
-    def record_call_args(node: ast.Call, thread: str, visible: Set[str]) -> None:
+    def record_call_args(
+        node: ast.Call,
+        kernels: FrozenSet[KernelSelector],
+        visible: Set[str],
+    ) -> None:
         for arg in node.args:
             root = _expr_root_name(arg)
             if root in visible:
-                users[root].add(thread)
+                inferred_users[root].update(kernels)
         for kw in node.keywords:
+            if kw.arg == "kernel":
+                continue
             root = _expr_root_name(kw.value)
             if root in visible:
-                users[root].add(thread)
+                inferred_users[root].update(kernels)
 
-    def visit(node, visible, dm):
+    def visit(
+        node,
+        visible: Set[str],
+        current_data_movement_kernels: FrozenSet[KernelSelector],
+        current_external_kernels: FrozenSet[KernelSelector],
+    ):
         if isinstance(node, ast.Call):
             func = node.func
-            thread = _classify_ttl_call(func, dm)
-            sub_dm = dm
+            sub_data_movement_kernels = current_data_movement_kernels
+            sub_external_kernels = current_external_kernels
+            block_method_selection: Optional[FrozenSet[KernelSelector]] = None
             if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-                recv = func.value.id
+                receiver = func.value.id
                 method = func.attr
-                if thread is None and recv in visible and method == "store":
-                    users[recv].add("trisc")
-                    thread = "trisc"
+                if receiver in visible and method in {"push", "pop"}:
+                    explicit = selector_resolver.resolve_release(node)
+                    if explicit is not None:
+                        explicit_releases[receiver].append((node, explicit))
+                    for arg in node.args:
+                        visit(
+                            arg,
+                            visible,
+                            sub_data_movement_kernels,
+                            sub_external_kernels,
+                        )
+                    for keyword in node.keywords:
+                        visit(
+                            keyword.value,
+                            visible,
+                            sub_data_movement_kernels,
+                            sub_external_kernels,
+                        )
+                    return
+                if receiver in visible and method == "store":
+                    inferred_users[receiver].add(KernelKind.COMPUTE)
+                    block_method_selection = frozenset({KernelKind.COMPUTE})
                 if method in _PIPENET_METHODS:
-                    sub_dm = _PIPENET_METHODS[method]
-            if thread is not None:
-                record_call_args(node, thread, visible)
+                    callback_kernel = _PIPENET_METHODS[method]
+                    sub_data_movement_kernels = frozenset({callback_kernel})
+                    sub_external_kernels = sub_data_movement_kernels
+
+            selection = _classify_ttl_call(
+                node,
+                current_data_movement_kernels,
+                current_external_kernels,
+                selector_resolver,
+            )
+            selection = selection or block_method_selection
+            if selection is not None and not _is_external_call(node):
+                record_call_args(node, selection, visible)
             for arg in node.args:
-                visit(arg, visible, sub_dm)
+                visit(
+                    arg,
+                    visible,
+                    sub_data_movement_kernels,
+                    sub_external_kernels,
+                )
             for kw in node.keywords:
-                visit(kw.value, visible, sub_dm)
-            # Recurse into the callee so a chained call such as
-            # `ttl.copy(blk, pipe).wait()` still records `blk`'s use in the
-            # inner call (the inner call is func.value, not an arg/keyword).
+                visit(
+                    kw.value,
+                    visible,
+                    sub_data_movement_kernels,
+                    sub_external_kernels,
+                )
             if isinstance(func, ast.Attribute):
-                visit(func.value, visible, sub_dm)
+                visit(
+                    func.value,
+                    visible,
+                    sub_data_movement_kernels,
+                    sub_external_kernels,
+                )
             return
         if isinstance(node, ast.BinOp):
             for side in (node.left, node.right):
                 root = _expr_root_name(side)
                 if root in visible:
-                    users[root].add("trisc")
+                    inferred_users[root].add(KernelKind.COMPUTE)
         elif isinstance(node, ast.AugAssign):
             target = _expr_root_name(node.target)
             if target in visible:
-                users[target].add("trisc")
+                inferred_users[target].add(KernelKind.COMPUTE)
             rhs = _expr_root_name(node.value)
             if rhs in visible:
-                users[rhs].add("trisc")
+                inferred_users[rhs].add(KernelKind.COMPUTE)
         elif isinstance(node, ast.Assign):
             for tgt in node.targets:
                 if isinstance(tgt, ast.Subscript):
                     root = _expr_root_name(tgt.value)
                     if root in visible:
-                        users[root].add("trisc")
+                        inferred_users[root].add(KernelKind.COMPUTE)
 
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             inner = visible - _local_bindings(node)
-            sub_dm = "brisc" if node.name in brisc_callbacks else dm
+            selected_callback_kernels = callback_kernels.get(node.name)
+            if selected_callback_kernels is None:
+                nested_data_movement_kernels = current_data_movement_kernels
+                nested_external_kernels = current_external_kernels
+            else:
+                nested_data_movement_kernels = frozenset(selected_callback_kernels)
+                nested_external_kernels = nested_data_movement_kernels
             for child in node.body:
-                visit(child, inner, sub_dm)
+                visit(
+                    child,
+                    inner,
+                    nested_data_movement_kernels,
+                    nested_external_kernels,
+                )
             return
         if isinstance(node, ast.Lambda):
             inner = visible - _local_bindings(node)
-            visit(node.body, inner, dm)
+            visit(
+                node.body,
+                inner,
+                current_data_movement_kernels,
+                current_external_kernels,
+            )
             return
 
         for child in ast.iter_child_nodes(node):
-            visit(child, visible, dm)
+            visit(
+                child,
+                visible,
+                current_data_movement_kernels,
+                current_external_kernels,
+            )
 
     for stmt in stmts:
-        visit(stmt, block_names, dm_thread)
-    return users
+        visit(
+            stmt,
+            block_names,
+            data_movement_kernels,
+            inferred_external_kernels,
+        )
+    return inferred_users, explicit_releases

--- a/python/ttl/_src/global_semaphore.py
+++ b/python/ttl/_src/global_semaphore.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""TTNN GlobalSemaphore type and address validation."""
+
+
+def is_ttnn_global_semaphore(value: object) -> bool:
+    """Require the exact TTNN type so local and lookalike objects are rejected."""
+    try:
+        from ttnn._ttnn.global_semaphore import global_semaphore
+    except ImportError:
+        return False
+    return isinstance(value, global_semaphore)
+
+
+def get_ttnn_global_semaphore_address(value: object) -> int:
+    """Return one GlobalSemaphore address without suppressing TTNN failures."""
+    if not is_ttnn_global_semaphore(value):
+        raise TypeError(f"expected ttnn GlobalSemaphore, got {type(value)}")
+    import ttnn
+
+    address = ttnn.get_global_semaphore_address(value)
+    if type(address) is not int:
+        raise TypeError(
+            "ttnn.get_global_semaphore_address() must return one integer "
+            f"address, got {type(address)}"
+        )
+    if not 0 <= address < (1 << 32):
+        raise ValueError(
+            "ttnn.get_global_semaphore_address() result must fit in uint32_t, "
+            f"got {address}"
+        )
+    return address

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -23,6 +23,7 @@ from ..layouts import (
     detect_memory_layout,
     TENSOR_MEMORY_LAYOUT_INTERLEAVED,
 )
+from ..kernel import _DFB_RELEASE_METHODS
 from ..ttl_utils import get_thread_type_string
 from .auto_profile import (
     get_line_mapper,
@@ -353,6 +354,8 @@ class TTLGenericCompiler(TTCompilerBase):
         """Override to set location context, catch errors, and inject auto-profiling."""
         with self._loc_for_node(node):
             try:
+                self._strip_explicit_release_kernel_selector(node)
+
                 # Intercept print() to handle keyword arguments.
                 if (
                     not isinstance(node.func, ast.Attribute)
@@ -385,6 +388,25 @@ class TTLGenericCompiler(TTCompilerBase):
                 if isinstance(e, TTLangCompileError):
                     raise
                 self._raise_error(node, str(e))
+
+    def _strip_explicit_release_kernel_selector(self, node: ast.Call) -> None:
+        """Remove release placement because the thread decorator owns it."""
+        if not isinstance(node.func, ast.Attribute):
+            return
+        if node.func.attr not in _DFB_RELEASE_METHODS:
+            return
+        if not isinstance(node.func.value, ast.Name):
+            return
+        receiver_table = self._var_exists(node.func.value.id)
+        if not receiver_table:
+            return
+        from ..operators import _is_block
+
+        if not _is_block(receiver_table[node.func.value.id]):
+            return
+        node.keywords = [
+            keyword for keyword in node.keywords if keyword.arg != "kernel"
+        ]
 
     def visit_AugAssign(self, node):
         """Handle augmented assignment on tensor values.

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -23,6 +23,7 @@ from ..layouts import (
     detect_memory_layout,
     TENSOR_MEMORY_LAYOUT_INTERLEAVED,
 )
+from ..kernel import _DFB_RELEASE_METHODS
 from ..ttl_utils import get_thread_type_string
 from .auto_profile import (
     get_line_mapper,
@@ -354,6 +355,8 @@ class TTLGenericCompiler(TTCompilerBase):
         """Override to set location context, catch errors, and inject auto-profiling."""
         with self._loc_for_node(node):
             try:
+                self._strip_explicit_release_kernel_selector(node)
+
                 # Intercept print() to handle keyword arguments.
                 if (
                     not isinstance(node.func, ast.Attribute)
@@ -386,6 +389,25 @@ class TTLGenericCompiler(TTCompilerBase):
                 if isinstance(e, TTLangCompileError):
                     raise
                 self._raise_error(node, str(e))
+
+    def _strip_explicit_release_kernel_selector(self, node: ast.Call) -> None:
+        """Remove release placement because the thread decorator owns it."""
+        if not isinstance(node.func, ast.Attribute):
+            return
+        if node.func.attr not in _DFB_RELEASE_METHODS:
+            return
+        if not isinstance(node.func.value, ast.Name):
+            return
+        receiver_table = self._var_exists(node.func.value.id)
+        if not receiver_table:
+            return
+        from ..operators import _is_block
+
+        if not _is_block(receiver_table[node.func.value.id]):
+            return
+        node.keywords = [
+            keyword for keyword in node.keywords if keyword.arg != "kernel"
+        ]
 
     def visit_AugAssign(self, node):
         """Handle augmented assignment on tensor values.

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -29,36 +29,11 @@ from .auto_profile import (
     get_line_mapper,
     is_auto_profile_enabled,
 )
+from .global_semaphore import (
+    get_ttnn_global_semaphore_address,
+    is_ttnn_global_semaphore,
+)
 from .tensor_registry import get_tensor_global_index, get_tensor_source
-
-
-def is_ttnn_global_semaphore(value) -> bool:
-    """Require the exact TTNN type so local and lookalike objects are rejected."""
-    try:
-        from ttnn._ttnn.global_semaphore import global_semaphore
-    except ImportError:
-        return False
-    return isinstance(value, global_semaphore)
-
-
-def _get_ttnn_global_semaphore_address(value) -> int:
-    """Return one GlobalSemaphore address without suppressing TTNN failures."""
-    if not is_ttnn_global_semaphore(value):
-        raise TypeError(f"expected ttnn GlobalSemaphore, got {type(value)}")
-    import ttnn
-
-    address = ttnn.get_global_semaphore_address(value)
-    if type(address) is not int:
-        raise TypeError(
-            "ttnn.get_global_semaphore_address() must return one integer "
-            f"address, got {type(address)}"
-        )
-    if not 0 <= address < (1 << 32):
-        raise ValueError(
-            "ttnn.get_global_semaphore_address() result must fit in uint32_t, "
-            f"got {address}"
-        )
-    return address
 
 
 @dataclass(frozen=True)
@@ -1099,7 +1074,7 @@ class TTLGenericCompiler(TTCompilerBase):
                     # compiler can use it in diagnostics.
                     self._pipe_net_names.setdefault(id(val), name)
                 elif is_ttnn_global_semaphore(val):
-                    sem_addr = _get_ttnn_global_semaphore_address(val)
+                    sem_addr = get_ttnn_global_semaphore_address(val)
                     i32_ty = IntegerType.get_signless(32, self.ctx)
                     self._set_var(name, arith.ConstantOp(i32_ty, sem_addr).result)
                 else:
@@ -1637,7 +1612,7 @@ class TTLGenericCompiler(TTCompilerBase):
             if isinstance(val, float):
                 return _unsigned_integer(_float_bits(val))
             if is_ttnn_global_semaphore(val):
-                sem_addr = _get_ttnn_global_semaphore_address(val)
+                sem_addr = get_ttnn_global_semaphore_address(val)
                 return _unsigned_integer(sem_addr)
 
         if isinstance(node, ast.Name) and node.id in self.fn_globals:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -54,6 +54,7 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _PIPE_SOURCE_KERNEL_ROLE,
     _selector_implicit_role,
     _selector_kind,
 )
@@ -100,7 +101,7 @@ _BACKEND_KERNEL_SLOTS = (
         KernelKind.DATA_MOVEMENT,
         "datamovement",
         "brisc",
-        implicit_role="pipe_source",
+        implicit_role=_PIPE_SOURCE_KERNEL_ROLE,
     ),
 )
 

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -54,7 +54,6 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
-    _PIPE_SOURCE_KERNEL_ROLE,
     _bind_kernel_declarations,
     _operation_identity,
     _selector_implicit_role,
@@ -64,6 +63,9 @@ from .operators import _set_current_grid
 from .pipe import PipeNet
 from .ttl_api import (
     Program,
+    _BackendKernelSlot,
+    _backend_kernel_capacities,
+    _backend_kernel_slots,
     _build_pipenet_graph,
     _canonical_tensor_args,
     _detect_memory_space_from_tensor,
@@ -86,38 +88,14 @@ _KERNEL_FACTORY_NAMES = {"Kernel"}
 _SETUP_FACTORY_NAMES = _DFB_FACTORY_NAMES | _PIPE_FACTORY_NAMES | _KERNEL_FACTORY_NAMES
 
 
-@dataclass(frozen=True)
-class _BackendKernelSlot:
-    kind: KernelKind
-    kernel_type: str
-    source_name: str
-    implicit_role: Optional[str] = None
-
-
-_BACKEND_KERNEL_SLOTS = (
-    _BackendKernelSlot(KernelKind.COMPUTE, "compute", "trisc"),
-    _BackendKernelSlot(KernelKind.DATA_MOVEMENT, "datamovement", "ncrisc"),
-    _BackendKernelSlot(
-        KernelKind.DATA_MOVEMENT,
-        "datamovement",
-        "brisc",
-        implicit_role=_PIPE_SOURCE_KERNEL_ROLE,
-    ),
-)
-
-
-def _backend_kernel_capacities() -> Dict[KernelKind, int]:
-    return {
-        kind: sum(slot.kind == kind for slot in _BACKEND_KERNEL_SLOTS)
-        for kind in KernelKind
-    }
-
-
-def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelector]:
+def _assign_backend_kernel_slots(
+    split, target_arch: Optional[str] = None
+) -> Dict[_BackendKernelSlot, KernelSelector]:
     assignments: Dict[_BackendKernelSlot, KernelSelector] = {}
     remaining = list(split.kernels)
+    backend_slots = _backend_kernel_slots(target_arch)
 
-    for slot in _BACKEND_KERNEL_SLOTS:
+    for slot in backend_slots:
         if slot.implicit_role is None:
             selector: KernelSelector = slot.kind
             if selector in remaining:
@@ -140,7 +118,7 @@ def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelect
         slot = next(
             (
                 candidate
-                for candidate in _BACKEND_KERNEL_SLOTS
+                for candidate in backend_slots
                 if candidate not in assignments
                 and candidate.kind == _selector_kind(selector)
             ),
@@ -158,8 +136,9 @@ def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelect
 def _backend_kernel_bodies(
     split,
     assignments: Mapping[_BackendKernelSlot, KernelSelector],
+    target_arch: Optional[str],
 ) -> Iterator[Tuple[_BackendKernelSlot, Optional[KernelSelector], List[ast.stmt]]]:
-    for slot in _BACKEND_KERNEL_SLOTS:
+    for slot in _backend_kernel_slots(target_arch):
         logical_kernel = assignments.get(slot)
         body = (
             split.body_for(logical_kernel)
@@ -376,6 +355,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     external_pipenets = dict(inlined_pipenets)
     compile_time_captures: Dict[str, Any] = {}
     logical_kernels: Dict[str, Kernel] = dict(inlined_logical_kernels)
+    captured_logical_kernels: Dict[str, Kernel] = {}
     for capture_name in sorted(loaded_names & captured_values.keys()):
         value = captured_values[capture_name]
         if isinstance(value, DataflowBuffer):
@@ -387,7 +367,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         if isinstance(value, PipeNet):
             external_pipenets[capture_name] = value
         elif isinstance(value, Kernel):
-            logical_kernels[capture_name] = value
+            if not any(value is kernel for kernel in logical_kernels.values()):
+                captured_logical_kernels[capture_name] = value
         elif _is_compile_time_literal(value):
             compile_time_captures[capture_name] = copy.deepcopy(value)
         elif not isinstance(value, types.ModuleType) and not callable(value):
@@ -397,7 +378,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
                 f"{type(value).__name__}"
             )
 
-    _bind_logical_kernels(logical_kernels, operation_identity)
+    _bind_logical_kernels(captured_logical_kernels, operation_identity)
+    logical_kernels.update(captured_logical_kernels)
 
     frozen_scope = dict(scope)
     frozen_scope.update(compile_time_captures)
@@ -704,10 +686,12 @@ def _compile_atom(
         local_dfb_names=set(dfbs),
         logical_kernels=logical_kernels,
         selector_scope=selector_scope,
-        kernel_capacities=_backend_kernel_capacities(),
+        kernel_capacities=_backend_kernel_capacities(target_arch),
     )
-    backend_assignments = _assign_backend_kernel_slots(split)
-    backend_bodies = tuple(_backend_kernel_bodies(split, backend_assignments))
+    backend_assignments = _assign_backend_kernel_slots(split, target_arch)
+    backend_bodies = tuple(
+        _backend_kernel_bodies(split, backend_assignments, target_arch)
+    )
 
     if os.environ.get("TTLANG_ATOM_DUMP_SPLIT"):
         for slot, _, body in backend_bodies:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -33,7 +33,7 @@ import os
 import textwrap
 import types
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
 import ttl as _ttl
 from ttl.pykernel._src.utils import _cleanup_source_code
@@ -55,6 +55,8 @@ from .kernel import (
     KernelKind,
     KernelSelector,
     _PIPE_SOURCE_KERNEL_ROLE,
+    _bind_kernel_declarations,
+    _operation_identity,
     _selector_implicit_role,
     _selector_kind,
 )
@@ -153,6 +155,20 @@ def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelect
             )
         assignments[slot] = selector
     return assignments
+
+
+def _backend_kernel_bodies(
+    split,
+    assignments: Mapping[_BackendKernelSlot, KernelSelector],
+) -> Iterator[Tuple[_BackendKernelSlot, Optional[KernelSelector], List[ast.stmt]]]:
+    for slot in _BACKEND_KERNEL_SLOTS:
+        logical_kernel = assignments.get(slot)
+        body = (
+            split.body_for(logical_kernel)
+            if logical_kernel is not None
+            else [ast.Pass()]
+        )
+        yield slot, logical_kernel, body
 
 
 class DFB:
@@ -336,9 +352,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         elif stripped.startswith("def ") or stripped.startswith("async def "):
             break
     line_offset = start_lineno + num_decorator_lines - 1
-    operation_identity = (
-        f"{fn.__module__}.{fn.__qualname__}:{fn.__code__.co_firstlineno}"
-    )
+    operation_identity = _operation_identity(fn)
 
     module = ast.parse(_cleanup_source_code(fn))
     if len(module.body) != 1 or not isinstance(module.body[0], ast.FunctionDef):
@@ -350,7 +364,9 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
 
     # Inline statement-level calls to other unified operations, then keep
     # the post-inline AST + source.
-    inlined_pipenets = inline_atom_calls(fn_def, scope, caller_name=name)
+    inlined_pipenets, inlined_logical_kernels = inline_atom_calls(
+        fn_def, scope, caller_name=name
+    )
     _validate_resource_declarations(fn_def, name)
 
     loaded_names = set()
@@ -361,7 +377,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     captured_values = _captured_values(fn)
     external_pipenets = dict(inlined_pipenets)
     compile_time_captures: Dict[str, Any] = {}
-    logical_kernels: Dict[str, Kernel] = {}
+    logical_kernels: Dict[str, Kernel] = dict(inlined_logical_kernels)
     for capture_name in sorted(loaded_names & captured_values.keys()):
         value = captured_values[capture_name]
         if isinstance(value, DataflowBuffer):
@@ -410,27 +426,9 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
 
 def _bind_logical_kernels(
     logical_kernels: Dict[str, Kernel], operation_identity: str
-) -> Dict[str, Kernel]:
+) -> None:
     """Bind captured declarations in place during operation registration."""
-    source_names: Dict[int, str] = {}
-    for name, kernel in logical_kernels.items():
-        previous_name = source_names.get(id(kernel))
-        if previous_name is not None:
-            raise ValueError(
-                "one logical Kernel handle reached the final operation under "
-                f"multiple names: {previous_name!r} and {name!r}"
-            )
-        source_names[id(kernel)] = name
-        if kernel._identity is not None:
-            raise ValueError(
-                f"logical Kernel {name!r} is already bound as "
-                f"{kernel.identity!r} to operation "
-                f"{kernel._operation_identity!r}"
-            )
-
-    for name, kernel in logical_kernels.items():
-        kernel._bind(name, operation_identity)
-    return logical_kernels
+    _bind_kernel_declarations(logical_kernels, operation_identity)
 
 
 def _is_compile_time_literal(value: Any) -> bool:
@@ -591,7 +589,7 @@ def _lift_setup(
         elif isinstance(value, PipeNet):
             nets[name] = value
         elif isinstance(value, Kernel):
-            value = value._bind(name, operation_identity)
+            value._bind(name, operation_identity)
             kernels[name] = value
         ns[name] = value
         # A bare Pipe remains in ns for a later PipeNet reference.
@@ -696,6 +694,8 @@ def _compile_atom(
         operation_identity=spec.operation_identity,
     )
     logical_kernels.update(lifted_logical_kernels)
+    selector_scope = dict(eval_scope)
+    selector_scope.update(logical_kernels)
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe
@@ -712,18 +712,14 @@ def _compile_atom(
         dfb_param_names=set(spec.dfb_param_names),
         local_dfb_names=set(dfbs),
         logical_kernels=logical_kernels,
+        selector_scope=selector_scope,
         kernel_capacities=_backend_kernel_capacities(),
     )
     backend_assignments = _assign_backend_kernel_slots(split)
+    backend_bodies = tuple(_backend_kernel_bodies(split, backend_assignments))
 
     if os.environ.get("TTLANG_ATOM_DUMP_SPLIT"):
-        for slot in _BACKEND_KERNEL_SLOTS:
-            logical_kernel = backend_assignments.get(slot)
-            body = (
-                split.body_for(logical_kernel)
-                if logical_kernel is not None
-                else [ast.Pass()]
-            )
+        for slot, _, body in backend_bodies:
             _dbg = _synthesize_thread_module(f"{spec.name}__{slot.source_name}", body)
             print(f"\n===== @ttl.operation split: {slot.source_name} =====")
             print(ast.unparse(_dbg))
@@ -746,13 +742,7 @@ def _compile_atom(
     threads = []
     thread_logical_kernels = []
     any_real_work = False
-    for slot in _BACKEND_KERNEL_SLOTS:
-        logical_kernel = backend_assignments.get(slot)
-        body = (
-            split.body_for(logical_kernel)
-            if logical_kernel is not None
-            else [ast.Pass()]
-        )
+    for slot, logical_kernel, body in backend_bodies:
         any_real_work = any_real_work or _has_real_work(body)
         fn_name = f"{spec.name}__{slot.source_name}"
         threads.append(

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unified-body ``@ttl.operation`` kernels with automatic thread splitting.
+"""Unified-body ``@ttl.operation`` kernels with logical-kernel splitting.
 
 The unified form is a single function body instead of one @ttl.compute and
-two @ttl.datamovement thread functions. At decoration time, statement-level
-calls to other unified operations are inlined; at compile time the body is
-split into compute (TRISC) and data-movement
-(NCRISC / BRISC) threads, which then flow through the same MLIR pipeline
-as @ttl.operation.
+two @ttl.datamovement functions. At decoration time, statement-level calls to
+other unified operations are inlined. At compile time, the body is split into
+target-independent compute and data-movement kernels. Backend assignment then
+maps those logical kernels to the target's supported kernel slots.
 
 A unified operation may take TT-NN tensors, compile-time captures, and --
 when intended for composition -- ttl.DFB or ttl.PipeNet parameters. Dataflow
@@ -17,15 +16,11 @@ buffers used within a top-level operation are declared in its body. An
 operation with resource parameters is expand-only and cannot be called as a
 TT-NN operation.
 
-DFB declarations sit inline with the compute/copy work in a unified
-body, so after the split they land inside each thread body. The existing
-per-thread compiler is capture-based (thread functions take no
-parameters; DFBs arrive as closure captures), so before splitting we
-lift the top-level ``name = make_dfb(...)`` assigns out of the body,
-evaluate them to DataflowBuffer objects, and pass them as captures --
-the same shape the @ttl.operation flow produces by running its setup
-body. After that the per-thread compile, CB sizing, pass pipeline, and
-runner are identical to @ttl.operation.
+DFB declarations sit inline with the compute/copy work in a unified body. The
+existing per-kernel compiler is capture-based, so top-level static resource
+assignments are lifted before splitting and supplied as captures. The
+per-kernel compile, DFB sizing, pass pipeline, and runner remain identical to
+the explicit multi-kernel form.
 """
 
 from __future__ import annotations
@@ -55,6 +50,13 @@ from .dataflow_buffer import (
     make_tensor_backed_dfb,
 )
 from .dtype_utils import is_ttnn_tensor
+from .kernel import (
+    Kernel,
+    KernelKind,
+    KernelSelector,
+    _selector_implicit_role,
+    _selector_kind,
+)
 from .operators import _set_current_grid
 from .pipe import PipeNet
 from .ttl_api import (
@@ -71,17 +73,85 @@ from .ttl_api import (
     pykernel_gen,
 )
 
-
-# Names whose top-level ``x = <name>(...)`` assigns are lifted out of the body
-# and evaluated to capture objects (DataflowBuffer / Pipe / PipeNet) before the
-# split, the same way @ttl.operation constructs them in its setup body.
+# Names whose top-level ``x = <name>(...)`` assigns are evaluated as static
+# operation resources before logical-kernel splitting.
 _DFB_FACTORY_NAMES = {
     "make_dfb",
     "make_dataflow_buffer_like",
     "make_tensor_backed_dfb",
 }
 _PIPE_FACTORY_NAMES = {"Pipe", "PipeNet"}
-_SETUP_FACTORY_NAMES = _DFB_FACTORY_NAMES | _PIPE_FACTORY_NAMES
+_KERNEL_FACTORY_NAMES = {"Kernel"}
+_SETUP_FACTORY_NAMES = _DFB_FACTORY_NAMES | _PIPE_FACTORY_NAMES | _KERNEL_FACTORY_NAMES
+
+
+@dataclass(frozen=True)
+class _BackendKernelSlot:
+    kind: KernelKind
+    kernel_type: str
+    source_name: str
+    implicit_role: Optional[str] = None
+
+
+_BACKEND_KERNEL_SLOTS = (
+    _BackendKernelSlot(KernelKind.COMPUTE, "compute", "trisc"),
+    _BackendKernelSlot(KernelKind.DATA_MOVEMENT, "datamovement", "ncrisc"),
+    _BackendKernelSlot(
+        KernelKind.DATA_MOVEMENT,
+        "datamovement",
+        "brisc",
+        implicit_role="pipe_source",
+    ),
+)
+
+
+def _backend_kernel_capacities() -> Dict[KernelKind, int]:
+    return {
+        kind: sum(slot.kind == kind for slot in _BACKEND_KERNEL_SLOTS)
+        for kind in KernelKind
+    }
+
+
+def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelector]:
+    assignments: Dict[_BackendKernelSlot, KernelSelector] = {}
+    remaining = list(split.kernels)
+
+    for slot in _BACKEND_KERNEL_SLOTS:
+        if slot.implicit_role is None:
+            selector: KernelSelector = slot.kind
+            if selector in remaining:
+                assignments[slot] = selector
+                remaining.remove(selector)
+            continue
+        selector = next(
+            (
+                kernel
+                for kernel in remaining
+                if _selector_implicit_role(kernel) == slot.implicit_role
+            ),
+            None,
+        )
+        if selector is not None:
+            assignments[slot] = selector
+            remaining.remove(selector)
+
+    for selector in remaining:
+        slot = next(
+            (
+                candidate
+                for candidate in _BACKEND_KERNEL_SLOTS
+                if candidate not in assignments
+                and candidate.kind == _selector_kind(selector)
+            ),
+            None,
+        )
+        if slot is None:
+            raise AssertionError(
+                f"no backend slot for planned {selector!r}; capacity validation "
+                "must reject this before backend assignment"
+            )
+        assignments[slot] = selector
+    return assignments
 
 
 class DFB:
@@ -359,10 +429,11 @@ def _is_pipe_list_expr(node: ast.expr) -> bool:
 
 
 def _setup_assign_target(stmt: ast.stmt) -> Optional[str]:
-    """If ``stmt`` is a DFB/Pipe/PipeNet construction assign, return its name.
+    """Return the name of a static operation-resource assignment.
 
-    Recognizes ``name = <dfb/pipe-factory>(...)`` and ``name = [<pipes>]``
-    (a pipe list feeding a later PipeNet)."""
+    Recognizes DFB, Pipe, PipeNet, and logical Kernel construction plus a pipe
+    list feeding a later PipeNet.
+    """
     if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
         return None
     if not isinstance(stmt.targets[0], ast.Name):
@@ -445,27 +516,29 @@ def _validate_resource_declarations(
 def _lift_setup(
     fn_def: ast.FunctionDef,
     scope: Dict[str, Any],
-) -> Tuple[ast.FunctionDef, Dict[str, DataflowBuffer], Dict[str, PipeNet]]:
-    """Strip and evaluate the top-level DFB / Pipe / PipeNet construction
-    assigns.
+) -> Tuple[
+    ast.FunctionDef,
+    Dict[str, DataflowBuffer],
+    Dict[str, PipeNet],
+    Dict[str, Kernel],
+]:
+    """Strip and evaluate top-level static operation-resource assignments.
 
     Returns the kernel body with those statements removed, plus the
-    DataflowBuffer and PipeNet objects keyed by name. Each construction
-    expression is evaluated in source order in a controlled namespace, with
-    results threaded back in so a later ``PipeNet([p0])`` sees an earlier
-    ``p0`` and CB indices are assigned in source order. This runs just the
-    setup statements that @ttl.operation runs as part of executing its whole
-    body; the per-thread compiler consumes the results as captures, not as
-    in-body calls.
+    DataflowBuffer, PipeNet, and bound logical Kernel objects keyed by name.
+    Construction expressions are evaluated in source order so dependencies and
+    DFB indices remain deterministic.
     """
     ns = dict(scope)
     ns.setdefault("make_dfb", make_dfb)
     ns.setdefault("make_dataflow_buffer_like", make_dataflow_buffer_like)
     ns.setdefault("make_tensor_backed_dfb", make_tensor_backed_dfb)
+    ns.setdefault("Kernel", Kernel)
     ns.setdefault("ttl", _ttl)
 
     dfbs: Dict[str, DataflowBuffer] = {}
     nets: Dict[str, PipeNet] = {}
+    kernels: Dict[str, Kernel] = {}
     kept: List[ast.stmt] = []
     for stmt in fn_def.body:
         name = _setup_assign_target(stmt)
@@ -473,17 +546,19 @@ def _lift_setup(
             kept.append(stmt)
             continue
         value = eval(ast.unparse(stmt.value), ns)  # noqa: S307
-        ns[name] = value
         if isinstance(value, DataflowBuffer):
             dfbs[name] = value
         elif isinstance(value, PipeNet):
             nets[name] = value
-        # A bare Pipe stays in ns for a later PipeNet reference but is not a
-        # capture; only DataflowBuffers and PipeNets are bound on threads.
+        elif isinstance(value, Kernel):
+            value = value._bind(name)
+            kernels[name] = value
+        ns[name] = value
+        # A bare Pipe remains in ns for a later PipeNet reference.
 
     new_fn = copy.copy(fn_def)
     new_fn.body = kept
-    return new_fn, dfbs, nets
+    return new_fn, dfbs, nets, kernels
 
 
 def _has_real_work(body: List[ast.stmt]) -> bool:
@@ -573,7 +648,9 @@ def _compile_atom(
     _reset_cb_counter()
     _set_current_grid(grid)
 
-    stripped_fn, dfbs, nets = _lift_setup(copy.deepcopy(spec.fn_ast), eval_scope)
+    stripped_fn, dfbs, nets, logical_kernels = _lift_setup(
+        copy.deepcopy(spec.fn_ast), eval_scope
+    )
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe
@@ -589,14 +666,21 @@ def _compile_atom(
         fn_def=stripped_fn,
         dfb_param_names=set(spec.dfb_param_names),
         local_dfb_names=set(dfbs),
+        logical_kernels=logical_kernels,
+        kernel_capacities=_backend_kernel_capacities(),
     )
+    backend_assignments = _assign_backend_kernel_slots(split)
 
     if os.environ.get("TTLANG_ATOM_DUMP_SPLIT"):
-        for _thread in ("trisc", "ncrisc", "brisc"):
-            _dbg = _synthesize_thread_module(
-                f"{spec.name}__{_thread}", split.body_for(_thread)
+        for slot in _BACKEND_KERNEL_SLOTS:
+            logical_kernel = backend_assignments.get(slot)
+            body = (
+                split.body_for(logical_kernel)
+                if logical_kernel is not None
+                else [ast.Pass()]
             )
-            print(f"\n===== @ttl.operation split: {_thread} =====")
+            _dbg = _synthesize_thread_module(f"{spec.name}__{slot.source_name}", body)
+            print(f"\n===== @ttl.operation split: {slot.source_name} =====")
             print(ast.unparse(_dbg))
 
     # Captures shared by every thread: ttnn tensors and scalars (bound
@@ -616,16 +700,17 @@ def _compile_atom(
     # body, the same shape @ttl.operation produces.
     threads = []
     any_real_work = False
-    for kernel_type, thread in (
-        ("compute", "trisc"),
-        ("datamovement", "ncrisc"),
-        ("datamovement", "brisc"),
-    ):
-        body = split.body_for(thread)
+    for slot in _BACKEND_KERNEL_SLOTS:
+        logical_kernel = backend_assignments.get(slot)
+        body = (
+            split.body_for(logical_kernel)
+            if logical_kernel is not None
+            else [ast.Pass()]
+        )
         any_real_work = any_real_work or _has_real_work(body)
-        fn_name = f"{spec.name}__{thread}"
+        fn_name = f"{spec.name}__{slot.source_name}"
         threads.append(
-            _make_thread_callable(spec, kernel_type, fn_name, body, captures)
+            _make_thread_callable(spec, slot.kernel_type, fn_name, body, captures)
         )
 
     if not any_real_work:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -54,7 +54,6 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
-    _PIPE_SOURCE_KERNEL_ROLE,
     _bind_kernel_declarations,
     _operation_identity,
     _selector_implicit_role,
@@ -64,6 +63,9 @@ from .operators import _set_current_grid
 from .pipe import PipeNet
 from .ttl_api import (
     Program,
+    _BackendKernelSlot,
+    _backend_kernel_capacities,
+    _backend_kernel_slots,
     _build_pipenet_graph,
     _canonical_tensor_args,
     _detect_memory_space_from_tensor,
@@ -88,38 +90,14 @@ _KERNEL_FACTORY_NAMES = {"Kernel"}
 _SETUP_FACTORY_NAMES = _DFB_FACTORY_NAMES | _PIPE_FACTORY_NAMES | _KERNEL_FACTORY_NAMES
 
 
-@dataclass(frozen=True)
-class _BackendKernelSlot:
-    kind: KernelKind
-    kernel_type: str
-    source_name: str
-    implicit_role: Optional[str] = None
-
-
-_BACKEND_KERNEL_SLOTS = (
-    _BackendKernelSlot(KernelKind.COMPUTE, "compute", "trisc"),
-    _BackendKernelSlot(KernelKind.DATA_MOVEMENT, "datamovement", "ncrisc"),
-    _BackendKernelSlot(
-        KernelKind.DATA_MOVEMENT,
-        "datamovement",
-        "brisc",
-        implicit_role=_PIPE_SOURCE_KERNEL_ROLE,
-    ),
-)
-
-
-def _backend_kernel_capacities() -> Dict[KernelKind, int]:
-    return {
-        kind: sum(slot.kind == kind for slot in _BACKEND_KERNEL_SLOTS)
-        for kind in KernelKind
-    }
-
-
-def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelector]:
+def _assign_backend_kernel_slots(
+    split, target_arch: Optional[str] = None
+) -> Dict[_BackendKernelSlot, KernelSelector]:
     assignments: Dict[_BackendKernelSlot, KernelSelector] = {}
     remaining = list(split.kernels)
+    backend_slots = _backend_kernel_slots(target_arch)
 
-    for slot in _BACKEND_KERNEL_SLOTS:
+    for slot in backend_slots:
         if slot.implicit_role is None:
             selector: KernelSelector = slot.kind
             if selector in remaining:
@@ -142,7 +120,7 @@ def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelect
         slot = next(
             (
                 candidate
-                for candidate in _BACKEND_KERNEL_SLOTS
+                for candidate in backend_slots
                 if candidate not in assignments
                 and candidate.kind == _selector_kind(selector)
             ),
@@ -160,8 +138,9 @@ def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelect
 def _backend_kernel_bodies(
     split,
     assignments: Mapping[_BackendKernelSlot, KernelSelector],
+    target_arch: Optional[str],
 ) -> Iterator[Tuple[_BackendKernelSlot, Optional[KernelSelector], List[ast.stmt]]]:
-    for slot in _BACKEND_KERNEL_SLOTS:
+    for slot in _backend_kernel_slots(target_arch):
         logical_kernel = assignments.get(slot)
         body = (
             split.body_for(logical_kernel)
@@ -378,6 +357,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     external_pipenets = dict(inlined_pipenets)
     compile_time_captures: Dict[str, Any] = {}
     logical_kernels: Dict[str, Kernel] = dict(inlined_logical_kernels)
+    captured_logical_kernels: Dict[str, Kernel] = {}
     for capture_name in sorted(loaded_names & captured_values.keys()):
         value = captured_values[capture_name]
         if isinstance(value, DataflowBuffer):
@@ -389,7 +369,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         if isinstance(value, PipeNet):
             external_pipenets[capture_name] = value
         elif isinstance(value, Kernel):
-            logical_kernels[capture_name] = value
+            if not any(value is kernel for kernel in logical_kernels.values()):
+                captured_logical_kernels[capture_name] = value
         elif _is_compile_time_literal(value):
             compile_time_captures[capture_name] = copy.deepcopy(value)
         elif not isinstance(value, types.ModuleType) and not callable(value):
@@ -399,7 +380,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
                 f"{type(value).__name__}"
             )
 
-    _bind_logical_kernels(logical_kernels, operation_identity)
+    _bind_logical_kernels(captured_logical_kernels, operation_identity)
+    logical_kernels.update(captured_logical_kernels)
 
     frozen_scope = dict(scope)
     frozen_scope.update(compile_time_captures)
@@ -713,10 +695,12 @@ def _compile_atom(
         local_dfb_names=set(dfbs),
         logical_kernels=logical_kernels,
         selector_scope=selector_scope,
-        kernel_capacities=_backend_kernel_capacities(),
+        kernel_capacities=_backend_kernel_capacities(target_arch),
     )
-    backend_assignments = _assign_backend_kernel_slots(split)
-    backend_bodies = tuple(_backend_kernel_bodies(split, backend_assignments))
+    backend_assignments = _assign_backend_kernel_slots(split, target_arch)
+    backend_bodies = tuple(
+        _backend_kernel_bodies(split, backend_assignments, target_arch)
+    )
 
     if os.environ.get("TTLANG_ATOM_DUMP_SPLIT"):
         for slot, _, body in backend_bodies:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -33,7 +33,7 @@ import os
 import textwrap
 import types
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
 import ttl as _ttl
 from ttl.pykernel._src.utils import _cleanup_source_code
@@ -55,6 +55,8 @@ from .kernel import (
     KernelKind,
     KernelSelector,
     _PIPE_SOURCE_KERNEL_ROLE,
+    _bind_kernel_declarations,
+    _operation_identity,
     _selector_implicit_role,
     _selector_kind,
 )
@@ -151,6 +153,20 @@ def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelect
             )
         assignments[slot] = selector
     return assignments
+
+
+def _backend_kernel_bodies(
+    split,
+    assignments: Mapping[_BackendKernelSlot, KernelSelector],
+) -> Iterator[Tuple[_BackendKernelSlot, Optional[KernelSelector], List[ast.stmt]]]:
+    for slot in _BACKEND_KERNEL_SLOTS:
+        logical_kernel = assignments.get(slot)
+        body = (
+            split.body_for(logical_kernel)
+            if logical_kernel is not None
+            else [ast.Pass()]
+        )
+        yield slot, logical_kernel, body
 
 
 class DFB:
@@ -334,9 +350,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         elif stripped.startswith("def ") or stripped.startswith("async def "):
             break
     line_offset = start_lineno + num_decorator_lines - 1
-    operation_identity = (
-        f"{fn.__module__}.{fn.__qualname__}:{fn.__code__.co_firstlineno}"
-    )
+    operation_identity = _operation_identity(fn)
 
     module = ast.parse(_cleanup_source_code(fn))
     if len(module.body) != 1 or not isinstance(module.body[0], ast.FunctionDef):
@@ -348,7 +362,9 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
 
     # Inline statement-level calls to other unified operations, then keep
     # the post-inline AST + source.
-    inlined_pipenets = inline_atom_calls(fn_def, scope, caller_name=name)
+    inlined_pipenets, inlined_logical_kernels = inline_atom_calls(
+        fn_def, scope, caller_name=name
+    )
     _validate_resource_declarations(fn_def, name)
 
     loaded_names = set()
@@ -359,7 +375,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     captured_values = _captured_values(fn)
     external_pipenets = dict(inlined_pipenets)
     compile_time_captures: Dict[str, Any] = {}
-    logical_kernels: Dict[str, Kernel] = {}
+    logical_kernels: Dict[str, Kernel] = dict(inlined_logical_kernels)
     for capture_name in sorted(loaded_names & captured_values.keys()):
         value = captured_values[capture_name]
         if isinstance(value, DataflowBuffer):
@@ -408,27 +424,9 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
 
 def _bind_logical_kernels(
     logical_kernels: Dict[str, Kernel], operation_identity: str
-) -> Dict[str, Kernel]:
+) -> None:
     """Bind captured declarations in place during operation registration."""
-    source_names: Dict[int, str] = {}
-    for name, kernel in logical_kernels.items():
-        previous_name = source_names.get(id(kernel))
-        if previous_name is not None:
-            raise ValueError(
-                "one logical Kernel handle reached the final operation under "
-                f"multiple names: {previous_name!r} and {name!r}"
-            )
-        source_names[id(kernel)] = name
-        if kernel._identity is not None:
-            raise ValueError(
-                f"logical Kernel {name!r} is already bound as "
-                f"{kernel.identity!r} to operation "
-                f"{kernel._operation_identity!r}"
-            )
-
-    for name, kernel in logical_kernels.items():
-        kernel._bind(name, operation_identity)
-    return logical_kernels
+    _bind_kernel_declarations(logical_kernels, operation_identity)
 
 
 def _is_compile_time_literal(value: Any) -> bool:
@@ -589,7 +587,7 @@ def _lift_setup(
         elif isinstance(value, PipeNet):
             nets[name] = value
         elif isinstance(value, Kernel):
-            value = value._bind(name, operation_identity)
+            value._bind(name, operation_identity)
             kernels[name] = value
         ns[name] = value
         # A bare Pipe remains in ns for a later PipeNet reference.
@@ -687,6 +685,8 @@ def _compile_atom(
         operation_identity=spec.operation_identity,
     )
     logical_kernels.update(lifted_logical_kernels)
+    selector_scope = dict(eval_scope)
+    selector_scope.update(logical_kernels)
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe
@@ -703,18 +703,14 @@ def _compile_atom(
         dfb_param_names=set(spec.dfb_param_names),
         local_dfb_names=set(dfbs),
         logical_kernels=logical_kernels,
+        selector_scope=selector_scope,
         kernel_capacities=_backend_kernel_capacities(),
     )
     backend_assignments = _assign_backend_kernel_slots(split)
+    backend_bodies = tuple(_backend_kernel_bodies(split, backend_assignments))
 
     if os.environ.get("TTLANG_ATOM_DUMP_SPLIT"):
-        for slot in _BACKEND_KERNEL_SLOTS:
-            logical_kernel = backend_assignments.get(slot)
-            body = (
-                split.body_for(logical_kernel)
-                if logical_kernel is not None
-                else [ast.Pass()]
-            )
+        for slot, _, body in backend_bodies:
             _dbg = _synthesize_thread_module(f"{spec.name}__{slot.source_name}", body)
             print(f"\n===== @ttl.operation split: {slot.source_name} =====")
             print(ast.unparse(_dbg))
@@ -737,13 +733,7 @@ def _compile_atom(
     threads = []
     thread_logical_kernels = []
     any_real_work = False
-    for slot in _BACKEND_KERNEL_SLOTS:
-        logical_kernel = backend_assignments.get(slot)
-        body = (
-            split.body_for(logical_kernel)
-            if logical_kernel is not None
-            else [ast.Pass()]
-        )
+    for slot, logical_kernel, body in backend_bodies:
         any_real_work = any_real_work or _has_real_work(body)
         fn_name = f"{spec.name}__{slot.source_name}"
         threads.append(

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -33,7 +33,7 @@ import os
 import textwrap
 import types
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import ttl as _ttl
 from ttl.pykernel._src.utils import _cleanup_source_code
@@ -72,6 +72,7 @@ from .ttl_api import (
     _make_operation_wrapper,
     _require_device,
     _run_thread_compiler,
+    _slot_idle_kernel,
     _validate_operation_options,
     get_min_remaining_l1_for_device,
     pykernel_gen,
@@ -138,15 +139,28 @@ def _backend_kernel_bodies(
     split,
     assignments: Mapping[_BackendKernelSlot, KernelSelector],
     target_arch: Optional[str],
-) -> Iterator[Tuple[_BackendKernelSlot, Optional[KernelSelector], List[ast.stmt]]]:
+) -> Tuple[Tuple[_BackendKernelSlot, KernelSelector, List[ast.stmt]], ...]:
+    """Pair every backend slot with a logical kernel and the body it emits.
+
+    A slot the plan left unassigned still produces a kernel, so it takes its idle
+    logical identity rather than none; runtime resources can then select every
+    emitted kernel by identity.
+    """
+    bodies = []
     for slot in _backend_kernel_slots(target_arch):
         logical_kernel = assignments.get(slot)
-        body = (
-            split.body_for(logical_kernel)
-            if logical_kernel is not None
-            else [ast.Pass()]
+        if logical_kernel is None:
+            bodies.append((slot, _slot_idle_kernel(slot), [ast.Pass()]))
+            continue
+        bodies.append((slot, logical_kernel, split.body_for(logical_kernel)))
+
+    selectors = [logical_kernel for _, logical_kernel, _ in bodies]
+    if len(set(selectors)) != len(selectors):
+        raise AssertionError(
+            f"backend slots produced duplicate logical identities {selectors!r}; "
+            "each emitted kernel must be selectable by identity"
         )
-        yield slot, logical_kernel, body
+    return tuple(bodies)
 
 
 class DFB:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unified-body ``@ttl.operation`` kernels with automatic thread splitting.
+"""Unified-body ``@ttl.operation`` kernels with logical-kernel splitting.
 
 The unified form is a single function body instead of one @ttl.compute and
-two @ttl.datamovement thread functions. At decoration time, statement-level
-calls to other unified operations are inlined; at compile time the body is
-split into compute (TRISC) and data-movement
-(NCRISC / BRISC) threads, which then flow through the same MLIR pipeline
-as @ttl.operation.
+two @ttl.datamovement functions. At decoration time, statement-level calls to
+other unified operations are inlined. At compile time, the body is split into
+target-independent compute and data-movement kernels. Backend assignment then
+maps those logical kernels to the target's supported kernel slots.
 
 A unified operation may take TT-NN tensors, compile-time captures, and --
 when intended for composition -- ttl.DFB or ttl.PipeNet parameters. Dataflow
@@ -17,15 +16,11 @@ buffers used within a top-level operation are declared in its body. An
 operation with resource parameters is expand-only and cannot be called as a
 TT-NN operation.
 
-DFB declarations sit inline with the compute/copy work in a unified
-body, so after the split they land inside each thread body. The existing
-per-thread compiler is capture-based (thread functions take no
-parameters; DFBs arrive as closure captures), so before splitting we
-lift the top-level ``name = make_dfb(...)`` assigns out of the body,
-evaluate them to DataflowBuffer objects, and pass them as captures --
-the same shape the @ttl.operation flow produces by running its setup
-body. After that the per-thread compile, CB sizing, pass pipeline, and
-runner are identical to @ttl.operation.
+DFB declarations sit inline with the compute/copy work in a unified body. The
+existing per-kernel compiler is capture-based, so top-level static resource
+assignments are lifted before splitting and supplied as captures. The
+per-kernel compile, DFB sizing, pass pipeline, and runner remain identical to
+the explicit multi-kernel form.
 """
 
 from __future__ import annotations
@@ -55,6 +50,13 @@ from .dataflow_buffer import (
     make_tensor_backed_dfb,
 )
 from .dtype_utils import is_ttnn_tensor
+from .kernel import (
+    Kernel,
+    KernelKind,
+    KernelSelector,
+    _selector_implicit_role,
+    _selector_kind,
+)
 from .operators import _set_current_grid
 from .pipe import PipeNet
 from .ttl_api import (
@@ -69,17 +71,85 @@ from .ttl_api import (
     pykernel_gen,
 )
 
-
-# Names whose top-level ``x = <name>(...)`` assigns are lifted out of the body
-# and evaluated to capture objects (DataflowBuffer / Pipe / PipeNet) before the
-# split, the same way @ttl.operation constructs them in its setup body.
+# Names whose top-level ``x = <name>(...)`` assigns are evaluated as static
+# operation resources before logical-kernel splitting.
 _DFB_FACTORY_NAMES = {
     "make_dfb",
     "make_dataflow_buffer_like",
     "make_tensor_backed_dfb",
 }
 _PIPE_FACTORY_NAMES = {"Pipe", "PipeNet"}
-_SETUP_FACTORY_NAMES = _DFB_FACTORY_NAMES | _PIPE_FACTORY_NAMES
+_KERNEL_FACTORY_NAMES = {"Kernel"}
+_SETUP_FACTORY_NAMES = _DFB_FACTORY_NAMES | _PIPE_FACTORY_NAMES | _KERNEL_FACTORY_NAMES
+
+
+@dataclass(frozen=True)
+class _BackendKernelSlot:
+    kind: KernelKind
+    kernel_type: str
+    source_name: str
+    implicit_role: Optional[str] = None
+
+
+_BACKEND_KERNEL_SLOTS = (
+    _BackendKernelSlot(KernelKind.COMPUTE, "compute", "trisc"),
+    _BackendKernelSlot(KernelKind.DATA_MOVEMENT, "datamovement", "ncrisc"),
+    _BackendKernelSlot(
+        KernelKind.DATA_MOVEMENT,
+        "datamovement",
+        "brisc",
+        implicit_role="pipe_source",
+    ),
+)
+
+
+def _backend_kernel_capacities() -> Dict[KernelKind, int]:
+    return {
+        kind: sum(slot.kind == kind for slot in _BACKEND_KERNEL_SLOTS)
+        for kind in KernelKind
+    }
+
+
+def _assign_backend_kernel_slots(split) -> Dict[_BackendKernelSlot, KernelSelector]:
+    assignments: Dict[_BackendKernelSlot, KernelSelector] = {}
+    remaining = list(split.kernels)
+
+    for slot in _BACKEND_KERNEL_SLOTS:
+        if slot.implicit_role is None:
+            selector: KernelSelector = slot.kind
+            if selector in remaining:
+                assignments[slot] = selector
+                remaining.remove(selector)
+            continue
+        selector = next(
+            (
+                kernel
+                for kernel in remaining
+                if _selector_implicit_role(kernel) == slot.implicit_role
+            ),
+            None,
+        )
+        if selector is not None:
+            assignments[slot] = selector
+            remaining.remove(selector)
+
+    for selector in remaining:
+        slot = next(
+            (
+                candidate
+                for candidate in _BACKEND_KERNEL_SLOTS
+                if candidate not in assignments
+                and candidate.kind == _selector_kind(selector)
+            ),
+            None,
+        )
+        if slot is None:
+            raise AssertionError(
+                f"no backend slot for planned {selector!r}; capacity validation "
+                "must reject this before backend assignment"
+            )
+        assignments[slot] = selector
+    return assignments
 
 
 class DFB:
@@ -357,10 +427,11 @@ def _is_pipe_list_expr(node: ast.expr) -> bool:
 
 
 def _setup_assign_target(stmt: ast.stmt) -> Optional[str]:
-    """If ``stmt`` is a DFB/Pipe/PipeNet construction assign, return its name.
+    """Return the name of a static operation-resource assignment.
 
-    Recognizes ``name = <dfb/pipe-factory>(...)`` and ``name = [<pipes>]``
-    (a pipe list feeding a later PipeNet)."""
+    Recognizes DFB, Pipe, PipeNet, and logical Kernel construction plus a pipe
+    list feeding a later PipeNet.
+    """
     if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
         return None
     if not isinstance(stmt.targets[0], ast.Name):
@@ -443,27 +514,29 @@ def _validate_resource_declarations(
 def _lift_setup(
     fn_def: ast.FunctionDef,
     scope: Dict[str, Any],
-) -> Tuple[ast.FunctionDef, Dict[str, DataflowBuffer], Dict[str, PipeNet]]:
-    """Strip and evaluate the top-level DFB / Pipe / PipeNet construction
-    assigns.
+) -> Tuple[
+    ast.FunctionDef,
+    Dict[str, DataflowBuffer],
+    Dict[str, PipeNet],
+    Dict[str, Kernel],
+]:
+    """Strip and evaluate top-level static operation-resource assignments.
 
     Returns the kernel body with those statements removed, plus the
-    DataflowBuffer and PipeNet objects keyed by name. Each construction
-    expression is evaluated in source order in a controlled namespace, with
-    results threaded back in so a later ``PipeNet([p0])`` sees an earlier
-    ``p0`` and CB indices are assigned in source order. This runs just the
-    setup statements that @ttl.operation runs as part of executing its whole
-    body; the per-thread compiler consumes the results as captures, not as
-    in-body calls.
+    DataflowBuffer, PipeNet, and bound logical Kernel objects keyed by name.
+    Construction expressions are evaluated in source order so dependencies and
+    DFB indices remain deterministic.
     """
     ns = dict(scope)
     ns.setdefault("make_dfb", make_dfb)
     ns.setdefault("make_dataflow_buffer_like", make_dataflow_buffer_like)
     ns.setdefault("make_tensor_backed_dfb", make_tensor_backed_dfb)
+    ns.setdefault("Kernel", Kernel)
     ns.setdefault("ttl", _ttl)
 
     dfbs: Dict[str, DataflowBuffer] = {}
     nets: Dict[str, PipeNet] = {}
+    kernels: Dict[str, Kernel] = {}
     kept: List[ast.stmt] = []
     for stmt in fn_def.body:
         name = _setup_assign_target(stmt)
@@ -471,17 +544,19 @@ def _lift_setup(
             kept.append(stmt)
             continue
         value = eval(ast.unparse(stmt.value), ns)  # noqa: S307
-        ns[name] = value
         if isinstance(value, DataflowBuffer):
             dfbs[name] = value
         elif isinstance(value, PipeNet):
             nets[name] = value
-        # A bare Pipe stays in ns for a later PipeNet reference but is not a
-        # capture; only DataflowBuffers and PipeNets are bound on threads.
+        elif isinstance(value, Kernel):
+            value = value._bind(name)
+            kernels[name] = value
+        ns[name] = value
+        # A bare Pipe remains in ns for a later PipeNet reference.
 
     new_fn = copy.copy(fn_def)
     new_fn.body = kept
-    return new_fn, dfbs, nets
+    return new_fn, dfbs, nets, kernels
 
 
 def _has_real_work(body: List[ast.stmt]) -> bool:
@@ -564,7 +639,9 @@ def _compile_atom(
     _reset_cb_counter()
     _set_current_grid(grid)
 
-    stripped_fn, dfbs, nets = _lift_setup(copy.deepcopy(spec.fn_ast), eval_scope)
+    stripped_fn, dfbs, nets, logical_kernels = _lift_setup(
+        copy.deepcopy(spec.fn_ast), eval_scope
+    )
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe
@@ -580,14 +657,21 @@ def _compile_atom(
         fn_def=stripped_fn,
         dfb_param_names=set(spec.dfb_param_names),
         local_dfb_names=set(dfbs),
+        logical_kernels=logical_kernels,
+        kernel_capacities=_backend_kernel_capacities(),
     )
+    backend_assignments = _assign_backend_kernel_slots(split)
 
     if os.environ.get("TTLANG_ATOM_DUMP_SPLIT"):
-        for _thread in ("trisc", "ncrisc", "brisc"):
-            _dbg = _synthesize_thread_module(
-                f"{spec.name}__{_thread}", split.body_for(_thread)
+        for slot in _BACKEND_KERNEL_SLOTS:
+            logical_kernel = backend_assignments.get(slot)
+            body = (
+                split.body_for(logical_kernel)
+                if logical_kernel is not None
+                else [ast.Pass()]
             )
-            print(f"\n===== @ttl.operation split: {_thread} =====")
+            _dbg = _synthesize_thread_module(f"{spec.name}__{slot.source_name}", body)
+            print(f"\n===== @ttl.operation split: {slot.source_name} =====")
             print(ast.unparse(_dbg))
 
     # Captures shared by every thread: ttnn tensors and scalars (bound
@@ -607,16 +691,17 @@ def _compile_atom(
     # body, the same shape @ttl.operation produces.
     threads = []
     any_real_work = False
-    for kernel_type, thread in (
-        ("compute", "trisc"),
-        ("datamovement", "ncrisc"),
-        ("datamovement", "brisc"),
-    ):
-        body = split.body_for(thread)
+    for slot in _BACKEND_KERNEL_SLOTS:
+        logical_kernel = backend_assignments.get(slot)
+        body = (
+            split.body_for(logical_kernel)
+            if logical_kernel is not None
+            else [ast.Pass()]
+        )
         any_real_work = any_real_work or _has_real_work(body)
-        fn_name = f"{spec.name}__{thread}"
+        fn_name = f"{spec.name}__{slot.source_name}"
         threads.append(
-            _make_thread_callable(spec, kernel_type, fn_name, body, captures)
+            _make_thread_callable(spec, slot.kernel_type, fn_name, body, captures)
         )
 
     if not any_real_work:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -52,7 +52,6 @@ from .dataflow_buffer import (
 from .dtype_utils import is_ttnn_tensor
 from .kernel import (
     Kernel,
-    KernelKind,
     KernelSelector,
     _bind_kernel_declarations,
     _operation_identity,
@@ -720,9 +719,8 @@ def _compile_atom(
     captures.update(nets)
     captures.update(spec.external_pipenets)
 
-    # TTNN interop requires exactly 3 kernels (1 compute + 2 data movement);
-    # emit all three even when a thread has no work, filling it with a pass
-    # body, the same shape @ttl.operation produces.
+    # TTNN interop requires one emitted thread for every backend slot. Empty
+    # slots retain a pass body so argument metadata stays aligned with slot order.
     threads = []
     thread_logical_kernels = []
     any_real_work = False

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -52,7 +52,6 @@ from .dataflow_buffer import (
 from .dtype_utils import is_ttnn_tensor
 from .kernel import (
     Kernel,
-    KernelKind,
     KernelSelector,
     _bind_kernel_declarations,
     _operation_identity,
@@ -711,9 +710,8 @@ def _compile_atom(
     captures.update(nets)
     captures.update(spec.external_pipenets)
 
-    # TTNN interop requires exactly 3 kernels (1 compute + 2 data movement);
-    # emit all three even when a thread has no work, filling it with a pass
-    # body, the same shape @ttl.operation produces.
+    # TTNN interop requires one emitted thread for every backend slot. Empty
+    # slots retain a pass body so argument metadata stays aligned with slot order.
     threads = []
     thread_logical_kernels = []
     any_real_work = False

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -173,6 +173,7 @@ class _ParamInfo:
 @dataclass
 class _AtomSpec:
     name: str
+    operation_identity: str
     fn: Callable
     source: str
     source_file: str
@@ -183,6 +184,7 @@ class _AtomSpec:
     compile_time_captures: Dict[str, Any]
     frozen_scope: Dict[str, Any]
     external_pipenets: Dict[str, PipeNet]
+    logical_kernels: Dict[str, Kernel]
 
 
 class _ReturnFinder(ast.NodeVisitor):
@@ -333,6 +335,9 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         elif stripped.startswith("def ") or stripped.startswith("async def "):
             break
     line_offset = start_lineno + num_decorator_lines - 1
+    operation_identity = (
+        f"{fn.__module__}.{fn.__qualname__}:{fn.__code__.co_firstlineno}"
+    )
 
     module = ast.parse(_cleanup_source_code(fn))
     if len(module.body) != 1 or not isinstance(module.body[0], ast.FunctionDef):
@@ -355,7 +360,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     captured_values = _captured_values(fn)
     external_pipenets = dict(inlined_pipenets)
     compile_time_captures: Dict[str, Any] = {}
-    for capture_name in loaded_names & captured_values.keys():
+    logical_kernels: Dict[str, Kernel] = {}
+    for capture_name in sorted(loaded_names & captured_values.keys()):
         value = captured_values[capture_name]
         if isinstance(value, DataflowBuffer):
             raise ValueError(
@@ -365,6 +371,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
             )
         if isinstance(value, PipeNet):
             external_pipenets[capture_name] = value
+        elif isinstance(value, Kernel):
+            logical_kernels[capture_name] = value
         elif _is_compile_time_literal(value):
             compile_time_captures[capture_name] = copy.deepcopy(value)
         elif not isinstance(value, types.ModuleType) and not callable(value):
@@ -374,13 +382,17 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
                 f"{type(value).__name__}"
             )
 
+    _bind_logical_kernels(logical_kernels, operation_identity)
+
     frozen_scope = dict(scope)
     frozen_scope.update(compile_time_captures)
+    frozen_scope.update(logical_kernels)
     source = ast.unparse(fn_def)
 
     params = _classify_params(fn)
     return _AtomSpec(
         name=name,
+        operation_identity=operation_identity,
         fn=fn,
         source=source,
         source_file=source_file,
@@ -391,7 +403,33 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         compile_time_captures=compile_time_captures,
         frozen_scope=frozen_scope,
         external_pipenets=external_pipenets,
+        logical_kernels=logical_kernels,
     )
+
+
+def _bind_logical_kernels(
+    logical_kernels: Dict[str, Kernel], operation_identity: str
+) -> Dict[str, Kernel]:
+    """Bind captured declarations in place during operation registration."""
+    source_names: Dict[int, str] = {}
+    for name, kernel in logical_kernels.items():
+        previous_name = source_names.get(id(kernel))
+        if previous_name is not None:
+            raise ValueError(
+                "one logical Kernel handle reached the final operation under "
+                f"multiple names: {previous_name!r} and {name!r}"
+            )
+        source_names[id(kernel)] = name
+        if kernel._identity is not None:
+            raise ValueError(
+                f"logical Kernel {name!r} is already bound as "
+                f"{kernel.identity!r} to operation "
+                f"{kernel._operation_identity!r}"
+            )
+
+    for name, kernel in logical_kernels.items():
+        kernel._bind(name, operation_identity)
+    return logical_kernels
 
 
 def _is_compile_time_literal(value: Any) -> bool:
@@ -516,6 +554,7 @@ def _validate_resource_declarations(
 def _lift_setup(
     fn_def: ast.FunctionDef,
     scope: Dict[str, Any],
+    operation_identity: str,
 ) -> Tuple[
     ast.FunctionDef,
     Dict[str, DataflowBuffer],
@@ -551,7 +590,7 @@ def _lift_setup(
         elif isinstance(value, PipeNet):
             nets[name] = value
         elif isinstance(value, Kernel):
-            value = value._bind(name)
+            value = value._bind(name, operation_identity)
             kernels[name] = value
         ns[name] = value
         # A bare Pipe remains in ns for a later PipeNet reference.
@@ -620,7 +659,9 @@ def _compile_atom(
 
     # The shared operation wrapper supplies values in signature order.
     bound_arguments = {param.name: value for param, value in zip(spec.params, args)}
+    logical_kernels = dict(spec.logical_kernels)
     eval_scope = dict(spec.frozen_scope)
+    eval_scope.update(logical_kernels)
     eval_scope.update(bound_arguments)
 
     # Register ttnn tensors so the per-thread compiler can resolve global
@@ -648,9 +689,12 @@ def _compile_atom(
     _reset_cb_counter()
     _set_current_grid(grid)
 
-    stripped_fn, dfbs, nets, logical_kernels = _lift_setup(
-        copy.deepcopy(spec.fn_ast), eval_scope
+    stripped_fn, dfbs, nets, lifted_logical_kernels = _lift_setup(
+        copy.deepcopy(spec.fn_ast),
+        eval_scope,
+        operation_identity=spec.operation_identity,
     )
+    logical_kernels.update(lifted_logical_kernels)
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe
@@ -699,6 +743,7 @@ def _compile_atom(
     # emit all three even when a thread has no work, filling it with a pass
     # body, the same shape @ttl.operation produces.
     threads = []
+    thread_logical_kernels = []
     any_real_work = False
     for slot in _BACKEND_KERNEL_SLOTS:
         logical_kernel = backend_assignments.get(slot)
@@ -712,6 +757,7 @@ def _compile_atom(
         threads.append(
             _make_thread_callable(spec, slot.kernel_type, fn_name, body, captures)
         )
+        thread_logical_kernels.append(logical_kernel)
 
     if not any_real_work:
         raise ValueError(
@@ -742,6 +788,7 @@ def _compile_atom(
         l1_budget_override=l1_budget_override,
         kernel_source_file=spec.source_file,
         kernel_line_offset=spec.line_offset,
+        logical_kernels=thread_logical_kernels,
     )
 
 

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -342,8 +342,6 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         elif stripped.startswith("def ") or stripped.startswith("async def "):
             break
     line_offset = start_lineno + num_decorator_lines - 1
-    operation_identity = _operation_identity(fn)
-
     module = ast.parse(_cleanup_source_code(fn))
     if len(module.body) != 1 or not isinstance(module.body[0], ast.FunctionDef):
         raise ValueError(
@@ -391,6 +389,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
                 f"{type(value).__name__}"
             )
 
+    operation_identity = _operation_identity(fn)
     _bind_logical_kernels(captured_logical_kernels, operation_identity)
     logical_kernels.update(captured_logical_kernels)
 
@@ -833,6 +832,9 @@ class Atom:
     @property
     def name(self) -> str:
         return self._spec.name
+
+    def _operation_identity_capture(self) -> tuple[str, str]:
+        return ("operation", self._spec.operation_identity)
 
     def __call__(self, *args, **kwargs):
         if self._grid is None:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -33,7 +33,7 @@ import os
 import textwrap
 import types
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import ttl as _ttl
 from ttl.pykernel._src.utils import _cleanup_source_code
@@ -71,6 +71,7 @@ from .ttl_api import (
     _lower_program_to_kernel,
     _make_operation_wrapper,
     _run_thread_compiler,
+    _slot_idle_kernel,
     _validate_operation_options,
     pykernel_gen,
 )
@@ -136,15 +137,28 @@ def _backend_kernel_bodies(
     split,
     assignments: Mapping[_BackendKernelSlot, KernelSelector],
     target_arch: Optional[str],
-) -> Iterator[Tuple[_BackendKernelSlot, Optional[KernelSelector], List[ast.stmt]]]:
+) -> Tuple[Tuple[_BackendKernelSlot, KernelSelector, List[ast.stmt]], ...]:
+    """Pair every backend slot with a logical kernel and the body it emits.
+
+    A slot the plan left unassigned still produces a kernel, so it takes its idle
+    logical identity rather than none; runtime resources can then select every
+    emitted kernel by identity.
+    """
+    bodies = []
     for slot in _backend_kernel_slots(target_arch):
         logical_kernel = assignments.get(slot)
-        body = (
-            split.body_for(logical_kernel)
-            if logical_kernel is not None
-            else [ast.Pass()]
+        if logical_kernel is None:
+            bodies.append((slot, _slot_idle_kernel(slot), [ast.Pass()]))
+            continue
+        bodies.append((slot, logical_kernel, split.body_for(logical_kernel)))
+
+    selectors = [logical_kernel for _, logical_kernel, _ in bodies]
+    if len(set(selectors)) != len(selectors):
+        raise AssertionError(
+            f"backend slots produced duplicate logical identities {selectors!r}; "
+            "each emitted kernel must be selectable by identity"
         )
-        yield slot, logical_kernel, body
+    return tuple(bodies)
 
 
 class DFB:

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -171,6 +171,7 @@ class _ParamInfo:
 @dataclass
 class _AtomSpec:
     name: str
+    operation_identity: str
     fn: Callable
     source: str
     source_file: str
@@ -181,6 +182,7 @@ class _AtomSpec:
     compile_time_captures: Dict[str, Any]
     frozen_scope: Dict[str, Any]
     external_pipenets: Dict[str, PipeNet]
+    logical_kernels: Dict[str, Kernel]
 
 
 class _ReturnFinder(ast.NodeVisitor):
@@ -331,6 +333,9 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         elif stripped.startswith("def ") or stripped.startswith("async def "):
             break
     line_offset = start_lineno + num_decorator_lines - 1
+    operation_identity = (
+        f"{fn.__module__}.{fn.__qualname__}:{fn.__code__.co_firstlineno}"
+    )
 
     module = ast.parse(_cleanup_source_code(fn))
     if len(module.body) != 1 or not isinstance(module.body[0], ast.FunctionDef):
@@ -353,7 +358,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
     captured_values = _captured_values(fn)
     external_pipenets = dict(inlined_pipenets)
     compile_time_captures: Dict[str, Any] = {}
-    for capture_name in loaded_names & captured_values.keys():
+    logical_kernels: Dict[str, Kernel] = {}
+    for capture_name in sorted(loaded_names & captured_values.keys()):
         value = captured_values[capture_name]
         if isinstance(value, DataflowBuffer):
             raise ValueError(
@@ -363,6 +369,8 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
             )
         if isinstance(value, PipeNet):
             external_pipenets[capture_name] = value
+        elif isinstance(value, Kernel):
+            logical_kernels[capture_name] = value
         elif _is_compile_time_literal(value):
             compile_time_captures[capture_name] = copy.deepcopy(value)
         elif not isinstance(value, types.ModuleType) and not callable(value):
@@ -372,13 +380,17 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
                 f"{type(value).__name__}"
             )
 
+    _bind_logical_kernels(logical_kernels, operation_identity)
+
     frozen_scope = dict(scope)
     frozen_scope.update(compile_time_captures)
+    frozen_scope.update(logical_kernels)
     source = ast.unparse(fn_def)
 
     params = _classify_params(fn)
     return _AtomSpec(
         name=name,
+        operation_identity=operation_identity,
         fn=fn,
         source=source,
         source_file=source_file,
@@ -389,7 +401,33 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         compile_time_captures=compile_time_captures,
         frozen_scope=frozen_scope,
         external_pipenets=external_pipenets,
+        logical_kernels=logical_kernels,
     )
+
+
+def _bind_logical_kernels(
+    logical_kernels: Dict[str, Kernel], operation_identity: str
+) -> Dict[str, Kernel]:
+    """Bind captured declarations in place during operation registration."""
+    source_names: Dict[int, str] = {}
+    for name, kernel in logical_kernels.items():
+        previous_name = source_names.get(id(kernel))
+        if previous_name is not None:
+            raise ValueError(
+                "one logical Kernel handle reached the final operation under "
+                f"multiple names: {previous_name!r} and {name!r}"
+            )
+        source_names[id(kernel)] = name
+        if kernel._identity is not None:
+            raise ValueError(
+                f"logical Kernel {name!r} is already bound as "
+                f"{kernel.identity!r} to operation "
+                f"{kernel._operation_identity!r}"
+            )
+
+    for name, kernel in logical_kernels.items():
+        kernel._bind(name, operation_identity)
+    return logical_kernels
 
 
 def _is_compile_time_literal(value: Any) -> bool:
@@ -514,6 +552,7 @@ def _validate_resource_declarations(
 def _lift_setup(
     fn_def: ast.FunctionDef,
     scope: Dict[str, Any],
+    operation_identity: str,
 ) -> Tuple[
     ast.FunctionDef,
     Dict[str, DataflowBuffer],
@@ -549,7 +588,7 @@ def _lift_setup(
         elif isinstance(value, PipeNet):
             nets[name] = value
         elif isinstance(value, Kernel):
-            value = value._bind(name)
+            value = value._bind(name, operation_identity)
             kernels[name] = value
         ns[name] = value
         # A bare Pipe remains in ns for a later PipeNet reference.
@@ -619,7 +658,9 @@ def _compile_atom(
 
     # The shared operation wrapper supplies values in signature order.
     bound_arguments = {param.name: value for param, value in zip(spec.params, args)}
+    logical_kernels = dict(spec.logical_kernels)
     eval_scope = dict(spec.frozen_scope)
+    eval_scope.update(logical_kernels)
     eval_scope.update(bound_arguments)
 
     # Register ttnn tensors so the per-thread compiler can resolve global
@@ -639,9 +680,12 @@ def _compile_atom(
     _reset_cb_counter()
     _set_current_grid(grid)
 
-    stripped_fn, dfbs, nets, logical_kernels = _lift_setup(
-        copy.deepcopy(spec.fn_ast), eval_scope
+    stripped_fn, dfbs, nets, lifted_logical_kernels = _lift_setup(
+        copy.deepcopy(spec.fn_ast),
+        eval_scope,
+        operation_identity=spec.operation_identity,
     )
+    logical_kernels.update(lifted_logical_kernels)
 
     # Assign each PipeNet a distinct operation-local id (and validate), the
     # same graph @ttl.operation builds; it also yields the runner's pipe
@@ -690,6 +734,7 @@ def _compile_atom(
     # emit all three even when a thread has no work, filling it with a pass
     # body, the same shape @ttl.operation produces.
     threads = []
+    thread_logical_kernels = []
     any_real_work = False
     for slot in _BACKEND_KERNEL_SLOTS:
         logical_kernel = backend_assignments.get(slot)
@@ -703,6 +748,7 @@ def _compile_atom(
         threads.append(
             _make_thread_callable(spec, slot.kernel_type, fn_name, body, captures)
         )
+        thread_logical_kernels.append(logical_kernel)
 
     if not any_real_work:
         raise ValueError(
@@ -733,6 +779,7 @@ def _compile_atom(
         l1_budget_override=l1_budget_override,
         kernel_source_file=spec.source_file,
         kernel_line_offset=spec.line_offset,
+        logical_kernels=thread_logical_kernels,
     )
 
 

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -54,6 +54,7 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _PIPE_SOURCE_KERNEL_ROLE,
     _selector_implicit_role,
     _selector_kind,
 )
@@ -98,7 +99,7 @@ _BACKEND_KERNEL_SLOTS = (
         KernelKind.DATA_MOVEMENT,
         "datamovement",
         "brisc",
-        implicit_role="pipe_source",
+        implicit_role=_PIPE_SOURCE_KERNEL_ROLE,
     ),
 )
 

--- a/python/ttl/dialects/ttl.py
+++ b/python/ttl/dialects/ttl.py
@@ -23,6 +23,7 @@ def ensure_dialects_registered(ctx):
 
 # Re-export C++-bound attributes/types for convenience.
 SliceAttr = ir.SliceAttr
+LogicalKernelAttr = ir.LogicalKernelAttr
 TensorBackingAttr = ir.TensorBackingAttr
 PipeRecordAttr = ir.PipeRecordAttr
 PipeNetRecordsAttr = ir.PipeNetRecordsAttr

--- a/python/ttl/dialects/ttl.py
+++ b/python/ttl/dialects/ttl.py
@@ -23,6 +23,7 @@ def ensure_dialects_registered(ctx):
 
 # Re-export C++-bound attributes/types for convenience.
 SliceAttr = ir.SliceAttr
+LogicalKernelAttr = ir.LogicalKernelAttr
 TensorBackingAttr = ir.TensorBackingAttr
 CircularBufferType = ir.CircularBufferType
 PipeType = ir.PipeType

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -25,6 +25,11 @@ class KernelKind(Enum):
     COMPUTE = str(_TableGenLogicalKernelKind.Compute)
     DATA_MOVEMENT = str(_TableGenLogicalKernelKind.DataMovement)
 
+    def __or__(self, other: object) -> Tuple["KernelKind", "KernelKind"]:
+        if not isinstance(other, KernelKind):
+            return NotImplemented
+        return (self, other)
+
 
 @dataclass(frozen=True)
 class _KernelIdentity:

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -12,6 +12,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Final, Iterable, Mapping, Optional, Tuple, Union
 
+from ._src.global_semaphore import (
+    get_ttnn_global_semaphore_address,
+    is_ttnn_global_semaphore,
+)
 from .dialects._ttl_enum_gen import LogicalKernelKind as _TableGenLogicalKernelKind
 
 
@@ -233,6 +237,9 @@ def _encode_identity_capture(
         return encoded
     if isinstance(value, Kernel):
         return f"kernel-kind:{value.kind.value}".encode("utf-8")
+    if is_ttnn_global_semaphore(value):
+        address = get_ttnn_global_semaphore_address(value)
+        return f"global-semaphore:{address}".encode("ascii")
 
     semantic_identity = getattr(value, "_operation_identity_capture", None)
     if callable(semantic_identity):

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -8,14 +8,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Tuple, Union
+from typing import Final, Optional, Tuple, Union
+
+from .dialects._ttl_enum_gen import LogicalKernelKind as _TableGenLogicalKernelKind
+
+
+_PIPE_SOURCE_KERNEL_ROLE: Final[str] = "pipe_source"
 
 
 class KernelKind(Enum):
     """A portable class of kernels supported by a target backend."""
 
-    COMPUTE = "compute"
-    DATA_MOVEMENT = "data_movement"
+    COMPUTE = str(_TableGenLogicalKernelKind.Compute)
+    DATA_MOVEMENT = str(_TableGenLogicalKernelKind.DataMovement)
 
 
 @dataclass(frozen=True)

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -18,91 +18,169 @@ class KernelKind(Enum):
     DATA_MOVEMENT = "data_movement"
 
 
+@dataclass(frozen=True)
+class _KernelIdentity:
+    name: str
+    operation: Optional[str]
+    implicit_role: Optional[str]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("Kernel identity must be a nonempty string")
+        if self.operation is not None and (
+            not isinstance(self.operation, str) or not self.operation
+        ):
+            raise ValueError("Kernel operation identity must be a nonempty string")
+        if self.implicit_role is not None and (
+            not isinstance(self.implicit_role, str) or not self.implicit_role
+        ):
+            raise ValueError("Kernel implicit role must be a nonempty string")
+        if (self.operation is None) == (self.implicit_role is None):
+            raise ValueError(
+                "Kernel identity requires exactly one operation or implicit role"
+            )
+
+
+class _KernelBinding:
+    """One-time mutable holder for an immutable logical identity."""
+
+    def __init__(self) -> None:
+        self._identity: Optional[_KernelIdentity] = None
+
+    @property
+    def identity(self) -> Optional[_KernelIdentity]:
+        return self._identity
+
+    def bind(self, identity: _KernelIdentity) -> None:
+        if self._identity is not None:
+            raise ValueError(
+                f"Kernel is already bound as {self._identity.name!r} to "
+                f"operation {self._identity.operation!r}"
+            )
+        self._identity = identity
+
+
 @dataclass(frozen=True, eq=False)
 class Kernel:
     """An operation-local logical kernel with a stable source identity.
 
-    Kernel declarations are top-level resources in a unified operation. The
-    operation setup binds the declaration's assignment name as its identity.
+    Kernel handles are static operation resources. Operation registration or
+    setup binds the handle's capture or assignment name as its identity.
     """
 
     kind: KernelKind
-    _identity: Optional[str] = field(default=None, repr=False)
-    _implicit_role: Optional[str] = field(default=None, repr=False)
+    _binding: _KernelBinding = field(
+        default_factory=_KernelBinding,
+        init=False,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         if not isinstance(self.kind, KernelKind):
             raise TypeError(
                 "Kernel kind must be a KernelKind, got " f"{type(self.kind).__name__}"
             )
-        if self._identity is not None and (
-            not isinstance(self._identity, str) or not self._identity
-        ):
-            raise ValueError("Kernel identity must be a nonempty string")
 
     @classmethod
     def _create_bound(
         cls,
         kind: KernelKind,
         identity: str,
+        operation_identity: Optional[str] = None,
         implicit_role: Optional[str] = None,
     ) -> "Kernel":
-        return cls(kind, identity, implicit_role)
+        kernel = cls(kind)
+        kernel._binding.bind(
+            _KernelIdentity(identity, operation_identity, implicit_role)
+        )
+        return kernel
 
-    def _bind(self, identity: str) -> "Kernel":
-        if self._identity is not None:
-            if self._identity != identity:
-                raise ValueError(
-                    f"Kernel is already bound as {self._identity!r}, not {identity!r}"
-                )
-            return self
-        if not isinstance(identity, str) or not identity:
-            raise ValueError("Kernel identity must be a nonempty string")
-        return self._create_bound(self.kind, identity)
+    def _bind(
+        self,
+        identity: str,
+        operation_identity: str,
+    ) -> "Kernel":
+        """Bind this declaration to one operation and return the same handle."""
+        self._binding.bind(
+            _KernelIdentity(
+                identity,
+                operation_identity,
+                implicit_role=None,
+            )
+        )
+        return self
+
+    @classmethod
+    def _from_metadata(
+        cls,
+        kind: KernelKind,
+        identity: str,
+        operation_identity: Optional[str],
+        implicit_role: Optional[str] = None,
+    ) -> "Kernel":
+        return cls._create_bound(
+            kind,
+            identity,
+            operation_identity=operation_identity,
+            implicit_role=implicit_role,
+        )
 
     @classmethod
     def _implicit(cls, kind: KernelKind, role: str) -> "Kernel":
         return cls._create_bound(kind, f"<{role}>", implicit_role=role)
 
     @property
+    def _identity(self) -> Optional[str]:
+        identity = self._binding.identity
+        return identity.name if identity is not None else None
+
+    @property
+    def _operation_identity(self) -> Optional[str]:
+        identity = self._binding.identity
+        return identity.operation if identity is not None else None
+
+    @property
+    def _implicit_role(self) -> Optional[str]:
+        identity = self._binding.identity
+        return identity.implicit_role if identity is not None else None
+
+    @property
     def identity(self) -> str:
-        if self._identity is None:
+        identity = self._binding.identity
+        if identity is None:
             raise ValueError(
                 "Kernel has no operation-local identity; declare it as a "
-                "top-level assignment in @ttl.operation"
+                "capture or top-level assignment in @ttl.operation"
             )
-        return self._identity
+        return identity.name
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Kernel):
             return NotImplemented
-        if self._identity is None or other._identity is None:
+        identity = self._binding.identity
+        other_identity = other._binding.identity
+        if identity is None or other_identity is None:
             raise ValueError(
                 "Kernel equality requires operation-local identities; declare "
-                "both kernels as top-level assignments in @ttl.operation"
+                "both kernels as captures or top-level assignments in "
+                "@ttl.operation"
             )
-        return (
-            self.kind,
-            self._identity,
-            self._implicit_role,
-        ) == (
-            other.kind,
-            other._identity,
-            other._implicit_role,
-        )
+        return (self.kind, identity) == (other.kind, other_identity)
 
     def __hash__(self) -> int:
-        if self._identity is None:
+        identity = self._binding.identity
+        if identity is None:
             raise ValueError(
                 "Kernel hashing requires an operation-local identity; declare "
-                "the kernel as a top-level assignment in @ttl.operation"
+                "the kernel as a capture or top-level assignment in "
+                "@ttl.operation"
             )
-        return hash((self.kind, self._identity, self._implicit_role))
+        return hash((self.kind, identity))
 
     def __repr__(self) -> str:
-        if self._identity is None:
+        if self._binding.identity is None:
             return f"Kernel({self.kind!r})"
-        return f"Kernel({self.kind!r}, identity={self._identity!r})"
+        return f"Kernel({self.kind!r}, identity={self.identity!r})"
 
 
 KernelSelector = Union[KernelKind, Kernel]

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -225,31 +225,77 @@ def _encode_identity_literal(value) -> Optional[bytes]:
     return None
 
 
-def _operation_identity(function: Callable) -> str:
-    """Return a deterministic semantic identity shared by both operation forms."""
+def _encode_identity_capture(
+    name: str, value: object, active_functions: set[int]
+) -> bytes:
+    encoded = _encode_identity_literal(value)
+    if encoded is not None:
+        return encoded
+    if isinstance(value, Kernel):
+        return f"kernel-kind:{value.kind.value}".encode("utf-8")
+
+    semantic_identity = getattr(value, "_operation_identity_capture", None)
+    if callable(semantic_identity):
+        encoded = _encode_identity_literal(semantic_identity())
+        if encoded is not None:
+            return b"semantic:" + encoded
+
+    if inspect.ismodule(value):
+        return f"module:{value.__name__}".encode("utf-8")
+    if inspect.isfunction(value):
+        identity = _operation_identity_impl(value, active_functions)
+        return f"function:{identity}".encode("utf-8")
+    if inspect.isbuiltin(value) or inspect.isclass(value):
+        module = getattr(value, "__module__", "")
+        qualname = getattr(value, "__qualname__", "")
+        if module and qualname:
+            return f"callable:{module}.{qualname}".encode("utf-8")
+
+    raise TypeError(
+        "operation identity cannot encode nonlocal capture "
+        f"{name!r} of type {type(value).__name__}"
+    )
+
+
+def _operation_identity_impl(function: Callable, active_functions: set[int]) -> str:
+    function_id = id(function)
+    if function_id in active_functions:
+        raise TypeError(
+            "operation identity cannot encode recursive nonlocal function "
+            f"{function.__qualname__!r}"
+        )
+    active_functions.add(function_id)
+
     base_identity = f"{function.__module__}.{function.__qualname__}"
     try:
         nonlocal_captures = inspect.getclosurevars(function).nonlocals
     except (TypeError, ValueError):
+        active_functions.remove(function_id)
         return base_identity
 
-    encoded_captures = []
-    for name, value in sorted(nonlocal_captures.items()):
-        encoded = _encode_identity_literal(value)
-        if encoded is None:
-            continue
-        encoded_name = name.encode("utf-8")
-        encoded_captures.append(
-            f"{len(encoded_name)}:".encode("ascii")
-            + encoded_name
-            + f"{len(encoded)}:".encode("ascii")
-            + encoded
-        )
+    try:
+        encoded_captures = []
+        for name, value in sorted(nonlocal_captures.items()):
+            encoded = _encode_identity_capture(name, value, active_functions)
+            encoded_name = name.encode("utf-8")
+            encoded_captures.append(
+                f"{len(encoded_name)}:".encode("ascii")
+                + encoded_name
+                + f"{len(encoded)}:".encode("ascii")
+                + encoded
+            )
+    finally:
+        active_functions.remove(function_id)
     if not encoded_captures:
         return base_identity
 
     digest = hashlib.sha256(b"".join(encoded_captures)).hexdigest()[:16]
     return f"{base_identity}[captures={digest}]"
+
+
+def _operation_identity(function: Callable) -> str:
+    """Return a deterministic semantic identity shared by both operation forms."""
+    return _operation_identity_impl(function, set())
 
 
 def _bind_kernel_declarations(

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -6,14 +6,17 @@
 
 from __future__ import annotations
 
+import hashlib
+import inspect
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Final, Mapping, Optional, Tuple, Union
+from typing import Callable, Final, Iterable, Mapping, Optional, Tuple, Union
 
 from .dialects._ttl_enum_gen import LogicalKernelKind as _TableGenLogicalKernelKind
 
 
 _PIPE_SOURCE_KERNEL_ROLE: Final[str] = "pipe_source"
+_DFB_RELEASE_METHODS: Final = frozenset(("push", "pop"))
 
 
 class KernelKind(Enum):
@@ -192,9 +195,56 @@ ExternalKernelSelection = Union[KernelSelector, Tuple[KernelSelector, ...]]
 ReleaseKernelSelection = KernelSelector
 
 
+def _encode_identity_literal(value) -> Optional[bytes]:
+    """Encode a supported compile-time literal without Python repr details."""
+    if value is None:
+        return b"none"
+    if isinstance(value, bool):
+        return b"bool:true" if value else b"bool:false"
+    if isinstance(value, int):
+        return f"int:{value}".encode("ascii")
+    if isinstance(value, float):
+        return f"float:{value.hex()}".encode("ascii")
+    if isinstance(value, str):
+        encoded = value.encode("utf-8")
+        return f"str:{len(encoded)}:".encode("ascii") + encoded
+    if isinstance(value, (tuple, list)):
+        elements = []
+        for element in value:
+            encoded = _encode_identity_literal(element)
+            if encoded is None:
+                return None
+            elements.append(f"{len(encoded)}:".encode("ascii") + encoded)
+        kind = b"tuple" if isinstance(value, tuple) else b"list"
+        return kind + b":" + b"".join(elements)
+    return None
+
+
 def _operation_identity(function: Callable) -> str:
-    """Return the source identity shared by both operation forms."""
-    return f"{function.__module__}.{function.__qualname__}"
+    """Return a deterministic semantic identity shared by both operation forms."""
+    base_identity = f"{function.__module__}.{function.__qualname__}"
+    try:
+        nonlocal_captures = inspect.getclosurevars(function).nonlocals
+    except (TypeError, ValueError):
+        return base_identity
+
+    encoded_captures = []
+    for name, value in sorted(nonlocal_captures.items()):
+        encoded = _encode_identity_literal(value)
+        if encoded is None:
+            continue
+        encoded_name = name.encode("utf-8")
+        encoded_captures.append(
+            f"{len(encoded_name)}:".encode("ascii")
+            + encoded_name
+            + f"{len(encoded)}:".encode("ascii")
+            + encoded
+        )
+    if not encoded_captures:
+        return base_identity
+
+    digest = hashlib.sha256(b"".join(encoded_captures)).hexdigest()[:16]
+    return f"{base_identity}[captures={digest}]"
 
 
 def _bind_kernel_declarations(
@@ -248,6 +298,20 @@ def _format_selector(selector: KernelSelector) -> str:
     if isinstance(selector, KernelKind):
         return selector.value
     return f"{selector.kind.value} kernel {selector.identity!r}"
+
+
+def _format_kernel_capacity_error(
+    kind: KernelKind,
+    selected: Iterable[KernelSelector],
+    capacity: int,
+) -> str:
+    selected = tuple(selected)
+    selected_text = ", ".join(_format_selector(selector) for selector in selected)
+    required = len(selected)
+    return (
+        f"operation requires {required} {kind.value} kernels, but the target "
+        f"supports {capacity}; selected kernels: {selected_text}"
+    )
 
 
 __all__ = [

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Final, Optional, Tuple, Union
+from typing import Callable, Final, Mapping, Optional, Tuple, Union
 
 from .dialects._ttl_enum_gen import LogicalKernelKind as _TableGenLogicalKernelKind
 
@@ -104,8 +104,8 @@ class Kernel:
         self,
         identity: str,
         operation_identity: str,
-    ) -> "Kernel":
-        """Bind this declaration to one operation and return the same handle."""
+    ) -> None:
+        """Bind this declaration to one operation."""
         self._binding.bind(
             _KernelIdentity(
                 identity,
@@ -113,7 +113,6 @@ class Kernel:
                 implicit_role=None,
             )
         )
-        return self
 
     @classmethod
     def _from_metadata(
@@ -191,6 +190,35 @@ class Kernel:
 KernelSelector = Union[KernelKind, Kernel]
 ExternalKernelSelection = Union[KernelSelector, Tuple[KernelSelector, ...]]
 ReleaseKernelSelection = KernelSelector
+
+
+def _operation_identity(function: Callable) -> str:
+    """Return the source identity shared by both operation forms."""
+    return f"{function.__module__}.{function.__qualname__}"
+
+
+def _bind_kernel_declarations(
+    logical_kernels: Mapping[str, Kernel], operation_identity: str
+) -> None:
+    """Bind uniquely named declarations during operation registration."""
+    source_names = {}
+    for name, kernel in logical_kernels.items():
+        previous_name = source_names.get(id(kernel))
+        if previous_name is not None:
+            raise ValueError(
+                "one logical Kernel handle reached the final operation under "
+                f"multiple names: {previous_name!r} and {name!r}"
+            )
+        source_names[id(kernel)] = name
+        if kernel._identity is not None:
+            raise ValueError(
+                f"logical Kernel {name!r} is already bound as "
+                f"{kernel.identity!r} to operation "
+                f"{kernel._operation_identity!r}"
+            )
+
+    for name, kernel in logical_kernels.items():
+        kernel._bind(name, operation_identity)
 
 
 def _selector_kind(selector: KernelSelector) -> KernelKind:

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Target-independent logical kernel selectors for unified operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Tuple, Union
+
+
+class KernelKind(Enum):
+    """A portable class of kernels supported by a target backend."""
+
+    COMPUTE = "compute"
+    DATA_MOVEMENT = "data_movement"
+
+
+@dataclass(frozen=True, eq=False)
+class Kernel:
+    """An operation-local logical kernel with a stable source identity.
+
+    Kernel declarations are top-level resources in a unified operation. The
+    operation setup binds the declaration's assignment name as its identity.
+    """
+
+    kind: KernelKind
+    _identity: Optional[str] = field(default=None, repr=False)
+    _implicit_role: Optional[str] = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, KernelKind):
+            raise TypeError(
+                "Kernel kind must be a KernelKind, got " f"{type(self.kind).__name__}"
+            )
+        if self._identity is not None and (
+            not isinstance(self._identity, str) or not self._identity
+        ):
+            raise ValueError("Kernel identity must be a nonempty string")
+
+    @classmethod
+    def _create_bound(
+        cls,
+        kind: KernelKind,
+        identity: str,
+        implicit_role: Optional[str] = None,
+    ) -> "Kernel":
+        return cls(kind, identity, implicit_role)
+
+    def _bind(self, identity: str) -> "Kernel":
+        if self._identity is not None:
+            if self._identity != identity:
+                raise ValueError(
+                    f"Kernel is already bound as {self._identity!r}, not {identity!r}"
+                )
+            return self
+        if not isinstance(identity, str) or not identity:
+            raise ValueError("Kernel identity must be a nonempty string")
+        return self._create_bound(self.kind, identity)
+
+    @classmethod
+    def _implicit(cls, kind: KernelKind, role: str) -> "Kernel":
+        return cls._create_bound(kind, f"<{role}>", implicit_role=role)
+
+    @property
+    def identity(self) -> str:
+        if self._identity is None:
+            raise ValueError(
+                "Kernel has no operation-local identity; declare it as a "
+                "top-level assignment in @ttl.operation"
+            )
+        return self._identity
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Kernel):
+            return NotImplemented
+        if self._identity is None or other._identity is None:
+            raise ValueError(
+                "Kernel equality requires operation-local identities; declare "
+                "both kernels as top-level assignments in @ttl.operation"
+            )
+        return (
+            self.kind,
+            self._identity,
+            self._implicit_role,
+        ) == (
+            other.kind,
+            other._identity,
+            other._implicit_role,
+        )
+
+    def __hash__(self) -> int:
+        if self._identity is None:
+            raise ValueError(
+                "Kernel hashing requires an operation-local identity; declare "
+                "the kernel as a top-level assignment in @ttl.operation"
+            )
+        return hash((self.kind, self._identity, self._implicit_role))
+
+    def __repr__(self) -> str:
+        if self._identity is None:
+            return f"Kernel({self.kind!r})"
+        return f"Kernel({self.kind!r}, identity={self._identity!r})"
+
+
+KernelSelector = Union[KernelKind, Kernel]
+ExternalKernelSelection = Union[KernelSelector, Tuple[KernelSelector, ...]]
+ReleaseKernelSelection = KernelSelector
+
+
+def _selector_kind(selector: KernelSelector) -> KernelKind:
+    if isinstance(selector, KernelKind):
+        return selector
+    return selector.kind
+
+
+def _selector_sort_key(selector: KernelSelector):
+    kind_order = {
+        KernelKind.COMPUTE: 0,
+        KernelKind.DATA_MOVEMENT: 1,
+    }
+    if isinstance(selector, KernelKind):
+        return kind_order[selector], 0, ""
+    role_order = 1 if selector._implicit_role is not None else 2
+    return kind_order[selector.kind], role_order, selector.identity
+
+
+def _selector_implicit_role(selector: KernelSelector) -> Optional[str]:
+    if isinstance(selector, KernelKind):
+        return None
+    return selector._implicit_role
+
+
+def _format_selector(selector: KernelSelector) -> str:
+    if isinstance(selector, KernelKind):
+        return selector.value
+    return f"{selector.kind.value} kernel {selector.identity!r}"
+
+
+__all__ = [
+    "Kernel",
+    "KernelKind",
+    "KernelSelector",
+    "ExternalKernelSelection",
+    "ReleaseKernelSelection",
+]

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -283,9 +283,15 @@ def _selector_sort_key(selector: KernelSelector):
         KernelKind.DATA_MOVEMENT: 1,
     }
     if isinstance(selector, KernelKind):
-        return kind_order[selector], 0, ""
+        return kind_order[selector], 0, "", "", ""
     role_order = 1 if selector._implicit_role is not None else 2
-    return kind_order[selector.kind], role_order, selector.identity
+    return (
+        kind_order[selector.kind],
+        role_order,
+        selector.identity,
+        selector._operation_identity or "",
+        selector._implicit_role or "",
+    )
 
 
 def _selector_implicit_role(selector: KernelSelector) -> Optional[str]:

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -25,7 +25,7 @@ class KernelKind(Enum):
     COMPUTE = str(_TableGenLogicalKernelKind.Compute)
     DATA_MOVEMENT = str(_TableGenLogicalKernelKind.DataMovement)
 
-    def __or__(self, other: object) -> Tuple["KernelKind", "KernelKind"]:
+    def __or__(self, other: object) -> tuple[KernelKind, KernelKind]:
         if not isinstance(other, KernelKind):
             return NotImplemented
         return (self, other)

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -42,6 +42,7 @@ from .dataflow_buffer import (
 )
 from .constants import DEFAULT_L1_CB_BUDGET_BYTES
 from .dtype_utils import format_name_to_ttnn_dtype
+from .kernel import KernelSelector
 
 
 @dataclass(frozen=True)
@@ -158,6 +159,7 @@ class KernelSpec:
         core_ranges: Optional per-kernel ttnn.CoreRangeSet. When set, this
             specialized kernel binary is dispatched only to these cores. When None,
             the whole-grid core_ranges passed to build_kernel_descriptors is used.
+        logical_kernel: Target-independent selector retained across kernel cloning.
     """
 
     path: str
@@ -167,6 +169,7 @@ class KernelSpec:
     compiler_include_paths: List[str] = field(default_factory=list)
     pipe_computed_address_dfb_indices: List[int] = field(default_factory=list)
     core_ranges: Optional[Any] = None
+    logical_kernel: Optional[KernelSelector] = None
 
 
 @dataclass

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -40,9 +40,11 @@ def call_extern_func(
 ) -> None:
     """Call external C++ in selected logical kernels.
 
-    ``kernel`` accepts one ``KernelKind`` or operation-local ``Kernel``. A
-    nonempty tuple emits the call once in each selected logical kernel. The
-    unified-operation splitter removes the selector before AST lowering.
+    ``kernel`` accepts one ``KernelKind`` or operation-local ``Kernel``.
+    ``KernelKind`` values may be combined with ``|``. A nonempty tuple also
+    supports multiple selectors, including operation-local kernels. The call is
+    emitted once in each selected logical kernel. The unified-operation splitter
+    removes the selector before AST lowering.
     """
     raise RuntimeError("ttl.call_extern_func() is valid only in a compiled kernel")
 

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Tuple, Union
 
-from ttl.dialects import arith
+from ttl.dialects import arith, ttl
 from ttl.ir import (
     Context,
     F32Type,
@@ -25,7 +25,7 @@ from ._generated_elementwise import *  # noqa: F401,F403
 from ._generated_elementwise import __all__ as _generated_all
 from ._src.ttl_ast import syntax
 from .constants import DEFAULT_TILE_SIZE
-from ttl.dialects import ttl
+from .kernel import ExternalKernelSelection, ReleaseKernelSelection
 from .pipe import Pipe
 
 
@@ -36,8 +36,14 @@ def call_extern_func(
     template_args=None,
     func_args=None,
     include_paths=None,
+    kernel: Optional[ExternalKernelSelection] = None,
 ) -> None:
-    """Call an external C++ function from a compiled kernel."""
+    """Call external C++ in selected logical kernels.
+
+    ``kernel`` accepts one ``KernelKind`` or operation-local ``Kernel``. A
+    nonempty tuple emits the call once in each selected logical kernel. The
+    unified-operation splitter removes the selector before AST lowering.
+    """
     raise RuntimeError("ttl.call_extern_func() is valid only in a compiled kernel")
 
 
@@ -287,17 +293,22 @@ class TensorBlock:
         ttl.store(rhs, reserve, accumulate=True)
         return ast_self
 
-    def push(ast_self: TensorBlock) -> None:
+    def push(
+        ast_self: TensorBlock,
+        *,
+        kernel: Optional[ReleaseKernelSelection] = None,
+    ) -> None:
         """
-        Signal that data is ready in the circular buffer (producer release).
+        Signal that data is ready in the dataflow buffer (producer release).
 
         Finalizes a reserve() operation by signaling that the block has been
         written and is ready for consumers. This operation is non-blocking.
 
-        Must be called on a block acquired via reserve().
+        Must be called on a block acquired via reserve(). ``kernel`` assigns
+        an otherwise uninferable release to one logical kernel.
 
         Example:
-            block = cb.reserve()
+            block = dfb.reserve()
             ttl.copy(data, block).wait()
             block.push()  # Signal data ready
         """
@@ -308,17 +319,22 @@ class TensorBlock:
         cb = _get_cb_from_block(ast_self)
         ttl.cb_push(cb)
 
-    def pop(ast_self: TensorBlock) -> None:
+    def pop(
+        ast_self: TensorBlock,
+        *,
+        kernel: Optional[ReleaseKernelSelection] = None,
+    ) -> None:
         """
         Signal that data has been consumed (consumer release).
 
         Finalizes a wait() operation by signaling that the block has been
         consumed and space is available for producers. This operation is non-blocking.
 
-        Must be called on a block acquired via wait().
+        Must be called on a block acquired via wait(). ``kernel`` assigns an
+        otherwise uninferable release to one logical kernel.
 
         Example:
-            block = cb.wait()
+            block = dfb.wait()
             result = compute(block)
             block.pop()  # Signal consumption complete
         """

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -305,7 +305,8 @@ class TensorBlock:
         written and is ready for consumers. This operation is non-blocking.
 
         Must be called on a block acquired via reserve(). ``kernel`` assigns
-        an otherwise uninferable release to one logical kernel.
+        an otherwise uninferable release to one logical kernel. An explicit
+        thread ignores it because its decorator already determines ownership.
 
         Example:
             block = dfb.reserve()
@@ -331,7 +332,8 @@ class TensorBlock:
         consumed and space is available for producers. This operation is non-blocking.
 
         Must be called on a block acquired via wait(). ``kernel`` assigns an
-        otherwise uninferable release to one logical kernel.
+        otherwise uninferable release to one logical kernel. An explicit thread
+        ignores it because its decorator already determines ownership.
 
         Example:
             block = dfb.wait()

--- a/python/ttl/pipe.py
+++ b/python/ttl/pipe.py
@@ -252,6 +252,20 @@ class PipeNet:
         except (IndexError, AttributeError):
             pass
 
+    def _operation_identity_capture(self) -> tuple:
+        return (
+            "pipenet",
+            tuple(
+                (
+                    tuple(pipe.src),
+                    tuple(pipe.dst_start),
+                    tuple(pipe.dst_end),
+                    pipe.is_collective,
+                )
+                for pipe in self.pipes
+            ),
+        )
+
     def if_src(self, callback: Callable[["SrcPipeIdentity"], None]) -> None:
         """
         Execute callback for each pipe where current core is source.

--- a/python/ttl/pipe.py
+++ b/python/ttl/pipe.py
@@ -172,6 +172,15 @@ class Pipe:
         )
         return self.is_collective
 
+    def _operation_identity_capture(self) -> tuple:
+        return (
+            "pipe",
+            tuple(self.src),
+            tuple(self.dst_start),
+            tuple(self.dst_end),
+            self.is_collective,
+        )
+
 
 def _pipe_to_pipe_use(pipe: Pipe):
     """Convert a ttl.Pipe to a PipeUse for OperationPipeNets validation/build."""
@@ -255,15 +264,7 @@ class PipeNet:
     def _operation_identity_capture(self) -> tuple:
         return (
             "pipenet",
-            tuple(
-                (
-                    tuple(pipe.src),
-                    tuple(pipe.dst_start),
-                    tuple(pipe.dst_end),
-                    pipe.is_collective,
-                )
-                for pipe in self.pipes
-            ),
+            tuple(pipe._operation_identity_capture() for pipe in self.pipes),
         )
 
     def if_src(self, callback: Callable[["SrcPipeIdentity"], None]) -> None:

--- a/python/ttl/ttl.py
+++ b/python/ttl/ttl.py
@@ -23,6 +23,7 @@ Math operations:
 
 from .ttl_api import compute, datamovement, Program
 from .atom import operation, DFB
+from .kernel import Kernel, KernelKind
 from .dataflow_buffer import (
     make_dataflow_buffer_like,
     make_dfb,
@@ -45,6 +46,8 @@ from . import ttl_math as math
 __all__ = [
     "operation",
     "DFB",
+    "Kernel",
+    "KernelKind",
     "compute",
     "datamovement",
     "Program",

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -12,8 +12,9 @@ import inspect
 import os
 import random
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Mapping, Optional, Union
 
 ttnn = None  # Lazy-loaded on first access via _ensure_ttnn()
 
@@ -107,7 +108,9 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _PIPE_SOURCE_KERNEL_ROLE,
     _bind_kernel_declarations,
+    _format_kernel_capacity_error,
     _operation_identity,
     _selector_implicit_role,
     _selector_kind,
@@ -120,6 +123,50 @@ _TTCORE_ARCH_BY_DEVICE_NAME = {
     "blackhole": ttcore.Arch.Blackhole,
     "wormhole_b0": ttcore.Arch.WormholeB0,
 }
+
+
+@dataclass(frozen=True)
+class _BackendKernelSlot:
+    kind: KernelKind
+    kernel_type: str
+    source_name: str
+    implicit_role: Optional[str] = None
+
+
+_COMMON_BACKEND_KERNEL_SLOTS = (
+    _BackendKernelSlot(KernelKind.COMPUTE, "compute", "trisc"),
+    _BackendKernelSlot(KernelKind.DATA_MOVEMENT, "datamovement", "ncrisc"),
+    _BackendKernelSlot(
+        KernelKind.DATA_MOVEMENT,
+        "datamovement",
+        "brisc",
+        implicit_role=_PIPE_SOURCE_KERNEL_ROLE,
+    ),
+)
+_BACKEND_KERNEL_SLOTS_BY_ARCH = {
+    target_arch: _COMMON_BACKEND_KERNEL_SLOTS
+    for target_arch in _TTCORE_ARCH_BY_DEVICE_NAME
+}
+
+
+def _backend_kernel_slots(
+    target_arch: Optional[str] = None,
+) -> tuple[_BackendKernelSlot, ...]:
+    """Return the processor slots declared by the selected backend target."""
+    if target_arch is None:
+        return _COMMON_BACKEND_KERNEL_SLOTS
+    try:
+        return _BACKEND_KERNEL_SLOTS_BY_ARCH[target_arch]
+    except KeyError:
+        raise ValueError(f"unsupported target architecture {target_arch!r}") from None
+
+
+def _backend_kernel_capacities(
+    target_arch: Optional[str] = None,
+) -> Mapping[KernelKind, int]:
+    slots = _backend_kernel_slots(target_arch)
+    return {kind: sum(slot.kind == kind for slot in slots) for kind in KernelKind}
+
 
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
@@ -142,7 +189,10 @@ def _get_registered_threads() -> List[Callable]:
     return threads
 
 
-def _validate_explicit_logical_kernel_uses(threads: List[Callable]) -> None:
+def _validate_explicit_logical_kernel_uses(
+    threads: List[Callable],
+    kernel_capacities: Optional[Mapping[KernelKind, int]] = None,
+) -> None:
     """Require each named logical kernel to identify one explicit thread."""
     thread_by_kernel: Dict[Kernel, Callable] = {}
     for thread in threads:
@@ -157,6 +207,17 @@ def _validate_explicit_logical_kernel_uses(threads: List[Callable]) -> None:
                 f"{previous_thread.__name__!r} and {thread.__name__!r}"
             )
         thread_by_kernel[logical_kernel] = thread
+
+    if kernel_capacities is None:
+        return
+    selectors = tuple(thread._logical_kernel for thread in threads)
+    for kind in KernelKind:
+        capacity = kernel_capacities[kind]
+        selected = tuple(
+            selector for selector in selectors if _selector_kind(selector) == kind
+        )
+        if len(selected) > capacity:
+            raise ValueError(_format_kernel_capacity_error(kind, selected, capacity))
 
 
 def _captured_kernel_declarations(function: Callable) -> Dict[str, Kernel]:
@@ -995,6 +1056,7 @@ def _compile_ttnn_kernel(
     pipe_sram_scratch_bytes: int = 0,
     num_pipe_global_semaphores: int = 0,
     opaque_include_paths: Optional[List[str]] = None,
+    target_arch: Optional[str] = None,
 ):
     """
     Compile kernel to CompiledTTNNKernel for execution via ttnn.generic_op.
@@ -1053,18 +1115,39 @@ def _compile_ttnn_kernel(
 
     compute_count = sum(1 for _, t in kernel_info if t == "compute")
     dm_count = sum(1 for _, t in kernel_info if t == "noc")
+    kernel_capacities = _backend_kernel_capacities(target_arch)
+    kernel_counts = {
+        KernelKind.COMPUTE: compute_count,
+        KernelKind.DATA_MOVEMENT: dm_count,
+    }
     if not specialize_cores:
-        # Validate kernel count: for now we must have exactly 3 kernels (1 compute + 2 data movement).
-        # Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts.
-        # TODO: in the future we should figure out how to map arbitrary kernels.
-        if len(kernel_info) != 3:
+        for kind in KernelKind:
+            if kernel_counts[kind] > kernel_capacities[kind]:
+                selected = tuple(
+                    selector
+                    for selector in kernel_logical_selectors
+                    if selector is not None and _selector_kind(selector) == kind
+                )
+                if len(selected) != kernel_counts[kind]:
+                    selected = (kind,) * kernel_counts[kind]
+                raise ValueError(
+                    _format_kernel_capacity_error(
+                        kind, selected, kernel_capacities[kind]
+                    )
+                )
+        if kernel_counts != kernel_capacities:
+            required = ", ".join(
+                f"{kernel_capacities[kind]} {kind.value}" for kind in KernelKind
+            )
+            provided = ", ".join(
+                f"{kernel_counts[kind]} {kind.value}" for kind in KernelKind
+            )
             raise ValueError(
-                f"TTNN interop requires exactly 3 kernels (1 compute + 2 data movement), "
-                f"got {len(kernel_info)} kernels ({compute_count} compute, {dm_count} data movement). "
-                f"Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts."
+                f"TTNN interop requires the target kernel set ({required}); "
+                f"the operation provides {provided}"
             )
     else:
-        # Check no core has more than one compute or two NOC kernels.
+        # Validate every specialized core against the selected target.
         grid_cols, grid_rows = grid
         all_cores = [(x, y) for y in range(grid_rows) for x in range(grid_cols)]
         per_core_counts = {}
@@ -1077,11 +1160,17 @@ def _compile_ttnn_kernel(
                 elif thread_type == "noc":
                     counts[1] += 1
         for coord, (n_compute, n_noc) in per_core_counts.items():
-            if n_compute > 1 or n_noc > 2:
+            if (
+                n_compute > kernel_capacities[KernelKind.COMPUTE]
+                or n_noc > kernel_capacities[KernelKind.DATA_MOVEMENT]
+            ):
                 raise ValueError(
                     f"Per-core specialization assigned {n_compute} compute and "
-                    f"{n_noc} data movement kernels to core {coord}. Each core "
-                    f"supports at most one compute and two NOC kernels."
+                    f"{n_noc} data movement kernels to core {coord}. The target "
+                    f"supports at most "
+                    f"{kernel_capacities[KernelKind.COMPUTE]} compute and "
+                    f"{kernel_capacities[KernelKind.DATA_MOVEMENT]} data movement "
+                    "kernels per core."
                 )
 
     if verbose:
@@ -1940,7 +2029,9 @@ def _compile_kernel(
             "@ttl.datamovement() function inside your kernel."
         )
 
-    _validate_explicit_logical_kernel_uses(threads)
+    _validate_explicit_logical_kernel_uses(
+        threads, _backend_kernel_capacities(target_arch)
+    )
 
     pipenets = _build_operation_pipenets(f, threads)
 
@@ -2362,6 +2453,7 @@ def _lower_program_to_kernel(
             pipe_sram_scratch_bytes=pipe_sram_scratch_bytes,
             num_pipe_global_semaphores=pipe_global_semaphore_count,
             opaque_include_paths=opaque_include_paths,
+            target_arch=target_arch,
         )
         return compiled_kernel
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -122,8 +122,6 @@ _TTCORE_ARCH_BY_DEVICE_NAME = {
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
 
-_LOGICAL_KERNEL_ATTR = "ttl.logical_kernel"
-
 
 def _register_thread(thread_fn: Callable) -> None:
     """Register a thread function during decoration."""
@@ -902,12 +900,14 @@ def _get_kernel_core_coords(module, kernel_name: str):
 def _get_kernel_logical_selector(module, kernel_name: str) -> Optional[KernelSelector]:
     """Recover logical-kernel metadata retained by specialization clones."""
     operation = _lookup_kernel_func_op(module, kernel_name)
-    raw_attribute = operation.attributes.get(_LOGICAL_KERNEL_ATTR, None)
+    raw_attribute = operation.attributes.get(_ttl_ir.LOGICAL_KERNEL_ATTR, None)
     if raw_attribute is None:
         return None
     attribute = ttl_dialect.LogicalKernelAttr.maybe_downcast(raw_attribute)
     if attribute is None:
-        raise ValueError(f"Invalid '{_LOGICAL_KERNEL_ATTR}' on kernel {kernel_name!r}")
+        raise ValueError(
+            f"Invalid '{_ttl_ir.LOGICAL_KERNEL_ATTR}' on kernel {kernel_name!r}"
+        )
 
     if attribute.kind == ttl_dialect.ir.LogicalKernelKind.Compute:
         kind = KernelKind.COMPUTE
@@ -2020,7 +2020,7 @@ def _lower_program_to_kernel(
                     identity = logical_kernel.identity
                     operation_identity = logical_kernel._operation_identity
                     implicit_role = _selector_implicit_role(logical_kernel)
-                ct.func_entry.attributes[_LOGICAL_KERNEL_ATTR] = (
+                ct.func_entry.attributes[_ttl_ir.LOGICAL_KERNEL_ATTR] = (
                     ttl_dialect.LogicalKernelAttr.get(
                         ctx,
                         ir_kind,

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -12,8 +12,9 @@ import inspect
 import os
 import random
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Mapping, Optional, Union
 
 ttnn = None  # Lazy-loaded on first access via _ensure_ttnn()
 
@@ -107,7 +108,9 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _PIPE_SOURCE_KERNEL_ROLE,
     _bind_kernel_declarations,
+    _format_kernel_capacity_error,
     _operation_identity,
     _selector_implicit_role,
     _selector_kind,
@@ -120,6 +123,50 @@ _TTCORE_ARCH_BY_DEVICE_NAME = {
     "blackhole": ttcore.Arch.Blackhole,
     "wormhole_b0": ttcore.Arch.WormholeB0,
 }
+
+
+@dataclass(frozen=True)
+class _BackendKernelSlot:
+    kind: KernelKind
+    kernel_type: str
+    source_name: str
+    implicit_role: Optional[str] = None
+
+
+_COMMON_BACKEND_KERNEL_SLOTS = (
+    _BackendKernelSlot(KernelKind.COMPUTE, "compute", "trisc"),
+    _BackendKernelSlot(KernelKind.DATA_MOVEMENT, "datamovement", "ncrisc"),
+    _BackendKernelSlot(
+        KernelKind.DATA_MOVEMENT,
+        "datamovement",
+        "brisc",
+        implicit_role=_PIPE_SOURCE_KERNEL_ROLE,
+    ),
+)
+_BACKEND_KERNEL_SLOTS_BY_ARCH = {
+    target_arch: _COMMON_BACKEND_KERNEL_SLOTS
+    for target_arch in _TTCORE_ARCH_BY_DEVICE_NAME
+}
+
+
+def _backend_kernel_slots(
+    target_arch: Optional[str] = None,
+) -> tuple[_BackendKernelSlot, ...]:
+    """Return the processor slots declared by the selected backend target."""
+    if target_arch is None:
+        return _COMMON_BACKEND_KERNEL_SLOTS
+    try:
+        return _BACKEND_KERNEL_SLOTS_BY_ARCH[target_arch]
+    except KeyError:
+        raise ValueError(f"unsupported target architecture {target_arch!r}") from None
+
+
+def _backend_kernel_capacities(
+    target_arch: Optional[str] = None,
+) -> Mapping[KernelKind, int]:
+    slots = _backend_kernel_slots(target_arch)
+    return {kind: sum(slot.kind == kind for slot in slots) for kind in KernelKind}
+
 
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
@@ -142,7 +189,10 @@ def _get_registered_threads() -> List[Callable]:
     return threads
 
 
-def _validate_explicit_logical_kernel_uses(threads: List[Callable]) -> None:
+def _validate_explicit_logical_kernel_uses(
+    threads: List[Callable],
+    kernel_capacities: Optional[Mapping[KernelKind, int]] = None,
+) -> None:
     """Require each named logical kernel to identify one explicit thread."""
     thread_by_kernel: Dict[Kernel, Callable] = {}
     for thread in threads:
@@ -157,6 +207,17 @@ def _validate_explicit_logical_kernel_uses(threads: List[Callable]) -> None:
                 f"{previous_thread.__name__!r} and {thread.__name__!r}"
             )
         thread_by_kernel[logical_kernel] = thread
+
+    if kernel_capacities is None:
+        return
+    selectors = tuple(thread._logical_kernel for thread in threads)
+    for kind in KernelKind:
+        capacity = kernel_capacities[kind]
+        selected = tuple(
+            selector for selector in selectors if _selector_kind(selector) == kind
+        )
+        if len(selected) > capacity:
+            raise ValueError(_format_kernel_capacity_error(kind, selected, capacity))
 
 
 def _captured_kernel_declarations(function: Callable) -> Dict[str, Kernel]:
@@ -1009,6 +1070,7 @@ def _compile_ttnn_kernel(
     pipe_sram_scratch_bytes: int = 0,
     num_pipe_global_semaphores: int = 0,
     opaque_include_paths: Optional[List[str]] = None,
+    target_arch: Optional[str] = None,
 ):
     """
     Compile kernel to CompiledTTNNKernel for execution via ttnn.generic_op.
@@ -1067,18 +1129,39 @@ def _compile_ttnn_kernel(
 
     compute_count = sum(1 for _, t in kernel_info if t == "compute")
     dm_count = sum(1 for _, t in kernel_info if t == "noc")
+    kernel_capacities = _backend_kernel_capacities(target_arch)
+    kernel_counts = {
+        KernelKind.COMPUTE: compute_count,
+        KernelKind.DATA_MOVEMENT: dm_count,
+    }
     if not specialize_cores:
-        # Validate kernel count: for now we must have exactly 3 kernels (1 compute + 2 data movement).
-        # Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts.
-        # TODO: in the future we should figure out how to map arbitrary kernels.
-        if len(kernel_info) != 3:
+        for kind in KernelKind:
+            if kernel_counts[kind] > kernel_capacities[kind]:
+                selected = tuple(
+                    selector
+                    for selector in kernel_logical_selectors
+                    if selector is not None and _selector_kind(selector) == kind
+                )
+                if len(selected) != kernel_counts[kind]:
+                    selected = (kind,) * kernel_counts[kind]
+                raise ValueError(
+                    _format_kernel_capacity_error(
+                        kind, selected, kernel_capacities[kind]
+                    )
+                )
+        if kernel_counts != kernel_capacities:
+            required = ", ".join(
+                f"{kernel_capacities[kind]} {kind.value}" for kind in KernelKind
+            )
+            provided = ", ".join(
+                f"{kernel_counts[kind]} {kind.value}" for kind in KernelKind
+            )
             raise ValueError(
-                f"TTNN interop requires exactly 3 kernels (1 compute + 2 data movement), "
-                f"got {len(kernel_info)} kernels ({compute_count} compute, {dm_count} data movement). "
-                f"Each core has only 2 NOCs, so more than 2 DM kernels causes NOC conflicts."
+                f"TTNN interop requires the target kernel set ({required}); "
+                f"the operation provides {provided}"
             )
     else:
-        # Check no core has more than one compute or two NOC kernels.
+        # Validate every specialized core against the selected target.
         grid_cols, grid_rows = grid
         all_cores = [(x, y) for y in range(grid_rows) for x in range(grid_cols)]
         per_core_counts = {}
@@ -1091,11 +1174,17 @@ def _compile_ttnn_kernel(
                 elif thread_type == "noc":
                     counts[1] += 1
         for coord, (n_compute, n_noc) in per_core_counts.items():
-            if n_compute > 1 or n_noc > 2:
+            if (
+                n_compute > kernel_capacities[KernelKind.COMPUTE]
+                or n_noc > kernel_capacities[KernelKind.DATA_MOVEMENT]
+            ):
                 raise ValueError(
                     f"Per-core specialization assigned {n_compute} compute and "
-                    f"{n_noc} data movement kernels to core {coord}. Each core "
-                    f"supports at most one compute and two NOC kernels."
+                    f"{n_noc} data movement kernels to core {coord}. The target "
+                    f"supports at most "
+                    f"{kernel_capacities[KernelKind.COMPUTE]} compute and "
+                    f"{kernel_capacities[KernelKind.DATA_MOVEMENT]} data movement "
+                    "kernels per core."
                 )
 
     if verbose:
@@ -1948,7 +2037,9 @@ def _compile_kernel(
             "@ttl.datamovement() function inside your kernel."
         )
 
-    _validate_explicit_logical_kernel_uses(threads)
+    _validate_explicit_logical_kernel_uses(
+        threads, _backend_kernel_capacities(target_arch)
+    )
 
     pipenets = _build_operation_pipenets(f, threads)
 
@@ -2380,6 +2471,7 @@ def _lower_program_to_kernel(
             pipe_sram_scratch_bytes=pipe_sram_scratch_bytes,
             num_pipe_global_semaphores=pipe_global_semaphore_count,
             opaque_include_paths=opaque_include_paths,
+            target_arch=target_arch,
         )
         return compiled_kernel
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -168,6 +168,18 @@ def _backend_kernel_capacities(
     return {kind: sum(slot.kind == kind for slot in slots) for kind in KernelKind}
 
 
+def _slot_idle_kernel(slot: _BackendKernelSlot) -> KernelSelector:
+    """Return the logical identity a slot carries when it holds no work.
+
+    A slot the target reserves for a compiler-owned affinity keeps that role. Any
+    other slot is the canonical kernel of its kind, which is unoccupied precisely
+    when no selector of that kind was planned.
+    """
+    if slot.implicit_role is None:
+        return slot.kind
+    return Kernel._implicit(slot.kind, slot.implicit_role)
+
+
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -103,6 +103,13 @@ from .kernel_runner import (
     run_kernel_on_device,
     emit_runner_file,
 )
+from .kernel import (
+    Kernel,
+    KernelKind,
+    KernelSelector,
+    _selector_implicit_role,
+    _selector_kind,
+)
 from .operators import CopyTransferHandler, TensorBlock, copy
 from .compiler_options import CompilerOptions
 from .ttl_utils import get_thread_type_string
@@ -114,6 +121,8 @@ _TTCORE_ARCH_BY_DEVICE_NAME = {
 
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
+
+_LOGICAL_KERNEL_ATTR = "ttl.logical_kernel"
 
 
 def _register_thread(thread_fn: Callable) -> None:
@@ -607,6 +616,7 @@ class CompiledTTNNKernel:
         num_pipe_global_semaphores=0,
         opaque_include_paths=None,
         kernel_pipe_computed_address_dfb_indices=None,
+        kernel_logical_selectors=None,
     ):
         """
         Initialize with pre-compiled kernel artifacts.
@@ -636,6 +646,7 @@ class CompiledTTNNKernel:
                 PipeNet counters used by this kernel.
             kernel_pipe_computed_address_dfb_indices: Per-kernel receiver DFB indices whose
                 L1 bases are supplied as common runtime args.
+            kernel_logical_selectors: Logical selector for each compiled kernel.
         """
         self.kernel_paths = kernel_paths
         self.kernel_configs = kernel_configs
@@ -656,6 +667,9 @@ class CompiledTTNNKernel:
         self.kernel_pipe_computed_address_dfb_indices = (
             kernel_pipe_computed_address_dfb_indices or [[] for _ in kernel_paths]
         )
+        self.kernel_logical_selectors = kernel_logical_selectors or [
+            None for _ in kernel_paths
+        ]
         self._pipe_global_semaphore_lifetime = []
         self.opaque_include_paths = opaque_include_paths or []
 
@@ -690,6 +704,7 @@ class CompiledTTNNKernel:
                     kernel_idx
                 ],
                 core_ranges=self.kernel_core_ranges[kernel_idx],
+                logical_kernel=self.kernel_logical_selectors[kernel_idx],
             )
             kernel_specs.append(spec)
 
@@ -870,6 +885,33 @@ def _get_kernel_core_coords(module, kernel_name: str):
     return coords
 
 
+def _get_kernel_logical_selector(module, kernel_name: str) -> Optional[KernelSelector]:
+    """Recover logical-kernel metadata retained by specialization clones."""
+    operation = _lookup_kernel_func_op(module, kernel_name)
+    raw_attribute = operation.attributes.get(_LOGICAL_KERNEL_ATTR, None)
+    if raw_attribute is None:
+        return None
+    attribute = ttl_dialect.LogicalKernelAttr.maybe_downcast(raw_attribute)
+    if attribute is None:
+        raise ValueError(f"Invalid '{_LOGICAL_KERNEL_ATTR}' on kernel {kernel_name!r}")
+
+    if attribute.kind == ttl_dialect.ir.LogicalKernelKind.Compute:
+        kind = KernelKind.COMPUTE
+    elif attribute.kind == ttl_dialect.ir.LogicalKernelKind.DataMovement:
+        kind = KernelKind.DATA_MOVEMENT
+    else:
+        raise ValueError(f"Unknown logical kernel kind on kernel {kernel_name!r}")
+
+    if not attribute.identity:
+        return kind
+    return Kernel._from_metadata(
+        kind,
+        attribute.identity,
+        operation_identity=attribute.operation,
+        implicit_role=attribute.role,
+    )
+
+
 def _get_kernel_noc_index(module, kernel_name: str):
     """Read the `ttl.noc_index` attribute (0 = reader, 1 = writer).
 
@@ -973,6 +1015,9 @@ def _compile_ttnn_kernel(
     # When present, get_ttkernel_names returns per-coordinate clones instead of
     # a single (compute + reader + writer) triple.
     kernel_coords = [_get_kernel_core_coords(module, name) for name, _ in kernel_info]
+    kernel_logical_selectors = [
+        _get_kernel_logical_selector(module, name) for name, _ in kernel_info
+    ]
     specialize_cores = any(coords is not None for coords in kernel_coords)
 
     compute_count = sum(1 for _, t in kernel_info if t == "compute")
@@ -1155,6 +1200,7 @@ def _compile_ttnn_kernel(
         num_pipe_global_semaphores=num_pipe_global_semaphores,
         opaque_include_paths=opaque_include_paths or [],
         kernel_pipe_computed_address_dfb_indices=kernel_pipe_computed_address_dfb_indices,
+        kernel_logical_selectors=kernel_logical_selectors,
     )
 
     if verbose:
@@ -1176,6 +1222,7 @@ def _compile_ttnn_kernel(
                     kernel_idx
                 ],
                 core_ranges=kernel_core_ranges[kernel_idx],
+                logical_kernel=kernel_logical_selectors[kernel_idx],
             )
             kernel_specs_for_emit.append(spec)
 
@@ -1880,6 +1927,7 @@ def _lower_program_to_kernel(
     l1_budget_override,
     kernel_source_file,
     kernel_line_offset,
+    logical_kernels=None,
 ):
     """Lower compiled threads to a CompiledTTNNKernel.
 
@@ -1890,6 +1938,10 @@ def _lower_program_to_kernel(
     # Always generate source locations for error messages
     # TTLANG_DEBUG_LOCATIONS only controls whether locations are printed in MLIR output
     print_debug_locations = os.environ.get("TTLANG_DEBUG_LOCATIONS", "0") == "1"
+    if logical_kernels is not None and len(logical_kernels) != len(program.threads):
+        raise ValueError(
+            "logical kernel metadata must align one-to-one with program threads"
+        )
 
     ctx = Context()
     loc = Location.unknown(ctx)
@@ -1905,7 +1957,7 @@ def _lower_program_to_kernel(
         kernel_line_offsets = {}
         noc_kernel_idx = 0
 
-        for compile_thread in program.threads:
+        for thread_index, compile_thread in enumerate(program.threads):
             try:
                 ct = compile_thread(*program.args, **program.kwargs)
             except TTLangCompileError as e:
@@ -1941,6 +1993,34 @@ def _lower_program_to_kernel(
                     IntegerType.get_signless(32, ctx), noc_kernel_idx
                 )
                 noc_kernel_idx += 1
+
+            logical_kernel = (
+                logical_kernels[thread_index] if logical_kernels is not None else None
+            )
+            if logical_kernel is not None:
+                kind = _selector_kind(logical_kernel)
+                ir_kind = {
+                    KernelKind.COMPUTE: ttl_dialect.ir.LogicalKernelKind.Compute,
+                    KernelKind.DATA_MOVEMENT: (
+                        ttl_dialect.ir.LogicalKernelKind.DataMovement
+                    ),
+                }[kind]
+                identity = None
+                operation_identity = None
+                implicit_role = None
+                if isinstance(logical_kernel, Kernel):
+                    identity = logical_kernel.identity
+                    operation_identity = logical_kernel._operation_identity
+                    implicit_role = _selector_implicit_role(logical_kernel)
+                ct.func_entry.attributes[_LOGICAL_KERNEL_ATTR] = (
+                    ttl_dialect.LogicalKernelAttr.get(
+                        ctx,
+                        ir_kind,
+                        identity,
+                        operation_identity,
+                        implicit_role,
+                    )
+                )
 
             # Collect source info for error reporting
             if hasattr(ct, "source_file") and hasattr(ct, "source_lines"):

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -107,6 +107,8 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _bind_kernel_declarations,
+    _operation_identity,
     _selector_implicit_role,
     _selector_kind,
 )
@@ -138,6 +140,35 @@ def _get_registered_threads() -> List[Callable]:
     threads = list(_thread_registry)
     _thread_registry.clear()
     return threads
+
+
+def _validate_explicit_logical_kernel_uses(threads: List[Callable]) -> None:
+    """Require each named logical kernel to identify one explicit thread."""
+    thread_by_kernel: Dict[Kernel, Callable] = {}
+    for thread in threads:
+        logical_kernel = thread._logical_kernel
+        if not isinstance(logical_kernel, Kernel):
+            continue
+        previous_thread = thread_by_kernel.get(logical_kernel)
+        if previous_thread is not None:
+            raise ValueError(
+                f"logical Kernel {logical_kernel.identity!r} is selected by "
+                "multiple explicit threads: "
+                f"{previous_thread.__name__!r} and {thread.__name__!r}"
+            )
+        thread_by_kernel[logical_kernel] = thread
+
+
+def _captured_kernel_declarations(function: Callable) -> Dict[str, Kernel]:
+    """Return logical kernels referenced by an explicit operation."""
+    closure = inspect.getclosurevars(function)
+    captures = dict(closure.globals)
+    captures.update(closure.nonlocals)
+    return {
+        name: value
+        for name, value in sorted(captures.items())
+        if isinstance(value, Kernel)
+    }
 
 
 def _get_tensor_cache_info(tensor) -> tuple:
@@ -1652,6 +1683,7 @@ def _run_thread_compiler(
 def _compile(
     kernel_type: Optional[str] = None,
     verbose: bool = False,
+    logical_kernel: Optional[KernelSelector] = None,
 ) -> Callable:
     """
     Internal decorator for compiling kernel threads.
@@ -1659,12 +1691,34 @@ def _compile(
     Args:
         kernel_type: Type of kernel ("compute" or "datamovement")
         verbose: Enable verbose compilation output
+        logical_kernel: Target-independent logical kernel selector
 
     Returns:
         Decorator function for kernel compilation
     """
 
     def _decorator(f):
+        expected_kind = {
+            "compute": KernelKind.COMPUTE,
+            "datamovement": KernelKind.DATA_MOVEMENT,
+        }[kernel_type]
+        selected_kernel = expected_kind if logical_kernel is None else logical_kernel
+        if not isinstance(selected_kernel, (KernelKind, Kernel)):
+            raise TypeError(
+                "kernel must be a KernelKind or Kernel, got "
+                f"{type(selected_kernel).__name__}"
+            )
+        if _selector_kind(selected_kernel) != expected_kind:
+            raise ValueError(
+                f"{kernel_type} thread kernel kind must be "
+                f"{expected_kind.value}, got {_selector_kind(selected_kernel).value}"
+            )
+        if isinstance(selected_kernel, Kernel) and selected_kernel._identity is None:
+            raise ValueError(
+                "kernel handle must be captured by the enclosing @ttl.operation "
+                "before it is used by a thread decorator"
+            )
+
         # Capture source file at decoration time
         try:
             source_file = inspect.getfile(f)
@@ -1702,6 +1756,7 @@ def _compile(
 
         _wrapper._decorator_name = kernel_type + "_thread"
         _wrapper._source_file = source_file
+        _wrapper._logical_kernel = selected_kernel
         # Register thread for automatic collection
         _register_thread(_wrapper)
         if inspect.ismethod(f):
@@ -1711,7 +1766,9 @@ def _compile(
     return _decorator
 
 
-def compute(verbose: bool = False) -> Callable:
+def compute(
+    verbose: bool = False, *, kernel: Optional[KernelSelector] = None
+) -> Callable:
     """
     Decorator for compute thread functions.
 
@@ -1719,6 +1776,7 @@ def compute(verbose: bool = False) -> Callable:
 
     Args:
         verbose: Enable verbose compilation output
+        kernel: Logical compute kernel selected for this thread
 
     Returns:
         Decorator for compute kernel compilation
@@ -1726,10 +1784,13 @@ def compute(verbose: bool = False) -> Callable:
     return _compile(
         kernel_type="compute",
         verbose=verbose,
+        logical_kernel=kernel,
     )
 
 
-def datamovement(verbose: bool = False) -> Callable:
+def datamovement(
+    verbose: bool = False, *, kernel: Optional[KernelSelector] = None
+) -> Callable:
     """
     Decorator for data movement thread functions.
 
@@ -1737,6 +1798,7 @@ def datamovement(verbose: bool = False) -> Callable:
 
     Args:
         verbose: Enable verbose compilation output
+        kernel: Logical data-movement kernel selected for this thread
 
     Returns:
         Decorator for data movement kernel compilation
@@ -1744,6 +1806,7 @@ def datamovement(verbose: bool = False) -> Callable:
     return _compile(
         kernel_type="datamovement",
         verbose=verbose,
+        logical_kernel=kernel,
     )
 
 
@@ -1885,6 +1948,8 @@ def _compile_kernel(
             "@ttl.datamovement() function inside your kernel."
         )
 
+    _validate_explicit_logical_kernel_uses(threads)
+
     pipenets = _build_operation_pipenets(f, threads)
 
     launch_grid = grid
@@ -1916,6 +1981,7 @@ def _compile_kernel(
         l1_budget_override=l1_budget_override,
         kernel_source_file=kernel_source_file,
         kernel_line_offset=kernel_line_offset,
+        logical_kernels=[thread._logical_kernel for thread in threads],
     )
 
 
@@ -2519,6 +2585,10 @@ def pykernel_gen(
         iterator_types = []
 
     def _decorator(f):
+        _bind_kernel_declarations(
+            _captured_kernel_declarations(f), _operation_identity(f)
+        )
+
         def _compile_explicit(
             runtime_args,
             runtime_kwargs,

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -107,6 +107,8 @@ from .kernel import (
     Kernel,
     KernelKind,
     KernelSelector,
+    _bind_kernel_declarations,
+    _operation_identity,
     _selector_implicit_role,
     _selector_kind,
 )
@@ -138,6 +140,35 @@ def _get_registered_threads() -> List[Callable]:
     threads = list(_thread_registry)
     _thread_registry.clear()
     return threads
+
+
+def _validate_explicit_logical_kernel_uses(threads: List[Callable]) -> None:
+    """Require each named logical kernel to identify one explicit thread."""
+    thread_by_kernel: Dict[Kernel, Callable] = {}
+    for thread in threads:
+        logical_kernel = thread._logical_kernel
+        if not isinstance(logical_kernel, Kernel):
+            continue
+        previous_thread = thread_by_kernel.get(logical_kernel)
+        if previous_thread is not None:
+            raise ValueError(
+                f"logical Kernel {logical_kernel.identity!r} is selected by "
+                "multiple explicit threads: "
+                f"{previous_thread.__name__!r} and {thread.__name__!r}"
+            )
+        thread_by_kernel[logical_kernel] = thread
+
+
+def _captured_kernel_declarations(function: Callable) -> Dict[str, Kernel]:
+    """Return logical kernels referenced by an explicit operation."""
+    closure = inspect.getclosurevars(function)
+    captures = dict(closure.globals)
+    captures.update(closure.nonlocals)
+    return {
+        name: value
+        for name, value in sorted(captures.items())
+        if isinstance(value, Kernel)
+    }
 
 
 def _get_tensor_cache_info(tensor) -> tuple:
@@ -1638,6 +1669,7 @@ def _run_thread_compiler(
 def _compile(
     kernel_type: Optional[str] = None,
     verbose: bool = False,
+    logical_kernel: Optional[KernelSelector] = None,
 ) -> Callable:
     """
     Internal decorator for compiling kernel threads.
@@ -1645,12 +1677,34 @@ def _compile(
     Args:
         kernel_type: Type of kernel ("compute" or "datamovement")
         verbose: Enable verbose compilation output
+        logical_kernel: Target-independent logical kernel selector
 
     Returns:
         Decorator function for kernel compilation
     """
 
     def _decorator(f):
+        expected_kind = {
+            "compute": KernelKind.COMPUTE,
+            "datamovement": KernelKind.DATA_MOVEMENT,
+        }[kernel_type]
+        selected_kernel = expected_kind if logical_kernel is None else logical_kernel
+        if not isinstance(selected_kernel, (KernelKind, Kernel)):
+            raise TypeError(
+                "kernel must be a KernelKind or Kernel, got "
+                f"{type(selected_kernel).__name__}"
+            )
+        if _selector_kind(selected_kernel) != expected_kind:
+            raise ValueError(
+                f"{kernel_type} thread kernel kind must be "
+                f"{expected_kind.value}, got {_selector_kind(selected_kernel).value}"
+            )
+        if isinstance(selected_kernel, Kernel) and selected_kernel._identity is None:
+            raise ValueError(
+                "kernel handle must be captured by the enclosing @ttl.operation "
+                "before it is used by a thread decorator"
+            )
+
         # Capture source file at decoration time
         try:
             source_file = inspect.getfile(f)
@@ -1688,6 +1742,7 @@ def _compile(
 
         _wrapper._decorator_name = kernel_type + "_thread"
         _wrapper._source_file = source_file
+        _wrapper._logical_kernel = selected_kernel
         # Register thread for automatic collection
         _register_thread(_wrapper)
         if inspect.ismethod(f):
@@ -1697,7 +1752,9 @@ def _compile(
     return _decorator
 
 
-def compute(verbose: bool = False) -> Callable:
+def compute(
+    verbose: bool = False, *, kernel: Optional[KernelSelector] = None
+) -> Callable:
     """
     Decorator for compute thread functions.
 
@@ -1705,6 +1762,7 @@ def compute(verbose: bool = False) -> Callable:
 
     Args:
         verbose: Enable verbose compilation output
+        kernel: Logical compute kernel selected for this thread
 
     Returns:
         Decorator for compute kernel compilation
@@ -1712,10 +1770,13 @@ def compute(verbose: bool = False) -> Callable:
     return _compile(
         kernel_type="compute",
         verbose=verbose,
+        logical_kernel=kernel,
     )
 
 
-def datamovement(verbose: bool = False) -> Callable:
+def datamovement(
+    verbose: bool = False, *, kernel: Optional[KernelSelector] = None
+) -> Callable:
     """
     Decorator for data movement thread functions.
 
@@ -1723,6 +1784,7 @@ def datamovement(verbose: bool = False) -> Callable:
 
     Args:
         verbose: Enable verbose compilation output
+        kernel: Logical data-movement kernel selected for this thread
 
     Returns:
         Decorator for data movement kernel compilation
@@ -1730,6 +1792,7 @@ def datamovement(verbose: bool = False) -> Callable:
     return _compile(
         kernel_type="datamovement",
         verbose=verbose,
+        logical_kernel=kernel,
     )
 
 
@@ -1877,6 +1940,8 @@ def _compile_kernel(
             "@ttl.datamovement() function inside your kernel."
         )
 
+    _validate_explicit_logical_kernel_uses(threads)
+
     pipenets = _build_operation_pipenets(f, threads)
 
     launch_grid = grid
@@ -1908,6 +1973,7 @@ def _compile_kernel(
         l1_budget_override=l1_budget_override,
         kernel_source_file=kernel_source_file,
         kernel_line_offset=kernel_line_offset,
+        logical_kernels=[thread._logical_kernel for thread in threads],
     )
 
 
@@ -2498,6 +2564,10 @@ def pykernel_gen(
         iterator_types = []
 
     def _decorator(f):
+        _bind_kernel_declarations(
+            _captured_kernel_declarations(f), _operation_identity(f)
+        )
+
         def _compile_explicit(
             runtime_args,
             runtime_kwargs,

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -122,8 +122,6 @@ _TTCORE_ARCH_BY_DEVICE_NAME = {
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
 
-_LOGICAL_KERNEL_ATTR = "ttl.logical_kernel"
-
 
 def _register_thread(thread_fn: Callable) -> None:
     """Register a thread function during decoration."""
@@ -888,12 +886,14 @@ def _get_kernel_core_coords(module, kernel_name: str):
 def _get_kernel_logical_selector(module, kernel_name: str) -> Optional[KernelSelector]:
     """Recover logical-kernel metadata retained by specialization clones."""
     operation = _lookup_kernel_func_op(module, kernel_name)
-    raw_attribute = operation.attributes.get(_LOGICAL_KERNEL_ATTR, None)
+    raw_attribute = operation.attributes.get(_ttl_ir.LOGICAL_KERNEL_ATTR, None)
     if raw_attribute is None:
         return None
     attribute = ttl_dialect.LogicalKernelAttr.maybe_downcast(raw_attribute)
     if attribute is None:
-        raise ValueError(f"Invalid '{_LOGICAL_KERNEL_ATTR}' on kernel {kernel_name!r}")
+        raise ValueError(
+            f"Invalid '{_ttl_ir.LOGICAL_KERNEL_ATTR}' on kernel {kernel_name!r}"
+        )
 
     if attribute.kind == ttl_dialect.ir.LogicalKernelKind.Compute:
         kind = KernelKind.COMPUTE
@@ -2012,7 +2012,7 @@ def _lower_program_to_kernel(
                     identity = logical_kernel.identity
                     operation_identity = logical_kernel._operation_identity
                     implicit_role = _selector_implicit_role(logical_kernel)
-                ct.func_entry.attributes[_LOGICAL_KERNEL_ATTR] = (
+                ct.func_entry.attributes[_ttl_ir.LOGICAL_KERNEL_ATTR] = (
                     ttl_dialect.LogicalKernelAttr.get(
                         ctx,
                         ir_kind,

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -103,6 +103,13 @@ from .kernel_runner import (
     run_kernel_on_device,
     emit_runner_file,
 )
+from .kernel import (
+    Kernel,
+    KernelKind,
+    KernelSelector,
+    _selector_implicit_role,
+    _selector_kind,
+)
 from .operators import CopyTransferHandler, TensorBlock, copy
 from .compiler_options import CompilerOptions
 from .ttl_utils import get_thread_type_string
@@ -114,6 +121,8 @@ _TTCORE_ARCH_BY_DEVICE_NAME = {
 
 # Thread registry for automatic collection of @compute and @datamovement threads
 _thread_registry: List[Callable] = []
+
+_LOGICAL_KERNEL_ATTR = "ttl.logical_kernel"
 
 
 def _register_thread(thread_fn: Callable) -> None:
@@ -621,6 +630,7 @@ class CompiledTTNNKernel:
         num_pipe_global_semaphores=0,
         opaque_include_paths=None,
         kernel_pipe_computed_address_dfb_indices=None,
+        kernel_logical_selectors=None,
     ):
         """
         Initialize with pre-compiled kernel artifacts.
@@ -650,6 +660,7 @@ class CompiledTTNNKernel:
                 PipeNet counters used by this kernel.
             kernel_pipe_computed_address_dfb_indices: Per-kernel receiver DFB indices whose
                 L1 bases are supplied as common runtime args.
+            kernel_logical_selectors: Logical selector for each compiled kernel.
         """
         self.kernel_paths = kernel_paths
         self.kernel_configs = kernel_configs
@@ -670,6 +681,9 @@ class CompiledTTNNKernel:
         self.kernel_pipe_computed_address_dfb_indices = (
             kernel_pipe_computed_address_dfb_indices or [[] for _ in kernel_paths]
         )
+        self.kernel_logical_selectors = kernel_logical_selectors or [
+            None for _ in kernel_paths
+        ]
         self._pipe_global_semaphore_lifetime = []
         self.opaque_include_paths = opaque_include_paths or []
 
@@ -704,6 +718,7 @@ class CompiledTTNNKernel:
                     kernel_idx
                 ],
                 core_ranges=self.kernel_core_ranges[kernel_idx],
+                logical_kernel=self.kernel_logical_selectors[kernel_idx],
             )
             kernel_specs.append(spec)
 
@@ -884,6 +899,33 @@ def _get_kernel_core_coords(module, kernel_name: str):
     return coords
 
 
+def _get_kernel_logical_selector(module, kernel_name: str) -> Optional[KernelSelector]:
+    """Recover logical-kernel metadata retained by specialization clones."""
+    operation = _lookup_kernel_func_op(module, kernel_name)
+    raw_attribute = operation.attributes.get(_LOGICAL_KERNEL_ATTR, None)
+    if raw_attribute is None:
+        return None
+    attribute = ttl_dialect.LogicalKernelAttr.maybe_downcast(raw_attribute)
+    if attribute is None:
+        raise ValueError(f"Invalid '{_LOGICAL_KERNEL_ATTR}' on kernel {kernel_name!r}")
+
+    if attribute.kind == ttl_dialect.ir.LogicalKernelKind.Compute:
+        kind = KernelKind.COMPUTE
+    elif attribute.kind == ttl_dialect.ir.LogicalKernelKind.DataMovement:
+        kind = KernelKind.DATA_MOVEMENT
+    else:
+        raise ValueError(f"Unknown logical kernel kind on kernel {kernel_name!r}")
+
+    if not attribute.identity:
+        return kind
+    return Kernel._from_metadata(
+        kind,
+        attribute.identity,
+        operation_identity=attribute.operation,
+        implicit_role=attribute.role,
+    )
+
+
 def _get_kernel_noc_index(module, kernel_name: str):
     """Read the `ttl.noc_index` attribute (0 = reader, 1 = writer).
 
@@ -987,6 +1029,9 @@ def _compile_ttnn_kernel(
     # When present, get_ttkernel_names returns per-coordinate clones instead of
     # a single (compute + reader + writer) triple.
     kernel_coords = [_get_kernel_core_coords(module, name) for name, _ in kernel_info]
+    kernel_logical_selectors = [
+        _get_kernel_logical_selector(module, name) for name, _ in kernel_info
+    ]
     specialize_cores = any(coords is not None for coords in kernel_coords)
 
     compute_count = sum(1 for _, t in kernel_info if t == "compute")
@@ -1169,6 +1214,7 @@ def _compile_ttnn_kernel(
         num_pipe_global_semaphores=num_pipe_global_semaphores,
         opaque_include_paths=opaque_include_paths or [],
         kernel_pipe_computed_address_dfb_indices=kernel_pipe_computed_address_dfb_indices,
+        kernel_logical_selectors=kernel_logical_selectors,
     )
 
     if verbose:
@@ -1190,6 +1236,7 @@ def _compile_ttnn_kernel(
                     kernel_idx
                 ],
                 core_ranges=kernel_core_ranges[kernel_idx],
+                logical_kernel=kernel_logical_selectors[kernel_idx],
             )
             kernel_specs_for_emit.append(spec)
 
@@ -1888,6 +1935,7 @@ def _lower_program_to_kernel(
     l1_budget_override,
     kernel_source_file,
     kernel_line_offset,
+    logical_kernels=None,
 ):
     """Lower compiled threads to a CompiledTTNNKernel.
 
@@ -1898,6 +1946,10 @@ def _lower_program_to_kernel(
     # Always generate source locations for error messages
     # TTLANG_DEBUG_LOCATIONS only controls whether locations are printed in MLIR output
     print_debug_locations = os.environ.get("TTLANG_DEBUG_LOCATIONS", "0") == "1"
+    if logical_kernels is not None and len(logical_kernels) != len(program.threads):
+        raise ValueError(
+            "logical kernel metadata must align one-to-one with program threads"
+        )
 
     ctx = Context()
     loc = Location.unknown(ctx)
@@ -1913,7 +1965,7 @@ def _lower_program_to_kernel(
         kernel_line_offsets = {}
         noc_kernel_idx = 0
 
-        for compile_thread in program.threads:
+        for thread_index, compile_thread in enumerate(program.threads):
             try:
                 ct = compile_thread(*program.args, **program.kwargs)
             except TTLangCompileError as e:
@@ -1949,6 +2001,34 @@ def _lower_program_to_kernel(
                     IntegerType.get_signless(32, ctx), noc_kernel_idx
                 )
                 noc_kernel_idx += 1
+
+            logical_kernel = (
+                logical_kernels[thread_index] if logical_kernels is not None else None
+            )
+            if logical_kernel is not None:
+                kind = _selector_kind(logical_kernel)
+                ir_kind = {
+                    KernelKind.COMPUTE: ttl_dialect.ir.LogicalKernelKind.Compute,
+                    KernelKind.DATA_MOVEMENT: (
+                        ttl_dialect.ir.LogicalKernelKind.DataMovement
+                    ),
+                }[kind]
+                identity = None
+                operation_identity = None
+                implicit_role = None
+                if isinstance(logical_kernel, Kernel):
+                    identity = logical_kernel.identity
+                    operation_identity = logical_kernel._operation_identity
+                    implicit_role = _selector_implicit_role(logical_kernel)
+                ct.func_entry.attributes[_LOGICAL_KERNEL_ATTR] = (
+                    ttl_dialect.LogicalKernelAttr.get(
+                        ctx,
+                        ir_kind,
+                        identity,
+                        operation_identity,
+                        implicit_role,
+                    )
+                )
 
             # Collect source info for error reporting
             if hasattr(ct, "source_file") and hasattr(ct, "source_lines"):

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -78,7 +78,8 @@ from ._src.tensor_registry import (
     register_tensor_name,
     register_tensor_source,
 )
-from ._src.ttl_ast import TTLGenericCompiler, is_ttnn_global_semaphore
+from ._src.global_semaphore import is_ttnn_global_semaphore
+from ._src.ttl_ast import TTLGenericCompiler
 from .dataflow_buffer import (
     CircularBuffer,
     DataflowBuffer,

--- a/python/ttlang/TTLModule.cpp
+++ b/python/ttlang/TTLModule.cpp
@@ -38,6 +38,8 @@ void populateTTLModule(nb::module_ &m) {
   m.attr("PIPE_COMPUTED_ADDRESS_DFB_INDICES_ATTR") =
       nb::str(kPipeComputedAddressDFBIndicesAttrName.data(),
               kPipeComputedAddressDFBIndicesAttrName.size());
+  m.attr("LOGICAL_KERNEL_ATTR") =
+      nb::str(kLogicalKernelAttrName.data(), kLogicalKernelAttrName.size());
 
   nb::enum_<LogicalKernelKind>(m, "LogicalKernelKind")
       .value("Compute", LogicalKernelKind::Compute)

--- a/python/ttlang/TTLModule.cpp
+++ b/python/ttlang/TTLModule.cpp
@@ -39,6 +39,57 @@ void populateTTLModule(nb::module_ &m) {
       nb::str(kPipeComputedAddressDFBIndicesAttrName.data(),
               kPipeComputedAddressDFBIndicesAttrName.size());
 
+  nb::enum_<LogicalKernelKind>(m, "LogicalKernelKind")
+      .value("Compute", LogicalKernelKind::Compute)
+      .value("DataMovement", LogicalKernelKind::DataMovement);
+
+  tt_attribute_class<LogicalKernelAttr>(m, "LogicalKernelAttr")
+      .def_static(
+          "get",
+          [](MlirContext context, LogicalKernelKind kind,
+             const std::optional<std::string> &identity,
+             const std::optional<std::string> &operation,
+             const std::optional<std::string> &role) {
+            MLIRContext *cppContext = unwrap(context);
+            auto optionalStringAttr =
+                [cppContext](
+                    const std::optional<std::string> &value) -> StringAttr {
+              return value ? StringAttr::get(cppContext, *value) : StringAttr();
+            };
+            LogicalKernelAttr attribute = LogicalKernelAttr::getChecked(
+                [cppContext]() {
+                  return emitError(UnknownLoc::get(cppContext));
+                },
+                cppContext, kind, optionalStringAttr(identity),
+                optionalStringAttr(operation), optionalStringAttr(role));
+            if (!attribute) {
+              throw nb::value_error("invalid logical kernel metadata");
+            }
+            return wrap(attribute);
+          },
+          nb::arg("context"), nb::arg("kind"), nb::arg("identity") = nb::none(),
+          nb::arg("operation") = nb::none(), nb::arg("role") = nb::none())
+      .def_prop_ro("kind", &LogicalKernelAttr::getKind)
+      .def_prop_ro("identity",
+                   [](LogicalKernelAttr attribute) {
+                     StringAttr identity = attribute.getIdentity();
+                     return identity ? std::optional<std::string>(
+                                           identity.getValue().str())
+                                     : std::nullopt;
+                   })
+      .def_prop_ro("operation",
+                   [](LogicalKernelAttr attribute) {
+                     StringAttr operation = attribute.getOperation();
+                     return operation ? std::optional<std::string>(
+                                            operation.getValue().str())
+                                      : std::nullopt;
+                   })
+      .def_prop_ro("role", [](LogicalKernelAttr attribute) {
+        StringAttr role = attribute.getRole();
+        return role ? std::optional<std::string>(role.getValue().str())
+                    : std::nullopt;
+      });
+
   nb::enum_<ExternalTemplateArgKind>(m, "ExternalTemplateArgKind")
       .value("SignedInteger", ExternalTemplateArgKind::SignedInteger)
       .value("Boolean", ExternalTemplateArgKind::Boolean)

--- a/python/ttlang/TTLModule.cpp
+++ b/python/ttlang/TTLModule.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/Location.h"
 
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
 namespace nb = nanobind;
@@ -37,6 +38,57 @@ void populateTTLModule(nb::module_ &m) {
   m.attr("PIPE_COMPUTED_ADDRESS_DFB_INDICES_ATTR") =
       nb::str(kPipeComputedAddressDFBIndicesAttrName.data(),
               kPipeComputedAddressDFBIndicesAttrName.size());
+
+  nb::enum_<LogicalKernelKind>(m, "LogicalKernelKind")
+      .value("Compute", LogicalKernelKind::Compute)
+      .value("DataMovement", LogicalKernelKind::DataMovement);
+
+  tt_attribute_class<LogicalKernelAttr>(m, "LogicalKernelAttr")
+      .def_static(
+          "get",
+          [](MlirContext context, LogicalKernelKind kind,
+             const std::optional<std::string> &identity,
+             const std::optional<std::string> &operation,
+             const std::optional<std::string> &role) {
+            MLIRContext *cppContext = unwrap(context);
+            auto optionalStringAttr =
+                [cppContext](
+                    const std::optional<std::string> &value) -> StringAttr {
+              return value ? StringAttr::get(cppContext, *value) : StringAttr();
+            };
+            LogicalKernelAttr attribute = LogicalKernelAttr::getChecked(
+                [cppContext]() {
+                  return emitError(UnknownLoc::get(cppContext));
+                },
+                cppContext, kind, optionalStringAttr(identity),
+                optionalStringAttr(operation), optionalStringAttr(role));
+            if (!attribute) {
+              throw nb::value_error("invalid logical kernel metadata");
+            }
+            return wrap(attribute);
+          },
+          nb::arg("context"), nb::arg("kind"), nb::arg("identity") = nb::none(),
+          nb::arg("operation") = nb::none(), nb::arg("role") = nb::none())
+      .def_prop_ro("kind", &LogicalKernelAttr::getKind)
+      .def_prop_ro("identity",
+                   [](LogicalKernelAttr attribute) {
+                     StringAttr identity = attribute.getIdentity();
+                     return identity ? std::optional<std::string>(
+                                           identity.getValue().str())
+                                     : std::nullopt;
+                   })
+      .def_prop_ro("operation",
+                   [](LogicalKernelAttr attribute) {
+                     StringAttr operation = attribute.getOperation();
+                     return operation ? std::optional<std::string>(
+                                            operation.getValue().str())
+                                      : std::nullopt;
+                   })
+      .def_prop_ro("role", [](LogicalKernelAttr attribute) {
+        StringAttr role = attribute.getRole();
+        return role ? std::optional<std::string>(role.getValue().str())
+                    : std::nullopt;
+      });
 
   nb::enum_<ExternalTemplateArgKind>(m, "ExternalTemplateArgKind")
       .value("SignedInteger", ExternalTemplateArgKind::SignedInteger)

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -140,8 +140,8 @@ def test_captured_kernel_cannot_have_two_names():
         reader.identity
 
 
-def test_composition_copies_captured_kernel_into_final_operation():
-    """A composed capture receives a fresh identity owned by the caller."""
+def test_composition_preserves_captured_kernel_handle():
+    """Composition retains the callee-owned handle used by child resources."""
     reader = Kernel(KernelKind.DATA_MOVEMENT)
 
     @ttl.operation()
@@ -155,9 +155,11 @@ def test_composition_copies_captured_kernel_into_final_operation():
     spec = selected_caller._spec
     assert len(spec.logical_kernels) == 1
     inlined_reader = next(iter(spec.logical_kernels.values()))
-    assert inlined_reader is not reader
-    assert inlined_reader.identity.startswith("reader__selected_callee_inl_")
-    assert inlined_reader._operation_identity == spec.operation_identity
+    assert inlined_reader is reader
+    assert inlined_reader.identity == "reader"
+    assert (
+        inlined_reader._operation_identity == selected_callee._spec.operation_identity
+    )
 
     result = split_function_body(
         spec.fn_ast,
@@ -165,11 +167,11 @@ def test_composition_copies_captured_kernel_into_final_operation():
         logical_kernels=spec.logical_kernels,
         kernel_capacities=_backend_kernel_capacities(),
     )
-    assert result.kernels == (inlined_reader,)
+    assert result.kernels == (reader,)
 
 
-def test_composition_kernel_suffix_is_stable_across_caller_registration():
-    """Earlier composition in the process does not change the suffix."""
+def test_repeated_composition_reuses_callee_logical_kernel():
+    """Sequential calls to one helper share its declared logical kernel."""
     reader = Kernel(KernelKind.DATA_MOVEMENT)
 
     @ttl.operation()
@@ -177,16 +179,71 @@ def test_composition_kernel_suffix_is_stable_across_caller_registration():
         ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
 
     @ttl.operation(grid=(1, 1))
-    def first_caller():
+    def selected_caller():
         selected_callee()
+        selected_callee()
+
+    spec = selected_caller._spec
+    assert tuple(spec.logical_kernels.values()) == (reader,)
+
+    result = split_function_body(
+        spec.fn_ast,
+        dfb_param_names=set(),
+        logical_kernels=spec.logical_kernels,
+        kernel_capacities=_backend_kernel_capacities(),
+    )
+    assert result.kernels == (reader,)
+
+
+def test_factory_instances_with_different_captures_keep_distinct_kernels():
+    """Different immutable captures distinguish factory-created operations."""
+
+    def make_helper(entry):
+        reader = Kernel(KernelKind.DATA_MOVEMENT)
+
+        @ttl.operation()
+        def selected_helper():
+            ttl.call_extern_func("reader.hpp", entry, kernel=reader)
+
+        return selected_helper, reader
+
+    first_helper, first_reader = make_helper("first_entry")
+    second_helper, second_reader = make_helper("second_entry")
 
     @ttl.operation(grid=(1, 1))
-    def second_caller():
-        selected_callee()
+    def selected_caller():
+        first_helper()
+        second_helper()
 
-    first_name = next(iter(first_caller._spec.logical_kernels))
-    second_name = next(iter(second_caller._spec.logical_kernels))
-    assert first_name == second_name
+    assert (
+        first_helper._spec.operation_identity != second_helper._spec.operation_identity
+    )
+    assert first_reader != second_reader
+    assert set(selected_caller._spec.logical_kernels.values()) == {
+        first_reader,
+        second_reader,
+    }
+
+
+def test_factory_instances_with_equal_captures_share_logical_identity():
+    """Equivalent immutable captures retain deterministic identity."""
+
+    def make_helper(entry):
+        reader = Kernel(KernelKind.DATA_MOVEMENT)
+
+        @ttl.operation()
+        def selected_helper():
+            ttl.call_extern_func("reader.hpp", entry, kernel=reader)
+
+        return selected_helper, reader
+
+    first_helper, first_reader = make_helper("shared_entry")
+    second_helper, second_reader = make_helper("shared_entry")
+
+    assert (
+        first_helper._spec.operation_identity == second_helper._spec.operation_identity
+    )
+    assert first_reader == second_reader
 
 
 def test_composition_preserves_body_local_kernel_declaration():

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -17,6 +17,7 @@ import textwrap
 
 import pytest
 import ttl
+import ttl.kernel as kernel_module
 
 from ttl._src.atom_split import split_function_body
 from ttl.atom import (
@@ -327,6 +328,36 @@ def test_operation_identity_encodes_pipe_topology(capture_kind):
 
     assert identity_for((1, 0)) == identity_for((1, 0))
     assert identity_for((1, 0)) != identity_for((2, 0))
+
+
+def test_operation_identity_encodes_global_semaphore_address(monkeypatch):
+    """Global semaphore addresses distinguish compiled template identities."""
+
+    class GlobalSemaphore:
+        def __init__(self, address):
+            self.address = address
+
+    monkeypatch.setattr(
+        kernel_module,
+        "is_ttnn_global_semaphore",
+        lambda value: isinstance(value, GlobalSemaphore),
+    )
+    monkeypatch.setattr(
+        kernel_module,
+        "get_ttnn_global_semaphore_address",
+        lambda value: value.address,
+    )
+
+    def identity_for(address):
+        global_semaphore = GlobalSemaphore(address)
+
+        def selected_operation():
+            return global_semaphore
+
+        return _operation_identity(selected_operation)
+
+    assert identity_for(0x1000) == identity_for(0x1000)
+    assert identity_for(0x1000) != identity_for(0x2000)
 
 
 def test_operation_identity_rejects_unsupported_nonlocal_capture():

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -21,6 +21,7 @@ import ttl
 from ttl._src.atom_split import split_function_body
 from ttl.atom import (
     _assign_backend_kernel_slots,
+    _backend_kernel_bodies,
     _backend_kernel_capacities,
     _build_atom_spec,
     _lift_setup,
@@ -84,6 +85,38 @@ def test_kernel_resource_is_lifted_before_logical_split():
     )
     assignments = _assign_backend_kernel_slots(result)
     assert tuple(assignments.values()) == (reader,)
+
+
+def test_empty_backend_kernels_retain_logical_selectors():
+    """Empty backend fillers retain stable target-independent selectors."""
+    reader = _logical_kernel(KernelKind.DATA_MOVEMENT, "reader")
+    function = _fn(
+        """
+        def k():
+            ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+        """
+    )
+    result = split_function_body(
+        function,
+        dfb_param_names=set(),
+        logical_kernels={"reader": reader},
+        kernel_capacities=_backend_kernel_capacities(),
+    )
+    assignments = _assign_backend_kernel_slots(result)
+
+    first = tuple(_backend_kernel_bodies(result, assignments, None))
+    second = tuple(_backend_kernel_bodies(result, assignments, None))
+    selectors = tuple(selector for _, selector, _ in first)
+
+    assert selectors == tuple(selector for _, selector, _ in second)
+    assert selectors[0] is KernelKind.COMPUTE
+    assert selectors[1] is reader
+    assert isinstance(selectors[2], Kernel)
+    assert selectors[2].kind is KernelKind.DATA_MOVEMENT
+    assert selectors[2].identity == "<pipe_source>"
+    assert selectors[2]._implicit_role == "pipe_source"
+    assert isinstance(first[0][2][0], ast.Pass)
+    assert isinstance(first[2][2][0], ast.Pass)
 
 
 def test_captured_kernel_is_bound_for_final_operation():

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -698,6 +698,61 @@ def test_external_call_tuple_selects_multiple_logical_kernels():
         assert "kernel=" not in source
 
 
+def test_external_call_kind_union_selects_multiple_logical_kernels():
+    """A kind union selects both canonical logical kernels."""
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func(
+                "shared.hpp",
+                "shared",
+                kernel=ttl.KernelKind.COMPUTE | ttl.KernelKind.DATA_MOVEMENT,
+            )
+        """
+    )
+
+    result = split_function_body(fn, dfb_param_names=set())
+
+    assert result.kernels == (
+        KernelKind.COMPUTE,
+        KernelKind.DATA_MOVEMENT,
+    )
+    for kernel in result.kernels:
+        source = _kernel_src(result, kernel)
+        assert source.count("call_extern_func") == 1
+        assert "kernel=" not in source
+
+
+def test_kernel_kind_union_builds_tuple_selection():
+    """The public union expression evaluates to an accepted selector tuple."""
+    assert KernelKind.COMPUTE | KernelKind.DATA_MOVEMENT == (
+        KernelKind.COMPUTE,
+        KernelKind.DATA_MOVEMENT,
+    )
+
+
+def test_external_call_kind_union_rejects_named_kernel():
+    """Named logical kernels remain explicit tuple elements."""
+    reader = _logical_kernel(KernelKind.DATA_MOVEMENT, "reader")
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func(
+                "shared.hpp",
+                "shared",
+                kernel=ttl.KernelKind.COMPUTE | reader,
+            )
+        """
+    )
+
+    with pytest.raises(ValueError, match="kind union operands must be KernelKind"):
+        split_function_body(
+            fn,
+            dfb_param_names=set(),
+            logical_kernels={"reader": reader},
+        )
+
+
 @pytest.mark.parametrize(
     "selector, message",
     [
@@ -762,6 +817,25 @@ def test_acquire_rejects_kernel_selector(acquire, form):
     with pytest.raises(
         ValueError,
         match=rf"kernel= is not supported on DFB {acquire}\(\)",
+    ):
+        split_function_body(fn, dfb_param_names={"buffer"})
+
+
+@pytest.mark.parametrize("method", ["push", "pop"])
+def test_release_rejects_kind_union(method):
+    """A DFB release executes in exactly one logical kernel."""
+    fn = _fn(
+        f"""
+        def k():
+            block = buffer.reserve()
+            block.{method}(
+                kernel=ttl.KernelKind.COMPUTE | ttl.KernelKind.DATA_MOVEMENT
+            )
+        """
+    )
+
+    with pytest.raises(
+        ValueError, match="accepts one kernel selector, not a kind union"
     ):
         split_function_body(fn, dfb_param_names={"buffer"})
 

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -312,14 +312,16 @@ def test_factory_instances_with_different_callees_keep_distinct_kernels():
     assert first_reader != second_reader
 
 
-def test_operation_identity_encodes_pipenet_topology():
-    """PipeNet topology distinguishes factory-created operations."""
+@pytest.mark.parametrize("capture_kind", ["pipe", "pipenet"])
+def test_operation_identity_encodes_pipe_topology(capture_kind):
+    """Pipe and PipeNet topology distinguish factory-created operations."""
 
     def identity_for(destination):
-        pipe_net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=destination)])
+        pipe = ttl.Pipe(src=(0, 0), dst=destination)
+        capture = pipe if capture_kind == "pipe" else ttl.PipeNet([pipe])
 
         def selected_operation():
-            return pipe_net
+            return capture
 
         return _operation_identity(selected_operation)
 

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -26,7 +26,7 @@ from ttl.atom import (
     _build_atom_spec,
     _lift_setup,
 )
-from ttl.kernel import Kernel, KernelKind
+from ttl.kernel import Kernel, KernelKind, _operation_identity
 
 
 def _fn(src: str) -> ast.FunctionDef:
@@ -277,6 +277,75 @@ def test_factory_instances_with_equal_captures_share_logical_identity():
         first_helper._spec.operation_identity == second_helper._spec.operation_identity
     )
     assert first_reader == second_reader
+
+
+def test_factory_instances_with_different_callees_keep_distinct_kernels():
+    """Composed operation identity distinguishes generated parent kernels."""
+
+    def make_callee(entry):
+        @ttl.operation()
+        def selected_callee():
+            ttl.call_extern_func(
+                "callee.hpp",
+                entry,
+                kernel=KernelKind.DATA_MOVEMENT,
+            )
+
+        return selected_callee
+
+    def make_parent(selected_callee):
+        reader = Kernel(KernelKind.DATA_MOVEMENT)
+
+        @ttl.operation()
+        def selected_parent():
+            selected_callee()
+            ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+
+        return selected_parent, reader
+
+    first_parent, first_reader = make_parent(make_callee("first_entry"))
+    second_parent, second_reader = make_parent(make_callee("second_entry"))
+
+    assert (
+        first_parent._spec.operation_identity != second_parent._spec.operation_identity
+    )
+    assert first_reader != second_reader
+
+
+def test_operation_identity_encodes_pipenet_topology():
+    """PipeNet topology distinguishes factory-created operations."""
+
+    def identity_for(destination):
+        pipe_net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=destination)])
+
+        def selected_operation():
+            return pipe_net
+
+        return _operation_identity(selected_operation)
+
+    assert identity_for((1, 0)) == identity_for((1, 0))
+    assert identity_for((1, 0)) != identity_for((2, 0))
+
+
+def test_operation_identity_rejects_unsupported_nonlocal_capture():
+    """Unsupported captures cannot silently collapse distinct operations."""
+
+    class UnsupportedCapture:
+        pass
+
+    unsupported_capture = UnsupportedCapture()
+
+    def selected_operation():
+        return unsupported_capture
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "operation identity cannot encode nonlocal capture "
+            "'unsupported_capture' of type UnsupportedCapture"
+        ),
+    ):
+        _operation_identity(selected_operation)
 
 
 def test_composition_preserves_body_local_kernel_declaration():

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -4,27 +4,102 @@
 
 # RUN: %python -m pytest %s -v
 
-"""Off-device unit tests for the unified @ttl.operation thread splitter.
+"""Off-device unit tests for unified-operation logical-kernel splitting.
 
 These drive ``split_function_body`` directly on small ASTs, so they need
 neither ttnn nor a device and run anywhere ttl imports. They lock in the
-split-time error paths for ambiguous thread ownership and the basic
+split-time error paths for ambiguous kernel ownership and the basic
 compute/data-movement routing."""
 
 import ast
 import textwrap
 
 import pytest
+import ttl
 
 from ttl._src.atom_split import split_function_body
+from ttl.atom import (
+    _assign_backend_kernel_slots,
+    _backend_kernel_capacities,
+    _lift_setup,
+)
+from ttl.kernel import Kernel, KernelKind
 
 
 def _fn(src: str) -> ast.FunctionDef:
     return ast.parse(textwrap.dedent(src)).body[0]
 
 
-def _thread_src(result, thread: str) -> str:
-    return "\n".join(ast.unparse(s) for s in result.body_for(thread))
+def _kernel_src(result, kernel) -> str:
+    return "\n".join(ast.unparse(statement) for statement in result.body_for(kernel))
+
+
+def _kind_src(result, kind: KernelKind, index: int = 0) -> str:
+    kernels = [
+        kernel
+        for kernel in result.kernels
+        if kernel == kind or isinstance(kernel, Kernel) and kernel.kind == kind
+    ]
+    if index >= len(kernels):
+        return _kernel_src(result, kind)
+    return _kernel_src(result, kernels[index])
+
+
+def _logical_kernel(kind: KernelKind, name: str) -> Kernel:
+    return Kernel(kind)._bind(name)
+
+
+def test_kernel_resource_is_lifted_before_logical_split():
+    """A top-level Kernel declaration receives its operation-local name."""
+    function = _fn(
+        """
+        def k():
+            reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+            ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+        """
+    )
+
+    stripped, dfbs, nets, logical_kernels = _lift_setup(function, {"ttl": ttl})
+
+    assert not dfbs
+    assert not nets
+    assert tuple(logical_kernels) == ("reader",)
+    reader = logical_kernels["reader"]
+    assert reader.identity == "reader"
+    assert "Kernel(" not in ast.unparse(stripped)
+
+    result = split_function_body(
+        stripped,
+        dfb_param_names=set(),
+        logical_kernels=logical_kernels,
+        kernel_capacities=_backend_kernel_capacities(),
+    )
+    assignments = _assign_backend_kernel_slots(result)
+    assert tuple(assignments.values()) == (reader,)
+
+
+def test_split_analysis_does_not_mutate_input_ast():
+    """Planning and application leave the source AST unchanged."""
+    function = _fn(
+        """
+        def k():
+            ttl.call_extern_func(
+                "shared.hpp",
+                "shared",
+                kernel=(ttl.KernelKind.COMPUTE, ttl.KernelKind.DATA_MOVEMENT),
+            )
+        """
+    )
+    before = ast.dump(function, include_attributes=True)
+
+    result = split_function_body(function, dfb_param_names=set())
+
+    assert ast.dump(function, include_attributes=True) == before
+    assert result.plan.statements[0].source_line == 3
+    assert result.plan.kernel_requirements == (
+        (KernelKind.COMPUTE, 1),
+        (KernelKind.DATA_MOVEMENT, 1),
+    )
 
 
 def test_unknown_ttl_op_is_rejected():
@@ -38,7 +113,7 @@ def test_unknown_ttl_op_is_rejected():
         split_function_body(fn, dfb_param_names=set())
 
 
-def test_raw_addr_is_a_thread_neutral_scalar_producer():
+def test_raw_addr_is_a_kernel_neutral_scalar_producer():
     fn = _fn(
         """
         def k(inp):
@@ -46,23 +121,26 @@ def test_raw_addr_is_a_thread_neutral_scalar_producer():
                 "header.hpp",
                 "kernel",
                 func_args=[ttl.raw_addr(inp)],
+                kernel=(ttl.KernelKind.COMPUTE, ttl.KernelKind.DATA_MOVEMENT),
             )
         """
     )
 
     result = split_function_body(fn, dfb_param_names=set())
 
-    for thread in ("trisc", "ncrisc", "brisc"):
-        thread_source = _thread_src(result, thread)
-        assert "call_extern_func" in thread_source
-        assert "ttl.raw_addr(inp)" in thread_source
+    for kind in (KernelKind.COMPUTE, KernelKind.DATA_MOVEMENT):
+        kernel_source = _kind_src(result, kind)
+        assert "call_extern_func" in kernel_source
+        assert "ttl.raw_addr(inp)" in kernel_source
+        assert "kernel=" not in kernel_source
 
 
-def test_tensor_backed_dfb_factory_and_publish_are_split_by_thread():
+def test_tensor_backed_dfb_factory_and_publish_are_split_by_kernel():
     fn = _fn(
         """
         def k(inp):
             inp_dfb = ttl.make_tensor_backed_dfb(inp, shape=(1, 1))
+            value = ttl.exp(inp)
             inp_dfb.publish()
         """
     )
@@ -73,15 +151,12 @@ def test_tensor_backed_dfb_factory_and_publish_are_split_by_thread():
         local_dfb_names={"inp_dfb"},
     )
 
-    trisc = _thread_src(result, "trisc")
-    ncrisc = _thread_src(result, "ncrisc")
-    brisc = _thread_src(result, "brisc")
-    assert "make_tensor_backed_dfb" in trisc
-    assert "make_tensor_backed_dfb" in ncrisc
-    assert "make_tensor_backed_dfb" in brisc
-    assert "inp_dfb.publish()" not in trisc
-    assert "inp_dfb.publish()" in ncrisc
-    assert "inp_dfb.publish()" not in brisc
+    compute = _kind_src(result, KernelKind.COMPUTE)
+    data_movement = _kind_src(result, KernelKind.DATA_MOVEMENT)
+    assert "make_tensor_backed_dfb" in compute
+    assert "make_tensor_backed_dfb" in data_movement
+    assert "inp_dfb.publish()" not in compute
+    assert "inp_dfb.publish()" in data_movement
 
 
 def test_producer_with_no_uses_is_rejected():
@@ -95,9 +170,8 @@ def test_producer_with_no_uses_is_rejected():
         split_function_body(fn, dfb_param_names=set(), local_dfb_names={"a_cb"})
 
 
-def test_producer_split_across_ncrisc_and_brisc_is_rejected():
-    """A single reserve whose block feeds both an if_src (BRISC) and an
-    if_dst (NCRISC) callback would double-reserve the CB."""
+def test_producer_split_across_data_movement_kernels_is_rejected():
+    """One reserve cannot feed two distinct data-movement callbacks."""
     fn = _fn(
         """
         def k(net):
@@ -114,7 +188,7 @@ def test_producer_split_across_ncrisc_and_brisc_is_rejected():
             net.if_dst(recv)
         """
     )
-    with pytest.raises(ValueError, match="multiple threads .*NCRISC, BRISC"):
+    with pytest.raises(ValueError, match="multiple logical kernels .*data_movement"):
         split_function_body(
             fn,
             dfb_param_names=set(),
@@ -123,7 +197,7 @@ def test_producer_split_across_ncrisc_and_brisc_is_rejected():
 
 
 def test_statement_mixing_compute_and_data_movement_is_rejected():
-    """One statement cannot contain work for both TRISC and NCRISC."""
+    """One statement cannot contain compute and data-movement work."""
     fn = _fn(
         """
         def k(x, out):
@@ -132,7 +206,7 @@ def test_statement_mixing_compute_and_data_movement_is_rejected():
         """
     )
 
-    with pytest.raises(ValueError, match="statement is pinned to multiple threads"):
+    with pytest.raises(ValueError, match="statement is assigned to multiple logical"):
         split_function_body(
             fn,
             dfb_param_names=set(),
@@ -151,7 +225,7 @@ def test_acquired_block_used_by_compute_and_data_movement_is_rejected():
         """
     )
 
-    with pytest.raises(ValueError, match="multiple threads .*TRISC, NCRISC"):
+    with pytest.raises(ValueError, match="multiple logical kernels .*compute"):
         split_function_body(
             fn,
             dfb_param_names=set(),
@@ -159,8 +233,36 @@ def test_acquired_block_used_by_compute_and_data_movement_is_rejected():
         )
 
 
-def test_with_acquired_block_used_by_multiple_threads_is_rejected():
-    """The scoped DFB acquire form has the same single-thread requirement."""
+def test_store_assigns_source_and_destination_blocks_to_compute():
+    """A direct block store owns both DFB transactions on compute."""
+    fn = _fn(
+        """
+        def k():
+            source = source_dfb.wait()
+            destination = destination_dfb.reserve()
+            destination.store(source)
+            source.pop()
+            destination.push()
+        """
+    )
+
+    result = split_function_body(
+        fn,
+        dfb_param_names={"source_dfb", "destination_dfb"},
+    )
+
+    compute = _kind_src(result, KernelKind.COMPUTE)
+    data_movement = _kind_src(result, KernelKind.DATA_MOVEMENT)
+    assert "source_dfb.wait()" in compute
+    assert "destination_dfb.reserve()" in compute
+    assert "destination.store(source)" in compute
+    assert "source.pop()" in compute
+    assert "destination.push()" in compute
+    assert "source_dfb.wait()" not in data_movement
+
+
+def test_with_acquired_block_used_by_multiple_kernels_is_rejected():
+    """The scoped DFB acquire form has the same single-kernel requirement."""
     fn = _fn(
         """
         def k(x, out):
@@ -170,7 +272,7 @@ def test_with_acquired_block_used_by_multiple_threads_is_rejected():
         """
     )
 
-    with pytest.raises(ValueError, match="acquire statement resolves to multiple"):
+    with pytest.raises(ValueError, match="DFB block.*multiple logical kernels"):
         split_function_body(
             fn,
             dfb_param_names=set(),
@@ -196,7 +298,7 @@ def test_assigned_copy_transfer_handle_is_rejected():
 
 
 def test_chained_copy_wait_routes_to_data_movement():
-    """The supported non-assigned transfer wait remains on NCRISC."""
+    """The supported non-assigned transfer wait remains on data movement."""
     fn = _fn(
         """
         def k(x, out):
@@ -209,14 +311,12 @@ def test_chained_copy_wait_routes_to_data_movement():
         dfb_param_names=set(),
     )
 
-    assert "ttl.copy" not in _thread_src(result, "trisc")
-    assert "ttl.copy" in _thread_src(result, "ncrisc")
-    assert "ttl.copy" not in _thread_src(result, "brisc")
+    assert "ttl.copy" not in _kind_src(result, KernelKind.COMPUTE)
+    assert "ttl.copy" in _kind_src(result, KernelKind.DATA_MOVEMENT)
 
 
-def test_compute_and_dm_route_to_separate_threads():
-    """Copies land on NCRISC, the compute op on TRISC, and the unused
-    BRISC thread is empty."""
+def test_compute_and_data_movement_route_to_separate_logical_kernels():
+    """Copies and compute operations receive distinct logical kernels."""
     fn = _fn(
         """
         def k(a, out):
@@ -235,12 +335,310 @@ def test_compute_and_dm_route_to_separate_threads():
         local_dfb_names={"a_cb", "out_cb"},
     )
 
-    trisc = _thread_src(result, "trisc")
-    ncrisc = _thread_src(result, "ncrisc")
-    brisc = _thread_src(result, "brisc")
+    compute = _kind_src(result, KernelKind.COMPUTE)
+    data_movement = _kind_src(result, KernelKind.DATA_MOVEMENT)
 
-    assert "ttl.exp" in trisc
-    assert "ttl.copy" not in trisc
-    assert "ttl.copy" in ncrisc
-    assert "ttl.exp" not in ncrisc
-    assert brisc.strip() == "pass"
+    assert "ttl.exp" in compute
+    assert "ttl.copy" not in compute
+    assert "ttl.copy" in data_movement
+    assert "ttl.exp" not in data_movement
+
+
+def test_external_call_selects_canonical_compute_kernel():
+    """A kind selector emits an opaque call only in the canonical kernel."""
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func("compute.hpp", "compute", kernel=ttl.KernelKind.COMPUTE)
+        """
+    )
+
+    result = split_function_body(fn, dfb_param_names=set())
+
+    compute = _kernel_src(result, KernelKind.COMPUTE)
+    data_movement = _kernel_src(result, KernelKind.DATA_MOVEMENT)
+    assert "call_extern_func" in compute
+    assert "kernel=" not in compute
+    assert "call_extern_func" not in data_movement
+
+
+def test_direct_external_call_selects_canonical_data_movement_kernel():
+    """The directly imported call form accepts the same kind selector."""
+    fn = _fn(
+        """
+        def k():
+            call_extern_func(
+                "reader.hpp", "reader", kernel=KernelKind.DATA_MOVEMENT
+            )
+        """
+    )
+
+    result = split_function_body(fn, dfb_param_names=set())
+
+    compute = _kernel_src(result, KernelKind.COMPUTE)
+    data_movement = _kernel_src(result, KernelKind.DATA_MOVEMENT)
+    assert "call_extern_func" not in compute
+    assert "call_extern_func" in data_movement
+    assert "kernel=" not in data_movement
+
+
+def test_external_call_selects_named_logical_kernel():
+    """A logical handle distinguishes a noncanonical kernel of the same kind."""
+    reader = _logical_kernel(KernelKind.DATA_MOVEMENT, "reader")
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+        """
+    )
+
+    result = split_function_body(
+        fn,
+        dfb_param_names=set(),
+        logical_kernels={"reader": reader},
+    )
+
+    assert "call_extern_func" in _kernel_src(result, reader)
+    assert "call_extern_func" not in _kernel_src(result, KernelKind.DATA_MOVEMENT)
+
+
+def test_two_named_data_movement_kernels_remain_distinct():
+    """Two handles of one kind receive only their selected statements."""
+    reader = _logical_kernel(KernelKind.DATA_MOVEMENT, "reader")
+    writer = _logical_kernel(KernelKind.DATA_MOVEMENT, "writer")
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+            ttl.call_extern_func("writer.hpp", "writer", kernel=writer)
+        """
+    )
+
+    result = split_function_body(
+        fn,
+        dfb_param_names=set(),
+        logical_kernels={"reader": reader, "writer": writer},
+    )
+
+    reader_source = _kernel_src(result, reader)
+    writer_source = _kernel_src(result, writer)
+    assert "'reader'" in reader_source
+    assert "'writer'" not in reader_source
+    assert "'writer'" in writer_source
+    assert "'reader'" not in writer_source
+
+
+def test_external_call_tuple_selects_multiple_logical_kernels():
+    """An external tuple emits one stripped call in every selected kernel."""
+    reader = _logical_kernel(KernelKind.DATA_MOVEMENT, "reader")
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func(
+                "shared.hpp",
+                "shared",
+                kernel=(ttl.KernelKind.COMPUTE, reader),
+            )
+        """
+    )
+
+    result = split_function_body(
+        fn,
+        dfb_param_names=set(),
+        logical_kernels={"reader": reader},
+    )
+
+    for kernel in (KernelKind.COMPUTE, reader):
+        source = _kernel_src(result, kernel)
+        assert source.count("call_extern_func") == 1
+        assert "kernel=" not in source
+
+
+@pytest.mark.parametrize(
+    "selector, message",
+    [
+        ("()", "nonempty tuple"),
+        (
+            "(ttl.KernelKind.COMPUTE, ttl.KernelKind.COMPUTE)",
+            "duplicate kernel selector",
+        ),
+    ],
+)
+def test_external_call_rejects_invalid_selector_tuple(selector, message):
+    """External tuples must be nonempty and unique after canonicalization."""
+    fn = _fn(
+        f"""
+        def k():
+            ttl.call_extern_func("shared.hpp", "shared", kernel={selector})
+        """
+    )
+
+    with pytest.raises(ValueError, match=message):
+        split_function_body(fn, dfb_param_names=set())
+
+
+@pytest.mark.parametrize("method", ["push", "pop"])
+def test_release_rejects_tuple_selector(method):
+    """A DFB release executes once and therefore rejects tuple selection."""
+    acquire = "reserve" if method == "push" else "wait"
+    fn = _fn(
+        f"""
+        def k():
+            block = buffer.{acquire}()
+            block.{method}(kernel=(ttl.KernelKind.DATA_MOVEMENT,))
+        """
+    )
+
+    with pytest.raises(ValueError, match="accepts one kernel selector"):
+        split_function_body(
+            fn,
+            dfb_param_names={"buffer"},
+        )
+
+
+@pytest.mark.parametrize(
+    "acquire, release",
+    [("reserve", "push"), ("wait", "pop")],
+)
+def test_release_without_selector_retains_inferred_ownership(acquire, release):
+    """Argument-free releases retain ownership inferred from block uses."""
+    fn = _fn(
+        f"""
+        def k(source):
+            block = buffer.{acquire}()
+            ttl.copy(source, block).wait()
+            block.{release}()
+        """
+    )
+
+    result = split_function_body(fn, dfb_param_names={"buffer"})
+    data_movement = _kernel_src(result, KernelKind.DATA_MOVEMENT)
+    compute = _kernel_src(result, KernelKind.COMPUTE)
+    assert f"buffer.{acquire}()" in data_movement
+    assert f"block.{release}()" in data_movement
+    assert f"block.{release}()" not in compute
+
+
+@pytest.mark.parametrize(
+    "acquire, release",
+    [("reserve", "push"), ("wait", "pop")],
+)
+def test_otherwise_unused_block_accepts_explicit_release_owner(acquire, release):
+    """An explicit kind assigns an otherwise unreferenced DFB transaction."""
+    fn = _fn(
+        f"""
+        def k():
+            block = buffer.{acquire}()
+            block.{release}(kernel=ttl.KernelKind.DATA_MOVEMENT)
+        """
+    )
+
+    result = split_function_body(fn, dfb_param_names={"buffer"})
+    data_movement = _kernel_src(result, KernelKind.DATA_MOVEMENT)
+    compute = _kernel_src(result, KernelKind.COMPUTE)
+    assert f"buffer.{acquire}()" in data_movement
+    assert f"block.{release}()" in data_movement
+    assert "kernel=" not in data_movement
+    assert f"buffer.{acquire}()" not in compute
+
+
+def test_explicit_release_conflicting_with_inferred_owner_is_rejected():
+    """Explicit and inferred DFB release ownership must agree."""
+    fn = _fn(
+        """
+        def k(value):
+            block = buffer.reserve()
+            block.store(value)
+            block.push(kernel=ttl.KernelKind.DATA_MOVEMENT)
+        """
+    )
+
+    with pytest.raises(ValueError, match="explicit.*data_movement.*inferred.*compute"):
+        split_function_body(fn, dfb_param_names={"buffer"})
+
+
+def test_external_call_requires_inferred_or_explicit_kernel():
+    """An unselected top-level opaque call is never cloned speculatively."""
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func("opaque.hpp", "opaque")
+        """
+    )
+
+    with pytest.raises(ValueError, match="call_extern_func.*kernel selector"):
+        split_function_body(fn, dfb_param_names=set())
+
+
+@pytest.mark.parametrize("selector", ["42", "selected_kernel()"])
+def test_external_call_rejects_nonconstant_selector(selector):
+    """Only enum members and lifted logical handles are valid selectors."""
+    fn = _fn(
+        f"""
+        def k():
+            ttl.call_extern_func("opaque.hpp", "opaque", kernel={selector})
+        """
+    )
+
+    with pytest.raises(ValueError, match="KernelKind or Kernel"):
+        split_function_body(fn, dfb_param_names=set())
+
+
+def test_selector_tuple_order_does_not_change_kernel_order():
+    """Canonical kernel ordering is independent of selector tuple order."""
+    reader = _logical_kernel(KernelKind.DATA_MOVEMENT, "reader")
+    writer = _logical_kernel(KernelKind.DATA_MOVEMENT, "writer")
+    logical_kernels = {"reader": reader, "writer": writer}
+    first = _fn(
+        """
+        def k():
+            ttl.call_extern_func("shared.hpp", "shared", kernel=(reader, writer))
+        """
+    )
+    second = _fn(
+        """
+        def k():
+            ttl.call_extern_func("shared.hpp", "shared", kernel=(writer, reader))
+        """
+    )
+
+    first_result = split_function_body(
+        first, dfb_param_names=set(), logical_kernels=logical_kernels
+    )
+    second_result = split_function_body(
+        second, dfb_param_names=set(), logical_kernels=logical_kernels
+    )
+
+    assert first_result.kernels == second_result.kernels
+    assert [_kernel_src(first_result, kernel) for kernel in first_result.kernels] == [
+        _kernel_src(second_result, kernel) for kernel in second_result.kernels
+    ]
+
+
+def test_logical_kernel_capacity_uses_supplied_target_limit():
+    """Capacity diagnostics use backend-provided limits for each kernel kind."""
+    readers = {
+        name: _logical_kernel(KernelKind.DATA_MOVEMENT, name)
+        for name in ("first", "second")
+    }
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func("first.hpp", "first", kernel=first)
+            ttl.call_extern_func("second.hpp", "second", kernel=second)
+        """
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="2 data_movement kernels.*target supports 1",
+    ):
+        split_function_body(
+            fn,
+            dfb_param_names=set(),
+            logical_kernels=readers,
+            kernel_capacities={
+                KernelKind.COMPUTE: 1,
+                KernelKind.DATA_MOVEMENT: 1,
+            },
+        )

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -21,6 +21,7 @@ from ttl._src.atom_split import split_function_body
 from ttl.atom import (
     _assign_backend_kernel_slots,
     _backend_kernel_capacities,
+    _build_atom_spec,
     _lift_setup,
 )
 from ttl.kernel import Kernel, KernelKind
@@ -46,7 +47,7 @@ def _kind_src(result, kind: KernelKind, index: int = 0) -> str:
 
 
 def _logical_kernel(kind: KernelKind, name: str) -> Kernel:
-    return Kernel(kind)._bind(name)
+    return Kernel(kind)._bind(name, "test.operation")
 
 
 def test_kernel_resource_is_lifted_before_logical_split():
@@ -59,7 +60,11 @@ def test_kernel_resource_is_lifted_before_logical_split():
         """
     )
 
-    stripped, dfbs, nets, logical_kernels = _lift_setup(function, {"ttl": ttl})
+    stripped, dfbs, nets, logical_kernels = _lift_setup(
+        function,
+        {"ttl": ttl},
+        "test.operation",
+    )
 
     assert not dfbs
     assert not nets
@@ -76,6 +81,69 @@ def test_kernel_resource_is_lifted_before_logical_split():
     )
     assignments = _assign_backend_kernel_slots(result)
     assert tuple(assignments.values()) == (reader,)
+
+
+def test_captured_kernel_is_bound_for_final_operation():
+    """Registration binds the captured source handle in place."""
+    reader = Kernel(KernelKind.DATA_MOVEMENT)
+
+    def operation():
+        ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+
+    spec = _build_atom_spec(operation)
+
+    assert spec.logical_kernels["reader"] is reader
+    assert reader.identity == "reader"
+    assert reader._operation_identity == spec.operation_identity
+
+    result = split_function_body(
+        spec.fn_ast,
+        dfb_param_names=set(),
+        logical_kernels=spec.logical_kernels,
+        kernel_capacities=_backend_kernel_capacities(),
+    )
+    assert result.kernels == (reader,)
+
+
+def test_captured_kernel_cannot_bind_to_two_operations():
+    """One public handle has one operation-local binding."""
+    sender = Kernel(KernelKind.DATA_MOVEMENT)
+
+    def first_operation():
+        ttl.call_extern_func("first.hpp", "first", kernel=sender)
+
+    first_spec = _build_atom_spec(first_operation)
+    assert sender._operation_identity == first_spec.operation_identity
+
+    def second_operation():
+        ttl.call_extern_func("second.hpp", "second", kernel=sender)
+
+    with pytest.raises(ValueError, match="already bound"):
+        _build_atom_spec(second_operation)
+
+
+def test_captured_kernel_cannot_have_two_names():
+    """Alias validation completes before the handle is bound."""
+    reader = Kernel(KernelKind.DATA_MOVEMENT)
+    reader_alias = reader
+
+    def operation():
+        ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+        ttl.call_extern_func("reader.hpp", "reader", kernel=reader_alias)
+
+    with pytest.raises(ValueError, match="multiple names"):
+        _build_atom_spec(operation)
+    with pytest.raises(ValueError, match="no operation-local identity"):
+        reader.identity
+
+
+def test_bound_kernel_equality_uses_logical_identity():
+    """Equivalent bindings compare equally without object-address identity."""
+    first = Kernel(KernelKind.DATA_MOVEMENT)._bind("reader", "operation")
+    second = Kernel(KernelKind.DATA_MOVEMENT)._bind("reader", "operation")
+
+    assert first == second
+    assert hash(first) == hash(second)
 
 
 def test_split_analysis_does_not_mutate_input_ast():

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -12,6 +12,7 @@ split-time error paths for ambiguous kernel ownership and the basic
 compute/data-movement routing."""
 
 import ast
+import copy
 import textwrap
 
 import pytest
@@ -47,7 +48,9 @@ def _kind_src(result, kind: KernelKind, index: int = 0) -> str:
 
 
 def _logical_kernel(kind: KernelKind, name: str) -> Kernel:
-    return Kernel(kind)._bind(name, "test.operation")
+    kernel = Kernel(kind)
+    kernel._bind(name, "test.operation")
+    return kernel
 
 
 def test_kernel_resource_is_lifted_before_logical_split():
@@ -137,10 +140,93 @@ def test_captured_kernel_cannot_have_two_names():
         reader.identity
 
 
+def test_composition_copies_captured_kernel_into_final_operation():
+    """A composed capture receives a fresh identity owned by the caller."""
+    reader = Kernel(KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation()
+    def selected_callee():
+        ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+
+    @ttl.operation(grid=(1, 1))
+    def selected_caller():
+        selected_callee()
+
+    spec = selected_caller._spec
+    assert len(spec.logical_kernels) == 1
+    inlined_reader = next(iter(spec.logical_kernels.values()))
+    assert inlined_reader is not reader
+    assert inlined_reader.identity.startswith("reader__selected_callee_inl_")
+    assert inlined_reader._operation_identity == spec.operation_identity
+
+    result = split_function_body(
+        spec.fn_ast,
+        dfb_param_names=set(),
+        logical_kernels=spec.logical_kernels,
+        kernel_capacities=_backend_kernel_capacities(),
+    )
+    assert result.kernels == (inlined_reader,)
+
+
+def test_composition_kernel_suffix_is_stable_across_caller_registration():
+    """Earlier composition in the process does not change the suffix."""
+    reader = Kernel(KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation()
+    def selected_callee():
+        ttl.call_extern_func("reader.hpp", "reader", kernel=reader)
+
+    @ttl.operation(grid=(1, 1))
+    def first_caller():
+        selected_callee()
+
+    @ttl.operation(grid=(1, 1))
+    def second_caller():
+        selected_callee()
+
+    first_name = next(iter(first_caller._spec.logical_kernels))
+    second_name = next(iter(second_caller._spec.logical_kernels))
+    assert first_name == second_name
+
+
+def test_composition_preserves_body_local_kernel_declaration():
+    """An inlined local declaration is renamed and rebound to the caller."""
+
+    @ttl.operation()
+    def selected_callee():
+        local_reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+        ttl.call_extern_func("reader.hpp", "reader", kernel=local_reader)
+
+    @ttl.operation(grid=(1, 1))
+    def selected_caller():
+        selected_callee()
+
+    spec = selected_caller._spec
+    stripped, _, _, logical_kernels = _lift_setup(
+        copy.deepcopy(spec.fn_ast),
+        spec.frozen_scope,
+        spec.operation_identity,
+    )
+    assert len(logical_kernels) == 1
+    local_name, local_reader = next(iter(logical_kernels.items()))
+    assert local_name.startswith("local_reader__selected_callee_inl_")
+    assert local_reader._operation_identity == spec.operation_identity
+
+    result = split_function_body(
+        stripped,
+        dfb_param_names=set(),
+        logical_kernels=logical_kernels,
+        kernel_capacities=_backend_kernel_capacities(),
+    )
+    assert result.kernels == (local_reader,)
+
+
 def test_bound_kernel_equality_uses_logical_identity():
     """Equivalent bindings compare equally without object-address identity."""
-    first = Kernel(KernelKind.DATA_MOVEMENT)._bind("reader", "operation")
-    second = Kernel(KernelKind.DATA_MOVEMENT)._bind("reader", "operation")
+    first = Kernel(KernelKind.DATA_MOVEMENT)
+    second = Kernel(KernelKind.DATA_MOVEMENT)
+    first._bind("reader", "operation")
+    second._bind("reader", "operation")
 
     assert first == second
     assert hash(first) == hash(second)
@@ -564,6 +650,61 @@ def test_release_rejects_tuple_selector(method):
         )
 
 
+@pytest.mark.parametrize("acquire", ["reserve", "wait"])
+@pytest.mark.parametrize("form", ["assign", "with"])
+def test_acquire_rejects_kernel_selector(acquire, form):
+    """DFB acquisition ownership cannot be selected directly."""
+    if form == "assign":
+        source = f"""
+            def k():
+                block = buffer.{acquire}(kernel=ttl.KernelKind.DATA_MOVEMENT)
+        """
+    else:
+        source = f"""
+            def k():
+                with buffer.{acquire}(
+                    kernel=ttl.KernelKind.DATA_MOVEMENT
+                ) as block:
+                    block.pop()
+        """
+    fn = _fn(source)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"kernel= is not supported on DFB {acquire}\(\)",
+    ):
+        split_function_body(fn, dfb_param_names={"buffer"})
+
+
+@pytest.mark.parametrize("acquire", ["reserve", "wait"])
+@pytest.mark.parametrize(
+    "selector",
+    [
+        "ttl.KernelKind.COMPUTE",
+        "named_compute",
+        "(ttl.KernelKind.DATA_MOVEMENT, ttl.KernelKind.COMPUTE)",
+    ],
+)
+def test_acquire_block_rejects_nested_selection_outside_owner(acquire, selector):
+    """A selected nested statement must execute with its DFB acquire."""
+    named_compute = _logical_kernel(KernelKind.COMPUTE, "named_compute")
+    fn = _fn(
+        f"""
+        def k(inp):
+            with buffer.{acquire}() as block:
+                ttl.copy(inp, block).wait()
+                ttl.call_extern_func("compute.hpp", "compute", kernel={selector})
+        """
+    )
+
+    with pytest.raises(ValueError, match="outside its enclosing DFB acquire owner"):
+        split_function_body(
+            fn,
+            dfb_param_names={"buffer"},
+            logical_kernels={"named_compute": named_compute},
+        )
+
+
 @pytest.mark.parametrize(
     "acquire, release",
     [("reserve", "push"), ("wait", "pop")],
@@ -652,6 +793,47 @@ def test_external_call_rejects_nonconstant_selector(selector):
         split_function_body(fn, dfb_param_names=set())
 
 
+def test_external_call_accepts_kernel_kind_import_alias():
+    """Selector resolution uses the frozen value rather than its spelling."""
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func("compute.hpp", "compute", kernel=KK.COMPUTE)
+        """
+    )
+
+    result = split_function_body(
+        fn,
+        dfb_param_names=set(),
+        selector_scope={"KK": KernelKind},
+    )
+
+    assert result.kernels == (KernelKind.COMPUTE,)
+
+
+def test_external_call_respects_rebound_kernel_kind_name():
+    """A rebound name is not interpreted as the public selector enum."""
+
+    class ReboundKernelKind:
+        COMPUTE = 42
+
+    fn = _fn(
+        """
+        def k():
+            ttl.call_extern_func(
+                "compute.hpp", "compute", kernel=KernelKind.COMPUTE
+            )
+        """
+    )
+
+    with pytest.raises(ValueError, match="KernelKind or Kernel.*got int"):
+        split_function_body(
+            fn,
+            dfb_param_names=set(),
+            selector_scope={"KernelKind": ReboundKernelKind},
+        )
+
+
 def test_selector_tuple_order_does_not_change_kernel_order():
     """Canonical kernel ordering is independent of selector tuple order."""
     reader = _logical_kernel(KernelKind.DATA_MOVEMENT, "reader")
@@ -710,3 +892,30 @@ def test_logical_kernel_capacity_uses_supplied_target_limit():
                 KernelKind.DATA_MOVEMENT: 1,
             },
         )
+
+
+def test_kernel_capacity_diagnostic_names_conflicts_at_last_introduction():
+    """Capacity failures identify the selected kernels and later statement."""
+    extra_compute = _logical_kernel(KernelKind.COMPUTE, "extra_compute")
+    fn = _fn(
+        """
+        def k(value):
+            ttl.call_extern_func("compute.hpp", "compute", kernel=extra_compute)
+            ttl.fill(value)
+        """
+    )
+
+    with pytest.raises(ValueError) as error:
+        split_function_body(
+            fn,
+            dfb_param_names=set(),
+            logical_kernels={"extra_compute": extra_compute},
+            kernel_capacities={
+                KernelKind.COMPUTE: 1,
+                KernelKind.DATA_MOVEMENT: 2,
+            },
+        )
+
+    message = str(error.value)
+    assert "selected kernels: compute, compute kernel 'extra_compute'" in message
+    assert "(line 4)" in message

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -922,6 +922,33 @@ def test_selector_tuple_order_does_not_change_kernel_order():
     ]
 
 
+def test_named_kernel_order_uses_operation_identity_to_break_name_ties():
+    """Distinct operations provide a total order for same-named kernels."""
+    operation_b_reader = Kernel(KernelKind.DATA_MOVEMENT)
+    operation_b_reader._bind("reader", "operation.b")
+    operation_a_reader = Kernel(KernelKind.DATA_MOVEMENT)
+    operation_a_reader._bind("reader", "operation.a")
+    function = _fn(
+        """
+        def k():
+            ttl.call_extern_func("reader.hpp", "b", kernel=operation_b_reader)
+            ttl.call_extern_func("reader.hpp", "a", kernel=operation_a_reader)
+        """
+    )
+
+    result = split_function_body(
+        function,
+        dfb_param_names=set(),
+        logical_kernels={
+            "operation_b_reader": operation_b_reader,
+            "operation_a_reader": operation_a_reader,
+        },
+    )
+
+    assert result.kernels == (operation_a_reader, operation_b_reader)
+    assert tuple(_assign_backend_kernel_slots(result).values()) == result.kernels
+
+
 def test_logical_kernel_capacity_uses_supplied_target_limit():
     """Capacity diagnostics use backend-provided limits for each kernel kind."""
     readers = {

--- a/test/python/atom/test_explicit_kernel.py
+++ b/test/python/atom/test_explicit_kernel.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python -m pytest %s -v
+
+"""Off-device tests for logical selectors on explicit kernel decorators."""
+
+import pytest
+import ttl
+
+from ttl.ttl_api import (
+    _clear_thread_registry,
+    _get_registered_threads,
+    _validate_explicit_logical_kernel_uses,
+)
+
+
+def test_explicit_operation_binds_captured_kernel_declaration():
+    """Operation registration binds the name used by a thread decorator."""
+    data_movement_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(1, 1))
+    def explicit_operation(inp):
+        @ttl.compute()
+        def compute_thread():
+            pass
+
+        @ttl.datamovement(kernel=data_movement_kernel)
+        def data_movement_thread():
+            pass
+
+    assert data_movement_kernel.identity == "data_movement_kernel"
+    assert data_movement_kernel._operation_identity == (
+        f"{__name__}.test_explicit_operation_binds_captured_kernel_declaration"
+        ".<locals>.explicit_operation"
+    )
+
+    _clear_thread_registry()
+    explicit_operation.__wrapped__(object())
+    threads = _get_registered_threads()
+    assert [thread._logical_kernel for thread in threads] == [
+        ttl.KernelKind.COMPUTE,
+        data_movement_kernel,
+    ]
+
+
+def test_explicit_kernel_decorator_rejects_wrong_kind():
+    """A thread decorator requires a selector of its declared kind."""
+    with pytest.raises(
+        ValueError,
+        match="compute thread kernel kind must be compute, got data_movement",
+    ):
+
+        @ttl.compute(kernel=ttl.KernelKind.DATA_MOVEMENT)
+        def compute_thread():
+            pass
+
+
+def test_explicit_kernel_decorator_rejects_invalid_type():
+    """A thread decorator accepts only one logical selector."""
+    with pytest.raises(
+        TypeError,
+        match="kernel must be a KernelKind or Kernel, got tuple",
+    ):
+
+        @ttl.datamovement(kernel=(ttl.KernelKind.DATA_MOVEMENT,))
+        def data_movement_thread():
+            pass
+
+
+def test_explicit_threads_reject_reused_named_kernel():
+    """One named logical identity cannot denote two explicit threads."""
+    shared_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(1, 1))
+    def explicit_operation(inp):
+        @ttl.datamovement(kernel=shared_kernel)
+        def reader_thread():
+            pass
+
+        @ttl.datamovement(kernel=shared_kernel)
+        def writer_thread():
+            pass
+
+    _clear_thread_registry()
+    explicit_operation.__wrapped__(object())
+    threads = _get_registered_threads()
+    with pytest.raises(
+        ValueError,
+        match=(
+            "logical Kernel 'shared_kernel' is selected by multiple explicit "
+            "threads: 'reader_thread' and 'writer_thread'"
+        ),
+    ):
+        _validate_explicit_logical_kernel_uses(threads)

--- a/test/python/atom/test_explicit_kernel.py
+++ b/test/python/atom/test_explicit_kernel.py
@@ -31,9 +31,9 @@ def test_explicit_operation_binds_captured_kernel_declaration():
             pass
 
     assert data_movement_kernel.identity == "data_movement_kernel"
-    assert data_movement_kernel._operation_identity == (
+    assert data_movement_kernel._operation_identity.startswith(
         f"{__name__}.test_explicit_operation_binds_captured_kernel_declaration"
-        ".<locals>.explicit_operation"
+        ".<locals>.explicit_operation[captures="
     )
 
     _clear_thread_registry()

--- a/test/python/atom/test_explicit_kernel.py
+++ b/test/python/atom/test_explicit_kernel.py
@@ -94,3 +94,32 @@ def test_explicit_threads_reject_reused_named_kernel():
         ),
     ):
         _validate_explicit_logical_kernel_uses(threads)
+
+
+def test_explicit_threads_use_target_kernel_capacity_diagnostic():
+    """Explicit threads report the same logical capacity terms as splitting."""
+    _clear_thread_registry()
+
+    @ttl.compute()
+    def first_compute():
+        pass
+
+    @ttl.compute()
+    def second_compute():
+        pass
+
+    threads = _get_registered_threads()
+    with pytest.raises(
+        ValueError,
+        match=(
+            "operation requires 2 compute kernels, but the target supports 1; "
+            "selected kernels: compute, compute"
+        ),
+    ):
+        _validate_explicit_logical_kernel_uses(
+            threads,
+            {
+                ttl.KernelKind.COMPUTE: 1,
+                ttl.KernelKind.DATA_MOVEMENT: 2,
+            },
+        )

--- a/test/python/atom/test_explicit_kernel.py
+++ b/test/python/atom/test_explicit_kernel.py
@@ -57,6 +57,20 @@ def test_explicit_kernel_decorator_rejects_wrong_kind():
             pass
 
 
+def test_explicit_kernel_decorator_rejects_wrong_named_kernel_kind():
+    """A named selector's kind must match its thread decorator."""
+    data_movement_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    with pytest.raises(
+        ValueError,
+        match="compute thread kernel kind must be compute, got data_movement",
+    ):
+
+        @ttl.compute(kernel=data_movement_kernel)
+        def compute_thread():
+            pass
+
+
 def test_explicit_kernel_decorator_rejects_invalid_type():
     """A thread decorator accepts only one logical selector."""
     with pytest.raises(

--- a/test/python/atom/test_kernel_metadata.py
+++ b/test/python/atom/test_kernel_metadata.py
@@ -31,9 +31,7 @@ def logical_kernel_module():
 
 
 def test_recovers_canonical_kernel_kind(logical_kernel_module):
-    recovered = _get_kernel_logical_selector(
-        logical_kernel_module, "canonical_compute"
-    )
+    recovered = _get_kernel_logical_selector(logical_kernel_module, "canonical_compute")
     assert recovered is KernelKind.COMPUTE
 
 

--- a/test/python/atom/test_kernel_metadata.py
+++ b/test/python/atom/test_kernel_metadata.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Off-device tests for logical-kernel metadata recovery from MLIR."""
+
+import pytest
+
+from ttl.dialects import ttl as ttl_dialect
+from ttl.ir import Context, Module
+from ttl.kernel import Kernel, KernelKind
+from ttl.ttl_api import _get_kernel_logical_selector
+
+
+_LOGICAL_KERNEL_MODULE = """
+module {
+  func.func @canonical_compute() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = compute>} { return }
+  func.func @named_dm() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "mod.op">} { return }
+  func.func @role_dm() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<pipe_source>", role = "pipe_source">} { return }
+  func.func @no_attribute() { return }
+  func.func @wrong_type() attributes {ttl.logical_kernel = "not an attribute"} { return }
+}
+"""
+
+
+@pytest.fixture
+def logical_kernel_module():
+    context = Context()
+    ttl_dialect.ensure_dialects_registered(context)
+    return Module.parse(_LOGICAL_KERNEL_MODULE, context)
+
+
+def test_recovers_canonical_kernel_kind(logical_kernel_module):
+    recovered = _get_kernel_logical_selector(
+        logical_kernel_module, "canonical_compute"
+    )
+    assert recovered is KernelKind.COMPUTE
+
+
+def test_recovers_named_kernel_identity(logical_kernel_module):
+    recovered = _get_kernel_logical_selector(logical_kernel_module, "named_dm")
+    expected = Kernel._from_metadata(KernelKind.DATA_MOVEMENT, "reader", "mod.op")
+    assert recovered == expected
+
+
+def test_recovers_implicit_kernel_role(logical_kernel_module):
+    recovered = _get_kernel_logical_selector(logical_kernel_module, "role_dm")
+    expected = Kernel._from_metadata(
+        KernelKind.DATA_MOVEMENT,
+        "<pipe_source>",
+        operation_identity=None,
+        implicit_role="pipe_source",
+    )
+    assert recovered == expected
+
+
+def test_missing_logical_kernel_metadata_returns_none(logical_kernel_module):
+    assert _get_kernel_logical_selector(logical_kernel_module, "no_attribute") is None
+
+
+def test_wrong_logical_kernel_attribute_type_is_rejected(logical_kernel_module):
+    with pytest.raises(ValueError, match="Invalid 'ttl.logical_kernel'"):
+        _get_kernel_logical_selector(logical_kernel_module, "wrong_type")

--- a/test/python/atom/test_kernel_spec_identity.py
+++ b/test/python/atom/test_kernel_spec_identity.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python -m pytest %s -v
+
+"""Every synthesized backend kernel reaches KernelSpec with a logical identity.
+
+A unified operation always emits one kernel per backend slot, including the
+mandatory empty ones the plan never assigned. Runtime resources select kernels by
+logical identity, so an empty kernel must still carry one.
+"""
+
+import inspect
+
+import pytest
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import torch  # noqa: E402
+import ttl  # noqa: E402
+from ttl.kernel_runner import KernelSpec  # noqa: E402
+
+HEADER = "/dev/null/fake_shim.hpp"
+
+
+def _compiled_kernel(operation):
+    """Return the single compiled artifact cached by an operation wrapper."""
+    cache = inspect.getclosurevars(operation._wrapper).nonlocals["cache"]
+    assert len(cache) == 1
+    return next(iter(cache.values()))
+
+
+def _kernel_specs(compiled):
+    """Rebuild the specs the runner hands to the device, without a device."""
+    return [
+        KernelSpec(
+            path=path,
+            thread_type=thread_type,
+            tensor_indices=compiled.kernel_tensor_indices[index],
+            config=compiled.kernel_configs[index],
+            logical_kernel=compiled.kernel_logical_selectors[index],
+        )
+        for index, (path, thread_type) in enumerate(compiled.kernel_paths)
+    ]
+
+
+def test_every_emitted_kernel_spec_has_a_logical_identity(monkeypatch):
+    """One explicit selector still leaves every other slot identifiable."""
+    monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")
+    reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(1, 1))
+    def single_selected_reader(inp):
+        ttl.call_extern_func(HEADER, "reader_entry", kernel=reader)
+
+    single_selected_reader(
+        ttnn.from_torch(
+            torch.zeros((32, 32), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+    )
+
+    specs = _kernel_specs(_compiled_kernel(single_selected_reader))
+
+    assert specs
+    assert all(spec.logical_kernel is not None for spec in specs)
+    assert [spec.logical_kernel for spec in specs].count(reader) == 1

--- a/test/python/composed_factory_kernel_selection.py
+++ b/test/python/composed_factory_kernel_selection.py
@@ -54,7 +54,7 @@ def selected_caller(inp):
 # CALLS-DAG: ttl.opaque_call "second_entry"
 
 # SPECIALIZED-LABEL: func.func @selected_caller__ncrisc()
-# SPECIALIZED-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "__main__.make_helper.<locals>.selected_helper[captures=0fd3119a74cbacf9]">
+# SPECIALIZED-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "__main__.make_helper.<locals>.selected_helper[captures=6142f2ea4f753c85]">
 # SPECIALIZED-NEXT: emitc.call_opaque "second_entry"
 
 

--- a/test/python/composed_factory_kernel_selection.py
+++ b/test/python/composed_factory_kernel_selection.py
@@ -6,6 +6,10 @@
 # RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
 # RUN: FileCheck %s --check-prefix=IDENTITY < %t.initial.mlir
 # RUN: FileCheck %s --check-prefix=CALLS < %t.initial.mlir
+# RUN: env PYTHONHASHSEED=0 TTLANG_COMPILE_ONLY=1 TTLANG_FINAL_MLIR=%t.seed0.mlir TTLANG_COMPILER_OPTIONS=--ttl-specialize-cores %python %s > %t.seed0.output 2>&1
+# RUN: FileCheck %s --check-prefix=SPECIALIZED < %t.seed0.mlir
+# RUN: env PYTHONHASHSEED=12345 TTLANG_COMPILE_ONLY=1 TTLANG_FINAL_MLIR=%t.seed12345.mlir TTLANG_COMPILER_OPTIONS=--ttl-specialize-cores %python %s > %t.seed12345.output 2>&1
+# RUN: FileCheck %s --check-prefix=SPECIALIZED < %t.seed12345.mlir
 
 """Compile distinct factory instances without merging their logical kernels."""
 
@@ -48,6 +52,10 @@ def selected_caller(inp):
 # CALLS-DAG: ttl.opaque_call "first_entry"
 # CALLS-DAG: ttl.opaque_call "first_entry"
 # CALLS-DAG: ttl.opaque_call "second_entry"
+
+# SPECIALIZED-LABEL: func.func @selected_caller__ncrisc()
+# SPECIALIZED-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "__main__.make_helper.<locals>.selected_helper[captures=0fd3119a74cbacf9]">
+# SPECIALIZED-NEXT: emitc.call_opaque "second_entry"
 
 
 if __name__ == "__main__":

--- a/test/python/composed_factory_kernel_selection.py
+++ b/test/python/composed_factory_kernel_selection.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
+# RUN: FileCheck %s --check-prefix=IDENTITY < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CALLS < %t.initial.mlir
+
+"""Compile distinct factory instances without merging their logical kernels."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+
+
+def make_helper(entry):
+    reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation()
+    def selected_helper(inp):
+        ttl.call_extern_func(FAKE_HEADER, entry, kernel=reader)
+
+    return selected_helper
+
+
+first_helper = make_helper("first_entry")
+second_helper = make_helper("second_entry")
+
+
+@ttl.operation(grid=(1, 1))
+def selected_caller(inp):
+    first_helper(inp)
+    first_helper(inp)
+    second_helper(inp)
+
+
+# IDENTITY-COUNT-2: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "__main__.make_helper.<locals>.selected_helper[captures={{[0-9a-f]+}}]">
+# IDENTITY-NOT: ttl.logical_kernel = #ttl.logical_kernel<{{.*}}_inl_
+
+# CALLS-DAG: ttl.opaque_call "first_entry"
+# CALLS-DAG: ttl.opaque_call "first_entry"
+# CALLS-DAG: ttl.opaque_call "second_entry"
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    selected_caller(inp)

--- a/test/python/composed_kernel_selection.py
+++ b/test/python/composed_kernel_selection.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
+# RUN: FileCheck %s < %t.initial.mlir
+
+"""Compile repeated composition with one callee-owned logical kernel."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+
+@ttl.operation()
+def selected_helper(inp):
+    ttl.call_extern_func(FAKE_HEADER, "reader_entry", kernel=reader)
+
+
+@ttl.operation(grid=(1, 1))
+def selected_caller(inp):
+    selected_helper(inp)
+    selected_helper(inp)
+    selected_helper(inp)
+
+
+# CHECK-LABEL: func.func @selected_caller__ncrisc
+# CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "__main__.selected_helper">
+# CHECK-COUNT-3: ttl.opaque_call "reader_entry"
+# CHECK-NOT: ttl.logical_kernel = #ttl.logical_kernel<{{.*}}_inl_
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    selected_caller(inp)

--- a/test/python/explicit_kernel_selection.py
+++ b/test/python/explicit_kernel_selection.py
@@ -36,20 +36,20 @@ def explicit_selected_add(inp, out):
             output_block.store(input_block + input_block)
         else:
             output_block.store(input_block)
-        input_block.pop()
-        output_block.push()
+        input_block.pop(kernel=compute_kernel)
+        output_block.push(kernel=compute_kernel)
 
     @ttl.datamovement(kernel=reader_kernel)
     def reader_thread():
         input_block = input_dfb.reserve()
         ttl.copy(inp[0, 0], input_block).wait()
-        input_block.push()
+        input_block.push(kernel=reader_kernel)
 
     @ttl.datamovement()
     def writer_thread():
         output_block = output_dfb.wait()
         ttl.copy(output_block, out[0, 0]).wait()
-        output_block.pop()
+        output_block.pop(kernel=ttl.KernelKind.DATA_MOVEMENT)
 
 
 # CHECK-LABEL: func.func @compute_thread

--- a/test/python/explicit_kernel_selection.py
+++ b/test/python/explicit_kernel_selection.py
@@ -29,9 +29,13 @@ def explicit_selected_add(inp, out):
 
     @ttl.compute(kernel=compute_kernel)
     def compute_thread():
+        core_x, _ = ttl.node(dims=2)
         input_block = input_dfb.wait()
         output_block = output_dfb.reserve()
-        output_block.store(input_block + input_block)
+        if core_x == 0:
+            output_block.store(input_block + input_block)
+        else:
+            output_block.store(input_block)
         input_block.pop()
         output_block.push()
 
@@ -55,7 +59,12 @@ def explicit_selected_add(inp, out):
 # CHECK-LABEL: func.func @writer_thread
 # CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>
 
-# SPECIALIZED: ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute_kernel", operation = "__main__.explicit_selected_add">
+# SPECIALIZED-LABEL: func.func @compute_thread_c0_0
+# SPECIALIZED-SAME: ttl.core_coord = {{\[\[}}0, 0]]
+# SPECIALIZED-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute_kernel", operation = "__main__.explicit_selected_add">
+# SPECIALIZED-LABEL: func.func @compute_thread_c1_0
+# SPECIALIZED-SAME: ttl.core_coord = {{\[\[}}1, 0]]
+# SPECIALIZED-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute_kernel", operation = "__main__.explicit_selected_add">
 # SPECIALIZED: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader_kernel", operation = "__main__.explicit_selected_add">
 # SPECIALIZED: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>
 

--- a/test/python/explicit_kernel_selection.py
+++ b/test/python/explicit_kernel_selection.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
+# RUN: FileCheck %s < %t.initial.mlir
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_FINAL_MLIR=%t.final.mlir TTLANG_COMPILER_OPTIONS=--ttl-specialize-cores %python %s > %t.specialized.output 2>&1
+# RUN: FileCheck %s --check-prefix=SPECIALIZED < %t.final.mlir
+
+"""Compile explicit thread decorators with named logical kernel selectors."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+
+@ttl.operation(grid=(2, 1))
+def explicit_selected_add(inp, out):
+    input_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
+    output_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=1)
+
+    @ttl.compute(kernel=compute_kernel)
+    def compute_thread():
+        input_block = input_dfb.wait()
+        output_block = output_dfb.reserve()
+        output_block.store(input_block + input_block)
+        input_block.pop()
+        output_block.push()
+
+    @ttl.datamovement(kernel=reader_kernel)
+    def reader_thread():
+        input_block = input_dfb.reserve()
+        ttl.copy(inp[0, 0], input_block).wait()
+        input_block.push()
+
+    @ttl.datamovement()
+    def writer_thread():
+        output_block = output_dfb.wait()
+        ttl.copy(output_block, out[0, 0]).wait()
+        output_block.pop()
+
+
+# CHECK-LABEL: func.func @compute_thread
+# CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute_kernel", operation = "__main__.explicit_selected_add">
+# CHECK-LABEL: func.func @reader_thread
+# CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader_kernel", operation = "__main__.explicit_selected_add">
+# CHECK-LABEL: func.func @writer_thread
+# CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>
+
+# SPECIALIZED: ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute_kernel", operation = "__main__.explicit_selected_add">
+# SPECIALIZED: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader_kernel", operation = "__main__.explicit_selected_add">
+# SPECIALIZED: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    out = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    explicit_selected_add(inp, out)

--- a/test/python/include/raw_address_capture.hpp
+++ b/test/python/include/raw_address_capture.hpp
@@ -49,3 +49,19 @@ inline void raw_address_capture_unified(uint32_t tensor_address,
   (void)output_address;
 #endif
 }
+
+template <typename Drain, uint32_t WordCount>
+inline void raw_address_capture_selected(uint32_t tensor_address,
+                                         uint32_t output_address) {
+#if defined(COMPILE_FOR_TRISC)
+  raw_address_capture_compute<WordCount>(tensor_address, output_address);
+#else
+  auto *output =
+      reinterpret_cast<volatile tt_l1_ptr uint32_t *>(output_address);
+  for (uint32_t word_index = 0; word_index < WordCount; ++word_index) {
+    output[WordCount + word_index] = ~tensor_address;
+  }
+  cb_reserve_back(Drain::index, Drain::pages_per_block);
+  cb_push_back(Drain::index, Drain::pages_per_block);
+#endif
+}

--- a/test/python/invalid/acquire_kernel_selector_invalid.py
+++ b/test/python/invalid/acquire_kernel_selector_invalid.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Reject logical-kernel selection on a DFB acquisition."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+
+# CHECK: kernel= is not supported on DFB reserve(); select release ownership on push() or pop()
+@ttl.operation(grid=(1, 1))
+def invalid_acquire_selector(inp):
+    output_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
+    output_dfb.reserve(kernel=ttl.KernelKind.COMPUTE)
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_acquire_selector(inp)

--- a/test/python/invalid/invalid_explicit_kernel_capacity.py
+++ b/test/python/invalid/invalid_explicit_kernel_capacity.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Reject explicit logical threads beyond the target-provided capacity."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+
+first_compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+second_compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+
+
+# CHECK: operation requires 2 compute kernels, but the target supports 1; selected kernels: compute kernel 'first_compute_kernel', compute kernel 'second_compute_kernel'
+@ttl.operation(grid=(1, 1))
+def invalid_explicit_kernel_capacity(inp):
+    @ttl.compute(kernel=first_compute_kernel)
+    def first_compute():
+        pass
+
+    @ttl.compute(kernel=second_compute_kernel)
+    def second_compute():
+        pass
+
+    @ttl.datamovement()
+    def reader():
+        pass
+
+    @ttl.datamovement()
+    def writer():
+        pass
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_explicit_kernel_capacity(inp)

--- a/test/python/invalid/invalid_kernel_capacity.py
+++ b/test/python/invalid/invalid_kernel_capacity.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Reject logical-kernel requirements beyond the target-provided capacity."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+
+
+# CHECK: operation requires 3 data_movement kernels, but the target supports 2
+@ttl.operation(grid=(1, 1))
+def invalid_kernel_capacity(inp):
+    first = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    second = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    third = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    ttl.call_extern_func(FAKE_HEADER, "first", kernel=first)
+    ttl.call_extern_func(FAKE_HEADER, "second", kernel=second)
+    ttl.call_extern_func(FAKE_HEADER, "third", kernel=third)
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_kernel_capacity(inp)

--- a/test/python/invalid/invalid_kernel_selector_expression.py
+++ b/test/python/invalid/invalid_kernel_selector_expression.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Reject a kernel selector computed during operation execution."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+
+
+def select_kernel():
+    return ttl.KernelKind.COMPUTE
+
+
+# CHECK: kernel selector must be a KernelKind or Kernel declared as a top-level operation resource
+@ttl.operation(grid=(1, 1))
+def invalid_kernel_expression(inp):
+    ttl.call_extern_func(
+        FAKE_HEADER,
+        "external_entry",
+        kernel=select_kernel(),
+    )
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_kernel_expression(inp)

--- a/test/python/invalid/invalid_kernel_selector_missing.py
+++ b/test/python/invalid/invalid_kernel_selector_missing.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Reject a top-level external call without an inferable kernel."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+
+
+# CHECK: call_extern_func requires a kernel selector when its logical kernel cannot be inferred
+@ttl.operation(grid=(1, 1))
+def invalid_missing_kernel(inp):
+    ttl.call_extern_func(FAKE_HEADER, "external_entry")
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_missing_kernel(inp)

--- a/test/python/invalid/invalid_kernel_selector_type.py
+++ b/test/python/invalid/invalid_kernel_selector_type.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Reject an external-call selector that is not a logical kernel value."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+
+
+# CHECK: kernel selector must be a KernelKind or Kernel declared as a top-level operation resource
+@ttl.operation(grid=(1, 1))
+def invalid_kernel_type(inp):
+    ttl.call_extern_func(FAKE_HEADER, "external_entry", kernel=42)
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_kernel_type(inp)

--- a/test/python/invalid/kernel_selection_in_acquire_invalid.py
+++ b/test/python/invalid/kernel_selection_in_acquire_invalid.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+
+"""Reject nested selection that cannot execute with its DFB acquisition."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+
+
+# CHECK: statement selects logical kernels (compute, data_movement) outside its enclosing DFB acquire owner (data_movement)
+@ttl.operation(grid=(1, 1))
+def invalid_nested_selector(inp):
+    input_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
+    with input_dfb.wait() as input_block:
+        ttl.copy(input_block, inp[0, 0]).wait()
+        ttl.call_extern_func(
+            FAKE_HEADER,
+            "shared_entry",
+            kernel=(ttl.KernelKind.COMPUTE, ttl.KernelKind.DATA_MOVEMENT),
+        )
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_nested_selector(inp)

--- a/test/python/kernel_selection.py
+++ b/test/python/kernel_selection.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
+# RUN: FileCheck %s < %t.initial.mlir
+# RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
+
+"""Compile logical-kernel selectors with every external-call argument class."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+from ttl import KernelKind, call_extern_func
+
+FAKE_HEADER = "/dev/null/fake_shim.hpp"
+
+
+@ttl.operation(grid=(1, 1))
+def selected_external_calls(inp):
+    reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    descriptor_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
+    drain_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
+
+    ttl.call_extern_func(
+        FAKE_HEADER,
+        "compute_entry",
+        template_args=[ttl.dfb_descriptor(descriptor_dfb), -3, True],
+        func_args=[ttl.raw_addr(inp), 7],
+        include_paths=["/tmp"],
+        kernel=ttl.KernelKind.COMPUTE,
+    )
+    call_extern_func(
+        FAKE_HEADER,
+        "reader_entry",
+        template_args=[5],
+        func_args=[ttl.raw_addr(inp)],
+        kernel=reader,
+    )
+    ttl.call_extern_func(
+        FAKE_HEADER,
+        "shared_entry",
+        kernel=(KernelKind.COMPUTE, reader),
+    )
+
+    unused = drain_dfb.wait()
+    unused.pop(kernel=reader)
+
+
+# CHECK-DAG: ttl.opaque_call "compute_entry"
+# CHECK-DAG: ttl.opaque_call "reader_entry"
+# CHECK-DAG: ttl.opaque_call "shared_entry"
+# CHECK-DAG: ttl.opaque_call "shared_entry"
+
+# CHECK-CPP-DAG: compute_entry<
+# CHECK-CPP-DAG: reader_entry<5>
+# CHECK-CPP-DAG: shared_entry()
+# CHECK-CPP-DAG: shared_entry()
+
+
+if __name__ == "__main__":
+    inp = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    selected_external_calls(inp)

--- a/test/python/kernel_selection.py
+++ b/test/python/kernel_selection.py
@@ -19,6 +19,7 @@ import torch
 import ttl
 import ttnn
 from ttl import KernelKind, call_extern_func
+from ttl import KernelKind as KK
 
 FAKE_HEADER = "/dev/null/fake_shim.hpp"
 reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
@@ -51,6 +52,7 @@ def selected_external_calls(inp):
         "shared_entry",
         kernel=(KernelKind.COMPUTE, reader),
     )
+    ttl.call_extern_func(FAKE_HEADER, "alias_entry", kernel=KK.COMPUTE)
 
     unused = drain_dfb.wait()
     unused.pop(kernel=reader)
@@ -60,6 +62,7 @@ def selected_external_calls(inp):
 # CHECK-DAG: ttl.opaque_call "reader_entry"
 # CHECK-DAG: ttl.opaque_call "shared_entry"
 # CHECK-DAG: ttl.opaque_call "shared_entry"
+# CHECK-DAG: ttl.opaque_call "alias_entry"
 # CHECK-DAG: ttl.logical_kernel = #ttl.logical_kernel<kind = compute>
 # CHECK-DAG: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation =
 
@@ -67,6 +70,7 @@ def selected_external_calls(inp):
 # CHECK-CPP-DAG: reader_entry<5>
 # CHECK-CPP-DAG: shared_entry()
 # CHECK-CPP-DAG: shared_entry()
+# CHECK-CPP-DAG: alias_entry()
 
 # SPECIALIZED-COUNT-2: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation =
 

--- a/test/python/kernel_selection.py
+++ b/test/python/kernel_selection.py
@@ -6,6 +6,8 @@
 # RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.initial.mlir %python %s > %t.output 2>&1
 # RUN: FileCheck %s < %t.initial.mlir
 # RUN: FileCheck %s --check-prefix=CHECK-CPP < %t.output
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_FINAL_MLIR=%t.final.mlir TTLANG_COMPILER_OPTIONS=--ttl-specialize-cores %python %s > %t.specialized.output 2>&1
+# RUN: FileCheck %s --check-prefix=SPECIALIZED < %t.final.mlir
 
 """Compile logical-kernel selectors with every external-call argument class."""
 
@@ -19,11 +21,11 @@ import ttnn
 from ttl import KernelKind, call_extern_func
 
 FAKE_HEADER = "/dev/null/fake_shim.hpp"
+reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
 
 
-@ttl.operation(grid=(1, 1))
+@ttl.operation(grid=(2, 1))
 def selected_external_calls(inp):
-    reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
     descriptor_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
     drain_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
 
@@ -35,13 +37,15 @@ def selected_external_calls(inp):
         include_paths=["/tmp"],
         kernel=ttl.KernelKind.COMPUTE,
     )
-    call_extern_func(
-        FAKE_HEADER,
-        "reader_entry",
-        template_args=[5],
-        func_args=[ttl.raw_addr(inp)],
-        kernel=reader,
-    )
+    core_x, _ = ttl.node(dims=2)
+    if core_x == 0:
+        call_extern_func(
+            FAKE_HEADER,
+            "reader_entry",
+            template_args=[5],
+            func_args=[ttl.raw_addr(inp)],
+            kernel=reader,
+        )
     ttl.call_extern_func(
         FAKE_HEADER,
         "shared_entry",
@@ -56,11 +60,15 @@ def selected_external_calls(inp):
 # CHECK-DAG: ttl.opaque_call "reader_entry"
 # CHECK-DAG: ttl.opaque_call "shared_entry"
 # CHECK-DAG: ttl.opaque_call "shared_entry"
+# CHECK-DAG: ttl.logical_kernel = #ttl.logical_kernel<kind = compute>
+# CHECK-DAG: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation =
 
 # CHECK-CPP-DAG: compute_entry<
 # CHECK-CPP-DAG: reader_entry<5>
 # CHECK-CPP-DAG: shared_entry()
 # CHECK-CPP-DAG: shared_entry()
+
+# SPECIALIZED-COUNT-2: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation =
 
 
 if __name__ == "__main__":

--- a/test/python/kernel_selection.py
+++ b/test/python/kernel_selection.py
@@ -50,7 +50,7 @@ def selected_external_calls(inp):
     ttl.call_extern_func(
         FAKE_HEADER,
         "shared_entry",
-        kernel=(KernelKind.COMPUTE, reader),
+        kernel=KernelKind.COMPUTE | KernelKind.DATA_MOVEMENT,
     )
     ttl.call_extern_func(FAKE_HEADER, "alias_entry", kernel=KK.COMPUTE)
 

--- a/test/python/many_fused_ops.py
+++ b/test/python/many_fused_ops.py
@@ -101,7 +101,7 @@ def fused_chain_kernel(a, b, c, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @fused_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = {{[0-9]+}} : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = {{[0-9]+}} : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # Wait for inputs and reserve output
 # CHECK: ttl.cb_wait

--- a/test/python/pipenet_predicate_emission.py
+++ b/test/python/pipenet_predicate_emission.py
@@ -14,6 +14,9 @@
 #
 # RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_FINAL_MLIR=%t.no_pipenet_final.mlir TTLANG_OP=no_pipenet %python %s
 # RUN: FileCheck %s --input-file=%t.no_pipenet_final.mlir --check-prefix=NO-PIPENET
+#
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_INITIAL_MLIR=%t.unified_pipenet_initial.mlir TTLANG_OP=unified_pipenet %python %s
+# RUN: FileCheck %s --input-file=%t.unified_pipenet_initial.mlir --check-prefix=LOGICAL
 
 """Frontend-pipeline integration check for the PipeNet verifier.
 
@@ -25,6 +28,9 @@ without any PipeNet must not contain the predicate machinery.
 
 # Frontend emits the predicate op for `if net.is_active()`.
 # INITIAL: ttl.is_active
+
+# A unified PipeNet source callback receives the compiler-owned affinity.
+# LOGICAL: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<pipe_source>", role = "pipe_source">
 
 # After lowering, the user's guard survives as an emitc.if; the
 # predicate chain reduces to a logical_or over the per-pipe role
@@ -112,16 +118,47 @@ def no_pipenet_op(inp, out):
             ttl.copy(blk, out[0, 0]).wait()
 
 
+@ttl.operation(grid=(4, 1))
+def unified_pipenet_op(inp, out):
+    net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(slice(1, 4), 0))])
+    send_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
+    receive_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=1)
+
+    if net.is_src():
+        with send_dfb.reserve() as send_block:
+            ttl.copy(inp[0, 0], send_block).wait()
+
+    def send(pipe):
+        with send_dfb.wait() as send_block:
+            ttl.copy(send_block, pipe).wait()
+
+    net.if_src(send)
+
+    def receive(pipe):
+        with receive_dfb.reserve() as receive_block:
+            ttl.copy(pipe, receive_block).wait()
+
+    net.if_dst(receive)
+
+    if net.is_dst():
+        with receive_dfb.wait() as receive_block:
+            ttl.copy(receive_block, out[0, 0]).wait()
+
+
 def main():
     op_name = os.environ.get("TTLANG_OP", "with_pipenet")
     if op_name == "with_pipenet":
         inp = _host_ttnn((32, 4 * 32))
         out = _host_ttnn((32, 4 * 32))
         with_pipenet_op(inp, out)
-    else:
+    elif op_name == "no_pipenet":
         inp = _host_ttnn((32, 32))
         out = _host_ttnn((32, 32))
         no_pipenet_op(inp, out)
+    else:
+        inp = _host_ttnn((32, 32))
+        out = _host_ttnn((32, 32))
+        unified_pipenet_op(inp, out)
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add.py
+++ b/test/python/simple_add.py
@@ -70,7 +70,7 @@ def add_kernel(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # Bind circular buffers (alphabetical order of capture names: lhs_cb, out_cb, rhs_cb)
 # CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
@@ -104,7 +104,7 @@ def add_kernel(lhs, rhs, out):
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
 # CHECK-SAME: %arg1: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 0 : i32}
 
 # Bind CBs (alphabetical order: lhs_cb, rhs_cb)
 # CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
@@ -126,7 +126,7 @@ def add_kernel(lhs, rhs, out):
 
 # CHECK-LABEL: func.func @dm_write
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 1 : i32}
 
 # Wait for output DFB, slice, copy to device, pop
 # CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}

--- a/test/python/simple_add_dram.py
+++ b/test/python/simple_add_dram.py
@@ -72,7 +72,7 @@ def add_dram_kernel(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # DFB operations (alphabetical order of capture names: lhs_cb, out_cb, rhs_cb)
 # CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0
@@ -97,7 +97,7 @@ def add_dram_kernel(lhs, rhs, out):
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
 # CHECK-SAME: %arg1: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 0 : i32}
 
 # Bind CBs (alphabetical order: lhs_cb, rhs_cb)
 # CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0
@@ -119,7 +119,7 @@ def add_dram_kernel(lhs, rhs, out):
 
 # CHECK-LABEL: func.func @dm_write
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, bf16>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, bf16>, buffer = l1, grid = [1, 1], memory = interleaved>>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 1 : i32}
 
 # Wait for output DFB, slice, copy to device, pop
 # CHECK: %[[CB2:.+]] = ttl.bind_cb{cb_index = 2

--- a/test/python/simple_add_f32.py
+++ b/test/python/simple_add_f32.py
@@ -61,16 +61,16 @@ def add_kernel_f32(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, f32>, buffer = l1, grid = [1, 1], memory = interleaved>>
 # CHECK-SAME: %arg1: tensor<1x1x!ttcore.tile<32x32, f32>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, f32>, buffer = l1, grid = [1, 1], memory = interleaved>>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 0 : i32}
 
 # CHECK-LABEL: func.func @dm_write
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, f32>, buffer = l1, grid = [1, 1], memory = interleaved>>
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 1 : i32}
 
 
 if __name__ == "__main__":

--- a/test/python/simple_add_loop.py
+++ b/test/python/simple_add_loop.py
@@ -65,7 +65,7 @@ def add_loop_kernel(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 # CHECK: %[[LHS:.+]] = ttl.bind_cb{cb_index = 0
 # CHECK: %[[OUT:.+]] = ttl.bind_cb{cb_index = 2
 # CHECK: %[[RHS:.+]] = ttl.bind_cb{cb_index = 1

--- a/test/python/simple_add_multitile.py
+++ b/test/python/simple_add_multitile.py
@@ -70,7 +70,7 @@ def add_multitile_kernel(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # DFB operations (alphabetical order: lhs_cb=0, out_cb=2, rhs_cb=1)
 # CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0

--- a/test/python/simple_add_with_stmt.py
+++ b/test/python/simple_add_with_stmt.py
@@ -75,7 +75,7 @@ def add_with_kernel(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # DFB binding (alphabetical order: lhs_cb=0, out_cb=2, rhs_cb=1)
 # CHECK: %[[CB0:.+]] = ttl.bind_cb{cb_index = 0
@@ -106,7 +106,7 @@ def add_with_kernel(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @dm_read
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 0 : i32}
 
 # First DFB: reserve (with DFB association), copy, push
 # CHECK: ttl.cb_reserve
@@ -124,7 +124,7 @@ def add_with_kernel(lhs, rhs, out):
 # CHECK-NEXT: return
 
 # CHECK-LABEL: func.func @dm_write
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [2 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 1 : i32}
 
 # Output DFB: wait (with DFB association), copy, pop
 # CHECK: ttl.cb_wait

--- a/test/python/simple_fill.py
+++ b/test/python/simple_fill.py
@@ -48,7 +48,7 @@ def fill_kernel(out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @fill_compute
-# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # CHECK: %[[OUT_CB:.+]] = ttl.bind_cb{cb_index = 0
 

--- a/test/python/simple_fused.py
+++ b/test/python/simple_fused.py
@@ -74,7 +74,7 @@ def fused_kernel(inp, bias, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @fused_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = {{[0-9]+}} : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {ttl.base_cta_index = {{[0-9]+}} : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # Wait for inputs and reserve output
 # CHECK: ttl.cb_wait

--- a/test/python/simple_multinode.py
+++ b/test/python/simple_multinode.py
@@ -61,7 +61,7 @@ def multinode_add(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @dm_read
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32}
+# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [0 : i32, 1 : i32], ttl.kernel_thread = #ttkernel.thread<noc>, ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>, ttl.noc_index = 0 : i32}
 
 # Verify core_x() and core_y() ops appear in the IR (from x, y = ttl.node(dims=2))
 # CHECK: ttl.core_x

--- a/test/python/simple_reduce.py
+++ b/test/python/simple_reduce.py
@@ -49,7 +49,7 @@ def reduce_kernel(inp, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @reduce_compute
-# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # CHECK: ttl.bind_cb{cb_index = 0
 # CHECK: ttl.bind_cb{cb_index =

--- a/test/python/simple_reduce_bcast.py
+++ b/test/python/simple_reduce_bcast.py
@@ -56,7 +56,7 @@ def reduce_bcast_kernel(inp, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @compute_fn
-# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # Reduce stores into intermediate CB, then broadcast reads from it.
 # CHECK: ttl.reduce

--- a/test/python/simple_reduce_scalar.py
+++ b/test/python/simple_reduce_scalar.py
@@ -72,7 +72,7 @@ def reduce_scalar_kernel(inp, scalar_out, col_out, row_out):
 
 
 # CHECK-LABEL: func.func @reduce_compute
-# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 # Each reduce uses an internally-synthesized fill(1.0) scaler; the user's
 # Python-float coefficient is applied separately by mul_unary_const.
 # CHECK: ttl.fill 1.000000e+00

--- a/test/python/simple_transpose.py
+++ b/test/python/simple_transpose.py
@@ -49,7 +49,7 @@ def transpose_kernel(inp, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @transpose_compute
-# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # CHECK: %[[IN_CB:.+]] = ttl.bind_cb{cb_index = 0
 # CHECK: %[[OUT_CB:.+]] = ttl.bind_cb{cb_index = 1

--- a/test/python/simple_typecast.py
+++ b/test/python/simple_typecast.py
@@ -53,7 +53,7 @@ def typecast_kernel(inp, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @compute_fn
-# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {{{.*}}ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # Bind input (bf16) and output (f32) circular buffers.
 # CHECK: %[[IN_CB:.+]] = ttl.bind_cb{cb_index = 0

--- a/test/python/test_cb_sync_intrathread_explicit.py
+++ b/test/python/test_cb_sync_intrathread_explicit.py
@@ -51,21 +51,21 @@ def _make_explicit_kernel():
                     x0 = inp_dfb.wait()
                     acc0 = acc_dfb.reserve()
                     acc0.store(x0)
-                    acc0.push()
-                    x0.pop()
+                    acc0.push(kernel=ttl.KernelKind.COMPUTE)
+                    x0.pop(kernel=ttl.KernelKind.COMPUTE)
                     for _ in range(DIM_TILES - 1):
                         xj = inp_dfb.wait()
                         av = acc_dfb.wait()
                         acc_next = acc_dfb.reserve()
                         acc_next.store(av + xj)
-                        acc_next.push()
-                        av.pop()
-                        xj.pop()
+                        acc_next.push(kernel=ttl.KernelKind.COMPUTE)
+                        av.pop(kernel=ttl.KernelKind.COMPUTE)
+                        xj.pop(kernel=ttl.KernelKind.COMPUTE)
                     final = acc_dfb.wait()
                     o = out_dfb.reserve()
                     o.store(final)
-                    o.push()
-                    final.pop()
+                    o.push(kernel=ttl.KernelKind.COMPUTE)
+                    final.pop(kernel=ttl.KernelKind.COMPUTE)
 
         @ttl.datamovement()
         def dm_read():
@@ -76,6 +76,7 @@ def _make_explicit_kernel():
                     for j in range(DIM_TILES):
                         blk = inp_dfb.reserve()
                         ttl.copy(inp[tile_idx, j], blk).wait()
+                        blk.push(kernel=ttl.KernelKind.DATA_MOVEMENT)
 
         @ttl.datamovement()
         def dm_write():
@@ -85,6 +86,7 @@ def _make_explicit_kernel():
                 if tile_idx < seq_tiles:
                     blk = out_dfb.wait()
                     ttl.copy(blk, out[tile_idx, 0]).wait()
+                    blk.pop(kernel=ttl.KernelKind.DATA_MOVEMENT)
 
     return explicit_kernel
 

--- a/test/python/test_external_dfb_reuse.py
+++ b/test/python/test_external_dfb_reuse.py
@@ -52,6 +52,7 @@ def _external_eltwise_mul(lhs: ttl.DFB, rhs: ttl.DFB, result: ttl.DFB):
             dfb_descriptor(rhs),
             dfb_descriptor(result),
         ],
+        kernel=ttl.KernelKind.COMPUTE,
     )
 
 

--- a/test/python/test_external_raw_addr.py
+++ b/test/python/test_external_raw_addr.py
@@ -15,11 +15,11 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 import ttl
 from ttlang_test_utils import to_dram, to_l1, to_l1_sharded
 
-
 RAW_ADDRESS_HEADER = os.path.join(
     os.path.dirname(__file__), "include", "raw_address_capture.hpp"
 )
 OUTPUT_WORD_COUNT = 32 * 32
+SELECTED_OUTPUT_WORD_COUNT = OUTPUT_WORD_COUNT // 2
 INPUT_MEMORY_CONFIGS = [
     pytest.param(to_dram, id="dram-interleaved"),
     pytest.param(to_l1, id="l1-interleaved"),
@@ -80,7 +80,43 @@ def external_unified_raw_address_capture(inp, out):
         "raw_address_capture_unified",
         template_args=[OUTPUT_WORD_COUNT],
         func_args=[ttl.raw_addr(inp), ttl.raw_addr(out)],
+        kernel=ttl.KernelKind.COMPUTE,
     )
+
+
+@ttl.operation(grid=(1, 1))
+def external_unified_data_movement_raw_address_capture(inp, out):
+    address_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=1)
+
+    ttl.call_extern_func(
+        RAW_ADDRESS_HEADER,
+        "raw_address_capture",
+        template_args=[ttl.dfb_descriptor(address_dfb)],
+        func_args=[ttl.raw_addr(inp)],
+        kernel=ttl.KernelKind.DATA_MOVEMENT,
+    )
+    address_block = address_dfb.wait()
+    ttl.copy(address_block, out[0, 0]).wait()
+    address_block.pop()
+
+
+@ttl.operation(grid=(1, 1))
+def external_multi_kernel_raw_address_capture(inp, out):
+    reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    drain_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=1)
+
+    ttl.call_extern_func(
+        RAW_ADDRESS_HEADER,
+        "raw_address_capture_selected",
+        template_args=[ttl.dfb_descriptor(drain_dfb), SELECTED_OUTPUT_WORD_COUNT],
+        func_args=[
+            ttl.raw_addr(inp),
+            ttl.raw_addr(out),
+        ],
+        kernel=(ttl.KernelKind.COMPUTE, reader),
+    )
+    unused = drain_dfb.wait()
+    unused.pop(kernel=reader)
 
 
 def _assert_address_bits(output, expected_address):
@@ -102,8 +138,9 @@ def _assert_address_bits(output, expected_address):
         external_raw_address_capture,
         external_compute_raw_address_capture,
         external_unified_raw_address_capture,
+        external_unified_data_movement_raw_address_capture,
     ],
-    ids=["noc", "compute", "unified"],
+    ids=["noc", "compute", "unified-compute", "unified-data-movement"],
 )
 def test_external_raw_address_uses_each_runtime_tensor(
     device, dtype, to_input, operation
@@ -130,3 +167,28 @@ def test_external_raw_address_uses_each_runtime_tensor(
 
     _assert_address_bits(first_output, first_input.buffer_address())
     _assert_address_bits(second_output, second_input.buffer_address())
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float32],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize("to_input", INPUT_MEMORY_CONFIGS)
+def test_external_call_can_execute_in_multiple_logical_kernels(device, dtype, to_input):
+    """One call emits observable compute and data-movement behavior."""
+    host_input = torch.zeros((32, 32), dtype=dtype)
+    input_tensor = to_input(host_input, device)
+    host_output = torch.zeros((32, 32), dtype=torch.float32)
+    output = to_l1_sharded(host_output, device, layout="height")
+
+    external_multi_kernel_raw_address_capture(input_tensor, output)
+
+    input_address = input_tensor.buffer_address()
+    output_bits = ttnn.to_torch(output).contiguous().view(torch.int32).flatten()
+    expected_compute = torch.tensor(input_address, dtype=torch.uint32).view(torch.int32)
+    expected_data = torch.tensor(input_address ^ 0xFFFFFFFF, dtype=torch.uint32).view(
+        torch.int32
+    )
+    assert torch.all(output_bits[:SELECTED_OUTPUT_WORD_COUNT] == expected_compute)
+    assert torch.all(output_bits[SELECTED_OUTPUT_WORD_COUNT:] == expected_data)

--- a/test/sim/conftest.py
+++ b/test/sim/conftest.py
@@ -30,7 +30,6 @@ def pytest_collection_modifyitems(
 
 
 from greenlet import greenlet
-from sim.blockstate import KernelType
 from sim.context import set_current_kernel_type, reset_context
 from sim.greenlet_scheduler import (
     GreenletScheduler,
@@ -39,6 +38,7 @@ from sim.greenlet_scheduler import (
     set_scheduler,
     set_scheduler_algorithm,
 )
+from sim.kernel import KernelKind
 from sim.trace import set_tracing
 
 
@@ -58,11 +58,11 @@ def reset_simulator_context():
     yield
 
 
-def setup_scheduler_and_kernel_context(kernel_type: KernelType) -> GreenletScheduler:
+def setup_scheduler_and_kernel_context(kernel_type: KernelKind) -> GreenletScheduler:
     """Set up scheduler and kernel context for unit tests.
 
     Args:
-        kernel_type: Type of kernel to simulate (COMPUTE or DM)
+        kernel_type: Kind of kernel to simulate (COMPUTE or DATA_MOVEMENT)
 
     Returns:
         Configured GreenletScheduler instance
@@ -108,7 +108,7 @@ def teardown_scheduler_and_kernel_context() -> None:
 @pytest.fixture
 def compute_kernel_context():
     """Set up scheduler context with COMPUTE kernel for tests."""
-    setup_scheduler_and_kernel_context(KernelType.COMPUTE)
+    setup_scheduler_and_kernel_context(KernelKind.COMPUTE)
     yield
     teardown_scheduler_and_kernel_context()
 
@@ -116,6 +116,6 @@ def compute_kernel_context():
 @pytest.fixture
 def dm_kernel_context():
     """Set up scheduler context with DM kernel for tests."""
-    setup_scheduler_and_kernel_context(KernelType.DM)
+    setup_scheduler_and_kernel_context(KernelKind.DATA_MOVEMENT)
     yield
     teardown_scheduler_and_kernel_context()

--- a/test/sim/test_blockstate.py
+++ b/test/sim/test_blockstate.py
@@ -23,12 +23,12 @@ from sim.blockstate import (
     AccessState,
     BlockAcquisition,
     ExpectedOp,
-    KernelType,
     format_block_finished_error,
     format_cannot_read_block,
     format_cannot_write_block,
     format_validate_mismatch,
 )
+from sim.kernel import KernelKind
 from sim.context import (
     clear_current_kernel_type,
     set_current_kernel_type,
@@ -85,14 +85,14 @@ def test_block_state_machine_restrictions() -> None:
 
 def test_copy_sets_block_to_na_state() -> None:
     """Test that copy operations set blocks to NAW (No Access while Writing) state."""
-    set_current_kernel_type(KernelType.DM)
+    set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
     try:
         block = Block(
             ttnn.Tensor(torch.zeros((64, 32))),
             (2, 1),
             BlockAcquisition.RESERVE,
-            KernelType.DM,
+            KernelKind.DATA_MOVEMENT,
         )
 
         source_tensor = ttnn.Tensor(torch.ones((64, 32)))
@@ -117,14 +117,14 @@ def test_copy_sets_block_to_na_state() -> None:
 
 def test_push_validates_expected_state() -> None:
     """Test that push() validates the block is in a valid state before completing."""
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
 
     try:
         element = make_ones_tile()
         dfb = DataflowBuffer(likeness_tensor=element, shape=(1, 1), block_count=2)
 
         # Populate the DFB from a DM kernel
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         from sim.copy import copy as dm_copy
 
         src = make_ones_tile()
@@ -134,7 +134,7 @@ def test_push_validates_expected_state() -> None:
         blk.push()
 
         # Now wait for it in COMPUTE kernel
-        set_current_kernel_type(KernelType.COMPUTE)
+        set_current_kernel_type(KernelKind.COMPUTE)
         waited_block = dfb.wait()
 
         # push() on a wait() block must fail: STORE_SRC is expected, not PUSH
@@ -172,7 +172,7 @@ class TestAssignSrcTransition:
         self,
     ) -> tuple["DataflowBuffer", "Block"]:
         """Return a DFB and a WAIT/COMPUTE block ready for use."""
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         element = make_ones_tile()
         dfb = DataflowBuffer(likeness_tensor=element, shape=(1, 1), block_count=2)
         from sim.copy import copy as dm_copy
@@ -183,7 +183,7 @@ class TestAssignSrcTransition:
         tx.wait()
         blk.push()
 
-        set_current_kernel_type(KernelType.COMPUTE)
+        set_current_kernel_type(KernelKind.COMPUTE)
         waited = dfb.wait(name="compute_in")
         return dfb, waited
 
@@ -265,7 +265,7 @@ class TestRORState:
 
     def _make_wait_block(self) -> Block:
         """Return a DM WAIT block pre-loaded with data via a DFB reserve/push cycle."""
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         dfb = DataflowBuffer(
             likeness_tensor=make_element_for_buffer_shape((2, 1)),
             shape=(2, 1),
@@ -397,7 +397,7 @@ def test_format_validate_mismatch_includes_what_to_do_and_details() -> None:
         {ExpectedOp.STORE_SRC, ExpectedOp.POP},
         AccessState.MR,
         BlockAcquisition.WAIT,
-        KernelType.COMPUTE,
+        KernelKind.COMPUTE,
     )
     assert "Next:" in msg
     assert "Details: expected one of" in msg
@@ -417,7 +417,7 @@ def test_format_validate_mismatch_store_on_waited_block_mentions_out_block_store
         {ExpectedOp.STORE_SRC},
         AccessState.MR,
         BlockAcquisition.WAIT,
-        KernelType.COMPUTE,
+        KernelKind.COMPUTE,
     )
     assert "wait() block" in msg
     assert "out_block.store" in msg
@@ -431,7 +431,7 @@ def test_format_validate_mismatch_push_on_wait_block_mentions_pop_not_push() -> 
         {ExpectedOp.STORE_SRC},
         AccessState.MR,
         BlockAcquisition.WAIT,
-        KernelType.COMPUTE,
+        KernelKind.COMPUTE,
     )
     assert "push() is for reserve() only" in msg
     assert "pop()" in msg
@@ -445,7 +445,7 @@ def test_format_validate_mismatch_naw_mentions_in_flight_and_wait() -> None:
         {ExpectedOp.TX_WAIT},
         AccessState.NAW,
         BlockAcquisition.RESERVE,
-        KernelType.DM,
+        KernelKind.DATA_MOVEMENT,
     )
     assert (
         "may still be in flight" in msg.lower() or "wait until the copy" in msg.lower()
@@ -462,7 +462,7 @@ def test_format_validate_mismatch_includes_copy_callsite_when_pending_provided()
         {ExpectedOp.TX_WAIT},
         AccessState.NAW,
         BlockAcquisition.RESERVE,
-        KernelType.DM,
+        KernelKind.DATA_MOVEMENT,
         pending_copy_location=("/x/y/z.py", 12),
     )
     assert "Where: the copy involving this block was requested at /x/y/z.py:12" in msg
@@ -593,7 +593,7 @@ def test_validate_no_pending_wait_mentions_pop_and_incomplete(
     tx.wait()
     blk.push()
 
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
     try:
         waited = dfb.wait(name="consumer_view")
         with pytest.raises(RuntimeError) as err:

--- a/test/sim/test_copy.py
+++ b/test/sim/test_copy.py
@@ -19,12 +19,13 @@ from test_utils import (
     tensors_equal,
 )
 
-from sim.blockstate import BlockAcquisition, KernelType
+from sim.blockstate import BlockAcquisition
 from sim.context import set_current_kernel_type
 from sim.dfb import Block, DataflowBuffer
 from sim.ttnnsim import Tensor
 from sim.copy import CopyTransaction, GroupTransfer, copy
 from sim.pipe import Pipe
+from sim.kernel import KernelKind
 
 
 @pytest.fixture(autouse=True)
@@ -56,13 +57,13 @@ class TestCopyTransaction:
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
         block2 = Block(
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
         with pytest.raises(
             ValueError, match="No copy handler registered for \\(Block, Block\\)"
@@ -81,7 +82,7 @@ class TestTensorToBlockCopy:
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
 
         with pytest.raises(ValueError, match="does not match Block shape"):
@@ -97,7 +98,7 @@ class TestBlockToTensorCopy:
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.WAIT,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
 
         # Wrong destination shape
@@ -147,7 +148,7 @@ class TestCopySourceLocking:
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.WAIT,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
 
         # Create destination tensor (non-Block, so no state changes)
@@ -189,7 +190,7 @@ class TestCopyDestinationLocking:
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
 
         # Start copy
@@ -215,7 +216,7 @@ class TestCopyDestinationLocking:
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
 
         # Start copy
@@ -248,7 +249,7 @@ class TestMultipleCopyOperations:
             make_rand_tensor(64, 32),
             shape=(2, 1),
             acquisition=BlockAcquisition.WAIT,
-            kernel_type=KernelType.DM,
+            kernel_type=KernelKind.DATA_MOVEMENT,
         )
 
         # Create tensors (non-Block, so no state changes)
@@ -291,7 +292,7 @@ class TestCopyWithStateMachine:
         """Test Tensor -> Block copy using reserve() in DM kernel."""
 
         # Set DM kernel context for copy operations
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_rand_tensor(64, 32)  # 2x1 tiles
         dfb = DataflowBuffer(
@@ -311,7 +312,7 @@ class TestCopyWithStateMachine:
     def test_copy_block_to_tensor_with_wait(self) -> None:
         """Test Block -> Tensor copy using wait() in DM kernel."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         # Setup: Fill DFB with data using reserve->store->push pattern
         dfb = DataflowBuffer(
@@ -342,7 +343,7 @@ class TestCopyWithStateMachine:
     def test_copy_single_tile_tensor_to_block(self) -> None:
         """Test single tile Tensor -> Block copy."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_ones_tile()
         dfb = DataflowBuffer(
@@ -362,7 +363,7 @@ class TestCopyWithStateMachine:
     def test_copy_multi_tile_tensor_to_block(self) -> None:
         """Test multi-tile Tensor -> Block copy."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_rand_tensor(128, 32)  # 4x1 tiles
         dfb = DataflowBuffer(
@@ -383,7 +384,7 @@ class TestCopyWithStateMachine:
     def test_copy_with_pipe_single_tile(self) -> None:
         """Test Block -> Pipe -> Block copy with single tile."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         tile = make_full_tile(123.0)
         src_dfb = DataflowBuffer(
@@ -418,7 +419,7 @@ class TestCopyWithStateMachine:
     def test_copy_with_pipe_multiple_tiles(self) -> None:
         """Test Block -> Pipe -> Block copy with multiple tiles."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         grid = (100, 100)  # Set grid context for pipe operations
 
         source = make_rand_tensor(64, 32)  # 2x1 tiles
@@ -464,7 +465,7 @@ class TestCopyWithStateMachine:
     def test_copy_sequential_transfers(self) -> None:
         """Test multiple sequential copy operations."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_rand_tensor(64, 32)  # 2 tiles
         dfb = DataflowBuffer(
@@ -495,7 +496,7 @@ class TestCopyWithStateMachine:
     def test_copy_wait_idempotency(self) -> None:
         """Test that calling wait() multiple times is safe."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_ones_tile()
         dfb = DataflowBuffer(
@@ -518,7 +519,7 @@ class TestCopyWithStateMachine:
     def test_copy_can_wait_before_and_after(self) -> None:
         """Test can_wait() functionality."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_ones_tile()
         dfb = DataflowBuffer(
@@ -541,7 +542,7 @@ class TestCopyWithStateMachine:
     def test_copy_multi_tile_can_wait(self) -> None:
         """Test can_wait() with multi-tile transfer."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_rand_tensor(64, 64)  # 2x2 tiles
         dfb = DataflowBuffer(
@@ -562,7 +563,7 @@ class TestCopyWithStateMachine:
     def test_copy_with_pipe_can_wait(self) -> None:
         """Test can_wait() with pipe transfers."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         pipe = Pipe(10, 20)
         src_dfb = DataflowBuffer(
@@ -601,7 +602,7 @@ class TestCopyTransactionProperties:
         """Test that is_completed property correctly reflects transaction state."""
         from sim.copy import copy
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_ones_tile()
         dfb = DataflowBuffer(
@@ -629,7 +630,7 @@ class TestCopyTransactionProperties:
         """Test that calling wait() multiple times on completed transaction is safe."""
         from sim.copy import copy
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_rand_tensor(64, 32)
         dfb = DataflowBuffer(
@@ -655,7 +656,7 @@ class TestCopyTransactionProperties:
         """Test that can_wait() correctly delegates to handler."""
         from sim.copy import copy
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         # Tensor -> Block is always synchronous
         source = make_ones_tile()
@@ -682,7 +683,7 @@ class TestCopyContextManagerExtraction:
         """Test copy operations using context managers with Pipe."""
         from sim.copy import copy
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_full_tile(42.0)
         src_dfb = DataflowBuffer(
@@ -722,7 +723,7 @@ class TestCopyContextManagerExtraction:
         """Test mixing context managers with raw tensors."""
         from sim.copy import copy
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_full_tile(3.14)
         dfb = DataflowBuffer(
@@ -752,7 +753,7 @@ class TestCopyErrorConditions:
         """Test that copy() creates transaction immediately, not on wait()."""
         from sim.copy import copy, CopyTransaction
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_ones_tile()
         dfb = DataflowBuffer(

--- a/test/sim/test_copyhandlers.py
+++ b/test/sim/test_copyhandlers.py
@@ -22,7 +22,6 @@ from test_utils import (
 )
 
 from sim import ttnn
-from sim.blockstate import KernelType
 from sim.context import set_current_kernel_type
 from sim.copy import copy
 from sim.dfb import Block, DataflowBuffer
@@ -34,6 +33,7 @@ from sim.copyhandlers import (
     HANDLER_REGISTRY,
 )
 from sim.pipe import Pipe
+from sim.kernel import KernelKind
 from sim.ttnnsim import ROW_MAJOR_LAYOUT, Tensor
 
 if TYPE_CHECKING:
@@ -74,7 +74,7 @@ class TestCopyValidationErrors:
     def test_nd_tensor_tile_count_mismatch_to_block_fails(self) -> None:
         """Test that an N-D tensor with mismatched total tile count raises ValueError."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         # 3D tensor (2, 32, 32) has 2 total tiles; block (1, 1) has 1 total tile.
         torch_3d = torch.ones(2, 32, 32)
@@ -91,7 +91,7 @@ class TestCopyValidationErrors:
     def test_tile_count_mismatch_tensor_to_block(self) -> None:
         """Test that tile count mismatch raises ValueError (Tensor -> Block)."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         # 3 tiles in tensor but DFB expects 2 tiles
         source = make_rand_tensor(96, 32)  # 3x1 tiles
@@ -126,7 +126,7 @@ class TestPipeErrorHandling:
         try:
 
             def test_kernel() -> None:
-                set_current_kernel_type(KernelType.DM)
+                set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
                 # Use a unique pipe address to avoid interference
                 pipe = Pipe(9999, 10000)
@@ -138,7 +138,9 @@ class TestPipeErrorHandling:
                     tx = copy(pipe, block)
                     tx.wait()
 
-            scheduler.add_kernel(KernelId(0, KernelType.DM, "test-dm"), test_kernel)
+            scheduler.add_kernel(
+                KernelId(0, KernelKind.DATA_MOVEMENT, "test-dm"), test_kernel
+            )
 
             # With scheduler, waiting on pipe with no sender is detected as deadlock
             with pytest.raises(RuntimeError, match="Deadlock detected"):
@@ -149,7 +151,7 @@ class TestPipeErrorHandling:
     def test_pipe_length_mismatch(self) -> None:
         """Test that pipe receive fails when Block length doesn't match sent data."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         pipe = Pipe(5000, 5001)
         src_dfb = DataflowBuffer(
@@ -188,7 +190,7 @@ class TestPipeMulticast:
     def test_pipe_multiple_receivers(self) -> None:
         """Test that pipe correctly handles multiple receivers."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         grid = (100, 100)  # Set grid context for pipe operations
 
         # Range covering 2 nodes: (10,0) and (10,1)
@@ -241,7 +243,7 @@ class TestContextManagerHandlers:
     def test_tensor_to_reserve_context(self) -> None:
         """Test Tensor → ReserveContext handler delegation."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_full_tile(5.0)
         dfb = DataflowBuffer(
@@ -263,7 +265,7 @@ class TestContextManagerHandlers:
     def test_wait_context_to_tensor(self) -> None:
         """Test WaitContext → Tensor handler delegation."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_full_tile(7.0)
         dfb = DataflowBuffer(
@@ -286,7 +288,7 @@ class TestContextManagerHandlers:
     def test_pipe_to_reserve_context(self) -> None:
         """Test Pipe → ReserveContext handler delegation."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         pipe = Pipe(7000, 7001)
         tile = make_full_tile(9.0)
@@ -321,7 +323,7 @@ class TestContextManagerHandlers:
     def test_wait_context_to_pipe(self) -> None:
         """Test WaitContext → Pipe handler delegation."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         pipe = Pipe(8000, 8001)
         tile = make_full_tile(11.0)
@@ -356,7 +358,7 @@ class TestContextManagerHandlers:
     def test_reserve_context_to_pipe(self) -> None:
         """Test ReserveContext → Pipe handler delegation."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         pipe = Pipe(9000, 9001)
         tile = make_full_tile(13.0)
@@ -397,7 +399,7 @@ class TestPipeNodeRangeTypes:
     def test_pipe_single_node_int(self) -> None:
         """Test pipe with single 1D node (int)."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         # Single 1D node
         pipe = Pipe(0, 1)  # src_node=0, dst_node_range=1 (single int)
@@ -434,7 +436,7 @@ class TestPipeNodeRangeTypes:
     def test_pipe_single_node_tuple(self) -> None:
         """Test pipe with single multi-dimensional node (tuple)."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         # Single 2D node
         pipe = Pipe(
@@ -473,7 +475,7 @@ class TestPipeNodeRangeTypes:
     def test_pipe_node_range(self) -> None:
         """Test pipe with node range (2x2 = 4 receivers)."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         grid = (100, 100)  # Set grid context for pipe operations
 
         # Node range: (20,20) to (21,21) = 2x2 = 4 nodes
@@ -517,7 +519,7 @@ class TestCanWaitBehavior:
     def test_tensor_to_block_can_wait_immediate(self) -> None:
         """Test that Tensor → Block copy can_wait returns True immediately."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_ones_tile()
         dfb = DataflowBuffer(
@@ -533,7 +535,7 @@ class TestCanWaitBehavior:
     def test_block_to_tensor_can_wait_immediate(self) -> None:
         """Test that Block → Tensor copy can_wait returns True immediately."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_full_tile(21.0)
         dfb = DataflowBuffer(
@@ -556,7 +558,7 @@ class TestCanWaitBehavior:
     def test_block_to_pipe_can_wait_immediate(self) -> None:
         """Test that Block → Pipe copy can_wait returns True immediately."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         pipe = Pipe(11000, 11001)
         tile = make_full_tile(23.0)
@@ -579,7 +581,7 @@ class TestCanWaitBehavior:
     def test_pipe_to_block_can_wait_blocks_until_data(self) -> None:
         """Test that Pipe → Block copy can_wait blocks until data is available."""
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         pipe = Pipe(12000, 12001)
         dst_dfb = DataflowBuffer(

--- a/test/sim/test_dfb.py
+++ b/test/sim/test_dfb.py
@@ -26,7 +26,7 @@ from test_utils import (
     tensors_exact_equal,
 )
 
-from sim import TILE_SHAPE, copy, ttnn
+from sim import Kernel, KernelKind, TILE_SHAPE, copy, ttnn
 from sim.ttnnsim import ROW_MAJOR_LAYOUT, TILE_LAYOUT, Tensor
 from sim.dfb import (
     Block,
@@ -102,6 +102,24 @@ def test_dataflow_buffer_basic() -> None:
     read_view.pop()
 
     print("Basic DataflowBuffer test passed!")
+
+
+def test_logical_kernel_release_selectors_are_inert() -> None:
+    """Simulator releases accept both public selector forms."""
+    dfb = DataflowBuffer(likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1)
+
+    write_view = dfb.reserve()
+    write_view.store(Block.from_tensor(make_ones_tile()))
+    write_view.push(kernel=KernelKind.COMPUTE)
+
+    read_view = dfb.wait()
+    output_dfb = DataflowBuffer(
+        likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+    )
+    output_view = output_dfb.reserve()
+    output_view.store(read_view)
+    output_view.push()
+    read_view.pop(kernel=Kernel(KernelKind.DATA_MOVEMENT))
 
 
 def test_dataflow_buffer_multi_tile() -> None:

--- a/test/sim/test_dfb.py
+++ b/test/sim/test_dfb.py
@@ -34,10 +34,7 @@ from sim.dfb import (
     make_dataflow_buffer_like,
 )
 from sim.block import broadcast
-from sim.blockstate import (
-    KernelType,
-    BlockAcquisition,
-)
+from sim.blockstate import BlockAcquisition
 from sim.context import (
     set_current_kernel_type,
     clear_current_kernel_type,
@@ -172,7 +169,7 @@ def test_dataflow_buffer_multi_tile() -> None:
 
 def test_copy_operations_with_dm_context() -> None:
     """Test copy operations between tensor and DataflowBuffer with proper DM kernel context."""
-    set_current_kernel_type(KernelType.DM)
+    set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
     try:
         tensor_a = make_rand_tensor(TILE_SHAPE[0] * 2, TILE_SHAPE[1] * 2)
@@ -271,7 +268,7 @@ def test_copy_in_dm_kernel_context() -> None:
         assert c_in_dfb.capacity_tiles == 2
 
         # DM kernel: Producer side - copy data into DFBs
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         # Copy c_in data
         c_block = c_in_dfb.reserve()
@@ -288,7 +285,7 @@ def test_copy_in_dm_kernel_context() -> None:
         a_block.push()
 
         # Switch to COMPUTE kernel: Consumer side - read data back
-        set_current_kernel_type(KernelType.COMPUTE)
+        set_current_kernel_type(KernelKind.COMPUTE)
 
         c_data = c_in_dfb.wait()
         a_data = a_in_dfb.wait()
@@ -338,7 +335,7 @@ def test_single_pending_reserve_constraint() -> None:
     machine rejects the push with a diagnostic.
     """
 
-    set_current_kernel_type(KernelType.DM)
+    set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
     try:
         element = make_ones_tile()
@@ -382,13 +379,13 @@ def test_single_pending_wait_constraint() -> None:
     rejects the pop with a diagnostic.
     """
 
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
 
     try:
         element = make_ones_tile()
         dfb = DataflowBuffer(likeness_tensor=element, shape=(1, 1), block_count=2)
 
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         block = dfb.reserve()
         test_data = make_rand_tensor(TILE_SHAPE[0], TILE_SHAPE[1])
         test_slice = test_data[0:1, 0:1]
@@ -397,7 +394,7 @@ def test_single_pending_wait_constraint() -> None:
         block.push()
 
         # Switch to COMPUTE kernel for consumption
-        set_current_kernel_type(KernelType.COMPUTE)
+        set_current_kernel_type(KernelKind.COMPUTE)
 
         # First wait() should succeed
         data1 = dfb.wait()
@@ -415,13 +412,13 @@ def test_single_pending_wait_constraint() -> None:
         data1.pop()
 
         # Add more data (using DM kernel)
-        set_current_kernel_type(KernelType.DM)
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
         block = dfb.reserve()
         tx = copy(test_slice, block)
         tx.wait()
         block.push()
 
-        set_current_kernel_type(KernelType.COMPUTE)
+        set_current_kernel_type(KernelKind.COMPUTE)
         data2 = dfb.wait()
         assert data2 is not None
         # Use second waited block as STORE_SRC before pop
@@ -826,7 +823,6 @@ def test_iadd_raises_on_non_temporary() -> None:
 def test_pending_confirmation_cleared_when_result_is_stored() -> None:
     """Block used in arithmetic clears its pending confirmation when the result is stored."""
     from sim import ttnn, TILE_SHAPE
-    from sim.blockstate import KernelType
     from sim.context import set_current_kernel_type, clear_current_kernel_type
     from sim.copy import copy as dm_copy
 
@@ -835,7 +831,7 @@ def test_pending_confirmation_cleared_when_result_is_stored() -> None:
     dst_dfb = DataflowBuffer(likeness_tensor=element, shape=(1, 1), block_count=2)
 
     # DM kernel: write a value into src_dfb
-    set_current_kernel_type(KernelType.DM)
+    set_current_kernel_type(KernelKind.DATA_MOVEMENT)
     src_blk = src_dfb.reserve()
     tx = dm_copy(ttnn.Tensor(torch.full(TILE_SHAPE, 3.0)), src_blk)
     tx.wait()
@@ -843,7 +839,7 @@ def test_pending_confirmation_cleared_when_result_is_stored() -> None:
     clear_current_kernel_type()
 
     # Compute kernel: use src_blk in arithmetic, store the result
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
     try:
         with src_dfb.wait() as c_blk:
             # arithmetic use registers pending confirmation
@@ -866,7 +862,6 @@ def test_pending_confirmation_cleared_when_result_is_stored() -> None:
 def test_pending_confirmation_raises_at_termination_if_never_stored() -> None:
     """validate_no_pending_blocks() raises if block data was used in arithmetic but never stored."""
     from sim import ttnn, TILE_SHAPE
-    from sim.blockstate import KernelType
     from sim.context import set_current_kernel_type, clear_current_kernel_type
     from sim.copy import copy as dm_copy
 
@@ -874,7 +869,7 @@ def test_pending_confirmation_raises_at_termination_if_never_stored() -> None:
     src_dfb = DataflowBuffer(likeness_tensor=element, shape=(1, 1), block_count=2)
 
     # DM kernel: write a value
-    set_current_kernel_type(KernelType.DM)
+    set_current_kernel_type(KernelKind.DATA_MOVEMENT)
     src_blk = src_dfb.reserve()
     tx = dm_copy(ttnn.Tensor(torch.full(TILE_SHAPE, 1.0)), src_blk)
     tx.wait()
@@ -882,7 +877,7 @@ def test_pending_confirmation_raises_at_termination_if_never_stored() -> None:
     clear_current_kernel_type()
 
     # Compute kernel: use block in arithmetic but discard the result without storing
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
     try:
         with src_dfb.wait(name="arith_src") as c_blk:
             _unused = c_blk + Block.from_tensor(
@@ -1071,7 +1066,7 @@ def test_l1_limit_counts_unreferenced_dfbs() -> None:
 
 def test_heterogeneous_dfbs_independent() -> None:
     """Test that multiple DataflowBuffers operate independently."""
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
 
     try:
         element = make_full_tensor(64, 64, 1.0)
@@ -1114,7 +1109,7 @@ def test_heterogeneous_dfbs_independent() -> None:
 
 def test_two_dfbs_independent_state() -> None:
     """Test that two DataflowBuffers have fully independent ring-buffer state."""
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
 
     try:
         element = make_full_tensor(32, 32, 1.0)
@@ -1395,7 +1390,6 @@ def test_1d_block_from_list():
 
 def test_1d_dataflow_buffer_reserve_push_wait_pop():
     """DataflowBuffer with 1-D shape correctly reserves, pushes, and delivers data."""
-    from sim.blockstate import KernelType
     from sim.context import set_current_kernel_type, clear_current_kernel_type
 
     element = Tensor(torch.zeros(32))
@@ -1404,7 +1398,7 @@ def test_1d_dataflow_buffer_reserve_push_wait_pop():
     assert dfb.shape == (1,)
     assert dfb.capacity_tiles == 2
 
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
     try:
         write = dfb.reserve()
         assert len(write) == 1
@@ -1431,7 +1425,6 @@ def test_1d_dataflow_buffer_reserve_push_wait_pop():
 
 def test_1d_multi_tile_dataflow_buffer():
     """DataflowBuffer with 1-D shape (4,) operates over 4 tiles per operation."""
-    from sim.blockstate import KernelType
     from sim.context import set_current_kernel_type, clear_current_kernel_type
 
     # Full buffer element shape for 4 tiles of size 32 each
@@ -1441,7 +1434,7 @@ def test_1d_multi_tile_dataflow_buffer():
     assert dfb.shape == (4,)
     assert dfb.capacity_tiles == 8
 
-    set_current_kernel_type(KernelType.COMPUTE)
+    set_current_kernel_type(KernelKind.COMPUTE)
     try:
         write = dfb.reserve()
         assert len(write) == 4

--- a/test/sim/test_greenlet_scheduler.py
+++ b/test/sim/test_greenlet_scheduler.py
@@ -7,7 +7,6 @@ Tests for greenlet-based cooperative scheduler.
 
 import pytest
 
-from sim.blockstate import KernelType
 from sim.greenlet_scheduler import (
     GreenletScheduler,
     KernelId,
@@ -18,6 +17,7 @@ from sim.greenlet_scheduler import (
     set_scheduler,
     set_scheduler_algorithm,
 )
+from sim.kernel import KernelKind
 from test_helpers.mock_kernel import do_wait, do_reserve
 
 
@@ -69,8 +69,8 @@ class TestGreenletScheduler:
         def kernel2() -> None:
             executed.append("kernel2")
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
         set_scheduler(scheduler)
         try:
@@ -88,13 +88,13 @@ class TestGreenletScheduler:
             pass
 
         with pytest.raises(ValueError, match="non-negative"):
-            KernelId(-1, KernelType.COMPUTE, "a")
+            KernelId(-1, KernelKind.COMPUTE, "a")
 
         with pytest.raises(ValueError, match="non-empty"):
-            KernelId(0, KernelType.COMPUTE, "")
+            KernelId(0, KernelKind.COMPUTE, "")
 
         scheduler = GreenletScheduler()
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "role"), fn)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "role"), fn)
 
     def test_add_kernel_rejects_duplicate_func_name_on_same_node(self) -> None:
         """Two DM kernels with the same __name__ on the same node is rejected.
@@ -112,18 +112,18 @@ class TestGreenletScheduler:
             pass
 
         scheduler = GreenletScheduler()
-        scheduler.add_kernel(KernelId(0, KernelType.DM, "reader"), dm_a)
+        scheduler.add_kernel(KernelId(0, KernelKind.DATA_MOVEMENT, "reader"), dm_a)
         with pytest.raises(RuntimeError, match="Duplicate kernel registration"):
-            scheduler.add_kernel(KernelId(0, KernelType.DM, "reader"), dm_b)
+            scheduler.add_kernel(KernelId(0, KernelKind.DATA_MOVEMENT, "reader"), dm_b)
 
         # Different node: allowed.
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "reader"), dm_b)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "reader"), dm_b)
         # Different kind on same node: allowed (compute vs DM).
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "reader"), dm_a)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "reader"), dm_a)
 
     def test_kernel_display_name_matches_program_convention(self) -> None:
         assert (
-            kernel_display_name(KernelId(3, KernelType.COMPUTE, "compute"))
+            kernel_display_name(KernelId(3, KernelKind.COMPUTE, "compute"))
             == "node3-compute"
         )
 
@@ -138,8 +138,8 @@ class TestGreenletScheduler:
         def kernel2() -> None:
             completed.append("t2")
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
         set_scheduler(scheduler)
         try:
@@ -169,8 +169,8 @@ class TestGreenletScheduler:
             mock_obj.make_ready()
             execution_order.append("t2-end")
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
         set_scheduler(scheduler)
         try:
@@ -190,7 +190,7 @@ class TestGreenletScheduler:
             # This will block forever
             do_wait(mock_obj)
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), blocked_kernel)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), blocked_kernel)
 
         set_scheduler(scheduler)
         try:
@@ -211,8 +211,8 @@ class TestGreenletScheduler:
         def kernel2() -> None:
             do_reserve(mock2)
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
         set_scheduler(scheduler)
         try:
@@ -228,7 +228,7 @@ class TestGreenletScheduler:
         def failing_kernel() -> None:
             raise ValueError("Test error")
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), failing_kernel)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), failing_kernel)
 
         set_scheduler(scheduler)
         try:
@@ -258,8 +258,8 @@ class TestGreenletScheduler:
             do_wait(mock2)
             execution_order.append("t2-3")
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
         set_scheduler(scheduler)
         try:
@@ -291,7 +291,7 @@ class TestGreenletScheduler:
             do_wait(mock_obj)
             executed.append("after")
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel)
 
         set_scheduler(scheduler)
         try:
@@ -317,8 +317,8 @@ class TestGreenletScheduler:
             executed.append("t2")
             mock_obj.make_ready()
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
         set_scheduler(scheduler)
         try:
@@ -344,7 +344,7 @@ class TestGreenletScheduler:
                 do_wait(mock_obj)
                 count.append(i)
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel)
 
         set_scheduler(scheduler)
         try:
@@ -362,7 +362,7 @@ class TestGreenletScheduler:
             executed.append("done")
 
         scheduler = GreenletScheduler()
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel)
 
         set_scheduler(scheduler)
         try:
@@ -393,8 +393,8 @@ class TestBlockIfNeeded:
         def kernel2() -> None:
             mock_obj.make_ready()
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-        scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+        scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
         set_scheduler(scheduler)
         try:
@@ -417,7 +417,7 @@ class TestBlockIfNeeded:
             do_reserve(mock_obj)
             executed.append(3)
 
-        scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel)
+        scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel)
 
         set_scheduler(scheduler)
         try:
@@ -467,8 +467,8 @@ class TestSchedulerAlgorithm:
                 execution_order.append("t2-1")
                 execution_order.append("t2-2")
 
-            scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-            scheduler.add_kernel(KernelId(1, KernelType.DM, "t2"), kernel2)
+            scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+            scheduler.add_kernel(KernelId(1, KernelKind.DATA_MOVEMENT, "t2"), kernel2)
 
             set_scheduler(scheduler)
             try:
@@ -506,9 +506,9 @@ class TestSchedulerAlgorithm:
                 mock_obj1.make_ready()
                 mock_obj2.make_ready()
 
-            scheduler.add_kernel(KernelId(0, KernelType.COMPUTE, "t1"), kernel1)
-            scheduler.add_kernel(KernelId(1, KernelType.COMPUTE, "t2"), kernel2)
-            scheduler.add_kernel(KernelId(2, KernelType.DM, "t3"), kernel3)
+            scheduler.add_kernel(KernelId(0, KernelKind.COMPUTE, "t1"), kernel1)
+            scheduler.add_kernel(KernelId(1, KernelKind.COMPUTE, "t2"), kernel2)
+            scheduler.add_kernel(KernelId(2, KernelKind.DATA_MOVEMENT, "t3"), kernel3)
 
             set_scheduler(scheduler)
             try:

--- a/test/sim/test_ttlang_sim.py
+++ b/test/sim/test_ttlang_sim.py
@@ -123,6 +123,10 @@ class TestDefaultGrid:
     def test_explicit_kernel_selectors_are_inert(self):
         """Simulator thread decorators accept logical selectors."""
         data_movement_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+        assert ttl.KernelKind.COMPUTE | ttl.KernelKind.DATA_MOVEMENT == (
+            ttl.KernelKind.COMPUTE,
+            ttl.KernelKind.DATA_MOVEMENT,
+        )
 
         @ttl.operation(grid=(1, 1))
         def test_kernel(a: ttnn.Tensor):

--- a/test/sim/test_ttlang_sim.py
+++ b/test/sim/test_ttlang_sim.py
@@ -120,6 +120,26 @@ class TestDefaultGrid:
         finally:
             set_default_grid(original)
 
+    def test_explicit_kernel_selectors_are_inert(self):
+        """Simulator thread decorators accept logical selectors."""
+        data_movement_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+        @ttl.operation(grid=(1, 1))
+        def test_kernel(a: ttnn.Tensor):
+            @ttl.compute(kernel=ttl.KernelKind.COMPUTE)
+            def compute():
+                pass
+
+            @ttl.datamovement(kernel=data_movement_kernel)
+            def data_movement():
+                pass
+
+            @ttl.datamovement()
+            def second_data_movement():
+                pass
+
+        test_kernel(make_zeros_tensor(32, 32))
+
 
 class TestGridCommandLineOption:
     """Test --grid command-line option in tt-lang-sim."""

--- a/test/ttlang/Dialect/TTL/IR/logical_kernel_attr.mlir
+++ b/test/ttlang/Dialect/TTL/IR/logical_kernel_attr.mlir
@@ -18,7 +18,7 @@ func.func @named() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = d
 
 // Compiler-owned affinities use a logical role instead of an operation id.
 // CHECK-LABEL: func.func @role
-// CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<source>", role = "source">
-func.func @role() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<source>", role = "source">} {
+// CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<pipe_source>", role = "pipe_source">
+func.func @role() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<pipe_source>", role = "pipe_source">} {
   return
 }

--- a/test/ttlang/Dialect/TTL/IR/logical_kernel_attr.mlir
+++ b/test/ttlang/Dialect/TTL/IR/logical_kernel_attr.mlir
@@ -1,0 +1,24 @@
+// RUN: ttlang-opt %s | FileCheck %s
+
+// Tests parsing and printing portable logical-kernel metadata.
+
+// A kind-only selector records the canonical kernel without an identity.
+// CHECK-LABEL: func.func @canonical
+// CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = compute>
+func.func @canonical() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = compute>} {
+  return
+}
+
+// An operation-owned handle records its stable operation-local identity.
+// CHECK-LABEL: func.func @named
+// CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "operation">
+func.func @named() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "operation">} {
+  return
+}
+
+// Compiler-owned affinities use a logical role instead of an operation id.
+// CHECK-LABEL: func.func @role
+// CHECK-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<source>", role = "source">
+func.func @role() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<source>", role = "source">} {
+  return
+}

--- a/test/ttlang/Dialect/TTL/IR/logical_kernel_attr_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/logical_kernel_attr_invalid.mlir
@@ -1,0 +1,49 @@
+// RUN: ttlang-opt --verify-diagnostics --split-input-file %s
+
+// Tests malformed logical-kernel metadata independently.
+
+// A canonical selector cannot claim an operation.
+// expected-error @below {{canonical logical kernel cannot have an operation or role}}
+func.func @canonical_with_operation() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = compute, operation = "operation">} {
+  return
+}
+
+// -----
+
+// A named handle must belong to an operation or a compiler-owned role.
+// expected-error @below {{named logical kernel requires exactly one of an operation or compiler-owned role}}
+func.func @named_without_owner() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader">} {
+  return
+}
+
+// -----
+
+// An operation handle cannot also claim a compiler-owned role.
+// expected-error @below {{named logical kernel requires exactly one of an operation or compiler-owned role}}
+func.func @named_with_two_owners() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "operation", role = "source">} {
+  return
+}
+
+// -----
+
+// Present identities cannot use an empty string to denote absence.
+// expected-error @below {{logical kernel identity must be nonempty}}
+func.func @empty_identity() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "">} {
+  return
+}
+
+// -----
+
+// Present operation identities must be nonempty.
+// expected-error @below {{logical kernel operation must be nonempty}}
+func.func @empty_operation() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "">} {
+  return
+}
+
+// -----
+
+// Present compiler-owned roles must be nonempty.
+// expected-error @below {{logical kernel role must be nonempty}}
+func.func @empty_role() attributes {ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<source>", role = "">} {
+  return
+}


### PR DESCRIPTION
### PR stack

```
main
  |
  `-- #825 Portable logical-kernel selection (this PR)
        |-- #827 Portable operation runtime resources
        `-- #830 Typed DFB effects for opaque calls
```

### Problem description

A unified `@ttl.operation` is written as one Python function, but the compiler emits separate compute and data-movement kernels. For ordinary TT-Lang statements, visible operation semantics and data dependencies determine which kernel executes each statement. An opaque `ttl.call_extern_func` does not provide that information, and one external call may need to execute in more than one logical kernel.

A dataflow-buffer `push()` or `pop()` has the same ambiguity when its associated block is otherwise unused. Physical processor names are not a suitable selector API because they vary by target and cannot consistently identify multiple operation-level kernels of the same kind.

This PR provides explicit, target-independent logical-kernel selectors for these cases. A logical kernel identifies an operation-level compute or data-movement kernel independently of its physical backend assignment. The identity is retained through splitting and specialization.

The runtime requires a complete backend kernel set, so the compiler can also emit empty kernels. These synthesized kernels receive stable logical identities, ensuring every runtime `KernelSpec` can be addressed without relying on descriptor order or physical processor names.

### What's changed

- Add `KernelKind` and operation-local `Kernel` selectors.
- Add `kernel=` to `call_extern_func`, `TensorBlock.push`, and `TensorBlock.pop`.
- Allow one selector, a `KernelKind` union using `|`, or a nonempty tuple for external calls; require at most one selector for push/pop.
- Split unified operations by logical kernel without changing external-call lowering or DFB synchronization operations.
- Preserve verified logical-kernel identity through specialization and expose it on `KernelSpec`.
- Bind factory-captured kernel handles in place during operation registration.
- Enforce target capacity separately for compute and data-movement kernels, including explicit operations that previously accepted unsupported kernel mixes with three total threads.
- Document external-function arguments, kernel selection, include directories, and DFB synchronization ownership in the Sphinx user guide.

### Checklist

- [x] New/Existing tests provide coverage for changes
