### PR TITLE
[ttl] Prove DFB lifecycles under shared conditions [dfb-reuse-7]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1526,7 +1526,7 @@ pairs retain an `unknown-launch-node-domain` conflict. Nodes with identical
 facts are grouped for deterministic bounded output.
 
 If node-dependent IR has no launch grid, no base launch nodes are available
-for the counterfactual evaluation. The report retains logical DFB and access
+for the possible-domain evaluation. The report retains logical DFB and access
 facts but omits per-node rows.
 
 The allocation graph uses one vertex per logical DFB and one edge per pair

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1460,11 +1460,11 @@ analyzeConcurrentLifetimes(module, logicalIdentities):
         add previous completion -> entry
 
     for each logical DFB active on the node:
-      pair equal nonzero reserve, push, wait, and pop occurrence sequences
-      if every tuple forms a matched transaction:
-        append each tile count to DFB.nodeLifetime.transactionTileCounts
-        record the common read and write hardware processors
-        add each push completion -> matching wait completion
+      if statically counted reserve, push, wait, and pop runs match, or one
+         reserve, push, wait, and pop share one at-most-once condition:
+        DFB.nodeLifetime.transactionRuns = normalized counted transactions
+        DFB.nodeLifetime.pointerOwners = read and write hardware processors
+        add DFB.push.completion -> DFB.wait.completion
 
     compute transitive graph reachability
 
@@ -1475,8 +1475,14 @@ analyzeConcurrentLifetimes(module, logicalIdentities):
         DFB.nodeLifetime.terminalEvents = {final pop completion}
         DFB.nodeLifetime.quiescence = proven
 
+    build a second graph with every unknown access domain treated as possible
+    prove conditionally bounded lifetimes only for one complete conditional
+      transaction on every possible node
+    retain possible-domain order separately from exact-domain order
+
   return logical DFB lifecycles, per-node quiescence, pointer owners,
