### PR TITLE
[ttl] Match statically repeated DFB transactions [dfb-reuse-6]

### DIFF
--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -14,6 +14,7 @@
 #include "llvm/Support/ErrorHandling.h"
 
 #include <cassert>
+#include <cstdint>
 #include <tuple>
 
 namespace mlir::tt::ttl {

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -196,6 +196,43 @@ static void printOccurrences(llvm::raw_ostream &output,
   output << ']';
 }
 
+static void printTransactions(llvm::raw_ostream &output,
+                              const DFBPerNodeLifetime &lifetime) {
+  constexpr std::uint64_t maxExpandedTransactions = 64;
+  std::uint64_t remainingExpandedTransactions = maxExpandedTransactions;
+  bool expandTransactions = true;
+  for (const DFBTransactionRun &run : lifetime.transactionRuns) {
+    if (run.executionCount > remainingExpandedTransactions) {
+      expandTransactions = false;
+      break;
+    }
+    remainingExpandedTransactions -= run.executionCount;
+  }
+
+  output << '[';
+  bool first = true;
+  for (const DFBTransactionRun &run : lifetime.transactionRuns) {
+    if (!expandTransactions) {
+      if (!first) {
+        output << ", ";
+      }
+      first = false;
+      output << "run(count=" << run.executionCount
+             << ",tiles=" << run.tilesPerExecution << ')';
+      continue;
+    }
+    for (std::uint64_t transaction = 0; transaction < run.executionCount;
+         ++transaction) {
+      if (!first) {
+        output << ", ";
+      }
+      first = false;
+      output << run.tilesPerExecution;
+    }
+  }
+  output << ']';
+}
+
 static bool
 hasEqualDiagnosticFacts(const DFBPerNodeLifetime &lhs,
                         const DFBPerNodeLifetimeDiagnostics &lhsDiagnostics,
@@ -203,7 +240,7 @@ hasEqualDiagnosticFacts(const DFBPerNodeLifetime &lhs,
                         const DFBPerNodeLifetimeDiagnostics &rhsDiagnostics) {
   if (lhs.quiescence.failure != rhs.quiescence.failure ||
       lhs.quiescence.evidence != rhs.quiescence.evidence ||
-      lhs.transactionTileCounts != rhs.transactionTileCounts ||
+      lhs.transactionRuns != rhs.transactionRuns ||
       lhs.writePointerOwner != rhs.writePointerOwner ||
       lhs.readPointerOwner != rhs.readPointerOwner ||
       !(lhsDiagnostics == rhsDiagnostics)) {
@@ -221,7 +258,7 @@ printLifetimeFacts(llvm::raw_ostream &output,
   output << " occurrences=";
   printOccurrences(output, diagnostics);
   output << " transactions=";
-  printValues(output, lifetime.transactionTileCounts);
+  printTransactions(output, lifetime);
   output << " write_owner=";
   printPointerOwner(output, lifetime.writePointerOwner);
   output << " read_owner=";

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -6,6 +6,7 @@
 
 #include "DFBAcquireReleaseAnalysis.h"
 #include "DFBAnalysisFailure.h"
+#include "ttlang/Analysis/LoopIterationUtils.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
@@ -15,8 +16,10 @@
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "llvm/ADT/DenseMap.h"
@@ -24,6 +27,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/CheckedArithmetic.h"
 #include "llvm/Support/Debug.h"
 
 #include <algorithm>
@@ -42,6 +46,12 @@ namespace {
 struct EventPair {
   unsigned entry = 0;
   unsigned completion = 0;
+};
+
+// First and last dynamic executions represented by one static access.
+struct AccessEventSpan {
+  EventPair first;
+  EventPair last;
 };
 
 // Represents only ordering proved for one launch node. Cyclic reachability is
@@ -111,6 +121,25 @@ struct LivenessDomainState : LaunchNodeDomainState {
 using AccessExecutionCounts =
     DenseMap<const DFBAccessOccurrence *, std::optional<std::uint64_t>>;
 
+// Structured loops whose Cartesian iteration space executes one access once.
+// Loop operation identity, rather than a numeric count, distinguishes domains.
+struct StaticIterationDomain {
+  SmallVector<Operation *> loops;
+
+  bool operator==(const StaticIterationDomain &rhs) const {
+    return loops == rhs.loops;
+  }
+};
+
+// One statically counted run of an access occurrence.
+struct AccessRun {
+  const DFBAccessOccurrence *access = nullptr;
+  std::uint64_t executionCount = 0;
+  StaticIterationDomain iterationDomain;
+};
+
+using AccessRuns = DenseMap<const DFBAccessOccurrence *, AccessRun>;
+
 static AccessDomain refineUnknownAccessDomainFromExecutionCounts(
     Operation *operation, AccessDomain accessDomain,
     const LivenessDomainState &domainState) {
@@ -130,6 +159,93 @@ static AccessDomain refineUnknownAccessDomainFromExecutionCounts(
     }
   }
   return {std::move(exactDomain), nullptr};
+}
+
+// Proves that an access executes once in every iteration of one immutable
+// structured loop nest. Region selection between the loops and the access is
+// rejected because an aggregate count cannot prove per-iteration execution.
+static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
+    Operation *operation, std::uint64_t executionCount, LaunchNodeCoord node,
+    const LivenessDomainState &domainState) {
+  func::FuncOp function = operation->getParentOfType<func::FuncOp>();
+  if (!function || function.getBody().empty() ||
+      !function.getBody().hasOneBlock()) {
+    return std::nullopt;
+  }
+
+  // Exact count-one accesses retain the existing event-graph proof. Only
+  // repeated accesses require a uniform structured iteration domain.
+  if (executionCount == 1) {
+    return StaticIterationDomain{};
+  }
+
+  StaticIterationDomain domain;
+  std::uint64_t domainExecutionCount = 1;
+  Operation *nestedOperation = operation;
+  while (nestedOperation->getParentRegion() != &function.getBody()) {
+    Region *region = nestedOperation->getParentRegion();
+    Operation *parent = region ? region->getParentOp() : nullptr;
+    auto loop = dyn_cast_or_null<LoopLikeOpInterface>(parent);
+    if (!parent || !region->hasOneBlock() ||
+        nestedOperation->getBlock() != &region->front()) {
+      return std::nullopt;
+    }
+    if (!loop) {
+      std::optional<std::uint64_t> parentExecutionCount =
+          getExactExecutionCountAtLaunchNode(parent, node, domainState);
+      if (!parentExecutionCount || *parentExecutionCount != 1) {
+        return std::nullopt;
+      }
+      nestedOperation = parent;
+      continue;
+    }
+    SmallVector<Region *> loopRegions = loop.getLoopRegions();
+    if (loopRegions.size() != 1 || loopRegions.front() != region) {
+      return std::nullopt;
+    }
+    std::optional<std::uint64_t> tripCount = tt::getLoopTripCount(loop);
+    if (!tripCount || *tripCount == 0) {
+      return std::nullopt;
+    }
+    std::optional<std::uint64_t> product =
+        llvm::checkedMulUnsigned(domainExecutionCount, *tripCount);
+    if (!product) {
+      return std::nullopt;
+    }
+    domainExecutionCount = *product;
+    domain.loops.push_back(parent);
+    nestedOperation = parent;
+  }
+
+  if (nestedOperation->getBlock() != &function.getBody().front() ||
+      domainExecutionCount != executionCount) {
+    return std::nullopt;
+  }
+  std::reverse(domain.loops.begin(), domain.loops.end());
+  return domain;
+}
+
+// Proves an unresolved non-protocol access cannot repeat. Treating the access
+// as present once is conservative for lifetime ordering under conditionals.
+static bool structurallyExecutesAtMostOnce(Operation *operation) {
+  func::FuncOp function = operation->getParentOfType<func::FuncOp>();
+  if (!function || function.getBody().empty() ||
+      !function.getBody().hasOneBlock()) {
+    return false;
+  }
+
+  Operation *nestedOperation = operation;
+  while (nestedOperation->getParentRegion() != &function.getBody()) {
+    Region *region = nestedOperation->getParentRegion();
+    Operation *parent = region ? region->getParentOp() : nullptr;
+    if (!parent || !region->hasOneBlock() ||
+        nestedOperation->getBlock() != &region->front() ||
+        !isa<scf::IfOp, scf::IndexSwitchOp, scf::ExecuteRegionOp>(parent)) {
+      return false;
+    }
+    nestedOperation = parent;
+  }
+  return nestedOperation->getBlock() == &function.getBody().front();
 }
 
 // Unknown membership is included only for counterfactual diagnostics. Reuse
@@ -241,27 +357,54 @@ getProjectedEvents(Operation *operation,
              : std::optional<EventPair>(eventIt->second);
 }
 
-// Effect summaries receive occurrence-specific events; concrete and opaque
-// accesses use their projected operation events.
-static std::optional<EventPair> getAccessEvents(
-    const DFBAccessOccurrence &access,
-    const DenseMap<Operation *, EventPair> &operationEvents,
-    const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents) {
+// Effect summaries receive occurrence-specific event spans; concrete and
+// opaque accesses use their projected operation events.
+static std::optional<AccessEventSpan>
+getAccessEventSpan(const DFBAccessOccurrence &access,
+                   const DenseMap<Operation *, EventPair> &operationEvents,
+                   const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+                       &accessEvents) {
   auto accessEventIt = accessEvents.find(&access);
   if (accessEventIt != accessEvents.end()) {
     return accessEventIt->second;
   }
-  return getProjectedEvents(access.operation, operationEvents);
+  std::optional<EventPair> projectedEvents =
+      getProjectedEvents(access.operation, operationEvents);
+  return projectedEvents ? std::optional<AccessEventSpan>(AccessEventSpan{
+                               *projectedEvents, *projectedEvents})
+                         : std::nullopt;
+}
+
+// Proves ordering between corresponding executions, not all-before-all
+// ordering across the complete runs.
+static bool runPrecedesWithinEachIteration(const AccessRun &before,
+                                           const AccessRun &after) {
+  if (!(before.iterationDomain == after.iterationDomain) ||
+      before.executionCount != after.executionCount) {
+    return false;
+  }
+  if (before.access->operation == after.access->operation) {
+    return before.access->protocolEffect && after.access->protocolEffect &&
+           before.access->sequenceIndex < after.access->sequenceIndex;
+  }
+  if (before.executionCount <= 1) {
+    return false;
+  }
+  return before.access->operation->getBlock() ==
+             after.access->operation->getBlock() &&
+         before.access->operation->isBeforeInBlock(after.access->operation);
 }
 
 // Requires a release to follow every use owned by its acquisition; textual
 // acquire/release order alone does not prove storage quiescence.
-static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release) {
+// `sameKindAcquires` contains every same-DFB acquisition of the same kind.
+static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release,
+                                    ArrayRef<Operation *> sameKindAcquires) {
   if (acquire->getBlock() != release->getBlock()) {
     return false;
   }
-  SmallVector<Operation *> acquires = {acquire};
-  DFBAcquireInterval interval = makeDFBAcquireInterval(acquire, acquires);
+  DFBAcquireInterval interval =
+      makeDFBAcquireInterval(acquire, sameKindAcquires);
   Operation *lastOwnedUse = findLastDFBAcquireOwnedUse(interval);
   return lastOwnedUse == acquire || lastOwnedUse->isBeforeInBlock(release);
 }
@@ -272,23 +415,25 @@ static SmallVector<unsigned> findMinimalEntryEvents(
     ArrayRef<const DFBAccessOccurrence *> accesses,
     const HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
-    const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents) {
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
   SmallVector<unsigned> minimal;
   for (const DFBAccessOccurrence *candidate : accesses) {
-    std::optional<EventPair> candidateEvents =
-        getAccessEvents(*candidate, operationEvents, accessEvents);
+    std::optional<AccessEventSpan> candidateEvents =
+        getAccessEventSpan(*candidate, operationEvents, accessEvents);
     if (!candidateEvents) {
       continue;
     }
     bool hasPredecessor = llvm::any_of(accesses, [&](const auto *other) {
-      std::optional<EventPair> otherEvents =
-          getAccessEvents(*other, operationEvents, accessEvents);
+      std::optional<AccessEventSpan> otherEvents =
+          getAccessEventSpan(*other, operationEvents, accessEvents);
       return otherEvents &&
-             graph.strictlyPrecedes(otherEvents->entry, candidateEvents->entry);
+             graph.strictlyPrecedes(otherEvents->first.entry,
+                                    candidateEvents->first.entry);
     });
     if (!hasPredecessor &&
-        !llvm::is_contained(minimal, candidateEvents->entry)) {
-      minimal.push_back(candidateEvents->entry);
+        !llvm::is_contained(minimal, candidateEvents->first.entry)) {
+      minimal.push_back(candidateEvents->first.entry);
     }
   }
   return minimal;
@@ -570,7 +715,6 @@ static LogicalResult collectLogicalDFBs(
   return success();
 }
 
-// Collects complete per-access counts only for the enabled debug report.
 // Counts are cached by operation because one call may describe several DFB
 // effects or dependencies.
 static AccessExecutionCounts
@@ -599,6 +743,45 @@ collectAccessExecutionCounts(ArrayRef<DFBLogicalLifecycle> logicalDFBs,
   return executionCounts;
 }
 
+static AccessRuns
+collectAccessRuns(ArrayRef<DFBLogicalLifecycle> logicalDFBs,
+                  LaunchNodeCoord node, const LivenessDomainState &domainState,
+                  const AccessExecutionCounts &executionCounts,
+                  bool includeUnknownDomains) {
+  AccessRuns runs;
+  for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
+    for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+      if (!mayContainLaunchNode(access.launchDomain, node,
+                                includeUnknownDomains)) {
+        continue;
+      }
+      auto countIt = executionCounts.find(&access);
+      assert(countIt != executionCounts.end() &&
+             "active DFB access must have an execution-count fact");
+      if (countIt->second && *countIt->second == 0) {
+        continue;
+      }
+      if (!countIt->second) {
+        if (!access.protocolEffect &&
+            structurallyExecutesAtMostOnce(access.operation)) {
+          runs.try_emplace(&access,
+                           AccessRun{&access, 1, StaticIterationDomain{}});
+        }
+        continue;
+      }
+      std::optional<StaticIterationDomain> domain =
+          getUniformStaticIterationDomain(access.operation, *countIt->second,
+                                          node, domainState);
+      if (!domain) {
+        continue;
+      }
+      runs.try_emplace(
+          &access, AccessRun{&access, *countIt->second, std::move(*domain)});
+    }
+  }
+  return runs;
+}
+
 // Builds source-order events only for accesses active on `node`. Direct
 // protocol effects receive separate events in their declared sequence;
 // operations in different kernels remain concurrent unless protocol edges
@@ -607,24 +790,26 @@ static void buildProgramOrderGraph(
     ModuleOp module, ArrayRef<DFBLogicalLifecycle> logicalDFBs,
     LaunchNodeCoord node, HappensBeforeGraph &graph,
     DenseMap<Operation *, EventPair> &operationEvents,
-    DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents,
-    const AccessExecutionCounts *executionCounts, bool includeUnknownDomains) {
+    DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
+    const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
+    bool includeUnknownDomains) {
   llvm::DenseSet<Operation *> modeledOperations;
   DenseMap<Operation *, SmallVector<const DFBAccessOccurrence *>>
       directProtocolAccesses;
+  DenseMap<Operation *, SmallVector<const DFBAccessOccurrence *>>
+      projectedAccesses;
   for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
     for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
-      bool mayAccess = executionCounts
-                           ? mayAccessLaunchNode(access, node, *executionCounts,
-                                                 includeUnknownDomains)
-                           : mayContainLaunchNode(access.launchDomain, node,
-                                                  includeUnknownDomains);
-      if (!mayAccess) {
+      if (!mayAccessLaunchNode(access, node, executionCounts,
+                               includeUnknownDomains)) {
         continue;
       }
       if (Operation *projected = getTopLevelKernelOperation(access.operation)) {
         modeledOperations.insert(projected);
-        if (access.protocolEffect && projected == access.operation) {
+        projectedAccesses[projected].push_back(&access);
+        auto runIt = accessRuns.find(&access);
+        if (access.protocolEffect && projected == access.operation &&
+            runIt != accessRuns.end() && runIt->second.executionCount == 1) {
           directProtocolAccesses[projected].push_back(&access);
         }
       }
@@ -652,7 +837,7 @@ static void buildProgramOrderGraph(
         unsigned previousCompletion = events.entry;
         for (const DFBAccessOccurrence *access : protocolIt->second) {
           EventPair effectEvents = graph.addOperation();
-          accessEvents[access] = effectEvents;
+          accessEvents[access] = {effectEvents, effectEvents};
           graph.addEdge(previousCompletion, effectEvents.entry);
           graph.addEdge(effectEvents.completion, events.completion);
           previousCompletion = effectEvents.completion;
@@ -661,50 +846,240 @@ static void buildProgramOrderGraph(
       previousEvents = events;
     }
   }
+
+  for (auto &[projected, accesses] : projectedAccesses) {
+    EventPair projectedEvents = operationEvents.lookup(projected);
+    for (const DFBAccessOccurrence *access : accesses) {
+      auto runIt = accessRuns.find(access);
+      if (runIt == accessRuns.end() || runIt->second.executionCount <= 1) {
+        continue;
+      }
+      EventPair firstEvents = graph.addOperation();
+      EventPair lastEvents = graph.addOperation();
+      accessEvents[access] = {firstEvents, lastEvents};
+      graph.addEdge(projectedEvents.entry, firstEvents.entry);
+      graph.addEdge(firstEvents.completion, lastEvents.entry);
+      graph.addEdge(lastEvents.completion, projectedEvents.completion);
+    }
+    for (const DFBAccessOccurrence *beforeAccess : accesses) {
+      auto beforeRunIt = accessRuns.find(beforeAccess);
+      auto beforeEventsIt = accessEvents.find(beforeAccess);
+      if (beforeRunIt == accessRuns.end() ||
+          beforeRunIt->second.executionCount <= 1 ||
+          beforeEventsIt == accessEvents.end()) {
+        continue;
+      }
+      for (const DFBAccessOccurrence *afterAccess : accesses) {
+        auto afterRunIt = accessRuns.find(afterAccess);
+        auto afterEventsIt = accessEvents.find(afterAccess);
+        if (afterRunIt == accessRuns.end() ||
+            afterRunIt->second.executionCount <= 1 ||
+            afterEventsIt == accessEvents.end() ||
+            !runPrecedesWithinEachIteration(beforeRunIt->second,
+                                            afterRunIt->second)) {
+          continue;
+        }
+        graph.addEdge(beforeEventsIt->second.first.completion,
+                      afterEventsIt->second.first.entry);
+        graph.addEdge(afterEventsIt->second.first.completion,
+                      beforeEventsIt->second.last.entry);
+        graph.addEdge(beforeEventsIt->second.last.completion,
+                      afterEventsIt->second.last.entry);
+      }
+    }
+  }
 }
 
 // Adds the completion edge implied by each matching push/wait transaction.
 // Unknown-domain edges are restricted to the counterfactual debug graph.
 static void addMatchedPushWaitEdges(
-    ArrayRef<DFBLogicalLifecycle> logicalDFBs, LaunchNodeCoord node,
-    HappensBeforeGraph &graph,
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs, HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
-    const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents,
-    const AccessExecutionCounts *executionCounts, bool includeUnknownDomains) {
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
+    const AccessRuns &accessRuns) {
   for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
-    SmallVector<const DFBAccessOccurrence *> pushes;
-    SmallVector<const DFBAccessOccurrence *> waits;
+    SmallVector<const AccessRun *> pushes;
+    SmallVector<const AccessRun *> waits;
     for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
-      bool mayAccess = executionCounts
-                           ? mayAccessLaunchNode(access, node, *executionCounts,
-                                                 includeUnknownDomains)
-                           : mayContainLaunchNode(access.launchDomain, node,
-                                                  includeUnknownDomains);
-      if (!mayAccess) {
+      auto runIt = accessRuns.find(&access);
+      if (runIt == accessRuns.end()) {
         continue;
       }
       if (access.protocolEffect == DFBProtocolEffectKind::Push) {
-        pushes.push_back(&access);
+        pushes.push_back(&runIt->second);
       } else if (access.protocolEffect == DFBProtocolEffectKind::Wait) {
-        waits.push_back(&access);
+        waits.push_back(&runIt->second);
       }
     }
-    if (pushes.size() != waits.size()) {
+
+    std::size_t pushIndex = 0;
+    std::size_t waitIndex = 0;
+    std::uint64_t pushOffset = 0;
+    std::uint64_t waitOffset = 0;
+    SmallVector<std::pair<unsigned, unsigned>> synchronizationEdges;
+    bool matched = true;
+    while (pushIndex < pushes.size() && waitIndex < waits.size()) {
+      const AccessRun &push = *pushes[pushIndex];
+      const AccessRun &wait = *waits[waitIndex];
+      if (push.access->numTiles != wait.access->numTiles) {
+        matched = false;
+        break;
+      }
+      std::optional<AccessEventSpan> pushEvents =
+          getAccessEventSpan(*push.access, operationEvents, accessEvents);
+      std::optional<AccessEventSpan> waitEvents =
+          getAccessEventSpan(*wait.access, operationEvents, accessEvents);
+      if (!pushEvents || !waitEvents) {
+        matched = false;
+        break;
+      }
+
+      std::uint64_t matchedCount = std::min(push.executionCount - pushOffset,
+                                            wait.executionCount - waitOffset);
+      if (pushOffset == 0 && waitOffset == 0) {
+        synchronizationEdges.emplace_back(pushEvents->first.completion,
+                                          waitEvents->first.completion);
+      }
+      pushOffset += matchedCount;
+      waitOffset += matchedCount;
+      if (pushOffset == push.executionCount &&
+          waitOffset == wait.executionCount) {
+        synchronizationEdges.emplace_back(pushEvents->last.completion,
+                                          waitEvents->last.completion);
+      }
+      if (pushOffset == push.executionCount) {
+        ++pushIndex;
+        pushOffset = 0;
+      }
+      if (waitOffset == wait.executionCount) {
+        ++waitIndex;
+        waitOffset = 0;
+      }
+    }
+    matched &= pushIndex == pushes.size() && waitIndex == waits.size();
+    if (!matched) {
       continue;
     }
-    for (auto [push, wait] : llvm::zip_equal(pushes, waits)) {
-      if (push->numTiles != wait->numTiles) {
-        continue;
-      }
-      std::optional<EventPair> pushEvents =
-          getAccessEvents(*push, operationEvents, accessEvents);
-      std::optional<EventPair> waitEvents =
-          getAccessEvents(*wait, operationEvents, accessEvents);
-      if (pushEvents && waitEvents) {
-        graph.addEdge(pushEvents->completion, waitEvents->completion);
-      }
+    for (auto [pushCompletion, waitCompletion] : synchronizationEdges) {
+      graph.addEdge(pushCompletion, waitCompletion);
     }
   }
+}
+
+// Proves ordering between corresponding executions with equal counts and
+// iteration domains, not all-before-all ordering across the complete runs.
+static bool proveRunBeforeWithinEachIteration(
+    const AccessRun &before, const AccessRun &after,
+    const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
+  if (before.executionCount != after.executionCount ||
+      !(before.iterationDomain == after.iterationDomain)) {
+    return false;
+  }
+  if (runPrecedesWithinEachIteration(before, after)) {
+    return true;
+  }
+  if (before.executionCount != 1 || after.executionCount != 1) {
+    return false;
+  }
+  std::optional<AccessEventSpan> beforeEvents =
+      getAccessEventSpan(*before.access, operationEvents, accessEvents);
+  std::optional<AccessEventSpan> afterEvents =
+      getAccessEventSpan(*after.access, operationEvents, accessEvents);
+  return beforeEvents && afterEvents &&
+         graph.strictlyPrecedes(beforeEvents->last.completion,
+                                afterEvents->first.entry);
+}
+
+// Proves that the final execution of `before` completes before the first
+// execution of `after` begins.
+static bool proveAllRunExecutionsBefore(
+    const AccessRun &before, const AccessRun &after,
+    const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
+  if (before.executionCount == 1 && after.executionCount == 1 &&
+      runPrecedesWithinEachIteration(before, after)) {
+    return true;
+  }
+  std::optional<AccessEventSpan> beforeEvents =
+      getAccessEventSpan(*before.access, operationEvents, accessEvents);
+  std::optional<AccessEventSpan> afterEvents =
+      getAccessEventSpan(*after.access, operationEvents, accessEvents);
+  return beforeEvents && afterEvents &&
+         graph.strictlyPrecedes(beforeEvents->last.completion,
+                                afterEvents->first.entry);
+}
+
+static bool proveAlignedAcquireReleaseRuns(
+    ArrayRef<const AccessRun *> acquires, ArrayRef<const AccessRun *> releases,
+    const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
+  if (acquires.size() != releases.size()) {
+    return false;
+  }
+  bool pairsAreAligned =
+      llvm::all_of(llvm::zip_equal(acquires, releases), [&](auto pair) {
+        const AccessRun &acquire = *std::get<0>(pair);
+        const AccessRun &release = *std::get<1>(pair);
+        bool nativeAcquirePrecedesRelease =
+            ((isa<CBReserveOp>(acquire.access->operation) &&
+              isa<CBPushOp>(release.access->operation)) ||
+             (isa<CBWaitOp>(acquire.access->operation) &&
+              isa<CBPopOp>(release.access->operation))) &&
+            acquire.access->operation->getBlock() ==
+                release.access->operation->getBlock() &&
+            acquire.access->operation->isBeforeInBlock(
+                release.access->operation);
+        return acquire.executionCount == release.executionCount &&
+               acquire.iterationDomain == release.iterationDomain &&
+               acquire.access->numTiles == release.access->numTiles &&
+               (nativeAcquirePrecedesRelease ||
+                proveRunBeforeWithinEachIteration(
+                    acquire, release, graph, operationEvents, accessEvents));
+      });
+  if (!pairsAreAligned) {
+    return false;
+  }
+  for (std::size_t runIndex = 1; runIndex < acquires.size(); ++runIndex) {
+    if (!proveAllRunExecutionsBefore(*releases[runIndex - 1],
+                                     *acquires[runIndex], graph,
+                                     operationEvents, accessEvents)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool
+runIsInsideInterval(const AccessRun &use, const AccessRun &acquire,
+                    const AccessRun &release, const HappensBeforeGraph &graph,
+                    const DenseMap<Operation *, EventPair> &operationEvents,
+                    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+                        &accessEvents) {
+  return proveRunBeforeWithinEachIteration(acquire, use, graph, operationEvents,
+                                           accessEvents) &&
+         proveRunBeforeWithinEachIteration(use, release, graph, operationEvents,
+                                           accessEvents);
+}
+
+static void appendTransactionRun(DFBPerNodeLifetime &lifetime,
+                                 std::uint64_t executionCount,
+                                 int64_t tilesPerExecution) {
+  if (executionCount == 0) {
+    return;
+  }
+  if (!lifetime.transactionRuns.empty() &&
+      lifetime.transactionRuns.back().tilesPerExecution == tilesPerExecution) {
+    lifetime.transactionRuns.back().executionCount += executionCount;
+    return;
+  }
+  lifetime.transactionRuns.push_back({executionCount, tilesPerExecution});
 }
 
 // Derives per-node lifetime facts. Exact-domain facts control reuse;
@@ -715,66 +1090,78 @@ static DFBQuiescenceProof computePerNodeLifetime(
     SmallVectorImpl<DFBPerNodeLifetimeDiagnostics> *lifetimeDiagnostics,
     const HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
-    const DenseMap<const DFBAccessOccurrence *, EventPair> &accessEvents,
-    const LaunchNodeDomainState &domainState,
-    const AccessExecutionCounts *reportedExecutionCounts,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
+    const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
     bool includeUnknownDomains = false) {
   DFBPerNodeLifetime &lifetime = lifetimes.emplace_back();
   lifetime.node = node;
   DFBPerNodeLifetimeDiagnostics *diagnostics = nullptr;
-  if (reportedExecutionCounts) {
-    assert(lifetimeDiagnostics &&
-           "reported execution counts require lifetime diagnostics");
+  if (lifetimeDiagnostics) {
     diagnostics = &lifetimeDiagnostics->emplace_back();
-  } else {
-    assert(!lifetimeDiagnostics &&
-           "lifetime diagnostics require reported execution counts");
   }
-  SmallVector<const DFBAccessOccurrence *> reserves;
-  SmallVector<const DFBAccessOccurrence *> pushes;
-  SmallVector<const DFBAccessOccurrence *> waits;
-  SmallVector<const DFBAccessOccurrence *> pops;
+  SmallVector<const AccessRun *> reserves;
+  SmallVector<const AccessRun *> pushes;
+  SmallVector<const AccessRun *> waits;
+  SmallVector<const AccessRun *> pops;
   SmallVector<const DFBAccessOccurrence *> activeAccesses;
-  DenseMap<const DFBAccessOccurrence *, std::optional<std::uint64_t>>
-      executionCounts;
+  const DFBAccessOccurrence *unsupportedAccess = nullptr;
+  bool hasReserve = false;
+  bool hasPush = false;
+  bool hasWait = false;
+  bool hasPop = false;
   for (auto [accessIndex, access] : llvm::enumerate(logicalDFB.accesses)) {
     if (!mayContainLaunchNode(access.launchDomain, node,
                               includeUnknownDomains)) {
       continue;
     }
-    std::optional<std::uint64_t> executionCount;
-    if (reportedExecutionCounts) {
-      auto executionCountIt = reportedExecutionCounts->find(&access);
-      assert(executionCountIt != reportedExecutionCounts->end() &&
-             "every reported DFB access must have an execution-count fact");
-      executionCount = executionCountIt->second;
+    auto executionCountIt = executionCounts.find(&access);
+    assert(executionCountIt != executionCounts.end() &&
+           "every DFB access must have an execution-count fact");
+    std::optional<std::uint64_t> executionCount = executionCountIt->second;
+    if (diagnostics) {
       diagnostics->occurrences.push_back(
           {static_cast<unsigned>(accessIndex), executionCount});
     }
-    if (includeUnknownDomains && executionCount && *executionCount == 0) {
+    if (executionCount && *executionCount == 0) {
       continue;
     }
     activeAccesses.push_back(&access);
+    if (access.protocolEffect) {
+      switch (*access.protocolEffect) {
+      case DFBProtocolEffectKind::Reserve:
+        hasReserve = true;
+        break;
+      case DFBProtocolEffectKind::Push:
+        hasPush = true;
+        break;
+      case DFBProtocolEffectKind::Wait:
+        hasWait = true;
+        break;
+      case DFBProtocolEffectKind::Pop:
+        hasPop = true;
+        break;
+      }
+    }
+    auto runIt = accessRuns.find(&access);
+    if (runIt == accessRuns.end()) {
+      unsupportedAccess = &access;
+      continue;
+    }
     if (!access.protocolEffect) {
       continue;
     }
-    if (!reportedExecutionCounts) {
-      executionCount = getExactExecutionCountAtLaunchNode(access.operation,
-                                                          node, domainState);
-    }
-    executionCounts[&access] = executionCount;
     switch (*access.protocolEffect) {
     case DFBProtocolEffectKind::Reserve:
-      reserves.push_back(&access);
+      reserves.push_back(&runIt->second);
       break;
     case DFBProtocolEffectKind::Push:
-      pushes.push_back(&access);
+      pushes.push_back(&runIt->second);
       break;
     case DFBProtocolEffectKind::Wait:
-      waits.push_back(&access);
+      waits.push_back(&runIt->second);
       break;
     case DFBProtocolEffectKind::Pop:
-      pops.push_back(&access);
+      pops.push_back(&runIt->second);
       break;
     }
   }
@@ -786,140 +1173,203 @@ static DFBQuiescenceProof computePerNodeLifetime(
     return {};
   }
 
-  if (reserves.empty() || pushes.empty() || waits.empty() || pops.empty()) {
+  if (!hasReserve || !hasPush || !hasWait || !hasPop) {
     return {DFBQuiescenceFailureReason::MissingProtocolEffect,
             activeAccesses.empty() ? logicalDFB.declarations.front()
                                    : activeAccesses.front()->operation};
   }
-  if (reserves.size() != pushes.size() || reserves.size() != waits.size() ||
-      reserves.size() != pops.size()) {
+
+  if (unsupportedAccess) {
+    return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+            unsupportedAccess->operation};
+  }
+  assert(!reserves.empty() && !pushes.empty() && !waits.empty() &&
+         !pops.empty() && "supported protocol effects must have access runs");
+  auto getTransactionCount = [](ArrayRef<const AccessRun *> runs) {
+    std::optional<std::uint64_t> total = 0;
+    for (const AccessRun *run : runs) {
+      total = llvm::checkedAddUnsigned(*total, run->executionCount);
+      if (!total) {
+        break;
+      }
+    }
+    return total;
+  };
+  std::optional<std::uint64_t> reserveCount = getTransactionCount(reserves);
+  std::optional<std::uint64_t> pushCount = getTransactionCount(pushes);
+  std::optional<std::uint64_t> waitCount = getTransactionCount(waits);
+  std::optional<std::uint64_t> popCount = getTransactionCount(pops);
+  if (!reserveCount || !pushCount || !waitCount || !popCount ||
+      *reserveCount != *pushCount || *reserveCount != *waitCount ||
+      *reserveCount != *popCount) {
     return {DFBQuiescenceFailureReason::MismatchedTransaction,
             activeAccesses.front()->operation};
   }
 
-  for (const DFBAccessOccurrence *protocolAccess :
-       llvm::concat<const DFBAccessOccurrence *>(reserves, pushes, waits,
-                                                 pops)) {
-    auto executionCountIt = executionCounts.find(protocolAccess);
-    assert(executionCountIt != executionCounts.end() &&
-           "active protocol access must have an execution count fact");
-    std::optional<std::uint64_t> executionCount = executionCountIt->second;
-    if (!executionCount || *executionCount != 1) {
-      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
-              protocolAccess->operation};
-    }
+  if (!proveAlignedAcquireReleaseRuns(reserves, pushes, graph, operationEvents,
+                                      accessEvents) ||
+      !proveAlignedAcquireReleaseRuns(waits, pops, graph, operationEvents,
+                                      accessEvents)) {
+    return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+            activeAccesses.front()->operation};
   }
 
   int64_t physicalTileCount =
       cast<CircularBufferType>(logicalDFB.type).getTotalElements();
   if (physicalTileCount <= 0) {
     return {DFBQuiescenceFailureReason::MismatchedTransaction,
-            reserves.front()->operation};
+            reserves.front()->access->operation};
   }
   std::optional<DFBPointerOwner> writeOwner;
   std::optional<DFBPointerOwner> readOwner;
-  for (auto [reserve, push, wait, pop] :
-       llvm::zip_equal(reserves, pushes, waits, pops)) {
-    if (reserve->numTiles <= 0 || physicalTileCount % reserve->numTiles != 0 ||
-        reserve->numTiles != push->numTiles ||
-        reserve->numTiles != wait->numTiles ||
-        reserve->numTiles != pop->numTiles) {
+  SmallVector<Operation *> nativeReserves;
+  SmallVector<Operation *> nativeWaits;
+  for (const AccessRun *reserve : reserves) {
+    if (isa<CBReserveOp>(reserve->access->operation)) {
+      nativeReserves.push_back(reserve->access->operation);
+    }
+  }
+  for (const AccessRun *wait : waits) {
+    if (isa<CBWaitOp>(wait->access->operation)) {
+      nativeWaits.push_back(wait->access->operation);
+    }
+  }
+  for (auto [reserve, push] : llvm::zip_equal(reserves, pushes)) {
+    if (reserve->access->numTiles <= 0) {
       return {DFBQuiescenceFailureReason::MismatchedTransaction,
-              reserve->operation};
+              reserve->access->operation};
     }
-
-    std::optional<EventPair> reserveEvents =
-        getAccessEvents(*reserve, operationEvents, accessEvents);
-    std::optional<EventPair> pushEvents =
-        getAccessEvents(*push, operationEvents, accessEvents);
-    std::optional<EventPair> waitEvents =
-        getAccessEvents(*wait, operationEvents, accessEvents);
-    std::optional<EventPair> popEvents =
-        getAccessEvents(*pop, operationEvents, accessEvents);
-    bool reservePrecedesPush =
-        isa<CBReserveOp>(reserve->operation) && isa<CBPushOp>(push->operation)
-            ? reserve->operation->getBlock() == push->operation->getBlock() &&
-                  reserve->operation->isBeforeInBlock(push->operation)
-            : reserveEvents && pushEvents &&
-                  graph.strictlyPrecedes(reserveEvents->completion,
-                                         pushEvents->entry);
-    bool waitPrecedesPop =
-        isa<CBWaitOp>(wait->operation) && isa<CBPopOp>(pop->operation)
-            ? wait->operation->getBlock() == pop->operation->getBlock() &&
-                  wait->operation->isBeforeInBlock(pop->operation)
-            : waitEvents && popEvents &&
-                  graph.strictlyPrecedes(waitEvents->completion,
-                                         popEvents->entry);
-    if (!reserveEvents || !pushEvents || !waitEvents || !popEvents ||
-        !reservePrecedesPush || !waitPrecedesPop) {
-      return {DFBQuiescenceFailureReason::IncompleteUseOrder, pop->operation};
+    if (isa<CBReserveOp>(reserve->access->operation) &&
+        !releaseFollowsOwnedUses(reserve->access->operation,
+                                 push->access->operation, nativeReserves)) {
+      return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+              push->access->operation};
     }
-    if (isa<CBReserveOp>(reserve->operation) &&
-        !releaseFollowsOwnedUses(reserve->operation, push->operation)) {
-      return {DFBQuiescenceFailureReason::IncompleteUseOrder, push->operation};
-    }
-    if (isa<CBWaitOp>(wait->operation) &&
-        !releaseFollowsOwnedUses(wait->operation, pop->operation)) {
-      return {DFBQuiescenceFailureReason::IncompleteUseOrder, pop->operation};
-    }
-
     std::optional<DFBPointerOwner> reserveOwner = getPointerOwner(
-        reserve->operation, node, DFBProtocolEffectKind::Reserve);
-    std::optional<DFBPointerOwner> pushOwner =
-        getPointerOwner(push->operation, node, DFBProtocolEffectKind::Push);
-    std::optional<DFBPointerOwner> waitOwner =
-        getPointerOwner(wait->operation, node, DFBProtocolEffectKind::Wait);
-    std::optional<DFBPointerOwner> popOwner =
-        getPointerOwner(pop->operation, node, DFBProtocolEffectKind::Pop);
-    if (!reserveOwner || !pushOwner || !waitOwner || !popOwner ||
-        *reserveOwner != *pushOwner || *waitOwner != *popOwner ||
-        (writeOwner && *writeOwner != *reserveOwner) ||
-        (readOwner && *readOwner != *waitOwner)) {
+        reserve->access->operation, node, DFBProtocolEffectKind::Reserve);
+    std::optional<DFBPointerOwner> pushOwner = getPointerOwner(
+        push->access->operation, node, DFBProtocolEffectKind::Push);
+    if (!reserveOwner || !pushOwner || *reserveOwner != *pushOwner ||
+        (writeOwner && *writeOwner != *reserveOwner)) {
       return {DFBQuiescenceFailureReason::UnknownPointerOwner,
-              reserve->operation};
+              reserve->access->operation};
     }
     writeOwner = reserveOwner;
+  }
+  for (auto [wait, pop] : llvm::zip_equal(waits, pops)) {
+    if (wait->access->numTiles <= 0) {
+      return {DFBQuiescenceFailureReason::MismatchedTransaction,
+              wait->access->operation};
+    }
+    if (isa<CBWaitOp>(wait->access->operation) &&
+        !releaseFollowsOwnedUses(wait->access->operation,
+                                 pop->access->operation, nativeWaits)) {
+      return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+              pop->access->operation};
+    }
+    std::optional<DFBPointerOwner> waitOwner = getPointerOwner(
+        wait->access->operation, node, DFBProtocolEffectKind::Wait);
+    std::optional<DFBPointerOwner> popOwner = getPointerOwner(
+        pop->access->operation, node, DFBProtocolEffectKind::Pop);
+    if (!waitOwner || !popOwner || *waitOwner != *popOwner ||
+        (readOwner && *readOwner != *waitOwner)) {
+      return {DFBQuiescenceFailureReason::UnknownPointerOwner,
+              wait->access->operation};
+    }
     readOwner = waitOwner;
-    lifetime.transactionTileCounts.push_back(reserve->numTiles);
+  }
+
+  std::size_t reserveIndex = 0;
+  std::size_t waitIndex = 0;
+  std::uint64_t reserveOffset = 0;
+  std::uint64_t waitOffset = 0;
+  while (reserveIndex < reserves.size() && waitIndex < waits.size()) {
+    const AccessRun &reserve = *reserves[reserveIndex];
+    const AccessRun &wait = *waits[waitIndex];
+    if (reserve.access->numTiles != wait.access->numTiles ||
+        physicalTileCount % reserve.access->numTiles != 0) {
+      return {DFBQuiescenceFailureReason::MismatchedTransaction,
+              reserve.access->operation};
+    }
+    std::uint64_t matchedCount =
+        std::min(reserve.executionCount - reserveOffset,
+                 wait.executionCount - waitOffset);
+    appendTransactionRun(lifetime, matchedCount, reserve.access->numTiles);
+    reserveOffset += matchedCount;
+    waitOffset += matchedCount;
+    if (reserveOffset == reserve.executionCount) {
+      ++reserveIndex;
+      reserveOffset = 0;
+    }
+    if (waitOffset == wait.executionCount) {
+      ++waitIndex;
+      waitOffset = 0;
+    }
+  }
+  if (reserveIndex != reserves.size() || waitIndex != waits.size()) {
+    return {DFBQuiescenceFailureReason::MismatchedTransaction,
+            reserves.front()->access->operation};
   }
   lifetime.writePointerOwner = writeOwner;
   lifetime.readPointerOwner = readOwner;
 
-  std::optional<EventPair> terminalEvents =
-      getAccessEvents(*pops.back(), operationEvents, accessEvents);
+  for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
+    if (activeAccess->protocolEffect) {
+      continue;
+    }
+    const AccessRun &use = accessRuns.at(activeAccess);
+    bool covered = false;
+    for (auto [reserve, push] : llvm::zip_equal(reserves, pushes)) {
+      covered |= runIsInsideInterval(use, *reserve, *push, graph,
+                                     operationEvents, accessEvents);
+    }
+    for (auto [wait, pop] : llvm::zip_equal(waits, pops)) {
+      covered |= runIsInsideInterval(use, *wait, *pop, graph, operationEvents,
+                                     accessEvents);
+    }
+    if (!covered) {
+      return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+              activeAccess->operation};
+    }
+  }
+
+  std::optional<AccessEventSpan> terminalEvents =
+      getAccessEventSpan(*pops.back()->access, operationEvents, accessEvents);
   if (!terminalEvents) {
     return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
-            pops.back()->operation};
+            pops.back()->access->operation};
   }
   for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
-    std::optional<EventPair> useEvents =
-        getAccessEvents(*activeAccess, operationEvents, accessEvents);
-    if (!useEvents || (useEvents->completion != terminalEvents->completion &&
-                       !graph.strictlyPrecedes(useEvents->completion,
-                                               terminalEvents->completion))) {
+    std::optional<AccessEventSpan> useEvents =
+        getAccessEventSpan(*activeAccess, operationEvents, accessEvents);
+    if (!useEvents ||
+        (useEvents->last.completion != terminalEvents->last.completion &&
+         !graph.strictlyPrecedes(useEvents->last.completion,
+                                 terminalEvents->last.completion))) {
       return {DFBQuiescenceFailureReason::IncompleteUseOrder,
               activeAccess->operation};
     }
   }
   lifetime.earliestEntryEvents = findMinimalEntryEvents(
       activeAccesses, graph, operationEvents, accessEvents);
-  lifetime.terminalCompletionEvents = {terminalEvents->completion};
+  lifetime.terminalCompletionEvents = {terminalEvents->last.completion};
   if (diagnostics) {
     for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
-      std::optional<EventPair> activeEvents =
-          getAccessEvents(*activeAccess, operationEvents, accessEvents);
+      std::optional<AccessEventSpan> activeEvents =
+          getAccessEventSpan(*activeAccess, operationEvents, accessEvents);
       if (activeEvents && llvm::is_contained(lifetime.earliestEntryEvents,
-                                             activeEvents->entry)) {
+                                             activeEvents->first.entry)) {
         diagnostics->earliestAccessOccurrenceIndices.push_back(
             static_cast<unsigned>(activeAccess - logicalDFB.accesses.data()));
       }
     }
     diagnostics->terminalAccessOccurrenceIndices = {
-        static_cast<unsigned>(pops.back() - logicalDFB.accesses.data())};
+        static_cast<unsigned>(pops.back()->access -
+                              logicalDFB.accesses.data())};
   }
   if (lifetime.earliestEntryEvents.empty()) {
     return {DFBQuiescenceFailureReason::IncompleteUseOrder,
-            pops.back()->operation};
+            pops.back()->access->operation};
   }
   return {};
 }
@@ -1086,20 +1536,19 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     }
   }
   for (LaunchNodeCoord node : launchNodes) {
-    std::optional<AccessExecutionCounts> reportedExecutionCounts;
-    if (collectAllocationDiagnostics) {
-      reportedExecutionCounts.emplace(
-          collectAccessExecutionCounts(logicalDFBs, node, domainState));
-    }
+    AccessExecutionCounts executionCounts =
+        collectAccessExecutionCounts(logicalDFBs, node, domainState);
+    AccessRuns accessRuns =
+        collectAccessRuns(logicalDFBs, node, domainState, executionCounts,
+                          /*includeUnknownDomains=*/false);
     HappensBeforeGraph graph;
     DenseMap<Operation *, EventPair> operationEvents;
-    DenseMap<const DFBAccessOccurrence *, EventPair> accessEvents;
+    DenseMap<const DFBAccessOccurrence *, AccessEventSpan> accessEvents;
     buildProgramOrderGraph(module, logicalDFBs, node, graph, operationEvents,
-                           accessEvents, /*executionCounts=*/nullptr,
+                           accessEvents, executionCounts, accessRuns,
                            /*includeUnknownDomains=*/false);
-    addMatchedPushWaitEdges(logicalDFBs, node, graph, operationEvents,
-                            accessEvents, /*executionCounts=*/nullptr,
-                            /*includeUnknownDomains=*/false);
+    addMatchedPushWaitEdges(logicalDFBs, graph, operationEvents, accessEvents,
+                            accessRuns);
     graph.computeReachability();
 
     for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
@@ -1113,8 +1562,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           allocationDiagnostics
               ? &allocationDiagnostics->nodeLifetimeDiagnostics
               : nullptr,
-          graph, operationEvents, accessEvents, domainState,
-          reportedExecutionCounts ? &*reportedExecutionCounts : nullptr);
+          graph, operationEvents, accessEvents, executionCounts, accessRuns);
       logicalDFB.nodeLifetimes.back().quiescence = proof;
     }
 
