### PR TITLE
[ttl] Derive exact DFB launch domains [dfb-reuse-4]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1253,6 +1253,15 @@ Lifecycle operations inside a statically selected `scf.if`, `affine.if`,
 `ttl.if_src`, or `ttl.if_dst` region may satisfy these conditions. Repeated or
 unknown execution remains unproven.
 
+An access with an unknown launch-node domain is refined to an exact domain when
+execution-count analysis proves a count on every base launch node. Nodes with
+positive counts belong to the domain; nodes with zero counts do not. The proof
+applies per access before their domains are combined. One unresolved count
+preserves the unknown result. A logical DFB whose access-domain union is empty
+has no runtime storage access and may share a type-compatible scratch descriptor
+without a lifetime-order proof. Tensor-backed empty domains retain the issue
+#813 allocation diagnostic.
+
 The pass runs after `ttl-insert-copy-wait`. A transfer into or out of a DFB
 completes at its `ttl.wait`, whose transfer-handle operand does not identify the
 DFB. Inserting that wait before the corresponding push or pop ensures the
@@ -1439,6 +1448,8 @@ analyzeConcurrentLifetimes(module, logicalIdentities):
   logicalDFBs = group bind_cb declarations by logical dfb_id
   collect every lifecycle operation and direct runtime use
   compute the launch-node domain of every access
+  if every per-node execution count is exact for an otherwise unknown access:
+    use the nodes with positive counts as its exact access domain
 
   for each launched physical node:
     graph = empty happens-before graph

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -982,6 +982,15 @@ def TTLFinalizeDFBIndices
     order conflicts with every other DFB. Unsupported or unknown control flow
     can reduce reuse but cannot produce an unsafe physical assignment.
 
+    An access whose launch domain is otherwise unknown is refined to an exact
+    domain when execution-count analysis proves a count on every base launch
+    node. Nodes with positive counts belong to the domain; nodes with zero
+    counts do not. The logical DFB domain is exact only when every access has an
+    exact domain. A logical DFB is inactive when the union of all its access
+    domains is empty. An inactive scratch DFB may share a compatible physical
+    descriptor without a lifetime-order proof because no launched node accesses
+    it. Tensor-backed empty domains retain their existing allocation diagnostic.
+
     The allocator represents each logical DFB as a vertex, each pair that
     cannot share as an edge, and each physical index as a color. First-fit
     quickly produces a valid assignment by giving each DFB the lowest index

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1023,21 +1023,33 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     return;
   }
 
