### PR TITLE
[ttl] Fuse RMSNorm row compute

### DIFF
--- a/docs/development/ComputeKernelConfiguration.md
+++ b/docs/development/ComputeKernelConfiguration.md
@@ -33,6 +33,7 @@ Tile operations implement `TileExecutionOpInterface`. The interface reports:
 - the route for each operand: dataflow buffer, DST, or no tile-data route;
 - which DST operands the operation lowering initializes itself;
 - whether the result is resident in DST;
+- the maximum number of simultaneously resident DST slots;
 - the full-fp32 accumulation category, when configurable;
 - whether repeated operations accumulate into an existing DST slot.
 
@@ -120,6 +121,8 @@ Destination requirements use the result or resident operand type, not only DFB
 input storage width. The width query uses the TTCore tile element type, so a
 supported operation with 32-bit integer destination elements requires 32-bit
 destination registers without an integer-type exception in this analysis.
+Fixed-block operations also record their simultaneous DST residency. This
+requirement remains explicit when tensor operands are scalarized to tile values.
 
 ## Resolution
 
@@ -127,6 +130,7 @@ The resolver maintains a finite set of complete target configurations:
 
 ```text
 destination element width:     {Bits16, Bits32}
+destination synchronization:   {DoubleBuffered, Full}
 DFB N unpack mode:              {Default, UnpackToDestination}
 ```
 
@@ -134,10 +138,11 @@ Not every Cartesian-product combination is legal. Each target query returns
 the allowed width-and-mode relation for a primitive, element type, and operand
 route. `TileOperandRoute` separately records the primitive's physical operand
 route; the unpack mode does not describe that route for formats where the
-setting is inert. Hard policy constraints restrict the initial candidates.
-Fixed operation requirements are then intersected with the target-supported
-relations. Each strategy option is represented by the same requirement types
-as a fixed operation.
+setting is inert. Hard policy constraints restrict the initial candidates,
+including an explicit synchronization setting. Fixed operation requirements
+are then intersected with the target-supported relations and the DST capacity
+for each width-and-synchronization pair. Each strategy option is represented by
+the same requirement types as a fixed operation.
 
 Strategy selection and configuration selection are solved together. The
 search chooses the unresolved operation with the fewest compatible options,
@@ -156,13 +161,15 @@ After all hard constraints are satisfied, reduce and matmul preferences select
 32-bit destination elements when they remain supported. Preferences never make
 a valid domain empty.
 
-DST synchronization currently has no operation-specific compatibility
-constraints. `enabled` selects full synchronization; `auto` and `disabled`
-select double-buffered synchronization.
+DST synchronization affects the number of available DST slots. `enabled` and
+`disabled` select full and double-buffered synchronization, respectively.
+`auto` prefers double-buffered synchronization when it satisfies every fixed
+residency requirement and otherwise selects full synchronization.
 
-An empty domain produces a diagnostic identifying both incompatible
-requirements. The resolver retains typed conflict evidence rather than
-reconstructing a cause from mutated IR.
+An empty domain produces a diagnostic identifying incompatible requirements.
+A capacity conflict reports the required and maximum available slot counts.
+The resolver retains typed conflict evidence rather than reconstructing a cause
+from mutated IR.
 
 ## Application
 
@@ -189,6 +196,7 @@ additional policy.
   kernel.
 - One concrete destination width and synchronization mode apply to the complete
   kernel.
+- Every fixed-block residency fits the selected destination capacity.
 - Strategy selection is stable across later IR rewrites.
 - Failure before plan application leaves IR unchanged.
 - Unknown execution semantics and unresolved DFB identities are errors.

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -328,10 +328,11 @@ result = normalized * gamma  // optional
 
 Recognition occurs during immutable candidate analysis. The resulting
 `RowNormalizationPlan` records every absorbed operation and its operands, the
-input and optional gamma values, scalar attributes, row tile count, effective
-DST capacity, and gamma mode. Application verifies the recorded operands and
-emits one `ttl.tile_row_normalization_block`; it does not repeat recognition or
-legality analysis.
+input and optional gamma values, scalar attributes, row tile count, and gamma
+mode. Application verifies the recorded operands and emits one
+`ttl.tile_row_normalization_block`; it does not repeat recognition or legality
+analysis. Capacity is checked during planning and revalidated before compute
+lowering.
 
 The schedule is selected only when all of these conditions hold:
 

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -294,6 +294,85 @@ accumulator. Instrumentation between a matmul and add also keeps separate tile
 operations and emits a warning because the combined hardware operation cannot
 preserve the observation point.
 
+### Capacity-Fitting Reduction Fusion
+
+The ordinary fusion tracer composes operations that share one iteration
+domain. A full reduction followed by scalar operations and reuse across the
+original row has three domains:
+
+```text
+row tiles [1, N]
+  -> full reduction [1, 1]
+  -> scalar operations [1, 1]
+  -> scalar reuse across row tiles [1, N]
+```
+
+A tile recipe cannot represent this schedule as one pointwise iteration. The
+reduction must consume every row tile before its scalar result is available,
+and the result must then remain live while the row tiles are read again. The
+generic tracer therefore requires an unstored elementwise producer of a
+reduction to be materialized in a DFB. Direct reduction creation also requires
+DFB-backed input and scaler operands.
+
+Row normalization uses a target-specific schedule when the complete operation
+sequence has this semantic form:
+
+```text
+squared = input * input
+sum = reduce_sum(squared, dims=[0, 1])
+mean_square = sum * scale
+inverse_rms = rsqrt(mean_square + epsilon)
+normalized = input * broadcast(inverse_rms)
+result = normalized * gamma  // optional
+```
+
+Recognition occurs during immutable candidate analysis. The resulting
+`RowNormalizationPlan` records every absorbed operation and its operands, the
+input and optional gamma values, scalar attributes, row tile count, effective
+DST capacity, and gamma mode. Application verifies the recorded operands and
+emits one `ttl.tile_row_normalization_block`; it does not repeat recognition or
+legality analysis.
+
+The schedule is selected only when all of these conditions hold:
+
+- the target is Blackhole and the DFB data type is bf16;
+- input and result are the same static rank-2 one-row tensor type;
+- the row contains at least one tile and fits the effective DST capacity,
+  restricted to the block helper's eight-tile limit;
+- the sum reduces both tensor dimensions and uses a unit reduction scaler;
+- scale and epsilon are finite and positive;
+- each internal value has the uses required by the schedule;
+- optional gamma has the complete row type;
+- publication contains exactly one reserve/store transaction; and
+- no instrumentation would be absorbed into the block schedule.
+
+Failure to satisfy a specialization condition leaves the expression available
+to ordinary creation and intermediate DFB materialization. A rejected
+specialization does not modify IR.
+
+`LowerRowNormalizationCompute` verifies the planned compute against its target,
+formal inputs and output, row size, DST capacity, and store before mutation. It
+then creates one DST section for the entire row. Target lowering performs the
+sum of squares, applies scale and epsilon, computes reciprocal square root,
+moves the retained scalar to a compute source register, clears the acquired DST
+section, and multiplies it across all input tiles. Optional gamma multiplication
+occurs before the output block is packed. The generated kernel therefore uses
+one DST acquisition and no intermediate DFB.
+
+The row-normalization LLK applies its reduction scaler during both reduction
+stages. TTKernel-to-C++ lowering passes the square root of the semantic scale so
+the complete reduction applies the scale once.
+
+This schedule establishes the required representation for general reduction
+fusion but does not make the generic tracer multi-domain. A general planner
+must record ordered stages with independent iteration domains, explicit
+cross-stage values, and target storage capabilities. It must select whether a
+reduction result remains in DST, moves to a source register, or is materialized
+in a DFB from complete liveness, use, capacity, and publication facts. Extra
+consumers require either a recorded publication or materialization; spelling
+changes such as division by square root require semantic recipe equivalence.
+Application must remain mechanical and execute only the selected typed plan.
+
 ### Cross-Region Recomputation
 
 A pure producer defined in a dominating block may be recomputed in a nested
@@ -539,6 +618,11 @@ The design preserves these properties:
 9. **Conversion completeness.** Final conversion assigns every `ttl.store` to
    a selected `ComputeOp` creation or passthrough plan before modifying IR.
 
+10. **Capacity-fitting reduction schedule.** Row-normalization fusion checks
+    the complete expression, target support, DST capacity, value uses, and
+    output publication before mutation. Lowering revalidates the planned
+    `ttl.compute` and retains the scalar within one DST transaction.
+
 The proof assumes verified TTL operation types, valid DFB FIFO semantics, and
 recognized view-preserving operations for acquired DFB storage. Conservative
 or unresolved DFB ownership returns "may be released" and may require a
@@ -611,6 +695,9 @@ operations and user DFB publications.
   loop lowering.
 - Fused expressions require explicit TTL tile recipes. Unsupported tensor
   operations stop tracing and remain separate or require materialization.
+- Generic fused expressions currently use one iteration domain. Reduction
+  results reused by another domain require an explicit capacity-fitting block
+  schedule; row normalization is the first such schedule.
 - Cross-block fusion rejects instrumentation that cannot be ordered relative
   to the sink block.
 - `ttl.tile_store` does not encode its formal output index. The compiler traces
@@ -634,6 +721,12 @@ operations and user DFB publications.
   fixed point of storage requirements.
 - `lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp` mechanically applies
   direct, fused, elision, and passthrough plans.
+- `lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp` verifies and
+  lowers the capacity-fitting row-normalization compute to one DST section.
+- `lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp` converts the
+  block schedule after DFB identities are available.
+- `include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h`
+  implements scalar-retaining row normalization within one DST acquisition.
 - `lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp` applies grouped
   compiler-DFB materialization plans.
 - `lib/Dialect/TTL/Transforms/TTLPrintComputeOpCreationPlans.cpp` prints

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -332,10 +332,11 @@ result = normalized * gamma  // optional
 
 Recognition occurs during immutable candidate analysis. The resulting
 `RowNormalizationPlan` records every absorbed operation and its operands, the
-input and optional gamma values, scalar attributes, row tile count, effective
-DST capacity, and gamma mode. Application verifies the recorded operands and
-emits one `ttl.tile_row_normalization_block`; it does not repeat recognition or
-legality analysis.
+input and optional gamma values, scalar attributes, row tile count, and gamma
+mode. Application verifies the recorded operands and emits one
+`ttl.tile_row_normalization_block`; it does not repeat recognition or legality
+analysis. Capacity is checked during planning and revalidated before compute
+lowering.
 
 The schedule is selected only when all of these conditions hold:
 

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -318,7 +318,7 @@ generic tracer therefore requires an unstored elementwise producer of a
 reduction to be materialized in a DFB. Direct reduction creation also requires
 DFB-backed input and scaler operands.
 
-Row normalization uses a target-specific schedule when the complete operation
+Row normalization uses a target-supported schedule when the complete operation
 sequence has this semantic form:
 
 ```text
@@ -339,10 +339,10 @@ legality analysis.
 
 The schedule is selected only when all of these conditions hold:
 
-- the target is Blackhole and the DFB data type is bf16;
+- the target exposes the row-normalization capability for the DFB element type;
 - input and result are the same static rank-2 one-row tensor type;
-- the row contains at least one tile and fits the effective DST capacity,
-  restricted to the block helper's eight-tile limit;
+- the row contains at least one tile, does not exceed the target schedule limit,
+  and fits a DST configuration permitted by explicit kernel attributes;
 - the sum reduces both tensor dimensions and uses a unit reduction scaler;
 - scale and epsilon are finite and positive;
 - each internal value has the uses required by the schedule;
@@ -351,8 +351,8 @@ The schedule is selected only when all of these conditions hold:
 - no instrumentation would be absorbed into the block schedule.
 
 Failure to satisfy a specialization condition leaves the expression available
-to ordinary creation and intermediate DFB materialization. A rejected
-specialization does not modify IR.
+to the remaining compute-creation mechanisms and intermediate DFB
+materialization. A rejected specialization does not modify IR.
 
 `LowerRowNormalizationCompute` verifies the planned compute against its target,
 formal inputs and output, row size, DST capacity, and store before mutation. It
@@ -362,6 +362,13 @@ moves the retained scalar to a compute source register, clears the acquired DST
 section, and multiplies it across all input tiles. Optional gamma multiplication
 occurs before the output block is packed. The generated kernel therefore uses
 one DST acquisition and no intermediate DFB.
+
+`num_tiles` preserves the exact fixed-block residency after tensor operands are
+scalarized to tile values. Kernel-configuration resolution intersects this
+requirement with destination width and synchronization candidates. Automatic
+synchronization prefers double buffering when the row fits and selects full
+synchronization when it is required for capacity. An explicit configuration
+that cannot hold the row produces a capacity diagnostic before DST assignment.
 
 The row-normalization LLK applies its reduction scaler during both reduction
 stages. TTKernel-to-C++ lowering passes the square root of the semantic scale so

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -172,8 +172,9 @@ validates kernel tile dimensions, primitive data-type support, and matmul LLK
 combinations before compute creation or TTKernel conversion modifies IR. The
 environment is selected from the module's system description or
 `ttl.target_arch`. Modules without either use the intersection of capabilities
-implemented by all supported targets. Wormhole B0 and Blackhole currently
-provide the same compute capability set.
+implemented by all supported targets. Target implementations may expose
+different fixed-block schedules when their dependencies provide different LLK
+capabilities.
 
 Adding an architecture requires a capability implementation and an entry in
 `computeTargetRegistrations`. The registration table is the source for both

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -298,6 +298,85 @@ accumulator. Instrumentation between a matmul and add also keeps separate tile
 operations and emits a warning because the combined hardware operation cannot
 preserve the observation point.
 
+### Capacity-Fitting Reduction Fusion
+
+The ordinary fusion tracer composes operations that share one iteration
+domain. A full reduction followed by scalar operations and reuse across the
+original row has three domains:
+
+```text
+row tiles [1, N]
+  -> full reduction [1, 1]
+  -> scalar operations [1, 1]
+  -> scalar reuse across row tiles [1, N]
+```
+
+A tile recipe cannot represent this schedule as one pointwise iteration. The
+reduction must consume every row tile before its scalar result is available,
+and the result must then remain live while the row tiles are read again. The
+generic tracer therefore requires an unstored elementwise producer of a
+reduction to be materialized in a DFB. Direct reduction creation also requires
+DFB-backed input and scaler operands.
+
+Row normalization uses a target-specific schedule when the complete operation
+sequence has this semantic form:
+
+```text
+squared = input * input
+sum = reduce_sum(squared, dims=[0, 1])
+mean_square = sum * scale
+inverse_rms = rsqrt(mean_square + epsilon)
+normalized = input * broadcast(inverse_rms)
+result = normalized * gamma  // optional
+```
+
+Recognition occurs during immutable candidate analysis. The resulting
+`RowNormalizationPlan` records every absorbed operation and its operands, the
+input and optional gamma values, scalar attributes, row tile count, effective
+DST capacity, and gamma mode. Application verifies the recorded operands and
+emits one `ttl.tile_row_normalization_block`; it does not repeat recognition or
+legality analysis.
+
+The schedule is selected only when all of these conditions hold:
+
+- the target is Blackhole and the DFB data type is bf16;
+- input and result are the same static rank-2 one-row tensor type;
+- the row contains at least one tile and fits the effective DST capacity,
+  restricted to the block helper's eight-tile limit;
+- the sum reduces both tensor dimensions and uses a unit reduction scaler;
+- scale and epsilon are finite and positive;
+- each internal value has the uses required by the schedule;
+- optional gamma has the complete row type;
+- publication contains exactly one reserve/store transaction; and
+- no instrumentation would be absorbed into the block schedule.
+
+Failure to satisfy a specialization condition leaves the expression available
+to ordinary creation and intermediate DFB materialization. A rejected
+specialization does not modify IR.
+
+`LowerRowNormalizationCompute` verifies the planned compute against its target,
+formal inputs and output, row size, DST capacity, and store before mutation. It
+then creates one DST section for the entire row. Target lowering performs the
+sum of squares, applies scale and epsilon, computes reciprocal square root,
+moves the retained scalar to a compute source register, clears the acquired DST
+section, and multiplies it across all input tiles. Optional gamma multiplication
+occurs before the output block is packed. The generated kernel therefore uses
+one DST acquisition and no intermediate DFB.
+
+The row-normalization LLK applies its reduction scaler during both reduction
+stages. TTKernel-to-C++ lowering passes the square root of the semantic scale so
+the complete reduction applies the scale once.
+
+This schedule establishes the required representation for general reduction
+fusion but does not make the generic tracer multi-domain. A general planner
+must record ordered stages with independent iteration domains, explicit
+cross-stage values, and target storage capabilities. It must select whether a
+reduction result remains in DST, moves to a source register, or is materialized
+in a DFB from complete liveness, use, capacity, and publication facts. Extra
+consumers require either a recorded publication or materialization; spelling
+changes such as division by square root require semantic recipe equivalence.
+Application must remain mechanical and execute only the selected typed plan.
+
 ### Cross-Region Recomputation
 
 A pure producer defined in a dominating block may be recomputed in a nested
@@ -552,6 +631,11 @@ The design preserves these properties:
 9. **Conversion completeness.** Final conversion assigns every `ttl.store` to
    a selected `ComputeOp` creation or passthrough plan before modifying IR.
 
+10. **Capacity-fitting reduction schedule.** Row-normalization fusion checks
+    the complete expression, target support, DST capacity, value uses, and
+    output publication before mutation. Lowering revalidates the planned
+    `ttl.compute` and retains the scalar within one DST transaction.
+
 The proof assumes verified TTL operation types, valid DFB FIFO semantics, and
 recognized view-preserving operations for acquired DFB storage. Conservative
 or unresolved DFB ownership returns "may be released" and may require a
@@ -624,6 +708,9 @@ operations and user DFB publications.
   loop lowering.
 - Fused expressions require explicit TTL tile recipes. Unsupported tensor
   operations stop tracing and remain separate or require materialization.
+- Generic fused expressions currently use one iteration domain. Reduction
+  results reused by another domain require an explicit capacity-fitting block
+  schedule; row normalization is the first such schedule.
 - Cross-block fusion rejects instrumentation that cannot be ordered relative
   to the sink block.
 - `ttl.tile_store` does not encode its formal output index. The compiler traces
@@ -648,6 +735,12 @@ operations and user DFB publications.
   fixed point of storage requirements.
 - `lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp` mechanically applies
   direct, fused, elision, and passthrough plans.
+- `lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp` verifies and
+  lowers the capacity-fitting row-normalization compute to one DST section.
+- `lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp` converts the
+  block schedule after DFB identities are available.
+- `include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h`
+  implements scalar-retaining row normalization within one DST acquisition.
 - `lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp` applies grouped
   compiler-DFB materialization plans.
 - `lib/Dialect/TTL/Transforms/TTLPrintComputeOpCreationPlans.cpp` prints

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -314,7 +314,7 @@ generic tracer therefore requires an unstored elementwise producer of a
 reduction to be materialized in a DFB. Direct reduction creation also requires
 DFB-backed input and scaler operands.
 
-Row normalization uses a target-specific schedule when the complete operation
+Row normalization uses a target-supported schedule when the complete operation
 sequence has this semantic form:
 
 ```text
@@ -335,10 +335,10 @@ legality analysis.
 
 The schedule is selected only when all of these conditions hold:
 
-- the target is Blackhole and the DFB data type is bf16;
+- the target exposes the row-normalization capability for the DFB element type;
 - input and result are the same static rank-2 one-row tensor type;
-- the row contains at least one tile and fits the effective DST capacity,
-  restricted to the block helper's eight-tile limit;
+- the row contains at least one tile, does not exceed the target schedule limit,
+  and fits a DST configuration permitted by explicit kernel attributes;
 - the sum reduces both tensor dimensions and uses a unit reduction scaler;
 - scale and epsilon are finite and positive;
 - each internal value has the uses required by the schedule;
@@ -347,8 +347,8 @@ The schedule is selected only when all of these conditions hold:
 - no instrumentation would be absorbed into the block schedule.
 
 Failure to satisfy a specialization condition leaves the expression available
-to ordinary creation and intermediate DFB materialization. A rejected
-specialization does not modify IR.
+to the remaining compute-creation mechanisms and intermediate DFB
+materialization. A rejected specialization does not modify IR.
 
 `LowerRowNormalizationCompute` verifies the planned compute against its target,
 formal inputs and output, row size, DST capacity, and store before mutation. It
@@ -358,6 +358,13 @@ moves the retained scalar to a compute source register, clears the acquired DST
 section, and multiplies it across all input tiles. Optional gamma multiplication
 occurs before the output block is packed. The generated kernel therefore uses
 one DST acquisition and no intermediate DFB.
+
+`num_tiles` preserves the exact fixed-block residency after tensor operands are
+scalarized to tile values. Kernel-configuration resolution intersects this
+requirement with destination width and synchronization candidates. Automatic
+synchronization prefers double buffering when the row fits and selects full
+synchronization when it is required for capacity. An explicit configuration
+that cannot hold the row produces a capacity diagnostic before DST assignment.
 
 The row-normalization LLK applies its reduction scaler during both reduction
 stages. TTKernel-to-C++ lowering passes the square root of the semantic scale so

--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -176,8 +176,9 @@ validates kernel tile dimensions, primitive data-type support, and matmul LLK
 combinations before compute creation or TTKernel conversion modifies IR. The
 environment is selected from the module's system description or
 `ttl.target_arch`. Modules without either use the intersection of capabilities
-implemented by all supported targets. Wormhole B0 and Blackhole currently
-provide the same compute capability set.
+implemented by all supported targets. Target implementations may expose
+different fixed-block schedules when their dependencies provide different LLK
+capabilities.
 
 Adding an architecture requires a capability implementation and an entry in
 `computeTargetRegistrations`. The registration table is the source for both

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -652,13 +652,12 @@ def TTKernel_ExperimentalRowNormalizationBlockOp :
                        F32Attr:$scale,
                        F32Attr:$epsilon,
                        BoolAttr:$has_gamma,
-                       BoolAttr:$repeat_gamma,
                        TTCore_DataTypeAttr:$dtype);
   let assemblyFormat = [{
     `(` $input_cb `,` $gamma_cb `,` $output_cb `)`
     `num_tiles` `=` $num_tiles `scale` `=` $scale
     `epsilon` `=` $epsilon `has_gamma` `=` $has_gamma
-    `repeat_gamma` `=` $repeat_gamma `dtype` `=` $dtype
+    `dtype` `=` $dtype
     attr-dict `:` functional-type(operands, results)
   }];
   let hasVerifier = 1;

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -603,6 +603,37 @@ def TTKernel_BinaryDestReuseTilesOp : TTKernel_FPUOp<"binary_dest_reuse_tiles"> 
     }];
 }
 
+def TTKernel_ExperimentalRowNormalizationBlockOp :
+    TTKernel_FPUOp<"experimental_row_normalization_block"> {
+  let summary = "Normalize one row in a single DST acquisition";
+  let description = [{
+    Computes a full-row sum of squares, applies scale, epsilon, and reciprocal
+    square root, then reuses the retained scalar across a contiguous block of
+    input tiles. Optional gamma multiplication occurs in place before packing.
+
+    The operation does not acquire, commit, wait, release, reserve, push, pop,
+    or pack. Those transactions remain explicit surrounding TTKernel
+    operations.
+  }];
+  let arguments = (ins TTKernel_CB:$input_cb,
+                       TTKernel_CB:$gamma_cb,
+                       TTKernel_CB:$output_cb,
+                       I64Attr:$num_tiles,
+                       F32Attr:$scale,
+                       F32Attr:$epsilon,
+                       BoolAttr:$has_gamma,
+                       BoolAttr:$repeat_gamma,
+                       TTCore_DataTypeAttr:$dtype);
+  let assemblyFormat = [{
+    `(` $input_cb `,` $gamma_cb `,` $output_cb `)`
+    `num_tiles` `=` $num_tiles `scale` `=` $scale
+    `epsilon` `=` $epsilon `has_gamma` `=` $has_gamma
+    `repeat_gamma` `=` $repeat_gamma `dtype` `=` $dtype
+    attr-dict `:` functional-type(operands, results)
+  }];
+  let hasVerifier = 1;
+}
+
 def TTKernel_UnaryBcastInitOp : TTKernel_InitOp<"unary_bcast_init"> {
     let summary = "Init function";
     let description = [{

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -633,6 +633,37 @@ def TTKernel_BinaryDestReuseTilesOp : TTKernel_FPUOp<"binary_dest_reuse_tiles"> 
     }];
 }
 
+def TTKernel_ExperimentalRowNormalizationBlockOp :
+    TTKernel_FPUOp<"experimental_row_normalization_block"> {
+  let summary = "Normalize one row in a single DST acquisition";
+  let description = [{
+    Computes a full-row sum of squares, applies scale, epsilon, and reciprocal
+    square root, then reuses the retained scalar across a contiguous block of
+    input tiles. Optional gamma multiplication occurs in place before packing.
+
+    The operation does not acquire, commit, wait, release, reserve, push, pop,
+    or pack. Those transactions remain explicit surrounding TTKernel
+    operations.
+  }];
+  let arguments = (ins TTKernel_CB:$input_cb,
+                       TTKernel_CB:$gamma_cb,
+                       TTKernel_CB:$output_cb,
+                       I64Attr:$num_tiles,
+                       F32Attr:$scale,
+                       F32Attr:$epsilon,
+                       BoolAttr:$has_gamma,
+                       BoolAttr:$repeat_gamma,
+                       TTCore_DataTypeAttr:$dtype);
+  let assemblyFormat = [{
+    `(` $input_cb `,` $gamma_cb `,` $output_cb `)`
+    `num_tiles` `=` $num_tiles `scale` `=` $scale
+    `epsilon` `=` $epsilon `has_gamma` `=` $has_gamma
+    `repeat_gamma` `=` $repeat_gamma `dtype` `=` $dtype
+    attr-dict `:` functional-type(operands, results)
+  }];
+  let hasVerifier = 1;
+}
+
 def TTKernel_UnaryBcastInitOp : TTKernel_InitOp<"unary_bcast_init"> {
     let summary = "Init function";
     let description = [{

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -622,13 +622,12 @@ def TTKernel_ExperimentalRowNormalizationBlockOp :
                        F32Attr:$scale,
                        F32Attr:$epsilon,
                        BoolAttr:$has_gamma,
-                       BoolAttr:$repeat_gamma,
                        TTCore_DataTypeAttr:$dtype);
   let assemblyFormat = [{
     `(` $input_cb `,` $gamma_cb `,` $output_cb `)`
     `num_tiles` `=` $num_tiles `scale` `=` $scale
     `epsilon` `=` $epsilon `has_gamma` `=` $has_gamma
-    `repeat_gamma` `=` $repeat_gamma `dtype` `=` $dtype
+    `dtype` `=` $dtype
     attr-dict `:` functional-type(operands, results)
   }];
   let hasVerifier = 1;

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1473,6 +1473,46 @@ def TTL_TileReduceOp : TTL_TileOp<"tile_reduce", "Reduce",
   }];
 }
 
+def TTL_TileRowNormalizationBlockOp :
+    TTL_TileOp<"tile_row_normalization_block",
+               [TTL_CBInputTileOpTrait, TTL_DstResultOpTrait]> {
+  let summary = "Normalize one static row in one DST acquisition";
+  let description = [{
+    Computes `input * rsqrt(sum(input * input) * scale + epsilon)` for one
+    rank-2 row of tiles. The optional gamma tensor is multiplied into the
+    normalized result before publication. When `repeat_gamma` is true, gamma
+    contains one tile that is reused for every output tile.
+
+    `dst_index` identifies the first output slot. The operation initially
+    stores the inverse RMS scalar there, moves it to a compute source register,
+    clears the acquired DST section, and writes the normalized row to the
+    contiguous slots beginning at `dst_index`. The input, gamma, and output
+    operands identify dataflow buffers; gamma is equal to input when
+    `has_gamma` is false and is not read in that mode.
+
+    The operation is internal to block compute lowering. Its result represents
+    the complete contiguous DST footprint, not one independently executable
+    tile iteration.
+  }];
+  let arguments = (ins TTL_TileOrTensor:$input,
+                       TTL_TileOrTensor:$gamma,
+                       TTL_TileOrTensor:$output,
+                       F32Attr:$scale,
+                       F32Attr:$epsilon,
+                       BoolAttr:$has_gamma,
+                       BoolAttr:$repeat_gamma,
+                       Index:$dst_index);
+  let results = (outs TTL_TileOrTensor:$result);
+  let assemblyFormat = [{
+    $input `,` $gamma `,` $output
+    `scale` `=` $scale `epsilon` `=` $epsilon
+    `has_gamma` `=` $has_gamma `repeat_gamma` `=` $repeat_gamma
+    `into` `dst` `[` $dst_index `]` attr-dict `:`
+    type($input) `,` type($gamma) `,` type($output) `->` type($result)
+  }];
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Transpose Operation
 //===----------------------------------------------------------------------===//

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1568,6 +1568,46 @@ def TTL_TileReduceOp : TTL_TileOp<"tile_reduce", "Reduce",
   }];
 }
 
+def TTL_TileRowNormalizationBlockOp :
+    TTL_TileOp<"tile_row_normalization_block",
+               [TTL_CBInputTileOpTrait, TTL_DstResultOpTrait]> {
+  let summary = "Normalize one static row in one DST acquisition";
+  let description = [{
+    Computes `input * rsqrt(sum(input * input) * scale + epsilon)` for one
+    rank-2 row of tiles. The optional gamma tensor is multiplied into the
+    normalized result before publication. When `repeat_gamma` is true, gamma
+    contains one tile that is reused for every output tile.
+
+    `dst_index` identifies the first output slot. The operation initially
+    stores the inverse RMS scalar there, moves it to a compute source register,
+    clears the acquired DST section, and writes the normalized row to the
+    contiguous slots beginning at `dst_index`. The input, gamma, and output
+    operands identify dataflow buffers; gamma is equal to input when
+    `has_gamma` is false and is not read in that mode.
+
+    The operation is internal to block compute lowering. Its result represents
+    the complete contiguous DST footprint, not one independently executable
+    tile iteration.
+  }];
+  let arguments = (ins TTL_TileOrTensor:$input,
+                       TTL_TileOrTensor:$gamma,
+                       TTL_TileOrTensor:$output,
+                       F32Attr:$scale,
+                       F32Attr:$epsilon,
+                       BoolAttr:$has_gamma,
+                       BoolAttr:$repeat_gamma,
+                       Index:$dst_index);
+  let results = (outs TTL_TileOrTensor:$result);
+  let assemblyFormat = [{
+    $input `,` $gamma `,` $output
+    `scale` `=` $scale `epsilon` `=` $epsilon
+    `has_gamma` `=` $has_gamma `repeat_gamma` `=` $repeat_gamma
+    `into` `dst` `[` $dst_index `]` attr-dict `:`
+    type($input) `,` type($gamma) `,` type($output) `->` type($result)
+  }];
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Transpose Operation
 //===----------------------------------------------------------------------===//

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1575,8 +1575,7 @@ def TTL_TileRowNormalizationBlockOp :
   let description = [{
     Computes `input * rsqrt(sum(input * input) * scale + epsilon)` for one
     rank-2 row of tiles. The optional gamma tensor is multiplied into the
-    normalized result before publication. When `repeat_gamma` is true, gamma
-    contains one tile that is reused for every output tile.
+    normalized result before publication.
 
     `dst_index` identifies the first output slot. The operation initially
     stores the inverse RMS scalar there, moves it to a compute source register,
@@ -1595,13 +1594,12 @@ def TTL_TileRowNormalizationBlockOp :
                        F32Attr:$scale,
                        F32Attr:$epsilon,
                        BoolAttr:$has_gamma,
-                       BoolAttr:$repeat_gamma,
                        Index:$dst_index);
   let results = (outs TTL_TileOrTensor:$result);
   let assemblyFormat = [{
     $input `,` $gamma `,` $output
     `scale` `=` $scale `epsilon` `=` $epsilon
-    `has_gamma` `=` $has_gamma `repeat_gamma` `=` $repeat_gamma
+    `has_gamma` `=` $has_gamma
     `into` `dst` `[` $dst_index `]` attr-dict `:`
     type($input) `,` type($gamma) `,` type($output) `->` type($result)
   }];

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1570,6 +1570,7 @@ def TTL_TileReduceOp : TTL_TileOp<"tile_reduce", "Reduce",
 
 def TTL_TileRowNormalizationBlockOp :
     TTL_TileOp<"tile_row_normalization_block",
+               "Reduce",
                [TTL_CBInputTileOpTrait, TTL_DstResultOpTrait]> {
   let summary = "Normalize one static row in one DST acquisition";
   let description = [{

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1486,9 +1486,10 @@ def TTL_TileRowNormalizationBlockOp :
     `dst_index` identifies the first output slot. The operation initially
     stores the inverse RMS scalar there, moves it to a compute source register,
     clears the acquired DST section, and writes the normalized row to the
-    contiguous slots beginning at `dst_index`. The input, gamma, and output
-    operands identify dataflow buffers; gamma is equal to input when
-    `has_gamma` is false and is not read in that mode.
+    contiguous slots beginning at `dst_index`. `num_tiles` records the exact
+    row width because scalarization replaces tensor operands with tile values.
+    The input, gamma, and output operands identify dataflow buffers; gamma is
+    equal to input when `has_gamma` is false and is not read in that mode.
 
     The operation is internal to block compute lowering. Its result represents
     the complete contiguous DST footprint, not one independently executable
@@ -1500,12 +1501,14 @@ def TTL_TileRowNormalizationBlockOp :
                        F32Attr:$scale,
                        F32Attr:$epsilon,
                        BoolAttr:$has_gamma,
+                       ConfinedAttr<I64Attr, [IntPositive]>:$num_tiles,
                        Index:$dst_index);
   let results = (outs TTL_TileOrTensor:$result);
   let assemblyFormat = [{
     $input `,` $gamma `,` $output
     `scale` `=` $scale `epsilon` `=` $epsilon
     `has_gamma` `=` $has_gamma
+    `num_tiles` `=` $num_tiles
     `into` `dst` `[` $dst_index `]` attr-dict `:`
     type($input) `,` type($gamma) `,` type($output) `->` type($result)
   }];

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1480,8 +1480,7 @@ def TTL_TileRowNormalizationBlockOp :
   let description = [{
     Computes `input * rsqrt(sum(input * input) * scale + epsilon)` for one
     rank-2 row of tiles. The optional gamma tensor is multiplied into the
-    normalized result before publication. When `repeat_gamma` is true, gamma
-    contains one tile that is reused for every output tile.
+    normalized result before publication.
 
     `dst_index` identifies the first output slot. The operation initially
     stores the inverse RMS scalar there, moves it to a compute source register,
@@ -1500,13 +1499,12 @@ def TTL_TileRowNormalizationBlockOp :
                        F32Attr:$scale,
                        F32Attr:$epsilon,
                        BoolAttr:$has_gamma,
-                       BoolAttr:$repeat_gamma,
                        Index:$dst_index);
   let results = (outs TTL_TileOrTensor:$result);
   let assemblyFormat = [{
     $input `,` $gamma `,` $output
     `scale` `=` $scale `epsilon` `=` $epsilon
-    `has_gamma` `=` $has_gamma `repeat_gamma` `=` $repeat_gamma
+    `has_gamma` `=` $has_gamma
     `into` `dst` `[` $dst_index `]` attr-dict `:`
     type($input) `,` type($gamma) `,` type($output) `->` type($result)
   }];

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1475,6 +1475,7 @@ def TTL_TileReduceOp : TTL_TileOp<"tile_reduce", "Reduce",
 
 def TTL_TileRowNormalizationBlockOp :
     TTL_TileOp<"tile_row_normalization_block",
+               "Reduce",
                [TTL_CBInputTileOpTrait, TTL_DstResultOpTrait]> {
   let summary = "Normalize one static row in one DST acquisition";
   let description = [{

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1581,9 +1581,10 @@ def TTL_TileRowNormalizationBlockOp :
     `dst_index` identifies the first output slot. The operation initially
     stores the inverse RMS scalar there, moves it to a compute source register,
     clears the acquired DST section, and writes the normalized row to the
-    contiguous slots beginning at `dst_index`. The input, gamma, and output
-    operands identify dataflow buffers; gamma is equal to input when
-    `has_gamma` is false and is not read in that mode.
+    contiguous slots beginning at `dst_index`. `num_tiles` records the exact
+    row width because scalarization replaces tensor operands with tile values.
+    The input, gamma, and output operands identify dataflow buffers; gamma is
+    equal to input when `has_gamma` is false and is not read in that mode.
 
     The operation is internal to block compute lowering. Its result represents
     the complete contiguous DST footprint, not one independently executable
@@ -1595,12 +1596,14 @@ def TTL_TileRowNormalizationBlockOp :
                        F32Attr:$scale,
                        F32Attr:$epsilon,
                        BoolAttr:$has_gamma,
+                       ConfinedAttr<I64Attr, [IntPositive]>:$num_tiles,
                        Index:$dst_index);
   let results = (outs TTL_TileOrTensor:$result);
   let assemblyFormat = [{
     $input `,` $gamma `,` $output
     `scale` `=` $scale `epsilon` `=` $epsilon
     `has_gamma` `=` $has_gamma
+    `num_tiles` `=` $num_tiles
     `into` `dst` `[` $dst_index `]` attr-dict `:`
     type($input) `,` type($gamma) `,` type($output) `->` type($result)
   }];

--- a/include/ttlang/Dialect/TTL/IR/TileExecution.h
+++ b/include/ttlang/Dialect/TTL/IR/TileExecution.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <cstdint>
 #include <optional>
 
 namespace mlir::tt::ttl {
@@ -58,6 +59,8 @@ struct TileExecutionInfo {
   std::optional<FullFp32AccumulationKind> fullFp32Accumulation;
   /// Residual contents in a reused destination slot affect the result.
   bool accumulatesIntoDst = false;
+  /// Maximum simultaneous destination residency required by this operation.
+  std::uint64_t requiredDstSlots = 1;
 };
 
 /// Return strategies structurally permitted by the operation's SSA operands.

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -11,6 +11,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -117,6 +118,7 @@ struct DestinationUse {
   Operation *operation;
   TilePrimitive primitive;
   Type elementType;
+  std::uint64_t requiredDstSlots;
 };
 
 /// Requirements imposed by one legal execution strategy.

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -11,6 +11,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -114,6 +115,7 @@ struct DestinationUse {
   Operation *operation;
   TilePrimitive primitive;
   Type elementType;
+  std::uint64_t requiredDstSlots;
 };
 
 /// Requirements imposed by one legal execution strategy.

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeTarget.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeTarget.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -33,6 +34,17 @@ struct ReductionCapability {
   ttcore::TileType resultType;
   ReduceType reduceType;
   std::optional<ttkernel::ReduceDim> reduceDimension;
+};
+
+/// Target schedule whose legality is not described by one compute primitive.
+enum class ComputeScheduleCapability {
+  RowNormalization,
+};
+
+/// Target and tile-type limits for one compute schedule.
+struct ComputeScheduleCapabilityLimits {
+  bool targetSupported = false;
+  std::optional<std::uint32_t> maxTiles;
 };
 
 /// Immutable LLK capabilities for one compute target.
@@ -71,6 +83,10 @@ public:
   validateMatmulTileTypes(ttcore::TileType lhsType, ttcore::TileType rhsType,
                           ttcore::TileType resultType, bool transposeRhs,
                           std::string &failureReason) const = 0;
+
+  virtual ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability capability,
+                              ttcore::TileType tileType) const = 0;
 
   LogicalResult validateOperation(Operation *operation,
                                   std::string &failureReason) const;

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeTarget.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeTarget.h
@@ -11,6 +11,7 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -21,6 +22,17 @@ namespace mlir::tt::ttl {
 /// default device. Both sources must agree when present.
 FailureOr<std::optional<ttcore::Arch>>
 resolveComputeTargetArch(Operation *operation, std::string &failureReason);
+
+/// Target schedule whose legality is not described by one compute primitive.
+enum class ComputeScheduleCapability {
+  RowNormalization,
+};
+
+/// Target and tile-type limits for one compute schedule.
+struct ComputeScheduleCapabilityLimits {
+  bool targetSupported = false;
+  std::optional<std::uint32_t> maxTiles;
+};
 
 /// Immutable LLK capabilities for one compute target.
 class ComputeTargetEnvironment {
@@ -52,6 +64,10 @@ public:
   validateMatmulTileTypes(ttcore::TileType lhsType, ttcore::TileType rhsType,
                           ttcore::TileType resultType, bool transposeRhs,
                           std::string &failureReason) const = 0;
+
+  virtual ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability capability,
+                              ttcore::TileType tileType) const = 0;
 
   LogicalResult validateOperation(Operation *operation,
                                   std::string &failureReason) const;

--- a/include/ttlang/Dialect/TTL/Transforms/LowerRowNormalizationCompute.h
+++ b/include/ttlang/Dialect/TTL/Transforms/LowerRowNormalizationCompute.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_LOWERROWNORMALIZATIONCOMPUTE_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_LOWERROWNORMALIZATIONCOMPUTE_H
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttl {
+
+class ComputeOp;
+
+/// Verify the complete block schedule and its effective DST capacity before
+/// any compute lowering mutates the function.
+LogicalResult verifyRowNormalizationCompute(ComputeOp op);
+
+/// Replace a verified row-normalization compute with one DST section, one
+/// block compute operation, and explicit contiguous output stores.
+LogicalResult generateRowNormalizationCompute(PatternRewriter &rewriter,
+                                              Location loc, ComputeOp op);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_LOWERROWNORMALIZATIONCOMPUTE_H

--- a/include/ttlang/Target/TTKernel/LLKs/CMakeLists.txt
+++ b/include/ttlang/Target/TTKernel/LLKs/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LLK_HEADERS
     ${CMAKE_SOURCE_DIR}/include/ttlang/Target/TTKernel/LLKs/experimental_fabric_2d_routing.h
     ${CMAKE_SOURCE_DIR}/include/ttlang/Target/TTKernel/LLKs/experimental_fabric_api.h
     ${CMAKE_SOURCE_DIR}/include/ttlang/Target/TTKernel/LLKs/experimental_reg_api.h
+    ${CMAKE_SOURCE_DIR}/include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h
     ${CMAKE_SOURCE_DIR}/include/ttlang/Target/TTKernel/LLKs/experimental_semaphore.h
 )
 

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h
@@ -50,7 +50,6 @@ using ckernel::ckernel_template;
 using ckernel::dest_offset_id;
 using ckernel::DstSync;
 using ckernel::DstTileShape;
-using ckernel::EltwiseBinaryType;
 using ckernel::MathFidelity;
 using ckernel::to_underlying;
 using ckernel::UnpackDestination;
@@ -93,10 +92,8 @@ inline void applyAddRsqrt(std::uint32_t dstIndex, std::uint32_t addendBits) {
       dstIndex, VectorMode::RC_custom, addendBits);
 }
 
-template <EltwiseBinaryType binaryType, std::uint32_t numTiles,
-          MathFidelity mathFidelity>
-inline void configureMathMop(std::uint32_t numFaces = 4,
-                             std::uint32_t accumulateToDest = 0) {
+template <std::uint32_t numTiles, MathFidelity mathFidelity>
+inline void configureMathMop(std::uint32_t numFaces) {
   static_assert(numTiles >= 1 && numTiles <= 8,
                 "row normalization requires 1 to 8 tiles");
   LLK_ASSERT(numFaces == 1 || numFaces == 2 || numFaces == 4,
@@ -104,57 +101,26 @@ inline void configureMathMop(std::uint32_t numFaces = 4,
   constexpr bool highFidelity = is_high_fidelity(mathFidelity);
   constexpr auto broadcastType = ckernel::p_elwise::SRCB_BCAST_ALL;
 
-  if constexpr (binaryType == EltwiseBinaryType::ELWADD) {
+  if constexpr (highFidelity) {
     ckernel_template operationTemplate(
-        numTiles, numFaces,
-        TT_OP_ELWADD(0, accumulateToDest, broadcastType, ADDR_MOD_0, 0),
-        TT_OP_ELWADD(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
-                     ADDR_MOD_2, 0));
-    operationTemplate.set_last_inner_loop_instr(
-        TT_OP_ELWADD(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
-                     ADDR_MOD_3, 0));
-    operationTemplate.set_last_outer_loop_instr(
-        TT_OP_ELWADD(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
-                     ADDR_MOD_3, 0));
+        numFaces, to_underlying(mathFidelity),
+        TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_0, 0),
+        TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_2, 0));
+    operationTemplate.set_last_inner_loop_instr(TT_OP_ELWMUL(
+        ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
+    operationTemplate.set_last_outer_loop_instr(TT_OP_ELWMUL(
+        ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_4, 0));
     operationTemplate.program();
-  } else if constexpr (binaryType == EltwiseBinaryType::ELWSUB) {
-    ckernel_template operationTemplate(
-        numTiles, numFaces,
-        TT_OP_ELWSUB(0, accumulateToDest, broadcastType, ADDR_MOD_0, 0),
-        TT_OP_ELWSUB(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
-                     ADDR_MOD_2, 0));
-    operationTemplate.set_last_inner_loop_instr(
-        TT_OP_ELWSUB(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
-                     ADDR_MOD_3, 0));
-    operationTemplate.set_last_outer_loop_instr(
-        TT_OP_ELWSUB(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
-                     ADDR_MOD_3, 0));
-    operationTemplate.program();
-  } else if constexpr (binaryType == EltwiseBinaryType::ELWMUL) {
-    if constexpr (highFidelity) {
-      ckernel_template operationTemplate(
-          numFaces, to_underlying(mathFidelity),
-          TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_0, 0),
-          TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_2, 0));
-      operationTemplate.set_last_inner_loop_instr(TT_OP_ELWMUL(
-          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
-      operationTemplate.set_last_outer_loop_instr(TT_OP_ELWMUL(
-          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_4, 0));
-      operationTemplate.program();
-    } else {
-      ckernel_template operationTemplate(
-          numTiles, numFaces, TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_0, 0),
-          TT_OP_ELWMUL(ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_2,
-                       0));
-      operationTemplate.set_last_inner_loop_instr(TT_OP_ELWMUL(
-          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
-      operationTemplate.set_last_outer_loop_instr(TT_OP_ELWMUL(
-          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
-      operationTemplate.program();
-    }
   } else {
-    static_assert(binaryType == EltwiseBinaryType::ELWADD,
-                  "unsupported binary operation");
+    ckernel_template operationTemplate(
+        numTiles, numFaces, TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_0, 0),
+        TT_OP_ELWMUL(ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_2,
+                     0));
+    operationTemplate.set_last_inner_loop_instr(TT_OP_ELWMUL(
+        ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
+    operationTemplate.set_last_outer_loop_instr(TT_OP_ELWMUL(
+        ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
+    operationTemplate.program();
   }
 }
 
@@ -165,9 +131,8 @@ inline void reuseScalarAsSource() {
              ckernel::p_movd2b::MOV_1_ROW, 0);
 }
 
-template <EltwiseBinaryType binaryType, std::uint32_t numTiles, DstSync dstSync,
-          bool fp32DestAccEnabled, MathFidelity mathFidelity,
-          bool clearDest = false>
+template <std::uint32_t numTiles, DstSync dstSync, bool fp32DestAccEnabled,
+          MathFidelity mathFidelity>
 inline void applyScalar(std::uint32_t scalarDstIndex,
                         std::uint32_t outputDstIndex) {
   constexpr bool highFidelity = is_high_fidelity(mathFidelity);
@@ -175,20 +140,18 @@ inline void applyScalar(std::uint32_t scalarDstIndex,
   ckernel::math::set_dst_write_addr<DstTileShape::Tile32x32,
                                     UnpackDestination::SrcRegs>(scalarDstIndex);
   reuseScalarAsSource();
-  if constexpr (clearDest) {
-    if constexpr (dstSync == DstSync::SyncFull) {
-      TT_ZEROACC(ckernel::p_zeroacc::CLR_ALL, fp32DestAccEnabled, 0, ADDR_MOD_1,
-                 0);
-    } else {
-      static_assert(dstSync == DstSync::SyncHalf);
-      TT_ZEROACC(ckernel::p_zeroacc::CLR_HALF, fp32DestAccEnabled, 0,
-                 ADDR_MOD_1, dest_offset_id);
-    }
+  if constexpr (dstSync == DstSync::SyncFull) {
+    TT_ZEROACC(ckernel::p_zeroacc::CLR_ALL, fp32DestAccEnabled, 0, ADDR_MOD_1,
+               0);
+  } else {
+    static_assert(dstSync == DstSync::SyncHalf);
+    TT_ZEROACC(ckernel::p_zeroacc::CLR_HALF, fp32DestAccEnabled, 0, ADDR_MOD_1,
+               dest_offset_id);
   }
   ckernel::math::set_dst_write_addr<DstTileShape::Tile32x32,
                                     UnpackDestination::SrcRegs>(outputDstIndex);
 
-  if constexpr (binaryType == EltwiseBinaryType::ELWMUL && highFidelity) {
+  if constexpr (highFidelity) {
     for (std::uint32_t tileIndex = 0; tileIndex < numTiles; ++tileIndex) {
       ckernel_template::run();
     }
@@ -198,7 +161,7 @@ inline void applyScalar(std::uint32_t scalarDstIndex,
   TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, ckernel::p_setrwc::SET_D);
 }
 
-template <EltwiseBinaryType binaryType, MathFidelity mathFidelity>
+template <MathFidelity mathFidelity>
 inline void configureMathAddressModifiers(std::uint32_t numFaces) {
   constexpr bool highFidelity = is_high_fidelity(mathFidelity);
   constexpr std::uint32_t fidelityIncrement = highFidelity ? 1 : 0;
@@ -216,7 +179,7 @@ inline void configureMathAddressModifiers(std::uint32_t numFaces) {
   }
       .set(ADDR_MOD_1);
 
-  if constexpr (binaryType == EltwiseBinaryType::ELWMUL && highFidelity) {
+  if constexpr (highFidelity) {
     addr_mod_t{.srca = {.incr = 0, .clr = 1},
                .srcb = {.incr = 0, .clr = 1},
                .dest = {.incr = 0, .clr = 0, .cr = 1},
@@ -252,46 +215,34 @@ inline void configureMathAddressModifiers(std::uint32_t numFaces) {
   }
 }
 
-template <EltwiseBinaryType binaryType, std::uint32_t numTiles,
-          MathFidelity mathFidelity>
-inline void initializeMath(std::uint32_t numFaces,
-                           std::uint32_t accumulateToDest) {
+template <std::uint32_t numTiles, MathFidelity mathFidelity>
+inline void initializeMath(std::uint32_t numFaces) {
   LLK_ASSERT(numFaces == 1 || numFaces == 2 || numFaces == 4,
              "numFaces must be 1, 2, or 4");
-  configureMathAddressModifiers<binaryType, mathFidelity>(numFaces);
-  configureMathMop<binaryType, numTiles, mathFidelity>(numFaces,
-                                                       accumulateToDest);
+  configureMathAddressModifiers<mathFidelity>(numFaces);
+  configureMathMop<numTiles, mathFidelity>(numFaces);
   TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
   ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
 }
 
-template <EltwiseBinaryType binaryType, std::uint32_t numTiles,
-          MathFidelity mathFidelity>
+template <std::uint32_t numTiles, MathFidelity mathFidelity>
 inline void initializeMathForOperand(std::uint32_t operand) {
   const std::uint32_t operandId = get_operand_id(operand);
-  initializeMath<binaryType, numTiles, mathFidelity>(
-      get_operand_num_faces(operandId), 0);
+  initializeMath<numTiles, mathFidelity>(get_operand_num_faces(operandId));
 }
 
 #endif // TRISC_MATH
 
 #ifdef TRISC_UNPACK
 
-using ckernel::BroadcastType;
 using ckernel::cfg_reg_rmw_tensix;
 using ckernel::ckernel_template;
-using ckernel::EltwiseBinaryReuseDestType;
-using ckernel::load_replay_buf;
 using ckernel::SrcA;
 using ckernel::SrcB;
 using ckernel::unpacker::config_unpacker_x_end;
 
-template <std::uint32_t numTiles, BroadcastType broadcastType,
-          bool accumulateToDest, EltwiseBinaryReuseDestType binaryReuseDest>
-inline void configureUnpackMop(bool transposeFaces, std::uint32_t numFaces) {
-  static_assert(broadcastType == BroadcastType::SCALAR && accumulateToDest &&
-                    binaryReuseDest == EltwiseBinaryReuseDestType::DEST_TO_SRCB,
-                "row normalization requires scalar DEST_TO_SRCB reuse");
+template <std::uint32_t numTiles>
+inline void configureUnpackMop(std::uint32_t numFaces) {
   LLK_ASSERT(numFaces == 1 || numFaces == 2 || numFaces == 4,
              "numFaces must be 1, 2, or 4");
 
@@ -309,55 +260,25 @@ inline void configureUnpackMop(bool transposeFaces, std::uint32_t numFaces) {
     return;
   }
 
-  if (transposeFaces) {
-    LLK_ASSERT(numTiles == 1, "transposed scalar reuse supports one tile");
-    LLK_ASSERT(numFaces == 4, "transposed scalar reuse requires four faces");
-    constexpr std::uint32_t replayLength = 5;
-    load_replay_buf(0, replayLength, [] {
-      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
-                 0, 0, 0, 0, 1);
-      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
-                 0, 0, 0, 0, 1);
-      TTI_SETADCZW(ckernel::p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);
-      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
-                 0, 0, 0, 0, 1);
-      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
-                 0, 0, 0, 0, 1);
-    });
-    ckernel_template unpackTemplate(1, 1, lltt::replay_insn(0, replayLength));
-    unpackTemplate.set_start_op(setSourceBValid);
-    unpackTemplate.program();
-    return;
-  }
-
   const std::uint32_t iterations = numTiles * numFaces / 2;
   ckernel_template unpackTemplate(1, iterations, unpackSourceA, unpackSourceA);
   unpackTemplate.set_start_op(setSourceBValid);
   unpackTemplate.program();
 }
 
-template <std::uint32_t numTiles, BroadcastType broadcastType,
-          bool accumulateToDest, EltwiseBinaryReuseDestType binaryReuseDest>
-inline void initializeUnpack(std::uint32_t transposeFaces,
-                             std::uint32_t transposeWithinFace,
-                             std::uint32_t faceRowDimension,
+template <std::uint32_t numTiles>
+inline void initializeUnpack(std::uint32_t faceRowDimension,
                              std::uint32_t numFaces) {
-  cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transposeWithinFace);
-  constexpr std::uint32_t unpackSelection = broadcastType == BroadcastType::NONE
-                                                ? ckernel::p_setadc::UNP_A
-                                                : ckernel::p_setadc::UNP_B;
-  config_unpacker_x_end<unpackSelection>(faceRowDimension);
-  configureUnpackMop<numTiles, broadcastType, accumulateToDest,
-                     binaryReuseDest>(transposeFaces > 0, numFaces);
+  cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
+  config_unpacker_x_end<ckernel::p_setadc::UNP_B>(faceRowDimension);
+  configureUnpackMop<numTiles>(numFaces);
 }
 
 template <std::uint32_t numTiles>
 inline void initializeUnpackForOperand(std::uint32_t operand) {
   const std::uint32_t operandId = get_operand_id(operand);
-  initializeUnpack<numTiles, BroadcastType::SCALAR, true,
-                   EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-      false, false, get_operand_face_r_dim(operandId),
-      get_operand_num_faces(operandId));
+  initializeUnpack<numTiles>(get_operand_face_r_dim(operandId),
+                             get_operand_num_faces(operandId));
 }
 
 #endif // TRISC_UNPACK
@@ -367,8 +288,7 @@ ALWI void initializeScalarReuse(std::uint32_t inputDfb) {
   static_assert(numTiles >= 1 && numTiles <= 8,
                 "row normalization requires 1 to 8 tiles");
   UNPACK((initializeUnpackForOperand<numTiles>(inputDfb)));
-  MATH((initializeMathForOperand<ckernel::EltwiseBinaryType::ELWMUL, numTiles,
-                                 MATH_FIDELITY>(inputDfb)));
+  MATH((initializeMathForOperand<numTiles, MATH_FIDELITY>(inputDfb)));
 }
 
 template <std::uint32_t numTiles>
@@ -377,9 +297,8 @@ ALWI void multiplyByScalar(std::uint32_t inputDfb, std::uint32_t scalarDstIndex,
   UNPACK((llk_unpack_A<ckernel::BroadcastType::SCALAR, true,
                        ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
       inputDfb, 0)));
-  MATH((applyScalar<ckernel::EltwiseBinaryType::ELWMUL, numTiles, DST_SYNC_MODE,
-                    DST_ACCUM_MODE, MATH_FIDELITY, true>(scalarDstIndex,
-                                                         outputDstIndex)));
+  MATH((applyScalar<numTiles, DST_SYNC_MODE, DST_ACCUM_MODE, MATH_FIDELITY>(
+      scalarDstIndex, outputDstIndex)));
 }
 
 } // namespace row_normalization_detail
@@ -395,13 +314,15 @@ ALWI void row_normalization_block(std::uint32_t inputDfb,
   static_assert(dataFormat == DataFormat::Float16_b,
                 "row normalization supports bf16 DFBs only");
 
-  float reductionScaler;
-  __builtin_memcpy(&reductionScaler, &reductionScalerBits,
-                   sizeof(reductionScaler));
+  // mul_reduce_scalar_tile applies its scaler during both reduction stages.
+  // TTKernel lowering therefore passes sqrt of the semantic reduction scale.
+  float reductionStageScaler;
+  __builtin_memcpy(&reductionStageScaler, &reductionScalerBits,
+                   sizeof(reductionStageScaler));
   ckernel::mul_reduce_scalar_init(inputDfb, inputDfb);
   MATH((row_normalization_detail::initializeAddRsqrt<APPROX>()));
   ckernel::mul_reduce_scalar_tile(inputDfb, inputDfb, outputDfb, numTiles,
-                                  reductionScaler);
+                                  reductionStageScaler);
   ckernel::mul_reduce_scalar_uninit();
 
   MATH((

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h
@@ -384,8 +384,7 @@ ALWI void multiplyByScalar(std::uint32_t inputDfb, std::uint32_t scalarDstIndex,
 
 } // namespace row_normalization_detail
 
-template <std::uint32_t numTiles, bool hasGamma, bool repeatGamma,
-          DataFormat dataFormat>
+template <std::uint32_t numTiles, bool hasGamma, DataFormat dataFormat>
 ALWI void row_normalization_block(std::uint32_t inputDfb,
                                   std::uint32_t gammaDfb,
                                   std::uint32_t outputDfb,
@@ -395,8 +394,6 @@ ALWI void row_normalization_block(std::uint32_t inputDfb,
                 "row normalization requires 1 to 8 tiles");
   static_assert(dataFormat == DataFormat::Float16_b,
                 "row normalization supports bf16 DFBs only");
-  static_assert(hasGamma || !repeatGamma,
-                "repeated gamma requires gamma multiplication");
 
   float reductionScaler;
   __builtin_memcpy(&reductionScaler, &reductionScalerBits,
@@ -419,13 +416,10 @@ ALWI void row_normalization_block(std::uint32_t inputDfb,
         ckernel::EltwiseBinaryType::ELWMUL,
         ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA>(gammaDfb);
     for (std::uint32_t tileIndex = 0; tileIndex < numTiles; ++tileIndex) {
-      constexpr std::uint32_t repeatedGammaIndex = 0;
-      std::uint32_t gammaTileIndex =
-          repeatGamma ? repeatedGammaIndex : tileIndex;
       ckernel::binary_dest_reuse_tiles<
           ckernel::EltwiseBinaryType::ELWMUL,
           ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-          gammaDfb, gammaTileIndex, tileIndex);
+          gammaDfb, tileIndex, tileIndex);
     }
   }
 }

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_row_normalization.h
@@ -1,0 +1,435 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_ROW_NORMALIZATION_H
+#define TTLANG_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_ROW_NORMALIZATION_H
+
+#include <cstdint>
+
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/experimental/mul_reduce_scalar.h"
+
+#ifdef TRISC_MATH
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_sfpu_rsqrt.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_assert.h"
+#include "llk_math_common.h"
+#include "llk_math_common_api.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_globals.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cunpack_common.h"
+#include "llk_assert.h"
+#include "llk_unpack_common_api.h"
+#endif
+
+namespace experimental {
+namespace row_normalization_detail {
+
+#ifdef TRISC_MATH
+
+using ckernel::ADDR_MOD_0;
+using ckernel::ADDR_MOD_1;
+using ckernel::ADDR_MOD_2;
+using ckernel::ADDR_MOD_3;
+using ckernel::ADDR_MOD_4;
+using ckernel::addr_mod_t;
+using ckernel::ckernel_template;
+using ckernel::dest_offset_id;
+using ckernel::DstSync;
+using ckernel::DstTileShape;
+using ckernel::EltwiseBinaryType;
+using ckernel::MathFidelity;
+using ckernel::to_underlying;
+using ckernel::UnpackDestination;
+using ckernel::VectorMode;
+using ckernel::math::is_high_fidelity;
+
+template <bool approximationMode, int iterations, bool fp32DestAccEnabled,
+          bool fastApproximation>
+inline void calculateAddRsqrt(std::uint32_t addendBits) {
+#pragma GCC unroll 8
+  for (int iteration = 0; iteration < iterations; ++iteration) {
+    sfpi::vFloat input = sfpi::dst_reg[0];
+    sfpi::vFloat biased =
+        input + ckernel::sfpu::Converter::as_float(addendBits);
+    sfpi::vFloat inverseSquareRoot =
+        ckernel::sfpu::_calculate_sqrt_body_<approximationMode, true,
+                                             fastApproximation>(biased);
+    if constexpr (fp32DestAccEnabled) {
+      sfpi::dst_reg[0] = inverseSquareRoot;
+    } else {
+      sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16b>(
+          inverseSquareRoot, sfpi::RoundMode::Nearest);
+    }
+    sfpi::dst_reg++;
+  }
+}
+
+template <bool approximationMode>
+inline void initializeAddRsqrt() {
+  ckernel::llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt>(
+      ckernel::sfpu::sqrt_init<approximationMode>);
+}
+
+template <bool approximationMode, bool fp32DestAccEnabled,
+          bool fastApproximation, int iterations>
+inline void applyAddRsqrt(std::uint32_t dstIndex, std::uint32_t addendBits) {
+  _llk_math_eltwise_unary_sfpu_params_(
+      calculateAddRsqrt<approximationMode, iterations, fp32DestAccEnabled,
+                        fastApproximation>,
+      dstIndex, VectorMode::RC_custom, addendBits);
+}
+
+template <EltwiseBinaryType binaryType, std::uint32_t numTiles,
+          MathFidelity mathFidelity>
+inline void configureMathMop(std::uint32_t numFaces = 4,
+                             std::uint32_t accumulateToDest = 0) {
+  static_assert(numTiles >= 1 && numTiles <= 8,
+                "row normalization requires 1 to 8 tiles");
+  LLK_ASSERT(numFaces == 1 || numFaces == 2 || numFaces == 4,
+             "numFaces must be 1, 2, or 4");
+  constexpr bool highFidelity = is_high_fidelity(mathFidelity);
+  constexpr auto broadcastType = ckernel::p_elwise::SRCB_BCAST_ALL;
+
+  if constexpr (binaryType == EltwiseBinaryType::ELWADD) {
+    ckernel_template operationTemplate(
+        numTiles, numFaces,
+        TT_OP_ELWADD(0, accumulateToDest, broadcastType, ADDR_MOD_0, 0),
+        TT_OP_ELWADD(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
+                     ADDR_MOD_2, 0));
+    operationTemplate.set_last_inner_loop_instr(
+        TT_OP_ELWADD(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
+                     ADDR_MOD_3, 0));
+    operationTemplate.set_last_outer_loop_instr(
+        TT_OP_ELWADD(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
+                     ADDR_MOD_3, 0));
+    operationTemplate.program();
+  } else if constexpr (binaryType == EltwiseBinaryType::ELWSUB) {
+    ckernel_template operationTemplate(
+        numTiles, numFaces,
+        TT_OP_ELWSUB(0, accumulateToDest, broadcastType, ADDR_MOD_0, 0),
+        TT_OP_ELWSUB(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
+                     ADDR_MOD_2, 0));
+    operationTemplate.set_last_inner_loop_instr(
+        TT_OP_ELWSUB(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
+                     ADDR_MOD_3, 0));
+    operationTemplate.set_last_outer_loop_instr(
+        TT_OP_ELWSUB(ckernel::p_setrwc::CLR_A, accumulateToDest, broadcastType,
+                     ADDR_MOD_3, 0));
+    operationTemplate.program();
+  } else if constexpr (binaryType == EltwiseBinaryType::ELWMUL) {
+    if constexpr (highFidelity) {
+      ckernel_template operationTemplate(
+          numFaces, to_underlying(mathFidelity),
+          TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_0, 0),
+          TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_2, 0));
+      operationTemplate.set_last_inner_loop_instr(TT_OP_ELWMUL(
+          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
+      operationTemplate.set_last_outer_loop_instr(TT_OP_ELWMUL(
+          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_4, 0));
+      operationTemplate.program();
+    } else {
+      ckernel_template operationTemplate(
+          numTiles, numFaces, TT_OP_ELWMUL(0, 0, broadcastType, ADDR_MOD_0, 0),
+          TT_OP_ELWMUL(ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_2,
+                       0));
+      operationTemplate.set_last_inner_loop_instr(TT_OP_ELWMUL(
+          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
+      operationTemplate.set_last_outer_loop_instr(TT_OP_ELWMUL(
+          ckernel::p_setrwc::CLR_A, 0, broadcastType, ADDR_MOD_3, 0));
+      operationTemplate.program();
+    }
+  } else {
+    static_assert(binaryType == EltwiseBinaryType::ELWADD,
+                  "unsupported binary operation");
+  }
+}
+
+inline void reuseScalarAsSource() {
+  TTI_STALLWAIT(ckernel::p_stall::STALL_MATH,
+                ckernel::p_stall::WAIT_SFPU | ckernel::p_stall::SRCB_VLD);
+  TTI_MOVD2B(0, ckernel::p_movd2b::SRC_ZERO_OFFSET, ADDR_MOD_1,
+             ckernel::p_movd2b::MOV_1_ROW, 0);
+}
+
+template <EltwiseBinaryType binaryType, std::uint32_t numTiles, DstSync dstSync,
+          bool fp32DestAccEnabled, MathFidelity mathFidelity,
+          bool clearDest = false>
+inline void applyScalar(std::uint32_t scalarDstIndex,
+                        std::uint32_t outputDstIndex) {
+  constexpr bool highFidelity = is_high_fidelity(mathFidelity);
+
+  ckernel::math::set_dst_write_addr<DstTileShape::Tile32x32,
+                                    UnpackDestination::SrcRegs>(scalarDstIndex);
+  reuseScalarAsSource();
+  if constexpr (clearDest) {
+    if constexpr (dstSync == DstSync::SyncFull) {
+      TT_ZEROACC(ckernel::p_zeroacc::CLR_ALL, fp32DestAccEnabled, 0, ADDR_MOD_1,
+                 0);
+    } else {
+      static_assert(dstSync == DstSync::SyncHalf);
+      TT_ZEROACC(ckernel::p_zeroacc::CLR_HALF, fp32DestAccEnabled, 0,
+                 ADDR_MOD_1, dest_offset_id);
+    }
+  }
+  ckernel::math::set_dst_write_addr<DstTileShape::Tile32x32,
+                                    UnpackDestination::SrcRegs>(outputDstIndex);
+
+  if constexpr (binaryType == EltwiseBinaryType::ELWMUL && highFidelity) {
+    for (std::uint32_t tileIndex = 0; tileIndex < numTiles; ++tileIndex) {
+      ckernel_template::run();
+    }
+  } else {
+    ckernel_template::run();
+  }
+  TTI_SETRWC(ckernel::p_setrwc::CLR_B, 0, 0, 0, 0, ckernel::p_setrwc::SET_D);
+}
+
+template <EltwiseBinaryType binaryType, MathFidelity mathFidelity>
+inline void configureMathAddressModifiers(std::uint32_t numFaces) {
+  constexpr bool highFidelity = is_high_fidelity(mathFidelity);
+  constexpr std::uint32_t fidelityIncrement = highFidelity ? 1 : 0;
+
+  addr_mod_t{
+      .srca = {.incr = 8},
+      .srcb = {.incr = 0},
+      .dest = {.incr = 8},
+  }
+      .set(ADDR_MOD_0);
+  addr_mod_t{
+      .srca = {.incr = 0},
+      .srcb = {.incr = 0},
+      .dest = {.incr = 0},
+  }
+      .set(ADDR_MOD_1);
+
+  if constexpr (binaryType == EltwiseBinaryType::ELWMUL && highFidelity) {
+    addr_mod_t{.srca = {.incr = 0, .clr = 1},
+               .srcb = {.incr = 0, .clr = 1},
+               .dest = {.incr = 0, .clr = 0, .cr = 1},
+               .fidelity = {.incr = fidelityIncrement}}
+        .set(ADDR_MOD_2);
+    addr_mod_t{.srca = {.incr = 0, .clr = 1},
+               .srcb = {.incr = 0, .clr = 1},
+               .dest = {.incr = 8, .clr = 0, .cr = 0, .c_to_cr = 1},
+               .fidelity = {.incr = 0, .clr = 1}}
+        .set(ADDR_MOD_3);
+    addr_mod_t{
+        .srca = {.incr = 0, .clr = 1},
+        .srcb = {.incr = 0, .clr = 1},
+        .dest = {.incr = static_cast<std::int16_t>(8 + (4 - numFaces) * 16),
+                 .clr = 0,
+                 .cr = 0,
+                 .c_to_cr = 1},
+        .fidelity = {.incr = 0, .clr = 1}}
+        .set(ADDR_MOD_4);
+  } else {
+    addr_mod_t{
+        .srca = {.incr = 0, .clr = 1},
+        .srcb = {.incr = 0, .clr = 1},
+        .dest = {.incr = 8},
+    }
+        .set(ADDR_MOD_2);
+    addr_mod_t{
+        .srca = {.incr = 0, .clr = 1},
+        .srcb = {.incr = 0, .clr = 1},
+        .dest = {.incr = static_cast<std::int16_t>(8 + (4 - numFaces) * 16)},
+    }
+        .set(ADDR_MOD_3);
+  }
+}
+
+template <EltwiseBinaryType binaryType, std::uint32_t numTiles,
+          MathFidelity mathFidelity>
+inline void initializeMath(std::uint32_t numFaces,
+                           std::uint32_t accumulateToDest) {
+  LLK_ASSERT(numFaces == 1 || numFaces == 2 || numFaces == 4,
+             "numFaces must be 1, 2, or 4");
+  configureMathAddressModifiers<binaryType, mathFidelity>(numFaces);
+  configureMathMop<binaryType, numTiles, mathFidelity>(numFaces,
+                                                       accumulateToDest);
+  TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+  ckernel::math::reset_counters(ckernel::p_setrwc::SET_ABD_F);
+}
+
+template <EltwiseBinaryType binaryType, std::uint32_t numTiles,
+          MathFidelity mathFidelity>
+inline void initializeMathForOperand(std::uint32_t operand) {
+  const std::uint32_t operandId = get_operand_id(operand);
+  initializeMath<binaryType, numTiles, mathFidelity>(
+      get_operand_num_faces(operandId), 0);
+}
+
+#endif // TRISC_MATH
+
+#ifdef TRISC_UNPACK
+
+using ckernel::BroadcastType;
+using ckernel::cfg_reg_rmw_tensix;
+using ckernel::ckernel_template;
+using ckernel::EltwiseBinaryReuseDestType;
+using ckernel::load_replay_buf;
+using ckernel::SrcA;
+using ckernel::SrcB;
+using ckernel::unpacker::config_unpacker_x_end;
+
+template <std::uint32_t numTiles, BroadcastType broadcastType,
+          bool accumulateToDest, EltwiseBinaryReuseDestType binaryReuseDest>
+inline void configureUnpackMop(bool transposeFaces, std::uint32_t numFaces) {
+  static_assert(broadcastType == BroadcastType::SCALAR && accumulateToDest &&
+                    binaryReuseDest == EltwiseBinaryReuseDestType::DEST_TO_SRCB,
+                "row normalization requires scalar DEST_TO_SRCB reuse");
+  LLK_ASSERT(numFaces == 1 || numFaces == 2 || numFaces == 4,
+             "numFaces must be 1, 2, or 4");
+
+  static constexpr std::uint32_t unpackSourceA =
+      TT_OP_UNPACR(SrcA, 0b1, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
+                   0, 0, 0, 0, 1);
+  static constexpr std::uint32_t setSourceBValid =
+      TT_OP_UNPACR_NOP(SrcB, 0, 0, ckernel::p_unpacr_nop::SET_DVALID, 0, 0, 0,
+                       0, ckernel::p_unpacr_nop::UNP_ZEROSRC);
+
+  if (numFaces == 1) {
+    ckernel_template unpackTemplate(1, numTiles, unpackSourceA);
+    unpackTemplate.set_start_op(setSourceBValid);
+    unpackTemplate.program();
+    return;
+  }
+
+  if (transposeFaces) {
+    LLK_ASSERT(numTiles == 1, "transposed scalar reuse supports one tile");
+    LLK_ASSERT(numFaces == 4, "transposed scalar reuse requires four faces");
+    constexpr std::uint32_t replayLength = 5;
+    load_replay_buf(0, replayLength, [] {
+      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
+                 0, 0, 0, 0, 1);
+      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
+                 0, 0, 0, 0, 1);
+      TTI_SETADCZW(ckernel::p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);
+      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
+                 0, 0, 0, 0, 1);
+      TTI_UNPACR(SrcA, 0b10, 0, 0, 0, 1, 1, ckernel::p_unpacr::RAREFYB_DISABLE,
+                 0, 0, 0, 0, 1);
+    });
+    ckernel_template unpackTemplate(1, 1, lltt::replay_insn(0, replayLength));
+    unpackTemplate.set_start_op(setSourceBValid);
+    unpackTemplate.program();
+    return;
+  }
+
+  const std::uint32_t iterations = numTiles * numFaces / 2;
+  ckernel_template unpackTemplate(1, iterations, unpackSourceA, unpackSourceA);
+  unpackTemplate.set_start_op(setSourceBValid);
+  unpackTemplate.program();
+}
+
+template <std::uint32_t numTiles, BroadcastType broadcastType,
+          bool accumulateToDest, EltwiseBinaryReuseDestType binaryReuseDest>
+inline void initializeUnpack(std::uint32_t transposeFaces,
+                             std::uint32_t transposeWithinFace,
+                             std::uint32_t faceRowDimension,
+                             std::uint32_t numFaces) {
+  cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transposeWithinFace);
+  constexpr std::uint32_t unpackSelection = broadcastType == BroadcastType::NONE
+                                                ? ckernel::p_setadc::UNP_A
+                                                : ckernel::p_setadc::UNP_B;
+  config_unpacker_x_end<unpackSelection>(faceRowDimension);
+  configureUnpackMop<numTiles, broadcastType, accumulateToDest,
+                     binaryReuseDest>(transposeFaces > 0, numFaces);
+}
+
+template <std::uint32_t numTiles>
+inline void initializeUnpackForOperand(std::uint32_t operand) {
+  const std::uint32_t operandId = get_operand_id(operand);
+  initializeUnpack<numTiles, BroadcastType::SCALAR, true,
+                   EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+      false, false, get_operand_face_r_dim(operandId),
+      get_operand_num_faces(operandId));
+}
+
+#endif // TRISC_UNPACK
+
+template <std::uint32_t numTiles>
+ALWI void initializeScalarReuse(std::uint32_t inputDfb) {
+  static_assert(numTiles >= 1 && numTiles <= 8,
+                "row normalization requires 1 to 8 tiles");
+  UNPACK((initializeUnpackForOperand<numTiles>(inputDfb)));
+  MATH((initializeMathForOperand<ckernel::EltwiseBinaryType::ELWMUL, numTiles,
+                                 MATH_FIDELITY>(inputDfb)));
+}
+
+template <std::uint32_t numTiles>
+ALWI void multiplyByScalar(std::uint32_t inputDfb, std::uint32_t scalarDstIndex,
+                           std::uint32_t outputDstIndex) {
+  UNPACK((llk_unpack_A<ckernel::BroadcastType::SCALAR, true,
+                       ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+      inputDfb, 0)));
+  MATH((applyScalar<ckernel::EltwiseBinaryType::ELWMUL, numTiles, DST_SYNC_MODE,
+                    DST_ACCUM_MODE, MATH_FIDELITY, true>(scalarDstIndex,
+                                                         outputDstIndex)));
+}
+
+} // namespace row_normalization_detail
+
+template <std::uint32_t numTiles, bool hasGamma, bool repeatGamma,
+          DataFormat dataFormat>
+ALWI void row_normalization_block(std::uint32_t inputDfb,
+                                  std::uint32_t gammaDfb,
+                                  std::uint32_t outputDfb,
+                                  std::uint32_t reductionScalerBits,
+                                  std::uint32_t epsilonBits) {
+  static_assert(numTiles >= 1 && numTiles <= 8,
+                "row normalization requires 1 to 8 tiles");
+  static_assert(dataFormat == DataFormat::Float16_b,
+                "row normalization supports bf16 DFBs only");
+  static_assert(hasGamma || !repeatGamma,
+                "repeated gamma requires gamma multiplication");
+
+  float reductionScaler;
+  __builtin_memcpy(&reductionScaler, &reductionScalerBits,
+                   sizeof(reductionScaler));
+  ckernel::mul_reduce_scalar_init(inputDfb, inputDfb);
+  MATH((row_normalization_detail::initializeAddRsqrt<APPROX>()));
+  ckernel::mul_reduce_scalar_tile(inputDfb, inputDfb, outputDfb, numTiles,
+                                  reductionScaler);
+  ckernel::mul_reduce_scalar_uninit();
+
+  MATH((
+      row_normalization_detail::applyAddRsqrt<APPROX, DST_ACCUM_MODE, false, 1>(
+          0, epsilonBits)));
+
+  row_normalization_detail::initializeScalarReuse<numTiles>(inputDfb);
+  row_normalization_detail::multiplyByScalar<numTiles>(inputDfb, 0, 0);
+
+  if constexpr (hasGamma) {
+    ckernel::binary_dest_reuse_tiles_init<
+        ckernel::EltwiseBinaryType::ELWMUL,
+        ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA>(gammaDfb);
+    for (std::uint32_t tileIndex = 0; tileIndex < numTiles; ++tileIndex) {
+      constexpr std::uint32_t repeatedGammaIndex = 0;
+      std::uint32_t gammaTileIndex =
+          repeatGamma ? repeatedGammaIndex : tileIndex;
+      ckernel::binary_dest_reuse_tiles<
+          ckernel::EltwiseBinaryType::ELWMUL,
+          ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+          gammaDfb, gammaTileIndex, tileIndex);
+    }
+  }
+}
+
+} // namespace experimental
+
+#endif // TTLANG_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_ROW_NORMALIZATION_H

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -2811,8 +2811,6 @@ public:
                                std::to_string(op.getNumTiles())),
         emitc::OpaqueAttr::get(op.getContext(),
                                op.getHasGamma() ? "true" : "false"),
-        emitc::OpaqueAttr::get(op.getContext(),
-                               op.getRepeatGamma() ? "true" : "false"),
         datatypeToDataformatEnumNameOpaqueAttr(rewriter, op.getDtype())};
     SmallVector<Value, 5> operands = {
         adaptor.getInputCb(), adaptor.getGammaCb(), adaptor.getOutputCb(),

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -2812,8 +2812,6 @@ public:
                                std::to_string(op.getNumTiles())),
         emitc::OpaqueAttr::get(op.getContext(),
                                op.getHasGamma() ? "true" : "false"),
-        emitc::OpaqueAttr::get(op.getContext(),
-                               op.getRepeatGamma() ? "true" : "false"),
         datatypeToDataformatEnumNameOpaqueAttr(rewriter, op.getDtype())};
     SmallVector<Value, 5> operands = {
         adaptor.getInputCb(), adaptor.getGammaCb(), adaptor.getOutputCb(),

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/xxhash.h"
 
 #include <array>
+#include <cmath>
 #include <functional>
 #include <optional>
 #include <string>
@@ -2781,6 +2782,48 @@ public:
   }
 };
 
+class ExperimentalRowNormalizationBlockOpConversion
+    : public OpConversionPattern<
+          ttkernel::ExperimentalRowNormalizationBlockOp> {
+public:
+  using OpConversionPattern<
+      ttkernel::ExperimentalRowNormalizationBlockOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ttkernel::ExperimentalRowNormalizationBlockOp op,
+      ttkernel::ExperimentalRowNormalizationBlockOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const final {
+    auto createBitsLiteral = [&](FloatAttr value) {
+      std::uint64_t bits = value.getValue().bitcastToAPInt().getZExtValue();
+      return emitc::LiteralOp::create(rewriter, op.getLoc(),
+                                      rewriter.getI32Type(),
+                                      (Twine(bits) + "U").str());
+    };
+    // The fused LLK multiplies its scaler during both reduction stages, so its
+    // argument is the square root of the semantic scale.
+    FloatAttr reductionScaler = rewriter.getF32FloatAttr(
+        std::sqrt(op.getScaleAttr().getValueAsDouble()));
+    Value reductionScalerBits = createBitsLiteral(reductionScaler);
+    Value epsilonBits = createBitsLiteral(op.getEpsilonAttr());
+
+    SmallVector<Attribute, 4> templateArguments = {
+        emitc::OpaqueAttr::get(op.getContext(),
+                               std::to_string(op.getNumTiles())),
+        emitc::OpaqueAttr::get(op.getContext(),
+                               op.getHasGamma() ? "true" : "false"),
+        emitc::OpaqueAttr::get(op.getContext(),
+                               op.getRepeatGamma() ? "true" : "false"),
+        datatypeToDataformatEnumNameOpaqueAttr(rewriter, op.getDtype())};
+    SmallVector<Value, 5> operands = {
+        adaptor.getInputCb(), adaptor.getGammaCb(), adaptor.getOutputCb(),
+        reductionScalerBits, epsilonBits};
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange(), "experimental::row_normalization_block", ArrayAttr(),
+        ArrayAttr::get(op.getContext(), templateArguments), operands);
+    return success();
+  }
+};
+
 // Arith MaxUIOp doesn't have an emitc lowering. We can lower it to a call to
 // std::max.
 class ArithMaxUIRewriter : public OpConversionPattern<arith::MaxUIOp> {
@@ -3266,6 +3309,8 @@ public:
         typeConverter, context, state, "async_write_barrier");
 
     patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter, context);
+    patterns.add<ExperimentalRowNormalizationBlockOpConversion>(typeConverter,
+                                                                context);
     patterns.add<TTKernelToEmitCGetDeviceIdFromLogicalMeshPositionOpRewriter>(
         typeConverter, context, state);
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/xxhash.h"
 
 #include <array>
+#include <cmath>
 #include <functional>
 #include <optional>
 #include <string>
@@ -2782,6 +2783,48 @@ public:
   }
 };
 
+class ExperimentalRowNormalizationBlockOpConversion
+    : public OpConversionPattern<
+          ttkernel::ExperimentalRowNormalizationBlockOp> {
+public:
+  using OpConversionPattern<
+      ttkernel::ExperimentalRowNormalizationBlockOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ttkernel::ExperimentalRowNormalizationBlockOp op,
+      ttkernel::ExperimentalRowNormalizationBlockOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const final {
+    auto createBitsLiteral = [&](FloatAttr value) {
+      std::uint64_t bits = value.getValue().bitcastToAPInt().getZExtValue();
+      return emitc::LiteralOp::create(rewriter, op.getLoc(),
+                                      rewriter.getI32Type(),
+                                      (Twine(bits) + "U").str());
+    };
+    // The fused LLK multiplies its scaler during both reduction stages, so its
+    // argument is the square root of the semantic scale.
+    FloatAttr reductionScaler = rewriter.getF32FloatAttr(
+        std::sqrt(op.getScaleAttr().getValueAsDouble()));
+    Value reductionScalerBits = createBitsLiteral(reductionScaler);
+    Value epsilonBits = createBitsLiteral(op.getEpsilonAttr());
+
+    SmallVector<Attribute, 4> templateArguments = {
+        emitc::OpaqueAttr::get(op.getContext(),
+                               std::to_string(op.getNumTiles())),
+        emitc::OpaqueAttr::get(op.getContext(),
+                               op.getHasGamma() ? "true" : "false"),
+        emitc::OpaqueAttr::get(op.getContext(),
+                               op.getRepeatGamma() ? "true" : "false"),
+        datatypeToDataformatEnumNameOpaqueAttr(rewriter, op.getDtype())};
+    SmallVector<Value, 5> operands = {
+        adaptor.getInputCb(), adaptor.getGammaCb(), adaptor.getOutputCb(),
+        reductionScalerBits, epsilonBits};
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange(), "experimental::row_normalization_block", ArrayAttr(),
+        ArrayAttr::get(op.getContext(), templateArguments), operands);
+    return success();
+  }
+};
+
 // Arith MaxUIOp doesn't have an emitc lowering. We can lower it to a call to
 // std::max.
 class ArithMaxUIRewriter : public OpConversionPattern<arith::MaxUIOp> {
@@ -3263,6 +3306,8 @@ public:
         typeConverter, context, state, "async_write_barrier");
 
     patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter, context);
+    patterns.add<ExperimentalRowNormalizationBlockOpConversion>(typeConverter,
+                                                                context);
     patterns.add<TTKernelToEmitCGetDeviceIdFromLogicalMeshPositionOpRewriter>(
         typeConverter, context, state);
 

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -29,9 +29,6 @@ namespace mlir::tt::ttkernel {
   if (getNumTiles() < 1 || getNumTiles() > 8) {
     return emitOpError("num_tiles must be in the range [1, 8]");
   }
-  if (!getHasGamma() && getRepeatGamma()) {
-    return emitOpError("repeat_gamma requires has_gamma");
-  }
   if (!getHasGamma() && getGammaCb() != getInputCb()) {
     return emitOpError("gamma_cb must equal input_cb when has_gamma is false");
   }

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -25,6 +25,47 @@
 
 namespace mlir::tt::ttkernel {
 
+::mlir::LogicalResult ExperimentalRowNormalizationBlockOp::verify() {
+  if (getNumTiles() < 1 || getNumTiles() > 8) {
+    return emitOpError("num_tiles must be in the range [1, 8]");
+  }
+  if (!getHasGamma() && getRepeatGamma()) {
+    return emitOpError("repeat_gamma requires has_gamma");
+  }
+  if (!getHasGamma() && getGammaCb() != getInputCb()) {
+    return emitOpError("gamma_cb must equal input_cb when has_gamma is false");
+  }
+  if (getDtype() != ttcore::DataType::BFloat16) {
+    return emitOpError("supports bf16 DFBs only");
+  }
+
+  const llvm::APFloat &scale = getScaleAttr().getValue();
+  const llvm::APFloat &epsilon = getEpsilonAttr().getValue();
+  if (!scale.isFinite() || scale.isZero() || scale.isNegative()) {
+    return emitOpError("scale must be finite and positive");
+  }
+  if (!epsilon.isFinite() || epsilon.isZero() || epsilon.isNegative()) {
+    return emitOpError("epsilon must be finite and positive");
+  }
+
+  auto inputCBType = mlir::cast<CBType>(getInputCb().getType());
+  auto gammaCBType = mlir::cast<CBType>(getGammaCb().getType());
+  auto outputCBType = mlir::cast<CBType>(getOutputCb().getType());
+  if (inputCBType.getElementType() != outputCBType.getElementType()) {
+    return emitOpError("input and output dataflow buffer types must match");
+  }
+  if (getHasGamma() &&
+      gammaCBType.getElementType() != outputCBType.getElementType()) {
+    return emitOpError("gamma and output dataflow buffer types must match");
+  }
+  auto outputTileType =
+      mlir::dyn_cast<ttcore::TileType>(outputCBType.getElementType());
+  if (!outputTileType || outputTileType.getDataType() != getDtype()) {
+    return emitOpError("dtype must match the output tile data type");
+  }
+  return success();
+}
+
 void ComputeKernelHWStartupOp::print(::mlir::OpAsmPrinter &printer) {
   printer << "(" << getIcb0();
   if (getIcb1()) {

--- a/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
@@ -397,6 +397,15 @@ analyzeSyncRegion(ttk::TileRegsAcquireOp acquireOp, Value &inputCB,
         if (!inputCB) {
           inputCB = transpose.getIcb();
         }
+      } else if (auto normalization =
+                     dyn_cast<ttk::ExperimentalRowNormalizationBlockOp>(
+                         inner)) {
+        if (!inputCB) {
+          inputCB = normalization.getInputCb();
+        }
+        if (!outputCB) {
+          outputCB = normalization.getOutputCb();
+        }
       }
       // Collect output CB from pack ops (both single-tile and block variants).
       auto collectOutputCB = [&](Value packCB, Operation *packOp) {

--- a/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
@@ -367,6 +367,15 @@ analyzeSyncRegion(ttk::TileRegsAcquireOp acquireOp, Value &inputCB,
         if (!inputCB) {
           inputCB = transpose.getIcb();
         }
+      } else if (auto normalization =
+                     dyn_cast<ttk::ExperimentalRowNormalizationBlockOp>(
+                         inner)) {
+        if (!inputCB) {
+          inputCB = normalization.getInputCb();
+        }
+        if (!outputCB) {
+          outputCB = normalization.getOutputCb();
+        }
       }
       // Collect output CB from pack ops (both single-tile and block variants).
       auto collectOutputCB = [&](Value packCB, Operation *packOp) {

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1992,6 +1992,98 @@ mlir::LogicalResult mlir::tt::ttl::ReduceOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// TileRowNormalizationBlockOp
+//===----------------------------------------------------------------------===//
+
+static mlir::FailureOr<mlir::tt::ttcore::TileType>
+getRowNormalizationTileType(mlir::Type type) {
+  if (auto tileType = mlir::dyn_cast<mlir::tt::ttcore::TileType>(type)) {
+    return tileType;
+  }
+  auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(type);
+  if (!tensorType) {
+    return mlir::failure();
+  }
+  auto tileType =
+      mlir::dyn_cast<mlir::tt::ttcore::TileType>(tensorType.getElementType());
+  if (!tileType) {
+    return mlir::failure();
+  }
+  return tileType;
+}
+
+mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
+  FailureOr<ttcore::TileType> inputTileType =
+      getRowNormalizationTileType(getInput().getType());
+  FailureOr<ttcore::TileType> gammaTileType =
+      getRowNormalizationTileType(getGamma().getType());
+  FailureOr<ttcore::TileType> outputTileType =
+      getRowNormalizationTileType(getOutput().getType());
+  FailureOr<ttcore::TileType> resultTileType =
+      getRowNormalizationTileType(getResult().getType());
+  if (failed(inputTileType) || failed(gammaTileType) ||
+      failed(outputTileType) || failed(resultTileType)) {
+    return emitOpError("input, gamma, output, and result must contain tiles");
+  }
+  if (*inputTileType != *outputTileType || *resultTileType != *outputTileType) {
+    return emitOpError(
+        "input, output, and result tile types must match exactly");
+  }
+  if (inputTileType->getDataType() != ttcore::DataType::BFloat16) {
+    return emitOpError("supports bf16 tiles only");
+  }
+  if (getHasGamma() && *gammaTileType != *outputTileType) {
+    return emitOpError("gamma tile type must match the output tile type");
+  }
+  if (!getHasGamma() && getRepeatGamma()) {
+    return emitOpError("repeat_gamma requires has_gamma");
+  }
+  if (!getHasGamma() && getGamma() != getInput()) {
+    return emitOpError("gamma must equal input when has_gamma is false");
+  }
+
+  const llvm::APFloat &scale = getScaleAttr().getValue();
+  const llvm::APFloat &epsilon = getEpsilonAttr().getValue();
+  if (!scale.isFinite() || scale.isZero() || scale.isNegative()) {
+    return emitOpError("scale must be finite and positive");
+  }
+  if (!epsilon.isFinite() || epsilon.isZero() || epsilon.isNegative()) {
+    return emitOpError("epsilon must be finite and positive");
+  }
+
+  auto inputTensor = dyn_cast<RankedTensorType>(getInput().getType());
+  auto outputTensor = dyn_cast<RankedTensorType>(getOutput().getType());
+  auto gammaTensor = dyn_cast<RankedTensorType>(getGamma().getType());
+  if (!inputTensor && !outputTensor && !gammaTensor) {
+    return success();
+  }
+  if (!inputTensor || !outputTensor || !gammaTensor) {
+    return emitOpError(
+        "block lowering requires input, gamma, and output to all be tensors");
+  }
+  if (!inputTensor.hasStaticShape() || !outputTensor.hasStaticShape() ||
+      !gammaTensor.hasStaticShape() || inputTensor.getRank() != 2 ||
+      outputTensor.getRank() != 2 || gammaTensor.getRank() != 2) {
+    return emitOpError("tensor operands must be static rank-2 tensors");
+  }
+  if (inputTensor.getShape() != outputTensor.getShape() ||
+      inputTensor.getDimSize(0) != 1) {
+    return emitOpError(
+        "input and output must have the same one-row tensor shape");
+  }
+  if (getHasGamma()) {
+    bool gammaShapeMatches =
+        getRepeatGamma()
+            ? gammaTensor.getDimSize(0) == 1 && gammaTensor.getDimSize(1) == 1
+            : gammaTensor.getShape() == outputTensor.getShape();
+    if (!gammaShapeMatches) {
+      return emitOpError("gamma tensor shape does not match gamma mode");
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // BlockBroadcastOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -2339,6 +2339,98 @@ mlir::LogicalResult mlir::tt::ttl::ReduceOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// TileRowNormalizationBlockOp
+//===----------------------------------------------------------------------===//
+
+static mlir::FailureOr<mlir::tt::ttcore::TileType>
+getRowNormalizationTileType(mlir::Type type) {
+  if (auto tileType = mlir::dyn_cast<mlir::tt::ttcore::TileType>(type)) {
+    return tileType;
+  }
+  auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(type);
+  if (!tensorType) {
+    return mlir::failure();
+  }
+  auto tileType =
+      mlir::dyn_cast<mlir::tt::ttcore::TileType>(tensorType.getElementType());
+  if (!tileType) {
+    return mlir::failure();
+  }
+  return tileType;
+}
+
+mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
+  FailureOr<ttcore::TileType> inputTileType =
+      getRowNormalizationTileType(getInput().getType());
+  FailureOr<ttcore::TileType> gammaTileType =
+      getRowNormalizationTileType(getGamma().getType());
+  FailureOr<ttcore::TileType> outputTileType =
+      getRowNormalizationTileType(getOutput().getType());
+  FailureOr<ttcore::TileType> resultTileType =
+      getRowNormalizationTileType(getResult().getType());
+  if (failed(inputTileType) || failed(gammaTileType) ||
+      failed(outputTileType) || failed(resultTileType)) {
+    return emitOpError("input, gamma, output, and result must contain tiles");
+  }
+  if (*inputTileType != *outputTileType || *resultTileType != *outputTileType) {
+    return emitOpError(
+        "input, output, and result tile types must match exactly");
+  }
+  if (inputTileType->getDataType() != ttcore::DataType::BFloat16) {
+    return emitOpError("supports bf16 tiles only");
+  }
+  if (getHasGamma() && *gammaTileType != *outputTileType) {
+    return emitOpError("gamma tile type must match the output tile type");
+  }
+  if (!getHasGamma() && getRepeatGamma()) {
+    return emitOpError("repeat_gamma requires has_gamma");
+  }
+  if (!getHasGamma() && getGamma() != getInput()) {
+    return emitOpError("gamma must equal input when has_gamma is false");
+  }
+
+  const llvm::APFloat &scale = getScaleAttr().getValue();
+  const llvm::APFloat &epsilon = getEpsilonAttr().getValue();
+  if (!scale.isFinite() || scale.isZero() || scale.isNegative()) {
+    return emitOpError("scale must be finite and positive");
+  }
+  if (!epsilon.isFinite() || epsilon.isZero() || epsilon.isNegative()) {
+    return emitOpError("epsilon must be finite and positive");
+  }
+
+  auto inputTensor = dyn_cast<RankedTensorType>(getInput().getType());
+  auto outputTensor = dyn_cast<RankedTensorType>(getOutput().getType());
+  auto gammaTensor = dyn_cast<RankedTensorType>(getGamma().getType());
+  if (!inputTensor && !outputTensor && !gammaTensor) {
+    return success();
+  }
+  if (!inputTensor || !outputTensor || !gammaTensor) {
+    return emitOpError(
+        "block lowering requires input, gamma, and output to all be tensors");
+  }
+  if (!inputTensor.hasStaticShape() || !outputTensor.hasStaticShape() ||
+      !gammaTensor.hasStaticShape() || inputTensor.getRank() != 2 ||
+      outputTensor.getRank() != 2 || gammaTensor.getRank() != 2) {
+    return emitOpError("tensor operands must be static rank-2 tensors");
+  }
+  if (inputTensor.getShape() != outputTensor.getShape() ||
+      inputTensor.getDimSize(0) != 1) {
+    return emitOpError(
+        "input and output must have the same one-row tensor shape");
+  }
+  if (getHasGamma()) {
+    bool gammaShapeMatches =
+        getRepeatGamma()
+            ? gammaTensor.getDimSize(0) == 1 && gammaTensor.getDimSize(1) == 1
+            : gammaTensor.getShape() == outputTensor.getShape();
+    if (!gammaShapeMatches) {
+      return emitOpError("gamma tensor shape does not match gamma mode");
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // BlockBroadcastOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -2382,9 +2382,6 @@ mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
   if (getHasGamma() && *gammaTileType != *outputTileType) {
     return emitOpError("gamma tile type must match the output tile type");
   }
-  if (!getHasGamma() && getRepeatGamma()) {
-    return emitOpError("repeat_gamma requires has_gamma");
-  }
   if (!getHasGamma() && getGamma() != getInput()) {
     return emitOpError("gamma must equal input when has_gamma is false");
   }
@@ -2419,12 +2416,8 @@ mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
         "input and output must have the same one-row tensor shape");
   }
   if (getHasGamma()) {
-    bool gammaShapeMatches =
-        getRepeatGamma()
-            ? gammaTensor.getDimSize(0) == 1 && gammaTensor.getDimSize(1) == 1
-            : gammaTensor.getShape() == outputTensor.getShape();
-    if (!gammaShapeMatches) {
-      return emitOpError("gamma tensor shape does not match gamma mode");
+    if (gammaTensor.getShape() != outputTensor.getShape()) {
+      return emitOpError("gamma tensor shape must match the output shape");
     }
   }
   return success();

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -2035,9 +2035,6 @@ mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
   if (getHasGamma() && *gammaTileType != *outputTileType) {
     return emitOpError("gamma tile type must match the output tile type");
   }
-  if (!getHasGamma() && getRepeatGamma()) {
-    return emitOpError("repeat_gamma requires has_gamma");
-  }
   if (!getHasGamma() && getGamma() != getInput()) {
     return emitOpError("gamma must equal input when has_gamma is false");
   }
@@ -2072,12 +2069,8 @@ mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
         "input and output must have the same one-row tensor shape");
   }
   if (getHasGamma()) {
-    bool gammaShapeMatches =
-        getRepeatGamma()
-            ? gammaTensor.getDimSize(0) == 1 && gammaTensor.getDimSize(1) == 1
-            : gammaTensor.getShape() == outputTensor.getShape();
-    if (!gammaShapeMatches) {
-      return emitOpError("gamma tensor shape does not match gamma mode");
+    if (gammaTensor.getShape() != outputTensor.getShape()) {
+      return emitOpError("gamma tensor shape must match the output shape");
     }
   }
   return success();

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -2415,6 +2415,9 @@ mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
     return emitOpError(
         "input and output must have the same one-row tensor shape");
   }
+  if (inputTensor.getNumElements() != static_cast<int64_t>(getNumTiles())) {
+    return emitOpError("num_tiles must match the row tensor width");
+  }
   if (getHasGamma()) {
     if (gammaTensor.getShape() != outputTensor.getShape()) {
       return emitOpError("gamma tensor shape must match the output shape");

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -2068,6 +2068,9 @@ mlir::LogicalResult mlir::tt::ttl::TileRowNormalizationBlockOp::verify() {
     return emitOpError(
         "input and output must have the same one-row tensor shape");
   }
+  if (inputTensor.getNumElements() != static_cast<int64_t>(getNumTiles())) {
+    return emitOpError("num_tiles must match the row tensor width");
+  }
   if (getHasGamma()) {
     if (gammaTensor.getShape() != outputTensor.getShape()) {
       return emitOpError("gamma tensor shape must match the output shape");

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -415,6 +415,7 @@ getDefaultTileExecutionInfo(Operation *operation,
     if (normalization.getHasGamma()) {
       info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
     }
+    info.requiredDstSlots = normalization.getNumTiles();
     return info;
   }
   if (isa<TileTransposeOp>(operation)) {
@@ -493,6 +494,10 @@ LogicalResult verifyTileExecutionInfo(Operation *operation,
         << "defines " << info.dstOperandsMaterializedByOperation.size()
         << " DST operand materialization entries for "
         << operation->getNumOperands() << " operands";
+    return failure();
+  }
+  if (info.requiredDstSlots == 0) {
+    operation->emitOpError("defines a zero-slot DST residency requirement");
     return failure();
   }
   return success();
@@ -700,19 +705,6 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
   return lhsType.getDimSize(0) * rhsType.getDimSize(1);
 }
 
-/// Row normalization moves its scalar to a compute source register before
-/// overwriting the acquired DST section with the normalized row.
-static int64_t
-getRowNormalizationBlockTileCount(TileRowNormalizationBlockOp op) {
-  if (isa<ttcore::TileType>(op.getInput().getType())) {
-    return 1;
-  }
-  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
-  assert(inputType && inputType.hasStaticShape() &&
-         "verified row-normalization tensor form must have static shape");
-  return inputType.getNumElements();
-}
-
 /// Interface defaults require resolved DST operands because callers use this
 /// after DST assignment, where unresolved tile residency is invalid IR.
 static LogicalResult
@@ -759,7 +751,7 @@ SmallVector<DstFootprint, 2> getDefaultDstWriteFootprints(Operation *op) {
   }
   if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
     return {{normalization.getDstIndex(),
-             getRowNormalizationBlockTileCount(normalization)}};
+             static_cast<int64_t>(normalization.getNumTiles())}};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return {{*dstIndex, 1}};
@@ -783,7 +775,7 @@ FailureOr<DstFootprint> getDefaultResultDstFootprint(Operation *op,
   }
   if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
     return DstFootprint{normalization.getDstIndex(),
-                        getRowNormalizationBlockTileCount(normalization)};
+                        static_cast<int64_t>(normalization.getNumTiles())};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return DstFootprint{*dstIndex, 1};

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -321,6 +321,7 @@ getDefaultTileExecutionInfo(Operation *operation,
     if (normalization.getHasGamma()) {
       info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
     }
+    info.requiredDstSlots = normalization.getNumTiles();
     return info;
   }
   if (isa<TileTransposeOp>(operation)) {
@@ -389,6 +390,10 @@ LogicalResult verifyTileExecutionInfo(Operation *operation,
         << "defines " << info.dstOperandsMaterializedByOperation.size()
         << " DST operand materialization entries for "
         << operation->getNumOperands() << " operands";
+    return failure();
+  }
+  if (info.requiredDstSlots == 0) {
+    operation->emitOpError("defines a zero-slot DST residency requirement");
     return failure();
   }
   return success();
@@ -596,19 +601,6 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
   return lhsType.getDimSize(0) * rhsType.getDimSize(1);
 }
 
-/// Row normalization moves its scalar to a compute source register before
-/// overwriting the acquired DST section with the normalized row.
-static int64_t
-getRowNormalizationBlockTileCount(TileRowNormalizationBlockOp op) {
-  if (isa<ttcore::TileType>(op.getInput().getType())) {
-    return 1;
-  }
-  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
-  assert(inputType && inputType.hasStaticShape() &&
-         "verified row-normalization tensor form must have static shape");
-  return inputType.getNumElements();
-}
-
 /// Interface defaults require resolved DST operands because callers use this
 /// after DST assignment, where unresolved tile residency is invalid IR.
 static LogicalResult
@@ -655,7 +647,7 @@ SmallVector<DstFootprint, 2> getDefaultDstWriteFootprints(Operation *op) {
   }
   if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
     return {{normalization.getDstIndex(),
-             getRowNormalizationBlockTileCount(normalization)}};
+             static_cast<int64_t>(normalization.getNumTiles())}};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return {{*dstIndex, 1}};
@@ -679,7 +671,7 @@ FailureOr<DstFootprint> getDefaultResultDstFootprint(Operation *op,
   }
   if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
     return DstFootprint{normalization.getDstIndex(),
-                        getRowNormalizationBlockTileCount(normalization)};
+                        static_cast<int64_t>(normalization.getNumTiles())};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return DstFootprint{*dstIndex, 1};

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -315,6 +315,14 @@ getDefaultTileExecutionInfo(Operation *operation,
     }
     return info;
   }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(operation)) {
+    info.primitive = TilePrimitive::Reduce;
+    info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
+    if (normalization.getHasGamma()) {
+      info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
+    }
+    return info;
+  }
   if (isa<TileTransposeOp>(operation)) {
     info.primitive = TilePrimitive::Transpose;
     info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -409,6 +409,14 @@ getDefaultTileExecutionInfo(Operation *operation,
     }
     return info;
   }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(operation)) {
+    info.primitive = TilePrimitive::Reduce;
+    info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;
+    if (normalization.getHasGamma()) {
+      info.operandRoutes[1] = TileOperandRoute::DataflowBuffer;
+    }
+    return info;
+  }
   if (isa<TileTransposeOp>(operation)) {
     info.primitive = TilePrimitive::Transpose;
     info.operandRoutes[0] = TileOperandRoute::DataflowBuffer;

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -588,6 +588,17 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
   return lhsType.getDimSize(0) * rhsType.getDimSize(1);
 }
 
+/// Row normalization moves its scalar to a compute source register before
+/// overwriting the acquired DST section with the normalized row.
+static int64_t
+getRowNormalizationBlockTileCount(TileRowNormalizationBlockOp op) {
+  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+  if (!inputType || !inputType.hasStaticShape()) {
+    return 1;
+  }
+  return inputType.getNumElements();
+}
+
 /// Interface defaults require resolved DST operands because callers use this
 /// after DST assignment, where unresolved tile residency is invalid IR.
 static LogicalResult
@@ -623,14 +634,18 @@ getDefaultDstReadFootprints(Operation *op) {
   return footprints;
 }
 
-/// Most tile ops write one explicit `dst_index`; block matmul is the current
-/// multi-slot writer and stores only read DST for packing.
+/// Most tile ops write one explicit `dst_index`; block operations may write a
+/// contiguous range, and stores only read DST for packing.
 SmallVector<DstFootprint, 2> getDefaultDstWriteFootprints(Operation *op) {
   if (isa<TileStoreOp, DstIndexOp>(op)) {
     return {};
   }
   if (auto matmul = dyn_cast<TileMatmulBlockOp>(op)) {
     return {{matmul.getDstIndex(), getMatmulBlockOutputTileCount(matmul)}};
+  }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
+    return {{normalization.getDstIndex(),
+             getRowNormalizationBlockTileCount(normalization)}};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return {{*dstIndex, 1}};
@@ -651,6 +666,10 @@ FailureOr<DstFootprint> getDefaultResultDstFootprint(Operation *op,
   if (auto matmul = dyn_cast<TileMatmulBlockOp>(op)) {
     return DstFootprint{matmul.getDstIndex(),
                         getMatmulBlockOutputTileCount(matmul)};
+  }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
+    return DstFootprint{normalization.getDstIndex(),
+                        getRowNormalizationBlockTileCount(normalization)};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return DstFootprint{*dstIndex, 1};

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -692,6 +692,17 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
   return lhsType.getDimSize(0) * rhsType.getDimSize(1);
 }
 
+/// Row normalization moves its scalar to a compute source register before
+/// overwriting the acquired DST section with the normalized row.
+static int64_t
+getRowNormalizationBlockTileCount(TileRowNormalizationBlockOp op) {
+  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+  if (!inputType || !inputType.hasStaticShape()) {
+    return 1;
+  }
+  return inputType.getNumElements();
+}
+
 /// Interface defaults require resolved DST operands because callers use this
 /// after DST assignment, where unresolved tile residency is invalid IR.
 static LogicalResult
@@ -727,14 +738,18 @@ getDefaultDstReadFootprints(Operation *op) {
   return footprints;
 }
 
-/// Most tile ops write one explicit `dst_index`; block matmul is the current
-/// multi-slot writer and stores only read DST for packing.
+/// Most tile ops write one explicit `dst_index`; block operations may write a
+/// contiguous range, and stores only read DST for packing.
 SmallVector<DstFootprint, 2> getDefaultDstWriteFootprints(Operation *op) {
   if (isa<TileStoreOp, DstIndexOp>(op)) {
     return {};
   }
   if (auto matmul = dyn_cast<TileMatmulBlockOp>(op)) {
     return {{matmul.getDstIndex(), getMatmulBlockOutputTileCount(matmul)}};
+  }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
+    return {{normalization.getDstIndex(),
+             getRowNormalizationBlockTileCount(normalization)}};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return {{*dstIndex, 1}};
@@ -755,6 +770,10 @@ FailureOr<DstFootprint> getDefaultResultDstFootprint(Operation *op,
   if (auto matmul = dyn_cast<TileMatmulBlockOp>(op)) {
     return DstFootprint{matmul.getDstIndex(),
                         getMatmulBlockOutputTileCount(matmul)};
+  }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(op)) {
+    return DstFootprint{normalization.getDstIndex(),
+                        getRowNormalizationBlockTileCount(normalization)};
   }
   if (auto dstIndex = getTileOpDstIndex(op)) {
     return DstFootprint{*dstIndex, 1};

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -592,10 +592,12 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
 /// overwriting the acquired DST section with the normalized row.
 static int64_t
 getRowNormalizationBlockTileCount(TileRowNormalizationBlockOp op) {
-  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
-  if (!inputType || !inputType.hasStaticShape()) {
+  if (isa<ttcore::TileType>(op.getInput().getType())) {
     return 1;
   }
+  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+  assert(inputType && inputType.hasStaticShape() &&
+         "verified row-normalization tensor form must have static shape");
   return inputType.getNumElements();
 }
 

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -696,10 +696,12 @@ static int64_t getMatmulBlockOutputTileCount(TileMatmulBlockOp op) {
 /// overwriting the acquired DST section with the normalized row.
 static int64_t
 getRowNormalizationBlockTileCount(TileRowNormalizationBlockOp op) {
-  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
-  if (!inputType || !inputType.hasStaticShape()) {
+  if (isa<ttcore::TileType>(op.getInput().getType())) {
     return 1;
   }
+  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+  assert(inputType && inputType.hasStaticShape() &&
+         "verified row-normalization tensor form must have static shape");
   return inputType.getNumElements();
 }
 

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   LaunchNodeDomainAnalysis.cpp
 
   LowerMatmulCompute.cpp
+  LowerRowNormalizationCompute.cpp
   LowerSignpostToEmitC.cpp
   TTLAnnotateCBAssociations.cpp
   TTLCoalesceDFBAcquires.cpp

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   LaunchNodeDomainAnalysis.cpp
 
   LowerMatmulCompute.cpp
+  LowerRowNormalizationCompute.cpp
   LowerSignpostToEmitC.cpp
   TTLAnnotateCBAssociations.cpp
   TTLAnnotateL1AccLoops.cpp

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -208,7 +208,7 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
            operand.getOperandNumber(), info.primitive, route, *elementType});
     }
     if (route == TileOperandRoute::Dst) {
-      destinationUses.push_back({operation, info.primitive, *elementType});
+      destinationUses.push_back({operation, info.primitive, *elementType, 1});
     }
   }
 
@@ -226,8 +226,9 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     if (!tileType) {
       continue;
     }
-    destinationUses.push_back(
-        {operation, info.primitive, tileType.getElementType()});
+    destinationUses.push_back({operation, info.primitive,
+                               tileType.getElementType(),
+                               info.requiredDstSlots});
   }
   return success();
 }
@@ -346,27 +347,38 @@ struct UnsupportedDestinationConfiguration {
   DestinationUse use;
 };
 
+struct DestinationCapacityConflict {
+  DestinationUse use;
+  std::uint32_t availableDstSlots;
+};
+
 using ConfigConstraintConflict =
     std::variant<DestinationWidthConflict, ExplicitUnpackConflict,
                  DFBUnpackConflict, UnsupportedDFBConfiguration,
-                 UnsupportedDestinationConfiguration>;
+                 UnsupportedDestinationConfiguration,
+                 DestinationCapacityConflict>;
 
 struct ConfigurationCandidate {
-  explicit ConfigurationCandidate(DestinationElementWidth width)
-      : destinationElementWidth(width) {}
+  ConfigurationCandidate(DestinationElementWidth width, DstSyncMode syncMode)
+      : destinationElementWidth(width), dstSyncMode(syncMode) {}
 
   DestinationElementWidth destinationElementWidth;
+  DstSyncMode dstSyncMode;
   llvm::MapVector<int64_t, llvm::SmallSet<DFBUnpackMode, 2>> unpackModes;
   llvm::DenseMap<int64_t, DFBInputUse> firstUnpackUses;
 };
 
 struct ConfigConstraintState {
   ConfigConstraintState() {
-    candidates.emplace_back(DestinationElementWidth::Bits16);
-    candidates.emplace_back(DestinationElementWidth::Bits32);
+    candidates.emplace_back(DestinationElementWidth::Bits16,
+                            DstSyncMode::DoubleBuffered);
+    candidates.emplace_back(DestinationElementWidth::Bits16, DstSyncMode::Full);
+    candidates.emplace_back(DestinationElementWidth::Bits32,
+                            DstSyncMode::DoubleBuffered);
+    candidates.emplace_back(DestinationElementWidth::Bits32, DstSyncMode::Full);
   }
 
-  llvm::SmallVector<ConfigurationCandidate, 2> candidates;
+  llvm::SmallVector<ConfigurationCandidate, 4> candidates;
   DestinationWidthEvidence requires32Bits{nullptr, std::nullopt};
   DestinationWidthEvidence requires16Bits{nullptr, std::nullopt};
 };
@@ -410,6 +422,25 @@ ConfigConstraintResult applyConfigConstraints(
     if (state.candidates.empty()) {
       return ConfigConstraintConflict(
           DestinationWidthConflict{state.requires32Bits, state.requires16Bits});
+    }
+
+    std::uint32_t maximumAvailable = 0;
+    for (const ConfigurationCandidate &candidate : state.candidates) {
+      std::uint32_t capacity = getDstCapacity(
+          candidate.destinationElementWidth == DestinationElementWidth::Bits32,
+          candidate.dstSyncMode == DstSyncMode::Full);
+      maximumAvailable = std::max(maximumAvailable, capacity);
+    }
+    llvm::erase_if(
+        state.candidates, [&](const ConfigurationCandidate &candidate) {
+          return getDstCapacity(candidate.destinationElementWidth ==
+                                    DestinationElementWidth::Bits32,
+                                candidate.dstSyncMode == DstSyncMode::Full) <
+                 use.requiredDstSlots;
+        });
+    if (state.candidates.empty()) {
+      return ConfigConstraintConflict(
+          DestinationCapacityConflict{use, maximumAvailable});
     }
   }
 
@@ -527,10 +558,18 @@ void emitConfigConstraintConflict(func::FuncOp function,
               << "dataflow buffer " << typedConflict.use.dfbIndex
               << " has no target-supported destination-width and unpack-route "
                  "configuration";
-        } else {
+        } else if constexpr (std::is_same_v<
+                                 ConflictType,
+                                 UnsupportedDestinationConfiguration>) {
           typedConflict.use.operation->emitOpError()
               << "has no target-supported destination element width for "
               << typedConflict.use.elementType << " elements";
+        } else {
+          typedConflict.use.operation->emitOpError()
+              << "requires " << typedConflict.use.requiredDstSlots
+              << " simultaneous DST slots, but at most "
+              << typedConflict.availableDstSlots
+              << " are available under the kernel configuration";
         }
       },
       conflict);
@@ -1096,6 +1135,17 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
                    });
     initialState.requires16Bits = {function.getOperation(), std::nullopt};
   }
+  if (policy.dstSynchronization == ConfigSelection::Enabled) {
+    llvm::erase_if(initialState.candidates,
+                   [](const ConfigurationCandidate &candidate) {
+                     return candidate.dstSyncMode != DstSyncMode::Full;
+                   });
+  } else if (policy.dstSynchronization == ConfigSelection::Disabled) {
+    llvm::erase_if(
+        initialState.candidates, [](const ConfigurationCandidate &candidate) {
+          return candidate.dstSyncMode != DstSyncMode::DoubleBuffered;
+        });
+  }
   ConfigConstraintResult fixedResult = applyConfigConstraints(
       initialState, target, policy, requirements.dfbInputUses,
       requirements.destinationUses);
@@ -1173,17 +1223,23 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
              "kernel configuration; using non-full-fp32 lowering";
     }
   }
-  auto selectedCandidate = llvm::find_if(
-      resolvedState.constraints.candidates,
-      [&](const ConfigurationCandidate &candidate) {
-        return candidate.destinationElementWidth == destinationElementWidth;
-      });
-  assert(selectedCandidate != resolvedState.constraints.candidates.end() &&
-         "resolved destination width must have a candidate");
-
-  DstSyncMode syncMode = policy.dstSynchronization == ConfigSelection::Enabled
-                             ? DstSyncMode::Full
-                             : DstSyncMode::DoubleBuffered;
+  auto findCandidate = [&](DstSyncMode syncMode) {
+    return llvm::find_if(resolvedState.constraints.candidates,
+                         [&](const ConfigurationCandidate &candidate) {
+                           return candidate.destinationElementWidth ==
+                                      destinationElementWidth &&
+                                  candidate.dstSyncMode == syncMode;
+                         });
+  };
+  DstSyncMode syncMode = DstSyncMode::DoubleBuffered;
+  auto selectedCandidate = findCandidate(syncMode);
+  if (selectedCandidate == resolvedState.constraints.candidates.end()) {
+    syncMode = DstSyncMode::Full;
+    selectedCandidate = findCandidate(syncMode);
+  }
+  assert(
+      selectedCandidate != resolvedState.constraints.candidates.end() &&
+      "resolved destination width and synchronization must have a candidate");
 
   if (policy.unpackToDestFp32) {
     return KernelConfigPlan(destinationElementWidth, syncMode,

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -207,7 +207,7 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
                               *elementType});
     }
     if (route == TileOperandRoute::Dst) {
-      destinationUses.push_back({operation, info.primitive, *elementType});
+      destinationUses.push_back({operation, info.primitive, *elementType, 1});
     }
   }
 
@@ -225,8 +225,9 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     if (!tileType) {
       continue;
     }
-    destinationUses.push_back(
-        {operation, info.primitive, tileType.getElementType()});
+    destinationUses.push_back({operation, info.primitive,
+                               tileType.getElementType(),
+                               info.requiredDstSlots});
   }
   return success();
 }
@@ -345,27 +346,38 @@ struct UnsupportedDestinationConfiguration {
   DestinationUse use;
 };
 
+struct DestinationCapacityConflict {
+  DestinationUse use;
+  std::uint32_t availableDstSlots;
+};
+
 using ConfigConstraintConflict =
     std::variant<DestinationWidthConflict, ExplicitUnpackConflict,
                  DFBUnpackConflict, UnsupportedDFBConfiguration,
-                 UnsupportedDestinationConfiguration>;
+                 UnsupportedDestinationConfiguration,
+                 DestinationCapacityConflict>;
 
 struct ConfigurationCandidate {
-  explicit ConfigurationCandidate(DestinationElementWidth width)
-      : destinationElementWidth(width) {}
+  ConfigurationCandidate(DestinationElementWidth width, DstSyncMode syncMode)
+      : destinationElementWidth(width), dstSyncMode(syncMode) {}
 
   DestinationElementWidth destinationElementWidth;
+  DstSyncMode dstSyncMode;
   llvm::MapVector<int64_t, llvm::SmallSet<DFBUnpackMode, 2>> unpackModes;
   llvm::DenseMap<int64_t, DFBInputUse> firstUnpackUses;
 };
 
 struct ConfigConstraintState {
   ConfigConstraintState() {
-    candidates.emplace_back(DestinationElementWidth::Bits16);
-    candidates.emplace_back(DestinationElementWidth::Bits32);
+    candidates.emplace_back(DestinationElementWidth::Bits16,
+                            DstSyncMode::DoubleBuffered);
+    candidates.emplace_back(DestinationElementWidth::Bits16, DstSyncMode::Full);
+    candidates.emplace_back(DestinationElementWidth::Bits32,
+                            DstSyncMode::DoubleBuffered);
+    candidates.emplace_back(DestinationElementWidth::Bits32, DstSyncMode::Full);
   }
 
-  llvm::SmallVector<ConfigurationCandidate, 2> candidates;
+  llvm::SmallVector<ConfigurationCandidate, 4> candidates;
   DestinationWidthEvidence requires32Bits{nullptr, std::nullopt};
   DestinationWidthEvidence requires16Bits{nullptr, std::nullopt};
 };
@@ -409,6 +421,25 @@ ConfigConstraintResult applyConfigConstraints(
     if (state.candidates.empty()) {
       return ConfigConstraintConflict(
           DestinationWidthConflict{state.requires32Bits, state.requires16Bits});
+    }
+
+    std::uint32_t maximumAvailable = 0;
+    for (const ConfigurationCandidate &candidate : state.candidates) {
+      std::uint32_t capacity = getDstCapacity(
+          candidate.destinationElementWidth == DestinationElementWidth::Bits32,
+          candidate.dstSyncMode == DstSyncMode::Full);
+      maximumAvailable = std::max(maximumAvailable, capacity);
+    }
+    llvm::erase_if(
+        state.candidates, [&](const ConfigurationCandidate &candidate) {
+          return getDstCapacity(candidate.destinationElementWidth ==
+                                    DestinationElementWidth::Bits32,
+                                candidate.dstSyncMode == DstSyncMode::Full) <
+                 use.requiredDstSlots;
+        });
+    if (state.candidates.empty()) {
+      return ConfigConstraintConflict(
+          DestinationCapacityConflict{use, maximumAvailable});
     }
   }
 
@@ -526,10 +557,18 @@ void emitConfigConstraintConflict(func::FuncOp function,
               << "dataflow buffer " << typedConflict.use.dfbIndex
               << " has no target-supported destination-width and unpack-route "
                  "configuration";
-        } else {
+        } else if constexpr (std::is_same_v<
+                                 ConflictType,
+                                 UnsupportedDestinationConfiguration>) {
           typedConflict.use.operation->emitOpError()
               << "has no target-supported destination element width for "
               << typedConflict.use.elementType << " elements";
+        } else {
+          typedConflict.use.operation->emitOpError()
+              << "requires " << typedConflict.use.requiredDstSlots
+              << " simultaneous DST slots, but at most "
+              << typedConflict.availableDstSlots
+              << " are available under the kernel configuration";
         }
       },
       conflict);
@@ -903,6 +942,17 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
                    });
     initialState.requires16Bits = {function.getOperation(), std::nullopt};
   }
+  if (policy.dstSynchronization == ConfigSelection::Enabled) {
+    llvm::erase_if(initialState.candidates,
+                   [](const ConfigurationCandidate &candidate) {
+                     return candidate.dstSyncMode != DstSyncMode::Full;
+                   });
+  } else if (policy.dstSynchronization == ConfigSelection::Disabled) {
+    llvm::erase_if(
+        initialState.candidates, [](const ConfigurationCandidate &candidate) {
+          return candidate.dstSyncMode != DstSyncMode::DoubleBuffered;
+        });
+  }
   ConfigConstraintResult fixedResult = applyConfigConstraints(
       initialState, target, policy, requirements.dfbInputUses,
       requirements.destinationUses);
@@ -980,17 +1030,23 @@ FailureOr<KernelConfigPlan> resolveKernelConfig(
              "kernel configuration; using non-full-fp32 lowering";
     }
   }
-  auto selectedCandidate = llvm::find_if(
-      resolvedState.constraints.candidates,
-      [&](const ConfigurationCandidate &candidate) {
-        return candidate.destinationElementWidth == destinationElementWidth;
-      });
-  assert(selectedCandidate != resolvedState.constraints.candidates.end() &&
-         "resolved destination width must have a candidate");
-
-  DstSyncMode syncMode = policy.dstSynchronization == ConfigSelection::Enabled
-                             ? DstSyncMode::Full
-                             : DstSyncMode::DoubleBuffered;
+  auto findCandidate = [&](DstSyncMode syncMode) {
+    return llvm::find_if(resolvedState.constraints.candidates,
+                         [&](const ConfigurationCandidate &candidate) {
+                           return candidate.destinationElementWidth ==
+                                      destinationElementWidth &&
+                                  candidate.dstSyncMode == syncMode;
+                         });
+  };
+  DstSyncMode syncMode = DstSyncMode::DoubleBuffered;
+  auto selectedCandidate = findCandidate(syncMode);
+  if (selectedCandidate == resolvedState.constraints.candidates.end()) {
+    syncMode = DstSyncMode::Full;
+    selectedCandidate = findCandidate(syncMode);
+  }
+  assert(
+      selectedCandidate != resolvedState.constraints.candidates.end() &&
+      "resolved destination width and synchronization must have a candidate");
 
   if (policy.unpackToDestFp32) {
     return KernelConfigPlan(destinationElementWidth, syncMode,

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -895,7 +895,6 @@ matchRowNormalization(Operation *source) {
   MulOp normalized = finalMultiply;
   Value gamma;
   RowNormalizationGammaMode gammaMode = RowNormalizationGammaMode::None;
-  BlockBroadcastOp gammaBroadcast;
 
   Value input;
   BlockBroadcastOp scalarBroadcast;
@@ -925,27 +924,10 @@ matchRowNormalization(Operation *source) {
       return std::nullopt;
     }
 
-    if (getAttachedCB(gamma)) {
-      gammaMode = RowNormalizationGammaMode::FullRow;
-    } else {
-      gammaBroadcast = gamma.getDefiningOp<BlockBroadcastOp>();
-      if (!gammaBroadcast || !hasOnlyUser(gamma, source) ||
-          !getAttachedCB(gammaBroadcast.getInput())) {
-        return std::nullopt;
-      }
-      auto gammaInputType =
-          dyn_cast<RankedTensorType>(gammaBroadcast.getInput().getType());
-      llvm::SmallDenseSet<int64_t> gammaDimensions =
-          normalizeDimsToSet(gammaBroadcast.getDims(), 2);
-      if (!gammaInputType || !gammaInputType.hasStaticShape() ||
-          gammaInputType.getRank() != 2 || gammaInputType.getDimSize(0) != 1 ||
-          gammaInputType.getDimSize(1) != 1 || gammaDimensions.size() != 1 ||
-          !gammaDimensions.contains(1)) {
-        return std::nullopt;
-      }
-      gamma = gammaBroadcast.getInput();
-      gammaMode = RowNormalizationGammaMode::RepeatedPage;
+    if (!getAttachedCB(gamma)) {
+      return std::nullopt;
     }
+    gammaMode = RowNormalizationGammaMode::FullRow;
   }
 
   auto inputType = dyn_cast<RankedTensorType>(input.getType());
@@ -979,12 +961,7 @@ matchRowNormalization(Operation *source) {
         gammaType.getElementType() != inputType.getElementType()) {
       return std::nullopt;
     }
-    if (gammaMode == RowNormalizationGammaMode::FullRow &&
-        gammaType != resultType) {
-      return std::nullopt;
-    }
-    if (gammaMode == RowNormalizationGammaMode::RepeatedPage &&
-        gammaBroadcast.getResult().getType() != resultType) {
+    if (gammaType != resultType) {
       return std::nullopt;
     }
   }
@@ -1018,9 +995,6 @@ matchRowNormalization(Operation *source) {
   recordOperation(inverseRms);
   recordOperation(scalarBroadcast);
   recordOperation(normalized);
-  if (gammaBroadcast) {
-    recordOperation(gammaBroadcast);
-  }
   if (source != normalized.getOperation()) {
     recordOperation(source);
   }
@@ -1048,11 +1022,6 @@ static LogicalResult buildOperationSpecificPlan(ComputeOpCreationPlan &plan,
     if (plan.rowNormalization->gammaMode ==
         RowNormalizationGammaMode::FullRow) {
       plan.iteration.inputMaps.push_back(identity);
-    } else if (plan.rowNormalization->gammaMode ==
-               RowNormalizationGammaMode::RepeatedPage) {
-      AffineExpr zero = getAffineConstantExpr(0, context);
-      plan.iteration.inputMaps.push_back(
-          AffineMap::get(2, 0, {zero, zero}, context));
     }
     plan.iteration.outputMap = identity;
     plan.iteration.iteratorTypes.assign(2, utils::IteratorType::parallel);

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -890,10 +890,8 @@ static bool matchNormalizedProduct(MulOp normalized, Value &input,
 }
 
 static std::optional<MatchedRowNormalization>
-matchRowNormalization(Operation *source) {
-  if (!isBlackholeTarget(source)) {
-    return std::nullopt;
-  }
+matchRowNormalization(Operation *source,
+                      const ComputeTargetEnvironment &target) {
   auto finalMultiply = dyn_cast<MulOp>(source);
   if (!finalMultiply) {
     return std::nullopt;
@@ -953,10 +951,16 @@ matchRowNormalization(Operation *source) {
   if (dataType != ttcore::DataType::BFloat16) {
     return std::nullopt;
   }
+  ComputeScheduleCapabilityLimits limits = target.getScheduleCapabilityLimits(
+      ComputeScheduleCapability::RowNormalization,
+      cast<ttcore::TileType>(inputType.getElementType()));
+  if (!limits.maxTiles) {
+    return std::nullopt;
+  }
   bool isFloat32 = getKernelBoolAttr(source, kFp32DestAccEnAttrName);
   std::uint32_t dstCapacity = getDstCapacity(
       isFloat32, getKernelBoolAttr(source, kDstFullSyncEnAttrName));
-  dstCapacity = std::min<std::uint32_t>(8, dstCapacity);
+  dstCapacity = std::min(*limits.maxTiles, dstCapacity);
   if (numTiles < 1 || static_cast<std::uint64_t>(numTiles) >
                           static_cast<std::uint64_t>(dstCapacity)) {
     return std::nullopt;
@@ -1920,7 +1924,7 @@ buildComputeOpCreationPlan(Operation *source,
     plan.kind = ComputeOpCreationKind::Elide;
     plan.inputs = {cast<TypecastOp>(source).getInput()};
   } else if (std::optional<MatchedRowNormalization> rowNormalization =
-                 matchRowNormalization(source)) {
+                 matchRowNormalization(source, target)) {
     plan.kind = ComputeOpCreationKind::Fused;
     plan.trace = std::move(rowNormalization->trace);
     plan.rowNormalization = std::move(rowNormalization->schedule);

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
 #include <functional>
 
 namespace mlir::tt::ttl {
@@ -784,10 +785,284 @@ static LogicalResult buildFusedIterationPlan(ComputeOpCreationPlan &plan,
   return success();
 }
 
+struct MatchedRowNormalization {
+  RowNormalizationPlan schedule;
+  FusionTraceResult trace;
+};
+
+static bool hasOnlyUser(Value value, Operation *expectedUser) {
+  return value.hasOneUse() && *value.getUsers().begin() == expectedUser;
+}
+
+static bool isFullScalarReduction(ReduceOp reduce) {
+  if (reduce.getReduceType() != ReduceType::Sum) {
+    return false;
+  }
+  llvm::SmallDenseSet<int64_t> dimensions =
+      normalizeDimsToSet(reduce.getDims(), 2);
+  return dimensions.size() == 2 && dimensions.contains(0) &&
+         dimensions.contains(1);
+}
+
+static bool isFullScalarBroadcast(BlockBroadcastOp broadcast) {
+  llvm::SmallDenseSet<int64_t> dimensions =
+      normalizeDimsToSet(broadcast.getDims(), 2);
+  return dimensions.size() == 2 && dimensions.contains(0) &&
+         dimensions.contains(1);
+}
+
+static bool isUnitFill(Value value, Operation *expectedUser, FillOp &fill) {
+  fill = value.getDefiningOp<FillOp>();
+  return fill && hasOnlyUser(value, expectedUser) &&
+         fill.getValueAttr().getValueAsDouble() == 1.0;
+}
+
+static bool isFinitePositiveFloat(FloatAttr value) {
+  const llvm::APFloat &number = value.getValue();
+  return number.isFinite() && !number.isZero() && !number.isNegative();
+}
+
+static bool matchAddWithConstant(Value value, Operation *expectedUser,
+                                 MulUnaryConstOp &scaledReduction,
+                                 FillOp &epsilonFill) {
+  auto add = value.getDefiningOp<AddOp>();
+  if (!add || !hasOnlyUser(value, expectedUser)) {
+    return false;
+  }
+  auto matchOperands = [&](Value scaledValue, Value fillValue) {
+    scaledReduction = scaledValue.getDefiningOp<MulUnaryConstOp>();
+    epsilonFill = fillValue.getDefiningOp<FillOp>();
+    return scaledReduction && epsilonFill && hasOnlyUser(scaledValue, add) &&
+           hasOnlyUser(fillValue, add);
+  };
+  return matchOperands(add.getLhs(), add.getRhs()) ||
+         matchOperands(add.getRhs(), add.getLhs());
+}
+
+static bool matchNormalizedProduct(MulOp normalized, Value &input,
+                                   BlockBroadcastOp &scalarBroadcast,
+                                   RsqrtOp &inverseRms, AddOp &biasedMeanSquare,
+                                   MulUnaryConstOp &scaledReduction,
+                                   FillOp &epsilonFill, ReduceOp &reduce,
+                                   FillOp &reductionScaler, MulOp &square) {
+  auto matchOperands = [&](Value inputValue, Value broadcastValue) {
+    if (!getAttachedCB(inputValue)) {
+      return false;
+    }
+    scalarBroadcast = broadcastValue.getDefiningOp<BlockBroadcastOp>();
+    if (!scalarBroadcast || !hasOnlyUser(broadcastValue, normalized) ||
+        !isFullScalarBroadcast(scalarBroadcast)) {
+      return false;
+    }
+    input = inputValue;
+    return true;
+  };
+  if (!matchOperands(normalized.getLhs(), normalized.getRhs()) &&
+      !matchOperands(normalized.getRhs(), normalized.getLhs())) {
+    return false;
+  }
+
+  inverseRms = scalarBroadcast.getInput().getDefiningOp<RsqrtOp>();
+  if (!inverseRms || !hasOnlyUser(inverseRms.getResult(), scalarBroadcast)) {
+    return false;
+  }
+  biasedMeanSquare = inverseRms.getInput().getDefiningOp<AddOp>();
+  if (!biasedMeanSquare ||
+      !matchAddWithConstant(inverseRms.getInput(), inverseRms, scaledReduction,
+                            epsilonFill)) {
+    return false;
+  }
+
+  reduce = scaledReduction.getInput().getDefiningOp<ReduceOp>();
+  if (!reduce || !hasOnlyUser(reduce.getResult(), scaledReduction) ||
+      !isFullScalarReduction(reduce)) {
+    return false;
+  }
+  if (!isUnitFill(reduce.getScaler(), reduce, reductionScaler)) {
+    return false;
+  }
+  square = reduce.getInput().getDefiningOp<MulOp>();
+  if (!square || !hasOnlyUser(square.getResult(), reduce) ||
+      square.getLhs() != input || square.getRhs() != input) {
+    return false;
+  }
+  return true;
+}
+
+static std::optional<MatchedRowNormalization>
+matchRowNormalization(Operation *source) {
+  if (!isBlackholeTarget(source)) {
+    return std::nullopt;
+  }
+  auto finalMultiply = dyn_cast<MulOp>(source);
+  if (!finalMultiply) {
+    return std::nullopt;
+  }
+
+  MulOp normalized = finalMultiply;
+  Value gamma;
+  RowNormalizationGammaMode gammaMode = RowNormalizationGammaMode::None;
+  BlockBroadcastOp gammaBroadcast;
+
+  Value input;
+  BlockBroadcastOp scalarBroadcast;
+  RsqrtOp inverseRms;
+  AddOp biasedMeanSquare;
+  MulUnaryConstOp scaledReduction;
+  FillOp epsilonFill;
+  ReduceOp reduce;
+  FillOp reductionScaler;
+  MulOp square;
+  if (!matchNormalizedProduct(normalized, input, scalarBroadcast, inverseRms,
+                              biasedMeanSquare, scaledReduction, epsilonFill,
+                              reduce, reductionScaler, square)) {
+    auto matchGammaProduct = [&](Value normalizedValue, Value gammaValue) {
+      normalized = normalizedValue.getDefiningOp<MulOp>();
+      if (!normalized || !hasOnlyUser(normalizedValue, source) ||
+          !matchNormalizedProduct(
+              normalized, input, scalarBroadcast, inverseRms, biasedMeanSquare,
+              scaledReduction, epsilonFill, reduce, reductionScaler, square)) {
+        return false;
+      }
+      gamma = gammaValue;
+      return true;
+    };
+    if (!matchGammaProduct(finalMultiply.getLhs(), finalMultiply.getRhs()) &&
+        !matchGammaProduct(finalMultiply.getRhs(), finalMultiply.getLhs())) {
+      return std::nullopt;
+    }
+
+    if (getAttachedCB(gamma)) {
+      gammaMode = RowNormalizationGammaMode::FullRow;
+    } else {
+      gammaBroadcast = gamma.getDefiningOp<BlockBroadcastOp>();
+      if (!gammaBroadcast || !hasOnlyUser(gamma, source) ||
+          !getAttachedCB(gammaBroadcast.getInput())) {
+        return std::nullopt;
+      }
+      auto gammaInputType =
+          dyn_cast<RankedTensorType>(gammaBroadcast.getInput().getType());
+      llvm::SmallDenseSet<int64_t> gammaDimensions =
+          normalizeDimsToSet(gammaBroadcast.getDims(), 2);
+      if (!gammaInputType || !gammaInputType.hasStaticShape() ||
+          gammaInputType.getRank() != 2 || gammaInputType.getDimSize(0) != 1 ||
+          gammaInputType.getDimSize(1) != 1 || gammaDimensions.size() != 1 ||
+          !gammaDimensions.contains(1)) {
+        return std::nullopt;
+      }
+      gamma = gammaBroadcast.getInput();
+      gammaMode = RowNormalizationGammaMode::RepeatedPage;
+    }
+  }
+
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  auto resultType = dyn_cast<RankedTensorType>(source->getResult(0).getType());
+  if (!inputType || !resultType || !inputType.hasStaticShape() ||
+      !resultType.hasStaticShape() || inputType.getRank() != 2 ||
+      resultType.getRank() != 2 || inputType.getDimSize(0) != 1 ||
+      inputType != resultType ||
+      !isa<ttcore::TileType>(inputType.getElementType())) {
+    return std::nullopt;
+  }
+
+  int64_t numTiles = inputType.getNumElements();
+  ttcore::DataType dataType =
+      cast<ttcore::TileType>(inputType.getElementType()).getDataType();
+  if (dataType != ttcore::DataType::BFloat16) {
+    return std::nullopt;
+  }
+  bool isFloat32 = getKernelBoolAttr(source, kFp32DestAccEnAttrName);
+  std::uint32_t dstCapacity = getDstCapacity(
+      isFloat32, getKernelBoolAttr(source, kDstFullSyncEnAttrName));
+  dstCapacity = std::min<std::uint32_t>(8, dstCapacity);
+  if (numTiles < 1 || static_cast<std::uint64_t>(numTiles) >
+                          static_cast<std::uint64_t>(dstCapacity)) {
+    return std::nullopt;
+  }
+
+  if (gammaMode != RowNormalizationGammaMode::None) {
+    auto gammaType = dyn_cast<RankedTensorType>(gamma.getType());
+    if (!gammaType ||
+        gammaType.getElementType() != inputType.getElementType()) {
+      return std::nullopt;
+    }
+    if (gammaMode == RowNormalizationGammaMode::FullRow &&
+        gammaType != resultType) {
+      return std::nullopt;
+    }
+    if (gammaMode == RowNormalizationGammaMode::RepeatedPage &&
+        gammaBroadcast.getResult().getType() != resultType) {
+      return std::nullopt;
+    }
+  }
+  if (!isFinitePositiveFloat(scaledReduction.getValueAttr()) ||
+      !isFinitePositiveFloat(epsilonFill.getValueAttr())) {
+    return std::nullopt;
+  }
+
+  MatchedRowNormalization match;
+  match.schedule.input = input;
+  match.schedule.gamma = gamma;
+  match.schedule.scale = scaledReduction.getValueAttr();
+  match.schedule.epsilon = epsilonFill.getValueAttr();
+  match.schedule.numTiles = numTiles;
+  match.schedule.dstCapacity = dstCapacity;
+  match.schedule.gammaMode = gammaMode;
+
+  auto recordOperation = [&](Operation *operation) {
+    RowNormalizationOperationPlan operationPlan;
+    operationPlan.source = operation;
+    llvm::append_range(operationPlan.operands, operation->getOperands());
+    match.schedule.operations.push_back(std::move(operationPlan));
+    match.trace.opsInOrder.insert(operation);
+  };
+  recordOperation(square);
+  recordOperation(reductionScaler);
+  recordOperation(reduce);
+  recordOperation(scaledReduction);
+  recordOperation(epsilonFill);
+  recordOperation(biasedMeanSquare);
+  recordOperation(inverseRms);
+  recordOperation(scalarBroadcast);
+  recordOperation(normalized);
+  if (gammaBroadcast) {
+    recordOperation(gammaBroadcast);
+  }
+  if (source != normalized.getOperation()) {
+    recordOperation(source);
+  }
+
+  match.trace.rootInputs.insert(input);
+  match.trace.lifetimeRootInputs.insert(input);
+  if (gammaMode != RowNormalizationGammaMode::None) {
+    match.trace.rootInputs.insert(gamma);
+    match.trace.lifetimeRootInputs.insert(gamma);
+  }
+  return match;
+}
+
 static LogicalResult buildOperationSpecificPlan(ComputeOpCreationPlan &plan,
                                                 std::string &failureReason) {
   if (plan.kind == ComputeOpCreationKind::Elide) {
     plan.recipe = ComputeOpCreationRecipe::Elide;
+    return success();
+  }
+  if (plan.rowNormalization) {
+    plan.recipe = ComputeOpCreationRecipe::RowNormalization;
+    MLIRContext *context = plan.source->getContext();
+    AffineMap identity = AffineMap::getMultiDimIdentityMap(2, context);
+    plan.iteration.inputMaps.push_back(identity);
+    if (plan.rowNormalization->gammaMode ==
+        RowNormalizationGammaMode::FullRow) {
+      plan.iteration.inputMaps.push_back(identity);
+    } else if (plan.rowNormalization->gammaMode ==
+               RowNormalizationGammaMode::RepeatedPage) {
+      AffineExpr zero = getAffineConstantExpr(0, context);
+      plan.iteration.inputMaps.push_back(
+          AffineMap::get(2, 0, {zero, zero}, context));
+    }
+    plan.iteration.outputMap = identity;
+    plan.iteration.iteratorTypes.assign(2, utils::IteratorType::parallel);
     return success();
   }
   if (plan.kind == ComputeOpCreationKind::Fused) {
@@ -1675,6 +1950,15 @@ buildComputeOpCreationPlan(Operation *source,
   if (isComputeOpCreationElision(source)) {
     plan.kind = ComputeOpCreationKind::Elide;
     plan.inputs = {cast<TypecastOp>(source).getInput()};
+  } else if (std::optional<MatchedRowNormalization> rowNormalization =
+                 matchRowNormalization(source)) {
+    plan.kind = ComputeOpCreationKind::Fused;
+    plan.trace = std::move(rowNormalization->trace);
+    plan.rowNormalization = std::move(rowNormalization->schedule);
+    plan.inputs.push_back(plan.rowNormalization->input);
+    if (plan.rowNormalization->gammaMode != RowNormalizationGammaMode::None) {
+      plan.inputs.push_back(plan.rowNormalization->gamma);
+    }
   } else if (std::optional<SmallVector<Value>> directInputs =
                  collectDirectInputs(source,
                                      [](OpOperand &) { return false; })) {
@@ -1770,6 +2054,19 @@ buildComputeOpCreationPlan(Operation *source,
     plan.waitedMutations.push_back(std::move(*mutation));
   }
 
+  if (plan.rowNormalization &&
+      (plan.outputs.transactions.size() != 1 || plan.outputs.dfbs.size() != 1 ||
+       plan.outputs.stores.size() != 1)) {
+    plan.rejectionKind =
+        ComputeOpCreationRejectionKind::UnsupportedOutputPublication;
+    plan.rejectionReason =
+        "row-normalization block requires exactly one output store "
+        "transaction";
+    return rejectComputeOpCreation(
+        source, plan.rejectionKind, plan.rejectionReason,
+        std::optional<ComputeOpCreationPlan>(std::move(plan)));
+  }
+
   ComputeOpMovement movement =
       collectComputeOpMovement(source, plan.kind, plan.trace);
   if (failed(collectComputeInstrumentation(
@@ -1780,6 +2077,14 @@ buildComputeOpCreationPlan(Operation *source,
     return rejectComputeOpCreation(
         source, plan.rejectionKind, plan.rejectionReason,
         std::optional<ComputeOpCreationPlan>(std::move(plan)));
+  }
+
+  if (plan.rowNormalization && !plan.instrumentation.empty()) {
+    plan.rejectionKind =
+        ComputeOpCreationRejectionKind::InstrumentationWouldBeReordered;
+    plan.rejectionReason =
+        "row-normalization block fusion cannot preserve instrumentation "
+        "inside the absorbed expression";
   }
 
   SmallVector<ComputeOpCreationInstrumentationBoundary>

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
 #include <functional>
 
 namespace mlir::tt::ttl {
@@ -777,10 +778,284 @@ static LogicalResult buildFusedIterationPlan(ComputeOpCreationPlan &plan,
   return success();
 }
 
+struct MatchedRowNormalization {
+  RowNormalizationPlan schedule;
+  FusionTraceResult trace;
+};
+
+static bool hasOnlyUser(Value value, Operation *expectedUser) {
+  return value.hasOneUse() && *value.getUsers().begin() == expectedUser;
+}
+
+static bool isFullScalarReduction(ReduceOp reduce) {
+  if (reduce.getReduceType() != ReduceType::Sum) {
+    return false;
+  }
+  llvm::SmallDenseSet<int64_t> dimensions =
+      normalizeDimsToSet(reduce.getDims(), 2);
+  return dimensions.size() == 2 && dimensions.contains(0) &&
+         dimensions.contains(1);
+}
+
+static bool isFullScalarBroadcast(BlockBroadcastOp broadcast) {
+  llvm::SmallDenseSet<int64_t> dimensions =
+      normalizeDimsToSet(broadcast.getDims(), 2);
+  return dimensions.size() == 2 && dimensions.contains(0) &&
+         dimensions.contains(1);
+}
+
+static bool isUnitFill(Value value, Operation *expectedUser, FillOp &fill) {
+  fill = value.getDefiningOp<FillOp>();
+  return fill && hasOnlyUser(value, expectedUser) &&
+         fill.getValueAttr().getValueAsDouble() == 1.0;
+}
+
+static bool isFinitePositiveFloat(FloatAttr value) {
+  const llvm::APFloat &number = value.getValue();
+  return number.isFinite() && !number.isZero() && !number.isNegative();
+}
+
+static bool matchAddWithConstant(Value value, Operation *expectedUser,
+                                 MulUnaryConstOp &scaledReduction,
+                                 FillOp &epsilonFill) {
+  auto add = value.getDefiningOp<AddOp>();
+  if (!add || !hasOnlyUser(value, expectedUser)) {
+    return false;
+  }
+  auto matchOperands = [&](Value scaledValue, Value fillValue) {
+    scaledReduction = scaledValue.getDefiningOp<MulUnaryConstOp>();
+    epsilonFill = fillValue.getDefiningOp<FillOp>();
+    return scaledReduction && epsilonFill && hasOnlyUser(scaledValue, add) &&
+           hasOnlyUser(fillValue, add);
+  };
+  return matchOperands(add.getLhs(), add.getRhs()) ||
+         matchOperands(add.getRhs(), add.getLhs());
+}
+
+static bool matchNormalizedProduct(MulOp normalized, Value &input,
+                                   BlockBroadcastOp &scalarBroadcast,
+                                   RsqrtOp &inverseRms, AddOp &biasedMeanSquare,
+                                   MulUnaryConstOp &scaledReduction,
+                                   FillOp &epsilonFill, ReduceOp &reduce,
+                                   FillOp &reductionScaler, MulOp &square) {
+  auto matchOperands = [&](Value inputValue, Value broadcastValue) {
+    if (!getAttachedCB(inputValue)) {
+      return false;
+    }
+    scalarBroadcast = broadcastValue.getDefiningOp<BlockBroadcastOp>();
+    if (!scalarBroadcast || !hasOnlyUser(broadcastValue, normalized) ||
+        !isFullScalarBroadcast(scalarBroadcast)) {
+      return false;
+    }
+    input = inputValue;
+    return true;
+  };
+  if (!matchOperands(normalized.getLhs(), normalized.getRhs()) &&
+      !matchOperands(normalized.getRhs(), normalized.getLhs())) {
+    return false;
+  }
+
+  inverseRms = scalarBroadcast.getInput().getDefiningOp<RsqrtOp>();
+  if (!inverseRms || !hasOnlyUser(inverseRms.getResult(), scalarBroadcast)) {
+    return false;
+  }
+  biasedMeanSquare = inverseRms.getInput().getDefiningOp<AddOp>();
+  if (!biasedMeanSquare ||
+      !matchAddWithConstant(inverseRms.getInput(), inverseRms, scaledReduction,
+                            epsilonFill)) {
+    return false;
+  }
+
+  reduce = scaledReduction.getInput().getDefiningOp<ReduceOp>();
+  if (!reduce || !hasOnlyUser(reduce.getResult(), scaledReduction) ||
+      !isFullScalarReduction(reduce)) {
+    return false;
+  }
+  if (!isUnitFill(reduce.getScaler(), reduce, reductionScaler)) {
+    return false;
+  }
+  square = reduce.getInput().getDefiningOp<MulOp>();
+  if (!square || !hasOnlyUser(square.getResult(), reduce) ||
+      square.getLhs() != input || square.getRhs() != input) {
+    return false;
+  }
+  return true;
+}
+
+static std::optional<MatchedRowNormalization>
+matchRowNormalization(Operation *source) {
+  if (!isBlackholeTarget(source)) {
+    return std::nullopt;
+  }
+  auto finalMultiply = dyn_cast<MulOp>(source);
+  if (!finalMultiply) {
+    return std::nullopt;
+  }
+
+  MulOp normalized = finalMultiply;
+  Value gamma;
+  RowNormalizationGammaMode gammaMode = RowNormalizationGammaMode::None;
+  BlockBroadcastOp gammaBroadcast;
+
+  Value input;
+  BlockBroadcastOp scalarBroadcast;
+  RsqrtOp inverseRms;
+  AddOp biasedMeanSquare;
+  MulUnaryConstOp scaledReduction;
+  FillOp epsilonFill;
+  ReduceOp reduce;
+  FillOp reductionScaler;
+  MulOp square;
+  if (!matchNormalizedProduct(normalized, input, scalarBroadcast, inverseRms,
+                              biasedMeanSquare, scaledReduction, epsilonFill,
+                              reduce, reductionScaler, square)) {
+    auto matchGammaProduct = [&](Value normalizedValue, Value gammaValue) {
+      normalized = normalizedValue.getDefiningOp<MulOp>();
+      if (!normalized || !hasOnlyUser(normalizedValue, source) ||
+          !matchNormalizedProduct(
+              normalized, input, scalarBroadcast, inverseRms, biasedMeanSquare,
+              scaledReduction, epsilonFill, reduce, reductionScaler, square)) {
+        return false;
+      }
+      gamma = gammaValue;
+      return true;
+    };
+    if (!matchGammaProduct(finalMultiply.getLhs(), finalMultiply.getRhs()) &&
+        !matchGammaProduct(finalMultiply.getRhs(), finalMultiply.getLhs())) {
+      return std::nullopt;
+    }
+
+    if (getAttachedCB(gamma)) {
+      gammaMode = RowNormalizationGammaMode::FullRow;
+    } else {
+      gammaBroadcast = gamma.getDefiningOp<BlockBroadcastOp>();
+      if (!gammaBroadcast || !hasOnlyUser(gamma, source) ||
+          !getAttachedCB(gammaBroadcast.getInput())) {
+        return std::nullopt;
+      }
+      auto gammaInputType =
+          dyn_cast<RankedTensorType>(gammaBroadcast.getInput().getType());
+      llvm::SmallDenseSet<int64_t> gammaDimensions =
+          normalizeDimsToSet(gammaBroadcast.getDims(), 2);
+      if (!gammaInputType || !gammaInputType.hasStaticShape() ||
+          gammaInputType.getRank() != 2 || gammaInputType.getDimSize(0) != 1 ||
+          gammaInputType.getDimSize(1) != 1 || gammaDimensions.size() != 1 ||
+          !gammaDimensions.contains(1)) {
+        return std::nullopt;
+      }
+      gamma = gammaBroadcast.getInput();
+      gammaMode = RowNormalizationGammaMode::RepeatedPage;
+    }
+  }
+
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  auto resultType = dyn_cast<RankedTensorType>(source->getResult(0).getType());
+  if (!inputType || !resultType || !inputType.hasStaticShape() ||
+      !resultType.hasStaticShape() || inputType.getRank() != 2 ||
+      resultType.getRank() != 2 || inputType.getDimSize(0) != 1 ||
+      inputType != resultType ||
+      !isa<ttcore::TileType>(inputType.getElementType())) {
+    return std::nullopt;
+  }
+
+  int64_t numTiles = inputType.getNumElements();
+  ttcore::DataType dataType =
+      cast<ttcore::TileType>(inputType.getElementType()).getDataType();
+  if (dataType != ttcore::DataType::BFloat16) {
+    return std::nullopt;
+  }
+  bool isFloat32 = getKernelBoolAttr(source, kFp32DestAccEnAttrName);
+  std::uint32_t dstCapacity = getDstCapacity(
+      isFloat32, getKernelBoolAttr(source, kDstFullSyncEnAttrName));
+  dstCapacity = std::min<std::uint32_t>(8, dstCapacity);
+  if (numTiles < 1 || static_cast<std::uint64_t>(numTiles) >
+                          static_cast<std::uint64_t>(dstCapacity)) {
+    return std::nullopt;
+  }
+
+  if (gammaMode != RowNormalizationGammaMode::None) {
+    auto gammaType = dyn_cast<RankedTensorType>(gamma.getType());
+    if (!gammaType ||
+        gammaType.getElementType() != inputType.getElementType()) {
+      return std::nullopt;
+    }
+    if (gammaMode == RowNormalizationGammaMode::FullRow &&
+        gammaType != resultType) {
+      return std::nullopt;
+    }
+    if (gammaMode == RowNormalizationGammaMode::RepeatedPage &&
+        gammaBroadcast.getResult().getType() != resultType) {
+      return std::nullopt;
+    }
+  }
+  if (!isFinitePositiveFloat(scaledReduction.getValueAttr()) ||
+      !isFinitePositiveFloat(epsilonFill.getValueAttr())) {
+    return std::nullopt;
+  }
+
+  MatchedRowNormalization match;
+  match.schedule.input = input;
+  match.schedule.gamma = gamma;
+  match.schedule.scale = scaledReduction.getValueAttr();
+  match.schedule.epsilon = epsilonFill.getValueAttr();
+  match.schedule.numTiles = numTiles;
+  match.schedule.dstCapacity = dstCapacity;
+  match.schedule.gammaMode = gammaMode;
+
+  auto recordOperation = [&](Operation *operation) {
+    RowNormalizationOperationPlan operationPlan;
+    operationPlan.source = operation;
+    llvm::append_range(operationPlan.operands, operation->getOperands());
+    match.schedule.operations.push_back(std::move(operationPlan));
+    match.trace.opsInOrder.insert(operation);
+  };
+  recordOperation(square);
+  recordOperation(reductionScaler);
+  recordOperation(reduce);
+  recordOperation(scaledReduction);
+  recordOperation(epsilonFill);
+  recordOperation(biasedMeanSquare);
+  recordOperation(inverseRms);
+  recordOperation(scalarBroadcast);
+  recordOperation(normalized);
+  if (gammaBroadcast) {
+    recordOperation(gammaBroadcast);
+  }
+  if (source != normalized.getOperation()) {
+    recordOperation(source);
+  }
+
+  match.trace.rootInputs.insert(input);
+  match.trace.lifetimeRootInputs.insert(input);
+  if (gammaMode != RowNormalizationGammaMode::None) {
+    match.trace.rootInputs.insert(gamma);
+    match.trace.lifetimeRootInputs.insert(gamma);
+  }
+  return match;
+}
+
 static LogicalResult buildOperationSpecificPlan(ComputeOpCreationPlan &plan,
                                                 std::string &failureReason) {
   if (plan.kind == ComputeOpCreationKind::Elide) {
     plan.recipe = ComputeOpCreationRecipe::Elide;
+    return success();
+  }
+  if (plan.rowNormalization) {
+    plan.recipe = ComputeOpCreationRecipe::RowNormalization;
+    MLIRContext *context = plan.source->getContext();
+    AffineMap identity = AffineMap::getMultiDimIdentityMap(2, context);
+    plan.iteration.inputMaps.push_back(identity);
+    if (plan.rowNormalization->gammaMode ==
+        RowNormalizationGammaMode::FullRow) {
+      plan.iteration.inputMaps.push_back(identity);
+    } else if (plan.rowNormalization->gammaMode ==
+               RowNormalizationGammaMode::RepeatedPage) {
+      AffineExpr zero = getAffineConstantExpr(0, context);
+      plan.iteration.inputMaps.push_back(
+          AffineMap::get(2, 0, {zero, zero}, context));
+    }
+    plan.iteration.outputMap = identity;
+    plan.iteration.iteratorTypes.assign(2, utils::IteratorType::parallel);
     return success();
   }
   if (plan.kind == ComputeOpCreationKind::Fused) {
@@ -1410,6 +1685,15 @@ buildComputeOpCreationPlan(Operation *source,
   if (isComputeOpCreationElision(source)) {
     plan.kind = ComputeOpCreationKind::Elide;
     plan.inputs = {cast<TypecastOp>(source).getInput()};
+  } else if (std::optional<MatchedRowNormalization> rowNormalization =
+                 matchRowNormalization(source)) {
+    plan.kind = ComputeOpCreationKind::Fused;
+    plan.trace = std::move(rowNormalization->trace);
+    plan.rowNormalization = std::move(rowNormalization->schedule);
+    plan.inputs.push_back(plan.rowNormalization->input);
+    if (plan.rowNormalization->gammaMode != RowNormalizationGammaMode::None) {
+      plan.inputs.push_back(plan.rowNormalization->gamma);
+    }
   } else if (std::optional<SmallVector<Value>> directInputs =
                  collectDirectInputs(source,
                                      [](OpOperand &) { return false; })) {
@@ -1491,6 +1775,19 @@ buildComputeOpCreationPlan(Operation *source,
   }
   plan.outputs = std::move(outputs).takePlan();
 
+  if (plan.rowNormalization &&
+      (plan.outputs.transactions.size() != 1 || plan.outputs.dfbs.size() != 1 ||
+       plan.outputs.stores.size() != 1)) {
+    plan.rejectionKind =
+        ComputeOpCreationRejectionKind::UnsupportedOutputPublication;
+    plan.rejectionReason =
+        "row-normalization block requires exactly one output store "
+        "transaction";
+    return rejectComputeOpCreation(
+        source, plan.rejectionKind, plan.rejectionReason,
+        std::optional<ComputeOpCreationPlan>(std::move(plan)));
+  }
+
   ComputeOpMovement movement =
       collectComputeOpMovement(source, plan.kind, plan.trace);
   if (failed(collectComputeInstrumentation(
@@ -1501,6 +1798,14 @@ buildComputeOpCreationPlan(Operation *source,
     return rejectComputeOpCreation(
         source, plan.rejectionKind, plan.rejectionReason,
         std::optional<ComputeOpCreationPlan>(std::move(plan)));
+  }
+
+  if (plan.rowNormalization && !plan.instrumentation.empty()) {
+    plan.rejectionKind =
+        ComputeOpCreationRejectionKind::InstrumentationWouldBeReordered;
+    plan.rejectionReason =
+        "row-normalization block fusion cannot preserve instrumentation "
+        "inside the absorbed expression";
   }
 
   SmallVector<ComputeOpCreationInstrumentationBoundary>

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -957,9 +957,14 @@ matchRowNormalization(Operation *source,
   if (!limits.maxTiles) {
     return std::nullopt;
   }
-  bool isFloat32 = getKernelBoolAttr(source, kFp32DestAccEnAttrName);
-  std::uint32_t dstCapacity = getDstCapacity(
-      isFloat32, getKernelBoolAttr(source, kDstFullSyncEnAttrName));
+  func::FuncOp function = source->getParentOfType<func::FuncOp>();
+  auto fp32Constraint =
+      function->getAttrOfType<BoolAttr>(kFp32DestAccEnAttrName);
+  auto fullSyncConstraint =
+      function->getAttrOfType<BoolAttr>(kDstFullSyncEnAttrName);
+  bool isFloat32 = fp32Constraint && fp32Constraint.getValue();
+  bool fullSync = !fullSyncConstraint || fullSyncConstraint.getValue();
+  std::uint32_t dstCapacity = getDstCapacity(isFloat32, fullSync);
   dstCapacity = std::min(*limits.maxTiles, dstCapacity);
   if (numTiles < 1 || static_cast<std::uint64_t>(numTiles) >
                           static_cast<std::uint64_t>(dstCapacity)) {

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -992,7 +992,6 @@ matchRowNormalization(Operation *source,
   match.schedule.scale = scaledReduction.getValueAttr();
   match.schedule.epsilon = epsilonFill.getValueAttr();
   match.schedule.numTiles = numTiles;
-  match.schedule.dstCapacity = dstCapacity;
   match.schedule.gammaMode = gammaMode;
 
   auto recordOperation = [&](Operation *operation) {

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -985,7 +985,6 @@ matchRowNormalization(Operation *source,
   match.schedule.scale = scaledReduction.getValueAttr();
   match.schedule.epsilon = epsilonFill.getValueAttr();
   match.schedule.numTiles = numTiles;
-  match.schedule.dstCapacity = dstCapacity;
   match.schedule.gammaMode = gammaMode;
 
   auto recordOperation = [&](Operation *operation) {

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -950,9 +950,14 @@ matchRowNormalization(Operation *source,
   if (!limits.maxTiles) {
     return std::nullopt;
   }
-  bool isFloat32 = getKernelBoolAttr(source, kFp32DestAccEnAttrName);
-  std::uint32_t dstCapacity = getDstCapacity(
-      isFloat32, getKernelBoolAttr(source, kDstFullSyncEnAttrName));
+  func::FuncOp function = source->getParentOfType<func::FuncOp>();
+  auto fp32Constraint =
+      function->getAttrOfType<BoolAttr>(kFp32DestAccEnAttrName);
+  auto fullSyncConstraint =
+      function->getAttrOfType<BoolAttr>(kDstFullSyncEnAttrName);
+  bool isFloat32 = fp32Constraint && fp32Constraint.getValue();
+  bool fullSync = !fullSyncConstraint || fullSyncConstraint.getValue();
+  std::uint32_t dstCapacity = getDstCapacity(isFloat32, fullSync);
   dstCapacity = std::min(*limits.maxTiles, dstCapacity);
   if (numTiles < 1 || static_cast<std::uint64_t>(numTiles) >
                           static_cast<std::uint64_t>(dstCapacity)) {

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -883,10 +883,8 @@ static bool matchNormalizedProduct(MulOp normalized, Value &input,
 }
 
 static std::optional<MatchedRowNormalization>
-matchRowNormalization(Operation *source) {
-  if (!isBlackholeTarget(source)) {
-    return std::nullopt;
-  }
+matchRowNormalization(Operation *source,
+                      const ComputeTargetEnvironment &target) {
   auto finalMultiply = dyn_cast<MulOp>(source);
   if (!finalMultiply) {
     return std::nullopt;
@@ -946,10 +944,16 @@ matchRowNormalization(Operation *source) {
   if (dataType != ttcore::DataType::BFloat16) {
     return std::nullopt;
   }
+  ComputeScheduleCapabilityLimits limits = target.getScheduleCapabilityLimits(
+      ComputeScheduleCapability::RowNormalization,
+      cast<ttcore::TileType>(inputType.getElementType()));
+  if (!limits.maxTiles) {
+    return std::nullopt;
+  }
   bool isFloat32 = getKernelBoolAttr(source, kFp32DestAccEnAttrName);
   std::uint32_t dstCapacity = getDstCapacity(
       isFloat32, getKernelBoolAttr(source, kDstFullSyncEnAttrName));
-  dstCapacity = std::min<std::uint32_t>(8, dstCapacity);
+  dstCapacity = std::min(*limits.maxTiles, dstCapacity);
   if (numTiles < 1 || static_cast<std::uint64_t>(numTiles) >
                           static_cast<std::uint64_t>(dstCapacity)) {
     return std::nullopt;
@@ -1655,7 +1659,7 @@ buildComputeOpCreationPlan(Operation *source,
     plan.kind = ComputeOpCreationKind::Elide;
     plan.inputs = {cast<TypecastOp>(source).getInput()};
   } else if (std::optional<MatchedRowNormalization> rowNormalization =
-                 matchRowNormalization(source)) {
+                 matchRowNormalization(source, target)) {
     plan.kind = ComputeOpCreationKind::Fused;
     plan.trace = std::move(rowNormalization->trace);
     plan.rowNormalization = std::move(rowNormalization->schedule);

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -902,7 +902,6 @@ matchRowNormalization(Operation *source) {
   MulOp normalized = finalMultiply;
   Value gamma;
   RowNormalizationGammaMode gammaMode = RowNormalizationGammaMode::None;
-  BlockBroadcastOp gammaBroadcast;
 
   Value input;
   BlockBroadcastOp scalarBroadcast;
@@ -932,27 +931,10 @@ matchRowNormalization(Operation *source) {
       return std::nullopt;
     }
 
-    if (getAttachedCB(gamma)) {
-      gammaMode = RowNormalizationGammaMode::FullRow;
-    } else {
-      gammaBroadcast = gamma.getDefiningOp<BlockBroadcastOp>();
-      if (!gammaBroadcast || !hasOnlyUser(gamma, source) ||
-          !getAttachedCB(gammaBroadcast.getInput())) {
-        return std::nullopt;
-      }
-      auto gammaInputType =
-          dyn_cast<RankedTensorType>(gammaBroadcast.getInput().getType());
-      llvm::SmallDenseSet<int64_t> gammaDimensions =
-          normalizeDimsToSet(gammaBroadcast.getDims(), 2);
-      if (!gammaInputType || !gammaInputType.hasStaticShape() ||
-          gammaInputType.getRank() != 2 || gammaInputType.getDimSize(0) != 1 ||
-          gammaInputType.getDimSize(1) != 1 || gammaDimensions.size() != 1 ||
-          !gammaDimensions.contains(1)) {
-        return std::nullopt;
-      }
-      gamma = gammaBroadcast.getInput();
-      gammaMode = RowNormalizationGammaMode::RepeatedPage;
+    if (!getAttachedCB(gamma)) {
+      return std::nullopt;
     }
+    gammaMode = RowNormalizationGammaMode::FullRow;
   }
 
   auto inputType = dyn_cast<RankedTensorType>(input.getType());
@@ -986,12 +968,7 @@ matchRowNormalization(Operation *source) {
         gammaType.getElementType() != inputType.getElementType()) {
       return std::nullopt;
     }
-    if (gammaMode == RowNormalizationGammaMode::FullRow &&
-        gammaType != resultType) {
-      return std::nullopt;
-    }
-    if (gammaMode == RowNormalizationGammaMode::RepeatedPage &&
-        gammaBroadcast.getResult().getType() != resultType) {
+    if (gammaType != resultType) {
       return std::nullopt;
     }
   }
@@ -1025,9 +1002,6 @@ matchRowNormalization(Operation *source) {
   recordOperation(inverseRms);
   recordOperation(scalarBroadcast);
   recordOperation(normalized);
-  if (gammaBroadcast) {
-    recordOperation(gammaBroadcast);
-  }
   if (source != normalized.getOperation()) {
     recordOperation(source);
   }
@@ -1055,11 +1029,6 @@ static LogicalResult buildOperationSpecificPlan(ComputeOpCreationPlan &plan,
     if (plan.rowNormalization->gammaMode ==
         RowNormalizationGammaMode::FullRow) {
       plan.iteration.inputMaps.push_back(identity);
-    } else if (plan.rowNormalization->gammaMode ==
-               RowNormalizationGammaMode::RepeatedPage) {
-      AffineExpr zero = getAffineConstantExpr(0, context);
-      plan.iteration.inputMaps.push_back(
-          AffineMap::get(2, 0, {zero, zero}, context));
     }
     plan.iteration.outputMap = identity;
     plan.iteration.iteratorTypes.assign(2, utils::IteratorType::parallel);

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -40,6 +40,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -136,9 +137,36 @@ enum class ComputeOpCreationRecipe {
   /// Emit the recorded expression-level tile recipes.
   Fused,
 
+  /// Emit one capacity-fitting row-normalization block schedule.
+  RowNormalization,
+
   /// Replace an identity operation with its input without creating a
   /// `ComputeOp`.
   Elide,
+};
+
+enum class RowNormalizationGammaMode {
+  None,
+  FullRow,
+  RepeatedPage,
+};
+
+/// Exact operation state retained for row-normalization plan application.
+struct RowNormalizationOperationPlan {
+  Operation *source = nullptr;
+  SmallVector<Value> operands;
+};
+
+/// Immutable capacity-fitting row-normalization schedule.
+struct RowNormalizationPlan {
+  Value input;
+  Value gamma;
+  FloatAttr scale;
+  FloatAttr epsilon;
+  int64_t numTiles = 0;
+  std::uint32_t dstCapacity = 0;
+  RowNormalizationGammaMode gammaMode = RowNormalizationGammaMode::None;
+  SmallVector<RowNormalizationOperationPlan> operations;
 };
 
 /// Indexing and iteration semantics for one created `ComputeOp`.
@@ -561,6 +589,9 @@ struct ComputeOpCreationPlan {
 
   /// Tile-level recipes in expression dependency order.
   SmallVector<FusedOperationPlan> fusedOperations;
+
+  /// Complete capacity-fitting row-normalization schedule, when selected.
+  std::optional<RowNormalizationPlan> rowNormalization;
 
   /// Original result uses used to verify plan/application consistency.
   SmallVector<ComputeOpCreationUse> resultUses;

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -163,7 +163,6 @@ struct RowNormalizationPlan {
   FloatAttr scale;
   FloatAttr epsilon;
   int64_t numTiles = 0;
-  std::uint32_t dstCapacity = 0;
   RowNormalizationGammaMode gammaMode = RowNormalizationGammaMode::None;
   SmallVector<RowNormalizationOperationPlan> operations;
 };

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -40,6 +40,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -136,9 +137,36 @@ enum class ComputeOpCreationRecipe {
   /// Emit the recorded expression-level tile recipes.
   Fused,
 
+  /// Emit one capacity-fitting row-normalization block schedule.
+  RowNormalization,
+
   /// Replace an identity operation with its input without creating a
   /// `ComputeOp`.
   Elide,
+};
+
+enum class RowNormalizationGammaMode {
+  None,
+  FullRow,
+  RepeatedPage,
+};
+
+/// Exact operation state retained for row-normalization plan application.
+struct RowNormalizationOperationPlan {
+  Operation *source = nullptr;
+  SmallVector<Value> operands;
+};
+
+/// Immutable capacity-fitting row-normalization schedule.
+struct RowNormalizationPlan {
+  Value input;
+  Value gamma;
+  FloatAttr scale;
+  FloatAttr epsilon;
+  int64_t numTiles = 0;
+  std::uint32_t dstCapacity = 0;
+  RowNormalizationGammaMode gammaMode = RowNormalizationGammaMode::None;
+  SmallVector<RowNormalizationOperationPlan> operations;
 };
 
 /// Indexing and iteration semantics for one created `ComputeOp`.
@@ -533,6 +561,9 @@ struct ComputeOpCreationPlan {
 
   /// Tile-level recipes in expression dependency order.
   SmallVector<FusedOperationPlan> fusedOperations;
+
+  /// Complete capacity-fitting row-normalization schedule, when selected.
+  std::optional<RowNormalizationPlan> rowNormalization;
 
   /// Original result uses used to verify plan/application consistency.
   SmallVector<ComputeOpCreationUse> resultUses;

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -148,7 +148,6 @@ enum class ComputeOpCreationRecipe {
 enum class RowNormalizationGammaMode {
   None,
   FullRow,
-  RepeatedPage,
 };
 
 /// Exact operation state retained for row-normalization plan application.

--- a/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
@@ -588,6 +588,14 @@ ComputeTargetEnvironment::validateOperation(Operation *operation,
                             "schedule";
       return failure();
     }
+    if (normalization.getNumTiles() > *limits.maxTiles) {
+      failureReason =
+          (Twine("row-normalization schedule requires ") +
+           Twine(normalization.getNumTiles()) +
+           " tiles, but the target supports at most " + Twine(*limits.maxTiles))
+              .str();
+      return failure();
+    }
   }
   return success();
 }

--- a/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
@@ -101,7 +101,7 @@ bool supportsShortHeightTiles(ComputePrimitive primitive) {
   }
 }
 
-class WormholeBlackholeComputeTargetEnvironment final
+class WormholeBlackholeComputeTargetEnvironment
     : public ComputeTargetEnvironment {
 public:
   LogicalResult validateKernelTileType(ttcore::TileType tileType,
@@ -254,6 +254,30 @@ public:
     }
     return success();
   }
+
+  ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability,
+                              ttcore::TileType) const override {
+    return {};
+  }
+};
+
+class WormholeComputeTargetEnvironment final
+    : public WormholeBlackholeComputeTargetEnvironment {};
+
+class BlackholeComputeTargetEnvironment final
+    : public WormholeBlackholeComputeTargetEnvironment {
+public:
+  ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability capability,
+                              ttcore::TileType tileType) const override {
+    switch (capability) {
+    case ComputeScheduleCapability::RowNormalization:
+      return {true, tileType.getDataType() == ttcore::DataType::BFloat16
+                        ? std::optional<std::uint32_t>(8)
+                        : std::nullopt};
+    }
+  }
 };
 
 class IntersectionComputeTargetEnvironment final
@@ -330,6 +354,23 @@ public:
     return success();
   }
 
+  ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability capability,
+                              ttcore::TileType tileType) const final {
+    std::optional<std::uint32_t> maxTiles;
+    for (const std::unique_ptr<ComputeTargetEnvironment> &environment :
+         environments) {
+      ComputeScheduleCapabilityLimits limits =
+          environment->getScheduleCapabilityLimits(capability, tileType);
+      if (!limits.targetSupported || !limits.maxTiles) {
+        return {limits.targetSupported, std::nullopt};
+      }
+      maxTiles =
+          maxTiles ? std::min(*maxTiles, *limits.maxTiles) : limits.maxTiles;
+    }
+    return {true, maxTiles};
+  }
+
 private:
   SmallVector<std::unique_ptr<ComputeTargetEnvironment>, 2> environments;
 };
@@ -341,14 +382,17 @@ struct ComputeTargetRegistration {
   ComputeTargetFactory create;
 };
 
-std::unique_ptr<ComputeTargetEnvironment>
-createWormholeBlackholeTargetEnvironment() {
-  return std::make_unique<WormholeBlackholeComputeTargetEnvironment>();
+std::unique_ptr<ComputeTargetEnvironment> createWormholeTargetEnvironment() {
+  return std::make_unique<WormholeComputeTargetEnvironment>();
+}
+
+std::unique_ptr<ComputeTargetEnvironment> createBlackholeTargetEnvironment() {
+  return std::make_unique<BlackholeComputeTargetEnvironment>();
 }
 
 constexpr std::array<ComputeTargetRegistration, 2> computeTargetRegistrations =
-    {{{ttcore::Arch::WormholeB0, &createWormholeBlackholeTargetEnvironment},
-      {ttcore::Arch::Blackhole, &createWormholeBlackholeTargetEnvironment}}};
+    {{{ttcore::Arch::WormholeB0, &createWormholeTargetEnvironment},
+      {ttcore::Arch::Blackhole, &createBlackholeTargetEnvironment}}};
 
 FailureOr<std::unique_ptr<ComputeTargetEnvironment>>
 createTargetEnvironment(ttcore::Arch arch, std::string &failureReason) {
@@ -526,6 +570,24 @@ ComputeTargetEnvironment::validateOperation(Operation *operation,
     return validateMatmul(matmul.getLhs().getType(), matmul.getRhs().getType(),
                           matmul.getResult().getType(),
                           matmul.getTransposeRhs());
+  }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(operation)) {
+    FailureOr<ttcore::TileType> tileType =
+        getTileType(normalization.getInput().getType());
+    if (failed(tileType)) {
+      failureReason = "row-normalization input must contain a tile type";
+      return failure();
+    }
+    ComputeScheduleCapabilityLimits limits = getScheduleCapabilityLimits(
+        ComputeScheduleCapability::RowNormalization, *tileType);
+    if (!limits.maxTiles) {
+      failureReason = limits.targetSupported
+                          ? "row-normalization schedule does not support this "
+                            "tile type"
+                          : "target does not provide the row-normalization "
+                            "schedule";
+      return failure();
+    }
   }
   return success();
 }

--- a/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
@@ -678,6 +678,34 @@ ComputeTargetEnvironment::validateOperation(Operation *operation,
     }
   }
 
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(operation)) {
+    FailureOr<ttcore::TileType> tileType =
+        getTileType(normalization.getInput().getType());
+    if (failed(tileType)) {
+      failureReason = "row-normalization input must contain a tile type";
+      return failure();
+    }
+    ComputeScheduleCapabilityLimits limits = getScheduleCapabilityLimits(
+        ComputeScheduleCapability::RowNormalization, *tileType);
+    if (!limits.maxTiles) {
+      failureReason = limits.targetSupported
+                          ? "row-normalization schedule does not support this "
+                            "tile type"
+                          : "target does not provide the row-normalization "
+                            "schedule";
+      return failure();
+    }
+    if (normalization.getNumTiles() > *limits.maxTiles) {
+      failureReason =
+          (Twine("row-normalization schedule requires ") +
+           Twine(normalization.getNumTiles()) +
+           " tiles, but the target supports at most " + Twine(*limits.maxTiles))
+              .str();
+      return failure();
+    }
+    return success();
+  }
+
   if (*primitive == ComputePrimitive::Broadcast) {
     FailureOr<BroadcastCapability> capability =
         getBroadcastCapability(operation, failureReason);
@@ -713,32 +741,6 @@ ComputeTargetEnvironment::validateOperation(Operation *operation,
     return validateMatmul(matmul.getLhs().getType(), matmul.getRhs().getType(),
                           matmul.getResult().getType(),
                           matmul.getTransposeRhs());
-  }
-  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(operation)) {
-    FailureOr<ttcore::TileType> tileType =
-        getTileType(normalization.getInput().getType());
-    if (failed(tileType)) {
-      failureReason = "row-normalization input must contain a tile type";
-      return failure();
-    }
-    ComputeScheduleCapabilityLimits limits = getScheduleCapabilityLimits(
-        ComputeScheduleCapability::RowNormalization, *tileType);
-    if (!limits.maxTiles) {
-      failureReason = limits.targetSupported
-                          ? "row-normalization schedule does not support this "
-                            "tile type"
-                          : "target does not provide the row-normalization "
-                            "schedule";
-      return failure();
-    }
-    if (normalization.getNumTiles() > *limits.maxTiles) {
-      failureReason =
-          (Twine("row-normalization schedule requires ") +
-           Twine(normalization.getNumTiles()) +
-           " tiles, but the target supports at most " + Twine(*limits.maxTiles))
-              .str();
-      return failure();
-    }
   }
   return success();
 }

--- a/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
@@ -106,7 +106,7 @@ bool supportsShortHeightTiles(ComputePrimitive primitive) {
   }
 }
 
-class WormholeBlackholeComputeTargetEnvironment final
+class WormholeBlackholeComputeTargetEnvironment
     : public ComputeTargetEnvironment {
 public:
   LogicalResult validateKernelTileType(ttcore::TileType tileType,
@@ -330,6 +330,30 @@ public:
     }
     return success();
   }
+
+  ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability,
+                              ttcore::TileType) const override {
+    return {};
+  }
+};
+
+class WormholeComputeTargetEnvironment final
+    : public WormholeBlackholeComputeTargetEnvironment {};
+
+class BlackholeComputeTargetEnvironment final
+    : public WormholeBlackholeComputeTargetEnvironment {
+public:
+  ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability capability,
+                              ttcore::TileType tileType) const override {
+    switch (capability) {
+    case ComputeScheduleCapability::RowNormalization:
+      return {true, tileType.getDataType() == ttcore::DataType::BFloat16
+                        ? std::optional<std::uint32_t>(8)
+                        : std::nullopt};
+    }
+  }
 };
 
 class IntersectionComputeTargetEnvironment final
@@ -428,6 +452,23 @@ public:
     return success();
   }
 
+  ComputeScheduleCapabilityLimits
+  getScheduleCapabilityLimits(ComputeScheduleCapability capability,
+                              ttcore::TileType tileType) const final {
+    std::optional<std::uint32_t> maxTiles;
+    for (const std::unique_ptr<ComputeTargetEnvironment> &environment :
+         environments) {
+      ComputeScheduleCapabilityLimits limits =
+          environment->getScheduleCapabilityLimits(capability, tileType);
+      if (!limits.targetSupported || !limits.maxTiles) {
+        return {limits.targetSupported, std::nullopt};
+      }
+      maxTiles =
+          maxTiles ? std::min(*maxTiles, *limits.maxTiles) : limits.maxTiles;
+    }
+    return {true, maxTiles};
+  }
+
 private:
   SmallVector<std::unique_ptr<ComputeTargetEnvironment>, 2> environments;
 };
@@ -439,14 +480,17 @@ struct ComputeTargetRegistration {
   ComputeTargetFactory create;
 };
 
-std::unique_ptr<ComputeTargetEnvironment>
-createWormholeBlackholeTargetEnvironment() {
-  return std::make_unique<WormholeBlackholeComputeTargetEnvironment>();
+std::unique_ptr<ComputeTargetEnvironment> createWormholeTargetEnvironment() {
+  return std::make_unique<WormholeComputeTargetEnvironment>();
+}
+
+std::unique_ptr<ComputeTargetEnvironment> createBlackholeTargetEnvironment() {
+  return std::make_unique<BlackholeComputeTargetEnvironment>();
 }
 
 constexpr std::array<ComputeTargetRegistration, 2> computeTargetRegistrations =
-    {{{ttcore::Arch::WormholeB0, &createWormholeBlackholeTargetEnvironment},
-      {ttcore::Arch::Blackhole, &createWormholeBlackholeTargetEnvironment}}};
+    {{{ttcore::Arch::WormholeB0, &createWormholeTargetEnvironment},
+      {ttcore::Arch::Blackhole, &createBlackholeTargetEnvironment}}};
 
 FailureOr<std::unique_ptr<ComputeTargetEnvironment>>
 createTargetEnvironment(ttcore::Arch arch, std::string &failureReason) {
@@ -669,6 +713,24 @@ ComputeTargetEnvironment::validateOperation(Operation *operation,
     return validateMatmul(matmul.getLhs().getType(), matmul.getRhs().getType(),
                           matmul.getResult().getType(),
                           matmul.getTransposeRhs());
+  }
+  if (auto normalization = dyn_cast<TileRowNormalizationBlockOp>(operation)) {
+    FailureOr<ttcore::TileType> tileType =
+        getTileType(normalization.getInput().getType());
+    if (failed(tileType)) {
+      failureReason = "row-normalization input must contain a tile type";
+      return failure();
+    }
+    ComputeScheduleCapabilityLimits limits = getScheduleCapabilityLimits(
+        ComputeScheduleCapability::RowNormalization, *tileType);
+    if (!limits.maxTiles) {
+      failureReason = limits.targetSupported
+                          ? "row-normalization schedule does not support this "
+                            "tile type"
+                          : "target does not provide the row-normalization "
+                            "schedule";
+      return failure();
+    }
   }
   return success();
 }

--- a/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
@@ -731,6 +731,14 @@ ComputeTargetEnvironment::validateOperation(Operation *operation,
                             "schedule";
       return failure();
     }
+    if (normalization.getNumTiles() > *limits.maxTiles) {
+      failureReason =
+          (Twine("row-normalization schedule requires ") +
+           Twine(normalization.getNumTiles()) +
+           " tiles, but the target supports at most " + Twine(*limits.maxTiles))
+              .str();
+      return failure();
+    }
   }
   return success();
 }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -637,6 +637,42 @@ unrollTileLoopNestAndAssignDST(SmallVector<scf::ForOp> &nest) {
   return success();
 }
 
+static LogicalResult validateRowNormalizationComputes(func::FuncOp func) {
+  SmallVector<ComputeOp> rowNormalizationComputes;
+  func.walk([&](ComputeOp computeOp) {
+    if (computeOp.containsOp<TileRowNormalizationBlockOp>()) {
+      rowNormalizationComputes.push_back(computeOp);
+    }
+  });
+  if (rowNormalizationComputes.empty()) {
+    return success();
+  }
+
+  std::string targetFailureReason;
+  FailureOr<std::unique_ptr<ComputeTargetEnvironment>> target =
+      ComputeTargetEnvironment::get(func, targetFailureReason);
+  if (failed(target)) {
+    func.emitOpError(targetFailureReason);
+    return failure();
+  }
+
+  bool hasInvalidCompute = false;
+  for (ComputeOp computeOp : rowNormalizationComputes) {
+    TileRowNormalizationBlockOp block =
+        *computeOp.getBody().getOps<TileRowNormalizationBlockOp>().begin();
+    std::string capabilityFailureReason;
+    if (failed((*target)->validateOperation(block, capabilityFailureReason))) {
+      block.emitOpError(capabilityFailureReason);
+      hasInvalidCompute = true;
+      continue;
+    }
+    if (failed(verifyRowNormalizationCompute(computeOp))) {
+      hasInvalidCompute = true;
+    }
+  }
+  return failure(hasInvalidCompute);
+}
+
 struct TTLLowerToLoopsPass
     : public tt::ttl::impl::TTLLowerToLoopsBase<TTLLowerToLoopsPass> {
   using tt::ttl::impl::TTLLowerToLoopsBase<
@@ -665,33 +701,7 @@ struct TTLLowerToLoopsPass
         return signalPassFailure();
       }
     }
-    bool invalidRowNormalization = false;
-    std::string targetFailureReason;
-    FailureOr<std::unique_ptr<ComputeTargetEnvironment>> target =
-        ComputeTargetEnvironment::get(func, targetFailureReason);
-    if (failed(target)) {
-      func.emitOpError(targetFailureReason);
-      return signalPassFailure();
-    }
-    func.walk([&](ComputeOp computeOp) {
-      TileRowNormalizationBlockOp block;
-      for (TileRowNormalizationBlockOp candidate :
-           computeOp.getBody().getOps<TileRowNormalizationBlockOp>()) {
-        block = candidate;
-        break;
-      }
-      if (block) {
-        std::string capabilityFailureReason;
-        if (failed(
-                (*target)->validateOperation(block, capabilityFailureReason))) {
-          block.emitOpError(capabilityFailureReason);
-          invalidRowNormalization = true;
-        } else if (failed(verifyRowNormalizationCompute(computeOp))) {
-          invalidRowNormalization = true;
-        }
-      }
-    });
-    if (invalidRowNormalization) {
+    if (failed(validateRowNormalizationComputes(func))) {
       return signalPassFailure();
     }
 

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -664,14 +664,14 @@ struct TTLLowerToLoopsPass
         return signalPassFailure();
       }
     }
-    WalkResult rowNormalizationResult = func.walk([](ComputeOp computeOp) {
+    bool invalidRowNormalization = false;
+    func.walk([&](ComputeOp computeOp) {
       if (computeOp.containsOp<TileRowNormalizationBlockOp>() &&
           failed(verifyRowNormalizationCompute(computeOp))) {
-        return WalkResult::interrupt();
+        invalidRowNormalization = true;
       }
-      return WalkResult::advance();
     });
-    if (rowNormalizationResult.wasInterrupted()) {
+    if (invalidRowNormalization) {
       return signalPassFailure();
     }
 

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttlang/Dialect/TTL/Transforms/LowerMatmulCompute.h"
+#include "ttlang/Dialect/TTL/Transforms/LowerRowNormalizationCompute.h"
 
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
@@ -429,6 +430,9 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
     if (useBlockMatmul && op.containsOp<TileMatmulBlockOp>()) {
       return generateMatmulCompute(rewriter, loc, op, indexingMaps, iterTypes);
     }
+    if (op.containsOp<TileRowNormalizationBlockOp>()) {
+      return generateRowNormalizationCompute(rewriter, loc, op);
+    }
 
     // Side-effect-only loops: no iter_args, no tensor.insert, no scf.yield
     // with tensor values. Stores are explicit side effects (tile_store).
@@ -754,6 +758,16 @@ struct TTLLowerToLoopsPass
       if (capacityResult.wasInterrupted()) {
         return signalPassFailure();
       }
+    }
+    WalkResult rowNormalizationResult = func.walk([](ComputeOp computeOp) {
+      if (computeOp.containsOp<TileRowNormalizationBlockOp>() &&
+          failed(verifyRowNormalizationCompute(computeOp))) {
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (rowNormalizationResult.wasInterrupted()) {
+      return signalPassFailure();
     }
 
     // Step 1: Lower compute ops to scf.for tile loops.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -759,14 +759,14 @@ struct TTLLowerToLoopsPass
         return signalPassFailure();
       }
     }
-    WalkResult rowNormalizationResult = func.walk([](ComputeOp computeOp) {
+    bool invalidRowNormalization = false;
+    func.walk([&](ComputeOp computeOp) {
       if (computeOp.containsOp<TileRowNormalizationBlockOp>() &&
           failed(verifyRowNormalizationCompute(computeOp))) {
-        return WalkResult::interrupt();
+        invalidRowNormalization = true;
       }
-      return WalkResult::advance();
     });
-    if (rowNormalizationResult.wasInterrupted()) {
+    if (invalidRowNormalization) {
       return signalPassFailure();
     }
 

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -10,6 +10,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
 #include "ttlang/Dialect/TTL/Transforms/AccumulationUtils.h"
+#include "ttlang/Dialect/TTL/Transforms/ComputeTarget.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
@@ -760,10 +761,29 @@ struct TTLLowerToLoopsPass
       }
     }
     bool invalidRowNormalization = false;
+    std::string targetFailureReason;
+    FailureOr<std::unique_ptr<ComputeTargetEnvironment>> target =
+        ComputeTargetEnvironment::get(func, targetFailureReason);
+    if (failed(target)) {
+      func.emitOpError(targetFailureReason);
+      return signalPassFailure();
+    }
     func.walk([&](ComputeOp computeOp) {
-      if (computeOp.containsOp<TileRowNormalizationBlockOp>() &&
-          failed(verifyRowNormalizationCompute(computeOp))) {
-        invalidRowNormalization = true;
+      TileRowNormalizationBlockOp block;
+      for (TileRowNormalizationBlockOp candidate :
+           computeOp.getBody().getOps<TileRowNormalizationBlockOp>()) {
+        block = candidate;
+        break;
+      }
+      if (block) {
+        std::string capabilityFailureReason;
+        if (failed(
+                (*target)->validateOperation(block, capabilityFailureReason))) {
+          block.emitOpError(capabilityFailureReason);
+          invalidRowNormalization = true;
+        } else if (failed(verifyRowNormalizationCompute(computeOp))) {
+          invalidRowNormalization = true;
+        }
       }
     });
     if (invalidRowNormalization) {

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -9,6 +9,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
+#include "ttlang/Dialect/TTL/Transforms/ComputeTarget.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
@@ -665,10 +666,29 @@ struct TTLLowerToLoopsPass
       }
     }
     bool invalidRowNormalization = false;
+    std::string targetFailureReason;
+    FailureOr<std::unique_ptr<ComputeTargetEnvironment>> target =
+        ComputeTargetEnvironment::get(func, targetFailureReason);
+    if (failed(target)) {
+      func.emitOpError(targetFailureReason);
+      return signalPassFailure();
+    }
     func.walk([&](ComputeOp computeOp) {
-      if (computeOp.containsOp<TileRowNormalizationBlockOp>() &&
-          failed(verifyRowNormalizationCompute(computeOp))) {
-        invalidRowNormalization = true;
+      TileRowNormalizationBlockOp block;
+      for (TileRowNormalizationBlockOp candidate :
+           computeOp.getBody().getOps<TileRowNormalizationBlockOp>()) {
+        block = candidate;
+        break;
+      }
+      if (block) {
+        std::string capabilityFailureReason;
+        if (failed(
+                (*target)->validateOperation(block, capabilityFailureReason))) {
+          block.emitOpError(capabilityFailureReason);
+          invalidRowNormalization = true;
+        } else if (failed(verifyRowNormalizationCompute(computeOp))) {
+          invalidRowNormalization = true;
+        }
       }
     });
     if (invalidRowNormalization) {

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttlang/Dialect/TTL/Transforms/LowerMatmulCompute.h"
+#include "ttlang/Dialect/TTL/Transforms/LowerRowNormalizationCompute.h"
 
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
@@ -329,6 +330,9 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
     // the compute falls through to per-tile loop lowering (matmul_tile).
     if (useBlockMatmul && op.containsOp<TileMatmulBlockOp>()) {
       return generateMatmulCompute(rewriter, loc, op, indexingMaps, iterTypes);
+    }
+    if (op.containsOp<TileRowNormalizationBlockOp>()) {
+      return generateRowNormalizationCompute(rewriter, loc, op);
     }
 
     // Side-effect-only loops: no iter_args, no tensor.insert, no scf.yield
@@ -659,6 +663,16 @@ struct TTLLowerToLoopsPass
       if (capacityResult.wasInterrupted()) {
         return signalPassFailure();
       }
+    }
+    WalkResult rowNormalizationResult = func.walk([](ComputeOp computeOp) {
+      if (computeOp.containsOp<TileRowNormalizationBlockOp>() &&
+          failed(verifyRowNormalizationCompute(computeOp))) {
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (rowNormalizationResult.wasInterrupted()) {
+      return signalPassFailure();
     }
 
     // Step 1: Lower compute ops to scf.for tile loops.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -732,6 +732,42 @@ unrollTileLoopNestAndAssignDST(SmallVector<scf::ForOp> &nest) {
   return success();
 }
 
+static LogicalResult validateRowNormalizationComputes(func::FuncOp func) {
+  SmallVector<ComputeOp> rowNormalizationComputes;
+  func.walk([&](ComputeOp computeOp) {
+    if (computeOp.containsOp<TileRowNormalizationBlockOp>()) {
+      rowNormalizationComputes.push_back(computeOp);
+    }
+  });
+  if (rowNormalizationComputes.empty()) {
+    return success();
+  }
+
+  std::string targetFailureReason;
+  FailureOr<std::unique_ptr<ComputeTargetEnvironment>> target =
+      ComputeTargetEnvironment::get(func, targetFailureReason);
+  if (failed(target)) {
+    func.emitOpError(targetFailureReason);
+    return failure();
+  }
+
+  bool hasInvalidCompute = false;
+  for (ComputeOp computeOp : rowNormalizationComputes) {
+    TileRowNormalizationBlockOp block =
+        *computeOp.getBody().getOps<TileRowNormalizationBlockOp>().begin();
+    std::string capabilityFailureReason;
+    if (failed((*target)->validateOperation(block, capabilityFailureReason))) {
+      block.emitOpError(capabilityFailureReason);
+      hasInvalidCompute = true;
+      continue;
+    }
+    if (failed(verifyRowNormalizationCompute(computeOp))) {
+      hasInvalidCompute = true;
+    }
+  }
+  return failure(hasInvalidCompute);
+}
+
 struct TTLLowerToLoopsPass
     : public tt::ttl::impl::TTLLowerToLoopsBase<TTLLowerToLoopsPass> {
   using tt::ttl::impl::TTLLowerToLoopsBase<
@@ -760,33 +796,7 @@ struct TTLLowerToLoopsPass
         return signalPassFailure();
       }
     }
-    bool invalidRowNormalization = false;
-    std::string targetFailureReason;
-    FailureOr<std::unique_ptr<ComputeTargetEnvironment>> target =
-        ComputeTargetEnvironment::get(func, targetFailureReason);
-    if (failed(target)) {
-      func.emitOpError(targetFailureReason);
-      return signalPassFailure();
-    }
-    func.walk([&](ComputeOp computeOp) {
-      TileRowNormalizationBlockOp block;
-      for (TileRowNormalizationBlockOp candidate :
-           computeOp.getBody().getOps<TileRowNormalizationBlockOp>()) {
-        block = candidate;
-        break;
-      }
-      if (block) {
-        std::string capabilityFailureReason;
-        if (failed(
-                (*target)->validateOperation(block, capabilityFailureReason))) {
-          block.emitOpError(capabilityFailureReason);
-          invalidRowNormalization = true;
-        } else if (failed(verifyRowNormalizationCompute(computeOp))) {
-          invalidRowNormalization = true;
-        }
-      }
-    });
-    if (invalidRowNormalization) {
+    if (failed(validateRowNormalizationComputes(func))) {
       return signalPassFailure();
     }
 

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -1133,6 +1133,50 @@ struct TTLTileMatmulBlockToTTKernel : OpConversionPattern<TileMatmulBlockOp> {
   }
 };
 
+/// Lower the planned row-normalization block after its tensor operands have
+/// acquired concrete TTKernel DFB identities.
+struct TTLTileRowNormalizationBlockToTTKernel
+    : OpConversionPattern<TileRowNormalizationBlockOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(TileRowNormalizationBlockOp op,
+                  TileRowNormalizationBlockOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto funcOp = op->getParentOfType<func::FuncOp>();
+    if (!funcOp) {
+      return rewriter.notifyMatchFailure(op, "op not in function");
+    }
+    const TypeConverter *typeConverter = this->getTypeConverter();
+    FailureOr<Value> inputDfb =
+        lookupAndConvertCB(op.getInput(), funcOp, typeConverter, rewriter, loc);
+    FailureOr<Value> gammaDfb =
+        lookupAndConvertCB(op.getGamma(), funcOp, typeConverter, rewriter, loc);
+    FailureOr<Value> outputDfb = lookupAndConvertCB(
+        op.getOutput(), funcOp, typeConverter, rewriter, loc);
+    if (failed(inputDfb) || failed(gammaDfb) || failed(outputDfb)) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot find or convert row-normalization DFBs");
+    }
+
+    auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+    auto resultType = dyn_cast<ttcore::TileType>(op.getResult().getType());
+    if (!inputType || !inputType.hasStaticShape() || !resultType) {
+      return rewriter.notifyMatchFailure(
+          op, "requires a static tensor input and tile result");
+    }
+
+    ttk::ExperimentalRowNormalizationBlockOp::create(
+        rewriter, loc, *inputDfb, *gammaDfb, *outputDfb,
+        static_cast<std::uint64_t>(inputType.getNumElements()),
+        op.getScaleAttr().getValue(), op.getEpsilonAttr().getValue(),
+        op.getHasGamma(), op.getRepeatGamma(), resultType.getDataType());
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Fill Tile Op Lowering
 //===----------------------------------------------------------------------===//
@@ -1236,6 +1280,7 @@ void populateTTLTileOpsToTTKernelPatterns(TypeConverter *typeConverter,
 
   // Matmul block needs the type converter for CB lookup.
   patterns.add<TTLTileMatmulBlockToTTKernel>(*typeConverter, ctx);
+  patterns.add<TTLTileRowNormalizationBlockToTTKernel>(*typeConverter, ctx);
 }
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -1056,6 +1056,50 @@ struct TTLTileMatmulBlockToTTKernel : OpConversionPattern<TileMatmulBlockOp> {
   }
 };
 
+/// Lower the planned row-normalization block after its tensor operands have
+/// acquired concrete TTKernel DFB identities.
+struct TTLTileRowNormalizationBlockToTTKernel
+    : OpConversionPattern<TileRowNormalizationBlockOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(TileRowNormalizationBlockOp op,
+                  TileRowNormalizationBlockOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto funcOp = op->getParentOfType<func::FuncOp>();
+    if (!funcOp) {
+      return rewriter.notifyMatchFailure(op, "op not in function");
+    }
+    const TypeConverter *typeConverter = this->getTypeConverter();
+    FailureOr<Value> inputDfb =
+        lookupAndConvertCB(op.getInput(), funcOp, typeConverter, rewriter, loc);
+    FailureOr<Value> gammaDfb =
+        lookupAndConvertCB(op.getGamma(), funcOp, typeConverter, rewriter, loc);
+    FailureOr<Value> outputDfb = lookupAndConvertCB(
+        op.getOutput(), funcOp, typeConverter, rewriter, loc);
+    if (failed(inputDfb) || failed(gammaDfb) || failed(outputDfb)) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot find or convert row-normalization DFBs");
+    }
+
+    auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+    auto resultType = dyn_cast<ttcore::TileType>(op.getResult().getType());
+    if (!inputType || !inputType.hasStaticShape() || !resultType) {
+      return rewriter.notifyMatchFailure(
+          op, "requires a static tensor input and tile result");
+    }
+
+    ttk::ExperimentalRowNormalizationBlockOp::create(
+        rewriter, loc, *inputDfb, *gammaDfb, *outputDfb,
+        static_cast<std::uint64_t>(inputType.getNumElements()),
+        op.getScaleAttr().getValue(), op.getEpsilonAttr().getValue(),
+        op.getHasGamma(), op.getRepeatGamma(), resultType.getDataType());
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Fill Tile Op Lowering
 //===----------------------------------------------------------------------===//
@@ -1158,6 +1202,7 @@ void populateTTLTileOpsToTTKernelPatterns(TypeConverter *typeConverter,
 
   // Matmul block needs the type converter for CB lookup.
   patterns.add<TTLTileMatmulBlockToTTKernel>(*typeConverter, ctx);
+  patterns.add<TTLTileRowNormalizationBlockToTTKernel>(*typeConverter, ctx);
 }
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -1094,7 +1094,7 @@ struct TTLTileRowNormalizationBlockToTTKernel
         rewriter, loc, *inputDfb, *gammaDfb, *outputDfb,
         static_cast<std::uint64_t>(inputType.getNumElements()),
         op.getScaleAttr().getValue(), op.getEpsilonAttr().getValue(),
-        op.getHasGamma(), op.getRepeatGamma(), resultType.getDataType());
+        op.getHasGamma(), resultType.getDataType());
     rewriter.replaceOp(op, adaptor.getInput());
     return success();
   }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -1083,16 +1083,13 @@ struct TTLTileRowNormalizationBlockToTTKernel
           op, "cannot find or convert row-normalization DFBs");
     }
 
-    auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
     auto resultType = dyn_cast<ttcore::TileType>(op.getResult().getType());
-    if (!inputType || !inputType.hasStaticShape() || !resultType) {
-      return rewriter.notifyMatchFailure(
-          op, "requires a static tensor input and tile result");
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "requires a tile result");
     }
 
     ttk::ExperimentalRowNormalizationBlockOp::create(
-        rewriter, loc, *inputDfb, *gammaDfb, *outputDfb,
-        static_cast<std::uint64_t>(inputType.getNumElements()),
+        rewriter, loc, *inputDfb, *gammaDfb, *outputDfb, op.getNumTiles(),
         op.getScaleAttr().getValue(), op.getEpsilonAttr().getValue(),
         op.getHasGamma(), resultType.getDataType());
     rewriter.replaceOp(op, adaptor.getInput());

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -1160,16 +1160,13 @@ struct TTLTileRowNormalizationBlockToTTKernel
           op, "cannot find or convert row-normalization DFBs");
     }
 
-    auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
     auto resultType = dyn_cast<ttcore::TileType>(op.getResult().getType());
-    if (!inputType || !inputType.hasStaticShape() || !resultType) {
-      return rewriter.notifyMatchFailure(
-          op, "requires a static tensor input and tile result");
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "requires a tile result");
     }
 
     ttk::ExperimentalRowNormalizationBlockOp::create(
-        rewriter, loc, *inputDfb, *gammaDfb, *outputDfb,
-        static_cast<std::uint64_t>(inputType.getNumElements()),
+        rewriter, loc, *inputDfb, *gammaDfb, *outputDfb, op.getNumTiles(),
         op.getScaleAttr().getValue(), op.getEpsilonAttr().getValue(),
         op.getHasGamma(), resultType.getDataType());
     rewriter.replaceOp(op, adaptor.getInput());

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -1171,7 +1171,7 @@ struct TTLTileRowNormalizationBlockToTTKernel
         rewriter, loc, *inputDfb, *gammaDfb, *outputDfb,
         static_cast<std::uint64_t>(inputType.getNumElements()),
         op.getScaleAttr().getValue(), op.getEpsilonAttr().getValue(),
-        op.getHasGamma(), op.getRepeatGamma(), resultType.getDataType());
+        op.getHasGamma(), resultType.getDataType());
     rewriter.replaceOp(op, adaptor.getInput());
     return success();
   }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -624,21 +624,14 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
     return rewriter.notifyMatchFailure(
         sinkOp, "row-normalization expression changed after planning");
   }
-  if (!creation.instrumentation.empty()) {
-    return rewriter.notifyMatchFailure(
-        sinkOp, "row-normalization schedule contains instrumentation");
-  }
-
   Location loc = sinkOp->getLoc();
   RankedTensorType outputType = creation.resultType;
   SmallVector<Attribute> maps;
   for (AffineMap inputMap : creation.iteration.inputMaps) {
     maps.push_back(AffineMapAttr::get(inputMap));
   }
-  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
-       ++outputIndex) {
-    maps.push_back(AffineMapAttr::get(creation.iteration.outputMap));
-  }
+  maps.append(outputs.dfbs.size(),
+              AffineMapAttr::get(creation.iteration.outputMap));
   SmallVector<Attribute> iteratorTypes =
       buildIteratorTypeAttributes(rewriter, creation.iteration.iteratorTypes);
 
@@ -663,10 +656,9 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
     body->addArgument(getTileValueType(inputType.getElementType()), loc);
   }
   Type outputTileType = getTileValueType(outputType.getElementType());
-  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
-       ++outputIndex) {
-    body->addArgument(outputTileType, loc);
-  }
+  SmallVector<Type> outputTileTypes(outputs.dfbs.size(), outputTileType);
+  SmallVector<Location> outputLocations(outputs.dfbs.size(), loc);
+  body->addArguments(outputTileTypes, outputLocations);
 
   rewriter.setInsertionPointToStart(body);
   Value inputTile = body->getArgument(0);
@@ -804,19 +796,20 @@ static LogicalResult tryFusion(Operation *op, PatternRewriter &rewriter,
   if (failed(getCreationPlan(op, rewriter, kernelPlan, creation))) {
     return failure();
   }
-  if (creation->kind == ComputeOpCreationKind::Fused) {
-    OutputPublicationPlan outputs;
-    if (failed(resolveCurrentOutputs(op, rewriter, *creation, outputs))) {
-      return failure();
-    }
-    if (creation->recipe == ComputeOpCreationRecipe::RowNormalization) {
-      return buildRowNormalizationCompute(op, rewriter, *creation, outputs);
-    }
-    if (creation->recipe == ComputeOpCreationRecipe::Fused) {
-      return buildFusedCompute(op, rewriter, *creation, outputs);
-    }
+  if (creation->kind != ComputeOpCreationKind::Fused ||
+      (creation->recipe != ComputeOpCreationRecipe::RowNormalization &&
+       creation->recipe != ComputeOpCreationRecipe::Fused)) {
+    return rewriter.notifyMatchFailure(op,
+                                       "operation has no fusable expression");
   }
-  return rewriter.notifyMatchFailure(op, "operation has no fusable expression");
+  OutputPublicationPlan outputs;
+  if (failed(resolveCurrentOutputs(op, rewriter, *creation, outputs))) {
+    return failure();
+  }
+  if (creation->recipe == ComputeOpCreationRecipe::RowNormalization) {
+    return buildRowNormalizationCompute(op, rewriter, *creation, outputs);
+  }
+  return buildFusedCompute(op, rewriter, *creation, outputs);
 }
 
 /// Build a ttl.compute op with a single binary tile operation in the body.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -667,7 +667,8 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   Value result =
       createTileOpWithPlaceholderDstIndex<TileRowNormalizationBlockOp>(
           rewriter, loc, outputTileType, inputTile, gammaTile, outputTile,
-          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma));
+          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma),
+          rewriter.getI64IntegerAttr(schedule.numTiles));
 
   for (StoreOp store : outputs.stores) {
     emitTileStore(rewriter, loc, result, computeOp, store, outputs);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -574,6 +574,99 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   return success();
 }
 
+/// Applies a precomputed row-normalization schedule. Expression recognition,
+/// capacity, lifetimes, publication, and operation erasure are fixed by the
+/// immutable plan; application emits one block operation mechanically.
+static LogicalResult
+buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
+                             const ComputeOpCreationPlan &creation,
+                             const OutputPublicationPlan &outputs) {
+  assert(creation.recipe == ComputeOpCreationRecipe::RowNormalization &&
+         creation.rowNormalization &&
+         "row-normalization builder requires its typed schedule");
+  const RowNormalizationPlan &schedule = *creation.rowNormalization;
+  if (llvm::any_of(schedule.operations,
+                   [](const RowNormalizationOperationPlan &operation) {
+                     return !llvm::equal(operation.source->getOperands(),
+                                         operation.operands);
+                   })) {
+    return rewriter.notifyMatchFailure(
+        sinkOp, "row-normalization expression changed after planning");
+  }
+  if (!creation.instrumentation.empty()) {
+    return rewriter.notifyMatchFailure(
+        sinkOp, "row-normalization schedule contains instrumentation");
+  }
+
+  Location loc = sinkOp->getLoc();
+  RankedTensorType outputType = creation.resultType;
+  SmallVector<Attribute> maps;
+  for (AffineMap inputMap : creation.iteration.inputMaps) {
+    maps.push_back(AffineMapAttr::get(inputMap));
+  }
+  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
+       ++outputIndex) {
+    maps.push_back(AffineMapAttr::get(creation.iteration.outputMap));
+  }
+  SmallVector<Attribute> iteratorTypes =
+      buildIteratorTypeAttributes(rewriter, creation.iteration.iteratorTypes);
+
+  insertAtCreationAnchor(rewriter, outputs);
+  SmallVector<Value> outputViews;
+  SmallVector<Type> resultTypes;
+  for (Value outputDFB : outputs.dfbs) {
+    Value init =
+        buildInitTensor(rewriter, loc, outputType, creation.inputs.front());
+    outputViews.push_back(
+        AttachCBOp::create(rewriter, loc, init.getType(), init, outputDFB));
+    resultTypes.push_back(outputType);
+  }
+
+  auto computeOp = ComputeOp::create(
+      rewriter, loc, TypeRange(resultTypes), ValueRange(creation.inputs),
+      ValueRange(outputViews), rewriter.getArrayAttr(maps),
+      rewriter.getArrayAttr(iteratorTypes));
+  Block *body = rewriter.createBlock(&computeOp.getBody());
+  for (Value inputValue : creation.inputs) {
+    auto inputType = cast<RankedTensorType>(inputValue.getType());
+    body->addArgument(getTileValueType(inputType.getElementType()), loc);
+  }
+  Type outputTileType = getTileValueType(outputType.getElementType());
+  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
+       ++outputIndex) {
+    body->addArgument(outputTileType, loc);
+  }
+
+  rewriter.setInsertionPointToStart(body);
+  Value inputTile = body->getArgument(0);
+  bool hasGamma = schedule.gammaMode != RowNormalizationGammaMode::None;
+  Value gammaTile = hasGamma ? body->getArgument(1) : inputTile;
+  Value outputTile = body->getArgument(creation.inputs.size());
+  Value result =
+      createTileOpWithPlaceholderDstIndex<TileRowNormalizationBlockOp>(
+          rewriter, loc, outputTileType, inputTile, gammaTile, outputTile,
+          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma),
+          rewriter.getBoolAttr(schedule.gammaMode ==
+                               RowNormalizationGammaMode::RepeatedPage));
+
+  for (StoreOp store : outputs.stores) {
+    emitTileStore(rewriter, loc, result, computeOp, store, outputs);
+  }
+  YieldOp::create(rewriter, loc);
+
+  SmallVector<CBPushOp> replacedPushes;
+  replaceOutputPushesBeforeCompute(rewriter, computeOp, outputs,
+                                   replacedPushes);
+  eraseAbsorbedOutputOps(rewriter, outputs, computeOp, replacedPushes);
+  rewriter.replaceOp(sinkOp, computeOp.getResult(0));
+  for (Operation *operation : llvm::reverse(creation.trace.opsInOrder)) {
+    if (operation != sinkOp && operation->use_empty()) {
+      rewriter.eraseOp(operation);
+    }
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Lowering to ttl.compute with tile ops
 //===----------------------------------------------------------------------===//
@@ -687,7 +780,12 @@ static LogicalResult tryFusion(Operation *op, PatternRewriter &rewriter,
     if (failed(resolveCurrentOutputs(op, rewriter, *creation, outputs))) {
       return failure();
     }
-    return buildFusedCompute(op, rewriter, *creation, outputs);
+    if (creation->recipe == ComputeOpCreationRecipe::RowNormalization) {
+      return buildRowNormalizationCompute(op, rewriter, *creation, outputs);
+    }
+    if (creation->recipe == ComputeOpCreationRecipe::Fused) {
+      return buildFusedCompute(op, rewriter, *creation, outputs);
+    }
   }
   return rewriter.notifyMatchFailure(op, "operation has no fusable expression");
 }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -671,7 +671,7 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
           rewriter.getI64IntegerAttr(schedule.numTiles));
 
   for (StoreOp store : outputs.stores) {
-    emitTileStore(rewriter, loc, result, computeOp, store, outputs);
+    emitTileStore(rewriter, loc, result, computeOp, store, creation);
   }
   YieldOp::create(rewriter, loc);
 

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -620,11 +620,10 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
       ValueRange(outputViews), rewriter.getArrayAttr(maps),
       rewriter.getArrayAttr(iteratorTypes));
   Block *body = rewriter.createBlock(&computeOp.getBody());
-  for (Value inputValue : creation.inputs) {
-    auto inputType = cast<RankedTensorType>(inputValue.getType());
-    body->addArgument(getTileValueType(inputType.getElementType()), loc);
+  for (ttcore::TileType inputTileType : creation.inputTileTypes) {
+    body->addArgument(inputTileType, loc);
   }
-  Type outputTileType = getTileValueType(outputType.getElementType());
+  Type outputTileType = creation.resultTileType;
   SmallVector<Type> outputTileTypes(outputs.dfbs.size(), outputTileType);
   SmallVector<Location> outputLocations(outputs.dfbs.size(), loc);
   body->addArguments(outputTileTypes, outputLocations);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -645,9 +645,7 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   Value result =
       createTileOpWithPlaceholderDstIndex<TileRowNormalizationBlockOp>(
           rewriter, loc, outputTileType, inputTile, gammaTile, outputTile,
-          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma),
-          rewriter.getBoolAttr(schedule.gammaMode ==
-                               RowNormalizationGammaMode::RepeatedPage));
+          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma));
 
   for (StoreOp store : outputs.stores) {
     emitTileStore(rewriter, loc, result, computeOp, store, outputs);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -605,6 +605,99 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   return success();
 }
 
+/// Applies a precomputed row-normalization schedule. Expression recognition,
+/// capacity, lifetimes, publication, and operation erasure are fixed by the
+/// immutable plan; application emits one block operation mechanically.
+static LogicalResult
+buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
+                             const ComputeOpCreationPlan &creation,
+                             const OutputPublicationPlan &outputs) {
+  assert(creation.recipe == ComputeOpCreationRecipe::RowNormalization &&
+         creation.rowNormalization &&
+         "row-normalization builder requires its typed schedule");
+  const RowNormalizationPlan &schedule = *creation.rowNormalization;
+  if (llvm::any_of(schedule.operations,
+                   [](const RowNormalizationOperationPlan &operation) {
+                     return !llvm::equal(operation.source->getOperands(),
+                                         operation.operands);
+                   })) {
+    return rewriter.notifyMatchFailure(
+        sinkOp, "row-normalization expression changed after planning");
+  }
+  if (!creation.instrumentation.empty()) {
+    return rewriter.notifyMatchFailure(
+        sinkOp, "row-normalization schedule contains instrumentation");
+  }
+
+  Location loc = sinkOp->getLoc();
+  RankedTensorType outputType = creation.resultType;
+  SmallVector<Attribute> maps;
+  for (AffineMap inputMap : creation.iteration.inputMaps) {
+    maps.push_back(AffineMapAttr::get(inputMap));
+  }
+  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
+       ++outputIndex) {
+    maps.push_back(AffineMapAttr::get(creation.iteration.outputMap));
+  }
+  SmallVector<Attribute> iteratorTypes =
+      buildIteratorTypeAttributes(rewriter, creation.iteration.iteratorTypes);
+
+  insertAtCreationAnchor(rewriter, outputs);
+  SmallVector<Value> outputViews;
+  SmallVector<Type> resultTypes;
+  for (Value outputDFB : outputs.dfbs) {
+    Value init =
+        buildInitTensor(rewriter, loc, outputType, creation.inputs.front());
+    outputViews.push_back(
+        AttachCBOp::create(rewriter, loc, init.getType(), init, outputDFB));
+    resultTypes.push_back(outputType);
+  }
+
+  auto computeOp = ComputeOp::create(
+      rewriter, loc, TypeRange(resultTypes), ValueRange(creation.inputs),
+      ValueRange(outputViews), rewriter.getArrayAttr(maps),
+      rewriter.getArrayAttr(iteratorTypes));
+  Block *body = rewriter.createBlock(&computeOp.getBody());
+  for (Value inputValue : creation.inputs) {
+    auto inputType = cast<RankedTensorType>(inputValue.getType());
+    body->addArgument(getTileValueType(inputType.getElementType()), loc);
+  }
+  Type outputTileType = getTileValueType(outputType.getElementType());
+  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
+       ++outputIndex) {
+    body->addArgument(outputTileType, loc);
+  }
+
+  rewriter.setInsertionPointToStart(body);
+  Value inputTile = body->getArgument(0);
+  bool hasGamma = schedule.gammaMode != RowNormalizationGammaMode::None;
+  Value gammaTile = hasGamma ? body->getArgument(1) : inputTile;
+  Value outputTile = body->getArgument(creation.inputs.size());
+  Value result =
+      createTileOpWithPlaceholderDstIndex<TileRowNormalizationBlockOp>(
+          rewriter, loc, outputTileType, inputTile, gammaTile, outputTile,
+          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma),
+          rewriter.getBoolAttr(schedule.gammaMode ==
+                               RowNormalizationGammaMode::RepeatedPage));
+
+  for (StoreOp store : outputs.stores) {
+    emitTileStore(rewriter, loc, result, computeOp, store, outputs);
+  }
+  YieldOp::create(rewriter, loc);
+
+  SmallVector<CBPushOp> replacedPushes;
+  replaceOutputPushesBeforeCompute(rewriter, computeOp, outputs,
+                                   replacedPushes);
+  eraseAbsorbedOutputOps(rewriter, outputs, computeOp, replacedPushes);
+  rewriter.replaceOp(sinkOp, computeOp.getResult(0));
+  for (Operation *operation : llvm::reverse(creation.trace.opsInOrder)) {
+    if (operation != sinkOp && operation->use_empty()) {
+      rewriter.eraseOp(operation);
+    }
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Lowering to ttl.compute with tile ops
 //===----------------------------------------------------------------------===//
@@ -718,7 +811,12 @@ static LogicalResult tryFusion(Operation *op, PatternRewriter &rewriter,
     if (failed(resolveCurrentOutputs(op, rewriter, *creation, outputs))) {
       return failure();
     }
-    return buildFusedCompute(op, rewriter, *creation, outputs);
+    if (creation->recipe == ComputeOpCreationRecipe::RowNormalization) {
+      return buildRowNormalizationCompute(op, rewriter, *creation, outputs);
+    }
+    if (creation->recipe == ComputeOpCreationRecipe::Fused) {
+      return buildFusedCompute(op, rewriter, *creation, outputs);
+    }
   }
   return rewriter.notifyMatchFailure(op, "operation has no fusable expression");
 }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -636,7 +636,8 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   Value result =
       createTileOpWithPlaceholderDstIndex<TileRowNormalizationBlockOp>(
           rewriter, loc, outputTileType, inputTile, gammaTile, outputTile,
-          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma));
+          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma),
+          rewriter.getI64IntegerAttr(schedule.numTiles));
 
   for (StoreOp store : outputs.stores) {
     emitTileStore(rewriter, loc, result, computeOp, store, outputs);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -676,9 +676,7 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   Value result =
       createTileOpWithPlaceholderDstIndex<TileRowNormalizationBlockOp>(
           rewriter, loc, outputTileType, inputTile, gammaTile, outputTile,
-          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma),
-          rewriter.getBoolAttr(schedule.gammaMode ==
-                               RowNormalizationGammaMode::RepeatedPage));
+          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma));
 
   for (StoreOp store : outputs.stores) {
     emitTileStore(rewriter, loc, result, computeOp, store, outputs);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -651,11 +651,10 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
       ValueRange(outputViews), rewriter.getArrayAttr(maps),
       rewriter.getArrayAttr(iteratorTypes));
   Block *body = rewriter.createBlock(&computeOp.getBody());
-  for (Value inputValue : creation.inputs) {
-    auto inputType = cast<RankedTensorType>(inputValue.getType());
-    body->addArgument(getTileValueType(inputType.getElementType()), loc);
+  for (ttcore::TileType inputTileType : creation.inputTileTypes) {
+    body->addArgument(inputTileType, loc);
   }
-  Type outputTileType = getTileValueType(outputType.getElementType());
+  Type outputTileType = creation.resultTileType;
   SmallVector<Type> outputTileTypes(outputs.dfbs.size(), outputTileType);
   SmallVector<Location> outputLocations(outputs.dfbs.size(), loc);
   body->addArguments(outputTileTypes, outputLocations);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -593,21 +593,14 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
     return rewriter.notifyMatchFailure(
         sinkOp, "row-normalization expression changed after planning");
   }
-  if (!creation.instrumentation.empty()) {
-    return rewriter.notifyMatchFailure(
-        sinkOp, "row-normalization schedule contains instrumentation");
-  }
-
   Location loc = sinkOp->getLoc();
   RankedTensorType outputType = creation.resultType;
   SmallVector<Attribute> maps;
   for (AffineMap inputMap : creation.iteration.inputMaps) {
     maps.push_back(AffineMapAttr::get(inputMap));
   }
-  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
-       ++outputIndex) {
-    maps.push_back(AffineMapAttr::get(creation.iteration.outputMap));
-  }
+  maps.append(outputs.dfbs.size(),
+              AffineMapAttr::get(creation.iteration.outputMap));
   SmallVector<Attribute> iteratorTypes =
       buildIteratorTypeAttributes(rewriter, creation.iteration.iteratorTypes);
 
@@ -632,10 +625,9 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
     body->addArgument(getTileValueType(inputType.getElementType()), loc);
   }
   Type outputTileType = getTileValueType(outputType.getElementType());
-  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
-       ++outputIndex) {
-    body->addArgument(outputTileType, loc);
-  }
+  SmallVector<Type> outputTileTypes(outputs.dfbs.size(), outputTileType);
+  SmallVector<Location> outputLocations(outputs.dfbs.size(), loc);
+  body->addArguments(outputTileTypes, outputLocations);
 
   rewriter.setInsertionPointToStart(body);
   Value inputTile = body->getArgument(0);
@@ -773,19 +765,20 @@ static LogicalResult tryFusion(Operation *op, PatternRewriter &rewriter,
   if (failed(getCreationPlan(op, rewriter, kernelPlan, creation))) {
     return failure();
   }
-  if (creation->kind == ComputeOpCreationKind::Fused) {
-    OutputPublicationPlan outputs;
-    if (failed(resolveCurrentOutputs(op, rewriter, *creation, outputs))) {
-      return failure();
-    }
-    if (creation->recipe == ComputeOpCreationRecipe::RowNormalization) {
-      return buildRowNormalizationCompute(op, rewriter, *creation, outputs);
-    }
-    if (creation->recipe == ComputeOpCreationRecipe::Fused) {
-      return buildFusedCompute(op, rewriter, *creation, outputs);
-    }
+  if (creation->kind != ComputeOpCreationKind::Fused ||
+      (creation->recipe != ComputeOpCreationRecipe::RowNormalization &&
+       creation->recipe != ComputeOpCreationRecipe::Fused)) {
+    return rewriter.notifyMatchFailure(op,
+                                       "operation has no fusable expression");
   }
-  return rewriter.notifyMatchFailure(op, "operation has no fusable expression");
+  OutputPublicationPlan outputs;
+  if (failed(resolveCurrentOutputs(op, rewriter, *creation, outputs))) {
+    return failure();
+  }
+  if (creation->recipe == ComputeOpCreationRecipe::RowNormalization) {
+    return buildRowNormalizationCompute(op, rewriter, *creation, outputs);
+  }
+  return buildFusedCompute(op, rewriter, *creation, outputs);
 }
 
 /// Build a ttl.compute op with a single binary tile operation in the body.

--- a/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
@@ -120,7 +120,7 @@ analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
     reason = "cannot determine effective DST capacity";
     return failure();
   }
-  analysis.dstCapacity = std::min<std::uint32_t>(8, *capacity);
+  analysis.dstCapacity = *capacity;
   if (analysis.numTiles < 1 || analysis.numTiles > analysis.dstCapacity) {
     reason =
         (Twine("row requires ") + Twine(analysis.numTiles) +

--- a/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
@@ -132,12 +132,8 @@ analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
       reason = "gamma must be a static rank-2 tensor";
       return failure();
     }
-    bool gammaShapeMatches =
-        analysis.block.getRepeatGamma()
-            ? gammaType.getDimSize(0) == 1 && gammaType.getDimSize(1) == 1
-            : gammaType == outputType;
-    if (!gammaShapeMatches) {
-      reason = "gamma tensor shape does not match the selected gamma mode";
+    if (gammaType != outputType) {
+      reason = "gamma tensor shape must match the output shape";
       return failure();
     }
   }
@@ -190,8 +186,7 @@ LogicalResult generateRowNormalizationCompute(PatternRewriter &rewriter,
       sectionBuilder, loc, tileType, analysis->inputTensor,
       analysis->gammaTensor, analysis->outputTensor,
       analysis->block.getScaleAttr(), analysis->block.getEpsilonAttr(),
-      analysis->block.getHasGammaAttr(), analysis->block.getRepeatGammaAttr(),
-      scalarDstIndex);
+      analysis->block.getHasGammaAttr(), scalarDstIndex);
 
   for (TileStoreOp originalStore : analysis->stores) {
     for (int64_t tileIndex = 0; tileIndex < analysis->numTiles; ++tileIndex) {

--- a/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
@@ -20,7 +20,7 @@ struct RowNormalizationComputeAnalysis {
   Value inputTensor;
   Value gammaTensor;
   Value outputTensor;
-  SmallVector<TileStoreOp> stores;
+  TileStoreOp store;
   int64_t numTiles = 0;
   std::uint32_t dstCapacity = 0;
 };
@@ -59,7 +59,11 @@ analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
       continue;
     }
     if (auto store = dyn_cast<TileStoreOp>(&operation)) {
-      analysis.stores.push_back(store);
+      if (analysis.store) {
+        reason = "requires exactly one output store";
+        return failure();
+      }
+      analysis.store = store;
       continue;
     }
     if (!isa<IterIndexOp>(&operation)) {
@@ -67,13 +71,13 @@ analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
       return failure();
     }
   }
-  if (!analysis.block || analysis.stores.empty()) {
-    reason = "requires one block operation and at least one output store";
+  if (!analysis.block || !analysis.store) {
+    reason = "requires one block operation and one output store";
     return failure();
   }
   unsigned expectedInputCount = analysis.block.getHasGamma() ? 2 : 1;
   if (compute.getInputs().size() != expectedInputCount ||
-      compute.getOutputs().size() != 1 || analysis.stores.size() != 1) {
+      compute.getOutputs().size() != 1) {
     reason = "requires the exact input list, one output, and one output store";
     return failure();
   }
@@ -138,13 +142,12 @@ analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
     }
   }
 
-  TileStoreOp store = analysis.stores.front();
-  if (store.getTile() != analysis.block.getResult()) {
+  if (analysis.store.getTile() != analysis.block.getResult()) {
     reason = "output store must consume the block result";
     return failure();
   }
   FailureOr<unsigned> outputIndex =
-      compute.getOutputIndexForView(store.getView());
+      compute.getOutputIndexForView(analysis.store.getView());
   if (failed(outputIndex) || *outputIndex != 0 ||
       analysis.outputTensor != compute.getOutputs().front()) {
     reason = "block and store must map to the sole formal compute output";
@@ -188,18 +191,16 @@ LogicalResult generateRowNormalizationCompute(PatternRewriter &rewriter,
       analysis->block.getScaleAttr(), analysis->block.getEpsilonAttr(),
       analysis->block.getHasGammaAttr(), scalarDstIndex);
 
-  for (TileStoreOp originalStore : analysis->stores) {
-    for (int64_t tileIndex = 0; tileIndex < analysis->numTiles; ++tileIndex) {
-      Value outputDstIndex = constantIndex(sectionBuilder, loc, tileIndex);
-      Value outputTile =
-          DstIndexOp::create(sectionBuilder, loc, tileType,
-                             loweredBlock.getResult(), outputDstIndex);
-      SmallVector<Value> indices = {
-          constantIndex(sectionBuilder, loc, 0),
-          constantIndex(sectionBuilder, loc, tileIndex)};
-      TileStoreOp::create(sectionBuilder, loc, outputTile,
-                          originalStore.getView(), indices, outputDstIndex);
-    }
+  for (int64_t tileIndex = 0; tileIndex < analysis->numTiles; ++tileIndex) {
+    Value outputDstIndex = constantIndex(sectionBuilder, loc, tileIndex);
+    Value outputTile =
+        DstIndexOp::create(sectionBuilder, loc, tileType,
+                           loweredBlock.getResult(), outputDstIndex);
+    SmallVector<Value> indices = {
+        constantIndex(sectionBuilder, loc, 0),
+        constantIndex(sectionBuilder, loc, tileIndex)};
+    TileStoreOp::create(sectionBuilder, loc, outputTile,
+                        analysis->store.getView(), indices, outputDstIndex);
   }
 
   rewriter.replaceOp(op, op.getOutputs());

--- a/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
@@ -110,6 +110,10 @@ analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
     return failure();
   }
   analysis.numTiles = inputType.getNumElements();
+  if (analysis.numTiles != static_cast<int64_t>(analysis.block.getNumTiles())) {
+    reason = "num_tiles must match the row tensor width";
+    return failure();
+  }
 
   FailureOr<std::uint32_t> capacity = computeDSTCapacity(compute);
   if (failed(capacity)) {
@@ -184,7 +188,8 @@ LogicalResult generateRowNormalizationCompute(PatternRewriter &rewriter,
       sectionBuilder, loc, tileType, analysis->inputTensor,
       analysis->gammaTensor, analysis->outputTensor,
       analysis->block.getScaleAttr(), analysis->block.getEpsilonAttr(),
-      analysis->block.getHasGammaAttr(), scalarDstIndex);
+      analysis->block.getHasGammaAttr(), analysis->block.getNumTilesAttr(),
+      scalarDstIndex);
 
   for (int64_t tileIndex = 0; tileIndex < analysis->numTiles; ++tileIndex) {
     Value outputDstIndex = constantIndex(sectionBuilder, loc, tileIndex);

--- a/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTL/Transforms/LowerRowNormalizationCompute.h"
+
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOps.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir::tt::ttl {
+namespace {
+
+struct RowNormalizationComputeAnalysis {
+  TileRowNormalizationBlockOp block;
+  Value inputTensor;
+  Value gammaTensor;
+  Value outputTensor;
+  SmallVector<TileStoreOp> stores;
+  int64_t numTiles = 0;
+  std::uint32_t dstCapacity = 0;
+};
+
+static FailureOr<Value> getInputTensor(ComputeOp compute, Value bodyValue) {
+  std::optional<unsigned> argumentIndex = traceToBlockArgIndex(bodyValue);
+  if (!argumentIndex || *argumentIndex >= compute.getInputs().size()) {
+    return failure();
+  }
+  return compute.getInputs()[*argumentIndex];
+}
+
+static FailureOr<Value> getOutputTensor(ComputeOp compute, Value bodyValue) {
+  std::optional<unsigned> argumentIndex = traceToBlockArgIndex(bodyValue);
+  if (!argumentIndex || *argumentIndex < compute.getInputs().size()) {
+    return failure();
+  }
+  unsigned outputIndex = *argumentIndex - compute.getInputs().size();
+  if (outputIndex >= compute.getOutputs().size()) {
+    return failure();
+  }
+  return compute.getOutputs()[outputIndex];
+}
+
+static FailureOr<RowNormalizationComputeAnalysis>
+analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
+  RowNormalizationComputeAnalysis analysis;
+  Block &body = compute.getBody().front();
+  for (Operation &operation : body.without_terminator()) {
+    if (auto block = dyn_cast<TileRowNormalizationBlockOp>(&operation)) {
+      if (analysis.block) {
+        reason = "requires exactly one ttl.tile_row_normalization_block";
+        return failure();
+      }
+      analysis.block = block;
+      continue;
+    }
+    if (auto store = dyn_cast<TileStoreOp>(&operation)) {
+      analysis.stores.push_back(store);
+      continue;
+    }
+    if (!isa<IterIndexOp>(&operation)) {
+      reason = "row-normalization compute contains an unsupported body op";
+      return failure();
+    }
+  }
+  if (!analysis.block || analysis.stores.empty()) {
+    reason = "requires one block operation and at least one output store";
+    return failure();
+  }
+  unsigned expectedInputCount = analysis.block.getHasGamma() ? 2 : 1;
+  if (compute.getInputs().size() != expectedInputCount ||
+      compute.getOutputs().size() != 1 || analysis.stores.size() != 1) {
+    reason = "requires the exact input list, one output, and one output store";
+    return failure();
+  }
+  if (!analysis.block.getHasGamma() &&
+      analysis.block.getGamma() != analysis.block.getInput()) {
+    reason = "gamma must equal input when gamma multiplication is disabled";
+    return failure();
+  }
+  if (!isBlackholeTarget(compute)) {
+    reason = "row-normalization block lowering requires a Blackhole target";
+    return failure();
+  }
+
+  FailureOr<Value> inputTensor =
+      getInputTensor(compute, analysis.block.getInput());
+  FailureOr<Value> gammaTensor =
+      getInputTensor(compute, analysis.block.getGamma());
+  FailureOr<Value> outputTensor =
+      getOutputTensor(compute, analysis.block.getOutput());
+  if (failed(inputTensor) || failed(gammaTensor) || failed(outputTensor)) {
+    reason = "block operands must map to formal compute inputs and outputs";
+    return failure();
+  }
+  analysis.inputTensor = *inputTensor;
+  analysis.gammaTensor = *gammaTensor;
+  analysis.outputTensor = *outputTensor;
+
+  auto inputType = dyn_cast<RankedTensorType>(analysis.inputTensor.getType());
+  auto outputType = dyn_cast<RankedTensorType>(analysis.outputTensor.getType());
+  if (!inputType || !outputType || !inputType.hasStaticShape() ||
+      !outputType.hasStaticShape() || inputType.getRank() != 2 ||
+      outputType.getRank() != 2 || inputType.getDimSize(0) != 1 ||
+      inputType != outputType) {
+    reason = "input and output must be matching static one-row tensors";
+    return failure();
+  }
+  analysis.numTiles = inputType.getNumElements();
+
+  FailureOr<std::uint32_t> capacity = computeDSTCapacity(compute);
+  if (failed(capacity)) {
+    reason = "cannot determine effective DST capacity";
+    return failure();
+  }
+  analysis.dstCapacity = std::min<std::uint32_t>(8, *capacity);
+  if (analysis.numTiles < 1 || analysis.numTiles > analysis.dstCapacity) {
+    reason =
+        (Twine("row requires ") + Twine(analysis.numTiles) +
+         " DST slots, but effective capacity is " + Twine(analysis.dstCapacity))
+            .str();
+    return failure();
+  }
+
+  if (analysis.block.getHasGamma()) {
+    auto gammaType = dyn_cast<RankedTensorType>(analysis.gammaTensor.getType());
+    if (!gammaType || !gammaType.hasStaticShape() || gammaType.getRank() != 2) {
+      reason = "gamma must be a static rank-2 tensor";
+      return failure();
+    }
+    bool gammaShapeMatches =
+        analysis.block.getRepeatGamma()
+            ? gammaType.getDimSize(0) == 1 && gammaType.getDimSize(1) == 1
+            : gammaType == outputType;
+    if (!gammaShapeMatches) {
+      reason = "gamma tensor shape does not match the selected gamma mode";
+      return failure();
+    }
+  }
+
+  TileStoreOp store = analysis.stores.front();
+  if (store.getTile() != analysis.block.getResult()) {
+    reason = "output store must consume the block result";
+    return failure();
+  }
+  FailureOr<unsigned> outputIndex =
+      compute.getOutputIndexForView(store.getView());
+  if (failed(outputIndex) || *outputIndex != 0 ||
+      analysis.outputTensor != compute.getOutputs().front()) {
+    reason = "block and store must map to the sole formal compute output";
+    return failure();
+  }
+  return analysis;
+}
+
+static Value constantIndex(OpBuilder &builder, Location loc, int64_t value) {
+  return arith::ConstantIndexOp::create(builder, loc, value);
+}
+
+} // namespace
+
+LogicalResult verifyRowNormalizationCompute(ComputeOp op) {
+  std::string reason;
+  if (failed(analyzeRowNormalizationCompute(op, reason))) {
+    return op.emitOpError(reason);
+  }
+  return success();
+}
+
+LogicalResult generateRowNormalizationCompute(PatternRewriter &rewriter,
+                                              Location loc, ComputeOp op) {
+  std::string reason;
+  FailureOr<RowNormalizationComputeAnalysis> analysis =
+      analyzeRowNormalizationCompute(op, reason);
+  if (failed(analysis)) {
+    return rewriter.notifyMatchFailure(op, reason);
+  }
+
+  auto dstSection = DstSectionOp::create(rewriter, loc);
+  Block &sectionBody = dstSection.getBody().front();
+  OpBuilder sectionBuilder(&sectionBody,
+                           Block::iterator(sectionBody.getTerminator()));
+  Value scalarDstIndex = constantIndex(sectionBuilder, loc, 0);
+  Type tileType = analysis->block.getResult().getType();
+  auto loweredBlock = TileRowNormalizationBlockOp::create(
+      sectionBuilder, loc, tileType, analysis->inputTensor,
+      analysis->gammaTensor, analysis->outputTensor,
+      analysis->block.getScaleAttr(), analysis->block.getEpsilonAttr(),
+      analysis->block.getHasGammaAttr(), analysis->block.getRepeatGammaAttr(),
+      scalarDstIndex);
+
+  for (TileStoreOp originalStore : analysis->stores) {
+    for (int64_t tileIndex = 0; tileIndex < analysis->numTiles; ++tileIndex) {
+      Value outputDstIndex = constantIndex(sectionBuilder, loc, tileIndex);
+      Value outputTile =
+          DstIndexOp::create(sectionBuilder, loc, tileType,
+                             loweredBlock.getResult(), outputDstIndex);
+      SmallVector<Value> indices = {
+          constantIndex(sectionBuilder, loc, 0),
+          constantIndex(sectionBuilder, loc, tileIndex)};
+      TileStoreOp::create(sectionBuilder, loc, outputTile,
+                          originalStore.getView(), indices, outputDstIndex);
+    }
+  }
+
+  rewriter.replaceOp(op, op.getOutputs());
+  return success();
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerRowNormalizationCompute.cpp
@@ -86,11 +86,6 @@ analyzeRowNormalizationCompute(ComputeOp compute, std::string &reason) {
     reason = "gamma must equal input when gamma multiplication is disabled";
     return failure();
   }
-  if (!isBlackholeTarget(compute)) {
-    reason = "row-normalization block lowering requires a Blackhole target";
-    return failure();
-  }
-
   FailureOr<Value> inputTensor =
       getInputTensor(compute, analysis.block.getInput());
   FailureOr<Value> gammaTensor =

--- a/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLAssignDST.cpp
@@ -654,6 +654,11 @@ struct TTLAssignDSTPass : public impl::TTLAssignDSTBase<TTLAssignDSTPass> {
     }
 
     funcOp.walk([&](ComputeOp computeOp) {
+      // This block schedule owns a fixed contiguous DST layout. Its complete
+      // capacity check and assignment occur in LowerRowNormalizationCompute.
+      if (computeOp.containsOp<TileRowNormalizationBlockOp>()) {
+        return;
+      }
       Block *body = &computeOp.getRegion().front();
 
       std::uint32_t capacity = dstCapacity;

--- a/lib/Dialect/TTL/Transforms/TTLPrintComputeOpCreationPlans.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLPrintComputeOpCreationPlans.cpp
@@ -53,6 +53,8 @@ static StringRef stringifyRecipe(ComputeOpCreationRecipe recipe) {
     return "transpose";
   case ComputeOpCreationRecipe::Fused:
     return "fused";
+  case ComputeOpCreationRecipe::RowNormalization:
+    return "row_normalization";
   case ComputeOpCreationRecipe::Elide:
     return "elide";
   }

--- a/lib/Target/TTKernel/CMakeLists.txt
+++ b/lib/Target/TTKernel/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LLK_HEADERS
   experimental_fabric_2d_routing
   experimental_fabric_api
   experimental_reg_api
+  experimental_row_normalization
   experimental_semaphore
 )
 

--- a/lib/Target/TTKernel/CMakeLists.txt
+++ b/lib/Target/TTKernel/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LLK_HEADERS
   experimental_fabric_2d_routing
   experimental_fabric_api
   experimental_reg_api
+  experimental_row_normalization
   experimental_semaphore
 )
 

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -20,6 +20,7 @@
 #include "ttlang/Target/TTKernel/LLKs/experimental_pack_untilize_llks_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_padding_llks_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_reg_api_generated.h"
+#include "ttlang/Target/TTKernel/LLKs/experimental_row_normalization_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_semaphore_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_tilize_llks_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_untilize_llks_generated.h"
@@ -175,6 +176,10 @@ public:
       if (callee == "experimental::matmul_block") {
         emitLlk(experimental_matmul_llks_generated,
                 experimental_matmul_llks_generated_len);
+      }
+      if (callee == "experimental::row_normalization_block") {
+        emitLlk(experimental_row_normalization_generated,
+                experimental_row_normalization_generated_len);
       }
       if (callee == "experimental::write_row_mask_tile" ||
           callee == "experimental::write_col_mask_tile" ||

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -18,6 +18,7 @@
 #include "ttlang/Target/TTKernel/LLKs/experimental_pack_untilize_llks_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_padding_llks_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_reg_api_generated.h"
+#include "ttlang/Target/TTKernel/LLKs/experimental_row_normalization_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_semaphore_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_tilize_llks_generated.h"
 #include "ttlang/Target/TTKernel/LLKs/experimental_untilize_llks_generated.h"
@@ -164,6 +165,10 @@ public:
       if (callee == "experimental::matmul_block") {
         emitLlk(experimental_matmul_llks_generated,
                 experimental_matmul_llks_generated_len);
+      }
+      if (callee == "experimental::row_normalization_block") {
+        emitLlk(experimental_row_normalization_generated,
+                experimental_row_normalization_generated_len);
       }
       if (callee == "experimental::write_row_mask_tile" ||
           callee == "experimental::write_col_mask_tile" ||

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -2425,6 +2425,18 @@ def _lower_program_to_kernel(
                 ctx,
             )
 
+            # Compute creation needs explicit DST constraints before the final
+            # kernel-wide configuration analysis resolves automatic choices.
+            if ct.kernel_type == "compute":
+                if fp32_dest_acc_en is not None:
+                    ct.func_entry.attributes["fp32_dest_acc_en"] = BoolAttr.get(
+                        fp32_dest_acc_en, ctx
+                    )
+                if dst_full_sync_en is not None:
+                    ct.func_entry.attributes["dst_full_sync_en"] = BoolAttr.get(
+                        dst_full_sync_en, ctx
+                    )
+
             # Tag noc functions with their index so pipe semaphore allocation
             # and TTNN reader/writer role assignment can distinguish threads.
             if ct.kernel_type == "datamovement":

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1942,6 +1942,18 @@ def _lower_program_to_kernel(
                 ctx,
             )
 
+            # Compute creation needs explicit DST constraints before the final
+            # kernel-wide configuration analysis resolves automatic choices.
+            if ct.kernel_type == "compute":
+                if fp32_dest_acc_en is not None:
+                    ct.func_entry.attributes["fp32_dest_acc_en"] = BoolAttr.get(
+                        fp32_dest_acc_en, ctx
+                    )
+                if dst_full_sync_en is not None:
+                    ct.func_entry.attributes["dst_full_sync_en"] = BoolAttr.get(
+                        dst_full_sync_en, ctx
+                    )
+
             # Tag noc functions with their index so pipe semaphore allocation
             # and TTNN reader/writer role assignment can distinguish threads.
             if ct.kernel_type == "datamovement":

--- a/test/python/simple_add_f32.py
+++ b/test/python/simple_add_f32.py
@@ -61,7 +61,7 @@ def add_kernel_f32(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
+# CHECK-SAME: attributes {dst_full_sync_en = false, fp32_dest_acc_en = true, ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>}
 
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, f32>, buffer = l1, grid = [1, 1], memory = interleaved>>

--- a/test/python/simple_add_f32.py
+++ b/test/python/simple_add_f32.py
@@ -61,7 +61,7 @@ def add_kernel_f32(lhs, rhs, out):
 # =============================================================================
 
 # CHECK-LABEL: func.func @add_compute
-# CHECK-SAME: attributes {ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
+# CHECK-SAME: attributes {dst_full_sync_en = false, fp32_dest_acc_en = true, ttl.base_cta_index = 3 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>}
 
 # CHECK-LABEL: func.func @dm_read
 # CHECK-SAME: %arg0: tensor<1x1x!ttcore.tile<32x32, f32>, #ttl.layout<shape = [32, 32], element_type = !ttcore.tile<32x32, f32>, buffer = l1, grid = [1, 1], memory = interleaved>>

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -16,12 +16,22 @@ TILE_WIDTH = 32
 EPSILON = 1.0e-5
 
 
-def make_rmsnorm_kernel(tile_height, num_tiles, gamma_mode):
+def make_rmsnorm_kernel(
+    tile_height,
+    num_tiles,
+    gamma_mode,
+    fp32_dest_acc_en=None,
+    dst_full_sync_en=None,
+):
     scale = 1.0 / (num_tiles * tile_height * TILE_WIDTH)
 
     if gamma_mode == "none":
 
-        @ttl.operation(grid=(1, 1))
+        @ttl.operation(
+            grid=(1, 1),
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            dst_full_sync_en=dst_full_sync_en,
+        )
         def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
             input_dfb = ttl.make_dataflow_buffer_like(
                 input_tensor, shape=(1, num_tiles), block_count=2
@@ -64,7 +74,11 @@ def make_rmsnorm_kernel(tile_height, num_tiles, gamma_mode):
 
     if gamma_mode == "full":
 
-        @ttl.operation(grid=(1, 1))
+        @ttl.operation(
+            grid=(1, 1),
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            dst_full_sync_en=dst_full_sync_en,
+        )
         def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
             input_dfb = ttl.make_dataflow_buffer_like(
                 input_tensor, shape=(1, num_tiles), block_count=2
@@ -114,6 +128,72 @@ def make_rmsnorm_kernel(tile_height, num_tiles, gamma_mode):
     raise ValueError(f"unsupported gamma mode: {gamma_mode}")
 
 
+def make_materialized_rmsnorm_kernel(tile_height, num_tiles):
+    """Build an equivalent RMSNorm with explicit intermediate DFBs."""
+    scale = 1.0 / (num_tiles * tile_height * TILE_WIDTH)
+
+    @ttl.operation(grid=(1, 1))
+    def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
+        input_dfb = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, num_tiles), block_count=2
+        )
+        squared_dfb = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, num_tiles), block_count=2
+        )
+        reduced_dfb = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, 1), block_count=2
+        )
+        inverse_rms_dfb = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, 1), block_count=2
+        )
+        output_dfb = ttl.make_dataflow_buffer_like(
+            output_tensor, shape=(1, num_tiles), block_count=2
+        )
+
+        @ttl.compute()
+        def compute():
+            with input_dfb.wait() as input_block:
+                with squared_dfb.reserve() as squared_block:
+                    squared_block.store(input_block * input_block)
+
+                with squared_dfb.wait() as squared_block:
+                    with reduced_dfb.reserve() as reduced_block:
+                        reduced_block.store(
+                            ttl.math.reduce_sum(squared_block, dims=[0, 1])
+                        )
+
+                with reduced_dfb.wait() as reduced_block:
+                    with inverse_rms_dfb.reserve() as inverse_rms_block:
+                        mean_square = reduced_block * scale
+                        biased = mean_square + ttl.block.fill(
+                            EPSILON,
+                            shape=mean_square.shape,
+                            tile=(tile_height, TILE_WIDTH),
+                        )
+                        inverse_rms_block.store(ttl.math.rsqrt(biased))
+
+                with (
+                    inverse_rms_dfb.wait() as inverse_rms_block,
+                    output_dfb.reserve() as output_block,
+                ):
+                    scalar = ttl.block.broadcast(
+                        inverse_rms_block, dims=[0, 1], shape=input_block.shape
+                    )
+                    output_block.store(input_block * scalar)
+
+        @ttl.datamovement()
+        def dm_read():
+            with input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0:1, 0:num_tiles], input_block).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with output_dfb.wait() as output_block:
+                ttl.copy(output_block, output_tensor[0:1, 0:num_tiles]).wait()
+
+    return rmsnorm_kernel
+
+
 GAMMA_MODES = ("none", "full")
 ROW_CASES = ((16, 1, 512), (16, 3, 1536), (32, 7, 7168))
 RMSNORM_KERNELS = {
@@ -123,6 +203,18 @@ RMSNORM_KERNELS = {
     for tile_height, num_tiles, _ in ROW_CASES
     for gamma_mode in GAMMA_MODES
 }
+KERNEL_CONFIGS = ((False, False), (True, False), (False, True), (True, True))
+CONFIG_RMSNORM_KERNELS = {
+    (fp32_dest_acc_en, dst_full_sync_en): make_rmsnorm_kernel(
+        32,
+        4,
+        "none",
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        dst_full_sync_en=dst_full_sync_en,
+    )
+    for fp32_dest_acc_en, dst_full_sync_en in KERNEL_CONFIGS
+}
+MATERIALIZED_RMSNORM_KERNEL = make_materialized_rmsnorm_kernel(16, 3)
 
 
 def to_dram_with_tile(torch_tensor, device, tile_height):
@@ -137,15 +229,8 @@ def to_dram_with_tile(torch_tensor, device, tile_height):
     )
 
 
-@pytest.mark.parametrize(
-    "tile_height, num_tiles, width",
-    ROW_CASES,
-    ids=[str(row_case[2]) for row_case in ROW_CASES],
-)
-@pytest.mark.parametrize("gamma_mode", GAMMA_MODES)
-def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
-    """Normalize benchmark row widths across supported gamma modes."""
-    # The specialized hardware operation intentionally accepts bf16 tiles only.
+def run_rmsnorm(device, tile_height, num_tiles, width, gamma_mode, kernel):
+    """Run one RMSNorm kernel and return its result and reference."""
     shape = (tile_height, num_tiles * TILE_WIDTH)
     assert shape[0] * shape[1] == width
     input_torch = torch.randn(shape, dtype=torch.bfloat16)
@@ -156,14 +241,83 @@ def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
     gamma_tensor = to_dram_with_tile(gamma_torch, device, tile_height)
     output_tensor = to_dram_with_tile(output_torch, device, tile_height)
 
-    RMSNORM_KERNELS[(tile_height, num_tiles, gamma_mode)](
-        input_tensor, gamma_tensor, output_tensor
-    )
+    kernel(input_tensor, gamma_tensor, output_tensor)
     result = ttnn.to_torch(output_tensor).float()
 
     input_float = input_torch.float()
     expected = input_float * torch.rsqrt(input_float.square().mean() + EPSILON)
     if gamma_mode == "full":
         expected = expected * gamma_torch.float()
+    return result, expected
+
+
+def assert_rmsnorm_close(result, expected):
+    """Check RMSNorm correlation and magnitude at bf16 precision."""
     assert_pcc(expected, result, threshold=0.999)
-    assert_allclose(result, expected, rtol=0.05, atol=1.0)
+    assert_allclose(result, expected, rtol=0.05, atol=0.4)
+
+
+@pytest.mark.parametrize(
+    "tile_height, num_tiles, width",
+    ROW_CASES,
+    ids=[str(row_case[2]) for row_case in ROW_CASES],
+)
+@pytest.mark.parametrize("gamma_mode", GAMMA_MODES)
+def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
+    """Normalize benchmark row widths across supported gamma modes."""
+    # The specialized hardware operation intentionally accepts bf16 tiles only.
+    result, expected = run_rmsnorm(
+        device,
+        tile_height,
+        num_tiles,
+        width,
+        gamma_mode,
+        RMSNORM_KERNELS[(tile_height, num_tiles, gamma_mode)],
+    )
+    assert_rmsnorm_close(result, expected)
+
+
+@pytest.mark.parametrize(
+    "fp32_dest_acc_en, dst_full_sync_en",
+    KERNEL_CONFIGS,
+    ids=["bf16-half", "fp32-half", "bf16-full", "fp32-full"],
+)
+def test_rmsnorm_kernel_config(device, fp32_dest_acc_en, dst_full_sync_en):
+    """Exercise the fused LLK under every DST register configuration."""
+    result, expected = run_rmsnorm(
+        device,
+        tile_height=32,
+        num_tiles=4,
+        width=4096,
+        gamma_mode="none",
+        kernel=CONFIG_RMSNORM_KERNELS[(fp32_dest_acc_en, dst_full_sync_en)],
+    )
+    assert_rmsnorm_close(result, expected)
+
+
+def test_rmsnorm_matches_materialized(device):
+    """Compare scalar-retaining fusion with explicit DFB materialization."""
+    tile_height = 16
+    num_tiles = 3
+    shape = (tile_height, num_tiles * TILE_WIDTH)
+    input_torch = torch.randn(shape, dtype=torch.bfloat16)
+    gamma_torch = torch.zeros(shape, dtype=torch.bfloat16)
+    output_torch = torch.zeros(shape, dtype=torch.bfloat16)
+    materialized_output_torch = torch.zeros(shape, dtype=torch.bfloat16)
+
+    input_tensor = to_dram_with_tile(input_torch, device, tile_height)
+    gamma_tensor = to_dram_with_tile(gamma_torch, device, tile_height)
+    output_tensor = to_dram_with_tile(output_torch, device, tile_height)
+    materialized_output_tensor = to_dram_with_tile(
+        materialized_output_torch, device, tile_height
+    )
+
+    RMSNORM_KERNELS[(tile_height, num_tiles, "none")](
+        input_tensor, gamma_tensor, output_tensor
+    )
+    MATERIALIZED_RMSNORM_KERNEL(input_tensor, gamma_tensor, materialized_output_tensor)
+
+    result = ttnn.to_torch(output_tensor).float()
+    materialized_result = ttnn.to_torch(materialized_output_tensor).float()
+    assert_pcc(materialized_result, result, threshold=0.999)
+    assert_allclose(result, materialized_result, rtol=0.05, atol=0.2)

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -270,6 +270,12 @@ CONFIG_RMSNORM_KERNELS = {
     )
     for fp32_dest_acc_en, dst_full_sync_en in KERNEL_CONFIGS
 }
+FIVE_TILE_FP32_KERNEL = make_rmsnorm_kernel(
+    32,
+    5,
+    "none",
+    fp32_dest_acc_en=True,
+)
 MATERIALIZED_RMSNORM_KERNEL = make_materialized_rmsnorm_kernel(16, 3)
 
 
@@ -356,6 +362,26 @@ def test_rmsnorm_kernel_config(device, fp32_dest_acc_en, dst_full_sync_en):
         kernel=CONFIG_RMSNORM_KERNELS[(fp32_dest_acc_en, dst_full_sync_en)],
     )
     assert_rmsnorm_close(result, expected)
+
+
+def test_rmsnorm_five_tile_fp32_dest(
+    device,
+    monkeypatch,
+    tmp_path,
+):
+    """Select full synchronization when FP32 destination needs five slots."""
+    final_mlir = tmp_path / "rmsnorm.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir))
+    result, expected = run_rmsnorm(
+        device,
+        tile_height=32,
+        num_tiles=5,
+        width=5120,
+        gamma_mode="none",
+        kernel=FIVE_TILE_FP32_KERNEL,
+    )
+    assert_rmsnorm_close(result, expected)
+    assert final_mlir.read_text().count("tile_regs_acquire") == 1
 
 
 def test_rmsnorm_matches_materialized(device):

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -11,6 +11,7 @@ from ttl import ttl_api
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
 from utils.correctness import assert_allclose, assert_pcc  # noqa: E402
 
 TILE_WIDTH = 32
@@ -291,21 +292,12 @@ FIVE_TILE_FP32_KERNEL = make_rmsnorm_kernel(
     fp32_dest_acc_en=True,
 )
 MATERIALIZED_RMSNORM_KERNEL = make_materialized_rmsnorm_kernel(16, 3)
+TENSOR_FACTORIES = (to_dram, to_l1)
 
 
-def to_dram_with_tile(torch_tensor, device, tile_height):
-    """Create a tiled bf16 tensor with the benchmark's physical tile height."""
-    return ttnn.from_torch(
-        torch_tensor,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        tile=ttnn.Tile((tile_height, TILE_WIDTH)),
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-
-def run_rmsnorm(device, tile_height, num_tiles, width, gamma_mode, kernel):
+def run_rmsnorm(
+    device, tile_height, num_tiles, width, gamma_mode, kernel, tensor_factory
+):
     """Run one RMSNorm kernel and return its result and reference."""
     shape = (tile_height, num_tiles * TILE_WIDTH)
     assert shape[0] * shape[1] == width
@@ -316,9 +308,10 @@ def run_rmsnorm(device, tile_height, num_tiles, width, gamma_mode, kernel):
     gamma_torch = torch.randn(gamma_shape, dtype=torch.bfloat16)
     output_torch = torch.zeros(shape, dtype=torch.bfloat16)
 
-    input_tensor = to_dram_with_tile(input_torch, device, tile_height)
-    gamma_tensor = to_dram_with_tile(gamma_torch, device, tile_height)
-    output_tensor = to_dram_with_tile(output_torch, device, tile_height)
+    tile = (tile_height, TILE_WIDTH)
+    input_tensor = tensor_factory(input_torch, device, tile=tile)
+    gamma_tensor = tensor_factory(gamma_torch, device, tile=tile)
+    output_tensor = tensor_factory(output_torch, device, tile=tile)
 
     kernel(input_tensor, gamma_tensor, output_tensor)
     result = ttnn.to_torch(output_tensor).float()
@@ -346,7 +339,8 @@ def assert_rmsnorm_close(result, expected):
     ids=[str(row_case[2]) for row_case in ROW_CASES],
 )
 @pytest.mark.parametrize("gamma_mode", GAMMA_MODES)
-def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
+@pytest.mark.parametrize("tensor_factory", TENSOR_FACTORIES, ids=("dram", "l1"))
+def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode, tensor_factory):
     """Validate RMSNorm semantics at benchmark widths and gamma modes."""
     # The specialized hardware operation intentionally accepts bf16 tiles only.
     # Column-broadcast gamma exercises ordinary compute creation because the
@@ -360,6 +354,7 @@ def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
         width,
         gamma_mode,
         RMSNORM_KERNELS[(tile_height, num_tiles, gamma_mode)],
+        tensor_factory,
     )
     assert_rmsnorm_close(result, expected)
 
@@ -369,7 +364,10 @@ def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
     KERNEL_CONFIGS,
     ids=["bf16-half", "fp32-half", "bf16-full", "fp32-full"],
 )
-def test_rmsnorm_kernel_config(device, fp32_dest_acc_en, dst_full_sync_en):
+@pytest.mark.parametrize("tensor_factory", TENSOR_FACTORIES, ids=("dram", "l1"))
+def test_rmsnorm_kernel_config(
+    device, fp32_dest_acc_en, dst_full_sync_en, tensor_factory
+):
     """Exercise the fused LLK under every DST register configuration."""
     require_row_normalization_schedule(device)
     result, expected = run_rmsnorm(
@@ -379,14 +377,17 @@ def test_rmsnorm_kernel_config(device, fp32_dest_acc_en, dst_full_sync_en):
         width=4096,
         gamma_mode="none",
         kernel=CONFIG_RMSNORM_KERNELS[(fp32_dest_acc_en, dst_full_sync_en)],
+        tensor_factory=tensor_factory,
     )
     assert_rmsnorm_close(result, expected)
 
 
+@pytest.mark.parametrize("tensor_factory", TENSOR_FACTORIES, ids=("dram", "l1"))
 def test_rmsnorm_five_tile_fp32_dest(
     device,
     monkeypatch,
     tmp_path,
+    tensor_factory,
 ):
     """Select full synchronization when FP32 destination needs five slots."""
     require_row_normalization_schedule(device)
@@ -399,12 +400,14 @@ def test_rmsnorm_five_tile_fp32_dest(
         width=5120,
         gamma_mode="none",
         kernel=FIVE_TILE_FP32_KERNEL,
+        tensor_factory=tensor_factory,
     )
     assert_rmsnorm_close(result, expected)
     assert final_mlir.read_text().count("tile_regs_acquire") == 1
 
 
-def test_rmsnorm_matches_materialized(device):
+@pytest.mark.parametrize("tensor_factory", TENSOR_FACTORIES, ids=("dram", "l1"))
+def test_rmsnorm_matches_materialized(device, tensor_factory):
     """Compare scalar-retaining fusion with explicit DFB materialization."""
     tile_height = 16
     num_tiles = 3
@@ -414,11 +417,12 @@ def test_rmsnorm_matches_materialized(device):
     output_torch = torch.zeros(shape, dtype=torch.bfloat16)
     materialized_output_torch = torch.zeros(shape, dtype=torch.bfloat16)
 
-    input_tensor = to_dram_with_tile(input_torch, device, tile_height)
-    gamma_tensor = to_dram_with_tile(gamma_torch, device, tile_height)
-    output_tensor = to_dram_with_tile(output_torch, device, tile_height)
-    materialized_output_tensor = to_dram_with_tile(
-        materialized_output_torch, device, tile_height
+    tile = (tile_height, TILE_WIDTH)
+    input_tensor = tensor_factory(input_torch, device, tile=tile)
+    gamma_tensor = tensor_factory(gamma_torch, device, tile=tile)
+    output_tensor = tensor_factory(output_torch, device, tile=tile)
+    materialized_output_tensor = tensor_factory(
+        materialized_output_torch, device, tile=tile
     )
 
     RMSNORM_KERNELS[(tile_height, num_tiles, "none")](

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -125,6 +125,62 @@ def make_rmsnorm_kernel(
 
         return rmsnorm_kernel
 
+    if gamma_mode == "column_broadcast":
+
+        @ttl.operation(
+            grid=(1, 1),
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            dst_full_sync_en=dst_full_sync_en,
+        )
+        def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
+            input_dfb = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, num_tiles), block_count=2
+            )
+            gamma_dfb = ttl.make_dataflow_buffer_like(
+                gamma_tensor, shape=(1, 1), block_count=2
+            )
+            output_dfb = ttl.make_dataflow_buffer_like(
+                output_tensor, shape=(1, num_tiles), block_count=2
+            )
+
+            @ttl.compute()
+            def compute():
+                with (
+                    input_dfb.wait() as input_block,
+                    gamma_dfb.wait() as gamma_block,
+                    output_dfb.reserve() as output_block,
+                ):
+                    squared = input_block * input_block
+                    reduced = ttl.math.reduce_sum(squared, dims=[0, 1])
+                    mean_square = reduced * scale
+                    biased = mean_square + ttl.block.fill(
+                        EPSILON,
+                        shape=mean_square.shape,
+                        tile=(tile_height, TILE_WIDTH),
+                    )
+                    inverse_rms = ttl.math.rsqrt(biased)
+                    scalar = ttl.block.broadcast(
+                        inverse_rms, dims=[0, 1], shape=input_block.shape
+                    )
+                    repeated_gamma = ttl.block.broadcast(
+                        gamma_block, dims=[1], shape=input_block.shape
+                    )
+                    output_block.store(input_block * scalar * repeated_gamma)
+
+            @ttl.datamovement()
+            def dm_read():
+                with input_dfb.reserve() as input_block:
+                    ttl.copy(input_tensor[0:1, 0:num_tiles], input_block).wait()
+                with gamma_dfb.reserve() as gamma_block:
+                    ttl.copy(gamma_tensor[0:1, 0:1], gamma_block).wait()
+
+            @ttl.datamovement()
+            def dm_write():
+                with output_dfb.wait() as output_block:
+                    ttl.copy(output_block, output_tensor[0:1, 0:num_tiles]).wait()
+
+        return rmsnorm_kernel
+
     raise ValueError(f"unsupported gamma mode: {gamma_mode}")
 
 
@@ -194,7 +250,7 @@ def make_materialized_rmsnorm_kernel(tile_height, num_tiles):
     return rmsnorm_kernel
 
 
-GAMMA_MODES = ("none", "full")
+GAMMA_MODES = ("none", "full", "column_broadcast")
 ROW_CASES = ((16, 1, 512), (16, 3, 1536), (32, 7, 7168))
 RMSNORM_KERNELS = {
     (tile_height, num_tiles, gamma_mode): make_rmsnorm_kernel(
@@ -234,7 +290,10 @@ def run_rmsnorm(device, tile_height, num_tiles, width, gamma_mode, kernel):
     shape = (tile_height, num_tiles * TILE_WIDTH)
     assert shape[0] * shape[1] == width
     input_torch = torch.randn(shape, dtype=torch.bfloat16)
-    gamma_torch = torch.randn(shape, dtype=torch.bfloat16)
+    gamma_shape = (
+        (tile_height, TILE_WIDTH) if gamma_mode == "column_broadcast" else shape
+    )
+    gamma_torch = torch.randn(gamma_shape, dtype=torch.bfloat16)
     output_torch = torch.zeros(shape, dtype=torch.bfloat16)
 
     input_tensor = to_dram_with_tile(input_torch, device, tile_height)
@@ -248,6 +307,10 @@ def run_rmsnorm(device, tile_height, num_tiles, width, gamma_mode, kernel):
     expected = input_float * torch.rsqrt(input_float.square().mean() + EPSILON)
     if gamma_mode == "full":
         expected = expected * gamma_torch.float()
+    elif gamma_mode == "column_broadcast":
+        expected = expected * gamma_torch[:, :1].float().repeat(
+            1, num_tiles * TILE_WIDTH
+        )
     return result, expected
 
 

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""RMSNorm rows lowered through scalar reuse in one DST acquisition."""
+
+import pytest
+import torch
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from utils.correctness import assert_allclose, assert_pcc  # noqa: E402
+
+TILE_WIDTH = 32
+EPSILON = 1.0e-5
+
+
+def make_rmsnorm_kernel(tile_height, num_tiles, gamma_mode):
+    scale = 1.0 / (num_tiles * tile_height * TILE_WIDTH)
+
+    if gamma_mode == "none":
+
+        @ttl.operation(grid=(1, 1))
+        def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
+            input_dfb = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, num_tiles), block_count=2
+            )
+            output_dfb = ttl.make_dataflow_buffer_like(
+                output_tensor, shape=(1, num_tiles), block_count=2
+            )
+
+            @ttl.compute()
+            def compute():
+                with (
+                    input_dfb.wait() as input_block,
+                    output_dfb.reserve() as output_block,
+                ):
+                    squared = input_block * input_block
+                    reduced = ttl.math.reduce_sum(squared, dims=[0, 1])
+                    mean_square = reduced * scale
+                    biased = mean_square + ttl.block.fill(
+                        EPSILON,
+                        shape=mean_square.shape,
+                        tile=(tile_height, TILE_WIDTH),
+                    )
+                    inverse_rms = ttl.math.rsqrt(biased)
+                    scalar = ttl.block.broadcast(
+                        inverse_rms, dims=[0, 1], shape=input_block.shape
+                    )
+                    output_block.store(input_block * scalar)
+
+            @ttl.datamovement()
+            def dm_read():
+                with input_dfb.reserve() as input_block:
+                    ttl.copy(input_tensor[0:1, 0:num_tiles], input_block).wait()
+
+            @ttl.datamovement()
+            def dm_write():
+                with output_dfb.wait() as output_block:
+                    ttl.copy(output_block, output_tensor[0:1, 0:num_tiles]).wait()
+
+        return rmsnorm_kernel
+
+    if gamma_mode == "full":
+
+        @ttl.operation(grid=(1, 1))
+        def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
+            input_dfb = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, num_tiles), block_count=2
+            )
+            gamma_dfb = ttl.make_dataflow_buffer_like(
+                gamma_tensor, shape=(1, num_tiles), block_count=2
+            )
+            output_dfb = ttl.make_dataflow_buffer_like(
+                output_tensor, shape=(1, num_tiles), block_count=2
+            )
+
+            @ttl.compute()
+            def compute():
+                with (
+                    input_dfb.wait() as input_block,
+                    gamma_dfb.wait() as gamma_block,
+                    output_dfb.reserve() as output_block,
+                ):
+                    squared = input_block * input_block
+                    reduced = ttl.math.reduce_sum(squared, dims=[0, 1])
+                    mean_square = reduced * scale
+                    biased = mean_square + ttl.block.fill(
+                        EPSILON,
+                        shape=mean_square.shape,
+                        tile=(tile_height, TILE_WIDTH),
+                    )
+                    inverse_rms = ttl.math.rsqrt(biased)
+                    scalar = ttl.block.broadcast(
+                        inverse_rms, dims=[0, 1], shape=input_block.shape
+                    )
+                    output_block.store(input_block * scalar * gamma_block)
+
+            @ttl.datamovement()
+            def dm_read():
+                with input_dfb.reserve() as input_block:
+                    ttl.copy(input_tensor[0:1, 0:num_tiles], input_block).wait()
+                with gamma_dfb.reserve() as gamma_block:
+                    ttl.copy(gamma_tensor[0:1, 0:num_tiles], gamma_block).wait()
+
+            @ttl.datamovement()
+            def dm_write():
+                with output_dfb.wait() as output_block:
+                    ttl.copy(output_block, output_tensor[0:1, 0:num_tiles]).wait()
+
+        return rmsnorm_kernel
+
+    @ttl.operation(grid=(1, 1))
+    def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
+        input_dfb = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, num_tiles), block_count=2
+        )
+        gamma_dfb = ttl.make_dataflow_buffer_like(
+            gamma_tensor, shape=(1, 1), block_count=2
+        )
+        output_dfb = ttl.make_dataflow_buffer_like(
+            output_tensor, shape=(1, num_tiles), block_count=2
+        )
+
+        @ttl.compute()
+        def compute():
+            with (
+                input_dfb.wait() as input_block,
+                gamma_dfb.wait() as gamma_block,
+                output_dfb.reserve() as output_block,
+            ):
+                squared = input_block * input_block
+                reduced = ttl.math.reduce_sum(squared, dims=[0, 1])
+                mean_square = reduced * scale
+                biased = mean_square + ttl.block.fill(
+                    EPSILON,
+                    shape=mean_square.shape,
+                    tile=(tile_height, TILE_WIDTH),
+                )
+                inverse_rms = ttl.math.rsqrt(biased)
+                scalar = ttl.block.broadcast(
+                    inverse_rms, dims=[0, 1], shape=input_block.shape
+                )
+                repeated_gamma = ttl.block.broadcast(
+                    gamma_block, dims=[1], shape=input_block.shape
+                )
+                output_block.store(input_block * scalar * repeated_gamma)
+
+        @ttl.datamovement()
+        def dm_read():
+            with input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0:1, 0:num_tiles], input_block).wait()
+            with gamma_dfb.reserve() as gamma_block:
+                ttl.copy(gamma_tensor[0:1, 0:1], gamma_block).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with output_dfb.wait() as output_block:
+                ttl.copy(output_block, output_tensor[0:1, 0:num_tiles]).wait()
+
+    return rmsnorm_kernel
+
+
+GAMMA_MODES = ("none", "full", "repeated")
+ROW_CASES = ((16, 1, 512), (16, 3, 1536), (32, 7, 7168))
+RMSNORM_KERNELS = {
+    (tile_height, num_tiles, gamma_mode): make_rmsnorm_kernel(
+        tile_height, num_tiles, gamma_mode
+    )
+    for tile_height, num_tiles, _ in ROW_CASES
+    for gamma_mode in GAMMA_MODES
+}
+
+
+def to_dram_with_tile(torch_tensor, device, tile_height):
+    """Create a tiled bf16 tensor with the benchmark's physical tile height."""
+    return ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        tile=ttnn.Tile((tile_height, TILE_WIDTH)),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+@pytest.mark.parametrize(
+    "tile_height, num_tiles, width",
+    ROW_CASES,
+    ids=[str(row_case[2]) for row_case in ROW_CASES],
+)
+@pytest.mark.parametrize("gamma_mode", GAMMA_MODES)
+def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
+    """Normalize benchmark row widths across supported gamma modes."""
+    # The specialized hardware operation intentionally accepts bf16 tiles only.
+    shape = (tile_height, num_tiles * TILE_WIDTH)
+    assert shape[0] * shape[1] == width
+    input_torch = torch.randn(shape, dtype=torch.bfloat16)
+    gamma_shape = (tile_height, TILE_WIDTH) if gamma_mode == "repeated" else shape
+    gamma_torch = torch.randn(gamma_shape, dtype=torch.bfloat16)
+    output_torch = torch.zeros(shape, dtype=torch.bfloat16)
+
+    input_tensor = to_dram_with_tile(input_torch, device, tile_height)
+    gamma_tensor = to_dram_with_tile(gamma_torch, device, tile_height)
+    output_tensor = to_dram_with_tile(output_torch, device, tile_height)
+
+    RMSNORM_KERNELS[(tile_height, num_tiles, gamma_mode)](
+        input_tensor, gamma_tensor, output_tensor
+    )
+    result = ttnn.to_torch(output_tensor).float()
+
+    input_float = input_torch.float()
+    expected = input_float * torch.rsqrt(input_float.square().mean() + EPSILON)
+    if gamma_mode == "full":
+        expected = expected * gamma_torch.float()
+    elif gamma_mode == "repeated":
+        expected = expected * gamma_torch.float().repeat(1, num_tiles)
+    assert_pcc(expected, result, threshold=0.999)
+    assert_allclose(result, expected, rtol=0.05, atol=1.0)

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -111,58 +111,10 @@ def make_rmsnorm_kernel(tile_height, num_tiles, gamma_mode):
 
         return rmsnorm_kernel
 
-    @ttl.operation(grid=(1, 1))
-    def rmsnorm_kernel(input_tensor, gamma_tensor, output_tensor):
-        input_dfb = ttl.make_dataflow_buffer_like(
-            input_tensor, shape=(1, num_tiles), block_count=2
-        )
-        gamma_dfb = ttl.make_dataflow_buffer_like(
-            gamma_tensor, shape=(1, 1), block_count=2
-        )
-        output_dfb = ttl.make_dataflow_buffer_like(
-            output_tensor, shape=(1, num_tiles), block_count=2
-        )
-
-        @ttl.compute()
-        def compute():
-            with (
-                input_dfb.wait() as input_block,
-                gamma_dfb.wait() as gamma_block,
-                output_dfb.reserve() as output_block,
-            ):
-                squared = input_block * input_block
-                reduced = ttl.math.reduce_sum(squared, dims=[0, 1])
-                mean_square = reduced * scale
-                biased = mean_square + ttl.block.fill(
-                    EPSILON,
-                    shape=mean_square.shape,
-                    tile=(tile_height, TILE_WIDTH),
-                )
-                inverse_rms = ttl.math.rsqrt(biased)
-                scalar = ttl.block.broadcast(
-                    inverse_rms, dims=[0, 1], shape=input_block.shape
-                )
-                repeated_gamma = ttl.block.broadcast(
-                    gamma_block, dims=[1], shape=input_block.shape
-                )
-                output_block.store(input_block * scalar * repeated_gamma)
-
-        @ttl.datamovement()
-        def dm_read():
-            with input_dfb.reserve() as input_block:
-                ttl.copy(input_tensor[0:1, 0:num_tiles], input_block).wait()
-            with gamma_dfb.reserve() as gamma_block:
-                ttl.copy(gamma_tensor[0:1, 0:1], gamma_block).wait()
-
-        @ttl.datamovement()
-        def dm_write():
-            with output_dfb.wait() as output_block:
-                ttl.copy(output_block, output_tensor[0:1, 0:num_tiles]).wait()
-
-    return rmsnorm_kernel
+    raise ValueError(f"unsupported gamma mode: {gamma_mode}")
 
 
-GAMMA_MODES = ("none", "full", "repeated")
+GAMMA_MODES = ("none", "full")
 ROW_CASES = ((16, 1, 512), (16, 3, 1536), (32, 7, 7168))
 RMSNORM_KERNELS = {
     (tile_height, num_tiles, gamma_mode): make_rmsnorm_kernel(
@@ -197,8 +149,7 @@ def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
     shape = (tile_height, num_tiles * TILE_WIDTH)
     assert shape[0] * shape[1] == width
     input_torch = torch.randn(shape, dtype=torch.bfloat16)
-    gamma_shape = (tile_height, TILE_WIDTH) if gamma_mode == "repeated" else shape
-    gamma_torch = torch.randn(gamma_shape, dtype=torch.bfloat16)
+    gamma_torch = torch.randn(shape, dtype=torch.bfloat16)
     output_torch = torch.zeros(shape, dtype=torch.bfloat16)
 
     input_tensor = to_dram_with_tile(input_torch, device, tile_height)
@@ -214,7 +165,5 @@ def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
     expected = input_float * torch.rsqrt(input_float.square().mean() + EPSILON)
     if gamma_mode == "full":
         expected = expected * gamma_torch.float()
-    elif gamma_mode == "repeated":
-        expected = expected * gamma_torch.float().repeat(1, num_tiles)
     assert_pcc(expected, result, threshold=0.999)
     assert_allclose(result, expected, rtol=0.05, atol=1.0)

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""RMSNorm rows lowered through scalar reuse in one DST acquisition."""
+"""RMSNorm row-fusion and ordinary-lowering device coverage."""
 
 import pytest
 import torch
 import ttl
+from ttl import ttl_api
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
@@ -14,6 +15,19 @@ from utils.correctness import assert_allclose, assert_pcc  # noqa: E402
 
 TILE_WIDTH = 32
 EPSILON = 1.0e-5
+ROW_NORMALIZATION_TARGET_ARCHS = frozenset({"blackhole"})
+
+
+def require_row_normalization_schedule(device):
+    """Skip schedule-specific cases when the pinned LLK lacks the schedule."""
+    target_arch = ttl_api._detect_device_arch(device)
+    if target_arch is None:
+        pytest.fail("unable to determine the test device architecture")
+    if target_arch not in ROW_NORMALIZATION_TARGET_ARCHS:
+        pytest.skip(
+            "the pinned target dependency does not implement the fixed-block "
+            "row-normalization schedule"
+        )
 
 
 def make_rmsnorm_kernel(
@@ -333,10 +347,12 @@ def assert_rmsnorm_close(result, expected):
 )
 @pytest.mark.parametrize("gamma_mode", GAMMA_MODES)
 def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
-    """Validate fixed-block and ordinary gamma variants at benchmark widths."""
+    """Validate RMSNorm semantics at benchmark widths and gamma modes."""
     # The specialized hardware operation intentionally accepts bf16 tiles only.
     # Column-broadcast gamma exercises ordinary compute creation because the
-    # fixed-block schedule accepts only absent or full-row gamma.
+    # fixed-block schedule accepts only absent or full-row gamma. Targets whose
+    # dependencies lack that schedule use ordinary compute creation for all
+    # modes.
     result, expected = run_rmsnorm(
         device,
         tile_height,
@@ -355,6 +371,7 @@ def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
 )
 def test_rmsnorm_kernel_config(device, fp32_dest_acc_en, dst_full_sync_en):
     """Exercise the fused LLK under every DST register configuration."""
+    require_row_normalization_schedule(device)
     result, expected = run_rmsnorm(
         device,
         tile_height=32,
@@ -372,6 +389,7 @@ def test_rmsnorm_five_tile_fp32_dest(
     tmp_path,
 ):
     """Select full synchronization when FP32 destination needs five slots."""
+    require_row_normalization_schedule(device)
     final_mlir = tmp_path / "rmsnorm.mlir"
     monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir))
     result, expected = run_rmsnorm(

--- a/test/python/test_rmsnorm.py
+++ b/test/python/test_rmsnorm.py
@@ -333,8 +333,10 @@ def assert_rmsnorm_close(result, expected):
 )
 @pytest.mark.parametrize("gamma_mode", GAMMA_MODES)
 def test_rmsnorm(device, tile_height, num_tiles, width, gamma_mode):
-    """Normalize benchmark row widths across supported gamma modes."""
+    """Validate fixed-block and ordinary gamma variants at benchmark widths."""
     # The specialized hardware operation intentionally accepts bf16 tiles only.
+    # Column-broadcast gamma exercises ordinary compute creation because the
+    # fixed-block schedule accepts only absent or full-row gamma.
     result, expected = run_rmsnorm(
         device,
         tile_height,

--- a/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
@@ -2,7 +2,7 @@
 // sequence without compiler-allocated intermediate dataflow buffers.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' -o /dev/null 2>&1 | FileCheck %s --check-prefix=PLAN
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute))' | FileCheck %s --check-prefix=COMPUTE
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,func.func(ttkernel-combine-pack-tiles),canonicalize,cse,lower-affine)' -o %t.ttkernel.mlir
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,func.func(ttkernel-combine-pack-tiles),canonicalize,cse,lower-affine)' -o %t.ttkernel.mlir
 // RUN: FileCheck %s --input-file=%t.ttkernel.mlir --check-prefix=TTKERNEL
 // RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.ttkernel.mlir -o %t.emitc.mlir
 // RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir

--- a/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
@@ -47,7 +47,7 @@
 // CPP-NEXT:  tile_regs_release();
 // CPP-NOT:   tile_regs_acquire();
 
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @row_normalization_full_gamma()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}

--- a/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
@@ -1,0 +1,114 @@
+// Verifies recognition and end-to-end lowering of a one-row normalization
+// sequence without compiler-allocated intermediate dataflow buffers.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' -o /dev/null 2>&1 | FileCheck %s --check-prefix=PLAN
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute))' | FileCheck %s --check-prefix=COMPUTE
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,func.func(ttkernel-combine-pack-tiles),canonicalize,cse,lower-affine)' -o %t.ttkernel.mlir
+// RUN: FileCheck %s --input-file=%t.ttkernel.mlir --check-prefix=TTKERNEL
+// RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.ttkernel.mlir -o %t.emitc.mlir
+// RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
+// RUN: FileCheck %s --input-file=%t.cpp --check-prefix=CPP
+
+// The complete expression is recorded as one row-normalization recipe.
+// PLAN-LABEL: ComputeOp creation plan @row_normalization_full_gamma
+// PLAN:       ttl.mul kind=fused recipe=row_normalization legal=true inputs=2 outputs=1 transactions=1
+// PLAN:       order=[C0]
+
+// Producer creation preserves the expression until specialized conversion.
+// Conversion emits one compute with no intermediate DFB allocation.
+// COMPUTE-LABEL: func.func @row_normalization_full_gamma
+// COMPUTE-NOT:   ttl.bind_cb{{.*}}ttl.compiler_allocated
+// COMPUTE:       ttl.compute
+// COMPUTE:         ttl.tile_row_normalization_block
+// COMPUTE-NOT:   ttl.compute
+
+// TTKernel lowering initializes the common unpack/pack configuration and uses
+// one DST transaction for all output tiles.
+// TTKERNEL-LABEL: func.func @row_normalization_full_gamma
+// TTKERNEL-NOT:   ttl.bind_cb
+// TTKERNEL:       ttkernel.init_sfpu(%[[INPUT:[a-zA-Z0-9_]+]], %[[OUTPUT:[a-zA-Z0-9_]+]])
+// TTKERNEL-NEXT:  ttkernel.tile_regs_acquire
+// TTKERNEL-NEXT:  ttkernel.experimental_row_normalization_block(%[[INPUT]], %[[GAMMA:[a-zA-Z0-9_]+]], %[[OUTPUT]]) num_tiles = 3
+// TTKERNEL-SAME:  has_gamma = true repeat_gamma = false dtype = <bf16>
+// TTKERNEL-NEXT:  ttkernel.tile_regs_commit
+// TTKERNEL-NEXT:  ttkernel.tile_regs_wait
+// TTKERNEL-NEXT:  ttkernel.pack_tile_block(%{{.*}}, %[[OUTPUT]], %{{.*}})
+// TTKERNEL-NEXT:  ttkernel.tile_regs_release
+// TTKERNEL-NOT:   ttkernel.tile_regs_acquire
+
+// C++ translation retains the single-acquire and block-pack schedule.
+// CPP-LABEL: void kernel_main()
+// CPP:       init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
+// CPP-NEXT:  tile_regs_acquire();
+// CPP-NEXT:  experimental::row_normalization_block<3, true, false, DataFormat::Float16_b>(
+// CPP-SAME:  1020331500U,
+// CPP-NEXT:  tile_regs_commit();
+// CPP-NEXT:  tile_regs_wait();
+// CPP-NEXT:  pack_tile_block({{.*}}, get_compile_time_arg_val(2), {{.*}});
+// CPP-NEXT:  tile_regs_release();
+// CPP-NOT:   tile_regs_acquire();
+
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @row_normalization_full_gamma()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 3], !ttcore.tile<16x32, bf16>, 2>
+    %gamma_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 3], !ttcore.tile<16x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+        : !ttl.cb<[1, 3], !ttcore.tile<16x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 3], !ttcore.tile<16x32, bf16>, 2>
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x3x!ttcore.tile<16x32, bf16>>,
+           !ttl.cb<[1, 3], !ttcore.tile<16x32, bf16>, 2>)
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %gamma_wait = ttl.cb_wait %gamma_dfb
+        : <[1, 3], !ttcore.tile<16x32, bf16>, 2>
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %gamma = ttl.attach_cb %gamma_wait, %gamma_dfb
+        : (tensor<1x3x!ttcore.tile<16x32, bf16>>,
+           !ttl.cb<[1, 3], !ttcore.tile<16x32, bf16>, 2>)
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x3x!ttcore.tile<16x32, bf16>>,
+          tensor<1x3x!ttcore.tile<16x32, bf16>>
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<16x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x3x!ttcore.tile<16x32, bf16>>,
+           tensor<1x1x!ttcore.tile<16x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+    %mean_square = ttl.mul_unary_const %reduced, 6.510417e-04
+        : tensor<1x1x!ttcore.tile<16x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<16x32, bf16>>
+    %biased = ttl.add %mean_square, %epsilon
+        : tensor<1x1x!ttcore.tile<16x32, bf16>>,
+          tensor<1x1x!ttcore.tile<16x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+    %inverse_rms = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<16x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+    %scalar = ttl.block.broadcast %inverse_rms dims = [0, 1], shape = [1, 3]
+        : tensor<1x1x!ttcore.tile<16x32, bf16>>
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %normalized = ttl.mul %input, %scalar
+        : tensor<1x3x!ttcore.tile<16x32, bf16>>,
+          tensor<1x3x!ttcore.tile<16x32, bf16>>
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %result = ttl.mul %normalized, %gamma
+        : tensor<1x3x!ttcore.tile<16x32, bf16>>,
+          tensor<1x3x!ttcore.tile<16x32, bf16>>
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 3], !ttcore.tile<16x32, bf16>, 2>
+          -> tensor<1x3x!ttcore.tile<16x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x3x!ttcore.tile<16x32, bf16>>,
+          tensor<1x3x!ttcore.tile<16x32, bf16>>
+    return
+  }
+}

--- a/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/row_normalization.mlir
@@ -28,7 +28,7 @@
 // TTKERNEL:       ttkernel.init_sfpu(%[[INPUT:[a-zA-Z0-9_]+]], %[[OUTPUT:[a-zA-Z0-9_]+]])
 // TTKERNEL-NEXT:  ttkernel.tile_regs_acquire
 // TTKERNEL-NEXT:  ttkernel.experimental_row_normalization_block(%[[INPUT]], %[[GAMMA:[a-zA-Z0-9_]+]], %[[OUTPUT]]) num_tiles = 3
-// TTKERNEL-SAME:  has_gamma = true repeat_gamma = false dtype = <bf16>
+// TTKERNEL-SAME:  has_gamma = true dtype = <bf16>
 // TTKERNEL-NEXT:  ttkernel.tile_regs_commit
 // TTKERNEL-NEXT:  ttkernel.tile_regs_wait
 // TTKERNEL-NEXT:  ttkernel.pack_tile_block(%{{.*}}, %[[OUTPUT]], %{{.*}})
@@ -39,7 +39,7 @@
 // CPP-LABEL: void kernel_main()
 // CPP:       init_sfpu(get_compile_time_arg_val(0), get_compile_time_arg_val(2));
 // CPP-NEXT:  tile_regs_acquire();
-// CPP-NEXT:  experimental::row_normalization_block<3, true, false, DataFormat::Float16_b>(
+// CPP-NEXT:  experimental::row_normalization_block<3, true, DataFormat::Float16_b>(
 // CPP-SAME:  1020331500U,
 // CPP-NEXT:  tile_regs_commit();
 // CPP-NEXT:  tile_regs_wait();

--- a/test/ttlang/Conversion/TTLToSCF/compute_to_loops_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToSCF/compute_to_loops_invalid.mlir
@@ -38,3 +38,58 @@ func.func @two_block_matmuls(
   } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   func.return %0 : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
+
+// -----
+
+#identity = affine_map<(row, column) -> (row, column)>
+
+// The target capability, rather than DST capacity, restricts this schedule to
+// eight tiles.
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @row_normalization_exceeds_target_limit() {
+    %c-1 = arith.constant -1 : index
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 9], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 9], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 9], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x9x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 9], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %reserved = ttl.cb_reserve %output_dfb
+        : <[1, 9], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %empty = tensor.empty() : tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %output = ttl.attach_cb %empty, %output_dfb
+        : (tensor<1x9x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 9], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %result = ttl.compute
+        ins(%input : tensor<1x9x!ttcore.tile<32x32, bf16>>)
+        outs(%output : tensor<1x9x!ttcore.tile<32x32, bf16>>)
+        {indexing_maps = [#identity, #identity],
+         iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+         %output_tile: !ttcore.tile<32x32, bf16>):
+      %row = ttl.iter_index 0 : index
+      %column = ttl.iter_index 1 : index
+      // expected-error @below {{'ttl.tile_row_normalization_block' op row-normalization schedule requires 9 tiles, but the target supports at most 8}}
+      %normalized = ttl.tile_row_normalization_block
+          %input_tile, %input_tile, %output_tile
+          scale = 1.220703e-04 epsilon = 1.000000e-05
+          has_gamma = false num_tiles = 9 into dst[%c-1]
+          {ttl.dst_placeholder}
+          : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+            !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+      ttl.tile_store %normalized, %reserved[%row, %column] from dst[%c-1]
+          {ttl.dst_placeholder}
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x9x!ttcore.tile<32x32, bf16>>
+      ttl.yield
+    } -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}

--- a/test/ttlang/Conversion/TTLToSCF/compute_to_loops_target_independent.mlir
+++ b/test/ttlang/Conversion/TTLToSCF/compute_to_loops_target_independent.mlir
@@ -1,0 +1,63 @@
+// Tests that ordinary compute lowering does not require target-specific
+// schedule capabilities.
+
+// RUN: ttlang-opt %s -ttl-lower-to-loops | FileCheck %s
+
+#identity = affine_map<(dim0, dim1) -> (dim0, dim1)>
+
+module attributes {ttl.target_arch = #ttcore.arch<quasar>} {
+  // An unsupported schedule target does not affect ordinary tile addition.
+  // CHECK-LABEL: func.func @ordinary_compute
+  // CHECK: scf.for
+  // CHECK: ttl.tile_add
+  // CHECK-NOT: ttl.compute
+  func.func @ordinary_compute(
+      %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+    %output = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %lhs_cb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %rhs_cb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %output_cb = ttl.bind_cb {cb_index = 2, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lhs_attached = ttl.attach_cb %lhs, %lhs_cb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %rhs_attached = ttl.attach_cb %rhs, %rhs_cb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_attached = ttl.attach_cb %output, %output_cb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output_view = ttl.cb_reserve %output_cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %result = ttl.compute
+        ins(%lhs_attached, %rhs_attached
+            : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+              tensor<1x1x!ttcore.tile<32x32, bf16>>)
+        outs(%output_attached : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+        {indexing_maps = [#identity, #identity, #identity],
+         iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%lhs_tile: !ttcore.tile<32x32, bf16>,
+         %rhs_tile: !ttcore.tile<32x32, bf16>,
+         %output_tile: !ttcore.tile<32x32, bf16>):
+      %row = ttl.iter_index 0 : index
+      %column = ttl.iter_index 1 : index
+      %zero = arith.constant 0 : index
+      %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%zero]
+          : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>
+            -> !ttcore.tile<32x32, bf16>
+      ttl.tile_store %sum, %output_view[%row, %column] from dst[%zero]
+          : !ttcore.tile<32x32, bf16>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.yield
+    } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return %result : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+}

--- a/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
@@ -1,0 +1,135 @@
+// Verifies TTKernel lowering for optional and repeated gamma modes of the
+// planned row-normalization block.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,func.func(ttkernel-combine-pack-tiles),canonicalize,cse,lower-affine)' | FileCheck %s
+
+#identity = affine_map<(row, column) -> (row, column)>
+#scalar = affine_map<(row, column) -> (0, 0)>
+
+module attributes {ttl.target_arch = "blackhole"} {
+
+// Gamma-disabled lowering reuses the input DFB operand without reading gamma.
+// CHECK-LABEL: func.func @row_normalization_no_gamma
+// CHECK:       ttkernel.init_sfpu(%[[NO_GAMMA_INPUT:[a-zA-Z0-9_]+]], %[[NO_GAMMA_OUTPUT:[a-zA-Z0-9_]+]])
+// CHECK-NEXT:  ttkernel.tile_regs_acquire
+// CHECK-NEXT:  ttkernel.experimental_row_normalization_block(%[[NO_GAMMA_INPUT]], %[[NO_GAMMA_INPUT]], %[[NO_GAMMA_OUTPUT]]) num_tiles = 3
+// CHECK-SAME:  has_gamma = false repeat_gamma = false dtype = <bf16>
+// CHECK-NEXT:  ttkernel.tile_regs_commit
+// CHECK-NEXT:  ttkernel.tile_regs_wait
+// CHECK-NEXT:  ttkernel.pack_tile_block(%{{.*}}, %[[NO_GAMMA_OUTPUT]], %{{.*}})
+// CHECK-NEXT:  ttkernel.tile_regs_release
+func.func @row_normalization_no_gamma()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %c-1 = arith.constant -1 : index
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>
+  %input_wait = ttl.cb_wait %input_dfb
+      : <[1, 3], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %input = ttl.attach_cb %input_wait, %input_dfb
+      : (tensor<1x3x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %reserved = ttl.cb_reserve %output_dfb
+      : <[1, 3], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %empty = tensor.empty() : tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %output = ttl.attach_cb %empty, %output_dfb
+      : (tensor<1x3x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %result = ttl.compute
+      ins(%input : tensor<1x3x!ttcore.tile<32x32, bf16>>)
+      outs(%output : tensor<1x3x!ttcore.tile<32x32, bf16>>)
+      {indexing_maps = [#identity, #identity],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+       %output_tile: !ttcore.tile<32x32, bf16>):
+    %row = ttl.iter_index 0 : index
+    %column = ttl.iter_index 1 : index
+    %normalized = ttl.tile_row_normalization_block
+        %input_tile, %input_tile, %output_tile
+        scale = 3.255208e-04 epsilon = 1.000000e-05
+        has_gamma = false repeat_gamma = false into dst[%c-1]
+        {ttl.dst_placeholder}
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %normalized, %reserved[%row, %column] from dst[%c-1]
+        {ttl.dst_placeholder}
+        : !ttcore.tile<32x32, bf16>,
+          tensor<1x3x!ttcore.tile<32x32, bf16>>
+    ttl.yield
+  } -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// Repeated-gamma lowering passes one scalar DFB through the zero indexing map.
+// CHECK-LABEL: func.func @row_normalization_repeated_gamma
+// CHECK:       ttkernel.init_sfpu(%[[REPEAT_INPUT:[a-zA-Z0-9_]+]], %[[REPEAT_OUTPUT:[a-zA-Z0-9_]+]])
+// CHECK-NEXT:  ttkernel.tile_regs_acquire
+// CHECK-NEXT:  ttkernel.experimental_row_normalization_block(%[[REPEAT_INPUT]], %[[REPEAT_GAMMA:[a-zA-Z0-9_]+]], %[[REPEAT_OUTPUT]]) num_tiles = 3
+// CHECK-SAME:  has_gamma = true repeat_gamma = true dtype = <bf16>
+// CHECK-NEXT:  ttkernel.tile_regs_commit
+// CHECK-NEXT:  ttkernel.tile_regs_wait
+// CHECK-NEXT:  ttkernel.pack_tile_block(%{{.*}}, %[[REPEAT_OUTPUT]], %{{.*}})
+// CHECK-NEXT:  ttkernel.tile_regs_release
+func.func @row_normalization_repeated_gamma()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %c-1 = arith.constant -1 : index
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>
+  %gamma_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %output_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+      : !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>
+  %input_wait = ttl.cb_wait %input_dfb
+      : <[1, 3], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %input = ttl.attach_cb %input_wait, %input_dfb
+      : (tensor<1x3x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %gamma_wait = ttl.cb_wait %gamma_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %gamma = ttl.attach_cb %gamma_wait, %gamma_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %reserved = ttl.cb_reserve %output_dfb
+      : <[1, 3], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %empty = tensor.empty() : tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %output = ttl.attach_cb %empty, %output_dfb
+      : (tensor<1x3x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  %result = ttl.compute
+      ins(%input, %gamma
+          : tensor<1x3x!ttcore.tile<32x32, bf16>>,
+            tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      outs(%output : tensor<1x3x!ttcore.tile<32x32, bf16>>)
+      {indexing_maps = [#identity, #scalar, #identity],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+       %gamma_tile: !ttcore.tile<32x32, bf16>,
+       %output_tile: !ttcore.tile<32x32, bf16>):
+    %row = ttl.iter_index 0 : index
+    %column = ttl.iter_index 1 : index
+    %normalized = ttl.tile_row_normalization_block
+        %input_tile, %gamma_tile, %output_tile
+        scale = 3.255208e-04 epsilon = 1.000000e-05
+        has_gamma = true repeat_gamma = true into dst[%c-1]
+        {ttl.dst_placeholder}
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    ttl.tile_store %normalized, %reserved[%row, %column] from dst[%c-1]
+        {ttl.dst_placeholder}
+        : !ttcore.tile<32x32, bf16>,
+          tensor<1x3x!ttcore.tile<32x32, bf16>>
+    ttl.yield
+  } -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+  return
+}
+}

--- a/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
@@ -1,9 +1,7 @@
-// Verifies TTKernel lowering for optional and repeated gamma modes of the
-// planned row-normalization block.
+// Verifies TTKernel lowering when gamma multiplication is disabled.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,func.func(ttkernel-combine-pack-tiles),canonicalize,cse,lower-affine)' | FileCheck %s
 
 #identity = affine_map<(row, column) -> (row, column)>
-#scalar = affine_map<(row, column) -> (0, 0)>
 
 module attributes {ttl.target_arch = "blackhole"} {
 
@@ -12,7 +10,7 @@ module attributes {ttl.target_arch = "blackhole"} {
 // CHECK:       ttkernel.init_sfpu(%[[NO_GAMMA_INPUT:[a-zA-Z0-9_]+]], %[[NO_GAMMA_OUTPUT:[a-zA-Z0-9_]+]])
 // CHECK-NEXT:  ttkernel.tile_regs_acquire
 // CHECK-NEXT:  ttkernel.experimental_row_normalization_block(%[[NO_GAMMA_INPUT]], %[[NO_GAMMA_INPUT]], %[[NO_GAMMA_OUTPUT]]) num_tiles = 3
-// CHECK-SAME:  has_gamma = false repeat_gamma = false dtype = <bf16>
+// CHECK-SAME:  has_gamma = false dtype = <bf16>
 // CHECK-NEXT:  ttkernel.tile_regs_commit
 // CHECK-NEXT:  ttkernel.tile_regs_wait
 // CHECK-NEXT:  ttkernel.pack_tile_block(%{{.*}}, %[[NO_GAMMA_OUTPUT]], %{{.*}})
@@ -51,76 +49,7 @@ func.func @row_normalization_no_gamma()
     %normalized = ttl.tile_row_normalization_block
         %input_tile, %input_tile, %output_tile
         scale = 3.255208e-04 epsilon = 1.000000e-05
-        has_gamma = false repeat_gamma = false into dst[%c-1]
-        {ttl.dst_placeholder}
-        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
-          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
-    ttl.tile_store %normalized, %reserved[%row, %column] from dst[%c-1]
-        {ttl.dst_placeholder}
-        : !ttcore.tile<32x32, bf16>,
-          tensor<1x3x!ttcore.tile<32x32, bf16>>
-    ttl.yield
-  } -> tensor<1x3x!ttcore.tile<32x32, bf16>>
-  return
-}
-
-// Repeated-gamma lowering passes one scalar DFB through the zero indexing map.
-// CHECK-LABEL: func.func @row_normalization_repeated_gamma
-// CHECK:       ttkernel.init_sfpu(%[[REPEAT_INPUT:[a-zA-Z0-9_]+]], %[[REPEAT_OUTPUT:[a-zA-Z0-9_]+]])
-// CHECK-NEXT:  ttkernel.tile_regs_acquire
-// CHECK-NEXT:  ttkernel.experimental_row_normalization_block(%[[REPEAT_INPUT]], %[[REPEAT_GAMMA:[a-zA-Z0-9_]+]], %[[REPEAT_OUTPUT]]) num_tiles = 3
-// CHECK-SAME:  has_gamma = true repeat_gamma = true dtype = <bf16>
-// CHECK-NEXT:  ttkernel.tile_regs_commit
-// CHECK-NEXT:  ttkernel.tile_regs_wait
-// CHECK-NEXT:  ttkernel.pack_tile_block(%{{.*}}, %[[REPEAT_OUTPUT]], %{{.*}})
-// CHECK-NEXT:  ttkernel.tile_regs_release
-func.func @row_normalization_repeated_gamma()
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %c-1 = arith.constant -1 : index
-  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
-      : !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>
-  %gamma_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
-      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-  %output_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
-      : !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>
-  %input_wait = ttl.cb_wait %input_dfb
-      : <[1, 3], !ttcore.tile<32x32, bf16>, 2>
-        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
-  %input = ttl.attach_cb %input_wait, %input_dfb
-      : (tensor<1x3x!ttcore.tile<32x32, bf16>>,
-         !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
-  %gamma_wait = ttl.cb_wait %gamma_dfb
-      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %gamma = ttl.attach_cb %gamma_wait, %gamma_dfb
-      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
-         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %reserved = ttl.cb_reserve %output_dfb
-      : <[1, 3], !ttcore.tile<32x32, bf16>, 2>
-        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
-  %empty = tensor.empty() : tensor<1x3x!ttcore.tile<32x32, bf16>>
-  %output = ttl.attach_cb %empty, %output_dfb
-      : (tensor<1x3x!ttcore.tile<32x32, bf16>>,
-         !ttl.cb<[1, 3], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x3x!ttcore.tile<32x32, bf16>>
-  %result = ttl.compute
-      ins(%input, %gamma
-          : tensor<1x3x!ttcore.tile<32x32, bf16>>,
-            tensor<1x1x!ttcore.tile<32x32, bf16>>)
-      outs(%output : tensor<1x3x!ttcore.tile<32x32, bf16>>)
-      {indexing_maps = [#identity, #scalar, #identity],
-       iterator_types = ["parallel", "parallel"]} {
-  ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
-       %gamma_tile: !ttcore.tile<32x32, bf16>,
-       %output_tile: !ttcore.tile<32x32, bf16>):
-    %row = ttl.iter_index 0 : index
-    %column = ttl.iter_index 1 : index
-    %normalized = ttl.tile_row_normalization_block
-        %input_tile, %gamma_tile, %output_tile
-        scale = 3.255208e-04 epsilon = 1.000000e-05
-        has_gamma = true repeat_gamma = true into dst[%c-1]
+        has_gamma = false into dst[%c-1]
         {ttl.dst_placeholder}
         : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
           !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>

--- a/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
@@ -3,7 +3,7 @@
 
 #identity = affine_map<(row, column) -> (row, column)>
 
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
 
 // Gamma-disabled lowering reuses the input DFB operand without reading gamma.
 // CHECK-LABEL: func.func @row_normalization_no_gamma

--- a/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
@@ -1,5 +1,5 @@
 // Verifies TTKernel lowering when gamma multiplication is disabled.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,func.func(ttkernel-combine-pack-tiles),canonicalize,cse,lower-affine)' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,func.func(ttkernel-combine-pack-tiles),canonicalize,cse,lower-affine)' | FileCheck %s
 
 #identity = affine_map<(row, column) -> (row, column)>
 

--- a/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/row_normalization_gamma_modes.mlir
@@ -49,7 +49,7 @@ func.func @row_normalization_no_gamma()
     %normalized = ttl.tile_row_normalization_block
         %input_tile, %input_tile, %output_tile
         scale = 3.255208e-04 epsilon = 1.000000e-05
-        has_gamma = false into dst[%c-1]
+        has_gamma = false num_tiles = 3 into dst[%c-1]
         {ttl.dst_placeholder}
         : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
           !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>

--- a/test/ttlang/Dialect/TTKernel/IR/experimental_row_normalization_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/experimental_row_normalization_invalid.mlir
@@ -14,35 +14,13 @@ module {
     // expected-error @below {{'ttkernel.experimental_row_normalization_block' op num_tiles must be in the range [1, 8]}}
     ttkernel.experimental_row_normalization_block(%input, %gamma, %output)
         num_tiles = 9 scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = true repeat_gamma = false dtype = <bf16>
+        has_gamma = true dtype = <bf16>
         : (!ttkernel.cb<18, !ttcore.tile<32x32, bf16>>,
            !ttkernel.cb<18, !ttcore.tile<32x32, bf16>>,
            !ttkernel.cb<18, !ttcore.tile<32x32, bf16>>) -> ()
     return
   }
 }
-
-// -----
-
-// Repeated gamma is undefined when gamma multiplication is disabled.
-module {
-  func.func @repeat_without_gamma() {
-    %input = ttkernel.get_compile_time_arg_val(0)
-        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
-    %output = ttkernel.get_compile_time_arg_val(1)
-        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
-    // expected-error @below {{'ttkernel.experimental_row_normalization_block' op repeat_gamma requires has_gamma}}
-    ttkernel.experimental_row_normalization_block(%input, %input, %output)
-        num_tiles = 3 scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false repeat_gamma = true dtype = <bf16>
-        : (!ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
-           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
-           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>) -> ()
-    return
-  }
-}
-
-// -----
 
 // The target helper supports bf16 DFBs only.
 module {
@@ -54,7 +32,7 @@ module {
     // expected-error @below {{'ttkernel.experimental_row_normalization_block' op supports bf16 DFBs only}}
     ttkernel.experimental_row_normalization_block(%input, %input, %output)
         num_tiles = 3 scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false repeat_gamma = false dtype = <f32>
+        has_gamma = false dtype = <f32>
         : (!ttkernel.cb<6, !ttcore.tile<32x32, f32>>,
            !ttkernel.cb<6, !ttcore.tile<32x32, f32>>,
            !ttkernel.cb<6, !ttcore.tile<32x32, f32>>) -> ()
@@ -76,7 +54,7 @@ module {
     // expected-error @below {{'ttkernel.experimental_row_normalization_block' op gamma_cb must equal input_cb when has_gamma is false}}
     ttkernel.experimental_row_normalization_block(%input, %gamma, %output)
         num_tiles = 3 scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false repeat_gamma = false dtype = <bf16>
+        has_gamma = false dtype = <bf16>
         : (!ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
            !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
            !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>) -> ()

--- a/test/ttlang/Dialect/TTKernel/IR/experimental_row_normalization_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/experimental_row_normalization_invalid.mlir
@@ -22,6 +22,8 @@ module {
   }
 }
 
+// -----
+
 // The target helper supports bf16 DFBs only.
 module {
   func.func @unsupported_dtype() {
@@ -36,6 +38,46 @@ module {
         : (!ttkernel.cb<6, !ttcore.tile<32x32, f32>>,
            !ttkernel.cb<6, !ttcore.tile<32x32, f32>>,
            !ttkernel.cb<6, !ttcore.tile<32x32, f32>>) -> ()
+    return
+  }
+}
+
+// -----
+
+// The semantic scale must be finite and positive.
+module {
+  func.func @nonfinite_scale() {
+    %input = ttkernel.get_compile_time_arg_val(0)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    %output = ttkernel.get_compile_time_arg_val(1)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    // expected-error @below {{'ttkernel.experimental_row_normalization_block' op scale must be finite and positive}}
+    ttkernel.experimental_row_normalization_block(%input, %input, %output)
+        num_tiles = 3 scale = 0x7FC00000 epsilon = 1.000000e-05
+        has_gamma = false dtype = <bf16>
+        : (!ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>) -> ()
+    return
+  }
+}
+
+// -----
+
+// Epsilon must be finite and positive.
+module {
+  func.func @nonpositive_epsilon() {
+    %input = ttkernel.get_compile_time_arg_val(0)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    %output = ttkernel.get_compile_time_arg_val(1)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    // expected-error @below {{'ttkernel.experimental_row_normalization_block' op epsilon must be finite and positive}}
+    ttkernel.experimental_row_normalization_block(%input, %input, %output)
+        num_tiles = 3 scale = 1.000000e+00 epsilon = 0.000000e+00
+        has_gamma = false dtype = <bf16>
+        : (!ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>) -> ()
     return
   }
 }

--- a/test/ttlang/Dialect/TTKernel/IR/experimental_row_normalization_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/experimental_row_normalization_invalid.mlir
@@ -1,0 +1,85 @@
+// Verifies target-level constraints of the experimental row-normalization
+// block operation.
+// RUN: ttlang-opt %s --verify-diagnostics --split-input-file
+
+// One row must fit the helper's eight-tile upper bound.
+module {
+  func.func @too_many_tiles() {
+    %input = ttkernel.get_compile_time_arg_val(0)
+        : () -> !ttkernel.cb<18, !ttcore.tile<32x32, bf16>>
+    %gamma = ttkernel.get_compile_time_arg_val(1)
+        : () -> !ttkernel.cb<18, !ttcore.tile<32x32, bf16>>
+    %output = ttkernel.get_compile_time_arg_val(2)
+        : () -> !ttkernel.cb<18, !ttcore.tile<32x32, bf16>>
+    // expected-error @below {{'ttkernel.experimental_row_normalization_block' op num_tiles must be in the range [1, 8]}}
+    ttkernel.experimental_row_normalization_block(%input, %gamma, %output)
+        num_tiles = 9 scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = true repeat_gamma = false dtype = <bf16>
+        : (!ttkernel.cb<18, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<18, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<18, !ttcore.tile<32x32, bf16>>) -> ()
+    return
+  }
+}
+
+// -----
+
+// Repeated gamma is undefined when gamma multiplication is disabled.
+module {
+  func.func @repeat_without_gamma() {
+    %input = ttkernel.get_compile_time_arg_val(0)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    %output = ttkernel.get_compile_time_arg_val(1)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    // expected-error @below {{'ttkernel.experimental_row_normalization_block' op repeat_gamma requires has_gamma}}
+    ttkernel.experimental_row_normalization_block(%input, %input, %output)
+        num_tiles = 3 scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false repeat_gamma = true dtype = <bf16>
+        : (!ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>) -> ()
+    return
+  }
+}
+
+// -----
+
+// The target helper supports bf16 DFBs only.
+module {
+  func.func @unsupported_dtype() {
+    %input = ttkernel.get_compile_time_arg_val(0)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, f32>>
+    %output = ttkernel.get_compile_time_arg_val(1)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, f32>>
+    // expected-error @below {{'ttkernel.experimental_row_normalization_block' op supports bf16 DFBs only}}
+    ttkernel.experimental_row_normalization_block(%input, %input, %output)
+        num_tiles = 3 scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false repeat_gamma = false dtype = <f32>
+        : (!ttkernel.cb<6, !ttcore.tile<32x32, f32>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, f32>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, f32>>) -> ()
+    return
+  }
+}
+
+// -----
+
+// Disabled gamma multiplication uses the input DFB as the placeholder.
+module {
+  func.func @distinct_disabled_gamma() {
+    %input = ttkernel.get_compile_time_arg_val(0)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    %gamma = ttkernel.get_compile_time_arg_val(1)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    %output = ttkernel.get_compile_time_arg_val(2)
+        : () -> !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>
+    // expected-error @below {{'ttkernel.experimental_row_normalization_block' op gamma_cb must equal input_cb when has_gamma is false}}
+    ttkernel.experimental_row_normalization_block(%input, %gamma, %output)
+        num_tiles = 3 scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false repeat_gamma = false dtype = <bf16>
+        : (!ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>,
+           !ttkernel.cb<6, !ttcore.tile<32x32, bf16>>) -> ()
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
@@ -2,24 +2,6 @@
 // block operation.
 // RUN: ttlang-opt %s --verify-diagnostics --split-input-file
 
-// Repeated gamma is undefined when gamma multiplication is disabled.
-module {
-  func.func @repeat_without_gamma(
-      %input: !ttcore.tile<32x32, bf16>,
-      %output: !ttcore.tile<32x32, bf16>) {
-    %c0 = arith.constant 0 : index
-    // expected-error @below {{'ttl.tile_row_normalization_block' op repeat_gamma requires has_gamma}}
-    %result = ttl.tile_row_normalization_block
-        %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false repeat_gamma = true into dst[%c0]
-        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
-          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
-    return
-  }
-}
-
-// -----
-
 // The specialized hardware schedule supports bf16 tiles only.
 module {
   func.func @unsupported_dtype(
@@ -29,7 +11,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op supports bf16 tiles only}}
     %result = ttl.tile_row_normalization_block
         %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false repeat_gamma = false into dst[%c0]
+        has_gamma = false into dst[%c0]
         : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>,
           !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
     return
@@ -45,10 +27,10 @@ module {
       %gamma: tensor<1x1x!ttcore.tile<32x32, bf16>>,
       %output: tensor<1x3x!ttcore.tile<32x32, bf16>>) {
     %c0 = arith.constant 0 : index
-    // expected-error @below {{'ttl.tile_row_normalization_block' op gamma tensor shape does not match gamma mode}}
+    // expected-error @below {{'ttl.tile_row_normalization_block' op gamma tensor shape must match the output shape}}
     %result = ttl.tile_row_normalization_block
         %input, %gamma, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = true repeat_gamma = false into dst[%c0]
+        has_gamma = true into dst[%c0]
         : tensor<1x3x!ttcore.tile<32x32, bf16>>,
           tensor<1x1x!ttcore.tile<32x32, bf16>>,
           tensor<1x3x!ttcore.tile<32x32, bf16>>
@@ -69,7 +51,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op gamma must equal input when has_gamma is false}}
     %result = ttl.tile_row_normalization_block
         %input, %gamma, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false repeat_gamma = false into dst[%c0]
+        has_gamma = false into dst[%c0]
         : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
           !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
     return

--- a/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
@@ -20,6 +20,42 @@ module {
 
 // -----
 
+// The semantic scale must be finite and positive.
+module {
+  func.func @nonfinite_scale(
+      %input: !ttcore.tile<32x32, bf16>,
+      %output: !ttcore.tile<32x32, bf16>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op scale must be finite and positive}}
+    %result = ttl.tile_row_normalization_block
+        %input, %input, %output scale = 0x7FC00000 epsilon = 1.000000e-05
+        has_gamma = false into dst[%c0]
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+// Epsilon must be finite and positive.
+module {
+  func.func @nonpositive_epsilon(
+      %input: !ttcore.tile<32x32, bf16>,
+      %output: !ttcore.tile<32x32, bf16>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op epsilon must be finite and positive}}
+    %result = ttl.tile_row_normalization_block
+        %input, %input, %output scale = 1.000000e+00 epsilon = 0.000000e+00
+        has_gamma = false into dst[%c0]
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
 // Full gamma must have the same row extent as the output.
 module {
   func.func @mismatched_full_gamma(
@@ -33,6 +69,46 @@ module {
         has_gamma = true into dst[%c0]
         : tensor<1x3x!ttcore.tile<32x32, bf16>>,
           tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x3x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// Tensor operands must be static rank-2 values.
+module {
+  func.func @invalid_tensor_rank(
+      %input: tensor<1x1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x1x1x!ttcore.tile<32x32, bf16>>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op tensor operands must be static rank-2 tensors}}
+    %result = ttl.tile_row_normalization_block
+        %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false into dst[%c0]
+        : tensor<1x1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// Input and output must describe the same one-row tile tensor.
+module {
+  func.func @mismatched_input_output_shape(
+      %input: tensor<1x2x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x3x!ttcore.tile<32x32, bf16>>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op input and output must have the same one-row tensor shape}}
+    %result = ttl.tile_row_normalization_block
+        %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false into dst[%c0]
+        : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+          tensor<1x2x!ttcore.tile<32x32, bf16>>,
           tensor<1x3x!ttcore.tile<32x32, bf16>>
           -> tensor<1x3x!ttcore.tile<32x32, bf16>>
     return

--- a/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
@@ -1,0 +1,77 @@
+// Verifies structural and type invariants of the internal row-normalization
+// block operation.
+// RUN: ttlang-opt %s --verify-diagnostics --split-input-file
+
+// Repeated gamma is undefined when gamma multiplication is disabled.
+module {
+  func.func @repeat_without_gamma(
+      %input: !ttcore.tile<32x32, bf16>,
+      %output: !ttcore.tile<32x32, bf16>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op repeat_gamma requires has_gamma}}
+    %result = ttl.tile_row_normalization_block
+        %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false repeat_gamma = true into dst[%c0]
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+// The specialized hardware schedule supports bf16 tiles only.
+module {
+  func.func @unsupported_dtype(
+      %input: !ttcore.tile<32x32, f32>,
+      %output: !ttcore.tile<32x32, f32>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op supports bf16 tiles only}}
+    %result = ttl.tile_row_normalization_block
+        %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false repeat_gamma = false into dst[%c0]
+        : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>,
+          !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    return
+  }
+}
+
+// -----
+
+// Full gamma must have the same row extent as the output.
+module {
+  func.func @mismatched_full_gamma(
+      %input: tensor<1x3x!ttcore.tile<32x32, bf16>>,
+      %gamma: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x3x!ttcore.tile<32x32, bf16>>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op gamma tensor shape does not match gamma mode}}
+    %result = ttl.tile_row_normalization_block
+        %input, %gamma, %output scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = true repeat_gamma = false into dst[%c0]
+        : tensor<1x3x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x3x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x3x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// Disabled gamma multiplication uses the input operand as the placeholder.
+module {
+  func.func @distinct_disabled_gamma(
+      %input: !ttcore.tile<32x32, bf16>,
+      %gamma: !ttcore.tile<32x32, bf16>,
+      %output: !ttcore.tile<32x32, bf16>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op gamma must equal input when has_gamma is false}}
+    %result = ttl.tile_row_normalization_block
+        %input, %gamma, %output scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false repeat_gamma = false into dst[%c0]
+        : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+          !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tile_row_normalization_block_invalid.mlir
@@ -11,7 +11,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op supports bf16 tiles only}}
     %result = ttl.tile_row_normalization_block
         %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false into dst[%c0]
+        has_gamma = false num_tiles = 1 into dst[%c0]
         : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>,
           !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
     return
@@ -29,7 +29,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op scale must be finite and positive}}
     %result = ttl.tile_row_normalization_block
         %input, %input, %output scale = 0x7FC00000 epsilon = 1.000000e-05
-        has_gamma = false into dst[%c0]
+        has_gamma = false num_tiles = 1 into dst[%c0]
         : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
           !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
     return
@@ -47,7 +47,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op epsilon must be finite and positive}}
     %result = ttl.tile_row_normalization_block
         %input, %input, %output scale = 1.000000e+00 epsilon = 0.000000e+00
-        has_gamma = false into dst[%c0]
+        has_gamma = false num_tiles = 1 into dst[%c0]
         : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
           !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
     return
@@ -66,7 +66,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op gamma tensor shape must match the output shape}}
     %result = ttl.tile_row_normalization_block
         %input, %gamma, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = true into dst[%c0]
+        has_gamma = true num_tiles = 3 into dst[%c0]
         : tensor<1x3x!ttcore.tile<32x32, bf16>>,
           tensor<1x1x!ttcore.tile<32x32, bf16>>,
           tensor<1x3x!ttcore.tile<32x32, bf16>>
@@ -86,7 +86,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op tensor operands must be static rank-2 tensors}}
     %result = ttl.tile_row_normalization_block
         %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false into dst[%c0]
+        has_gamma = false num_tiles = 1 into dst[%c0]
         : tensor<1x1x1x!ttcore.tile<32x32, bf16>>,
           tensor<1x1x1x!ttcore.tile<32x32, bf16>>,
           tensor<1x1x1x!ttcore.tile<32x32, bf16>>
@@ -106,7 +106,7 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op input and output must have the same one-row tensor shape}}
     %result = ttl.tile_row_normalization_block
         %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false into dst[%c0]
+        has_gamma = false num_tiles = 2 into dst[%c0]
         : tensor<1x2x!ttcore.tile<32x32, bf16>>,
           tensor<1x2x!ttcore.tile<32x32, bf16>>,
           tensor<1x3x!ttcore.tile<32x32, bf16>>
@@ -127,9 +127,29 @@ module {
     // expected-error @below {{'ttl.tile_row_normalization_block' op gamma must equal input when has_gamma is false}}
     %result = ttl.tile_row_normalization_block
         %input, %gamma, %output scale = 1.000000e+00 epsilon = 1.000000e-05
-        has_gamma = false into dst[%c0]
+        has_gamma = false num_tiles = 1 into dst[%c0]
         : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
           !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+    return
+  }
+}
+
+// -----
+
+// Scalarization metadata must equal the tensor row width.
+module {
+  func.func @mismatched_num_tiles(
+      %input: tensor<1x3x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x3x!ttcore.tile<32x32, bf16>>) {
+    %c0 = arith.constant 0 : index
+    // expected-error @below {{'ttl.tile_row_normalization_block' op num_tiles must match the row tensor width}}
+    %result = ttl.tile_row_normalization_block
+        %input, %input, %output scale = 1.000000e+00 epsilon = 1.000000e-05
+        has_gamma = false num_tiles = 2 into dst[%c0]
+        : tensor<1x3x!ttcore.tile<32x32, bf16>>,
+          tensor<1x3x!ttcore.tile<32x32, bf16>>,
+          tensor<1x3x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x3x!ttcore.tile<32x32, bf16>>
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity.mlir
@@ -1,6 +1,6 @@
 // Verifies that fixed-block destination residency participates in kernel
 // configuration selection.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=auto reduce-full-fp32=0 matmul-full-fp32=0 enable-fpu-binary-ops=0}))' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=auto reduce-full-fp32=0 matmul-full-fp32=0 enable-fpu-binary-ops=0})' | FileCheck %s
 
 #identity = affine_map<(row, column) -> (row, column)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity.mlir
@@ -1,0 +1,56 @@
+// Verifies that fixed-block destination residency participates in kernel
+// configuration selection.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=auto reduce-full-fp32=0 matmul-full-fp32=0 enable-fpu-binary-ops=0}))' | FileCheck %s
+
+#identity = affine_map<(row, column) -> (row, column)>
+
+// Five 32-bit destination tiles require full synchronization.
+// CHECK-LABEL: func.func @five_tile_row
+// CHECK-SAME:  dst_full_sync_en = true
+// CHECK-SAME:  fp32_dest_acc_en = true
+// CHECK:       ttl.tile_row_normalization_block
+// CHECK-SAME:  num_tiles = 5
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @five_tile_row(
+      %input: tensor<1x5x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x5x!ttcore.tile<32x32, bf16>>)
+      -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %c-1 = arith.constant -1 : index
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>
+    %input_view = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x5x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %output_view = ttl.attach_cb %output, %output_dfb
+        : (tensor<1x5x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %result = ttl.compute
+        ins(%input_view : tensor<1x5x!ttcore.tile<32x32, bf16>>)
+        outs(%output_view : tensor<1x5x!ttcore.tile<32x32, bf16>>)
+        {indexing_maps = [#identity, #identity],
+         iterator_types = ["parallel", "parallel"]} {
+      ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+           %output_tile: !ttcore.tile<32x32, bf16>):
+        %row = ttl.iter_index 0 : index
+        %column = ttl.iter_index 1 : index
+        %normalized = ttl.tile_row_normalization_block
+            %input_tile, %input_tile, %output_tile
+            scale = 1.953125e-04 epsilon = 1.000000e-05
+            has_gamma = false num_tiles = 5 into dst[%c-1]
+            {ttl.dst_placeholder}
+            : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+              !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+        ttl.tile_store %normalized, %output_view[%row, %column] from dst[%c-1]
+            {ttl.dst_placeholder}
+            : !ttcore.tile<32x32, bf16>,
+              tensor<1x5x!ttcore.tile<32x32, bf16>>
+        ttl.yield
+    } -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    return %result : tensor<1x5x!ttcore.tile<32x32, bf16>>
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity_invalid.mlir
@@ -1,0 +1,51 @@
+// Verifies rejection when an explicit kernel configuration cannot satisfy a
+// fixed-block destination residency requirement.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=disabled reduce-full-fp32=0 matmul-full-fp32=0 enable-fpu-binary-ops=0}))' --verify-diagnostics
+
+#identity = affine_map<(row, column) -> (row, column)>
+
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @five_tile_row(
+      %input: tensor<1x5x!ttcore.tile<32x32, bf16>>,
+      %output: tensor<1x5x!ttcore.tile<32x32, bf16>>)
+      -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %c-1 = arith.constant -1 : index
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>
+    %input_view = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x5x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %output_view = ttl.attach_cb %output, %output_dfb
+        : (tensor<1x5x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %result = ttl.compute
+        ins(%input_view : tensor<1x5x!ttcore.tile<32x32, bf16>>)
+        outs(%output_view : tensor<1x5x!ttcore.tile<32x32, bf16>>)
+        {indexing_maps = [#identity, #identity],
+         iterator_types = ["parallel", "parallel"]} {
+      ^bb0(%input_tile: !ttcore.tile<32x32, bf16>,
+           %output_tile: !ttcore.tile<32x32, bf16>):
+        %row = ttl.iter_index 0 : index
+        %column = ttl.iter_index 1 : index
+        // expected-error @below {{'ttl.tile_row_normalization_block' op requires 5 simultaneous DST slots, but at most 4 are available under the kernel configuration}}
+        %normalized = ttl.tile_row_normalization_block
+            %input_tile, %input_tile, %output_tile
+            scale = 1.953125e-04 epsilon = 1.000000e-05
+            has_gamma = false num_tiles = 5 into dst[%c-1]
+            {ttl.dst_placeholder}
+            : !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>,
+              !ttcore.tile<32x32, bf16> -> !ttcore.tile<32x32, bf16>
+        ttl.tile_store %normalized, %output_view[%row, %column] from dst[%c-1]
+            {ttl.dst_placeholder}
+            : !ttcore.tile<32x32, bf16>,
+              tensor<1x5x!ttcore.tile<32x32, bf16>>
+        ttl.yield
+    } -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    return %result : tensor<1x5x!ttcore.tile<32x32, bf16>>
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/row_normalization_capacity_invalid.mlir
@@ -1,6 +1,6 @@
 // Verifies rejection when an explicit kernel configuration cannot satisfy a
 // fixed-block destination residency requirement.
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=disabled reduce-full-fp32=0 matmul-full-fp32=0 enable-fpu-binary-ops=0}))' --verify-diagnostics
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=disabled reduce-full-fp32=0 matmul-full-fp32=0 enable-fpu-binary-ops=0})' --verify-diagnostics
 
 #identity = affine_map<(row, column) -> (row, column)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/row_normalization_kernel_configs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_normalization_kernel_configs.mlir
@@ -5,9 +5,9 @@
 // Four fp32 half-sync tiles exactly fill the effective DST capacity.
 // CHECK-LABEL: ComputeOp creation plan @fp32_half_sync_fits
 // CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @fp32_half_sync_fits()
-      attributes {fp32_dest_acc_en = true,
+      attributes {dst_full_sync_en = false, fp32_dest_acc_en = true,
                   ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
@@ -64,9 +64,9 @@ module attributes {ttl.target_arch = "blackhole"} {
 // A fifth fp32 half-sync tile requires materialized lowering.
 // CHECK-LABEL: ComputeOp creation plan @fp32_half_sync_exceeds_capacity
 // CHECK-NOT:   recipe=row_normalization
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @fp32_half_sync_exceeds_capacity()
-      attributes {fp32_dest_acc_en = true,
+      attributes {dst_full_sync_en = false, fp32_dest_acc_en = true,
                   ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         : !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>
@@ -123,7 +123,7 @@ module attributes {ttl.target_arch = "blackhole"} {
 // Full sync retains the helper's eight-tile limit under bf16 accumulation.
 // CHECK-LABEL: ComputeOp creation plan @bf16_full_sync_fits
 // CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @bf16_full_sync_fits()
       attributes {dst_full_sync_en = true,
                   ttl.kernel_thread = #ttkernel.thread<compute>} {
@@ -182,7 +182,7 @@ module attributes {ttl.target_arch = "blackhole"} {
 // Full sync restores eight usable tiles under fp32 accumulation.
 // CHECK-LABEL: ComputeOp creation plan @fp32_full_sync_fits
 // CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @fp32_full_sync_fits()
       attributes {dst_full_sync_en = true, fp32_dest_acc_en = true,
                   ttl.kernel_thread = #ttkernel.thread<compute>} {

--- a/test/ttlang/Dialect/TTL/Transforms/row_normalization_kernel_configs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_normalization_kernel_configs.mlir
@@ -1,0 +1,237 @@
+// Verifies row-normalization planning at DST capacity boundaries for every
+// kernel register configuration exercised by the fused LLK.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' -o /dev/null 2>&1 | FileCheck %s
+
+// Four fp32 half-sync tiles exactly fill the effective DST capacity.
+// CHECK-LABEL: ComputeOp creation plan @fp32_half_sync_fits
+// CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @fp32_half_sync_fits()
+      attributes {fp32_dest_acc_en = true,
+                  ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x4x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x4x!ttcore.tile<32x32, bf16>>,
+          tensor<1x4x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x4x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean = ttl.mul_unary_const %reduced, 2.441406e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %mean, %epsilon
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %broadcast = ttl.block.broadcast %inverse dims = [0, 1], shape = [1, 4]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %input, %broadcast
+        : tensor<1x4x!ttcore.tile<32x32, bf16>>,
+          tensor<1x4x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x4x!ttcore.tile<32x32, bf16>>,
+          tensor<1x4x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// A fifth fp32 half-sync tile requires materialized lowering.
+// CHECK-LABEL: ComputeOp creation plan @fp32_half_sync_exceeds_capacity
+// CHECK-NOT:   recipe=row_normalization
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @fp32_half_sync_exceeds_capacity()
+      attributes {fp32_dest_acc_en = true,
+                  ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 5], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x5x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 5], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x5x!ttcore.tile<32x32, bf16>>,
+          tensor<1x5x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x5x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean = ttl.mul_unary_const %reduced, 1.953125e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %mean, %epsilon
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %broadcast = ttl.block.broadcast %inverse dims = [0, 1], shape = [1, 5]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %input, %broadcast
+        : tensor<1x5x!ttcore.tile<32x32, bf16>>,
+          tensor<1x5x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 5], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x5x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x5x!ttcore.tile<32x32, bf16>>,
+          tensor<1x5x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// Full sync retains the helper's eight-tile limit under bf16 accumulation.
+// CHECK-LABEL: ComputeOp creation plan @bf16_full_sync_fits
+// CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @bf16_full_sync_fits()
+      attributes {dst_full_sync_en = true,
+                  ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 8], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 8], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 8], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x8x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 8], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x8x!ttcore.tile<32x32, bf16>>,
+          tensor<1x8x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x8x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean = ttl.mul_unary_const %reduced, 1.220703e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %mean, %epsilon
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %broadcast = ttl.block.broadcast %inverse dims = [0, 1], shape = [1, 8]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %input, %broadcast
+        : tensor<1x8x!ttcore.tile<32x32, bf16>>,
+          tensor<1x8x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 8], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x8x!ttcore.tile<32x32, bf16>>,
+          tensor<1x8x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// Full sync restores eight usable tiles under fp32 accumulation.
+// CHECK-LABEL: ComputeOp creation plan @fp32_full_sync_fits
+// CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @fp32_full_sync_fits()
+      attributes {dst_full_sync_en = true, fp32_dest_acc_en = true,
+                  ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 8], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 8], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 8], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x8x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 8], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x8x!ttcore.tile<32x32, bf16>>,
+          tensor<1x8x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x8x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean = ttl.mul_unary_const %reduced, 1.220703e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %mean, %epsilon
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %broadcast = ttl.block.broadcast %inverse dims = [0, 1], shape = [1, 8]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %input, %broadcast
+        : tensor<1x8x!ttcore.tile<32x32, bf16>>,
+          tensor<1x8x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 8], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x8x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x8x!ttcore.tile<32x32, bf16>>,
+          tensor<1x8x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/row_normalization_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_normalization_planning.mlir
@@ -1,0 +1,244 @@
+// Verifies row-normalization recognition with commuted operands and
+// conservative rejection on unsupported architecture or DST capacity.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' -o /dev/null 2>&1 | FileCheck %s
+
+// Commuting the scalar add and final product does not change recognition.
+// CHECK-LABEL: ComputeOp creation plan @row_normalization_commuted
+// CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true inputs=1 outputs=1 transactions=1
+// CHECK:       order=[C0]
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @row_normalization_commuted()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean_square = ttl.mul_unary_const %reduced, 9.765625e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %epsilon, %mean_square
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse_rms = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scalar = ttl.block.broadcast %inverse_rms dims = [0, 1], shape = [1, 1]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %scalar, %input
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// Wormhole retains the ordinary materialized lowering.
+// CHECK-LABEL: ComputeOp creation plan @row_normalization_wrong_arch
+// CHECK-NOT:   recipe=row_normalization
+module attributes {ttl.target_arch = "wormhole_b0"} {
+  func.func @row_normalization_wrong_arch()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean_square = ttl.mul_unary_const %reduced, 9.765625e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %mean_square, %epsilon
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse_rms = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scalar = ttl.block.broadcast %inverse_rms dims = [0, 1], shape = [1, 1]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %input, %scalar
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// A nine-tile Blackhole row exceeds the specialized helper and effective DST
+// capacity limit.
+// CHECK-LABEL: ComputeOp creation plan @row_normalization_exceeds_capacity
+// CHECK-NOT:   recipe=row_normalization
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @row_normalization_exceeds_capacity()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 9], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 9], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 9], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x9x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 9], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x9x!ttcore.tile<32x32, bf16>>,
+          tensor<1x9x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x9x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean_square = ttl.mul_unary_const %reduced, 1.085069e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %mean_square, %epsilon
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse_rms = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scalar = ttl.block.broadcast %inverse_rms dims = [0, 1], shape = [1, 9]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %input, %scalar
+        : tensor<1x9x!ttcore.tile<32x32, bf16>>,
+          tensor<1x9x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 9], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x9x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x9x!ttcore.tile<32x32, bf16>>,
+          tensor<1x9x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}
+
+// -----
+
+// The specialized schedule publishes exactly one output transaction.
+// CHECK-LABEL: ComputeOp creation plan @row_normalization_multiple_outputs
+// CHECK:       ttl.mul kind=fused recipe=row_normalization legal=false inputs=1 outputs=2 transactions=2
+// CHECK:       rejected=row-normalization block requires exactly one output store transaction
+module attributes {ttl.target_arch = "blackhole"} {
+  func.func @row_normalization_multiple_outputs()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %other_output_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean_square = ttl.mul_unary_const %reduced, 9.765625e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %epsilon, %mean_square
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse_rms = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scalar = ttl.block.broadcast %inverse_rms dims = [0, 1], shape = [1, 1]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %scalar, %input
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %output
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %other_output = ttl.cb_reserve %other_output_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.store %result, %other_output
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/row_normalization_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_normalization_planning.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_commuted
 // CHECK:       ttl.mul kind=fused recipe=row_normalization legal=true inputs=1 outputs=1 transactions=1
 // CHECK:       order=[C0]
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @row_normalization_commuted()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
@@ -64,7 +64,7 @@ module attributes {ttl.target_arch = "blackhole"} {
 // Wormhole retains the ordinary materialized lowering.
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_wrong_arch
 // CHECK-NOT:   recipe=row_normalization
-module attributes {ttl.target_arch = "wormhole_b0"} {
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
   func.func @row_normalization_wrong_arch()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
@@ -123,7 +123,7 @@ module attributes {ttl.target_arch = "wormhole_b0"} {
 // capacity limit.
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_exceeds_capacity
 // CHECK-NOT:   recipe=row_normalization
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @row_normalization_exceeds_capacity()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
@@ -182,7 +182,7 @@ module attributes {ttl.target_arch = "blackhole"} {
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_multiple_outputs
 // CHECK:       ttl.mul kind=fused recipe=row_normalization legal=false inputs=1 outputs=2 transactions=2
 // CHECK:       rejected=row-normalization block requires exactly one output store transaction
-module attributes {ttl.target_arch = "blackhole"} {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @row_normalization_multiple_outputs()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}

--- a/test/ttlang/Dialect/TTL/Transforms/row_normalization_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_normalization_planning.mlir
@@ -1,5 +1,5 @@
 // Verifies row-normalization recognition with commuted operands and
-// conservative rejection on unsupported architecture or DST capacity.
+// conservative rejection when the target lacks the schedule or DST capacity.
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' -o /dev/null 2>&1 | FileCheck %s
 
 // Commuting the scalar add and final product does not change recognition.
@@ -61,11 +61,11 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
 
 // -----
 
-// Wormhole retains the ordinary materialized lowering.
-// CHECK-LABEL: ComputeOp creation plan @row_normalization_wrong_arch
+// A target without the schedule capability retains ordinary materialization.
+// CHECK-LABEL: ComputeOp creation plan @row_normalization_unsupported_schedule
 // CHECK-NOT:   recipe=row_normalization
 module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
-  func.func @row_normalization_wrong_arch()
+  func.func @row_normalization_unsupported_schedule()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -119,8 +119,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
 
 // -----
 
-// A nine-tile Blackhole row exceeds the specialized helper and effective DST
-// capacity limit.
+// A nine-tile row exceeds the schedule and effective DST capacity limits.
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_exceeds_capacity
 // CHECK-NOT:   recipe=row_normalization
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {


### PR DESCRIPTION
### Problem description

A static RMSNorm row expression lowers as separate compute operations and may require intermediate dataflow buffers. Blackhole can execute the supported expression in one fixed-row compute schedule.

```python
squared = input_block * input_block
mean_square = ttl.math.reduce_sum(squared, dims=[0, 1]) * scale
biased = mean_square + ttl.block.fill(
    EPSILON,
    shape=mean_square.shape,
    tile=(tile_height, TILE_WIDTH),
)
inverse_rms = ttl.math.rsqrt(biased)
output_block.store(input_block * ttl.block.broadcast(
    inverse_rms, dims=[0, 1], shape=input_block.shape
))
```

### What's changed

~1,550 LOC implementation (tests and documentation excluded).

The compiler recognizes the static RMSNorm expression, plans its DST residency, and lowers it to a target-specific row-normalization operation. Unsupported expressions retain ordinary compute lowering.

The specialized schedule supports one to eight BF16 tiles on Blackhole, with absent or full-row gamma. Column-broadcast gamma and unsupported targets continue through ordinary compute lowering.

### Validation

- New device coverage validates 30 BF16 cases across DRAM/L1 tensors, 512/1536/7168-element rows, gamma modes, DST configurations, and fused-versus-materialized results.
- New focused MLIR coverage validates recognition, lowering, target limits, gamma handling, and DST-capacity diagnostics.

### Checklist

- [x] New/Existing tests provide coverage for changes