@@ -1143,15 +1591,18 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     }
     HappensBeforeGraph diagnosticGraph;
     DenseMap<Operation *, EventPair> diagnosticOperationEvents;
-    DenseMap<const DFBAccessOccurrence *, EventPair> diagnosticAccessEvents;
+    DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        diagnosticAccessEvents;
+    AccessRuns diagnosticAccessRuns =
+        collectAccessRuns(logicalDFBs, node, domainState, executionCounts,
+                          /*includeUnknownDomains=*/true);
     buildProgramOrderGraph(module, logicalDFBs, node, diagnosticGraph,
                            diagnosticOperationEvents, diagnosticAccessEvents,
-                           &*reportedExecutionCounts,
+                           executionCounts, diagnosticAccessRuns,
                            /*includeUnknownDomains=*/true);
-    addMatchedPushWaitEdges(logicalDFBs, node, diagnosticGraph,
+    addMatchedPushWaitEdges(logicalDFBs, diagnosticGraph,
                             diagnosticOperationEvents, diagnosticAccessEvents,
-                            &*reportedExecutionCounts,
-                            /*includeUnknownDomains=*/true);
+                            diagnosticAccessRuns);
     diagnosticGraph.computeReachability();
     for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
       if (logicalDFB.launchDomain.known) {
@@ -1163,7 +1614,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           logicalDFB, node, allocationDiagnostics.counterfactualNodeLifetimes,
           &allocationDiagnostics.counterfactualNodeLifetimeDiagnostics,
           diagnosticGraph, diagnosticOperationEvents, diagnosticAccessEvents,
-          domainState, &*reportedExecutionCounts,
+          executionCounts, diagnosticAccessRuns,
           /*includeUnknownDomains=*/true);
       allocationDiagnostics.counterfactualNodeLifetimes.back().quiescence =
           proof;

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1363,9 +1363,8 @@ static DFBQuiescenceProof computePerNodeLifetime(
             static_cast<unsigned>(activeAccess - logicalDFB.accesses.data()));
       }
     }