+  DenseMap<Operation *, AccessDomain> refinedAccessDomains;
+  auto getRefinedAccessDomain =
+      [&](Operation *accessOperation) -> const AccessDomain & {
+    auto refinedDomainIt = refinedAccessDomains.find(accessOperation);
+    if (refinedDomainIt != refinedAccessDomains.end()) {
+      return refinedDomainIt->second;
+    }
+    auto domainIt = domainState.accessDomains.find(accessOperation);
+    AccessDomain accessDomain =
+        domainIt == domainState.accessDomains.end()
+            ? AccessDomain{LaunchNodeDomain::unknown(), accessOperation}
+            : domainIt->second;
+    return refinedAccessDomains
+        .try_emplace(accessOperation,
+                     refineUnknownAccessDomainFromExecutionCounts(
+                         accessOperation, accessDomain, domainState))
+        .first->second;
+  };
+
   for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
     if (logicalDFB.accesses.empty()) {
       logicalDFB.launchDomain = LaunchNodeDomain::unknown();
       continue;
     }
     for (DFBAccessOccurrence &access : logicalDFB.accesses) {
-      auto domainIt = domainState.accessDomains.find(access.operation);
-      AccessDomain accessDomain;
-      if (domainIt == domainState.accessDomains.end()) {
-        accessDomain = {LaunchNodeDomain::unknown(), access.operation};
-      } else {
-        accessDomain = domainIt->second;
-      }
-      accessDomain = refineUnknownAccessDomainFromExecutionCounts(
-          access.operation, accessDomain, domainState);
+      const AccessDomain &accessDomain =
+          getRefinedAccessDomain(access.operation);
       access.launchDomain = accessDomain.domain;
       access.unanalyzableDomainOperation = accessDomain.unanalyzableOperation;
       logicalDFB.launchDomain =
@@ -1049,13 +1061,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   // including one also declared by the operation. Compiler-created DFBs cannot
   // be referenced by external code without an explicit dependency.
   for (Operation *unknownAccess : unknownAccessOperations) {
-    auto domainIt = domainState.accessDomains.find(unknownAccess);
-    AccessDomain accessDomain =
-        domainIt == domainState.accessDomains.end()
-            ? AccessDomain{LaunchNodeDomain::unknown(), unknownAccess}
-            : domainIt->second;
-    accessDomain = refineUnknownAccessDomainFromExecutionCounts(
-        unknownAccess, accessDomain, domainState);
+    const AccessDomain &accessDomain = getRefinedAccessDomain(unknownAccess);
     for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
       if (logicalDFB.compilerCreated) {
         continue;

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -111,6 +111,27 @@ struct LivenessDomainState : LaunchNodeDomainState {
 using AccessExecutionCounts =
     DenseMap<const DFBAccessOccurrence *, std::optional<std::uint64_t>>;
 
+static AccessDomain refineUnknownAccessDomainFromExecutionCounts(
+    Operation *operation, AccessDomain accessDomain,
+    const LivenessDomainState &domainState) {
+  if (accessDomain.domain.known) {
+    return accessDomain;
+  }
+
+  LaunchNodeDomain exactDomain;
+  for (LaunchNodeCoord node : domainState.baseDomain.nodes) {
+    std::optional<std::uint64_t> executionCount =
+        getExactExecutionCountAtLaunchNode(operation, node, domainState);
+    if (!executionCount) {
+      return accessDomain;
+    }
+    if (*executionCount > 0) {
+      exactDomain.nodes.insert(node);
+    }
+  }
+  return {std::move(exactDomain), nullptr};
+}
+
 // Unknown membership is included only for counterfactual diagnostics. Reuse
 // proofs continue to require exact launch-node membership.
 static bool mayContainLaunchNode(const LaunchNodeDomain &domain,
@@ -1009,14 +1030,16 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     }
     for (DFBAccessOccurrence &access : logicalDFB.accesses) {
       auto domainIt = domainState.accessDomains.find(access.operation);
+      AccessDomain accessDomain;
       if (domainIt == domainState.accessDomains.end()) {
-        access.launchDomain = LaunchNodeDomain::unknown();
-        access.unanalyzableDomainOperation = access.operation;
+        accessDomain = {LaunchNodeDomain::unknown(), access.operation};
       } else {
-        access.launchDomain = domainIt->second.domain;
-        access.unanalyzableDomainOperation =
-            domainIt->second.unanalyzableOperation;
+        accessDomain = domainIt->second;
       }
+      accessDomain = refineUnknownAccessDomainFromExecutionCounts(
+          access.operation, accessDomain, domainState);
+      access.launchDomain = accessDomain.domain;
+      access.unanalyzableDomainOperation = accessDomain.unanalyzableOperation;
       logicalDFB.launchDomain =
           logicalDFB.launchDomain.unionWith(access.launchDomain);
     }
@@ -1031,6 +1054,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
         domainIt == domainState.accessDomains.end()
             ? AccessDomain{LaunchNodeDomain::unknown(), unknownAccess}
             : domainIt->second;
+    accessDomain = refineUnknownAccessDomainFromExecutionCounts(
+        unknownAccess, accessDomain, domainState);
     for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
       if (logicalDFB.compilerCreated) {
         continue;

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -95,6 +95,16 @@ private:
                   lhs.declarations.front(), rhs.declarations.front());
       return;
     }
+    bool lhsInactive = lhs.launchDomain.known && lhs.launchDomain.nodes.empty();
+    bool rhsInactive = rhs.launchDomain.known && rhs.launchDomain.nodes.empty();
+    if (lhsInactive || rhsInactive) {
+      if (lhs.tensorBacking || rhs.tensorBacking) {
+        addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                    DFBConflictReason::StorageMismatch, std::nullopt,
+                    lhs.declarations.front(), rhs.declarations.front());
+      }
+      return;
+    }
     if (!lhs.launchDomain.known || !rhs.launchDomain.known) {
       addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
                   DFBConflictReason::UnknownLaunchNodeDomain, std::nullopt,

--- a/test/python/include/scalar_result_op.hpp
+++ b/test/python/include/scalar_result_op.hpp
@@ -26,3 +26,9 @@ inline typename ScalarResult<BitWidth>::Type scalar_result() {
   }
   return 1;
 }
+
+template <std::uint32_t BitWidth, typename Coordinate>
+inline typename ScalarResult<BitWidth>::Type
+scalar_result_from_coordinate(Coordinate) {
+  return 1;
+}

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -4,6 +4,8 @@
 
 """Runtime coverage for physical reuse of user-declared DFBs."""
 
+import os
+
 import pytest
 import torch
 
@@ -25,6 +27,13 @@ CAPACITY_TEST_LOGICAL_DFBS = (1 << CAPACITY_TEST_COMPOSITION_LEVELS) + 1
 # bounds; f32 data movement and addition tests retain 1e-5 relative tolerance.
 F32_REPEATED_EXP_RTOL = 2e-3
 F32_REPEATED_EXP_ATOL = 5e-4
+SCALAR_RESULT_HEADER = os.path.join(
+    os.path.dirname(__file__), "include", "scalar_result_op.hpp"
+)
+
+
+def _count_final_dfb_allocations(final_mlir_path):
+    return final_mlir_path.read_text().count("dfb_index =")
 
 
 def _make_exp_via_scratch_atom(data_format, shape=(1, 1)):
@@ -128,12 +137,77 @@ def _make_capacity_test_atom_kernel(data_format):
     return capacity_test_atom_kernel
 
 
+def _make_exact_execution_domain_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(2, 1))
+    def exact_execution_domain_kernel(input_tensor, output_tensor):
+        input_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        first_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        second_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            node_x, _ = ttl.node(dims=2)
+            first_runtime_predicate = ttl.call_extern_func(
+                SCALAR_RESULT_HEADER,
+                "scalar_result_from_coordinate",
+                template_args=[32],
+                func_args=[node_x],
+                result_type=ttl.ScalarType.I32,
+            )
+            second_runtime_predicate = ttl.call_extern_func(
+                SCALAR_RESULT_HEADER,
+                "scalar_result_from_coordinate",
+                template_args=[32],
+                func_args=[node_x],
+                result_type=ttl.ScalarType.I32,
+            )
+            first_node = node_x == 0
+            second_node = node_x == 1
+            first_active = (first_runtime_predicate and first_node) or first_node
+            second_active = (second_runtime_predicate and second_node) or second_node
+
+            with input_dfb.wait() as input_block:
+                if first_active:
+                    with first_scratch_dfb.reserve() as first_scratch_block:
+                        first_scratch_block.store(input_block)
+                    with first_scratch_dfb.wait() as first_scratch_block:
+                        with output_dfb.reserve() as output_block:
+                            output_block.store(first_scratch_block)
+                if second_active:
+                    with second_scratch_dfb.reserve() as second_scratch_block:
+                        second_scratch_block.store(input_block)
+                    with second_scratch_dfb.wait() as second_scratch_block:
+                        with output_dfb.reserve() as output_block:
+                            output_block.store(second_scratch_block)
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            node_x, _ = ttl.node(dims=2)
+            with input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0, node_x], input_block).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            node_x, _ = ttl.node(dims=2)
+            with output_dfb.wait() as output_block:
+                ttl.copy(output_block, output_tensor[0, node_x]).wait()
+
+    return exact_execution_domain_kernel
+
+
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
 _in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
 _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
