### PR TITLE
[ttl] Report DFB allocation decisions [dfb-reuse-3]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1508,6 +1508,10 @@ counterfactual evidence only. They do not mark the DFB bounded, add lifetime
 ordering, or change the conflict relation. Nodes with identical diagnostic
 facts are grouped to keep large launch grids readable.
 
+If node-dependent IR has no launch grid, no base launch nodes are available
+for the counterfactual evaluation. The report retains logical DFB and access
+facts but omits per-node rows.
+
 The allocation graph uses one vertex per logical DFB and one edge per pair
 that cannot share. Assigning a graph color means assigning a physical DFB
 index; vertices joined by an edge must receive different indices. A clique is

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1475,6 +1475,39 @@ following reasons: descriptor mismatch, unknown launch-node domain, unproven
 quiescence, transaction mismatch, pointer-owner mismatch, or concurrent
 lifetime.
 
+#### Allocation diagnostics
+
+An assertions-enabled build can print the allocation inputs and conflict
+evidence without changing allocation behavior:
+
+```bash
+ttlang-opt input.mlir \
+  --ttl-finalize-dfb-indices='reuse-user-dfbs=true' \
+  -debug-only=ttl-finalize-dfb-indices \
+  -o /dev/null
+```
+
+The report is emitted after liveness and conflict construction and before
+capacity or L1-budget validation. Each logical DFB records its descriptor,
+tensor backing, launch-node domain, boundedness, accesses, protocol effects,
+exact execution counts, transaction sizes, pointer owners, and lifetime
+frontiers. Frontier entries are access-occurrence indices that refer to the
+numbered access records and their source locations. Each conflict records both
+logical IDs, the typed reason, an applicable launch node, and source
+operations.
+
+An unknown launch-node domain is itself sufficient to prevent reuse. For
+diagnosis, the report also evaluates each base launch node while assuming that
+unknown-domain accesses may be active. An exact-zero execution count still
+proves that an access is inactive and excludes its ordering edges. These rows
+use `domain_assumption=unknown-may-be-active`; they identify the next missing
+proof, such as a protocol effect, exact execution count, matched transaction,
+or complete use order. `may_be_active` is present only on these counterfactual
+rows and is false when every included access has an exact-zero count. They are
+counterfactual evidence only. They do not mark the DFB bounded, add lifetime
+ordering, or change the conflict relation. Nodes with identical diagnostic
+facts are grouped to keep large launch grids readable.
+
 The allocation graph uses one vertex per logical DFB and one edge per pair
 that cannot share. Assigning a graph color means assigning a physical DFB
 index; vertices joined by an edge must receive different indices. A clique is

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -999,6 +999,18 @@ def TTLFinalizeDFBIndices
     allocation diagnostic; it does not report that hardware capacity was
     proved insufficient.
 
+    An assertions-enabled build accepts
+    `-debug-only=ttl-finalize-dfb-indices` to print the immutable liveness facts
+    and typed conflicts before allocation succeeds or fails. The report includes
+    logical descriptors, access domains, protocol effects, exact execution
+    counts, transaction sizes, pointer owners, lifetime frontiers, and conflict
+    evidence. Lifetime frontiers use access-occurrence indices that map to the
+    report's numbered access records. For an unknown launch-node domain, it
+    separately labels a counterfactual per-node analysis that assumes
+    unknown-domain accesses may be active while preserving exact-zero
+    inactivity. Those diagnostic attempts do not establish boundedness or
+    affect the conflict relation.
+
     Every storage-accessing operation with a direct DFB operand is treated as a
     runtime access from operation entry through completion. Every direct DFB
     operand of `ttl.opaque_call` is a possible read or write; both require the

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1009,7 +1009,9 @@ def TTLFinalizeDFBIndices
     separately labels a counterfactual per-node analysis that assumes
     unknown-domain accesses may be active while preserving exact-zero
     inactivity. Those diagnostic attempts do not establish boundedness or
-    affect the conflict relation.
+    affect the conflict relation. If node-dependent IR has no launch grid, the
+    report retains logical DFB and access facts but omits per-node rows because
+    no base launch nodes are available.
 
     Every storage-accessing operation with a direct DFB operand is treated as a
     runtime access from operation entry through completion. Every direct DFB