-    diagnostics->terminalAccessOccurrenceIndices = {
-        static_cast<unsigned>(pops.back()->access -
-                              logicalDFB.accesses.data())};
+    diagnostics->terminalAccessOccurrenceIndices = {static_cast<unsigned>(
+        pops.back()->access - logicalDFB.accesses.data())};
   }
   if (lifetime.earliestEntryEvents.empty()) {
     return {DFBQuiescenceFailureReason::IncompleteUseOrder,

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -129,6 +129,17 @@ struct DFBPerNodeLifetimeDiagnostics {
   }
 };
 
+/// Consecutive normalized transactions with one tile count.
+struct DFBTransactionRun {
+  std::uint64_t executionCount = 0;
+  int64_t tilesPerExecution = 0;
+
+  bool operator==(const DFBTransactionRun &rhs) const {
+    return executionCount == rhs.executionCount &&
+           tilesPerExecution == rhs.tilesPerExecution;
+  }
+};
+
 /// Immutable lifetime and hardware-state facts for one launched node.
 struct DFBPerNodeLifetime {
   LaunchNodeCoord node;
@@ -139,8 +150,8 @@ struct DFBPerNodeLifetime {
   /// Completion event IDs after which the DFB is quiescent.
   SmallVector<unsigned> terminalCompletionEvents;
 
-  /// One tile count per transaction tuple, paired by occurrence order.
-  SmallVector<int64_t> transactionTileCounts;
+  /// Normalized transaction runs in occurrence order.
+  SmallVector<DFBTransactionRun> transactionRuns;
   std::optional<DFBPointerOwner> writePointerOwner;
   std::optional<DFBPointerOwner> readPointerOwner;
   DFBQuiescenceProof quiescence;

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -151,8 +151,7 @@ private:
                     getLifetimeEvidence(rhsLifetime, rhs));
         continue;
       }
-      if (lhsLifetime->transactionTileCounts !=
-          rhsLifetime->transactionTileCounts) {
+      if (lhsLifetime->transactionRuns != rhsLifetime->transactionRuns) {
         addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
                     DFBConflictReason::TransactionMismatch, node,
                     getLifetimeEvidence(lhsLifetime, lhs),

--- a/test/python/include/repeated_dfb_transactions.hpp
+++ b/test/python/include/repeated_dfb_transactions.hpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(COMPILE_FOR_TRISC)
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/pack.h"
+#include "api/compute/reg_api.h"
+#include "api/compute/tile_move_copy.h"
+#endif
+
+template <typename Source, typename Completion>
+inline void consume_repeated_dfb_and_signal() {
+#if defined(COMPILE_FOR_TRISC)
+  using namespace ckernel;
+  for (uint32_t transaction = 0; transaction < 4; ++transaction) {
+    cb_wait_front(Source::index, Source::pages_per_block);
+    cb_pop_front(Source::index, Source::pages_per_block);
+  }
+  cb_reserve_back(Completion::index, Completion::pages_per_block);
+  cb_push_back(Completion::index, Completion::pages_per_block);
+#endif
+}
+
+template <typename Source, typename Destination>
+inline void copy_repeated_dfb() {
+#if defined(COMPILE_FOR_TRISC)
+  using namespace ckernel;
+  unary_op_init_common(Source::index, Destination::index);
+  copy_tile_init(Source::index);
+  for (uint32_t transaction = 0; transaction < 4; ++transaction) {
+    cb_wait_front(Source::index, Source::pages_per_block);
+    cb_reserve_back(Destination::index, Destination::pages_per_block);
+    for (uint32_t tile = 0; tile < Source::pages_per_block; ++tile) {
+      tile_regs_acquire();
+      copy_tile(Source::index, tile, 0);
+      tile_regs_commit();
+      tile_regs_wait();
+      pack_tile(0, Destination::index);
+      tile_regs_release();
+    }
+    cb_pop_front(Source::index, Source::pages_per_block);
+    cb_push_back(Destination::index, Destination::pages_per_block);
+  }
+#endif
+}

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -30,6 +30,9 @@ F32_REPEATED_EXP_ATOL = 5e-4
 SCALAR_RESULT_HEADER = os.path.join(
     os.path.dirname(__file__), "include", "scalar_result_op.hpp"
 )
+REPEATED_TRANSACTION_HEADER = os.path.join(
+    os.path.dirname(__file__), "include", "repeated_dfb_transactions.hpp"
+)
 
 
 def _make_exp_via_scratch_atom(data_format, shape=(1, 1)):
@@ -233,6 +236,107 @@ def _incompatible_static_configuration_kernel(input_tensor, output_tensor):
             ttl.copy(output_block, output_tensor[0, node_x]).wait()
 
 
+def _make_repeated_transaction_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(1, 1))
+    def repeated_transaction_kernel(input_tensor, output_tensor):
+        first_source = ttl.make_dfb(data_format, shape=(1, 4), block_count=2)
+        completion = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        second_source = ttl.make_dfb(data_format, shape=(1, 4), block_count=2)
+        output = ttl.make_dfb(data_format, shape=(1, 4), block_count=2)
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            for transaction in range(4):
+                with first_source.reserve() as destination:
+                    ttl.copy(
+                        input_tensor[
+                            0:1,
+                            transaction * 4 : transaction * 4 + 4,
+                        ],
+                        destination,
+                    ).wait()
+
+            with completion.wait():
+                pass
+
+            for transaction in range(4):
+                with second_source.reserve() as destination:
+                    ttl.copy(
+                        input_tensor[
+                            0:1,
+                            transaction * 4 : transaction * 4 + 4,
+                        ],
+                        destination,
+                    ).wait()
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            ttl.call_extern_func(
+                REPEATED_TRANSACTION_HEADER,
+                "consume_repeated_dfb_and_signal",
+                template_args=[
+                    ttl.dfb_descriptor(first_source),
+                    ttl.dfb_descriptor(completion),
+                ],
+                dfb_effects=[
+                    ttl.DFBEffect.wait(first_source, tiles=4),
+                    ttl.DFBEffect.pop(first_source, tiles=4),
+                    ttl.DFBEffect.wait(first_source, tiles=4),
+                    ttl.DFBEffect.pop(first_source, tiles=4),
+                    ttl.DFBEffect.wait(first_source, tiles=4),
+                    ttl.DFBEffect.pop(first_source, tiles=4),
+                    ttl.DFBEffect.wait(first_source, tiles=4),
+                    ttl.DFBEffect.pop(first_source, tiles=4),
+                    ttl.DFBEffect.reserve(completion, tiles=1),
+                    ttl.DFBEffect.push(completion, tiles=1),
+                ],
+            )
+            ttl.call_extern_func(
+                REPEATED_TRANSACTION_HEADER,
+                "copy_repeated_dfb",
+                template_args=[
+                    ttl.dfb_descriptor(second_source),
+                    ttl.dfb_descriptor(output),
+                ],
+                dfb_effects=[
+                    ttl.DFBEffect.wait(second_source, tiles=4),
+                    ttl.DFBEffect.reserve(output, tiles=4),
+                    ttl.DFBEffect.pop(second_source, tiles=4),
+                    ttl.DFBEffect.push(output, tiles=4),
+                    ttl.DFBEffect.wait(second_source, tiles=4),
+                    ttl.DFBEffect.reserve(output, tiles=4),
+                    ttl.DFBEffect.pop(second_source, tiles=4),
+                    ttl.DFBEffect.push(output, tiles=4),
+                    ttl.DFBEffect.wait(second_source, tiles=4),
+                    ttl.DFBEffect.reserve(output, tiles=4),
+                    ttl.DFBEffect.pop(second_source, tiles=4),
+                    ttl.DFBEffect.push(output, tiles=4),
+                    ttl.DFBEffect.wait(second_source, tiles=4),
+                    ttl.DFBEffect.reserve(output, tiles=4),
+                    ttl.DFBEffect.pop(second_source, tiles=4),
+                    ttl.DFBEffect.push(output, tiles=4),
+                ],
+            )
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            for transaction in range(4):
+                with output.wait() as source:
+                    ttl.copy(
+                        source,
+                        output_tensor[
+                            0:1,
+                            transaction * 4 : transaction * 4 + 4,
+                        ],
+                    ).wait()
+
+    return repeated_transaction_kernel
+
+
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
@@ -241,6 +345,8 @@ _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
 _exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
 _exact_f32_execution_domain_kernel = _make_exact_execution_domain_kernel("float32")
+_repeated_bf16_transaction_kernel = _make_repeated_transaction_kernel("bf16")
+_repeated_f32_transaction_kernel = _make_repeated_transaction_kernel("float32")
 
 assert CAPACITY_TEST_LOGICAL_DFBS == 33
 
@@ -454,6 +560,46 @@ def test_exact_disjoint_execution_domains_reuse_dfb(
     # Input and output hardware owners keep them distinct from the compute
     # scratch DFBs. The scratch DFBs share because their exact node domains are
     # disjoint, without requiring a local lifetime-order proof.
+    physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
+    assert physical_dfb_count == 3
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_repeated_bf16_transaction_kernel, torch.bfloat16),
+        (_repeated_f32_transaction_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_repeated_transaction_lifecycles_reuse_dfb(
+    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    element_indices = torch.arange(TILE * 16 * TILE, dtype=torch.float32).reshape(
+        TILE, 16 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_path = tmp_path / "repeated_transactions.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+
+    # The two source DFBs have identical pointer owners and non-overlapping
+    # lifetimes. Completion and output retain distinct DFB types or owners.
     physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
     assert physical_dfb_count == 3
 

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -345,9 +345,6 @@ _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
 _exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
 _exact_f32_execution_domain_kernel = _make_exact_execution_domain_kernel("float32")
-_repeated_bf16_transaction_kernel = _make_repeated_transaction_kernel("bf16")
-_repeated_f32_transaction_kernel = _make_repeated_transaction_kernel("float32")
-
 assert CAPACITY_TEST_LOGICAL_DFBS == 33
 
 
@@ -572,10 +569,10 @@ def test_exact_disjoint_execution_domains_reuse_dfb(
 
 
 @pytest.mark.parametrize(
-    ("operation", "dtype"),
+    ("data_format", "dtype"),
     [
-        (_repeated_bf16_transaction_kernel, torch.bfloat16),
-        (_repeated_f32_transaction_kernel, torch.float32),
+        ("bf16", torch.bfloat16),
+        ("float32", torch.float32),
     ],
     ids=["bf16", "f32"],
 )
@@ -585,8 +582,9 @@ def test_exact_disjoint_execution_domains_reuse_dfb(
     ids=["dram", "l1"],
 )
 def test_repeated_transaction_lifecycles_reuse_dfb(
-    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+    device, data_format, dtype, memory_config, to_device, monkeypatch, tmp_path
 ):
+    operation = _make_repeated_transaction_kernel(data_format)
     element_indices = torch.arange(TILE * 16 * TILE, dtype=torch.float32).reshape(
         TILE, 16 * TILE
     )

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
@@ -241,18 +241,19 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// A count greater than one establishes domain membership but does not turn a
-// repeated protocol into a single bounded lifecycle.
+// A statically counted protocol under a launch-node condition that executes
+// once normalizes into repeated transactions.
 
 // REUSE-LABEL: func.func @repeated_exact_count
 // REUSE: %[[REPEATED:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 18 : index}
 // REUSE-NEXT: %[[AFTER_REPEATED:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 19 : index}
 
-// REPORT: DFB logical_id=18 bounded=0 compiler_created=0
+// REPORT: DFB logical_id=18 bounded=1 compiler_created=0
 // REPORT-SAME: domain={(0,0), (1,0)}
-// REPORT: node (0,0) quiescence=unsupported-control-flow
+// REPORT: node (0,0) quiescence=none
 // REPORT-SAME: occurrences=[0:2, 1:2, 2:2, 3:2]
-// REPORT: DFB conflict lhs=18 rhs=19 reason=unproven-quiescence node=(0,0)
+// REPORT-SAME: transactions=[1, 1]
+// REPORT: DFB conflict lhs=18 rhs=19 reason=transaction-mismatch node=(0,0)
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @repeated_exact_count(%runtime_offset: index)

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
@@ -1,0 +1,226 @@
+// Tests normalization of statically repeated DFB protocol transactions.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=REUSE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// A loop producer and an explicit external consumer describe the same four
+// transactions. The non-protocol producer access executes in the same loop.
+
+// REUSE-LABEL: func.func @loop_to_explicit
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @loop_to_explicit()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.opaque_call "producer_use" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) () {header = "producer_use.hpp"} : () -> ()
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "explicit_consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.opaque_call "producer_use" dfb_dependencies(%second : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) () {header = "producer_use.hpp"} : () -> ()
+      ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "explicit_consumer" dfb_dependencies(%second : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// Large exact runs remain compact while retaining their exact count and tile
+// size in the allocation report.
+
+// REPORT: operation=ttl.cb_reserve kernel=@large_static_run
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[run(count=1000,tiles=1)]
+
+module {
+  func.func @large_static_run()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 1000 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      %available = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// A launch-node condition may enclose the producer loop and the explicit
+// consumer independently. Effect sequence indices still order the four
+// wait/pop pairs within the consumer invocation.
+
+// REUSE-LABEL: func.func @nested_explicit_consumer
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// REPORT: operation=ttl.cb_reserve kernel=@nested_explicit_consumer
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: occurrences=[0:4, 1:4, 2:1, 3:1, 4:1, 5:1, 6:1, 7:1, 8:1, 9:1]
+// REPORT-SAME: transactions=[4, 4, 4, 4]
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @nested_explicit_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %four = arith.constant 4 : index
+    %one = arith.constant 1 : index
+    %inside_grid = arith.cmpi ne, %core_x, %two : index
+    scf.if %inside_grid {
+      scf.for %transaction = %zero to %four step %one {
+        %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+        ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+      }
+    }
+    scf.if %inside_grid {
+      ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    }
+    scf.for %transaction = %zero to %four step %one {
+      %reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%second : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// An explicit producer summary and a loop consumer normalize identically.
+
+// REUSE-LABEL: func.func @explicit_to_loop
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @explicit_to_loop()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    ttl.opaque_call "explicit_producer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>, #ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>, #ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>, #ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>] () {header = "producer.hpp"} : () -> ()
+    scf.for %transaction = %lower to %upper step %step {
+      %available = ttl.cb_wait %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.opaque_call "consumer_use" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) () {header = "consumer_use.hpp"} : () -> ()
+      ttl.cb_pop %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "explicit_producer" dfb_dependencies(%second : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>, #ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>, #ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>, #ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>] () {header = "producer.hpp"} : () -> ()
+    scf.for %transaction = %lower to %upper step %step {
+      %available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.opaque_call "consumer_use" dfb_dependencies(%second : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) () {header = "consumer_use.hpp"} : () -> ()
+      ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// Independent producer and consumer loops retain their distinct iteration
+// domains while matching by normalized transaction position.
+
+// REUSE-LABEL: func.func @loop_to_loop
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// REPORT-COUNT-6: transactions=[4, 4, 4, 4]
+
+module {
+  func.func @loop_to_loop()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.for %transaction = %lower to %upper step %step {
+      %available = ttl.cb_wait %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.for %transaction = %lower to %upper step %step {
+      %available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// Each straight-line acquisition owns only the direct DFB accesses before the
+// next same-kind acquisition. Both producer and consumer runs remain bounded.
+
+// REUSE-LABEL: func.func @straight_line_producer
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-LABEL: func.func @straight_line_consumer
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REPORT: DFB logical_id=0 bounded=1
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[1, 1]
+
+module {
+  func.func @straight_line_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved_0 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.opaque_call "producer_use" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "producer_use.hpp"} : () -> ()
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved_1 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.opaque_call "producer_use" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "producer_use.hpp"} : () -> ()
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @straight_line_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %waited_0 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.opaque_call "consumer_use" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "consumer_use.hpp"} : () -> ()
+    ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %waited_1 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.opaque_call "consumer_use" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "consumer_use.hpp"} : () -> ()
+    ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
@@ -13,6 +13,8 @@
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@unrelated_opaque_access
 
+// Producer and consumer transaction counts must match.
+
 module {
   func.func @mismatched_count()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
@@ -37,6 +39,8 @@ module {
 
 // -----
 
+// A second wait before the first pop leaves consumer acquisitions overlapping.
+
 module {
   func.func @overlapping_consumer_acquires()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
@@ -54,6 +58,8 @@ module {
 }
 
 // -----
+
+// Producer and consumer tile counts must match at every transaction position.
 
 module {
   func.func @mismatched_tiles()
@@ -79,6 +85,8 @@ module {
 
 // -----
 
+// A dynamic loop trip count cannot define an exact transaction run.
+
 module {
   func.func @dynamic_trip_count(%upper: index)
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
@@ -101,6 +109,8 @@ module {
 }
 
 // -----
+
+// Separate loops do not prove aligned reserve and push executions.
 
 module {
   func.func @differing_iteration_domains()
@@ -128,6 +138,8 @@ module {
 
 // -----
 
+// A runtime condition inside the loop prevents uniform per-iteration proof.
+
 module {
   func.func @conditional_iteration(%condition: i1)
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
@@ -153,6 +165,8 @@ module {
 }
 
 // -----
+
+// A payload access after the consumer release is outside the owned interval.
 
 module {
   func.func @access_outside_interval()
@@ -180,6 +194,8 @@ module {
 }
 
 // -----
+
+// Lifecycles controlled by different NoC processors cannot share one index.
 
 module {
   func.func @pointer_owner_noc0()
@@ -221,6 +237,8 @@ module {
 }
 
 // -----
+
+// An unknown external DFB access prevents a complete lifetime proof.
 
 module {
   func.func @unrelated_opaque_access()

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
@@ -1,0 +1,242 @@
+// Tests conservative rejection of unproved repeated DFB transactions.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=ALLOC
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// ALLOC-COUNT-9: ttl.base_cta_index = 2 : i32
+// REPORT: quiescence=mismatched-transaction {{.*}} kernel=@mismatched_count
+// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@overlapping_consumer_acquires
+// REPORT: quiescence=mismatched-transaction {{.*}} kernel=@mismatched_tiles
+// REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@dynamic_trip_count
+// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@differing_iteration_domains
+// REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@conditional_iteration
+// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@access_outside_interval
+// REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch
+// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@unrelated_opaque_access
+
+module {
+  func.func @mismatched_count()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @overlapping_consumer_acquires()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "producer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>, #ttl.dfb_protocol_effect<reserve, 0, 4>, #ttl.dfb_protocol_effect<push, 0, 4>] () {header = "producer.hpp"} : () -> ()
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @mismatched_tiles()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 2>, #ttl.dfb_protocol_effect<pop, 0, 2>, #ttl.dfb_protocol_effect<wait, 0, 2>, #ttl.dfb_protocol_effect<pop, 0, 2>, #ttl.dfb_protocol_effect<wait, 0, 2>, #ttl.dfb_protocol_effect<pop, 0, 2>, #ttl.dfb_protocol_effect<wait, 0, 2>, #ttl.dfb_protocol_effect<pop, 0, 2>] () {header = "consumer.hpp"} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @dynamic_trip_count(%upper: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @differing_iteration_domains()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    }
+    scf.for %transaction = %lower to %upper step %step {
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @conditional_iteration(%condition: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      scf.if %condition {
+        %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+        ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+      }
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @access_outside_interval()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>, #ttl.dfb_protocol_effect<wait, 0, 4>, #ttl.dfb_protocol_effect<pop, 0, 4>] () {header = "consumer.hpp"} : () -> ()
+    scf.for %transaction = %lower to %upper step %step {
+      ttl.opaque_call "late_use" dfb_dependencies(%first : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>) () {header = "late_use.hpp"} : () -> ()
+    }
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @pointer_owner_noc0()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.for %transaction = %lower to %upper step %step {
+      %available = ttl.cb_wait %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+  func.func @pointer_owner_noc1()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 1 : i32,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.for %transaction = %lower to %upper step %step {
+      %available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @unrelated_opaque_access()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = ttl.cb_reserve %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %first_available = ttl.cb_wait %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "unrelated" () {header = "unrelated.hpp", unknown_dfb_access} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
@@ -29,9 +29,9 @@
 // CHECK-SAME: occurrences=[0:0, 1:0, 2:0, 3:0]
 // CHECK: DFB logical_id=3 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: diagnostic_nodes quiescence=none domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(0,0)}
+// CHECK: diagnostic_nodes quiescence=incomplete-use-order domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(0,0)}
 // CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
-// CHECK-SAME: earliest_accesses=[0] terminal_accesses=[4]
+// CHECK-SAME: transactions=[1]
 // CHECK: diagnostic_nodes quiescence=incomplete-use-order domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(1,0)}
 // CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
 // CHECK: DFB conflict lhs=0 rhs=1 reason=unknown-launch-node-domain node=none


### PR DESCRIPTION
### Problem description

The liveness analysis treated one protocol operation in a static loop as one transaction. It could not match a loop-based producer against an external consumer that lists the same transactions explicitly, and it rejected repeated payload accesses such as `ttl.copy`.

### What's changed

~695 LOC implementation.

Normalize protocol and payload accesses into counted runs with an exact execution count, tiles per execution, and structured iteration domain. Matching uses dynamic transaction position instead of raw operation-vector length, so loop-to-explicit, explicit-to-loop, and loop-to-loop representations can prove the same queue lifecycle.

The proof requires identical structured iteration domains, balanced ordered reserve/push/wait/pop runs, equal positive tile counts, constant compatible pointer owners, covered payload accesses, terminal completion, and matched publication/readiness positions. Equal numeric counts without the same iteration domain do not prove per-iteration ordering.

```text
producer loop: 4 x { reserve(4), copy, push(4) }
consumer:      wait(4), pop(4), wait(4), pop(4), wait(4), pop(4), wait(4), pop(4)
normalized:    transactions=[4,4,4,4]
```

### Validation

- New device tests cover sequential repeated lifecycle reuse across BF16/FP32 and DRAM/L1.
- New analysis tests cover loop-to-explicit, explicit-to-loop, and loop-to-loop matches and conservative rejection cases.

### Checklist

- [x] New/Existing tests provide coverage for changes
