### PR TITLE
[uplift-B] Uplift tt-metal to v0.77.0-dev20260812 (S3-only)

### DIFF
--- a/.github/scripts/probe-docker-image.sh
+++ b/.github/scripts/probe-docker-image.sh
@@ -8,8 +8,9 @@
 #
 # Refuses to rebuild a bare release tag (vX.Y.Z without a deterministic hash suffix)
 # when the image is missing: pushing PR/main content under the release
-# tag would silently corrupt the release image in GHCR. Only
-# publish-pypi.yml on a tag push may rebuild the release tag.
+# tag would silently corrupt the release image in GHCR. publish-pypi.yml
+# publishes the release tag on a tag push; recover a missing one by running
+# call-build-docker.yml with push=true at that exact tag.
 #
 # Usage: probe-docker-image.sh <tag>
 
@@ -25,7 +26,7 @@ if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
 fi
 
 if [[ ! "$TAG" =~ -(uplift-)?[0-9a-f]{8}$ ]]; then
-    echo "::error::Release image $IMAGE is missing from GHCR. Refusing to rebuild from a non-release context — re-publish via publish-pypi.yml (workflow_dispatch on tag $TAG)."
+    echo "::error::Release image $IMAGE is missing from GHCR. Refusing to rebuild from a non-release context. Run call-build-docker.yml with push=true at ref $TAG."
     exit 1
 fi
 