+_exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
+_exact_f32_execution_domain_kernel = _make_exact_execution_domain_kernel("float32")
 
 assert CAPACITY_TEST_LOGICAL_DFBS == 33
 
@@ -311,6 +385,46 @@ def test_ordered_dfbs_with_distinct_noc_owners(
 
     actual = ttnn.to_torch(out).float()
     expected = second_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_exact_bf16_execution_domain_kernel, torch.bfloat16),
+        (_exact_f32_execution_domain_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_exact_disjoint_execution_domains_reuse_dfb(
+    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    element_indices = torch.arange(2 * TILE * TILE, dtype=torch.float32).reshape(
+        TILE, 2 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_path = tmp_path / "exact_execution_domain.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+
+    # Input and output hardware owners keep them distinct from the compute
+    # scratch DFBs. The scratch DFBs share because their exact node domains are
+    # disjoint, without requiring a local lifetime-order proof.
+    assert _count_final_dfb_allocations(final_mlir_path) == 3
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
     if dtype == torch.bfloat16:
         assert_allclose(actual, expected, rtol=0.05, atol=1.0)
     else:

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -32,10 +32,6 @@ SCALAR_RESULT_HEADER = os.path.join(
 )
 
 
-def _count_final_dfb_allocations(final_mlir_path):
-    return final_mlir_path.read_text().count("dfb_index =")
-
-
 def _make_exp_via_scratch_atom(data_format, shape=(1, 1)):
     @ttl.operation()
     def exp_via_scratch(source: ttl.DFB, destination: ttl.DFB):
@@ -421,7 +417,8 @@ def test_exact_disjoint_execution_domains_reuse_dfb(
     # Input and output hardware owners keep them distinct from the compute
     # scratch DFBs. The scratch DFBs share because their exact node domains are
     # disjoint, without requiring a local lifetime-order proof.
-    assert _count_final_dfb_allocations(final_mlir_path) == 3
+    physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
+    assert physical_dfb_count == 3
 
     actual = ttnn.to_torch(output_tensor).float()
     expected = input_host.float()

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
@@ -1,0 +1,443 @@
+// Tests exact access-domain refinement from per-node execution counts.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=REUSE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// An access that executes zero times on every launch node has an exact empty
+// domain and may share a compatible scratch descriptor with an unknown DFB.
+
+// REUSE-LABEL: func.func @all_nodes_inactive
+// REUSE: %[[INACTIVE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: %[[UNKNOWN:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+// REPORT: DFB logical_id=0 bounded=0 compiler_created=0
+// REPORT-SAME: domain={}
+// REPORT: access 0 effect=none tiles=0 sequence=0 domain={}
+// REPORT: DFB logical_id=1 bounded=0 compiler_created=0
+// REPORT-SAME: domain=unknown
+// REPORT-NOT: DFB conflict lhs=0 rhs=1
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @all_nodes_inactive(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %inactive_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %unknown_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+    %outside_grid = arith.cmpi eq, %core_x, %two : index
+    %inactive_condition = arith.andi %runtime_condition, %outside_grid : i1
+    scf.if %inactive_condition {
+      ttl.opaque_call "inactive_access" (%inactive_dfb)
+          {header = "inactive_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %runtime_condition {
+      ttl.opaque_call "unknown_access" (%unknown_dfb)
+          {header = "unknown_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Zero executions on only part of the launch grid do not establish an empty
+// domain. Both unknown DFBs remain distinct.
+
+// REUSE-LABEL: func.func @partially_inactive
+// REUSE: %[[PARTIAL:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 10 : index}
+// REUSE-NEXT: %[[PARTIAL_UNKNOWN:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 11 : index}
+
+// REPORT: DFB logical_id=10 bounded=0 compiler_created=0
+// REPORT-SAME: domain=unknown
+// REPORT: DFB conflict lhs=10 rhs=11 reason=unknown-launch-node-domain
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @partially_inactive(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %partial_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 10 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %unknown_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 11 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+    %first_node = arith.cmpi eq, %core_x, %zero : index
+    %partial_condition = arith.andi %runtime_condition, %first_node : i1
+    scf.if %partial_condition {
+      ttl.opaque_call "partial_access" (%partial_dfb)
+          {header = "partial_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %runtime_condition {
+      ttl.opaque_call "unknown_access" (%unknown_dfb)
+          {header = "unknown_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Exact positive counts on every launch node establish the full launch domain
+// even when launch-node domain analysis cannot resolve the condition.
+
+// REUSE-LABEL: func.func @all_nodes_nonzero
+// REUSE: %[[NONZERO:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 12 : index}
+// REUSE-NEXT: %[[NONZERO_UNKNOWN:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 13 : index}
+
+// REPORT: DFB logical_id=12 bounded=0 compiler_created=0
+// REPORT-SAME: domain={(0,0), (1,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0), (1,0)}
+// REPORT: DFB conflict lhs=12 rhs=13 reason=unknown-launch-node-domain
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @all_nodes_nonzero(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %nonzero_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 12 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %unknown_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 13 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+    %inside_grid = arith.cmpi ne, %core_x, %two : index
+    %nonzero_condition = arith.ori %runtime_condition, %inside_grid : i1
+    scf.if %nonzero_condition {
+      ttl.opaque_call "nonzero_access" (%nonzero_dfb)
+          {header = "nonzero_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %runtime_condition {
+      ttl.opaque_call "unknown_access" (%unknown_dfb)
+          {header = "unknown_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Per-node counts establish disjoint strict subsets. The DFBs therefore share
+// one physical index without a local lifetime-order proof.
+
+// REUSE-LABEL: func.func @exact_disjoint_subsets_reuse
+// REUSE: %[[FIRST_SUBSET:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 14 : index}
+// REUSE-NEXT: %[[SECOND_SUBSET:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 15 : index}
+
+// REPORT: DFB logical_id=14 bounded=0 compiler_created=0
+// REPORT-SAME: domain={(0,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0)}
+// REPORT: DFB logical_id=15 bounded=0 compiler_created=0
+// REPORT-SAME: domain={(1,0)}
+// REPORT-NOT: DFB conflict lhs=14 rhs=15
+// REPORT: DFB assignment: logical DFB 14 -> physical index 0 (unbounded)
+// REPORT-NEXT: DFB assignment: logical DFB 15 -> physical index 0 (unbounded)
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @exact_disjoint_subsets_reuse(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 14 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 15 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %first_runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %first_runtime = arith.cmpi eq, %first_runtime_sum, %zero : index
+    %first_node = arith.cmpi eq, %core_x, %zero : index
+    %first_masked_runtime = arith.andi %first_runtime, %first_node : i1
+    %first_condition = arith.ori %first_masked_runtime, %first_node : i1
+    scf.if %first_condition {
+      ttl.opaque_call "first" (%first)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
+    }
+    %second_runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %second_runtime = arith.cmpi eq, %second_runtime_sum, %zero : index
+    %one = arith.constant 1 : index
+    %second_node = arith.cmpi eq, %core_x, %one : index
+    %second_masked_runtime = arith.andi %second_runtime, %second_node : i1
+    %second_condition = arith.ori %second_masked_runtime, %second_node : i1
+    scf.if %second_condition {
+      ttl.opaque_call "second" (%second)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// One unresolved access prevents the union for its logical DFB from becoming
+// exact, even when the complete protocol access has an exact domain.
+
+// REUSE-LABEL: func.func @one_unresolved_access
+// REUSE: %[[MIXED:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 16 : index}
+// REUSE-NEXT: %[[EXACT:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 17 : index}
+
+// REPORT: DFB logical_id=16 bounded=0 compiler_created=0
+// REPORT-SAME: domain=unknown
+// REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(0,0), (1,0)}
+// REPORT: access 4 effect=none tiles=0 sequence=0 domain=unknown
+// REPORT: DFB logical_id=17 bounded=1 compiler_created=0
+// REPORT-SAME: domain={(0,0), (1,0)}
+// REPORT: DFB conflict lhs=16 rhs=17 reason=unknown-launch-node-domain
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @one_unresolved_access(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %mixed = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 16 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %exact = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 17 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %known_runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %known_runtime = arith.cmpi eq, %known_runtime_sum, %zero : index
+    %inside_grid = arith.cmpi ne, %core_x, %two : index
+    %known_condition = arith.ori %known_runtime, %inside_grid : i1
+    scf.if %known_condition {
+      ttl.opaque_call "mixed_protocol" dfb_dependencies(%mixed : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    %unknown_runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %unknown_condition = arith.cmpi eq, %unknown_runtime_sum, %zero : index
+    scf.if %unknown_condition {
+      ttl.opaque_call "mixed_unknown_access" (%mixed)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
+    }
+    ttl.opaque_call "exact" dfb_dependencies(%exact : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// A count greater than one establishes domain membership but does not turn a
+// repeated protocol into a single bounded lifecycle.
+
+// REUSE-LABEL: func.func @repeated_exact_count
+// REUSE: %[[REPEATED:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 18 : index}
+// REUSE-NEXT: %[[AFTER_REPEATED:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 19 : index}
+
+// REPORT: DFB logical_id=18 bounded=0 compiler_created=0
+// REPORT-SAME: domain={(0,0), (1,0)}
+// REPORT: node (0,0) quiescence=unsupported-control-flow
+// REPORT-SAME: occurrences=[0:2, 1:2, 2:2, 3:2]
+// REPORT: DFB conflict lhs=18 rhs=19 reason=unproven-quiescence node=(0,0)
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @repeated_exact_count(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %repeated = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 18 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %after_repeated = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 19 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %one = arith.constant 1 : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+    %inside_grid = arith.cmpi ne, %core_x, %two : index
+    %known_condition = arith.ori %runtime_condition, %inside_grid : i1
+    scf.if %known_condition {
+      scf.for %iteration = %zero to %two step %one {
+        ttl.opaque_call "repeated" dfb_dependencies(%repeated : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+      }
+    }
+    ttl.opaque_call "after_repeated" dfb_dependencies(%after_repeated : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// Refinement preserves domains that launch-node analysis already proved.
+
+// REUSE-LABEL: func.func @known_domain_is_preserved
+// REUSE: %[[KNOWN_FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 22 : index}
+// REUSE-NEXT: %[[KNOWN_SECOND:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 23 : index}
+
+// REPORT: DFB logical_id=22 bounded=1 compiler_created=0
+// REPORT-SAME: domain={(0,0), (1,0)}
+// REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(0,0), (1,0)}
+// REPORT: DFB logical_id=23 bounded=1 compiler_created=0
+// REPORT-SAME: domain={(0,0), (1,0)}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @known_domain_is_preserved()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 22 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 23 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// A generic external storage access receives the same exact-domain refinement
+// before it is conservatively attached to every user-managed DFB.
+
+// REUSE-LABEL: func.func @generic_access_exact_subset
+// REUSE: %[[GENERIC_SUBSET:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 24 : index}
+
+// REPORT: DFB logical_id=24 bounded=0 compiler_created=0
+// REPORT-SAME: domain={(0,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0)}
+// REPORT: access 1 effect=none tiles=0 sequence=0 domain={(0,0)}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @generic_access_exact_subset(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %subset = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 24 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %direct_runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %direct_runtime = arith.cmpi eq, %direct_runtime_sum, %zero : index
+    %direct_node = arith.cmpi eq, %core_x, %zero : index
+    %direct_masked_runtime = arith.andi %direct_runtime, %direct_node : i1
+    %direct_condition = arith.ori %direct_masked_runtime, %direct_node : i1
+    scf.if %direct_condition {
+      ttl.opaque_call "direct_access" (%subset)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
+    }
+    %generic_runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %generic_runtime = arith.cmpi eq, %generic_runtime_sum, %zero : index
+    %generic_node = arith.cmpi eq, %core_x, %zero : index
+    %generic_masked_runtime = arith.andi %generic_runtime, %generic_node : i1
+    %generic_condition = arith.ori %generic_masked_runtime, %generic_node : i1
+    scf.if %generic_condition {
+      ttl.opaque_call "generic_access" ()
+          {header = "effects.hpp", unknown_dfb_access} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Exact inactivity does not override CircularBufferType compatibility.
+
+// REUSE-LABEL: func.func @descriptor_mismatch
+// REUSE: %[[INACTIVE_NARROW:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 20 : index}
+// REUSE-NEXT: %[[UNKNOWN_WIDE:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 21 : index}
+
+// REPORT: DFB logical_id=20 bounded=0 compiler_created=0
+// REPORT-SAME: domain={}
+// REPORT: DFB conflict lhs=20 rhs=21 reason=descriptor-mismatch
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @descriptor_mismatch(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %inactive_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 20 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %unknown_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 21 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+    %outside_grid = arith.cmpi eq, %core_x, %two : index
+    %inactive_condition = arith.andi %runtime_condition, %outside_grid : i1
+    scf.if %inactive_condition {
+      ttl.opaque_call "inactive_access" (%inactive_dfb)
+          {header = "inactive_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %runtime_condition {
+      ttl.opaque_call "unknown_access" (%unknown_dfb)
+          {header = "unknown_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x32, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Empty scratch domains remain distinct from tensor-backed descriptors until
+// tensor-backed empty-domain allocation is defined by issue #813.
+
+// REUSE-LABEL: func.func @tensor_backing_is_distinct
+// REUSE: %[[INACTIVE_SCRATCH:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 30 : index}
+// REUSE-NEXT: %[[TENSOR_BACKED:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 31 : index, tensor_backing = #ttl.tensor_backing
+
+// REPORT: DFB logical_id=30 bounded=0 compiler_created=0
+// REPORT-SAME: domain={}
+// REPORT: DFB conflict lhs=30 rhs=31 reason=storage-mismatch node=none
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @tensor_backing_is_distinct(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %inactive_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 30 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %tensor_backed_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 31 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    ttl.opaque_call "tensor_access" (%tensor_backed_dfb)
+        {header = "tensor_access.hpp"}
+        : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+    %outside_grid = arith.cmpi eq, %core_x, %two : index
+    %inactive_condition = arith.andi %runtime_condition, %outside_grid : i1
+    scf.if %inactive_condition {
+      ttl.opaque_call "inactive_access" (%inactive_dfb)
+          {header = "inactive_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/tensor_backing_allocation_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/tensor_backing_allocation_invalid.mlir
@@ -23,6 +23,33 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
 
 // -----
 
+// Exact-empty tensor-backed domains retain the existing issue #813 rejection.
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
+  func.func @empty_tensor_backing(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    // expected-error @below {{tensor-backed physical DFB requires an exact non-empty launch-node domain}}
+    %tensor_backed_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 2 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+    %outside_grid = arith.cmpi eq, %core_x, %one : index
+    %inactive_condition = arith.andi %runtime_condition, %outside_grid : i1
+    scf.if %inactive_condition {
+      ttl.opaque_call "inactive_tensor_access" (%tensor_backed_dfb)
+          {header = "inactive_tensor_access.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
 // Partially overlapping ranges cannot describe distinct physical DFBs on one
 // launch node.
 module attributes {ttl.launch_grid = array<i64: 1, 1>} {


### PR DESCRIPTION
### Problem description

Launch-domain propagation can remain unknown even when execution-count analysis proves an exact count for every node in the finite launch grid. Discarding those counts creates false interference between DFBs used on disjoint nodes and between active DFBs and accesses proven never to execute.

### What's changed

~64 LOC implementation (tests and documentation excluded).

Derive an exact per-access launch domain when every node has a known execution count: positive counts include the node and zero excludes it. Refinement occurs before access domains are combined, so one unresolved access keeps the complete DFB domain conservative.

Exact-empty scratch lifecycles may share a compatible physical index because they have no runtime access. Tensor-backed empty domains remain conservative. Positive repeated counts establish domain membership only; transaction completeness remains a separate liveness proof.

```text
execution counts: {(0,0): 1, (1,0): 0}
derived domain:   {(0,0)}
```

### Validation

- A new two-node device test covers exact disjoint-domain reuse for BF16 and FP32 tensors in DRAM and L1.
- New MLIR tests cover exact, disjoint, inactive, repeated, and unresolved launch domains and tensor-backed empty-domain rejection.