-         source evidence, and pairwise per-node lifetime order
+         conditional boundedness, source evidence, and pairwise per-node
+         exact and possible-domain lifetime order
 ```
 
 `DFBPhysicalAllocationPlanner` consumes those immutable facts and constructs a
@@ -1507,17 +1513,17 @@ numbered access records and their source locations. Each conflict records both
 logical IDs, the typed reason, an applicable launch node, and source
 operations.
 
-An unknown launch-node domain is itself sufficient to prevent reuse. For
-diagnosis, the report also evaluates each base launch node while assuming that
-unknown-domain accesses may be active. An exact-zero execution count still
-proves that an access is inactive and excludes its ordering edges. These rows
-use `domain_assumption=unknown-may-be-active`; they identify the next missing
-proof, such as a protocol effect, exact execution count, matched transaction,
-or complete use order. `may_be_active` is present only on these counterfactual
-rows and is false when every included access has an exact-zero count. They are
-counterfactual evidence only. They do not mark the DFB bounded, add lifetime
-ordering, or change the conflict relation. Nodes with identical diagnostic
-facts are grouped to keep large launch grids readable.
+The report evaluates each base launch node with every unknown-domain access
+treated as possible. Exact-zero execution excludes an access. These rows use
+`domain_assumption=unknown-possible`. A row records
+`conditional_execution=1` only when every unresolved active access shares one
+structured at-most-once condition and forms one complete transaction. A
+logical DFB becomes `conditionally_bounded=1` only when the proof succeeds on
+every possible node. Two conditionally bounded unknown-domain DFBs may share
+when their descriptors, transaction runs, pointer owners, and possible-domain
+lifetimes are compatible. Unknown/exact-domain pairs and all other unknown
+pairs retain an `unknown-launch-node-domain` conflict. Nodes with identical
+facts are grouped for deterministic bounded output.
 
 If node-dependent IR has no launch grid, no base launch nodes are available
 for the counterfactual evaluation. The report retains logical DFB and access
@@ -1549,7 +1555,8 @@ buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
 
   for each logical DFB pair A, B:
     add descriptor mismatch if A.type != B.type
-    add unknown-domain conflict if either launch-node domain is unknown
+    add unknown-domain conflict unless both unknown domains are conditionally
+      bounded
     for each node where A and B both execute:
       add unproven-quiescence conflict unless both node lifetimes are proven
       add transaction conflict unless their transaction tile-count sequences match

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -980,9 +980,14 @@ def TTLFinalizeDFBIndices
     `CircularBufferType` equality, equal transaction tile counts that divide
     the DFB capacity, and identical read- and write-pointer processors on each
     launch node. These requirements preserve hardware counter and ring-pointer
-    state. A logical DFB without an exact single lifecycle or a proven lifetime
-    order conflicts with every other DFB. Unsupported or unknown control flow
-    can reduce reuse but cannot produce an unsafe physical assignment.
+    state. One unresolved structured condition is supported when every active
+    DFB access belongs to one reserve, push, wait, and pop transaction
+    controlled by equivalent `scf.if` or `affine.if` frames in one kernel
+    function. Branch polarity, nesting, and control SSA values must match.
+    Unresolved loops, repeated conditional transactions, and separately
+    evaluated opaque predicates remain unsupported. A logical DFB without a
+    matched lifecycle or a proven lifetime order conflicts with every other
+    DFB.
 
     Two DFBs used by one compute kernel may share a physical index only when
     every target-supported destination width assigns compatible static unpack
@@ -1027,10 +1032,14 @@ def TTLFinalizeDFBIndices
     counts, transaction sizes, pointer owners, lifetime frontiers, and conflict
     evidence. Lifetime frontiers use access-occurrence indices that map to the
     report's numbered access records. For an unknown launch-node domain, it
-    separately labels a counterfactual per-node analysis that assumes
-    unknown-domain accesses may be active while preserving exact-zero
-    inactivity. Those diagnostic attempts do not establish boundedness or
-    affect the conflict relation. If node-dependent IR has no launch grid, the
+    separately labels a possible-domain per-node analysis that treats unknown
+    accesses as possible while preserving exact-zero inactivity. It may
+    establish conditional boundedness only for one complete transaction whose
+    active accesses share one structured at-most-once condition on every
+    possible node. Reuse remains restricted to two conditionally bounded
+    unknown-domain DFBs with matching transactions, pointer owners, and
+    possible-domain lifetime order. Per-access counts and lifetime-frontier
+    indices remain report-only. If node-dependent IR has no launch grid, the
     report retains logical DFB and access facts but omits per-node rows because
     no base launch nodes are available.
 

--- a/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
@@ -208,6 +208,13 @@ bool proveEqualUnresolvedExecutionCountAtLaunchNodes(
     llvm::function_ref<std::optional<Value>(BlockArgument)>
         resolveRhsFunctionArgument);
 
+/// Prove that two operations have the same unresolved conditional execution
+/// at their launch nodes. The proof accepts only structured conditions whose
+/// bodies execute at most once; unresolved loops are rejected.
+bool proveEquivalentConditionalExecutionAtLaunchNodes(
+    Operation *lhs, LaunchNodeCoord lhsCoord, Operation *rhs,
+    LaunchNodeCoord rhsCoord, const LaunchNodeDomainState &state);
+
 /// Prove that two operations execute equally often at their launch nodes.
 /// Exact counts prove equality directly. Otherwise, the operations must share
 /// equivalent unresolved control flow that does not require call-site values.

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -234,13 +234,15 @@ static void printTransactions(llvm::raw_ostream &output,
   output << ']';
 }
 
-static bool
-hasEqualDiagnosticFacts(const DFBPerNodeLifetime &lhs,
-                        const DFBPerNodeLifetimeDiagnostics &lhsDiagnostics,
-                        const DFBPerNodeLifetime &rhs,
-                        const DFBPerNodeLifetimeDiagnostics &rhsDiagnostics) {
+static bool hasEqualPossibleFacts(
+    const DFBPerNodeLifetime &lhs,
+    const DFBPerNodeLifetimeDiagnostics &lhsDiagnostics,
+    const DFBPerNodeLifetime &rhs,
+    const DFBPerNodeLifetimeDiagnostics &rhsDiagnostics) {
   if (lhs.quiescence.failure != rhs.quiescence.failure ||
       lhs.quiescence.evidence != rhs.quiescence.evidence ||
+      lhs.mayBeActive != rhs.mayBeActive ||
+      lhs.conditionalExecutionProven != rhs.conditionalExecutionProven ||
       lhs.transactionRuns != rhs.transactionRuns ||
       lhs.writePointerOwner != rhs.writePointerOwner ||
       lhs.readPointerOwner != rhs.readPointerOwner ||
@@ -275,29 +277,29 @@ struct LifetimeWithDiagnostics {
   const DFBPerNodeLifetimeDiagnostics *diagnostics = nullptr;
 };
 
-struct DiagnosticLifetimeGroup {
+struct PossibleLifetimeGroup {
   LifetimeWithDiagnostics representative;
   SmallVector<LaunchNodeCoord> nodes;
 };
 
-static void printDiagnosticLifetimes(
+static void printPossibleLifetimes(
     llvm::raw_ostream &output,
+    const DFBLogicalLifecycle &logicalDFB,
     const DFBLogicalLifecycleDiagnostics &allocationDiagnostics) {
-  assert(
-      allocationDiagnostics.counterfactualNodeLifetimes.size() ==
-          allocationDiagnostics.counterfactualNodeLifetimeDiagnostics.size() &&
-      "counterfactual lifetimes must have allocation-report data");
-  SmallVector<DiagnosticLifetimeGroup> groups;
+  assert(logicalDFB.possibleNodeLifetimes.size() ==
+             allocationDiagnostics.possibleNodeLifetimeDiagnostics.size() &&
+         "possible lifetimes must have allocation-report data");
+  SmallVector<PossibleLifetimeGroup> groups;
   for (auto lifetimeAndDiagnostics : llvm::zip_equal(
-           allocationDiagnostics.counterfactualNodeLifetimes,
-           allocationDiagnostics.counterfactualNodeLifetimeDiagnostics)) {
+           logicalDFB.possibleNodeLifetimes,
+           allocationDiagnostics.possibleNodeLifetimeDiagnostics)) {
     const DFBPerNodeLifetime &lifetime = std::get<0>(lifetimeAndDiagnostics);
     const DFBPerNodeLifetimeDiagnostics &diagnostics =
         std::get<1>(lifetimeAndDiagnostics);
     auto groupIt = llvm::find_if(groups, [&](const auto &group) {
-      return hasEqualDiagnosticFacts(*group.representative.lifetime,
-                                     *group.representative.diagnostics,
-                                     lifetime, diagnostics);
+      return hasEqualPossibleFacts(*group.representative.lifetime,
+                                   *group.representative.diagnostics, lifetime,
+                                   diagnostics);
     });
     if (groupIt == groups.end()) {
       groups.push_back({{&lifetime, &diagnostics}, {lifetime.node}});
@@ -306,14 +308,16 @@ static void printDiagnosticLifetimes(
     }
   }
 
-  for (const DiagnosticLifetimeGroup &group : groups) {
+  for (const PossibleLifetimeGroup &group : groups) {
     const DFBPerNodeLifetime &lifetime = *group.representative.lifetime;
     const DFBPerNodeLifetimeDiagnostics &diagnostics =
         *group.representative.diagnostics;
-    output << "  diagnostic_nodes quiescence="
+    output << "  possible_nodes quiescence="
            << getQuiescenceFailureName(lifetime.quiescence.failure)
-           << " domain_assumption=unknown-may-be-active may_be_active="
-           << diagnostics.mayBeActive << " node_count=" << group.nodes.size();
+           << " domain_assumption=unknown-possible may_be_active="
+           << lifetime.mayBeActive
+           << " conditional_execution=" << lifetime.conditionalExecutionProven
+           << " node_count=" << group.nodes.size();
     if (group.nodes.size() <= 8) {
       output << " nodes={";
       llvm::interleaveComma(group.nodes, output, [&](LaunchNodeCoord node) {
@@ -348,11 +352,12 @@ static void printNodeLifetimes(llvm::raw_ostream &output,
     printNode(output, lifetime.node);
     output << " quiescence="
            << getQuiescenceFailureName(lifetime.quiescence.failure)
-           << " domain_assumption=exact";
+           << " domain_assumption=exact conditional_execution="
+           << lifetime.conditionalExecutionProven;
     printLifetimeFacts(output, lifetime, diagnostics);
     output << '\n';
   }
-  printDiagnosticLifetimes(output, allocationDiagnostics);
+  printPossibleLifetimes(output, logicalDFB, allocationDiagnostics);
 }
 
 static void printConflictEvidence(llvm::raw_ostream &output,
@@ -385,7 +390,9 @@ void printDFBAllocationDebugReport(
        liveness.getLogicalDFBLifecycles()) {
     output << "DFB logical_id=" << logicalDFB.logicalId
            << " bounded=" << logicalDFB.bounded
-           << " compiler_created=" << logicalDFB.compilerCreated << " type=";
+           << " compiler_created=" << logicalDFB.compilerCreated
+           << " conditionally_bounded=" << logicalDFB.conditionallyBounded
+           << " type=";
     logicalDFB.type.print(output);
     output << " tensor_backing=";
     if (logicalDFB.tensorBacking) {

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -234,11 +234,11 @@ static void printTransactions(llvm::raw_ostream &output,
   output << ']';
 }
 
-static bool hasEqualPossibleFacts(
-    const DFBPerNodeLifetime &lhs,
-    const DFBPerNodeLifetimeDiagnostics &lhsDiagnostics,
-    const DFBPerNodeLifetime &rhs,
-    const DFBPerNodeLifetimeDiagnostics &rhsDiagnostics) {
+static bool
+hasEqualPossibleFacts(const DFBPerNodeLifetime &lhs,
+                      const DFBPerNodeLifetimeDiagnostics &lhsDiagnostics,
+                      const DFBPerNodeLifetime &rhs,
+                      const DFBPerNodeLifetimeDiagnostics &rhsDiagnostics) {
   if (lhs.quiescence.failure != rhs.quiescence.failure ||
       lhs.quiescence.evidence != rhs.quiescence.evidence ||
       lhs.mayBeActive != rhs.mayBeActive ||
@@ -283,16 +283,15 @@ struct PossibleLifetimeGroup {
 };
 
 static void printPossibleLifetimes(
-    llvm::raw_ostream &output,
-    const DFBLogicalLifecycle &logicalDFB,
+    llvm::raw_ostream &output, const DFBLogicalLifecycle &logicalDFB,
     const DFBLogicalLifecycleDiagnostics &allocationDiagnostics) {
   assert(logicalDFB.possibleNodeLifetimes.size() ==
              allocationDiagnostics.possibleNodeLifetimeDiagnostics.size() &&
          "possible lifetimes must have allocation-report data");
   SmallVector<PossibleLifetimeGroup> groups;
-  for (auto lifetimeAndDiagnostics : llvm::zip_equal(
-           logicalDFB.possibleNodeLifetimes,
-           allocationDiagnostics.possibleNodeLifetimeDiagnostics)) {
+  for (auto lifetimeAndDiagnostics :
+       llvm::zip_equal(logicalDFB.possibleNodeLifetimes,
+                       allocationDiagnostics.possibleNodeLifetimeDiagnostics)) {
     const DFBPerNodeLifetime &lifetime = std::get<0>(lifetimeAndDiagnostics);
     const DFBPerNodeLifetimeDiagnostics &diagnostics =
         std::get<1>(lifetimeAndDiagnostics);

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1561,7 +1561,6 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           logicalDFB.launchDomain.unionWith(access.launchDomain);
     }
   }
-
   // Unknown external access may name any user-managed physical allocation,
   // including one also declared by the operation. Compiler-created DFBs cannot
   // be referenced by external code without an explicit dependency.
@@ -1578,6 +1577,10 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           logicalDFB.launchDomain.unionWith(accessDomain.domain);
     }
   }
+  bool hasUnknownDFBLaunchDomain =
+      llvm::any_of(logicalDFBs, [](const DFBLogicalLifecycle &logicalDFB) {
+        return !logicalDFB.launchDomain.known;
+      });
 
   launchNodes.append(domainState.baseDomain.nodes.begin(),
                      domainState.baseDomain.nodes.end());
@@ -1642,6 +1645,13 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
       }
     }
     orderedBeforeByNode.push_back(std::move(nodeOrdering));
+
+    // Possible-domain reachability cannot affect exact-domain reuse.
+    if (!hasUnknownDFBLaunchDomain) {
+      conditionallyOrderedBeforeByNode.emplace_back(
+          logicalDFBs.size(), llvm::BitVector(logicalDFBs.size()));
+      continue;
+    }
 
     HappensBeforeGraph possibleGraph;
     DenseMap<Operation *, EventPair> possibleOperationEvents;

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1668,9 +1668,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           allocationDiagnostics
               ? &allocationDiagnostics->possibleNodeLifetimeDiagnostics
               : nullptr,
-          possibleGraph,
-          possibleOperationEvents, possibleAccessEvents, executionCounts,
-          possibleAccessRuns, domainState,
+          possibleGraph, possibleOperationEvents, possibleAccessEvents,
+          executionCounts, possibleAccessRuns, domainState,
           /*includeUnknownDomains=*/true);
       logicalDFB.possibleNodeLifetimes.back().quiescence = proof;
     }

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -136,6 +136,7 @@ struct AccessRun {
   const DFBAccessOccurrence *access = nullptr;
   std::uint64_t executionCount = 0;
   StaticIterationDomain iterationDomain;
+  bool conditionalExecution = false;
 };
 
 using AccessRuns = DenseMap<const DFBAccessOccurrence *, AccessRun>;
@@ -225,8 +226,8 @@ static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
   return domain;
 }
 
-// Proves an unresolved non-protocol access cannot repeat. Treating the access
-// as present once is conservative for lifetime ordering under conditionals.
+// Proves an unresolved access cannot repeat. Treating the access as present
+// once preserves the conditional lifetime without assuming it executes.
 static bool structurallyExecutesAtMostOnce(Operation *operation) {
   func::FuncOp function = operation->getParentOfType<func::FuncOp>();
   if (!function || function.getBody().empty() ||
@@ -240,7 +241,8 @@ static bool structurallyExecutesAtMostOnce(Operation *operation) {
     Operation *parent = region ? region->getParentOp() : nullptr;
     if (!parent || !region->hasOneBlock() ||
         nestedOperation->getBlock() != &region->front() ||
-        !isa<scf::IfOp, scf::IndexSwitchOp, scf::ExecuteRegionOp>(parent)) {
+        !isa<affine::AffineIfOp, scf::IfOp, scf::IndexSwitchOp,
+             scf::ExecuteRegionOp>(parent)) {
       return false;
     }
     nestedOperation = parent;
@@ -248,8 +250,8 @@ static bool structurallyExecutesAtMostOnce(Operation *operation) {
   return nestedOperation->getBlock() == &function.getBody().front();
 }
 
-// Unknown membership is included only for counterfactual diagnostics. Reuse
-// proofs continue to require exact launch-node membership.
+// Possible-domain analysis includes unknown membership while exact-domain
+// analysis continues to require proven launch-node membership.
 static bool mayContainLaunchNode(const LaunchNodeDomain &domain,
                                  LaunchNodeCoord node,
                                  bool includeUnknownDomains) {
@@ -386,6 +388,11 @@ static bool runPrecedesWithinEachIteration(const AccessRun &before,
   if (before.access->operation == after.access->operation) {
     return before.access->protocolEffect && after.access->protocolEffect &&
            before.access->sequenceIndex < after.access->sequenceIndex;
+  }
+  if (before.conditionalExecution && after.conditionalExecution) {
+    return before.access->operation->getBlock() ==
+               after.access->operation->getBlock() &&
+           before.access->operation->isBeforeInBlock(after.access->operation);
   }
   if (before.executionCount <= 1) {
     return false;
@@ -762,10 +769,9 @@ collectAccessRuns(ArrayRef<DFBLogicalLifecycle> logicalDFBs,
         continue;
       }
       if (!countIt->second) {
-        if (!access.protocolEffect &&
-            structurallyExecutesAtMostOnce(access.operation)) {
-          runs.try_emplace(&access,
-                           AccessRun{&access, 1, StaticIterationDomain{}});
+        if (structurallyExecutesAtMostOnce(access.operation)) {
+          runs.try_emplace(
+              &access, AccessRun{&access, 1, StaticIterationDomain{}, true});
         }
         continue;
       }
@@ -775,8 +781,8 @@ collectAccessRuns(ArrayRef<DFBLogicalLifecycle> logicalDFBs,
       if (!domain) {
         continue;
       }
-      runs.try_emplace(
-          &access, AccessRun{&access, *countIt->second, std::move(*domain)});
+      runs.try_emplace(&access, AccessRun{&access, *countIt->second,
+                                          std::move(*domain), false});
     }
   }
   return runs;
@@ -890,13 +896,28 @@ static void buildProgramOrderGraph(
   }
 }
 
-// Adds the completion edge implied by each matching push/wait transaction.
-// Unknown-domain edges are restricted to the counterfactual debug graph.
+// Conditional transaction effects match only when their structured execution
+// conditions are equivalent.
+static bool
+proveEquivalentConditionalRuns(const AccessRun &lhs, const AccessRun &rhs,
+                               LaunchNodeCoord node,
+                               const LaunchNodeDomainState &domainState) {
+  if (!lhs.conditionalExecution && !rhs.conditionalExecution) {
+    return true;
+  }
+  return lhs.conditionalExecution && rhs.conditionalExecution &&
+         proveEquivalentConditionalExecutionAtLaunchNodes(
+             lhs.access->operation, node, rhs.access->operation, node,
+             domainState);
+}
+
+// Adds completion edges between matched push/wait transaction instances.
 static void addMatchedPushWaitEdges(
     ArrayRef<DFBLogicalLifecycle> logicalDFBs, HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
-    const AccessRuns &accessRuns) {
+    const AccessRuns &accessRuns, LaunchNodeCoord node,
+    const LaunchNodeDomainState &domainState) {
   for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
     SmallVector<const AccessRun *> pushes;
     SmallVector<const AccessRun *> waits;
@@ -921,7 +942,8 @@ static void addMatchedPushWaitEdges(
     while (pushIndex < pushes.size() && waitIndex < waits.size()) {
       const AccessRun &push = *pushes[pushIndex];
       const AccessRun &wait = *waits[waitIndex];
-      if (push.access->numTiles != wait.access->numTiles) {
+      if (push.access->numTiles != wait.access->numTiles ||
+          !proveEquivalentConditionalRuns(push, wait, node, domainState)) {
         matched = false;
         break;
       }
@@ -1082,8 +1104,8 @@ static void appendTransactionRun(DFBPerNodeLifetime &lifetime,
   lifetime.transactionRuns.push_back({executionCount, tilesPerExecution});
 }
 
-// Derives per-node lifetime facts. Exact-domain facts control reuse;
-// counterfactual facts are retained only for debug reporting.
+// Derives exact-domain or possible-domain per-node lifetime facts. Possible
+// facts control reuse only after proving conditional boundedness.
 static DFBQuiescenceProof computePerNodeLifetime(
     DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
     SmallVectorImpl<DFBPerNodeLifetime> &lifetimes,
@@ -1092,6 +1114,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
+    const LaunchNodeDomainState &domainState,
     bool includeUnknownDomains = false) {
   DFBPerNodeLifetime &lifetime = lifetimes.emplace_back();
   lifetime.node = node;
@@ -1167,9 +1190,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
   }
 
   if (includeUnknownDomains && activeAccesses.empty()) {
-    assert(diagnostics &&
-           "counterfactual lifetimes require allocation-report data");
-    diagnostics->mayBeActive = false;
+    lifetime.mayBeActive = false;
     return {};
   }
 
@@ -1185,6 +1206,32 @@ static DFBQuiescenceProof computePerNodeLifetime(
   }
   assert(!reserves.empty() && !pushes.empty() && !waits.empty() &&
          !pops.empty() && "supported protocol effects must have access runs");
+
+  SmallVector<const AccessRun *> conditionalRuns;
+  for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
+    const AccessRun &run = accessRuns.at(activeAccess);
+    if (run.conditionalExecution) {
+      conditionalRuns.push_back(&run);
+    }
+  }
+  if (!conditionalRuns.empty()) {
+    bool singleConditionalTransaction =
+        conditionalRuns.size() == activeAccesses.size() &&
+        reserves.size() == 1 && pushes.size() == 1 && waits.size() == 1 &&
+        pops.size() == 1;
+    const AccessRun &reference = *conditionalRuns.front();
+    bool sameCondition = singleConditionalTransaction &&
+                         llvm::all_of(llvm::drop_begin(conditionalRuns),
+                                      [&](const AccessRun *run) {
+                                        return proveEquivalentConditionalRuns(
+                                            reference, *run, node, domainState);
+                                      });
+    if (!sameCondition) {
+      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+              reference.access->operation};
+    }
+    lifetime.conditionalExecutionProven = true;
+  }
   auto getTransactionCount = [](ArrayRef<const AccessRun *> runs) {
     std::optional<std::uint64_t> total = 0;
     for (const AccessRun *run : runs) {
@@ -1400,6 +1447,15 @@ DFBLogicalLifecycle::findNodeLifetime(LaunchNodeCoord node) const {
   return lifetimeIt == nodeLifetimes.end() ? nullptr : &*lifetimeIt;
 }
 
+const DFBPerNodeLifetime *
+DFBLogicalLifecycle::findPossibleNodeLifetime(LaunchNodeCoord node) const {
+  auto lifetimeIt =
+      llvm::find_if(possibleNodeLifetimes, [&](const auto &lifetime) {
+        return lifetime.node == node;
+      });
+  return lifetimeIt == possibleNodeLifetimes.end() ? nullptr : &*lifetimeIt;
+}
+
 // Logical identity is obtained through the analysis manager so every lifetime
 // uses the same declaration aggregation as physical allocation.
 DFBConcurrentKernelLivenessAnalysis::DFBConcurrentKernelLivenessAnalysis(
@@ -1526,6 +1582,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   launchNodes.append(domainState.baseDomain.nodes.begin(),
                      domainState.baseDomain.nodes.end());
   orderedBeforeByNode.reserve(launchNodes.size());
+  conditionallyOrderedBeforeByNode.reserve(launchNodes.size());
   bool collectAllocationDiagnostics = false;
   LLVM_DEBUG(collectAllocationDiagnostics = true);
   if (collectAllocationDiagnostics) {
@@ -1547,7 +1604,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
                            accessEvents, executionCounts, accessRuns,
                            /*includeUnknownDomains=*/false);
     addMatchedPushWaitEdges(logicalDFBs, graph, operationEvents, accessEvents,
-                            accessRuns);
+                            accessRuns, node, domainState);
     graph.computeReachability();
 
     for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
@@ -1561,7 +1618,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           allocationDiagnostics
               ? &allocationDiagnostics->nodeLifetimeDiagnostics
               : nullptr,
-          graph, operationEvents, accessEvents, executionCounts, accessRuns);
+          graph, operationEvents, accessEvents, executionCounts, accessRuns,
+          domainState);
       logicalDFB.nodeLifetimes.back().quiescence = proof;
     }
 
@@ -1585,39 +1643,58 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     }
     orderedBeforeByNode.push_back(std::move(nodeOrdering));
 
-    if (!collectAllocationDiagnostics) {
-      continue;
-    }
-    HappensBeforeGraph diagnosticGraph;
-    DenseMap<Operation *, EventPair> diagnosticOperationEvents;
-    DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
-        diagnosticAccessEvents;
-    AccessRuns diagnosticAccessRuns =
+    HappensBeforeGraph possibleGraph;
+    DenseMap<Operation *, EventPair> possibleOperationEvents;
+    DenseMap<const DFBAccessOccurrence *, AccessEventSpan> possibleAccessEvents;
+    AccessRuns possibleAccessRuns =
         collectAccessRuns(logicalDFBs, node, domainState, executionCounts,
                           /*includeUnknownDomains=*/true);
-    buildProgramOrderGraph(module, logicalDFBs, node, diagnosticGraph,
-                           diagnosticOperationEvents, diagnosticAccessEvents,
-                           executionCounts, diagnosticAccessRuns,
+    buildProgramOrderGraph(module, logicalDFBs, node, possibleGraph,
+                           possibleOperationEvents, possibleAccessEvents,
+                           executionCounts, possibleAccessRuns,
                            /*includeUnknownDomains=*/true);
-    addMatchedPushWaitEdges(logicalDFBs, diagnosticGraph,
-                            diagnosticOperationEvents, diagnosticAccessEvents,
-                            diagnosticAccessRuns);
-    diagnosticGraph.computeReachability();
+    addMatchedPushWaitEdges(logicalDFBs, possibleGraph, possibleOperationEvents,
+                            possibleAccessEvents, possibleAccessRuns, node,
+                            domainState);
+    possibleGraph.computeReachability();
     for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
       if (logicalDFB.launchDomain.known) {
         continue;
       }
-      DFBLogicalLifecycleDiagnostics &allocationDiagnostics =
-          *logicalDFB.allocationDiagnostics;
+      DFBLogicalLifecycleDiagnostics *allocationDiagnostics =
+          logicalDFB.allocationDiagnostics.get();
       DFBQuiescenceProof proof = computePerNodeLifetime(
-          logicalDFB, node, allocationDiagnostics.counterfactualNodeLifetimes,
-          &allocationDiagnostics.counterfactualNodeLifetimeDiagnostics,
-          diagnosticGraph, diagnosticOperationEvents, diagnosticAccessEvents,
-          executionCounts, diagnosticAccessRuns,
+          logicalDFB, node, logicalDFB.possibleNodeLifetimes,
+          allocationDiagnostics
+              ? &allocationDiagnostics->possibleNodeLifetimeDiagnostics
+              : nullptr,
+          possibleGraph,
+          possibleOperationEvents, possibleAccessEvents, executionCounts,
+          possibleAccessRuns, domainState,
           /*includeUnknownDomains=*/true);
-      allocationDiagnostics.counterfactualNodeLifetimes.back().quiescence =
-          proof;
+      logicalDFB.possibleNodeLifetimes.back().quiescence = proof;
     }
+
+    SmallVector<llvm::BitVector> conditionalNodeOrdering(
+        logicalDFBs.size(), llvm::BitVector(logicalDFBs.size()));
+    for (unsigned beforeIndex = 0; beforeIndex < logicalDFBs.size();
+         ++beforeIndex) {
+      const DFBPerNodeLifetime *before =
+          logicalDFBs[beforeIndex].findPossibleNodeLifetime(node);
+      if (!before) {
+        continue;
+      }
+      for (unsigned afterIndex = 0; afterIndex < logicalDFBs.size();
+           ++afterIndex) {
+        const DFBPerNodeLifetime *after =
+            logicalDFBs[afterIndex].findPossibleNodeLifetime(node);
+        if (after && proveOrderedBefore(*before, *after, possibleGraph)) {
+          conditionalNodeOrdering[beforeIndex].set(afterIndex);
+        }
+      }
+    }
+    conditionallyOrderedBeforeByNode.push_back(
+        std::move(conditionalNodeOrdering));
   }
 
   for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
@@ -1627,6 +1704,21 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
                                       [](const DFBPerNodeLifetime &lifetime) {
                                         return lifetime.quiescence.proven();
                                       });
+    bool hasProvenConditionalLifecycle =
+        llvm::any_of(logicalDFB.possibleNodeLifetimes,
+                     [](const DFBPerNodeLifetime &lifetime) {
+                       return lifetime.mayBeActive &&
+                              lifetime.conditionalExecutionProven &&
+                              lifetime.quiescence.proven();
+                     });
+    logicalDFB.conditionallyBounded =
+        !logicalDFB.launchDomain.known && hasProvenConditionalLifecycle &&
+        llvm::all_of(logicalDFB.possibleNodeLifetimes,
+                     [](const DFBPerNodeLifetime &lifetime) {
+                       return !lifetime.mayBeActive ||
+                              (lifetime.conditionalExecutionProven &&
+                               lifetime.quiescence.proven());
+                     });
   }
 }
 
@@ -1640,6 +1732,17 @@ bool DFBConcurrentKernelLivenessAnalysis::isOrderedBefore(
   assert(beforeIndex < orderedBeforeByNode[nodeIndex].size() &&
          afterIndex < orderedBeforeByNode[nodeIndex].size());
   return orderedBeforeByNode[nodeIndex][beforeIndex].test(afterIndex);
+}
+
+bool DFBConcurrentKernelLivenessAnalysis::isConditionallyOrderedBefore(
+    unsigned beforeIndex, unsigned afterIndex, LaunchNodeCoord node) const {
+  auto nodeIt = llvm::find(launchNodes, node);
+  assert(nodeIt != launchNodes.end() && "node must be in the launch grid");
+  unsigned nodeIndex = nodeIt - launchNodes.begin();
+  assert(beforeIndex < conditionallyOrderedBeforeByNode[nodeIndex].size() &&
+         afterIndex < conditionallyOrderedBeforeByNode[nodeIndex].size());
+  return conditionallyOrderedBeforeByNode[nodeIndex][beforeIndex].test(
+      afterIndex);
 }
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -108,9 +108,6 @@ struct DFBDiagnosticAccessOccurrence {
 
 /// Per-node data collected only for the allocation report.
 struct DFBPerNodeLifetimeDiagnostics {
-  /// False when counterfactual analysis proves that no access executes.
-  bool mayBeActive = true;
-
   /// Execution-count row for every access considered on the launch node.
   SmallVector<DFBDiagnosticAccessOccurrence> occurrences;
 
@@ -121,7 +118,7 @@ struct DFBPerNodeLifetimeDiagnostics {
   SmallVector<unsigned> terminalAccessOccurrenceIndices;
 
   bool operator==(const DFBPerNodeLifetimeDiagnostics &rhs) const {
-    return mayBeActive == rhs.mayBeActive && occurrences == rhs.occurrences &&
+    return occurrences == rhs.occurrences &&
            earliestAccessOccurrenceIndices ==
                rhs.earliestAccessOccurrenceIndices &&
            terminalAccessOccurrenceIndices ==
@@ -144,12 +141,17 @@ struct DFBTransactionRun {
 struct DFBPerNodeLifetime {
   LaunchNodeCoord node;
 
+  /// Whether an access may execute on `node`.
+  bool mayBeActive = true;
+
+  /// Whether all active accesses share one proved conditional execution.
+  bool conditionalExecutionProven = false;
+
   /// Minimal access-entry event IDs under the proved happens-before relation.
   SmallVector<unsigned> earliestEntryEvents;
 
   /// Completion event IDs after which the DFB is quiescent.
   SmallVector<unsigned> terminalCompletionEvents;
-
   /// Normalized transaction runs in occurrence order.
   SmallVector<DFBTransactionRun> transactionRuns;
   std::optional<DFBPointerOwner> writePointerOwner;
@@ -159,10 +161,9 @@ struct DFBPerNodeLifetime {
 
 /// Allocation-report data omitted from normal liveness analysis.
 struct DFBLogicalLifecycleDiagnostics {
-  SmallVector<DFBPerNodeLifetime, 0> counterfactualNodeLifetimes;
   SmallVector<DFBPerNodeLifetimeDiagnostics, 0> nodeLifetimeDiagnostics;
   SmallVector<DFBPerNodeLifetimeDiagnostics, 0>
-      counterfactualNodeLifetimeDiagnostics;
+      possibleNodeLifetimeDiagnostics;
 };
 
 /// Immutable protocol and per-node lifetime facts for one logical DFB.
@@ -175,11 +176,17 @@ struct DFBLogicalLifecycle {
   SmallVector<DFBAccessOccurrence> accesses;
   LaunchNodeDomain launchDomain;
   SmallVector<DFBPerNodeLifetime, 0> nodeLifetimes;
+  SmallVector<DFBPerNodeLifetime, 0> possibleNodeLifetimes;
   std::unique_ptr<DFBLogicalLifecycleDiagnostics> allocationDiagnostics;
   bool bounded = false;
+  bool conditionallyBounded = false;
 
   /// Returns the lifetime for `node`, or null when the DFB is inactive there.
   const DFBPerNodeLifetime *findNodeLifetime(LaunchNodeCoord node) const;
+
+  /// Returns the possible-domain lifetime for `node`, or null when absent.
+  const DFBPerNodeLifetime *
+  findPossibleNodeLifetime(LaunchNodeCoord node) const;
 };
 
 /// Builds per-node cross-kernel happens-before and DFB quiescence facts.
@@ -207,6 +214,10 @@ public:
   bool isOrderedBefore(unsigned beforeIndex, unsigned afterIndex,
                        LaunchNodeCoord node) const;
 
+  /// Returns ordering proved while treating unknown domains as possible.
+  bool isConditionallyOrderedBefore(unsigned beforeIndex, unsigned afterIndex,
+                                    LaunchNodeCoord node) const;
+
 private:
   void analyze(Operation *operation,
                const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis);
@@ -214,6 +225,7 @@ private:
   SmallVector<DFBLogicalLifecycle, 0> logicalDFBs;
   SmallVector<LaunchNodeCoord> launchNodes;
   SmallVector<SmallVector<llvm::BitVector>> orderedBeforeByNode;
+  SmallVector<SmallVector<llvm::BitVector>> conditionallyOrderedBeforeByNode;
   Operation *errorOperation = nullptr;
   std::string errorMessage;
 };

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -162,8 +162,7 @@ struct DFBPerNodeLifetime {
 /// Allocation-report data omitted from normal liveness analysis.
 struct DFBLogicalLifecycleDiagnostics {
   SmallVector<DFBPerNodeLifetimeDiagnostics, 0> nodeLifetimeDiagnostics;
-  SmallVector<DFBPerNodeLifetimeDiagnostics, 0>
-      possibleNodeLifetimeDiagnostics;
+  SmallVector<DFBPerNodeLifetimeDiagnostics, 0> possibleNodeLifetimeDiagnostics;
 };
 
 /// Immutable protocol and per-node lifetime facts for one logical DFB.

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -125,24 +125,42 @@ private:
       }
       return;
     }
-    if (!lhs.launchDomain.known || !rhs.launchDomain.known) {
+    bool useConditionalProof =
+        !lhs.launchDomain.known && !rhs.launchDomain.known &&
+        lhs.conditionallyBounded && rhs.conditionallyBounded;
+    if ((!lhs.launchDomain.known || !rhs.launchDomain.known) &&
+        !useConditionalProof) {
       addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
                   DFBConflictReason::UnknownLaunchNodeDomain, std::nullopt,
                   lhs.declarations.front(), rhs.declarations.front());
       return;
     }
 
-    LaunchNodeDomain sharedNodes =
-        lhs.launchDomain.intersectWith(rhs.launchDomain);
-    for (LaunchNodeCoord node : sharedNodes.nodes) {
+    SmallVector<LaunchNodeCoord> sharedNodes;
+    if (useConditionalProof) {
+      llvm::append_range(sharedNodes, liveness.getLaunchNodes());
+    } else {
+      LaunchNodeDomain exactSharedNodes =
+          lhs.launchDomain.intersectWith(rhs.launchDomain);
+      llvm::append_range(sharedNodes, exactSharedNodes.nodes);
+    }
+    for (LaunchNodeCoord node : sharedNodes) {
+      const DFBPerNodeLifetime *lhsLifetime =
+          useConditionalProof ? lhs.findPossibleNodeLifetime(node)
+                              : lhs.findNodeLifetime(node);
+      const DFBPerNodeLifetime *rhsLifetime =
+          useConditionalProof ? rhs.findPossibleNodeLifetime(node)
+                              : rhs.findNodeLifetime(node);
+      if (lhsLifetime && rhsLifetime &&
+          (!lhsLifetime->mayBeActive || !rhsLifetime->mayBeActive)) {
+        continue;
+      }
       if (lhs.tensorBacking != rhs.tensorBacking) {
         addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
                     DFBConflictReason::StorageMismatch, node,
                     lhs.declarations.front(), rhs.declarations.front());
         continue;
       }
-      const DFBPerNodeLifetime *lhsLifetime = lhs.findNodeLifetime(node);
-      const DFBPerNodeLifetime *rhsLifetime = rhs.findNodeLifetime(node);
       if (!lhsLifetime || !rhsLifetime || !lhsLifetime->quiescence.proven() ||
           !rhsLifetime->quiescence.proven()) {
         addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
@@ -166,8 +184,15 @@ private:
                     getLifetimeEvidence(rhsLifetime, rhs));
         continue;
       }
-      if (!liveness.isOrderedBefore(lhsIndex, rhsIndex, node) &&
-          !liveness.isOrderedBefore(rhsIndex, lhsIndex, node)) {
+      bool ordered =
+          useConditionalProof
+              ? liveness.isConditionallyOrderedBefore(lhsIndex, rhsIndex,
+                                                      node) ||
+                    liveness.isConditionallyOrderedBefore(rhsIndex, lhsIndex,
+                                                          node)
+              : liveness.isOrderedBefore(lhsIndex, rhsIndex, node) ||
+                    liveness.isOrderedBefore(rhsIndex, lhsIndex, node);
+      if (!ordered) {
         addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
                     DFBConflictReason::ConcurrentLifetime, node,
                     getLifetimeEvidence(lhsLifetime, lhs),
@@ -440,7 +465,8 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
     allocation.assignments.push_back(
         {logicalDFB.logicalId, physicalIndex, logicalDFB.type,
          logicalDFB.tensorBacking, logicalDFB.launchDomain,
-         logicalDFB.declarations, logicalDFB.bounded});
+         logicalDFB.declarations,
+         logicalDFB.bounded || logicalDFB.conditionallyBounded});
     allocation.physicalDFBCount =
         std::max(allocation.physicalDFBCount, physicalIndex + 1);
   }
@@ -533,7 +559,8 @@ static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
     allocation.assignments.push_back(
         {logicalDFB.logicalId, physicalIndex, logicalDFB.type,
          logicalDFB.tensorBacking, logicalDFB.launchDomain,
-         logicalDFB.declarations, logicalDFB.bounded});
+         logicalDFB.declarations,
+         logicalDFB.bounded || logicalDFB.conditionallyBounded});
   }
 
   if (allocation.physicalDFBCount <= targetMaxDFBIndices) {

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -567,16 +567,20 @@ getAffineIfLaunchNodeDomain(affine::AffineIfOp ifOp,
 
 namespace {
 
-/// Structured-control frames and values that determine an unresolved count.
+enum class UnresolvedControlFrameKind { ScfIf, AffineIf, ScfFor };
+
+struct UnresolvedControlFrame {
+  UnresolvedControlFrameKind kind = UnresolvedControlFrameKind::ScfIf;
+  Operation *operation = nullptr;
+  std::size_t regionNumber = 0;
+  IntegerSetAttr affinePredicate;
+  SmallVector<Value, 3> controlValues;
+};
+
+/// Structured-control frames that determine an unresolved count.
 struct UnresolvedExecutionCountContext {
   func::FuncOp function;
-  SmallVector<std::pair<Operation *, std::size_t>> frames;
-  SmallVector<Value> controlValues;
-
-  bool operator==(const UnresolvedExecutionCountContext &rhs) const {
-    return function == rhs.function && frames == rhs.frames &&
-           controlValues == rhs.controlValues;
-  }
+  SmallVector<UnresolvedControlFrame> frames;
 };
 
 static std::optional<UnresolvedExecutionCountContext>
@@ -631,8 +635,11 @@ getUnresolvedExecutionCountContext(Operation *op, LaunchNodeCoord coord,
         current = parent;
         continue;
       }
-      context.frames.push_back({parent, region->getRegionNumber()});
-      context.controlValues.push_back(ifOp.getCondition());
+      context.frames.push_back({UnresolvedControlFrameKind::ScfIf,
+                                parent,
+                                region->getRegionNumber(),
+                                nullptr,
+                                {ifOp.getCondition()}});
     } else if (auto affineIfOp = dyn_cast<affine::AffineIfOp>(parent);
                affineIfOp && state.hasLaunchGrid) {
       LaunchNodeDomainResult trueDomain =
@@ -646,13 +653,19 @@ getUnresolvedExecutionCountContext(Operation *op, LaunchNodeCoord coord,
         current = parent;
         continue;
       }
-      context.frames.push_back({parent, region->getRegionNumber()});
-      llvm::append_range(context.controlValues, affineIfOp.getOperands());
+      UnresolvedControlFrame &frame = context.frames.emplace_back();
+      frame.kind = UnresolvedControlFrameKind::AffineIf;
+      frame.operation = parent;
+      frame.regionNumber = region->getRegionNumber();
+      frame.affinePredicate = affineIfOp.getConditionAttr();
+      llvm::append_range(frame.controlValues, affineIfOp.getOperands());
     } else if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
-      context.frames.push_back({parent, region->getRegionNumber()});
-      context.controlValues.push_back(forOp.getLowerBound());
-      context.controlValues.push_back(forOp.getUpperBound());
-      context.controlValues.push_back(forOp.getStep());
+      context.frames.push_back(
+          {UnresolvedControlFrameKind::ScfFor,
+           parent,
+           region->getRegionNumber(),
+           nullptr,
+           {forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep()}});
     } else if (isa<scf::ExecuteRegionOp>(parent)) {
       current = parent;
       continue;
@@ -683,6 +696,11 @@ static bool proveEqualValuesAtLaunchNodes(
     return it->second;
   }
   cache[cacheKey] = false;
+
+  if (lhsValue == rhsValue && lhsCoord == rhsCoord) {
+    cache[cacheKey] = true;
+    return true;
+  }
 
   std::optional<llvm::APInt> maybeLhsValue =
       createLaunchNodeIntegerEvaluator(lhsCoord, &state).evaluate(lhsValue);
@@ -784,6 +802,44 @@ static bool proveEqualValuesAtLaunchNodes(
   return equal;
 }
 
+static bool proveEquivalentUnresolvedExecutionContexts(
+    const UnresolvedExecutionCountContext &lhsContext, LaunchNodeCoord lhsCoord,
+    llvm::function_ref<std::optional<Value>(BlockArgument)>
+        resolveLhsFunctionArgument,
+    const UnresolvedExecutionCountContext &rhsContext, LaunchNodeCoord rhsCoord,
+    llvm::function_ref<std::optional<Value>(BlockArgument)>
+        resolveRhsFunctionArgument,
+    const LaunchNodeDomainState &state, bool requireConditionalExecution) {
+  if (lhsContext.function != rhsContext.function ||
+      lhsContext.frames.size() != rhsContext.frames.size()) {
+    return false;
+  }
+
+  llvm::DenseMap<std::pair<Value, Value>, bool> equalValueCache;
+  for (auto &&[lhsFrame, rhsFrame] :
+       llvm::zip_equal(lhsContext.frames, rhsContext.frames)) {
+    if (lhsFrame.kind != rhsFrame.kind ||
+        (!requireConditionalExecution &&
+         lhsFrame.operation != rhsFrame.operation) ||
+        lhsFrame.regionNumber != rhsFrame.regionNumber ||
+        lhsFrame.affinePredicate != rhsFrame.affinePredicate ||
+        lhsFrame.controlValues.size() != rhsFrame.controlValues.size() ||
+        (requireConditionalExecution &&
+         lhsFrame.kind == UnresolvedControlFrameKind::ScfFor)) {
+      return false;
+    }
+    for (auto &&[lhsValue, rhsValue] :
+         llvm::zip_equal(lhsFrame.controlValues, rhsFrame.controlValues)) {
+      if (!proveEqualValuesAtLaunchNodes(
+              lhsValue, lhsCoord, resolveLhsFunctionArgument, rhsValue,
+              rhsCoord, resolveRhsFunctionArgument, state, equalValueCache)) {
+        return false;
+      }
+    }
+  }
+  return !requireConditionalExecution || !lhsContext.frames.empty();
+}
+
 } // namespace
 
 bool proveEqualUnresolvedExecutionCountAtLaunchNodes(
@@ -797,16 +853,32 @@ bool proveEqualUnresolvedExecutionCountAtLaunchNodes(
       getUnresolvedExecutionCountContext(lhs, lhsCoord, state);
   std::optional<UnresolvedExecutionCountContext> maybeRhsContext =
       getUnresolvedExecutionCountContext(rhs, rhsCoord, state);
-  if (!maybeLhsContext || !maybeRhsContext ||
-      !(*maybeLhsContext == *maybeRhsContext)) {
+  if (!maybeLhsContext || !maybeRhsContext) {
     return false;
   }
-  llvm::DenseMap<std::pair<Value, Value>, bool> equalValueCache;
-  return llvm::all_of(maybeLhsContext->controlValues, [&](Value value) {
-    return proveEqualValuesAtLaunchNodes(
-        value, lhsCoord, resolveLhsFunctionArgument, value, rhsCoord,
-        resolveRhsFunctionArgument, state, equalValueCache);
-  });
+  return proveEquivalentUnresolvedExecutionContexts(
+      *maybeLhsContext, lhsCoord, resolveLhsFunctionArgument, *maybeRhsContext,
+      rhsCoord, resolveRhsFunctionArgument, state,
+      /*requireConditionalExecution=*/false);
+}
+
+bool proveEquivalentConditionalExecutionAtLaunchNodes(
+    Operation *lhs, LaunchNodeCoord lhsCoord, Operation *rhs,
+    LaunchNodeCoord rhsCoord, const LaunchNodeDomainState &state) {
+  std::optional<UnresolvedExecutionCountContext> maybeLhsContext =
+      getUnresolvedExecutionCountContext(lhs, lhsCoord, state);
+  std::optional<UnresolvedExecutionCountContext> maybeRhsContext =
+      getUnresolvedExecutionCountContext(rhs, rhsCoord, state);
+  if (!maybeLhsContext || !maybeRhsContext) {
+    return false;
+  }
+  auto resolveNoFunctionArguments = [](BlockArgument) -> std::optional<Value> {
+    return std::nullopt;
+  };
+  return proveEquivalentUnresolvedExecutionContexts(
+      *maybeLhsContext, lhsCoord, resolveNoFunctionArguments, *maybeRhsContext,
+      rhsCoord, resolveNoFunctionArguments, state,
+      /*requireConditionalExecution=*/true);
 }
 
 bool proveEqualExecutionCountAtLaunchNodes(Operation *lhs,

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -697,11 +697,6 @@ static bool proveEqualValuesAtLaunchNodes(
   }
   cache[cacheKey] = false;
 
-  if (lhsValue == rhsValue && lhsCoord == rhsCoord) {
-    cache[cacheKey] = true;
-    return true;
-  }
-
   std::optional<llvm::APInt> maybeLhsValue =
       createLaunchNodeIntegerEvaluator(lhsCoord, &state).evaluate(lhsValue);
   std::optional<llvm::APInt> maybeRhsValue =
@@ -777,6 +772,11 @@ static bool proveEqualValuesAtLaunchNodes(
                                       resolveRhsFunctionArgument, state, cache);
     cache[cacheKey] = equal;
     return equal;
+  }
+
+  if (lhsValue == rhsValue && lhsCoord == rhsCoord) {
+    cache[cacheKey] = true;
+    return true;
   }
 
   Operation *lhsDefiningOp = lhsValue.getDefiningOp();

--- a/test/lib/Analysis/LaunchNodeDomain/LaunchNodeDomainTest.cpp
+++ b/test/lib/Analysis/LaunchNodeDomain/LaunchNodeDomainTest.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// This test driver prints the launch-node lattice immediately before every
-// operation with a test.label attribute.
+// This test driver prints launch-node lattices and conditional-execution
+// equivalence results requested by test attributes.
 
 #include "ttlang/Dialect/TTCore/IR/TTCore.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernel.h"

--- a/test/lib/Analysis/LaunchNodeDomain/LaunchNodeDomainTest.cpp
+++ b/test/lib/Analysis/LaunchNodeDomain/LaunchNodeDomainTest.cpp
@@ -16,11 +16,14 @@
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/Parser/Parser.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace {
 
 constexpr llvm::StringLiteral kLabelAttrName = "test.label";
+constexpr llvm::StringLiteral kConditionalPairAttrName =
+    "test.conditional_pair";
 
 } // namespace
 
@@ -59,7 +62,13 @@ int main(int argumentCount, char **argumentValues) {
   }
 
   bool succeeded = true;
+  llvm::MapVector<llvm::StringRef, llvm::SmallVector<mlir::Operation *, 2>>
+      conditionalPairs;
   module->walk([&](mlir::Operation *operation) {
+    if (auto pair = operation->getAttrOfType<mlir::StringAttr>(
+            kConditionalPairAttrName)) {
+      conditionalPairs[pair.getValue()].push_back(operation);
+    }
     auto label = operation->getAttrOfType<mlir::StringAttr>(kLabelAttrName);
     if (!label) {
       return;
@@ -76,5 +85,18 @@ int main(int argumentCount, char **argumentValues) {
     lattice->print(llvm::outs());
     llvm::outs() << "\n";
   });
+  for (const auto &[pairName, operations] : conditionalPairs) {
+    if (operations.size() != 2) {
+      module->emitError() << "conditional pair '" << pairName
+                          << "' requires exactly two operations";
+      succeeded = false;
+      continue;
+    }
+    bool equivalent =
+        mlir::tt::ttl::proveEquivalentConditionalExecutionAtLaunchNodes(
+            operations[0], {0, 0}, operations[1], {0, 0}, state);
+    llvm::outs() << pairName << " = "
+                 << (equivalent ? "equivalent" : "not-equivalent") << "\n";
+  }
   return succeeded ? 0 : 1;
 }

--- a/test/python/include/scalar_result_op.hpp
+++ b/test/python/include/scalar_result_op.hpp
@@ -32,3 +32,8 @@ inline typename ScalarResult<BitWidth>::Type
 scalar_result_from_coordinate(Coordinate) {
   return 1;
 }
+
+template <bool Value>
+inline std::int32_t scalar_predicate() {
+  return Value ? 1 : 0;
+}

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -337,6 +337,49 @@ def _make_repeated_transaction_kernel(data_format):
     return repeated_transaction_kernel
 
 
+def _make_conditional_lifecycle_kernel(data_format):
+    @ttl.operation(grid=(1, 1))
+    def conditional_lifecycle_kernel(input_tensor, output_tensor):
+        input_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        first_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        second_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            runtime_predicate = ttl.call_extern_func(
+                SCALAR_RESULT_HEADER,
+                "scalar_result",
+                template_args=[32],
+                result_type=ttl.ScalarType.I32,
+            )
+            with input_dfb.wait() as input_block:
+                if runtime_predicate:
+                    with first_scratch_dfb.reserve() as first_scratch_block:
+                        first_scratch_block.store(input_block)
+                    with first_scratch_dfb.wait():
+                        pass
+
+                if runtime_predicate:
+                    with second_scratch_dfb.reserve() as second_scratch_block:
+                        second_scratch_block.store(input_block)
+                    with second_scratch_dfb.wait() as second_scratch_block:
+                        with output_dfb.reserve() as output_block:
+                            output_block.store(second_scratch_block)
+
+        @ttl.datamovement()
+        def read():
+            with input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0, 0], input_block).wait()
+
+        @ttl.datamovement()
+        def write():
+            with output_dfb.wait() as output_block:
+                ttl.copy(output_block, output_tensor[0, 0]).wait()
+
+    return conditional_lifecycle_kernel
+
+
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
@@ -345,6 +388,9 @@ _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
 _exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
 _exact_f32_execution_domain_kernel = _make_exact_execution_domain_kernel("float32")
+_conditional_bf16_lifecycle_kernel = _make_conditional_lifecycle_kernel("bf16")
+_conditional_f32_lifecycle_kernel = _make_conditional_lifecycle_kernel("float32")
+
 assert CAPACITY_TEST_LOGICAL_DFBS == 33
 
 
@@ -600,6 +646,43 @@ def test_repeated_transaction_lifecycles_reuse_dfb(
     # lifetimes. Completion and output retain distinct DFB types or owners.
     physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
     assert physical_dfb_count == 3
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_conditional_bf16_lifecycle_kernel, torch.bfloat16),
+        (_conditional_f32_lifecycle_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_same_runtime_condition_reuses_sequential_dfbs(
+    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_path = tmp_path / "conditional_lifecycle.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+
+    # Input and output ownership prevent them from sharing with compute DFBs.
+    # Three allocations prove that the two guarded lifecycles share one index.
+    assert _count_final_dfb_allocations(final_mlir_path) == 3
 
     actual = ttnn.to_torch(output_tensor).float()
     expected = input_host.float()

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -700,7 +700,8 @@ def test_same_runtime_condition_reuses_sequential_dfbs(
 
     # Input and output ownership prevent them from sharing with compute DFBs.
     # Three allocations prove that all three scratch lifecycles share one index.
-    assert _count_final_dfb_allocations(final_mlir_path) == 3
+    physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
+    assert physical_dfb_count == 3
 
     actual = ttnn.to_torch(output_tensor).float()
     expected = input_host.float()

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -337,20 +337,21 @@ def _make_repeated_transaction_kernel(data_format):
     return repeated_transaction_kernel
 
 
-def _make_conditional_lifecycle_kernel(data_format):
+def _make_conditional_lifecycle_kernel(data_format, predicate_value):
     @ttl.operation(grid=(1, 1))
     def conditional_lifecycle_kernel(input_tensor, output_tensor):
         input_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
         first_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
         second_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        final_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
         output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
 
         @ttl.compute()
         def compute():
             runtime_predicate = ttl.call_extern_func(
                 SCALAR_RESULT_HEADER,
-                "scalar_result",
-                template_args=[32],
+                "scalar_predicate",
+                template_args=[predicate_value],
                 result_type=ttl.ScalarType.I32,
             )
             with input_dfb.wait() as input_block:
@@ -363,9 +364,14 @@ def _make_conditional_lifecycle_kernel(data_format):
                 if runtime_predicate:
                     with second_scratch_dfb.reserve() as second_scratch_block:
                         second_scratch_block.store(input_block)
-                    with second_scratch_dfb.wait() as second_scratch_block:
-                        with output_dfb.reserve() as output_block:
-                            output_block.store(second_scratch_block)
+                    with second_scratch_dfb.wait():
+                        pass
+
+                with final_scratch_dfb.reserve() as final_scratch_block:
+                    final_scratch_block.store(input_block)
+                with final_scratch_dfb.wait() as final_scratch_block:
+                    with output_dfb.reserve() as output_block:
+                        output_block.store(final_scratch_block)
 
         @ttl.datamovement()
         def read():
@@ -388,8 +394,18 @@ _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
 _exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
 _exact_f32_execution_domain_kernel = _make_exact_execution_domain_kernel("float32")
-_conditional_bf16_lifecycle_kernel = _make_conditional_lifecycle_kernel("bf16")
-_conditional_f32_lifecycle_kernel = _make_conditional_lifecycle_kernel("float32")
+_conditional_bf16_true_lifecycle_kernel = _make_conditional_lifecycle_kernel(
+    "bf16", True
+)
+_conditional_bf16_false_lifecycle_kernel = _make_conditional_lifecycle_kernel(
+    "bf16", False
+)
+_conditional_f32_true_lifecycle_kernel = _make_conditional_lifecycle_kernel(
+    "float32", True
+)
+_conditional_f32_false_lifecycle_kernel = _make_conditional_lifecycle_kernel(
+    "float32", False
+)
 
 assert CAPACITY_TEST_LOGICAL_DFBS == 33
 
@@ -658,10 +674,12 @@ def test_repeated_transaction_lifecycles_reuse_dfb(
 @pytest.mark.parametrize(
     ("operation", "dtype"),
     [
-        (_conditional_bf16_lifecycle_kernel, torch.bfloat16),
-        (_conditional_f32_lifecycle_kernel, torch.float32),
+        (_conditional_bf16_true_lifecycle_kernel, torch.bfloat16),
+        (_conditional_bf16_false_lifecycle_kernel, torch.bfloat16),
+        (_conditional_f32_true_lifecycle_kernel, torch.float32),
+        (_conditional_f32_false_lifecycle_kernel, torch.float32),
     ],
-    ids=["bf16", "f32"],
+    ids=["bf16-true", "bf16-false", "f32-true", "f32-false"],
 )
 @pytest.mark.parametrize(
     ("memory_config", "to_device"),
@@ -681,7 +699,7 @@ def test_same_runtime_condition_reuses_sequential_dfbs(
     operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
 
     # Input and output ownership prevent them from sharing with compute DFBs.
-    # Three allocations prove that the two guarded lifecycles share one index.
+    # Three allocations prove that all three scratch lifecycles share one index.
     assert _count_final_dfb_allocations(final_mlir_path) == 3
 
     actual = ttnn.to_torch(output_tensor).float()

--- a/test/ttlang/Analysis/launch_node_domain_analysis.mlir
+++ b/test/ttlang/Analysis/launch_node_domain_analysis.mlir
@@ -1,7 +1,7 @@
 // RUN: ttlang-launch-node-domain-test %s | FileCheck %s
 
-// Summary: Prints exact launch-node lattice values for full, narrowed, empty,
-// joined, and unknown execution domains.
+// Summary: Prints launch-node lattice values and conditional-execution
+// equivalence results.
 
 // CHECK:      entry = {(0,0), (0,1), (1,0), (1,1)}
 // CHECK-NEXT: x_zero = {(0,0), (0,1)}

--- a/test/ttlang/Analysis/launch_node_domain_analysis.mlir
+++ b/test/ttlang/Analysis/launch_node_domain_analysis.mlir
@@ -10,6 +10,8 @@
 // CHECK-NEXT: empty = {}
 // CHECK-NEXT: unknown = <unknown>
 // CHECK-NEXT: undeclared_pipe = <unknown>
+// CHECK-NEXT: kernel_argument_condition = equivalent
+// CHECK-NEXT: helper_argument_condition = not-equivalent
 // CHECK-NOT:  =
 
 module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
@@ -41,6 +43,35 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
     %undeclared = ttl.is_src {pipe_net_id = 7 : i64}
     scf.if %undeclared {
       "test.observe"() {test.label = "undeclared_pipe"} : () -> ()
+    }
+    func.return
+  }
+
+  // One kernel entry argument has the same runtime value throughout one
+  // launched kernel instance.
+  func.func @kernel_argument_condition(%condition: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    scf.if %condition {
+      "test.observe"() {test.conditional_pair = "kernel_argument_condition"}
+          : () -> ()
+    }
+    scf.if %condition {
+      "test.observe"() {test.conditional_pair = "kernel_argument_condition"}
+          : () -> ()
+    }
+    func.return
+  }
+
+  // A helper argument can receive different values at separate call sites, so
+  // SSA identity inside the helper does not prove one runtime condition.
+  func.func private @helper_argument_condition(%condition: i1) {
+    scf.if %condition {
+      "test.observe"() {test.conditional_pair = "helper_argument_condition"}
+          : () -> ()
+    }
+    scf.if %condition {
+      "test.observe"() {test.conditional_pair = "helper_argument_condition"}
+          : () -> ()
     }
     func.return
   }

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_conditional_lifecycle.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_conditional_lifecycle.mlir
@@ -1,0 +1,445 @@
+// Tests physical DFB reuse for balanced runtime-conditional lifecycles.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// REPORT: DFB logical_id=0 bounded=0 compiler_created=0 conditionally_bounded=1
+// REPORT-SAME: domain=unknown
+// REPORT: possible_nodes quiescence=none domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(0,0)}
+// REPORT: possible_nodes quiescence=none domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(1,0)}
+// REPORT: DFB logical_id=1 bounded=0 compiler_created=0 conditionally_bounded=1
+// REPORT-SAME: domain=unknown
+// REPORT: DFB assignment: logical DFB 0 -> physical index 0 (bounded)
+// REPORT-NEXT: DFB assignment: logical DFB 1 -> physical index 0 (bounded)
+
+// Separate regions controlled by one opaque predicate preserve one 0-or-1
+// transaction for each DFB and permit sequential physical-index reuse.
+// CHECK-LABEL: func.func @same_ssa_condition
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @same_ssa_condition()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %condition_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %zero = arith.constant 0 : i64
+    %condition = arith.cmpi ne, %condition_value, %zero : i64
+    scf.if %condition {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// A dynamic launch-node condition retains possible membership on every node.
+// Complete lifecycles and ordering on every possible node permit reuse.
+// CHECK-LABEL: func.func @unknown_domain_same_ssa_condition
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @unknown_domain_same_ssa_condition(%offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %sum = arith.addi %core_x, %offset : index
+    %c0 = arith.constant 0 : index
+    %condition = arith.cmpi eq, %sum, %c0 : index
+    scf.if %condition {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Separately evaluated opaque predicates do not prove that one DFB's producer
+// and consumer effects execute together.
+// CHECK-LABEL: func.func @recomputed_condition
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @recomputed_condition()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %producer_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %consumer_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %zero = arith.constant 0 : i64
+    %producer_condition = arith.cmpi ne, %producer_value, %zero : i64
+    %consumer_condition = arith.cmpi ne, %consumer_value, %zero : i64
+    scf.if %producer_condition {
+      ttl.opaque_call "produce_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %consumer_condition {
+      ttl.opaque_call "consume_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %producer_condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// The conditional proof does not compare an unknown launch domain with an
+// exact launch domain.
+// CHECK-LABEL: func.func @unknown_and_exact_domains
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @unknown_and_exact_domains(%offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %conditional = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %exact = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %sum = arith.addi %core_x, %offset : index
+    %c0 = arith.constant 0 : index
+    %condition = arith.cmpi eq, %sum, %c0 : index
+    scf.if %condition {
+      ttl.opaque_call "conditional" dfb_dependencies(%conditional : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    ttl.opaque_call "exact" dfb_dependencies(%exact : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// Opposite branch polarity does not prove that producer and consumer effects
+// execute together.
+// CHECK-LABEL: func.func @opposite_branch_polarity
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @opposite_branch_polarity()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %condition_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %zero = arith.constant 0 : i64
+    %condition = arith.cmpi ne, %condition_value, %zero : i64
+    scf.if %condition {
+      ttl.opaque_call "produce_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    } else {
+      ttl.opaque_call "consume_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// A complete conditional transaction is quiescent before a later exact-count
+// transaction whether its condition is false or true.
+// CHECK-LABEL: func.func @conditional_and_exact_domains
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @conditional_and_exact_domains()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %conditional = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %exact = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %condition_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %zero = arith.constant 0 : i64
+    %condition = arith.cmpi ne, %condition_value, %zero : i64
+    scf.if %condition {
+      ttl.opaque_call "conditional" dfb_dependencies(%conditional : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    ttl.opaque_call "exact" dfb_dependencies(%exact : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// Producer and consumer effects with different nested conditions do not form
+// one 0-or-1 transaction.
+// CHECK-LABEL: func.func @different_nested_conditions
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @different_nested_conditions(%outer: i1, %inner: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %outer {
+      scf.if %inner {
+        ttl.opaque_call "produce_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+      }
+      ttl.opaque_call "consume_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %outer {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// An opaque DFB access controlled by a separately evaluated condition is not
+// covered by the transaction's conditional completion frontier.
+// CHECK-LABEL: func.func @mismatched_opaque_access_condition
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @mismatched_opaque_access_condition()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %transaction_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %access_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %zero = arith.constant 0 : i64
+    %transaction_condition = arith.cmpi ne, %transaction_value, %zero : i64
+    %access_condition = arith.cmpi ne, %access_value, %zero : i64
+    scf.if %transaction_condition {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %access_condition {
+      ttl.opaque_call "use_first" (%first) {header = "effects.hpp"} : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
+    }
+    scf.if %transaction_condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Equal unresolved loop bounds do not prove a single 0-or-1 transaction.
+// CHECK-LABEL: func.func @unresolved_loop_count
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @unresolved_loop_count(%upper_bound: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    scf.for %iteration = %c0 to %upper_bound step %c1 {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.for %iteration = %c0 to %upper_bound step %c1 {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Multiple runtime-conditional transactions remain unsupported.
+// CHECK-LABEL: func.func @repeated_conditional_transactions
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @repeated_conditional_transactions()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %condition_value = ttl.opaque_call "predicate" () {header = "predicate.hpp"} : () -> i64
+    %zero = arith.constant 0 : i64
+    %condition = arith.cmpi ne, %condition_value, %zero : i64
+    scf.if %condition {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>, #ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Matching polarity and SSA values at every nesting level preserve one
+// structured condition across distinct regions.
+// CHECK-LABEL: func.func @matching_nested_conditions
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @matching_nested_conditions(%outer: i1, %inner: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %outer {
+      scf.if %inner {
+        ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+      }
+    }
+    scf.if %outer {
+      scf.if %inner {
+        ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Conditional boundedness does not relax equal transaction-size requirements.
+// REPORT: DFB conflict lhs=0 rhs=1 reason=transaction-mismatch node=(0,0)
+// CHECK-LABEL: func.func @conditional_transaction_mismatch
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @conditional_transaction_mismatch(%condition: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %condition {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    scf.if %condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 2>, #ttl.dfb_protocol_effect<push, 0, 2>, #ttl.dfb_protocol_effect<wait, 0, 2>, #ttl.dfb_protocol_effect<pop, 0, 2>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Conditional boundedness retains constant hardware pointer ownership.
+// REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch node=(0,0)
+// CHECK-LABEL: func.func @conditional_noc0_owner
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-LABEL: func.func @conditional_noc1_owner
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @conditional_noc0_owner(%condition: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %condition {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+
+  func.func @conditional_noc1_owner(%condition: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %condition {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Equal immutable IntegerSets and operand SSA values preserve one unresolved
+// affine condition across distinct regions.
+// CHECK-LABEL: func.func @matching_affine_conditions
+// CHECK-SAME: ttl.base_cta_index = 1 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+#matchingAffineCondition = affine_set<(d0)[s0] : (d0 - s0 == 0)>
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @matching_affine_conditions(%offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    affine.if #matchingAffineCondition(%core_x)[%offset] {
+      ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    affine.if #matchingAffineCondition(%core_x)[%offset] {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Equal affine operands do not establish condition identity when the
+// immutable IntegerSets differ.
+// REPORT: possible_nodes quiescence=unsupported-control-flow {{.*}} kernel=@different_affine_predicates
+// CHECK-LABEL: func.func @different_affine_predicates
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+#equalAffineCondition = affine_set<(d0)[s0] : (d0 - s0 == 0)>
+#greaterEqualAffineCondition = affine_set<(d0)[s0] : (d0 - s0 >= 0)>
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @different_affine_predicates(%offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    affine.if #equalAffineCondition(%core_x)[%offset] {
+      ttl.opaque_call "produce_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    affine.if #greaterEqualAffineCondition(%core_x)[%offset] {
+      ttl.opaque_call "consume_first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    affine.if #equalAffineCondition(%core_x)[%offset] {
+      ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
@@ -11,7 +11,7 @@
 // REPORT: DFB allocation liveness report
 // REPORT: DFB logical_id=0 bounded=1 compiler_created=0
 // REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(0,0)} operation=ttl.cb_reserve kernel=@producer
-// REPORT: node (0,0) quiescence=none domain_assumption=exact evidence=none occurrences=[0:1, 1:1, 2:1, 3:1] transactions=[1] write_owner=(0,0):noc0:write read_owner=(0,0):unpack:read
+// REPORT: node (0,0) quiescence=none domain_assumption=exact conditional_execution=0 evidence=none occurrences=[0:1, 1:1, 2:1, 3:1] transactions=[1] write_owner=(0,0):noc0:write read_owner=(0,0):unpack:read
 // REPORT-SAME: earliest_accesses=[0, 2] terminal_accesses=[3]
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch node=(0,0)
 // REPORT: DFB allocation liveness report end

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
@@ -1,4 +1,4 @@
-// Tests counterfactual lifetime diagnostics for an unknown launch-node domain.
+// Tests possible-domain lifetime diagnostics for an unknown launch-node domain.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' > %t.no-report.mlir 2> %t.no-report.log
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices > %t.report.mlir 2> %t.report.log
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' -debug-only=ttl-finalize-dfb-indices > %t.repeat.mlir 2> %t.repeat.log
@@ -15,25 +15,25 @@
 // CHECK: access 4 effect=none tiles=0 sequence=0 domain=unknown
 // CHECK-SAME: operation=ttl.opaque_call kernel=@unknown_domain
 // CHECK-SAME: unresolved_at=arith.cmpi kernel=@unknown_domain
-// CHECK: diagnostic_nodes quiescence=unsupported-control-flow domain_assumption=unknown-may-be-active may_be_active=1 node_count=10 exemplar=(0,0)
+// CHECK: possible_nodes quiescence=incomplete-use-order domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(0,0)}
+// CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
+// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=9 exemplar=(1,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
 // CHECK: DFB logical_id=1 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: diagnostic_nodes quiescence=missing-protocol-effect domain_assumption=unknown-may-be-active may_be_active=1 node_count=10 exemplar=(0,0)
+// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved]
 // CHECK: DFB logical_id=2 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: diagnostic_nodes quiescence=unsupported-control-flow domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(0,0)}
+// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=1 nodes={(0,0)}
 // CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved]
-// CHECK: diagnostic_nodes quiescence=none domain_assumption=unknown-may-be-active may_be_active=0 node_count=9 exemplar=(1,0)
+// CHECK: possible_nodes quiescence=none domain_assumption=unknown-possible may_be_active=0 conditional_execution=0 node_count=9 exemplar=(1,0)
 // CHECK-SAME: occurrences=[0:0, 1:0, 2:0, 3:0]
 // CHECK: DFB logical_id=3 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: diagnostic_nodes quiescence=incomplete-use-order domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(0,0)}
+// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
-// CHECK-SAME: transactions=[1]
-// CHECK: diagnostic_nodes quiescence=incomplete-use-order domain_assumption=unknown-may-be-active may_be_active=1 node_count=1 nodes={(1,0)}
-// CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
+// CHECK-SAME: transactions=[]
 // CHECK: DFB conflict lhs=0 rhs=1 reason=unknown-launch-node-domain node=none
 // CHECK: DFB allocation liveness report end
 // CHECK-NEXT: Total DFB count: 4


### PR DESCRIPTION
### Problem description

Balanced producer and consumer effects inside structured conditionals were
rejected because their execution counts were unresolved. Reusing the same SSA
condition proves that both sides execute together without inferring equality
from external function names or generated code.

### What's changed

~480 LOC implementation.

Prove one complete DFB lifecycle when its accesses use the same at-most-once
structured condition with identical polarity, nesting, and immutable affine
predicate. The proof retains the existing transaction, pointer-owner, payload,
completion, and ordering requirements.

Unknown-domain reuse is allowed only when both lifecycles are complete and
ordered on every possible launch node. Separately evaluated predicates,
opposite polarity, different nesting, helper arguments without call-site
resolution, unresolved loops, repeated conditional transactions, and mixed
exact/unknown domains remain conservative.

```python
active = ttl.call_extern_func(
    HEADER,
    "is_active",
    result_type=ttl.ScalarType.I32,
)

if active:
    with first_scratch.reserve() as first_block:
        first_block.store(input_block)
    with first_scratch.wait():
        pass

if active:
    with second_scratch.reserve() as second_block:
        second_block.store(input_block)
    with second_scratch.wait():
        pass
```

### Validation

- New device tests cover true and false runtime predicates across BF16/FP32 and
  DRAM/L1, including unconditional reuse after skipped lifecycles.
- New analysis tests cover matching SSA and affine conditions and conservative
  rejection of mismatched conditions, transactions, owners, and helper
  arguments.

### Checklist

- [x] New/Existing tests provide coverage for changes