--- a/.github/scripts/tests/test_probe_docker_image.bats
+++ b/.github/scripts/tests/test_probe_docker_image.bats
@@ -78,14 +78,17 @@ setup() {
 @test "bare release tag, image missing -> refuse (exit 1)" {
     FAKE_DOCKER_MISSING=1 run -1 "$SCRIPT" "$BARE_TAG"
     assert_equal "$(read_needs_rebuild "$GH_OUT")" ""
+    assert_output --partial "Run call-build-docker.yml with push=true at ref $BARE_TAG"
 }
 
 @test "rc release tag, image missing -> refuse (exit 1)" {
     FAKE_DOCKER_MISSING=1 run -1 "$SCRIPT" "$RC_TAG"
+    assert_output --partial "Run call-build-docker.yml with push=true at ref $RC_TAG"
 }
 
 @test "dev release tag, image missing -> refuse (exit 1)" {
     FAKE_DOCKER_MISSING=1 run -1 "$SCRIPT" "$DEV_TAG"
+    assert_output --partial "Run call-build-docker.yml with push=true at ref $DEV_TAG"
 }
 
 # --- Mock invoked with the expected image reference ---

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -80,6 +80,23 @@ jobs:
     with:
       ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
+  # Release-tag pushes publish the dist and IRD images under the release tag.
+  # ci.yml's probe requires the IRD image to exist at that tag, and rebuilding it
+  # from a PR or main commit would overwrite the release with newer content.
+  # No ttlang_sha_override: on a tag push github.sha is already the tagged commit,
+  # and the reusable workflow resolves from the same ref as this caller.
+  build-docker:
+    needs: preflight
+    if: ${{ github.event_name == 'push' }}
+    permissions:
+      checks: write
+      contents: read
+      packages: write
+    uses: ./.github/workflows/call-build-docker.yml
+    secrets: inherit
+    with:
+      push: true
+
   build-wheels:
     needs: [preflight, build-wheel-images]
     if: ${{ always() && needs.preflight.result == 'success' && (needs.build-wheel-images.result == 'success' || needs.build-wheel-images.result == 'skipped') }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -83,10 +83,16 @@ jobs:
   # Release-tag pushes publish the dist and IRD images under the release tag.
   # ci.yml's probe requires the IRD image to exist at that tag, and rebuilding it
   # from a PR or main commit would overwrite the release with newer content.
+  #
+  # Deliberately does not depend on preflight. preflight decides whether the
+  # release is publishable to public PyPI, which an S3-only pin fails by design;
+  # gating image publication on it would leave those releases without the image
+  # ci.yml needs. The image tag comes from get-version-tag.sh at checkout, not
+  # from preflight, and on.push.tags already restricts this event to release tags.
+  #
   # No ttlang_sha_override: on a tag push github.sha is already the tagged commit,
   # and the reusable workflow resolves from the same ref as this caller.
   build-docker:
-    needs: preflight
     if: ${{ github.event_name == 'push' }}
     permissions:
       checks: write

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -554,18 +554,17 @@ rejected.
    push release tag
  or workflow_dispatch
           |
-          v
-   +--------------+
-   |  preflight   |   verify the selected source and release tag
-   +--------------+   (release checks skipped if dry_run=true)
-          |
           +---------------------------+
           |                           v
           |                    +--------------+
-          |                    | build-docker |   call-build-docker.yml
-          |                    +--------------+   (release-tag pushes only;
-          |                                        publishes the dist and IRD
-          |                                        images under the release tag)
+          v                    | build-docker |   call-build-docker.yml
+   +--------------+            +--------------+   (release-tag pushes only;
+   |  preflight   |                                publishes the dist and IRD
+   +--------------+                                images under the release tag;
+          |                                        independent of preflight so
+          |   verify the selected source            an S3-only pin still gets
+          |   and release tag (release              its image)
+          |   checks skipped if dry_run=true)
           v
    +--------------------+
    | build-wheel-images |   call-build-wheel-images.yml
@@ -611,12 +610,22 @@ Job-by-job:
    cache. Unchanged component inputs restore from GHCR instead of recompiling.
 3. **`build-docker`** — calls `call-build-docker.yml` with `push: true` on a
    release-tag push, publishing the dist and IRD images under the release tag.
-   It runs concurrently with `build-wheel-images` and passes no source
-   override, so the images are built from the tagged commit that
-   `github.sha` already points at. Manual PyPI dispatches skip it, because
+   It passes no source override, so the images are built from the tagged commit
+   that `github.sha` already points at. Manual PyPI dispatches skip it, because
    the release images belong to the tag rather than to the dispatch. This job
    is what `ci.yml`'s `resolve-docker-tag` probe depends on: without it, a
    release tag resolves to an IRD image that was never published.
+
+   It declares no `needs`, so it starts immediately and never waits on
+   `preflight`. That independence is required, not incidental: `preflight`
+   decides whether the release is publishable to public PyPI, and an S3-only
+   pin fails that check by design (see [Two-phase
+   uplift](#two-phase-uplift-publishable-release-then-latest-s3-only)). A
+   dependent job is skipped when its `needs` fail, so gating image publication
+   on `preflight` would leave every S3-only release without the image `ci.yml`
+   requires. The image tag comes from `get-version-tag.sh` at checkout rather
+   than from `preflight`, and `on.push.tags` already restricts the event to
+   release tags.
 4. **`build-wheels`** — calls `call-build-manylinux-wheels.yml` against either
    the `docker_tag` input or the image-build output. It builds Python 3.10 and
    3.12 `tt-lang` wheels with an exact public `ttnn` dependency and builds the

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -454,9 +454,11 @@ with `push: true` and uploads the rebuilt image so downstream jobs
 (`build`, `build-wheels`, `test-hardware`, `test-dist-tutorials`) can pull
 it. If the image is missing and the resolved tag is the bare release form
 (e.g. `vX.Y.Z`), the probe step fails the job with an error directing the
-maintainer to re-publish the release via `publish-pypi.yml`; rebuilding the
-release tag from a PR or main commit would push newer content under the
-release tag and overwrite the released image.
+maintainer to run `call-build-docker.yml` with `push: true` at that exact
+release tag. Recovery uses that workflow rather than `publish-pypi.yml` so the
+image is rebuilt from the tagged commit alone; rebuilding the release tag from
+a PR or main commit would push newer content under the release tag and
+overwrite the released image.
 
 `ci.yml` also has a `dryrun-docker` job that runs only on
 pull_request events when the PR touches container-relevant files
@@ -557,6 +559,13 @@ rejected.
    |  preflight   |   verify the selected source and release tag
    +--------------+   (release checks skipped if dry_run=true)
           |
+          +---------------------------+
+          |                           v
+          |                    +--------------+
+          |                    | build-docker |   call-build-docker.yml
+          |                    +--------------+   (release-tag pushes only;
+          |                                        publishes the dist and IRD
+          |                                        images under the release tag)
           v
    +--------------------+
    | build-wheel-images |   call-build-wheel-images.yml
@@ -585,7 +594,7 @@ rejected.
    dry_run=false
    (uploads to PyPI)        (lists artifacts only)
 
-   Release-tag pushes complete after test-wheels.
+   Release-tag pushes complete after build-docker and test-wheels.
 ```
 
 Job-by-job:
@@ -600,22 +609,30 @@ Job-by-job:
    `docker_tag` is supplied. The multi-stage `manylinux_2_34` build stores LLVM
    caches separately for Python 3.10 and 3.12 and stores tt-metal in a third
    cache. Unchanged component inputs restore from GHCR instead of recompiling.
-3. **`build-wheels`** — calls `call-build-manylinux-wheels.yml` against either
+3. **`build-docker`** — calls `call-build-docker.yml` with `push: true` on a
+   release-tag push, publishing the dist and IRD images under the release tag.
+   It runs concurrently with `build-wheel-images` and passes no source
+   override, so the images are built from the tagged commit that
+   `github.sha` already points at. Manual PyPI dispatches skip it, because
+   the release images belong to the tag rather than to the dispatch. This job
+   is what `ci.yml`'s `resolve-docker-tag` probe depends on: without it, a
+   release tag resolves to an IRD image that was never published.
+4. **`build-wheels`** — calls `call-build-manylinux-wheels.yml` against either
    the `docker_tag` input or the image-build output. It builds Python 3.10 and
    3.12 `tt-lang` wheels with an exact public `ttnn` dependency and builds the
    ABI-independent `tt-lang-sim` wheel. The workflow verifies wheel names,
    versions, dependency metadata, and the `manylinux_2_34` platform tag before
    uploading the `tt-lang-wheels` artifact.
-4. **`test-wheels`**: installs the Python 3.12 public wheel and its PyPI `ttnn`
+5. **`test-wheels`**: installs the Python 3.12 public wheel and its PyPI `ttnn`
    dependency in an isolated environment on an `n150` runner, installs the sfpi
    release recorded by `ttnn`, then runs the smoke test and tutorials. It runs
    during dry runs and must pass before `publish`.
-5. **`publish`**: runs only for a manual dispatch from `main` when `dry_run` is
+6. **`publish`**: runs only for a manual dispatch from `main` when `dry_run` is
    false and `test-wheels` succeeded. Downloads the artifact, verifies
    every wheel filename's version field matches `preflight.outputs.tag_version`,
    and uploads via `pypa/gh-action-pypi-publish` using OIDC trusted publishing
    (`environment: pypi`, `id-token: write`).
-6. **`dry-run-summary`**: runs only on `workflow_dispatch` with
+7. **`dry-run-summary`**: runs only on `workflow_dispatch` with
    `dry_run: true`. Downloads the artifact and lists what would have been
    uploaded. No `environment`, no PyPI credentials.
 

--- a/test/hw-sim/vm-install-sim.sh
+++ b/test/hw-sim/vm-install-sim.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 TOOLCHAIN="${TTLANG_TOOLCHAIN_DIR:-/opt/ttlang-toolchain}"
 # Pinned to a release ABI-compatible with the tt-metal built into the toolchain;
 # bump alongside tt-metal submodule uplifts.
-TTSIM_VERSION="${TTSIM_VERSION:-v1.9.6}"
+TTSIM_VERSION="${TTSIM_VERSION:-v1.9.9}"
 TTSIM_CHIP="${TTSIM_CHIP:-wh}"
 SIM_DIR="$TOOLCHAIN/sim"
 mkdir -p "$SIM_DIR"

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -501,9 +501,12 @@ def test_release_tag_builds_ird_and_manylinux_images_independently() -> None:
     # source would decouple the published image from the release.
     assert "ttlang_sha_override" not in build_docker_job
 
-    # Both depend only on preflight, so neither serializes behind the other.
     assert "needs: preflight" in build_wheel_images_job
-    assert "needs: preflight" in build_docker_job
+    # IRD publication must not depend on preflight. preflight fails the PyPI
+    # alignment check on an S3-only pin (TT_METAL_TAG ahead of the public ttnn
+    # provenance tag), and a dependent job is skipped when its needs fail, which
+    # would leave those releases without the image ci.yml's probe requires.
+    assert "needs:" not in build_docker_job
 
 
 def test_publish_pypi_terminal_jobs_override_skipped_docker_build_status() -> None:

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -471,6 +471,41 @@ def test_publish_pypi_supports_release_sha_from_main() -> None:
     assert "inputs.ttlang_sha" not in publish_job
 
 
+def test_release_tag_builds_ird_and_manylinux_images_independently() -> None:
+    """A release-tag push must publish the IRD image ci.yml's probe requires.
+
+    The two image builds are separate reusable workflows and must both run,
+    concurrently, off the tagged commit.
+    """
+    workflow = PUBLISH_PYPI_WORKFLOW.read_text()
+    build_wheel_images_job = workflow.split("\n  build-wheel-images:", 1)[1].split(
+        "\n  build-docker:", 1
+    )[0]
+    build_docker_job = workflow.split("\n  build-docker:", 1)[1].split(
+        "\n  build-wheels:", 1
+    )[0]
+
+    assert "uses: ./.github/workflows/call-build-wheel-images.yml" in (
+        build_wheel_images_job
+    )
+    assert "if: ${{ github.event_name == 'push' || inputs.docker_tag == '' }}" in (
+        build_wheel_images_job
+    )
+
+    assert "uses: ./.github/workflows/call-build-docker.yml" in build_docker_job
+    assert "if: ${{ github.event_name == 'push' }}" in build_docker_job
+    assert "push: true" in build_docker_job
+    # Pushing to GHCR under the release tag needs packages: write.
+    assert "packages: write" in build_docker_job
+    # On a tag push github.sha is already the tagged commit; overriding the
+    # source would decouple the published image from the release.
+    assert "ttlang_sha_override" not in build_docker_job
+
+    # Both depend only on preflight, so neither serializes behind the other.
+    assert "needs: preflight" in build_wheel_images_job
+    assert "needs: preflight" in build_docker_job
+
+
 def test_publish_pypi_terminal_jobs_override_skipped_docker_build_status() -> None:
     workflow = PUBLISH_PYPI_WORKFLOW.read_text()
     publish_job = workflow.split("\n  publish:", 1)[1].split("\n  dry-run-summary:", 1)[

--- a/third-party/tt-metal-version
+++ b/third-party/tt-metal-version
@@ -36,4 +36,7 @@
 
 TTNN_PYPI="0.75.0"
 TTNN_PYPI_TT_METAL_TAG="v0.75.0"
-TT_METAL_TAG="v0.75.0"
+# DANGER: public PyPI publish is blocked until TT_METAL_TAG and
+# TTNN_PYPI_TT_METAL_TAG share the same vX.Y.Z component. See
+# docs/sphinx/build.md#publishing-to-s3-pypi.
+TT_METAL_TAG="v0.77.0-dev20260812"


### PR DESCRIPTION
### Problem description

Building on the PyPI-aligned base in `[uplift-A]`, the S3 development wheels should track the latest tagged tt-metal. Public `ttnn` has nothing newer than 0.75.0, so advancing `TT_METAL_TAG` past it intentionally keeps this wheel S3-only until a matching public `ttnn` ships. Splitting the work this way means `[uplift-A]` can still cut a public PyPI release while this change picks up the newest tt-metal.

This PR also carries two CI corrections that the `v1.1.8` release exposed. `publish-pypi.yml` lost its `call-build-docker.yml` invocation when 816df6269 split public wheel construction into manylinux images, so a release-tag push built wheels only and never published the dist and IRD images. `ci.yml`'s `resolve-docker-tag` probe then failed for every PR that resolved to that release tag, because the IRD image it requires was absent from GHCR.

### What's changed

- Bump `third-party/tt-metal` to `v0.77.0-dev20260812` (`ea042c4ad623`) and set `TT_METAL_TAG` accordingly. `TTNN_PYPI` and `TTNN_PYPI_TT_METAL_TAG` stay at `0.75.0` and `v0.75.0`, so the two tags diverge on their `vX.Y.Z` component and the wheel remains S3-only. LLVM is unchanged from `[uplift-A]`.
- Restore the `DANGER` note recording that public PyPI publishing is blocked at this pin.
- Bump `TTSIM_VERSION` in `test/hw-sim/vm-install-sim.sh` from `v1.9.6` to `v1.9.9`, matching the `tt_metal/ttsim-version` pin tt-metal records at this tag. The macOS simulator harness downloads that release, and its `libttsim.so` must be ABI-compatible with the tt-metal being built.
- Both tt-metal patches apply unchanged at this tag, so neither needed regenerating.
- Add an independent `build-docker` job to `publish-pypi.yml` that runs on release-tag pushes and calls `call-build-docker.yml` with `push: true`. It runs concurrently with `build-wheel-images` rather than serializing behind it, and it passes no source override: on a tag push `github.sha` is already the tagged commit, and a reusable workflow referenced by path resolves from the same ref as its caller. The job grants `checks: write`, `contents: read`, and `packages: write`, which is what pushing to GHCR under the release tag requires.
- Point the `probe-docker-image.sh` recovery instruction at `call-build-docker.yml` run at the exact release tag rather than at `publish-pypi.yml`, and correct the same stale claim in the script's header comment.
- Cover the corrected diagnostic in the probe Bats tests and add a contract test asserting that a release-tag push invokes both image workflows, that IRD publication uses `call-build-docker.yml`, that it is restricted to tag pushes, that `push: true` is set, and that no source SHA override is supplied.
- Decouple IRD publication from PyPI publishability. `build-docker` initially declared `needs: preflight`, but `preflight` fails the PyPI alignment check on an S3-only pin, where `TT_METAL_TAG` is deliberately ahead of the public `ttnn` provenance tag. A job whose `needs` fail is skipped, so every S3-only release tag -- including the `v1.1.9` this PR sets up -- would have published no IRD image, reintroducing the same breakage for exactly the releases this two-phase uplift creates. `preflight` validates the public PyPI target and computes wheel versions; image publication needs neither, since the image tag comes from `get-version-tag.sh` at checkout and `on.push.tags` already restricts the event to release tags. The dependency is dropped and asserted absent in the contract test.
- Update `docs/sphinx/build.md` to show `build-docker` running parallel to `build-wheel-images`, to state that release-tag pushes complete after both image publication and wheel validation, and to document exact-tag recovery through `call-build-docker.yml`.

### Testing

Built the toolchain from this pin into a separate prefix and built tt-lang against it. The MLIR lit suite passes 308 of 308. On hardware, `test/python` passes 2719 tests and `test/me2e` passes 858, with no failures; the local device runs used a single chip, so the two SPMD tests skip locally and are covered by the Galaxy hardware job. For the CI change, the full `.github/scripts/tests/` Bats suite passes 553 tests, the packaging workflow tests pass 62, and `actionlint`, `shellcheck`, and `pre-commit run --all-files` are clean.

### Checklist

- [x] New/Existing tests provide coverage for changes