--- a/lib/Dialect/TTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTL/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(TTLangTTLTransforms
   IntermediateDFBPlanning.cpp
   ConvertTTLToTTKernel.cpp
   DFBAcquireReleaseAnalysis.cpp
+  DFBAllocationDebugReport.cpp
   DFBAllocationLimits.cpp
   DFBLogicalIdentityAnalysis.cpp
   DFBValueLifetimeAnalysis.cpp

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -13,6 +13,9 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include <cassert>
+#include <tuple>
+
 namespace mlir::tt::ttl {
 
 namespace {
@@ -177,10 +180,10 @@ static void printAccesses(llvm::raw_ostream &output,
 }
 
 static void printOccurrences(llvm::raw_ostream &output,
-                             const DFBPerNodeLifetime &lifetime) {
+                             const DFBPerNodeLifetimeDiagnostics &diagnostics) {
   output << '[';
-  llvm::interleaveComma(lifetime.reportedOccurrences, output,
-                        [&](const DFBPerNodeAccessOccurrence &occurrence) {
+  llvm::interleaveComma(diagnostics.occurrences, output,
+                        [&](const DFBDiagnosticAccessOccurrence &occurrence) {
                           output << occurrence.occurrenceIndex << ':';
                           if (occurrence.exactExecutionCount) {
                             output << *occurrence.exactExecutionCount;
@@ -191,57 +194,86 @@ static void printOccurrences(llvm::raw_ostream &output,
   output << ']';
 }
 
-static bool hasEqualDiagnosticFacts(const DFBPerNodeLifetime &lhs,
-                                    const DFBPerNodeLifetime &rhs) {
+static bool
+hasEqualDiagnosticFacts(const DFBPerNodeLifetime &lhs,
+                        const DFBPerNodeLifetimeDiagnostics &lhsDiagnostics,
+                        const DFBPerNodeLifetime &rhs,
+                        const DFBPerNodeLifetimeDiagnostics &rhsDiagnostics) {
   if (lhs.quiescence.failure != rhs.quiescence.failure ||
       lhs.quiescence.evidence != rhs.quiescence.evidence ||
-      lhs.mayBeActive != rhs.mayBeActive ||
-      lhs.reportedOccurrences.size() != rhs.reportedOccurrences.size() ||
-      lhs.earliestAccessOccurrenceIndices !=
-          rhs.earliestAccessOccurrenceIndices ||
-      lhs.terminalAccessOccurrenceIndices !=
-          rhs.terminalAccessOccurrenceIndices ||
       lhs.transactionTileCounts != rhs.transactionTileCounts ||
       lhs.writePointerOwner != rhs.writePointerOwner ||
-      lhs.readPointerOwner != rhs.readPointerOwner) {
+      lhs.readPointerOwner != rhs.readPointerOwner ||
+      !(lhsDiagnostics == rhsDiagnostics)) {
     return false;
   }
-  return llvm::equal(lhs.reportedOccurrences, rhs.reportedOccurrences,
-                     [](const DFBPerNodeAccessOccurrence &lhsOccurrence,
-                        const DFBPerNodeAccessOccurrence &rhsOccurrence) {
-                       return lhsOccurrence.occurrenceIndex ==
-                                  rhsOccurrence.occurrenceIndex &&
-                              lhsOccurrence.exactExecutionCount ==
-                                  rhsOccurrence.exactExecutionCount;
-                     });
+  return true;
 }
 
+static void
+printLifetimeFacts(llvm::raw_ostream &output,
+                   const DFBPerNodeLifetime &lifetime,
+                   const DFBPerNodeLifetimeDiagnostics &diagnostics) {
+  output << " evidence=";
+  printOperation(output, lifetime.quiescence.evidence);
+  output << " occurrences=";
+  printOccurrences(output, diagnostics);
+  output << " transactions=";
+  printValues(output, lifetime.transactionTileCounts);
+  output << " write_owner=";
+  printPointerOwner(output, lifetime.writePointerOwner);
+  output << " read_owner=";
+  printPointerOwner(output, lifetime.readPointerOwner);
+  output << " earliest_accesses=";
+  printValues(output, diagnostics.earliestAccessOccurrenceIndices);
+  output << " terminal_accesses=";
+  printValues(output, diagnostics.terminalAccessOccurrenceIndices);
+}
+
+struct LifetimeWithDiagnostics {
+  const DFBPerNodeLifetime *lifetime = nullptr;
+  const DFBPerNodeLifetimeDiagnostics *diagnostics = nullptr;
+};
+
 struct DiagnosticLifetimeGroup {
-  const DFBPerNodeLifetime *representative = nullptr;
+  LifetimeWithDiagnostics representative;
   SmallVector<LaunchNodeCoord> nodes;
 };
 
 static void printDiagnosticLifetimes(
     llvm::raw_ostream &output,
-    llvm::ArrayRef<const DFBPerNodeLifetime *> diagnosticLifetimes) {
+    const DFBLogicalLifecycleDiagnostics &allocationDiagnostics) {
+  assert(
+      allocationDiagnostics.counterfactualNodeLifetimes.size() ==
+          allocationDiagnostics.counterfactualNodeLifetimeDiagnostics.size() &&
+      "counterfactual lifetimes must have allocation-report data");
   SmallVector<DiagnosticLifetimeGroup> groups;
-  for (const DFBPerNodeLifetime *lifetime : diagnosticLifetimes) {
+  for (auto lifetimeAndDiagnostics : llvm::zip_equal(
+           allocationDiagnostics.counterfactualNodeLifetimes,
+           allocationDiagnostics.counterfactualNodeLifetimeDiagnostics)) {
+    const DFBPerNodeLifetime &lifetime = std::get<0>(lifetimeAndDiagnostics);
+    const DFBPerNodeLifetimeDiagnostics &diagnostics =
+        std::get<1>(lifetimeAndDiagnostics);
     auto groupIt = llvm::find_if(groups, [&](const auto &group) {
-      return hasEqualDiagnosticFacts(*group.representative, *lifetime);
+      return hasEqualDiagnosticFacts(*group.representative.lifetime,
+                                     *group.representative.diagnostics,
+                                     lifetime, diagnostics);
     });
     if (groupIt == groups.end()) {
-      groups.push_back({lifetime, {lifetime->node}});
+      groups.push_back({{&lifetime, &diagnostics}, {lifetime.node}});
     } else {
-      groupIt->nodes.push_back(lifetime->node);
+      groupIt->nodes.push_back(lifetime.node);
     }
   }
 
   for (const DiagnosticLifetimeGroup &group : groups) {
-    const DFBPerNodeLifetime &lifetime = *group.representative;
+    const DFBPerNodeLifetime &lifetime = *group.representative.lifetime;
+    const DFBPerNodeLifetimeDiagnostics &diagnostics =
+        *group.representative.diagnostics;
     output << "  diagnostic_nodes quiescence="
            << getQuiescenceFailureName(lifetime.quiescence.failure)
            << " domain_assumption=unknown-may-be-active may_be_active="
-           << lifetime.mayBeActive << " node_count=" << group.nodes.size();
+           << diagnostics.mayBeActive << " node_count=" << group.nodes.size();
     if (group.nodes.size() <= 8) {
       output << " nodes={";
       llvm::interleaveComma(group.nodes, output, [&](LaunchNodeCoord node) {
@@ -252,53 +284,35 @@ static void printDiagnosticLifetimes(
       output << " exemplar=";
       printNode(output, lifetime.node);
     }
-    output << " evidence=";
-    printOperation(output, lifetime.quiescence.evidence);
-    output << " occurrences=";
-    printOccurrences(output, lifetime);
-    output << " transactions=";
-    printValues(output, lifetime.transactionTileCounts);
-    output << " write_owner=";
-    printPointerOwner(output, lifetime.writePointerOwner);
-    output << " read_owner=";
-    printPointerOwner(output, lifetime.readPointerOwner);
-    output << " earliest_accesses=";
-    printValues(output, lifetime.earliestAccessOccurrenceIndices);
-    output << " terminal_accesses=";
-    printValues(output, lifetime.terminalAccessOccurrenceIndices);
+    printLifetimeFacts(output, lifetime, diagnostics);
     output << '\n';
   }
 }
 
 static void printNodeLifetimes(llvm::raw_ostream &output,
                                const DFBLogicalLifecycle &logicalDFB) {
-  for (const DFBPerNodeLifetime &lifetime : logicalDFB.nodeLifetimes) {
+  if (!logicalDFB.allocationDiagnostics) {
+    assert(logicalDFB.nodeLifetimes.empty() &&
+           "authoritative lifetimes require completed analysis");
+    return;
+  }
+  const DFBLogicalLifecycleDiagnostics &allocationDiagnostics =
+      *logicalDFB.allocationDiagnostics;
+  assert(logicalDFB.nodeLifetimes.size() ==
+             allocationDiagnostics.nodeLifetimeDiagnostics.size() &&
+         "exact lifetimes must have allocation-report data");
+  for (auto [lifetime, diagnostics] :
+       llvm::zip_equal(logicalDFB.nodeLifetimes,
+                       allocationDiagnostics.nodeLifetimeDiagnostics)) {
     output << "  node ";
     printNode(output, lifetime.node);
     output << " quiescence="
            << getQuiescenceFailureName(lifetime.quiescence.failure)
-           << " domain_assumption=exact evidence=";
-    printOperation(output, lifetime.quiescence.evidence);
-    output << " occurrences=";
-    printOccurrences(output, lifetime);
-    output << " transactions=";
-    printValues(output, lifetime.transactionTileCounts);
-    output << " write_owner=";
-    printPointerOwner(output, lifetime.writePointerOwner);
-    output << " read_owner=";
-    printPointerOwner(output, lifetime.readPointerOwner);
-    output << " earliest_accesses=";
-    printValues(output, lifetime.earliestAccessOccurrenceIndices);
-    output << " terminal_accesses=";
-    printValues(output, lifetime.terminalAccessOccurrenceIndices);
+           << " domain_assumption=exact";
+    printLifetimeFacts(output, lifetime, diagnostics);
     output << '\n';
   }
-  SmallVector<const DFBPerNodeLifetime *> diagnosticLifetimes;
-  for (const DFBPerNodeLifetime &lifetime :
-       logicalDFB.diagnosticNodeLifetimes) {
-    diagnosticLifetimes.push_back(&lifetime);
-  }
-  printDiagnosticLifetimes(output, diagnosticLifetimes);
+  printDiagnosticLifetimes(output, allocationDiagnostics);
 }
 
 static void printConflictEvidence(llvm::raw_ostream &output,

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "DFBAllocationDebugReport.h"
+
+#include "DFBConcurrentKernelLivenessAnalysis.h"
+#include "DFBPhysicalAllocationPlan.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace mlir::tt::ttl {
+
+namespace {
+
+static llvm::StringRef getProtocolEffectName(DFBProtocolEffectKind effect) {
+  switch (effect) {
+  case DFBProtocolEffectKind::Reserve:
+    return "reserve";
+  case DFBProtocolEffectKind::Push:
+    return "push";
+  case DFBProtocolEffectKind::Wait:
+    return "wait";
+  case DFBProtocolEffectKind::Pop:
+    return "pop";
+  }
+  llvm_unreachable("unknown DFB protocol effect");
+}
+
+static llvm::StringRef
+getQuiescenceFailureName(DFBQuiescenceFailureReason failure) {
+  switch (failure) {
+  case DFBQuiescenceFailureReason::None:
+    return "none";
+  case DFBQuiescenceFailureReason::MissingProtocolEffect:
+    return "missing-protocol-effect";
+  case DFBQuiescenceFailureReason::UnsupportedControlFlow:
+    return "unsupported-control-flow";
+  case DFBQuiescenceFailureReason::MismatchedTransaction:
+    return "mismatched-transaction";
+  case DFBQuiescenceFailureReason::IncompleteUseOrder:
+    return "incomplete-use-order";
+  case DFBQuiescenceFailureReason::UnknownPointerOwner:
+    return "unknown-pointer-owner";
+  }
+  llvm_unreachable("unknown DFB quiescence failure");
+}
+
+static llvm::StringRef getConflictReasonName(DFBConflictReason reason) {
+  switch (reason) {
+  case DFBConflictReason::DescriptorMismatch:
+    return "descriptor-mismatch";
+  case DFBConflictReason::StorageMismatch:
+    return "storage-mismatch";
+  case DFBConflictReason::UnknownLaunchNodeDomain:
+    return "unknown-launch-node-domain";
+  case DFBConflictReason::UnprovenQuiescence:
+    return "unproven-quiescence";
+  case DFBConflictReason::TransactionMismatch:
+    return "transaction-mismatch";
+  case DFBConflictReason::PointerOwnerMismatch:
+    return "pointer-owner-mismatch";
+  case DFBConflictReason::ConcurrentLifetime:
+    return "concurrent-lifetime";
+  }
+  llvm_unreachable("unknown DFB conflict reason");
+}
+
+static llvm::StringRef getPointerProcessorName(DFBPointerProcessor processor) {
+  switch (processor) {
+  case DFBPointerProcessor::Noc0:
+    return "noc0";
+  case DFBPointerProcessor::Noc1:
+    return "noc1";
+  case DFBPointerProcessor::Pack:
+    return "pack";
+  case DFBPointerProcessor::Unpack:
+    return "unpack";
+  }
+  llvm_unreachable("unknown DFB pointer processor");
+}
+
+static llvm::StringRef getPointerDirectionName(DFBPointerDirection direction) {
+  switch (direction) {
+  case DFBPointerDirection::Read:
+    return "read";
+  case DFBPointerDirection::Write:
+    return "write";
+  }
+  llvm_unreachable("unknown DFB pointer direction");
+}
+
+static void printNode(llvm::raw_ostream &output, LaunchNodeCoord node) {
+  output << '(' << node.x << ',' << node.y << ')';
+}
+
+static void printDomain(llvm::raw_ostream &output,
+                        const LaunchNodeDomain &domain) {
+  if (!domain.known) {
+    output << "unknown";
+    return;
+  }
+  output << '{';
+  llvm::interleaveComma(domain.nodes, output,
+                        [&](LaunchNodeCoord node) { printNode(output, node); });
+  output << '}';
+}
+
+static void printOperation(llvm::raw_ostream &output, Operation *operation) {
+  if (!operation) {
+    output << "none";
+    return;
+  }
+  output << operation->getName().getStringRef();
+  if (func::FuncOp kernel = operation->getParentOfType<func::FuncOp>()) {
+    output << " kernel=@" << kernel.getSymName();
+    if (Attribute thread = kernel->getAttr(kKernelThreadAttrName)) {
+      output << " thread=";
+      thread.print(output);
+    }
+    if (Attribute logicalKernel = kernel->getAttr(kLogicalKernelAttrName)) {
+      output << " logical_kernel=";
+      logicalKernel.print(output);
+    }
+    if (Attribute nocIndex = kernel->getAttr(kNocIndexAttrName)) {
+      output << " noc_index=";
+      nocIndex.print(output);
+    }
+  }
+  output << " loc=";
+  operation->getLoc().print(output);
+}
+
+static void printPointerOwner(llvm::raw_ostream &output,
+                              const std::optional<DFBPointerOwner> &owner) {
+  if (!owner) {
+    output << "unknown";
+    return;
+  }
+  printNode(output, owner->node);
+  output << ':' << getPointerProcessorName(owner->processor) << ':'
+         << getPointerDirectionName(owner->direction);
+}
+
+template <typename Range>
+static void printValues(llvm::raw_ostream &output, const Range &values) {
+  output << '[';
+  llvm::interleaveComma(values, output);
+  output << ']';
+}
+
+static void printAccesses(llvm::raw_ostream &output,
+                          const DFBLogicalLifecycle &logicalDFB) {
+  for (auto indexedAccess : llvm::enumerate(logicalDFB.accesses)) {
+    const DFBAccessOccurrence &access = indexedAccess.value();
+    output << "  access " << indexedAccess.index() << " effect=";
+    if (access.protocolEffect) {
+      output << getProtocolEffectName(*access.protocolEffect);
+    } else {
+      output << "none";
+    }
+    output << " tiles=" << access.numTiles
+           << " sequence=" << access.sequenceIndex << " domain=";
+    printDomain(output, access.launchDomain);
+    output << " operation=";
+    printOperation(output, access.operation);
+    if (access.unanalyzableDomainOperation) {
+      output << " unresolved_at=";
+      printOperation(output, access.unanalyzableDomainOperation);
+    }
+    output << '\n';
+  }
+}
+
+static void printOccurrences(llvm::raw_ostream &output,
+                             const DFBPerNodeLifetime &lifetime) {
+  output << '[';
+  llvm::interleaveComma(lifetime.reportedOccurrences, output,
+                        [&](const DFBPerNodeAccessOccurrence &occurrence) {
+                          output << occurrence.occurrenceIndex << ':';
+                          if (occurrence.exactExecutionCount) {
+                            output << *occurrence.exactExecutionCount;
+                          } else {
+                            output << "unresolved";
+                          }
+                        });
+  output << ']';
+}
+
+static bool hasEqualDiagnosticFacts(const DFBPerNodeLifetime &lhs,
+                                    const DFBPerNodeLifetime &rhs) {
+  if (lhs.quiescence.failure != rhs.quiescence.failure ||
+      lhs.quiescence.evidence != rhs.quiescence.evidence ||
+      lhs.mayBeActive != rhs.mayBeActive ||
+      lhs.reportedOccurrences.size() != rhs.reportedOccurrences.size() ||
+      lhs.earliestAccessOccurrenceIndices !=
+          rhs.earliestAccessOccurrenceIndices ||
+      lhs.terminalAccessOccurrenceIndices !=
+          rhs.terminalAccessOccurrenceIndices ||
+      lhs.transactionTileCounts != rhs.transactionTileCounts ||
+      lhs.writePointerOwner != rhs.writePointerOwner ||
+      lhs.readPointerOwner != rhs.readPointerOwner) {
+    return false;
+  }
+  return llvm::equal(lhs.reportedOccurrences, rhs.reportedOccurrences,
+                     [](const DFBPerNodeAccessOccurrence &lhsOccurrence,
+                        const DFBPerNodeAccessOccurrence &rhsOccurrence) {
+                       return lhsOccurrence.occurrenceIndex ==
+                                  rhsOccurrence.occurrenceIndex &&
+                              lhsOccurrence.exactExecutionCount ==
+                                  rhsOccurrence.exactExecutionCount;
+                     });
+}
+
+struct DiagnosticLifetimeGroup {
+  const DFBPerNodeLifetime *representative = nullptr;
+  SmallVector<LaunchNodeCoord> nodes;
+};
+
+static void printDiagnosticLifetimes(
+    llvm::raw_ostream &output,
+    llvm::ArrayRef<const DFBPerNodeLifetime *> diagnosticLifetimes) {
+  SmallVector<DiagnosticLifetimeGroup> groups;
+  for (const DFBPerNodeLifetime *lifetime : diagnosticLifetimes) {
+    auto groupIt = llvm::find_if(groups, [&](const auto &group) {
+      return hasEqualDiagnosticFacts(*group.representative, *lifetime);
+    });
+    if (groupIt == groups.end()) {
+      groups.push_back({lifetime, {lifetime->node}});
+    } else {
+      groupIt->nodes.push_back(lifetime->node);
+    }
+  }
+
+  for (const DiagnosticLifetimeGroup &group : groups) {
+    const DFBPerNodeLifetime &lifetime = *group.representative;
+    output << "  diagnostic_nodes quiescence="
+           << getQuiescenceFailureName(lifetime.quiescence.failure)
+           << " domain_assumption=unknown-may-be-active may_be_active="
+           << lifetime.mayBeActive << " node_count=" << group.nodes.size();
+    if (group.nodes.size() <= 8) {
+      output << " nodes={";
+      llvm::interleaveComma(group.nodes, output, [&](LaunchNodeCoord node) {
+        printNode(output, node);
+      });
+      output << '}';
+    } else {
+      output << " exemplar=";
+      printNode(output, lifetime.node);
+    }
+    output << " evidence=";
+    printOperation(output, lifetime.quiescence.evidence);
+    output << " occurrences=";
+    printOccurrences(output, lifetime);
+    output << " transactions=";
+    printValues(output, lifetime.transactionTileCounts);
+    output << " write_owner=";
+    printPointerOwner(output, lifetime.writePointerOwner);
+    output << " read_owner=";
+    printPointerOwner(output, lifetime.readPointerOwner);
+    output << " earliest_accesses=";
+    printValues(output, lifetime.earliestAccessOccurrenceIndices);
+    output << " terminal_accesses=";
+    printValues(output, lifetime.terminalAccessOccurrenceIndices);
+    output << '\n';
+  }
+}
+
+static void printNodeLifetimes(llvm::raw_ostream &output,
+                               const DFBLogicalLifecycle &logicalDFB) {
+  for (const DFBPerNodeLifetime &lifetime : logicalDFB.nodeLifetimes) {
+    output << "  node ";
+    printNode(output, lifetime.node);
+    output << " quiescence="
+           << getQuiescenceFailureName(lifetime.quiescence.failure)
+           << " domain_assumption=exact evidence=";
+    printOperation(output, lifetime.quiescence.evidence);
+    output << " occurrences=";
+    printOccurrences(output, lifetime);
+    output << " transactions=";
+    printValues(output, lifetime.transactionTileCounts);
+    output << " write_owner=";
+    printPointerOwner(output, lifetime.writePointerOwner);
+    output << " read_owner=";
+    printPointerOwner(output, lifetime.readPointerOwner);
+    output << " earliest_accesses=";
+    printValues(output, lifetime.earliestAccessOccurrenceIndices);
+    output << " terminal_accesses=";
+    printValues(output, lifetime.terminalAccessOccurrenceIndices);
+    output << '\n';
+  }
+  SmallVector<const DFBPerNodeLifetime *> diagnosticLifetimes;
+  for (const DFBPerNodeLifetime &lifetime :
+       logicalDFB.diagnosticNodeLifetimes) {
+    diagnosticLifetimes.push_back(&lifetime);
+  }
+  printDiagnosticLifetimes(output, diagnosticLifetimes);
+}
+
+static void printConflictEvidence(llvm::raw_ostream &output,
+                                  const DFBPhysicalConflictModel &model) {
+  for (const DFBConflictEvidence &evidence : model.getEvidence()) {
+    output << "DFB conflict lhs=" << evidence.lhsLogicalId
+           << " rhs=" << evidence.rhsLogicalId
+           << " reason=" << getConflictReasonName(evidence.reason) << " node=";
+    if (evidence.node) {
+      printNode(output, *evidence.node);
+    } else {
+      output << "none";
+    }
+    output << " lhs_operation=";
+    printOperation(output, evidence.lhsOperation);
+    output << " rhs_operation=";
+    printOperation(output, evidence.rhsOperation);
+    output << '\n';
+  }
+}
+
+} // namespace
+
+void printDFBAllocationDebugReport(
+    llvm::raw_ostream &output,
+    const DFBConcurrentKernelLivenessAnalysis &liveness,
+    const DFBPhysicalConflictModel &conflictModel) {
+  output << "DFB allocation liveness report\n";
+  for (const DFBLogicalLifecycle &logicalDFB :
+       liveness.getLogicalDFBLifecycles()) {
+    output << "DFB logical_id=" << logicalDFB.logicalId
+           << " bounded=" << logicalDFB.bounded
+           << " compiler_created=" << logicalDFB.compilerCreated << " type=";
+    logicalDFB.type.print(output);
+    output << " tensor_backing=";
+    if (logicalDFB.tensorBacking) {
+      Attribute tensorBacking = logicalDFB.tensorBacking;
+      tensorBacking.print(output);
+    } else {
+      output << "none";
+    }
+    output << " domain=";
+    printDomain(output, logicalDFB.launchDomain);
+    output << '\n';
+    printAccesses(output, logicalDFB);
+    printNodeLifetimes(output, logicalDFB);
+  }
+  printConflictEvidence(output, conflictModel);
+  output << "DFB allocation liveness report end\n";
+}
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.h
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONDEBUGREPORT_H
+#define TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONDEBUGREPORT_H
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir::tt::ttl {
+
+class DFBConcurrentKernelLivenessAnalysis;
+class DFBPhysicalConflictModel;
+
+/// Print deterministic lifetime and conflict facts used by DFB allocation.
+void printDFBAllocationDebugReport(
+    llvm::raw_ostream &output,
+    const DFBConcurrentKernelLivenessAnalysis &liveness,
+    const DFBPhysicalConflictModel &conflictModel);
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_DIALECT_TTL_TRANSFORMS_DFBALLOCATIONDEBUGREPORT_H

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -24,10 +24,13 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <cstdint>
 #include <optional>
+
+#define DEBUG_TYPE "ttl-finalize-dfb-indices"
 
 namespace mlir::tt::ttl {
 
@@ -103,6 +106,34 @@ struct AccessDomain {
 struct LivenessDomainState : LaunchNodeDomainState {
   DenseMap<Operation *, AccessDomain> accessDomains;
 };
+
+using AccessExecutionCounts =
+    DenseMap<const DFBAccessOccurrence *, std::optional<std::uint64_t>>;
+
+// Unknown membership is included only for counterfactual diagnostics. Reuse
+// proofs continue to require exact launch-node membership.
+static bool mayContainLaunchNode(const LaunchNodeDomain &domain,
+                                 LaunchNodeCoord node,
+                                 bool includeUnknownDomains) {
+  return knownLaunchNodeDomainContains(domain, node) ||
+         (includeUnknownDomains && !domain.known);
+}
+
+// Exact-zero accesses cannot contribute ordering edges even when their launch
+// domain is otherwise unknown.
+static bool mayAccessLaunchNode(const DFBAccessOccurrence &access,
+                                LaunchNodeCoord node,
+                                const AccessExecutionCounts &executionCounts,
+                                bool includeUnknownDomains) {
+  if (!mayContainLaunchNode(access.launchDomain, node, includeUnknownDomains)) {
+    return false;
+  }
+  auto executionCountIt = executionCounts.find(&access);
+  assert(executionCountIt != executionCounts.end() &&
+         "every reported DFB access must have an execution-count fact");
+  std::optional<std::uint64_t> executionCount = executionCountIt->second;
+  return !executionCount || *executionCount != 0;
+}
 
 // Identifies attributes that copy a provisional physical DFB index and would
 // become stale after allocation changes declaration indices.
@@ -214,13 +245,13 @@ static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release) {
 }
 
 // Finds every access without a proved predecessor so all possible lifetime
-// starts constrain reuse.
-static SmallVector<unsigned> findMinimalEntryEvents(
+// starts constrain reuse and remain traceable in the debug report.
+static SmallVector<const DFBAccessOccurrence *> findMinimalEntryAccesses(
     ArrayRef<const DFBAccessOccurrence *> accesses,
     const HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents) {
-  SmallVector<unsigned> minimal;
+  SmallVector<const DFBAccessOccurrence *> minimal;
   for (const DFBAccessOccurrence *candidate : accesses) {
     std::optional<EventPair> candidateEvents =
         getAccessEvents(*candidate, operationEvents, accessEvents);
@@ -233,9 +264,8 @@ static SmallVector<unsigned> findMinimalEntryEvents(
       return otherEvents &&
              graph.strictlyPrecedes(otherEvents->entry, candidateEvents->entry);
     });
-    if (!hasPredecessor &&
-        !llvm::is_contained(minimal, candidateEvents->entry)) {
-      minimal.push_back(candidateEvents->entry);
+    if (!hasPredecessor) {
+      minimal.push_back(candidate);
     }
   }
   return minimal;
@@ -517,6 +547,35 @@ static LogicalResult collectLogicalDFBs(
   return success();
 }
 
+// Collects complete per-access counts only for the enabled debug report.
+// Counts are cached by operation because one call may describe several DFB
+// effects or dependencies.
+static AccessExecutionCounts
+collectAccessExecutionCounts(ArrayRef<DFBLogicalLifecycle> logicalDFBs,
+                             LaunchNodeCoord node,
+                             const LaunchNodeDomainState &domainState) {
+  AccessExecutionCounts executionCounts;
+  DenseMap<Operation *, std::optional<std::uint64_t>> operationCounts;
+  for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+      if (!mayContainLaunchNode(access.launchDomain, node,
+                                /*includeUnknownDomains=*/true)) {
+        continue;
+      }
+      auto operationCountIt = operationCounts.find(access.operation);
+      if (operationCountIt == operationCounts.end()) {
+        std::optional<std::uint64_t> executionCount =
+            getExactExecutionCountAtLaunchNode(access.operation, node,
+                                               domainState);
+        operationCountIt =
+            operationCounts.try_emplace(access.operation, executionCount).first;
+      }
+      executionCounts.try_emplace(&access, operationCountIt->second);
+    }
+  }
+  return executionCounts;
+}
+
 // Builds source-order events only for accesses active on `node`. Direct
 // protocol effects receive separate events in their declared sequence;
 // operations in different kernels remain concurrent unless protocol edges
@@ -525,13 +584,19 @@ static void buildProgramOrderGraph(
     ModuleOp module, ArrayRef<DFBLogicalLifecycle> logicalDFBs,
     LaunchNodeCoord node, HappensBeforeGraph &graph,
     DenseMap<Operation *, EventPair> &operationEvents,
-    DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents) {
+    DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents,
+    const AccessExecutionCounts *executionCounts, bool includeUnknownDomains) {
   llvm::DenseSet<Operation *> modeledOperations;
   DenseMap<Operation *, SmallVector<const DFBAccessOccurrence *>>
       directProtocolAccesses;
   for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
     for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
-      if (!knownLaunchNodeDomainContains(access.launchDomain, node)) {
+      bool mayAccess = executionCounts
+                           ? mayAccessLaunchNode(access, node, *executionCounts,
+                                                 includeUnknownDomains)
+                           : mayContainLaunchNode(access.launchDomain, node,
+                                                  includeUnknownDomains);
+      if (!mayAccess) {
         continue;
       }
       if (Operation *projected = getTopLevelKernelOperation(access.operation)) {
@@ -575,31 +640,96 @@ static void buildProgramOrderGraph(
   }
 }
 
-// Derives the immutable per-node lifetime facts required for reuse. Any
-// unsupported or ambiguous protocol fact returns a typed failed proof, which
-// can only add conflicts.
+// Adds the completion edge implied by each matching push/wait transaction.
+// Unknown-domain edges are restricted to the counterfactual debug graph.
+static void addMatchedPushWaitEdges(
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs, LaunchNodeCoord node,
+    HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents,
+    const AccessExecutionCounts *executionCounts, bool includeUnknownDomains) {
+  for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    SmallVector<const DFBAccessOccurrence *> pushes;
+    SmallVector<const DFBAccessOccurrence *> waits;
+    for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+      bool mayAccess = executionCounts
+                           ? mayAccessLaunchNode(access, node, *executionCounts,
+                                                 includeUnknownDomains)
+                           : mayContainLaunchNode(access.launchDomain, node,
+                                                  includeUnknownDomains);
+      if (!mayAccess) {
+        continue;
+      }
+      if (access.protocolEffect == DFBProtocolEffectKind::Push) {
+        pushes.push_back(&access);
+      } else if (access.protocolEffect == DFBProtocolEffectKind::Wait) {
+        waits.push_back(&access);
+      }
+    }
+    if (pushes.size() != waits.size()) {
+      continue;
+    }
+    for (auto [push, wait] : llvm::zip_equal(pushes, waits)) {
+      if (push->numTiles != wait->numTiles) {
+        continue;
+      }
+      std::optional<EventPair> pushEvents =
+          getAccessEvents(*push, operationEvents, accessEvents);
+      std::optional<EventPair> waitEvents =
+          getAccessEvents(*wait, operationEvents, accessEvents);
+      if (pushEvents && waitEvents) {
+        graph.addEdge(pushEvents->completion, waitEvents->completion);
+      }
+    }
+  }
+}
+
+// Derives per-node lifetime facts. Exact-domain facts control reuse;
+// counterfactual facts are retained only for debug reporting.
 static DFBQuiescenceProof computePerNodeLifetime(
     DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
+    SmallVectorImpl<DFBPerNodeLifetime> &lifetimes,
     const HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents,
-    const LaunchNodeDomainState &domainState) {
-  DFBPerNodeLifetime &lifetime = logicalDFB.nodeLifetimes.emplace_back();
+    const LaunchNodeDomainState &domainState,
+    const AccessExecutionCounts *reportedExecutionCounts,
+    bool includeUnknownDomains = false) {
+  DFBPerNodeLifetime &lifetime = lifetimes.emplace_back();
   lifetime.node = node;
   SmallVector<const DFBAccessOccurrence *> reserves;
   SmallVector<const DFBAccessOccurrence *> pushes;
   SmallVector<const DFBAccessOccurrence *> waits;
   SmallVector<const DFBAccessOccurrence *> pops;
   SmallVector<const DFBAccessOccurrence *> activeAccesses;
+  DenseMap<const DFBAccessOccurrence *, std::optional<std::uint64_t>>
+      executionCounts;
   for (auto [accessIndex, access] : llvm::enumerate(logicalDFB.accesses)) {
-    if (!knownLaunchNodeDomainContains(access.launchDomain, node)) {
+    if (!mayContainLaunchNode(access.launchDomain, node,
+                              includeUnknownDomains)) {
       continue;
     }
-    lifetime.occurrenceIndices.push_back(accessIndex);
+    std::optional<std::uint64_t> executionCount;
+    if (reportedExecutionCounts) {
+      auto executionCountIt = reportedExecutionCounts->find(&access);
+      assert(executionCountIt != reportedExecutionCounts->end() &&
+             "every reported DFB access must have an execution-count fact");
+      executionCount = executionCountIt->second;
+      lifetime.reportedOccurrences.push_back(
+          {static_cast<unsigned>(accessIndex), executionCount});
+    }
+    if (includeUnknownDomains && executionCount && *executionCount == 0) {
+      continue;
+    }
     activeAccesses.push_back(&access);
     if (!access.protocolEffect) {
       continue;
     }
+    if (!reportedExecutionCounts) {
+      executionCount = getExactExecutionCountAtLaunchNode(access.operation,
+                                                          node, domainState);
+    }
+    executionCounts[&access] = executionCount;
     switch (*access.protocolEffect) {
     case DFBProtocolEffectKind::Reserve:
       reserves.push_back(&access);
@@ -616,6 +746,11 @@ static DFBQuiescenceProof computePerNodeLifetime(
     }
   }
 
+  if (includeUnknownDomains && activeAccesses.empty()) {
+    lifetime.mayBeActive = false;
+    return {};
+  }
+
   if (reserves.empty() || pushes.empty() || waits.empty() || pops.empty()) {
     return {DFBQuiescenceFailureReason::MissingProtocolEffect,
             activeAccesses.empty() ? logicalDFB.declarations.front()
@@ -630,9 +765,10 @@ static DFBQuiescenceProof computePerNodeLifetime(
   for (const DFBAccessOccurrence *protocolAccess :
        llvm::concat<const DFBAccessOccurrence *>(reserves, pushes, waits,
                                                  pops)) {
-    std::optional<std::uint64_t> executionCount =
-        getExactExecutionCountAtLaunchNode(protocolAccess->operation, node,
-                                           domainState);
+    auto executionCountIt = executionCounts.find(protocolAccess);
+    assert(executionCountIt != executionCounts.end() &&
+           "active protocol access must have an execution count fact");
+    std::optional<std::uint64_t> executionCount = executionCountIt->second;
     if (!executionCount || *executionCount != 1) {
       return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
               protocolAccess->operation};
@@ -730,9 +866,23 @@ static DFBQuiescenceProof computePerNodeLifetime(
               activeAccess->operation};
     }
   }
-  lifetime.earliestEntryEvents = findMinimalEntryEvents(
-      activeAccesses, graph, operationEvents, accessEvents);
+  SmallVector<const DFBAccessOccurrence *> earliestAccesses =
+      findMinimalEntryAccesses(activeAccesses, graph, operationEvents,
+                               accessEvents);
+  for (const DFBAccessOccurrence *earliestAccess : earliestAccesses) {
+    std::optional<EventPair> earliestEvents =
+        getAccessEvents(*earliestAccess, operationEvents, accessEvents);
+    assert(earliestEvents && "minimal access must have modeled events");
+    if (!llvm::is_contained(lifetime.earliestEntryEvents,
+                            earliestEvents->entry)) {
+      lifetime.earliestEntryEvents.push_back(earliestEvents->entry);
+    }
+    lifetime.earliestAccessOccurrenceIndices.push_back(
+        static_cast<unsigned>(earliestAccess - logicalDFB.accesses.data()));
+  }
   lifetime.terminalCompletionEvents = {terminalEvents->completion};
+  lifetime.terminalAccessOccurrenceIndices = {
+      static_cast<unsigned>(pops.back() - logicalDFB.accesses.data())};
   if (lifetime.earliestEntryEvents.empty()) {
     return {DFBQuiescenceFailureReason::IncompleteUseOrder,
             pops.back()->operation};
@@ -883,42 +1033,23 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   launchNodes.append(domainState.baseDomain.nodes.begin(),
                      domainState.baseDomain.nodes.end());
   orderedBeforeByNode.reserve(launchNodes.size());
+  bool collectAllocationDiagnostics = false;
+  LLVM_DEBUG(collectAllocationDiagnostics = true);
   for (LaunchNodeCoord node : launchNodes) {
+    std::optional<AccessExecutionCounts> reportedExecutionCounts;
+    if (collectAllocationDiagnostics) {
+      reportedExecutionCounts.emplace(
+          collectAccessExecutionCounts(logicalDFBs, node, domainState));
+    }
     HappensBeforeGraph graph;
     DenseMap<Operation *, EventPair> operationEvents;
     DenseMap<const DFBAccessOccurrence *, EventPair> accessEvents;
     buildProgramOrderGraph(module, logicalDFBs, node, graph, operationEvents,
-                           accessEvents);
-
-    for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
-      SmallVector<const DFBAccessOccurrence *> pushes;
-      SmallVector<const DFBAccessOccurrence *> waits;
-      for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
-        if (!knownLaunchNodeDomainContains(access.launchDomain, node)) {
-          continue;
-        }
-        if (access.protocolEffect == DFBProtocolEffectKind::Push) {
-          pushes.push_back(&access);
-        } else if (access.protocolEffect == DFBProtocolEffectKind::Wait) {
-          waits.push_back(&access);
-        }
-      }
-      if (pushes.size() == waits.size()) {
-        for (auto [push, wait] : llvm::zip_equal(pushes, waits)) {
-          if (push->numTiles != wait->numTiles) {
-            continue;
-          }
-          std::optional<EventPair> pushEvents =
-              getAccessEvents(*push, operationEvents, accessEvents);
-          std::optional<EventPair> waitEvents =
-              getAccessEvents(*wait, operationEvents, accessEvents);
-          if (!pushEvents || !waitEvents) {
-            continue;
-          }
-          graph.addEdge(pushEvents->completion, waitEvents->completion);
-        }
-      }
-    }
+                           accessEvents, /*executionCounts=*/nullptr,
+                           /*includeUnknownDomains=*/false);
+    addMatchedPushWaitEdges(logicalDFBs, node, graph, operationEvents,
+                            accessEvents, /*executionCounts=*/nullptr,
+                            /*includeUnknownDomains=*/false);
     graph.computeReachability();
 
     for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
@@ -926,7 +1057,9 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
         continue;
       }
       DFBQuiescenceProof proof = computePerNodeLifetime(
-          logicalDFB, node, graph, operationEvents, accessEvents, domainState);
+          logicalDFB, node, logicalDFB.nodeLifetimes, graph, operationEvents,
+          accessEvents, domainState,
+          reportedExecutionCounts ? &*reportedExecutionCounts : nullptr);
       logicalDFB.nodeLifetimes.back().quiescence = proof;
     }
 
@@ -949,6 +1082,33 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
       }
     }
     orderedBeforeByNode.push_back(std::move(nodeOrdering));
+
+    if (!collectAllocationDiagnostics) {
+      continue;
+    }
+    HappensBeforeGraph diagnosticGraph;
+    DenseMap<Operation *, EventPair> diagnosticOperationEvents;
+    DenseMap<const DFBAccessOccurrence *, EventPair> diagnosticAccessEvents;
+    buildProgramOrderGraph(module, logicalDFBs, node, diagnosticGraph,
+                           diagnosticOperationEvents, diagnosticAccessEvents,
+                           &*reportedExecutionCounts,
+                           /*includeUnknownDomains=*/true);
+    addMatchedPushWaitEdges(logicalDFBs, node, diagnosticGraph,
+                            diagnosticOperationEvents, diagnosticAccessEvents,
+                            &*reportedExecutionCounts,
+                            /*includeUnknownDomains=*/true);
+    diagnosticGraph.computeReachability();
+    for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+      if (logicalDFB.launchDomain.known) {
+        continue;
+      }
+      DFBQuiescenceProof proof = computePerNodeLifetime(
+          logicalDFB, node, logicalDFB.diagnosticNodeLifetimes, diagnosticGraph,
+          diagnosticOperationEvents, diagnosticAccessEvents, domainState,
+          &*reportedExecutionCounts,
+          /*includeUnknownDomains=*/true);
+      logicalDFB.diagnosticNodeLifetimes.back().quiescence = proof;
+    }
   }
 
   for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 #define DEBUG_TYPE "ttl-finalize-dfb-indices"
@@ -245,13 +246,13 @@ static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release) {
 }
 
 // Finds every access without a proved predecessor so all possible lifetime
-// starts constrain reuse and remain traceable in the debug report.
-static SmallVector<const DFBAccessOccurrence *> findMinimalEntryAccesses(
+// starts constrain reuse.
+static SmallVector<unsigned> findMinimalEntryEvents(
     ArrayRef<const DFBAccessOccurrence *> accesses,
     const HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents) {
-  SmallVector<const DFBAccessOccurrence *> minimal;
+  SmallVector<unsigned> minimal;
   for (const DFBAccessOccurrence *candidate : accesses) {
     std::optional<EventPair> candidateEvents =
         getAccessEvents(*candidate, operationEvents, accessEvents);
@@ -264,8 +265,9 @@ static SmallVector<const DFBAccessOccurrence *> findMinimalEntryAccesses(
       return otherEvents &&
              graph.strictlyPrecedes(otherEvents->entry, candidateEvents->entry);
     });
-    if (!hasPredecessor) {
-      minimal.push_back(candidate);
+    if (!hasPredecessor &&
+        !llvm::is_contained(minimal, candidateEvents->entry)) {
+      minimal.push_back(candidateEvents->entry);
     }
   }
   return minimal;
@@ -689,6 +691,7 @@ static void addMatchedPushWaitEdges(
 static DFBQuiescenceProof computePerNodeLifetime(
     DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
     SmallVectorImpl<DFBPerNodeLifetime> &lifetimes,
+    SmallVectorImpl<DFBPerNodeLifetimeDiagnostics> *lifetimeDiagnostics,
     const HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents,
@@ -697,6 +700,15 @@ static DFBQuiescenceProof computePerNodeLifetime(
     bool includeUnknownDomains = false) {
   DFBPerNodeLifetime &lifetime = lifetimes.emplace_back();
   lifetime.node = node;
+  DFBPerNodeLifetimeDiagnostics *diagnostics = nullptr;
+  if (reportedExecutionCounts) {
+    assert(lifetimeDiagnostics &&
+           "reported execution counts require lifetime diagnostics");
+    diagnostics = &lifetimeDiagnostics->emplace_back();
+  } else {
+    assert(!lifetimeDiagnostics &&
+           "lifetime diagnostics require reported execution counts");
+  }
   SmallVector<const DFBAccessOccurrence *> reserves;
   SmallVector<const DFBAccessOccurrence *> pushes;
   SmallVector<const DFBAccessOccurrence *> waits;
@@ -715,7 +727,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
       assert(executionCountIt != reportedExecutionCounts->end() &&
              "every reported DFB access must have an execution-count fact");
       executionCount = executionCountIt->second;
-      lifetime.reportedOccurrences.push_back(
+      diagnostics->occurrences.push_back(
           {static_cast<unsigned>(accessIndex), executionCount});
     }
     if (includeUnknownDomains && executionCount && *executionCount == 0) {
@@ -747,7 +759,9 @@ static DFBQuiescenceProof computePerNodeLifetime(
   }
 
   if (includeUnknownDomains && activeAccesses.empty()) {
-    lifetime.mayBeActive = false;
+    assert(diagnostics &&
+           "counterfactual lifetimes require allocation-report data");
+    diagnostics->mayBeActive = false;
     return {};
   }
 
@@ -866,23 +880,22 @@ static DFBQuiescenceProof computePerNodeLifetime(
               activeAccess->operation};
     }
   }
-  SmallVector<const DFBAccessOccurrence *> earliestAccesses =
-      findMinimalEntryAccesses(activeAccesses, graph, operationEvents,
-                               accessEvents);
-  for (const DFBAccessOccurrence *earliestAccess : earliestAccesses) {
-    std::optional<EventPair> earliestEvents =
-        getAccessEvents(*earliestAccess, operationEvents, accessEvents);
-    assert(earliestEvents && "minimal access must have modeled events");
-    if (!llvm::is_contained(lifetime.earliestEntryEvents,
-                            earliestEvents->entry)) {
-      lifetime.earliestEntryEvents.push_back(earliestEvents->entry);
-    }
-    lifetime.earliestAccessOccurrenceIndices.push_back(
-        static_cast<unsigned>(earliestAccess - logicalDFB.accesses.data()));
-  }
+  lifetime.earliestEntryEvents = findMinimalEntryEvents(
+      activeAccesses, graph, operationEvents, accessEvents);
   lifetime.terminalCompletionEvents = {terminalEvents->completion};
-  lifetime.terminalAccessOccurrenceIndices = {
-      static_cast<unsigned>(pops.back() - logicalDFB.accesses.data())};
+  if (diagnostics) {
+    for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
+      std::optional<EventPair> activeEvents =
+          getAccessEvents(*activeAccess, operationEvents, accessEvents);
+      if (activeEvents && llvm::is_contained(lifetime.earliestEntryEvents,
+                                             activeEvents->entry)) {
+        diagnostics->earliestAccessOccurrenceIndices.push_back(
+            static_cast<unsigned>(activeAccess - logicalDFB.accesses.data()));
+      }
+    }
+    diagnostics->terminalAccessOccurrenceIndices = {
+        static_cast<unsigned>(pops.back() - logicalDFB.accesses.data())};
+  }
   if (lifetime.earliestEntryEvents.empty()) {
     return {DFBQuiescenceFailureReason::IncompleteUseOrder,
             pops.back()->operation};
@@ -1035,6 +1048,12 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   orderedBeforeByNode.reserve(launchNodes.size());
   bool collectAllocationDiagnostics = false;
   LLVM_DEBUG(collectAllocationDiagnostics = true);
+  if (collectAllocationDiagnostics) {
+    for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+      logicalDFB.allocationDiagnostics =
+          std::make_unique<DFBLogicalLifecycleDiagnostics>();
+    }
+  }
   for (LaunchNodeCoord node : launchNodes) {
     std::optional<AccessExecutionCounts> reportedExecutionCounts;
     if (collectAllocationDiagnostics) {
@@ -1056,9 +1075,14 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
       if (!knownLaunchNodeDomainContains(logicalDFB.launchDomain, node)) {
         continue;
       }
+      DFBLogicalLifecycleDiagnostics *allocationDiagnostics =
+          logicalDFB.allocationDiagnostics.get();
       DFBQuiescenceProof proof = computePerNodeLifetime(
-          logicalDFB, node, logicalDFB.nodeLifetimes, graph, operationEvents,
-          accessEvents, domainState,
+          logicalDFB, node, logicalDFB.nodeLifetimes,
+          allocationDiagnostics
+              ? &allocationDiagnostics->nodeLifetimeDiagnostics
+              : nullptr,
+          graph, operationEvents, accessEvents, domainState,
           reportedExecutionCounts ? &*reportedExecutionCounts : nullptr);
       logicalDFB.nodeLifetimes.back().quiescence = proof;
     }
@@ -1102,12 +1126,16 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
       if (logicalDFB.launchDomain.known) {
         continue;
       }
+      DFBLogicalLifecycleDiagnostics &allocationDiagnostics =
+          *logicalDFB.allocationDiagnostics;
       DFBQuiescenceProof proof = computePerNodeLifetime(
-          logicalDFB, node, logicalDFB.diagnosticNodeLifetimes, diagnosticGraph,
-          diagnosticOperationEvents, diagnosticAccessEvents, domainState,
-          &*reportedExecutionCounts,
+          logicalDFB, node, allocationDiagnostics.counterfactualNodeLifetimes,
+          &allocationDiagnostics.counterfactualNodeLifetimeDiagnostics,
+          diagnosticGraph, diagnosticOperationEvents, diagnosticAccessEvents,
+          domainState, &*reportedExecutionCounts,
           /*includeUnknownDomains=*/true);
-      logicalDFB.diagnosticNodeLifetimes.back().quiescence = proof;
+      allocationDiagnostics.counterfactualNodeLifetimes.back().quiescence =
+          proof;
     }
   }
 

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -22,6 +22,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -91,24 +92,46 @@ struct DFBAccessOccurrence {
   Operation *unanalyzableDomainOperation = nullptr;
 };
 
-/// Execution count retained for one access in the debug report.
-struct DFBPerNodeAccessOccurrence {
+/// Execution count retained for one access in the allocation report.
+struct DFBDiagnosticAccessOccurrence {
   /// Index into the logical lifecycle's access occurrence list.
   unsigned occurrenceIndex = 0;
 
   /// Exact executions on the node, or null when the count is unknown.
   std::optional<std::uint64_t> exactExecutionCount;
+
+  bool operator==(const DFBDiagnosticAccessOccurrence &rhs) const {
+    return occurrenceIndex == rhs.occurrenceIndex &&
+           exactExecutionCount == rhs.exactExecutionCount;
+  }
+};
+
+/// Per-node data collected only for the allocation report.
+struct DFBPerNodeLifetimeDiagnostics {
+  /// False when counterfactual analysis proves that no access executes.
+  bool mayBeActive = true;
+
+  /// Execution-count row for every access considered on the launch node.
+  SmallVector<DFBDiagnosticAccessOccurrence> occurrences;
+
+  /// Every access whose entry belongs to the minimal lifetime frontier.
+  SmallVector<unsigned> earliestAccessOccurrenceIndices;
+
+  /// Accesses whose completion defines the retained terminal frontier.
+  SmallVector<unsigned> terminalAccessOccurrenceIndices;
+
+  bool operator==(const DFBPerNodeLifetimeDiagnostics &rhs) const {
+    return mayBeActive == rhs.mayBeActive && occurrences == rhs.occurrences &&
+           earliestAccessOccurrenceIndices ==
+               rhs.earliestAccessOccurrenceIndices &&
+           terminalAccessOccurrenceIndices ==
+               rhs.terminalAccessOccurrenceIndices;
+  }
 };
 
 /// Immutable lifetime and hardware-state facts for one launched node.
 struct DFBPerNodeLifetime {
   LaunchNodeCoord node;
-
-  /// False when counterfactual analysis proves no access executes on `node`.
-  bool mayBeActive = true;
-
-  /// Per-access execution counts retained for allocation diagnostics.
-  SmallVector<DFBPerNodeAccessOccurrence> reportedOccurrences;
 
   /// Minimal access-entry event IDs under the proved happens-before relation.
   SmallVector<unsigned> earliestEntryEvents;
@@ -116,17 +139,19 @@ struct DFBPerNodeLifetime {
   /// Completion event IDs after which the DFB is quiescent.
   SmallVector<unsigned> terminalCompletionEvents;
 
-  /// Access occurrence indices corresponding to `earliestEntryEvents`.
-  SmallVector<unsigned> earliestAccessOccurrenceIndices;
-
-  /// Access occurrence indices corresponding to `terminalCompletionEvents`.
-  SmallVector<unsigned> terminalAccessOccurrenceIndices;
-
   /// One tile count per transaction tuple, paired by occurrence order.
   SmallVector<int64_t> transactionTileCounts;
   std::optional<DFBPointerOwner> writePointerOwner;
   std::optional<DFBPointerOwner> readPointerOwner;
   DFBQuiescenceProof quiescence;
+};
+
+/// Allocation-report data omitted from normal liveness analysis.
+struct DFBLogicalLifecycleDiagnostics {
+  SmallVector<DFBPerNodeLifetime, 0> counterfactualNodeLifetimes;
+  SmallVector<DFBPerNodeLifetimeDiagnostics, 0> nodeLifetimeDiagnostics;
+  SmallVector<DFBPerNodeLifetimeDiagnostics, 0>
+      counterfactualNodeLifetimeDiagnostics;
 };
 
 /// Immutable protocol and per-node lifetime facts for one logical DFB.
@@ -139,7 +164,7 @@ struct DFBLogicalLifecycle {
   SmallVector<DFBAccessOccurrence> accesses;
   LaunchNodeDomain launchDomain;
   SmallVector<DFBPerNodeLifetime, 0> nodeLifetimes;
-  SmallVector<DFBPerNodeLifetime, 0> diagnosticNodeLifetimes;
+  std::unique_ptr<DFBLogicalLifecycleDiagnostics> allocationDiagnostics;
   bool bounded = false;
 
   /// Returns the lifetime for `node`, or null when the DFB is inactive there.

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -91,18 +91,36 @@ struct DFBAccessOccurrence {
   Operation *unanalyzableDomainOperation = nullptr;
 };
 
+/// Execution count retained for one access in the debug report.
+struct DFBPerNodeAccessOccurrence {
+  /// Index into the logical lifecycle's access occurrence list.
+  unsigned occurrenceIndex = 0;
+
+  /// Exact executions on the node, or null when the count is unknown.
+  std::optional<std::uint64_t> exactExecutionCount;
+};
+
 /// Immutable lifetime and hardware-state facts for one launched node.
 struct DFBPerNodeLifetime {
   LaunchNodeCoord node;
 
-  /// Indices of the logical lifecycle's accesses active on `node`.
-  SmallVector<unsigned> occurrenceIndices;
+  /// False when counterfactual analysis proves no access executes on `node`.
+  bool mayBeActive = true;
+
+  /// Per-access execution counts retained for allocation diagnostics.
+  SmallVector<DFBPerNodeAccessOccurrence> reportedOccurrences;
 
   /// Minimal access-entry event IDs under the proved happens-before relation.
   SmallVector<unsigned> earliestEntryEvents;
 
   /// Completion event IDs after which the DFB is quiescent.
   SmallVector<unsigned> terminalCompletionEvents;
+
+  /// Access occurrence indices corresponding to `earliestEntryEvents`.
+  SmallVector<unsigned> earliestAccessOccurrenceIndices;
+
+  /// Access occurrence indices corresponding to `terminalCompletionEvents`.
+  SmallVector<unsigned> terminalAccessOccurrenceIndices;
 
   /// One tile count per transaction tuple, paired by occurrence order.
   SmallVector<int64_t> transactionTileCounts;
@@ -121,6 +139,7 @@ struct DFBLogicalLifecycle {
   SmallVector<DFBAccessOccurrence> accesses;
   LaunchNodeDomain launchDomain;
   SmallVector<DFBPerNodeLifetime, 0> nodeLifetimes;
+  SmallVector<DFBPerNodeLifetime, 0> diagnosticNodeLifetimes;
   bool bounded = false;
 
   /// Returns the lifetime for `node`, or null when the DFB is inactive there.

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -4,6 +4,7 @@
 
 #include "DFBPhysicalAllocationPlan.h"
 
+#include "DFBAllocationDebugReport.h"
 #include "DFBAllocationLimits.h"
 #include "DFBAnalysisFailure.h"
 #include "DFBConcurrentKernelLivenessAnalysis.h"
@@ -22,6 +23,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
@@ -29,6 +31,8 @@
 #include <limits>
 #include <optional>
 #include <string>
+
+#define DEBUG_TYPE "ttl-finalize-dfb-indices"
 
 namespace mlir::tt::ttl {
 
@@ -800,6 +804,8 @@ DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
   }
   DFBAnalysisFailure analysisFailure;
   plan.conflictModel = DFBPhysicalConflictModelBuilder::build(liveness);
+  LLVM_DEBUG(printDFBAllocationDebugReport(llvm::dbgs(), liveness,
+                                           plan.conflictModel));
 
   auto computeAllocation =
       [&](bool requireMinimum) -> FailureOr<PhysicalAllocationCandidate> {

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_l1_exact_assignment.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_l1_exact_assignment.mlir
@@ -1,5 +1,8 @@
 // Tests minimum physical-index count when first-fit exceeds the L1 budget.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// REPORT: DFB conflict {{.*}} reason=concurrent-lifetime
 
 // The DFBs conflict in A-B-C-D order but are declared A,D,B,C, so first-fit
 // uses three indices although two suffice. Each physical DFB occupies 491520

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
@@ -1,5 +1,11 @@
 // Tests launch-node-local DFB lifetimes and hardware pointer ownership.
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// REPORT-DAG: DFB conflict {{.*}} reason=descriptor-mismatch
+// REPORT-DAG: DFB conflict {{.*}} reason=unproven-quiescence
+// REPORT-DAG: DFB conflict {{.*}} reason=transaction-mismatch
+// REPORT-DAG: DFB conflict {{.*}} reason=pointer-owner-mismatch
 
 // DFBs used on disjoint launch nodes may share without a global lifetime order.
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_missing_launch_grid_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_missing_launch_grid_debug.mlir
@@ -1,0 +1,30 @@
+// Tests allocation reporting when launch-node-dependent IR has no launch grid.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s
+
+// CHECK-LABEL: DFB allocation liveness report
+// CHECK: DFB logical_id=0 bounded=0 compiler_created=0
+// CHECK-SAME: domain=unknown
+// CHECK: access 0 effect=reserve tiles=1 sequence=0 domain=unknown
+// CHECK: access 3 effect=pop tiles=1 sequence=0 domain=unknown
+// CHECK-NOT: {{^  node }}
+// CHECK-NOT: {{^  diagnostic_nodes }}
+// CHECK: DFB allocation liveness report end
+
+module {
+  func.func @node_dependent_kernel()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %reserved = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %available = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
@@ -1,11 +1,27 @@
-// Tests default-mode debug reporting when three logical DFBs use two physical
-// indices.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s
+// Tests deterministic default-mode debug reporting and conflict evidence.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' > %t.no-report.mlir 2> %t.no-report.log
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices > %t.report.mlir 2> %t.report.log
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices > %t.repeat.mlir 2> %t.repeat.log
+// RUN: diff %t.no-report.mlir %t.report.mlir
+// RUN: diff %t.report.mlir %t.repeat.mlir
+// RUN: diff %t.report.log %t.repeat.log
+// RUN: FileCheck %s --check-prefix=REPORT < %t.report.log
+// RUN: FileCheck %s --check-prefix=NO-REPORT --allow-empty < %t.no-report.log
 
-// CHECK: Total DFB count: 2
-// CHECK-NEXT: DFB assignment: logical DFB 0 -> physical index 0 (bounded)
-// CHECK-NEXT: DFB assignment: logical DFB 1 -> physical index 1 (bounded)
-// CHECK-NEXT: DFB assignment: logical DFB 2 -> physical index 0 (bounded)
+// REPORT: DFB allocation liveness report
+// REPORT: DFB logical_id=0 bounded=1 compiler_created=0
+// REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(0,0)} operation=ttl.cb_reserve kernel=@producer
+// REPORT: node (0,0) quiescence=none domain_assumption=exact evidence=none occurrences=[0:1, 1:1, 2:1, 3:1] transactions=[1] write_owner=(0,0):noc0:write read_owner=(0,0):unpack:read
+// REPORT-SAME: earliest_accesses=[0, 2] terminal_accesses=[3]
+// REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch node=(0,0)
+// REPORT: DFB allocation liveness report end
+// REPORT-NEXT: Total DFB count: 2
+// REPORT-NEXT: DFB assignment: logical DFB 0 -> physical index 0 (bounded)
+// REPORT-NEXT: DFB assignment: logical DFB 1 -> physical index 1 (bounded)
+// REPORT-NEXT: DFB assignment: logical DFB 2 -> physical index 0 (bounded)
+// REPORT: DFB conflict {{.*}} reason=storage-mismatch
+
+// NO-REPORT-NOT: DFB allocation liveness report
 
 module {
   func.func @producer()
@@ -55,6 +71,38 @@ module {
     %second_block = ttl.cb_wait %second
         : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
           -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %second : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @different_tensor_backing()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %first : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %first_waited = ttl.cb_wait %first
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %first : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %second : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %second_waited = ttl.cb_wait %second
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
     ttl.cb_pop %second : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
     return
   }

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
@@ -1,0 +1,144 @@
+// Tests counterfactual lifetime diagnostics for an unknown launch-node domain.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' > %t.no-report.mlir 2> %t.no-report.log
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices > %t.report.mlir 2> %t.report.log
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices > %t.repeat.mlir 2> %t.repeat.log
+// RUN: diff %t.no-report.mlir %t.report.mlir
+// RUN: diff %t.report.mlir %t.repeat.mlir
+// RUN: diff %t.report.log %t.repeat.log
+// RUN: FileCheck %s < %t.report.log
+// RUN: FileCheck %s --check-prefix=NO-REPORT --allow-empty < %t.no-report.log
+
+// CHECK: DFB allocation liveness report
+// CHECK: DFB logical_id=0 bounded=0 compiler_created=0
+// CHECK-SAME: domain=unknown
+// CHECK: access 0 effect=reserve tiles=1 sequence=0 domain=unknown
+// CHECK: access 4 effect=none tiles=0 sequence=0 domain=unknown
+// CHECK-SAME: operation=ttl.opaque_call kernel=@unknown_domain
+// CHECK-SAME: unresolved_at=arith.cmpi kernel=@unknown_domain
+// CHECK: diagnostic_nodes quiescence=unsupported-control-flow domain_assumption=unknown-may-be-active may_be_active=1 node_count=10 exemplar=(0,0)
+// CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
+// CHECK: DFB logical_id=1 bounded=0 compiler_created=0
+// CHECK-SAME: domain=unknown
+// CHECK: diagnostic_nodes quiescence=missing-protocol-effect domain_assumption=unknown-may-be-active may_be_active=1 node_count=10 exemplar=(0,0)
+// CHECK-SAME: occurrences=[0:unresolved]
+// CHECK: DFB logical_id=2 bounded=0 compiler_created=0
+// CHECK-SAME: domain=unknown
+// CHECK: diagnostic_nodes quiescence=unsupported-control-flow domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(0,0)}
+// CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved]
+// CHECK: diagnostic_nodes quiescence=none domain_assumption=unknown-may-be-active may_be_active=0 node_count=9 exemplar=(1,0)
+// CHECK-SAME: occurrences=[0:0, 1:0, 2:0, 3:0]
+// CHECK: DFB logical_id=3 bounded=0 compiler_created=0
+// CHECK-SAME: domain=unknown
+// CHECK: diagnostic_nodes quiescence=none domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(0,0)}
+// CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
+// CHECK-SAME: earliest_accesses=[0] terminal_accesses=[4]
+// CHECK: diagnostic_nodes quiescence=incomplete-use-order domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(1,0)}
+// CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
+// CHECK: DFB conflict lhs=0 rhs=1 reason=unknown-launch-node-domain node=none
+// CHECK: DFB allocation liveness report end
+// CHECK-NEXT: Total DFB count: 4
+// CHECK-NEXT: DFB assignment: logical DFB 0 -> physical index 0 (unbounded)
+// CHECK-NEXT: DFB assignment: logical DFB 1 -> physical index 1 (unbounded)
+// CHECK-NEXT: DFB assignment: logical DFB 2 -> physical index 2 (unbounded)
+// CHECK-NEXT: DFB assignment: logical DFB 3 -> physical index 3 (unbounded)
+
+// NO-REPORT-NOT: DFB allocation liveness report
+
+module attributes {ttl.launch_grid = [10 : i64, 1 : i64]} {
+  func.func @unknown_domain(%offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %missing_effect_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %c0 = arith.constant 0 : index
+    %is_first_node = arith.cmpi eq, %core_x, %c0 : index
+    %sum = arith.addi %core_x, %offset : index
+    %unknown_condition = arith.cmpi eq, %sum, %c0 : index
+    scf.if %unknown_condition {
+      ttl.opaque_call "custom_use" (%missing_effect_dfb)
+          {header = "custom_use.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+      scf.if %is_first_node {
+        %reserved = ttl.cb_reserve %dfb
+            : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+            -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+        ttl.cb_push %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        %available = ttl.cb_wait %dfb
+            : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+            -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+        ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      }
+      ttl.opaque_call "custom_use" (%dfb) {header = "custom_use.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+
+  func.func @zero_edge_producer(%offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %zero_edge_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %target_dfb = ttl.bind_cb {cb_index = 3, block_count = 2}
+        {dfb_id = 3 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %c0 = arith.constant 0 : index
+    %is_first_node = arith.cmpi eq, %core_x, %c0 : index
+    %sum = arith.addi %core_x, %offset : index
+    %unknown_condition = arith.cmpi eq, %sum, %c0 : index
+    scf.if %unknown_condition {
+      ttl.opaque_call "custom_use" (%target_dfb) {header = "custom_use.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %is_first_node {
+      scf.if %unknown_condition {
+        %reserved = ttl.cb_reserve %zero_edge_dfb
+            : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+            -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+        ttl.cb_push %zero_edge_dfb
+            : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      }
+    }
+    return
+  }
+
+  func.func @zero_edge_consumer(%offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %zero_edge_dfb = ttl.bind_cb {cb_index = 2, block_count = 2}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %target_dfb = ttl.bind_cb {cb_index = 3, block_count = 2}
+        {dfb_id = 3 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %c0 = arith.constant 0 : index
+    %is_first_node = arith.cmpi eq, %core_x, %c0 : index
+    %sum = arith.addi %core_x, %offset : index
+    %unknown_condition = arith.cmpi eq, %sum, %c0 : index
+    scf.if %is_first_node {
+      scf.if %unknown_condition {
+        %available = ttl.cb_wait %zero_edge_dfb
+            : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+            -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+        ttl.cb_pop %zero_edge_dfb
+            : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+      }
+    }
+    %reserved = ttl.cb_reserve %target_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_push %target_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %available = ttl.cb_wait %target_dfb
+        : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<1x16, bf16>>
+    ttl.cb_pop %target_dfb : <[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    return
+  }
+}


### PR DESCRIPTION
### Problem description

A failed DFB allocation reported only the required physical-index count. That result was insufficient to determine which lifecycle proof failed, why two logical DFBs conflicted, or whether an unknown launch domain caused the rejection.

### What's changed

~680 LOC implementation (tests and documentation excluded).

Emit a deterministic allocation report under `-debug-only=ttl-finalize-dfb-indices`. The report records each logical DFB, descriptor and backing, access domain, ordered effects, execution counts, transaction sizes, pointer owners, lifetime frontiers, boundedness diagnosis, conflicts, and final assignment.

Debug-only lifetime storage preserves counterfactual evidence for unknown launch domains without allowing that evidence to establish boundedness, ordering, or conflict removal. This separation keeps diagnostics from changing allocation behavior.

```text
DFB logical_id=0 bounded=1
node (0,0) quiescence=none transactions=[1]
DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch node=(0,0)
DFB assignment: logical DFB 0 -> physical index 0 (bounded)
```

### Validation

- New allocation-report tests cover deterministic rendering, every conflict reason, large-domain aggregation, unknown-domain evidence, missing launch grids, and report non-interference across reuse modes.
