### PR TITLE
[ttl] Prevent incompatible DFB configuration reuse [dfb-reuse-5]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -84,7 +84,7 @@ ttl-verify-pipenet-guards      (Module)   Verify PipeNet launch-node domains
 ttl-verify-pipenet-schedule    (Module)   Verify PipeNet event ordering
 ttl-coalesce-dfb-acquires      (FuncOp)   Coalesce adjacent DFB acquisitions
 ttl-finalize-dfb-indices       (Module)   Finalize identities and allocations
-ttl-set-compute-kernel-config  (FuncOp)   Resolve per-kernel configuration
+ttl-set-compute-kernel-config  (ModuleOp) Resolve per-kernel configuration
   ... DST assignment, loop lowering, scheduling ...
 ttl-annotate-cb-associations   (FuncOp)   Copy CB indices to tile ops
 ttl-verify-dfb-spsc            (Module)   Reject DFBs shared across threads

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -221,7 +221,7 @@ for the algorithm and invariants.
 | `enable-fpu-binary-ops` | bool | `true` | Allow eligible add/sub/mul operations to select FPU. |
 
 ```bash
-ttlang-opt input.mlir -p 'func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled})'
+ttlang-opt input.mlir -p 'ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled}'
 ```
 
 #### `ttl-assign-dst`

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -559,14 +559,16 @@ def TTLAssignDST
 }
 
 def TTLSetComputeKernelConfig
-    : Pass<"ttl-set-compute-kernel-config", "::mlir::func::FuncOp"> {
+    : Pass<"ttl-set-compute-kernel-config", "::mlir::ModuleOp"> {
   let summary = "Resolve compute-kernel configuration";
   let description = [{
     Selects tile execution strategies and resolves kernel-wide destination
     element width, synchronization mode, and per-dataflow-buffer unpack mode.
     Target capabilities, user policy, and target-independent kernel
     requirements are analyzed separately. The pass validates a complete
-    configuration before writing operation or function attributes.
+    configuration for every function before writing operation or function
+    attributes. Module scope provides one immutable launch-domain snapshot and
+    a transformation barrier before destination assignment mutates functions.
   }];
 
   let options = [
@@ -982,6 +984,11 @@ def TTLFinalizeDFBIndices
     order conflicts with every other DFB. Unsupported or unknown control flow
     can reduce reuse but cannot produce an unsafe physical assignment.
 
+    Two DFBs used by one compute kernel may share a physical index only when
+    every target-supported destination width assigns compatible static unpack
+    modes to that index. This constraint is added to the conflict graph before
+    coloring.
+
     An access whose launch domain is otherwise unknown is refined to an exact
     domain when execution-count analysis proves a count on every base launch
     node. Nodes with positive counts belong to the domain; nodes with zero
@@ -990,6 +997,11 @@ def TTLFinalizeDFBIndices
     domains is empty. An inactive scratch DFB may share a compatible physical
     descriptor without a lifetime-order proof because no launched node accesses
     it. Tensor-backed empty domains retain their existing allocation diagnostic.
+    Operations proven to execute zero times on every launch node do not impose
+    runtime compute-configuration requirements, but strategy-dependent tile
+    operations still receive a strategy required by later lowering. Unknown
+    execution remains configuration-constraining. The subsequent compute
+    configuration pass uses the same exact-empty proof.
 
     The allocator represents each logical DFB as a vertex, each pair that
     cannot share as an edge, and each physical index as a color. First-fit

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h
@@ -17,6 +17,8 @@
 
 namespace mlir::tt::ttl {
 
+struct LaunchNodeDomainState;
+
 /// User policy for a configuration value that may otherwise be inferred.
 enum class ConfigSelection {
   Auto,
@@ -102,6 +104,7 @@ struct TileExecutionDecision {
 /// One dataflow-buffer operand and the facts used to determine unpack mode.
 struct DFBInputUse {
   int64_t dfbIndex;
+  Value dfb;
   Operation *consumer;
   unsigned operandIndex;
   TilePrimitive primitive;
@@ -144,6 +147,14 @@ struct KernelRequirements {
   llvm::SmallVector<TileExecutionChoice, 0> tileStrategyChoices;
 };
 
+/// Two logical DFBs whose static unpack requirements forbid physical aliasing.
+struct DFBConfigurationAliasConflict {
+  Value lhsDFB;
+  Value rhsDFB;
+  Operation *lhsOperation;
+  Operation *rhsOperation;
+};
+
 /// Complete configuration selected before any IR mutation. Apply the plan
 /// before mutating IR because its decisions contain operation pointers.
 class KernelConfigPlan {
@@ -178,8 +189,19 @@ private:
   llvm::SmallVector<TileExecutionDecision> tileStrategies;
 };
 
-/// Collect target-independent requirements and legal tile strategies.
-FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function);
+/// Collect executable requirements using exact launch-node counts.
+///
+/// Strategy choices are retained for exact-empty operations because later
+/// lowering requires a selected strategy. Their unreachable DFB, destination,
+/// and accumulation requirements do not constrain kernel configuration.
+FailureOr<KernelRequirements>
+collectKernelRequirements(func::FuncOp function,
+                          const LaunchNodeDomainState &launchDomains);
+
+/// Return conservative static-configuration conflicts between logical DFBs.
+SmallVector<DFBConfigurationAliasConflict>
+collectDFBConfigurationAliasConflicts(const KernelTargetEnvironment &target,
+                                      const KernelRequirements &requirements);
 
 /// Resolve one complete configuration from target, policy, and requirements.
 FailureOr<KernelConfigPlan> resolveKernelConfig(

--- a/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
+++ b/include/ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h
@@ -189,6 +189,10 @@ std::optional<std::uint64_t>
 getExactExecutionCountAtLaunchNode(Operation *op, LaunchNodeCoord coord,
                                    const LaunchNodeDomainState &state);
 
+/// Return true when `op` executes zero times on every launch node.
+bool hasExactEmptyLaunchDomain(Operation *op,
+                               const LaunchNodeDomainState &state);
+
 /// Prove that two operations with unknown exact counts have equivalent
 /// control flow at their launch nodes.
 ///

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -51,7 +51,7 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
     configOpts.reduceFullFp32 = options.reduceFullFp32;
     configOpts.matmulFullFp32 = options.matmulFullFp32;
     configOpts.enableFPUBinaryOps = options.enableFPUBinaryOps;
-    pm.addNestedPass<func::FuncOp>(createTTLSetComputeKernelConfig(configOpts));
+    pm.addPass(createTTLSetComputeKernelConfig(configOpts));
   }
   pm.addNestedPass<func::FuncOp>(createTTLAssignDST());
   if (options.maximizeDST) {

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -93,44 +93,41 @@ getOptionalUnpackConstraint(func::FuncOp function) {
   return std::optional<SmallVector<int32_t>>(std::move(dataflowBufferIndices));
 }
 
-/// Return the attached DFB after resolving a compute-region argument.
-Value resolveDataflowBuffer(Value value) {
+struct ResolvedDataflowBuffer {
+  Value dfb;
+  int64_t dfbIndex;
+};
+
+/// Return the attached DFB and index after resolving a compute-region argument.
+FailureOr<std::optional<ResolvedDataflowBuffer>>
+resolveDataflowBuffer(Value value, Operation *consumer) {
   if (auto blockArgument = dyn_cast<BlockArgument>(value)) {
     auto computeOp =
         dyn_cast_or_null<ComputeOp>(blockArgument.getOwner()->getParentOp());
     if (!computeOp) {
-      return {};
+      return std::optional<ResolvedDataflowBuffer>();
     }
     unsigned argumentNumber = blockArgument.getArgNumber();
     if (argumentNumber < computeOp.getNumInputs()) {
       value = computeOp.getInputs()[argumentNumber];
     } else {
       unsigned outputNumber = argumentNumber - computeOp.getNumInputs();
-      if (outputNumber >= computeOp.getNumOutputs()) {
-        return {};
-      }
+      assert(outputNumber < computeOp.getNumOutputs() &&
+             "compute region argument must map to an input or output");
       value = computeOp.getOutputs()[outputNumber];
     }
   }
 
-  return getAttachedCB(value);
-}
-
-/// Return the attached DFB index, or `std::nullopt` when no DFB is attached.
-FailureOr<std::optional<int64_t>>
-resolveDataflowBufferIndex(Value value, Operation *consumer) {
-  Value dfb = resolveDataflowBuffer(value);
-
-  if (dfb) {
-    std::optional<int64_t> dfbIndex = getCBIndex(dfb);
-    if (!dfbIndex) {
-      consumer->emitOpError("uses a dataflow buffer without a finalized index");
-      return failure();
-    }
-    return dfbIndex;
+  Value dfb = getAttachedCB(value);
+  if (!dfb) {
+    return std::optional<ResolvedDataflowBuffer>();
   }
-
-  return std::optional<int64_t>();
+  std::optional<int64_t> dfbIndex = getCBIndex(dfb);
+  if (!dfbIndex) {
+    consumer->emitOpError("uses a dataflow buffer without a finalized index");
+    return failure();
+  }
+  return std::make_optional(ResolvedDataflowBuffer{dfb, *dfbIndex});
 }
 
 /// Return the scalar element type of a tile or tensor of tiles.
@@ -167,12 +164,12 @@ findUnavailableDataflowBufferOperand(Operation *operation,
         TileOperandRoute::DataflowBuffer) {
       continue;
     }
-    FailureOr<std::optional<int64_t>> dataflowBufferIndex =
-        resolveDataflowBufferIndex(operand.get(), operation);
-    if (failed(dataflowBufferIndex)) {
+    FailureOr<std::optional<ResolvedDataflowBuffer>> dataflowBuffer =
+        resolveDataflowBuffer(operand.get(), operation);
+    if (failed(dataflowBuffer)) {
       return failure();
     }
-    if (!*dataflowBufferIndex) {
+    if (!*dataflowBuffer) {
       return std::optional<unsigned>(operand.getOperandNumber());
     }
   }
@@ -194,22 +191,21 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
     if (failed(elementType)) {
       return failure();
     }
-    FailureOr<std::optional<int64_t>> dataflowBufferIndex =
-        resolveDataflowBufferIndex(operand.get(), operation);
-    if (failed(dataflowBufferIndex)) {
+    FailureOr<std::optional<ResolvedDataflowBuffer>> dataflowBuffer =
+        resolveDataflowBuffer(operand.get(), operation);
+    if (failed(dataflowBuffer)) {
       return failure();
     }
-    if (route == TileOperandRoute::DataflowBuffer && !*dataflowBufferIndex) {
+    if (route == TileOperandRoute::DataflowBuffer && !*dataflowBuffer) {
       operation->emitOpError()
           << "operand " << operand.getOperandNumber()
           << " must resolve to a dataflow buffer for the selected strategy";
       return failure();
     }
-    if (*dataflowBufferIndex) {
-      dfbInputUses.push_back({**dataflowBufferIndex,
-                              resolveDataflowBuffer(operand.get()), operation,
-                              operand.getOperandNumber(), info.primitive, route,
-                              *elementType});
+    if (*dataflowBuffer) {
+      dfbInputUses.push_back(
+          {(*dataflowBuffer)->dfbIndex, (*dataflowBuffer)->dfb, operation,
+           operand.getOperandNumber(), info.primitive, route, *elementType});
     }
     if (route == TileOperandRoute::Dst) {
       destinationUses.push_back({operation, info.primitive, *elementType});

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -9,11 +9,13 @@
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Transforms/ComputeTarget.h"
+#include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallSet.h"
 
 #include <algorithm>
@@ -91,14 +93,13 @@ getOptionalUnpackConstraint(func::FuncOp function) {
   return std::optional<SmallVector<int32_t>>(std::move(dataflowBufferIndices));
 }
 
-/// Return the attached DFB index, or `std::nullopt` when no DFB is attached.
-FailureOr<std::optional<int64_t>>
-resolveDataflowBufferIndex(Value value, Operation *consumer) {
+/// Return the attached DFB after resolving a compute-region argument.
+Value resolveDataflowBuffer(Value value) {
   if (auto blockArgument = dyn_cast<BlockArgument>(value)) {
     auto computeOp =
         dyn_cast_or_null<ComputeOp>(blockArgument.getOwner()->getParentOp());
     if (!computeOp) {
-      return std::optional<int64_t>();
+      return {};
     }
     unsigned argumentNumber = blockArgument.getArgNumber();
     if (argumentNumber < computeOp.getNumInputs()) {
@@ -106,25 +107,24 @@ resolveDataflowBufferIndex(Value value, Operation *consumer) {
     } else {
       unsigned outputNumber = argumentNumber - computeOp.getNumInputs();
       if (outputNumber >= computeOp.getNumOutputs()) {
-        return std::optional<int64_t>();
+        return {};
       }
       value = computeOp.getOutputs()[outputNumber];
     }
   }
 
-  Value dfb = getAttachedCB(value);
+  return getAttachedCB(value);
+}
+
+/// Return the attached DFB index, or `std::nullopt` when no DFB is attached.
+FailureOr<std::optional<int64_t>>
+resolveDataflowBufferIndex(Value value, Operation *consumer) {
+  Value dfb = resolveDataflowBuffer(value);
+
   if (dfb) {
     std::optional<int64_t> dfbIndex = getCBIndex(dfb);
     if (!dfbIndex) {
       consumer->emitOpError("uses a dataflow buffer without a finalized index");
-      return failure();
-    }
-    int32_t targetMaxDFBIndices = getTargetMaxDFBIndices(consumer);
-    if (*dfbIndex < 0 || *dfbIndex >= targetMaxDFBIndices) {
-      consumer->emitOpError()
-          << "uses dataflow buffer index " << *dfbIndex
-          << " outside the supported range [0, " << targetMaxDFBIndices - 1
-          << "] for " << getTargetDFBIndexCapacityDescription(consumer);
       return failure();
     }
     return dfbIndex;
@@ -206,7 +206,8 @@ appendExecutionRequirements(Operation *operation, const TileExecutionInfo &info,
       return failure();
     }
     if (*dataflowBufferIndex) {
-      dfbInputUses.push_back({**dataflowBufferIndex, operation,
+      dfbInputUses.push_back({**dataflowBufferIndex,
+                              resolveDataflowBuffer(operand.get()), operation,
                               operand.getOperandNumber(), info.primitive, route,
                               *elementType});
     }
@@ -840,7 +841,9 @@ KernelConfigPolicy::get(func::FuncOp function, StringRef fp32Selection,
   return policy;
 }
 
-FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
+static FailureOr<KernelRequirements> collectKernelRequirementsImpl(
+    func::FuncOp function,
+    llvm::function_ref<bool(Operation *)> includeOperation) {
   KernelRequirements requirements;
   WalkResult result = function.walk([&](Operation *operation) {
     auto executionOp = dyn_cast<TileExecutionOpInterface>(operation);
@@ -851,11 +854,18 @@ FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
       }
       return WalkResult::advance();
     }
+    bool contributesConfiguration = includeOperation(operation);
     if (!executionOp.getLegalExecutionStrategies().empty()) {
       FailureOr<TileExecutionChoice> choice =
           getTileExecutionChoice(executionOp);
       if (failed(choice)) {
         return WalkResult::interrupt();
+      }
+      if (!contributesConfiguration) {
+        for (TileExecutionOption &option : choice->options) {
+          option.dfbInputUses.clear();
+          option.destinationUses.clear();
+        }
       }
       requirements.tileStrategyChoices.push_back(std::move(*choice));
       return WalkResult::advance();
@@ -870,8 +880,13 @@ FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
       operation->emitOpError("has no tile execution semantics");
       return WalkResult::interrupt();
     }
-    if (failed(verifyTileExecutionInfo(operation, *info)) ||
-        failed(appendExecutionRequirements(operation, *info,
+    if (failed(verifyTileExecutionInfo(operation, *info))) {
+      return WalkResult::interrupt();
+    }
+    if (!contributesConfiguration) {
+      return WalkResult::advance();
+    }
+    if (failed(appendExecutionRequirements(operation, *info,
                                            requirements.dfbInputUses,
                                            requirements.destinationUses))) {
       return WalkResult::interrupt();
@@ -888,9 +903,187 @@ FailureOr<KernelRequirements> collectKernelRequirements(func::FuncOp function) {
   return requirements;
 }
 
+FailureOr<KernelRequirements>
+collectKernelRequirements(func::FuncOp function,
+                          const LaunchNodeDomainState &launchDomains) {
+  return collectKernelRequirementsImpl(function, [&](Operation *operation) {
+    return !hasExactEmptyLaunchDomain(operation, launchDomains);
+  });
+}
+
+namespace {
+
+using DFBConfigurationMask = std::uint8_t;
+constexpr DFBConfigurationMask kAllDFBConfigurations = 0xF;
+
+DFBConfigurationMask
+getDFBConfigurationMask(const KernelTargetEnvironment &target,
+                        const DFBInputUse &use) {
+  DFBConfigurationMask mask = 0;
+  for (const DFBHardwareConfiguration &configuration :
+       target.getSupportedDFBConfigurations(use.primitive, use.route,
+                                            use.elementType)) {
+    unsigned widthOffset =
+        configuration.destinationElementWidth == DestinationElementWidth::Bits32
+            ? 2
+            : 0;
+    unsigned modeOffset =
+        configuration.unpackMode == DFBUnpackMode::UnpackToDestination ? 1 : 0;
+    mask |= DFBConfigurationMask{1} << (widthOffset + modeOffset);
+  }
+  return mask;
+}
+
+void appendUniqueMask(SmallVectorImpl<DFBConfigurationMask> &masks,
+                      DFBConfigurationMask mask) {
+  if (mask != 0 && !llvm::is_contained(masks, mask)) {
+    masks.push_back(mask);
+  }
+}
+
+struct DFBConfigurationProfile {
+  Value dfb;
+  Operation *evidence = nullptr;
+  SmallVector<DFBConfigurationMask, 4> alternatives;
+};
+
+DFBConfigurationProfile
+buildDFBConfigurationProfile(Value dfb, Operation *evidence,
+                             const KernelTargetEnvironment &target,
+                             const KernelRequirements &requirements) {
+  DFBConfigurationMask fixedMask = kAllDFBConfigurations;
+  for (const DFBInputUse &use : requirements.dfbInputUses) {
+    if (use.dfb == dfb) {
+      fixedMask &= getDFBConfigurationMask(target, use);
+    }
+  }
+
+  SmallVector<DFBConfigurationMask, 4> alternatives;
+  appendUniqueMask(alternatives, fixedMask);
+  for (const TileExecutionChoice &choice : requirements.tileStrategyChoices) {
+    SmallVector<DFBConfigurationMask, 2> choiceMasks;
+    for (const TileExecutionOption &option : choice.options) {
+      DFBConfigurationMask optionMask = kAllDFBConfigurations;
+      for (const DFBInputUse &use : option.dfbInputUses) {
+        if (use.dfb == dfb) {
+          optionMask &= getDFBConfigurationMask(target, use);
+        }
+      }
+      appendUniqueMask(choiceMasks, optionMask);
+    }
+
+    SmallVector<DFBConfigurationMask, 4> nextAlternatives;
+    for (DFBConfigurationMask priorMask : alternatives) {
+      for (DFBConfigurationMask choiceMask : choiceMasks) {
+        appendUniqueMask(nextAlternatives, priorMask & choiceMask);
+      }
+    }
+    alternatives = std::move(nextAlternatives);
+  }
+  return {dfb, evidence, std::move(alternatives)};
+}
+
+bool canAlwaysShareDFBConfiguration(const DFBConfigurationProfile &lhs,
+                                    const DFBConfigurationProfile &rhs) {
+  constexpr DFBConfigurationMask kBits16Configurations = 0x3;
+  constexpr DFBConfigurationMask kBits32Configurations = 0xC;
+  for (DFBConfigurationMask lhsMask : lhs.alternatives) {
+    for (DFBConfigurationMask rhsMask : rhs.alternatives) {
+      for (DFBConfigurationMask widthMask :
+           {kBits16Configurations, kBits32Configurations}) {
+        DFBConfigurationMask lhsWidthMask = lhsMask & widthMask;
+        DFBConfigurationMask rhsWidthMask = rhsMask & widthMask;
+        if (lhsWidthMask != 0 && rhsWidthMask != 0 &&
+            (lhsWidthMask & rhsWidthMask) == 0) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+SmallVector<DFBConfigurationAliasConflict>
+collectDFBConfigurationAliasConflicts(const KernelTargetEnvironment &target,
+                                      const KernelRequirements &requirements) {
+  llvm::MapVector<Value, Operation *> evidenceByDFB;
+  auto collectUses = [&](ArrayRef<DFBInputUse> uses) {
+    for (const DFBInputUse &use : uses) {
+      evidenceByDFB.try_emplace(use.dfb, use.consumer);
+    }
+  };
+  collectUses(requirements.dfbInputUses);
+  for (const TileExecutionChoice &choice : requirements.tileStrategyChoices) {
+    for (const TileExecutionOption &option : choice.options) {
+      collectUses(option.dfbInputUses);
+    }
+  }
+
+  SmallVector<DFBConfigurationProfile> profiles;
+  profiles.reserve(evidenceByDFB.size());
+  for (const auto &[dfb, evidence] : evidenceByDFB) {
+    DFBConfigurationProfile profile =
+        buildDFBConfigurationProfile(dfb, evidence, target, requirements);
+    if (!profile.alternatives.empty()) {
+      profiles.push_back(std::move(profile));
+    }
+  }
+
+  SmallVector<DFBConfigurationAliasConflict> conflicts;
+  for (unsigned lhsIndex = 0; lhsIndex < profiles.size(); ++lhsIndex) {
+    for (unsigned rhsIndex = lhsIndex + 1; rhsIndex < profiles.size();
+         ++rhsIndex) {
+      const DFBConfigurationProfile &lhs = profiles[lhsIndex];
+      const DFBConfigurationProfile &rhs = profiles[rhsIndex];
+      if (!canAlwaysShareDFBConfiguration(lhs, rhs)) {
+        conflicts.push_back({lhs.dfb, rhs.dfb, lhs.evidence, rhs.evidence});
+      }
+    }
+  }
+  return conflicts;
+}
+
+namespace {
+
+LogicalResult
+validateFinalizedDFBIndices(const KernelRequirements &requirements) {
+  auto validateUses = [](ArrayRef<DFBInputUse> uses) {
+    for (const DFBInputUse &use : uses) {
+      int32_t targetMaxDFBIndices = getTargetMaxDFBIndices(use.consumer);
+      if (use.dfbIndex < 0 || use.dfbIndex >= targetMaxDFBIndices) {
+        use.consumer->emitOpError()
+            << "uses dataflow buffer index " << use.dfbIndex
+            << " outside the supported range [0, " << targetMaxDFBIndices - 1
+            << "] for " << getTargetDFBIndexCapacityDescription(use.consumer);
+        return failure();
+      }
+    }
+    return success();
+  };
+
+  if (failed(validateUses(requirements.dfbInputUses))) {
+    return failure();
+  }
+  for (const TileExecutionChoice &choice : requirements.tileStrategyChoices) {
+    for (const TileExecutionOption &option : choice.options) {
+      if (failed(validateUses(option.dfbInputUses))) {
+        return failure();
+      }
+    }
+  }
+  return success();
+}
+
+} // namespace
+
 FailureOr<KernelConfigPlan> resolveKernelConfig(
     func::FuncOp function, const KernelTargetEnvironment &target,
     const KernelConfigPolicy &policy, const KernelRequirements &requirements) {
+  if (failed(validateFinalizedDFBIndices(requirements))) {
+    return failure();
+  }
   ConfigConstraintState initialState;
   if (policy.fp32DestAccumulation == ConfigSelection::Enabled) {
     llvm::erase_if(initialState.candidates,

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -69,6 +69,8 @@ static llvm::StringRef getConflictReasonName(DFBConflictReason reason) {
     return "pointer-owner-mismatch";
   case DFBConflictReason::ConcurrentLifetime:
     return "concurrent-lifetime";
+  case DFBConflictReason::StaticConfigurationMismatch:
+    return "static-configuration-mismatch";
   }
   llvm_unreachable("unknown DFB conflict reason");
 }

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -53,7 +53,8 @@ static Operation *getLifetimeEvidence(const DFBPerNodeLifetime *lifetime,
 class DFBPhysicalConflictModelBuilder {
 public:
   static DFBPhysicalConflictModel
-  build(const DFBConcurrentKernelLivenessAnalysis &liveness) {
+  build(const DFBConcurrentKernelLivenessAnalysis &liveness,
+        ArrayRef<DFBStaticConfigurationConflict> staticConflicts) {
     ArrayRef<DFBLogicalLifecycle> logicalDFBs =
         liveness.getLogicalDFBLifecycles();
     DFBPhysicalConflictModel model;
@@ -64,6 +65,25 @@ public:
            ++rhsIndex) {
         addPairConflicts(model, liveness, lhsIndex, rhsIndex);
       }
+    }
+    DenseMap<int64_t, unsigned> logicalIndexById;
+    for (auto [logicalIndex, logicalDFB] : llvm::enumerate(logicalDFBs)) {
+      logicalIndexById.try_emplace(logicalDFB.logicalId, logicalIndex);
+    }
+    for (const DFBStaticConfigurationConflict &conflict : staticConflicts) {
+      auto lhsIt = logicalIndexById.find(conflict.lhsLogicalId);
+      auto rhsIt = logicalIndexById.find(conflict.rhsLogicalId);
+      assert(lhsIt != logicalIndexById.end() &&
+             rhsIt != logicalIndexById.end() &&
+             "configuration conflicts must reference analyzed logical DFBs");
+      unsigned lhsIndex = lhsIt->second;
+      unsigned rhsIndex = rhsIt->second;
+      if (lhsIndex == rhsIndex || model.adjacency[lhsIndex].test(rhsIndex)) {
+        continue;
+      }
+      addEvidence(model, logicalDFBs[lhsIndex], logicalDFBs[rhsIndex], lhsIndex,
+                  rhsIndex, DFBConflictReason::StaticConfigurationMismatch,
+                  std::nullopt, conflict.lhsOperation, conflict.rhsOperation);
     }
     return model;
   }
@@ -787,6 +807,7 @@ validateTensorBackingRanges(ArrayRef<DFBPhysicalIndexAssignment> assignments,
 DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
     Operation *operation, bool reuseUserDFBs,
     std::uint64_t exactColoringSearchStateLimit,
+    ArrayRef<DFBStaticConfigurationConflict> staticConfigurationConflicts,
     AnalysisManager analysisManager) {
   ModuleOp moduleOp = cast<ModuleOp>(operation);
   std::string targetFailureReason;
@@ -813,7 +834,8 @@ DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
     return;
   }
   DFBAnalysisFailure analysisFailure;
-  plan.conflictModel = DFBPhysicalConflictModelBuilder::build(liveness);
+  plan.conflictModel = DFBPhysicalConflictModelBuilder::build(
+      liveness, staticConfigurationConflicts);
   LLVM_DEBUG(printDFBAllocationDebugReport(llvm::dbgs(), liveness,
                                            plan.conflictModel));
 

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
@@ -58,6 +58,14 @@ struct DFBKernelBaseIndexAssignment {
   int32_t baseIndex = 0;
 };
 
+/// Static kernel-configuration evidence that forbids one logical DFB alias.
+struct DFBStaticConfigurationConflict {
+  int64_t lhsLogicalId = 0;
+  int64_t rhsLogicalId = 0;
+  Operation *lhsOperation = nullptr;
+  Operation *rhsOperation = nullptr;
+};
+
 /// Semantic reason that two logical DFBs cannot share one physical index.
 enum class DFBConflictReason {
   DescriptorMismatch,
@@ -67,6 +75,7 @@ enum class DFBConflictReason {
   TransactionMismatch,
   PointerOwnerMismatch,
   ConcurrentLifetime,
+  StaticConfigurationMismatch,
 };
 
 /// Source evidence that explains why one logical DFB pair cannot share.
@@ -146,9 +155,11 @@ public:
   /// sharing, dense indices, runtime descriptors, and hardware capacity.
   /// Unknown lifetime facts add conflicts and can cause rejection, but cannot
   /// permit unsafe sharing.
-  DFBPhysicalAllocationPlanner(Operation *operation, bool reuseUserDFBs,
-                               std::uint64_t exactColoringSearchStateLimit,
-                               AnalysisManager analysisManager);
+  DFBPhysicalAllocationPlanner(
+      Operation *operation, bool reuseUserDFBs,
+      std::uint64_t exactColoringSearchStateLimit,
+      ArrayRef<DFBStaticConfigurationConflict> staticConfigurationConflicts,
+      AnalysisManager analysisManager);
 
   /// Returns true when the complete allocation plan is valid.
   bool succeeded() const { return errorMessage.empty(); }

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -467,6 +467,21 @@ getExactExecutionCountAtLaunchNode(Operation *op, LaunchNodeCoord coord,
   return analysisIt->second->getExecutionCount(op);
 }
 
+bool hasExactEmptyLaunchDomain(Operation *op,
+                               const LaunchNodeDomainState &state) {
+  if (!state.hasLaunchGrid || state.sawError) {
+    return false;
+  }
+  for (LaunchNodeCoord node : state.baseDomain.nodes) {
+    std::optional<std::uint64_t> executionCount =
+        getExactExecutionCountAtLaunchNode(op, node, state);
+    if (!executionCount || *executionCount != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Return true if evaluating `value` can depend on the current launch
 /// coordinate.
 static bool dependsOnCoord(Value value, llvm::DenseMap<Value, bool> &cache) {

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -12,7 +12,11 @@
 
 #include "DFBPhysicalAllocationPlan.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Passes.h"
+#include "ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h"
+#include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
+#include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -27,6 +31,44 @@ namespace mlir::tt::ttl {
 #include "ttlang/Dialect/TTL/Passes.h.inc"
 
 namespace {
+
+static FailureOr<SmallVector<DFBStaticConfigurationConflict>>
+collectStaticConfigurationConflicts(
+    ModuleOp moduleOp,
+    const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis) {
+  LaunchNodeDomainState launchDomains;
+  launchDomains.initialize(moduleOp);
+  SmallVector<DFBStaticConfigurationConflict> conflicts;
+  for (func::FuncOp function : moduleOp.getOps<func::FuncOp>()) {
+    if (getKernelThreadType(function) != ttkernel::ThreadType::Compute) {
+      continue;
+    }
+    FailureOr<std::unique_ptr<KernelTargetEnvironment>> target =
+        KernelTargetEnvironment::get(function);
+    if (failed(target)) {
+      return failure();
+    }
+    FailureOr<KernelRequirements> requirements =
+        collectKernelRequirements(function, launchDomains);
+    if (failed(requirements)) {
+      return failure();
+    }
+    for (const DFBConfigurationAliasConflict &conflict :
+         collectDFBConfigurationAliasConflicts(**target, *requirements)) {
+      FailureOr<int64_t> lhsLogicalId =
+          logicalIdentityAnalysis.getLogicalId(conflict.lhsDFB);
+      FailureOr<int64_t> rhsLogicalId =
+          logicalIdentityAnalysis.getLogicalId(conflict.rhsDFB);
+      assert(succeeded(lhsLogicalId) && succeeded(rhsLogicalId) &&
+             "configuration DFB uses must resolve to logical identities");
+      if (*lhsLogicalId != *rhsLogicalId) {
+        conflicts.push_back({*lhsLogicalId, *rhsLogicalId,
+                             conflict.lhsOperation, conflict.rhsOperation});
+      }
+    }
+  }
+  return conflicts;
+}
 
 /// Materializes decisions already validated by physical allocation analysis.
 static void
@@ -104,9 +146,28 @@ struct TTLFinalizeDFBIndicesPass
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis =
+        getAnalysis<DFBLogicalIdentityAnalysis>();
+    if (!logicalIdentityAnalysis.succeeded()) {
+      Operation *errorOperation = logicalIdentityAnalysis.getErrorOperation();
+      if (!errorOperation) {
+        errorOperation = moduleOp.getOperation();
+      }
+      errorOperation->emitOpError()
+          << logicalIdentityAnalysis.getErrorMessage();
+      signalPassFailure();
+      return;
+    }
+    FailureOr<SmallVector<DFBStaticConfigurationConflict>>
+        staticConfigurationConflicts = collectStaticConfigurationConflicts(
+            moduleOp, logicalIdentityAnalysis);
+    if (failed(staticConfigurationConflicts)) {
+      signalPassFailure();
+      return;
+    }
     DFBPhysicalAllocationPlanner allocationPlanner(
         moduleOp, reuseUserDFBs, exactColoringSearchStateLimit,
-        getAnalysisManager());
+        *staticConfigurationConflicts, getAnalysisManager());
     if (!allocationPlanner.succeeded()) {
       Operation *errorOperation = allocationPlanner.getErrorOperation();
       if (!errorOperation) {

--- a/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
@@ -10,6 +10,7 @@
 
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.h"
+#include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
 
 namespace mlir::tt::ttl {
 
@@ -26,35 +27,43 @@ struct TTLSetComputeKernelConfigPass
   using Base::Base;
 
   void runOnOperation() override {
-    func::FuncOp function = getOperation();
-    FailureOr<std::unique_ptr<KernelTargetEnvironment>> target =
-        KernelTargetEnvironment::get(function);
-    if (failed(target)) {
-      signalPassFailure();
-      return;
-    }
-    FailureOr<KernelConfigPolicy> policy = KernelConfigPolicy::get(
-        function, fp32DestAccEn, dstFullSyncEn, reduceFullFp32, matmulFullFp32,
-        enableFPUBinaryOps);
-    if (failed(policy)) {
-      signalPassFailure();
-      return;
+    ModuleOp module = getOperation();
+    LaunchNodeDomainState launchDomains;
+    launchDomains.initialize(module);
+
+    SmallVector<std::pair<func::FuncOp, KernelConfigPlan>> plans;
+    for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+      FailureOr<std::unique_ptr<KernelTargetEnvironment>> target =
+          KernelTargetEnvironment::get(function);
+      if (failed(target)) {
+        signalPassFailure();
+        return;
+      }
+      FailureOr<KernelConfigPolicy> policy = KernelConfigPolicy::get(
+          function, fp32DestAccEn, dstFullSyncEn, reduceFullFp32,
+          matmulFullFp32, enableFPUBinaryOps);
+      if (failed(policy)) {
+        signalPassFailure();
+        return;
+      }
+      FailureOr<KernelRequirements> requirements =
+          collectKernelRequirements(function, launchDomains);
+      if (failed(requirements)) {
+        signalPassFailure();
+        return;
+      }
+      FailureOr<KernelConfigPlan> plan =
+          resolveKernelConfig(function, **target, *policy, *requirements);
+      if (failed(plan)) {
+        signalPassFailure();
+        return;
+      }
+      plans.emplace_back(function, std::move(*plan));
     }
 
-    FailureOr<KernelRequirements> requirements =
-        collectKernelRequirements(function);
-    if (failed(requirements)) {
-      signalPassFailure();
-      return;
+    for (auto &[function, plan] : plans) {
+      applyKernelConfigPlan(function, plan);
     }
-
-    FailureOr<KernelConfigPlan> plan =
-        resolveKernelConfig(function, **target, *policy, *requirements);
-    if (failed(plan)) {
-      signalPassFailure();
-      return;
-    }
-    applyKernelConfigPlan(function, *plan);
   }
 };
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -2301,7 +2301,7 @@ def _lower_program_to_kernel(
         verify = True
 
         # fmt: off
-        set_compute_config_pass = "func.func(ttl-set-compute-kernel-config)"
+        set_compute_config_pass = "ttl-set-compute-kernel-config"
         config_options = []
         if fp32_dest_acc_en is not None:
             config_options.append(
@@ -2324,9 +2324,9 @@ def _lower_program_to_kernel(
         )
         if config_options:
             set_compute_config_pass = (
-                "func.func(ttl-set-compute-kernel-config{"
+                "ttl-set-compute-kernel-config{"
                 + " ".join(config_options)
-                + "})"
+                + "}"
             )
 
         # NOTE: Pipeline pass ordering mirrors

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -196,6 +196,43 @@ def _make_exact_execution_domain_kernel(data_format):
     return exact_execution_domain_kernel
 
 
+@ttl.operation(grid=(2, 1))
+def _incompatible_static_configuration_kernel(input_tensor, output_tensor):
+    first_input_dfb = ttl.make_dfb("float32", shape=(1, 1), block_count=2)
+    second_input_dfb = ttl.make_dfb("float32", shape=(1, 1), block_count=2)
+    output_dfb = ttl.make_dfb("float32", shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute():
+        node_x, _ = ttl.node(dims=2)
+        if node_x == 0:
+            with first_input_dfb.wait() as input_block:
+                with output_dfb.reserve() as output_block:
+                    output_block.store(ttl.exp(input_block))
+        if node_x == 1:
+            with second_input_dfb.wait() as input_block:
+                with output_dfb.reserve() as output_block:
+                    output_block.store(
+                        ttl.block.broadcast(input_block, dims=[0], shape=(1, 1))
+                    )
+
+    @ttl.datamovement()
+    def read():
+        node_x, _ = ttl.node(dims=2)
+        if node_x == 0:
+            with first_input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0, 0], input_block).wait()
+        if node_x == 1:
+            with second_input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0, 1], input_block).wait()
+
+    @ttl.datamovement()
+    def write():
+        node_x, _ = ttl.node(dims=2)
+        with output_dfb.wait() as output_block:
+            ttl.copy(output_block, output_tensor[0, node_x]).wait()
+
+
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
@@ -426,6 +463,42 @@ def test_exact_disjoint_execution_domains_reuse_dfb(
         assert_allclose(actual, expected, rtol=0.05, atol=1.0)
     else:
         assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_disjoint_incompatible_static_configurations_do_not_reuse_dfb(
+    device, memory_config, to_device, monkeypatch, tmp_path
+):
+    # Only FP32 requires distinct unpack modes for exponential and broadcast.
+    first_input = (
+        torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE) / 2048
+    )
+    second_input = torch.zeros((TILE, TILE), dtype=torch.float32)
+    second_input[0, :] = torch.arange(TILE, dtype=torch.float32) / 32
+    input_host = torch.cat((first_input, second_input), dim=1)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_path = tmp_path / "incompatible_static_configurations.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    _incompatible_static_configuration_kernel(
+        input_tensor, output_tensor, options="--ttl-reuse-user-dfbs"
+    )
+
+    # The two input DFBs are active on disjoint nodes, but their unpack modes
+    # require distinct physical indices. The output DFB adds a third index.
+    physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
+    assert physical_dfb_count == 3
+
+    first_expected = torch.exp(first_input)
+    second_expected = second_input[0:1, :].expand(TILE, TILE)
+    expected = torch.cat((first_expected, second_expected), dim=1)
+    actual = ttnn.to_torch(output_tensor).float()
+    assert_allclose(actual, expected.float(), rtol=2e-3, atol=5e-4)
 
 
 @pytest.mark.parametrize(

--- a/test/ttlang/Conversion/TTLToCompute/dst_assignment.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/dst_assignment.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst),canonicalize)' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst),canonicalize)' | FileCheck %s
 
 // Test: token-based lowering with dst_idx annotations on math ops.
 // Disabling FPU selection makes binary operands use DST.

--- a/test/ttlang/Conversion/TTLToCompute/elementwise_basic.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/elementwise_basic.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst),cse,canonicalize)' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst),cse,canonicalize)' | FileCheck %s
 
 // Basic elementwise operations lowered to ttl.compute with tile ops and DST assignment.
 // Disabling FPU selection makes binary operands use DST.

--- a/test/ttlang/Conversion/TTLToCompute/elementwise_coverage.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/elementwise_coverage.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst),cse,canonicalize)' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst),cse,canonicalize)' | FileCheck %s
 
 // Disabling FPU selection makes binary operands use DST.
 // Test: Binary elementwise operations lower to ttl.compute with tile ops

--- a/test/ttlang/Conversion/TTLToSCF/materialized_multi_output_reduce.mlir
+++ b/test/ttlang/Conversion/TTLToSCF/materialized_multi_output_reduce.mlir
@@ -1,7 +1,7 @@
 // Verifies that materializing a published reduction adds a second compute
 // output and that accumulating-loop lowering selects each formal output map.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute,ttl-set-compute-kernel-config,ttl-assign-dst,ttl-lower-to-loops{dst-accumulation=true}))' | FileCheck %s
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute,ttl-set-compute-kernel-config,ttl-assign-dst,ttl-lower-to-loops{dst-accumulation=true}))' | FileCheck %s --check-prefix=NO-COMPUTE
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute),ttl-set-compute-kernel-config,func.func(ttl-assign-dst,ttl-lower-to-loops{dst-accumulation=true}))' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-create-producer-compute,ttl-insert-intermediate-dfbs,convert-ttl-to-compute),ttl-set-compute-kernel-config,func.func(ttl-assign-dst,ttl-lower-to-loops{dst-accumulation=true}))' | FileCheck %s --check-prefix=NO-COMPUTE
 
 // NO-COMPUTE: module
 // NO-COMPUTE-NOT: ttl.compute

--- a/test/ttlang/Conversion/TTLToTTKernel/cb_tile_index.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/cb_tile_index.mlir
@@ -3,9 +3,7 @@
 // and reduction maps (output projection via cb_index_map attribute).
 
 // Identity map test: full pipeline.
-// RUN: ttlang-opt %s --split-input-file \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, canonicalize, cse)' \
-// RUN:   | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, canonicalize, cse)' | FileCheck %s
 
 // 2x3 output with tile loops (not unrolled): pack_tile receives
 // index from affine.linearize_index [%row, %col] by (2, 3).

--- a/test/ttlang/Conversion/TTLToTTKernel/compute_fused_chain.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/compute_fused_chain.mlir
@@ -2,14 +2,10 @@
 // Tests both FPU binary (default) and SFPU binary (disabled) paths.
 
 // FPU path (default): add uses add_tiles (reads from CB), mul uses SFPU (mixed inputs).
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=FPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=FPU
 
 // SFPU path: all binary ops use copy_tile + SFPU binary ops.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=SFPU
 
 // =============================================================================
 // FPU path checks

--- a/test/ttlang/Conversion/TTLToTTKernel/fpu_binary_lowering.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/fpu_binary_lowering.mlir
@@ -4,14 +4,10 @@
 // SFPU ops (ttkernel.add_binary_tile). FPU ops read from CBs, not DST.
 
 // FPU path (default): add_tiles reads from CB, binary_op_init_common init.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=true}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   --split-input-file | FileCheck %s --check-prefix=FPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config,func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=true},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=FPU
 
 // SFPU path: add_binary_tile reads from DST, init_sfpu init.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=true}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   --split-input-file | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=true},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SFPU
 
 // =============================================================================
 // Test 1: Simple FPU binary add (2x2 bf16)

--- a/test/ttlang/Conversion/TTLToTTKernel/matmul_block_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/matmul_block_invalid.mlir
@@ -1,9 +1,7 @@
 // Matmul outputs exceeding DST capacity are rejected when the subblock pass
 // is not in the pipeline. With subblocking enabled, these cases compile
 // successfully (tested by simple_matmul_subblock.py).
-// RUN: not ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops))' \
-// RUN:   --split-input-file 2>&1 | FileCheck %s
+// RUN: not ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops))' --split-input-file 2>&1 | FileCheck %s
 
 // bf16 DST capacity exceeded.
 // CHECK: output 3x3 with 1 DST slots per tile = 9 total slots exceeds DST capacity of 8

--- a/test/ttlang/Conversion/TTLToTTKernel/matmul_block_lowering.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/matmul_block_lowering.mlir
@@ -4,12 +4,8 @@
 // -> commit -> wait -> M*N pack_tile -> release.
 // DFB lifecycle (wait/pop/reserve/push) comes from user code, not the pass.
 
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, func.func(ttkernel-combine-pack-tiles), canonicalize, cse)' \
-// RUN:   --split-input-file | FileCheck %s --check-prefix=COMBINED
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, func.func(ttkernel-combine-pack-tiles), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=COMBINED
 
 // =============================================================================
 // Test 1: 1x1 bf16.

--- a/test/ttlang/Conversion/TTLToTTKernel/matmul_fused_postops.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/matmul_fused_postops.mlir
@@ -2,9 +2,7 @@
 // store must not be dropped. Verifies that scale * (A @ B) + bias produces
 // matmul_block followed by mul_binary_tile and add_binary_tile.
 
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' --split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_scale_bias
 // CHECK-DAG: %[[C0_I32:.*]] = arith.constant 0 : i32

--- a/test/ttlang/Conversion/TTLToTTKernel/matmul_scaled_accumulator.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/matmul_scaled_accumulator.mlir
@@ -2,12 +2,8 @@
 // matmul_block. Verifies that scale * acc is computed into DST before
 // matmul_block accumulates A @ B into the same output slots.
 
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops))' \
-// RUN:   --split-input-file | FileCheck %s --check-prefix=TTL
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   --split-input-file | FileCheck %s --check-prefix=TTK
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops))' --split-input-file | FileCheck %s --check-prefix=TTL
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=TTK
 
 // Simple scaled accumulator: out = scale * acc + (a @ b). The store must use
 // the indexed post-matmul DST slot, not the raw ranged matmul result.

--- a/test/ttlang/Conversion/TTLToTTKernel/matmul_subblock_l1_acc.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/matmul_subblock_l1_acc.mlir
@@ -3,16 +3,7 @@
 // with {accumulate} triggers L1 acc annotation and pack_reconfig_l1_acc
 // guard insertion.
 
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module( \
-// RUN:     func.func(ttl-annotate-l1-acc-loops, convert-ttl-to-compute, \
-// RUN:       ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, \
-// RUN:       ttl-subblock-compute-for-dst, \
-// RUN:       ttl-lower-to-loops{dst-accumulation=1}, ttl-schedule-operations, \
-// RUN:       ttl-annotate-cb-associations), \
-// RUN:     convert-ttl-to-ttkernel, ttkernel-insert-inits, \
-// RUN:     ttkernel-insert-l1-accumulation, canonicalize, cse)' \
-// RUN:   --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module( func.func(ttl-annotate-l1-acc-loops,convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops{dst-accumulation=1},ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, ttkernel-insert-l1-accumulation, canonicalize, cse)' --split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_3x3_k_loop
 // Disable before the K loop.

--- a/test/ttlang/Conversion/TTLToTTKernel/reduce_lowering_warning.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/reduce_lowering_warning.mlir
@@ -1,7 +1,6 @@
 // Verify configuration reports unavailable full-fp32 reduction before
 // TTKernel conversion.
-// RUN: ttlang-opt %s --verify-diagnostics \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config),convert-ttl-to-ttkernel)'
+// RUN: ttlang-opt %s --verify-diagnostics -pass-pipeline='builtin.module(ttl-set-compute-kernel-config,convert-ttl-to-ttkernel)'
 
 // Blackhole row reduction cannot use full-fp32 accumulation (tt-metal #47311).
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {

--- a/test/ttlang/Dialect/TTL/Pipelines/pipe_verifier_order.mlir
+++ b/test/ttlang/Dialect/TTL/Pipelines/pipe_verifier_order.mlir
@@ -29,6 +29,7 @@
 // CHECK-NEXT:   ttl-coalesce-dfb-acquires
 // CHECK-NEXT: ),
 // CHECK-NEXT: ttl-finalize-dfb-indices{exact-coloring-search-limit=1000000 reuse-user-dfbs=true},
+// CHECK-NEXT: ttl-set-compute-kernel-config{{.*}},
 // CHECK-NEXT: func.func(
 // CHECK-NOT:    ttl-verify-pipenet-guards
 // CHECK-NOT:    ttl-verify-pipenet-schedule

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_4d_tensor.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_4d_tensor.mlir
@@ -1,7 +1,7 @@
 // Summary: verify DST assignment and copy insertion on 4D tensors
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SFPU
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_add_mul_exp_chain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_add_mul_exp_chain.mlir
@@ -1,6 +1,6 @@
 // Summary: three-op chain (add -> mul -> exp) with DST register reuse.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_bcast_cb_input.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_bcast_cb_input.mlir
@@ -1,5 +1,5 @@
 // Summary: tile_bcast reads from CB (not DST), so no copy_tile for its input.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_binary_inplace.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_binary_inplace.mlir
@@ -3,7 +3,7 @@
 // is clobbered. When both max and min share operands, copies must be inserted
 // to prevent one op from destroying the other's inputs.
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}))' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}))' --split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_capacity_combinations.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_capacity_combinations.mlir
@@ -15,8 +15,7 @@
 // | false     | true       | 16       | 16            |
 // | true      | true       | 8        | 8             |
 //
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))' --split-input-file \
-// RUN:   | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst))' --split-input-file | FileCheck %s
 
 // bf16, double-buffered (default): capacity=8, unroll_factor=8.
 // CHECK-LABEL: func.func @bf16_double_buffer

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_copy_dst_intermediate.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_copy_dst_intermediate.mlir
@@ -15,7 +15,7 @@
 //   rsqrt(abs)       -> DST[1]  (in-place on abs result)
 //   mul(x, rsqrt)    -> DST[0]  (SFPU binary, consumes original x at DST[0])
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize)' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize)' | FileCheck %s
 
 // CHECK-LABEL: func.func @dst_intermediate_reuse_unary_chain
 // CHECK:           ttl.compute

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_copy_tile_cb_trait.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_copy_tile_cb_trait.mlir
@@ -1,7 +1,7 @@
 // Summary: copy_tile has TTLCBInputTileOpTrait so its input is excluded from
 // DST liveness (reads from CB, not DST). Verify no redundant copy insertion
 // and correct interval behavior when copy_tile coexists with compute ops.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_corner_cases.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_corner_cases.mlir
@@ -1,6 +1,6 @@
 // Summary: Corner case tests for DST allocation edge cases not covered elsewhere.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8 separate-output-region=1}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_f32_capacity.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_f32_capacity.mlir
@@ -1,6 +1,6 @@
 // Summary: Verify f32 compute ops use reduced DST capacity.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst),canonicalize,cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=OVERRIDE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst),canonicalize,cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=OVERRIDE
 
 #idx_map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_f32_capacity_regression.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_f32_capacity_regression.mlir
@@ -1,6 +1,4 @@
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))' \
-// RUN:   | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst))' | FileCheck %s
 //
 // Verify that f32 tiles get the correct DST capacity (4, not the bf16
 // default of 8). With dstPerIteration = 2 (SFPU binary: copy lhs + copy rhs),

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_fpu_binary.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_fpu_binary.mlir
@@ -2,9 +2,9 @@
 // operations read both operands from DFBs and consume no DST input slots,
 // increasing the available unroll factor for simple binary computations.
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8 separate-output-region=1}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SFPU
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_inplace_merge.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_inplace_merge.mlir
@@ -1,6 +1,6 @@
 // Summary: In-place SFPU ops merge dst_idx with their copy_tile source.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize,cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_matmul_accumulator.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_matmul_accumulator.mlir
@@ -1,6 +1,6 @@
 // Verify the matmul accumulator and result share a DST register. Matmul
 // lowering initializes that register from the accumulator tensor.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize,cse)' | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_multi_use_patterns.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_multi_use_patterns.mlir
@@ -2,8 +2,8 @@
 // and fan-out scenarios to ensure the DST allocator correctly handles values
 // used by multiple operations without clobbering live registers.
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}),canonicalize)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}),canonicalize)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8 separate-output-region=1}),canonicalize)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_register_reuse.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_register_reuse.mlir
@@ -1,6 +1,6 @@
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=4}), canonicalize, cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=4 separate-output-region=1}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=4}))' -debug-only=ttl-assign-dst --split-input-file 2>&1 | FileCheck %s --check-prefix=DEBUG
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=4}), canonicalize, cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=4 separate-output-region=1}), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=4}))' -debug-only=ttl-assign-dst --split-input-file 2>&1 | FileCheck %s --check-prefix=DEBUG
 
 // Verify no placeholder copies remain in final IR (they should all be replaced)
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_seven_op_chain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_seven_op_chain.mlir
@@ -1,7 +1,7 @@
 // Summary: Seven-operation fused chain to verify DST allocation handles long chains.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8 separate-output-region=1}), canonicalize, cse)' | FileCheck %s --check-prefix=SEPARATE
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8 separate-output-region=1}), canonicalize, cse)' | FileCheck %s --check-prefix=SEPARATE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}), canonicalize, cse)' | FileCheck %s --check-prefix=SFPU
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_tile_regs_acquire.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/dst_tile_regs_acquire.mlir
@@ -1,7 +1,7 @@
 // Summary: ensure DST assignment and tile_regs sync are correctly inserted in ttl.compute.
 // FPU binary ops (both operands from CB block args) skip copy_tile insertion.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst), canonicalize, cse)' --split-input-file | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst), canonicalize, cse)' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst), canonicalize, cse)' --split-input-file | FileCheck %s --check-prefix=SFPU
 
 // Verify no placeholder copies remain in final IR
 // CHECK-NOT: placeholder

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_capacity_overflow_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_capacity_overflow_invalid.mlir
@@ -1,5 +1,5 @@
 // Summary: capacity overflow should emit a clear diagnostic.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=2}))' --split-input-file --verify-diagnostics
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=2}))' --split-input-file --verify-diagnostics
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_f32_idx4_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_f32_idx4_invalid.mlir
@@ -1,5 +1,5 @@
 // Summary: f32 capacity overflow should fail before allocating dst_idx 4 (default with double buffering).
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))' --verify-diagnostics
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst))' --verify-diagnostics
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_mixed_dtypes_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_mixed_dtypes_invalid.mlir
@@ -1,6 +1,5 @@
 // Negative test: mixed f32 and non-f32 tile arguments in compute.
-// RUN: ttlang-opt %s --verify-diagnostics \
-// RUN:   --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))'
+// RUN: ttlang-opt %s --verify-diagnostics --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst))'
 
 #idx_map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_separate_output_region_overflow_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_separate_output_region_overflow_invalid.mlir
@@ -1,6 +1,6 @@
 // Summary: separate-output-region=1 with small capacity overflows when enough
 // unary results are simultaneously live.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=2 separate-output-region=1}))' --verify-diagnostics
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=2 separate-output-region=1}))' --verify-diagnostics
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_typecast_stray_mixed_dtypes_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/invalid/dst_typecast_stray_mixed_dtypes_invalid.mlir
@@ -1,6 +1,5 @@
 // Summary: Mixed input tile dtypes are rejected when only part of the mix is an explicit typecast.
-// RUN: ttlang-opt %s --verify-diagnostics \
-// RUN:   --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))'
+// RUN: ttlang-opt %s --verify-diagnostics --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst))'
 
 #idx_map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/separate_output_region_merged_set.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/separate_output_region_merged_set.mlir
@@ -3,8 +3,8 @@
 // region when the leader value is not yielded, even though one of its merged partners
 // IS yielded. The fix ensures Phase 3 skips merged sets if ANY member is yielded.
 //
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{separate-output-region=1}))' -debug-only=ttl-assign-dst 2>&1 | FileCheck %s
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{separate-output-region=1}), canonicalize, cse)' | FileCheck %s --check-prefix=IR
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{separate-output-region=1}))' -debug-only=ttl-assign-dst 2>&1 | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{separate-output-region=1}), canonicalize, cse)' | FileCheck %s --check-prefix=IR
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/AssignDST/unary_chain_merging.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/AssignDST/unary_chain_merging.mlir
@@ -1,5 +1,5 @@
 // Summary: Test unary operation interval merging - verify live intervals via LLVM_DEBUG.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))' -debug-only=ttl-assign-dst --split-input-file 2>&1 | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst))' -debug-only=ttl-assign-dst --split-input-file 2>&1 | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/bcast_init_grouping.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/bcast_init_grouping.mlir
@@ -1,6 +1,4 @@
-// RUN: ttlang-opt %s --split-input-file \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config, ttl-assign-dst, ttl-subblock-compute-for-dst, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config,func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s
 
 // Purpose: Test that the scheduler groups bcast ops by type (COL/ROW/SCALAR)
 // and the consolidation pass emits exactly one init per group.

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_dst_hazards.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_dst_hazards.mlir
@@ -1,6 +1,4 @@
-// RUN: ttlang-opt %s --split-input-file \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=CHECK-WAR
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=CHECK-WAR
 
 // Purpose: Regression test for WAR (Write-After-Read) hazard in DST scheduling.
 //

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_edge_cases.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_edge_cases.mlir
@@ -2,14 +2,10 @@
 // and multi-type chains that exercise different scheduler code paths.
 
 // FPU path (default): binary add uses add_tiles (reads from CB).
-// RUN: ttlang-opt %s --split-input-file \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=FPU
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=FPU
 
 // SFPU path: binary add uses copy_tile + add_binary_tile.
-// RUN: ttlang-opt %s --split-input-file \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=SFPU
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_operations.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_operations.mlir
@@ -1,18 +1,12 @@
 // FPU path (default): add uses add_tiles (0 DST input slots), dstPerIteration=1 (exp only).
 // All 4 tiles fit in one subblock (no outer loop). add_tiles grouped, then exp grouped.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=true}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=FPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=true},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=FPU
 
 // SFPU path: add uses copy_tile + add_binary_tile (dstPerIteration=2).
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=true}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=true},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=SFPU
 
 // subblock-sync disabled (default): reserve/push stays at outer level.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=false}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=MANUAL
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=false},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=MANUAL
 
 // Purpose: Integration test for ttl-schedule-operations with init consolidation.
 // Verifies: add + exp fused compute on 2x2 grid produces grouped ops with

--- a/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_subblock.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/ScheduleOperations/schedule_subblock.mlir
@@ -1,19 +1,13 @@
 // FPU path (default): add uses add_tiles (0 DST input slots), dstPerIteration=1 (tanh only).
 // unrollFactor = min(4, 6) = 4. Subblock [1, 3] = 3 tiles fits in f32 capacity.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=true}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=FPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=true},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=FPU
 
 // SFPU path: add uses copy_tile + add_binary_tile (2 DST input slots), dstPerIteration=2.
 // unrollFactor = min(2, 6) = 2. Subblock [2, 1] = 2 tiles.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=true}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=SFPU
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=true},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=SFPU
 
 // subblock-sync disabled: reserve/push stays at outer level.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst{subblock-sync=false}, ttl-lower-to-loops, ttl-schedule-operations, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' \
-// RUN:   | FileCheck %s --check-prefix=MANUAL
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{subblock-sync=false},ttl-lower-to-loops,ttl-schedule-operations,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse)' | FileCheck %s --check-prefix=MANUAL
 
 // =============================================================================
 // FPU path: 3 tiles per subblock, outer loop over 2 rows.

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/broadcast_dst_mode_invalid.mlir
@@ -1,7 +1,7 @@
 // Verify that non-f32 broadcasts reject f32 DST mode on every architecture
 // and broadcast dimension whose LLK ignores that configuration, including an
 // automatic conflict with an f32 SFPU operation.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file --verify-diagnostics
 
 module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
   // expected-error @below {{'func.func' op explicit 32-bit destination elements are unsupported by the kernel's tile operations}}

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/direct_tile_execution.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/direct_tile_execution.mlir
@@ -1,6 +1,6 @@
 // Verify direct tile operations in nested regions use the same strategy and
 // dataflow-buffer resolution as operations in ttl.compute.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0})' | FileCheck %s
 
 // CHECK-LABEL: func.func @nested_direct_tile_ops
 // CHECK-SAME: fp32_dest_acc_en = true

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/integer_destination_width.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/integer_destination_width.mlir
@@ -1,5 +1,5 @@
 // Summary: Verify integer compute types select the required destination width.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options.mlir
@@ -1,6 +1,6 @@
 // Verify explicit pass policy selects one complete kernel configuration.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=enabled}))' | FileCheck %s --check-prefix=ENABLED
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=disabled dst-full-sync-en=disabled}))' | FileCheck %s --check-prefix=DISABLED
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{fp32-dest-acc-en=enabled dst-full-sync-en=enabled})' | FileCheck %s --check-prefix=ENABLED
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{fp32-dest-acc-en=disabled dst-full-sync-en=disabled})' | FileCheck %s --check-prefix=DISABLED
 
 // ENABLED-LABEL: func.func @policy_options
 // ENABLED-SAME: dst_full_sync_en = true

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/policy_options_invalid.mlir
@@ -1,5 +1,5 @@
 // Verify an invalid three-state policy value is rejected.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=invalid}))' --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{fp32-dest-acc-en=invalid})' --verify-diagnostics
 
 // expected-error @below {{invalid fp32-dest-acc-en value 'invalid'; expected auto, enabled, or disabled}}
 func.func @invalid_policy_option() {

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/post_lower_to_loops.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/post_lower_to_loops.mlir
@@ -1,6 +1,6 @@
 // Verify configuration analysis accepts tensor-of-tile operands produced by
 // ttl-lower-to-loops when a pipeline re-runs configuration analysis.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0},ttl-assign-dst,ttl-lower-to-loops,ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops),ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0})' | FileCheck %s
 
 #identity = affine_map<(tileRow, tileColumn) -> (tileRow, tileColumn)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_explicit_disabled.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_explicit_disabled.mlir
@@ -1,6 +1,6 @@
 // Verify an explicit 16-bit DST constraint overrides a supported full-fp32
 // preference without warning about the requested fallback.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --verify-diagnostics | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --verify-diagnostics | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_fallback.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/preferred_fp32_fallback.mlir
@@ -1,7 +1,7 @@
 // Verifies a supported full-fp32 preference emits a warning when another
 // kernel requirement forces 16-bit destination elements.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --verify-diagnostics
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
@@ -1,11 +1,11 @@
 // Verify kernel configuration resolution from operation requirements, target
 // capabilities, and pass policy.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s --check-prefix=DEFAULT
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0}))' --split-input-file | FileCheck %s --check-prefix=NO-MATMUL-FP32
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{reduce-full-fp32=0}))' --split-input-file | FileCheck %s --check-prefix=NO-REDUCE-FP32
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0}))' --split-input-file | FileCheck %s --check-prefix=FPUOFF
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s --check-prefix=BLACKHOLE
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s --check-prefix=WORMHOLE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file | FileCheck %s --check-prefix=DEFAULT
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{matmul-full-fp32=0})' --split-input-file | FileCheck %s --check-prefix=NO-MATMUL-FP32
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{reduce-full-fp32=0})' --split-input-file | FileCheck %s --check-prefix=NO-REDUCE-FP32
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0})' --split-input-file | FileCheck %s --check-prefix=FPUOFF
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file | FileCheck %s --check-prefix=BLACKHOLE
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file | FileCheck %s --check-prefix=WORMHOLE
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
@@ -1,6 +1,6 @@
 // Verify invalid targets, policy constraints, and execution strategies are
 // diagnosed before kernel configuration mutates the IR.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' --split-input-file --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0})' --split-input-file --verify-diagnostics
 
 // expected-error @below {{'builtin.module' op ttl.target_arch must be a #ttcore.arch attribute}}
 module attributes {ttl.target_arch = "blackhole"} {

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_conflict_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_conflict_invalid.mlir
@@ -1,6 +1,6 @@
 // Verify that fixed execution requirements using one f32 dataflow buffer are
 // rejected when they require incompatible unpack modes.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file --verify-diagnostics
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file --verify-diagnostics
 
 // SFPU operations consume f32 input through DST, while tile_bcast requires the
 // default unpack mode. Neither operation has an alternative execution strategy.

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_inert.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_inert.mlir
@@ -1,7 +1,7 @@
 // Verify explicit unpack-to-DST-f32 entries for non-f32 dataflow buffers do not
 // require 32-bit destination elements.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s --check-prefix=AUTO
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{fp32-dest-acc-en=disabled matmul-full-fp32=0 reduce-full-fp32=0}))' | FileCheck %s --check-prefix=DISABLED
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{matmul-full-fp32=0 reduce-full-fp32=0})' | FileCheck %s --check-prefix=AUTO
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{fp32-dest-acc-en=disabled matmul-full-fp32=0 reduce-full-fp32=0})' | FileCheck %s --check-prefix=DISABLED
 
 // A fixed SFPU consumer ignores the f32 route entry for bf16.
 // AUTO-LABEL: func.func @bf16_sfpu_unary

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_negative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_negative.mlir
@@ -1,5 +1,5 @@
 // Verify DFB inputs that do not unpack through DST retain default mode.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_positive.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_positive.mlir
@@ -1,5 +1,5 @@
 // Verify f32 DFB inputs consumed through DST select unpack-to-DST-f32 mode.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/unpack_to_dest_fp32_strategy_resolution.mlir
@@ -1,6 +1,6 @@
 // Verify that execution strategy selection and f32 unpack configuration are
 // resolved together across the complete compute kernel.
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config))' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config)' --split-input-file | FileCheck %s
 
 // A binary operation with FPU/SFPU alternatives selects SFPU when a fixed
 // SFPU consumer requires unpack-to-DST mode for the same dataflow buffer.

--- a/test/ttlang/Dialect/TTL/Transforms/convert_ttl_to_compute_multi_output.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/convert_ttl_to_compute_multi_output.mlir
@@ -4,7 +4,7 @@
 // Covers: binary, unary, fused chains, 3 outputs, and larger shapes.
 
 // RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute))' | FileCheck %s --check-prefix=COMPUTE
-// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config,ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,canonicalize,cse))' | FileCheck %s --check-prefix=DST
+// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config,func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,ttl-lower-to-loops,canonicalize,cse))' | FileCheck %s --check-prefix=DST
 
 // ---- Test 1: Binary add, 1x1 shape, 2 outputs ----
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_static_configuration_compatibility.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_static_configuration_compatibility.mlir
@@ -1,0 +1,198 @@
+// Tests static compute-configuration constraints on physical DFB reuse.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=REUSE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices 2>&1 | FileCheck %s --check-prefix=REPORT
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefix=NO-REUSE
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true},ttl-set-compute-kernel-config)' | FileCheck %s --check-prefix=CONFIG
+
+// Disjoint launch-node domains do not permit f32 DFBs with incompatible
+// unpack modes to share one physical index.
+
+// REUSE-LABEL: func.func @disjoint_incompatible_configuration
+// REUSE: %[[SFPU:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: %[[BCAST:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+// REPORT: DFB conflict lhs=0 rhs=1 reason=static-configuration-mismatch
+
+// NO-REUSE-LABEL: func.func @disjoint_incompatible_configuration
+// NO-REUSE: %[[SFPU:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// NO-REUSE-NEXT: %[[BCAST:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @disjoint_incompatible_configuration()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %sfpu_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %bcast_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %node_x = ttl.core_x : index
+    %first_node = arith.cmpi eq, %node_x, %zero : index
+    scf.if %first_node {
+      %sfpu_wait = ttl.cb_wait %sfpu_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %sfpu_attached = ttl.attach_cb %sfpu_wait, %sfpu_dfb
+          : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %sfpu_tile = tensor.extract %sfpu_attached[%zero, %zero]
+          : tensor<1x1x!ttcore.tile<32x32, f32>>
+      %exponential = ttl.tile_exp %sfpu_tile into dst[%zero]
+          : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+      ttl.cb_pop %sfpu_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    }
+    %second_node = arith.cmpi eq, %node_x, %one : index
+    scf.if %second_node {
+      %bcast_wait = ttl.cb_wait %bcast_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %bcast_attached = ttl.attach_cb %bcast_wait, %bcast_dfb
+          : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %bcast_tile = tensor.extract %bcast_attached[%zero, %zero]
+          : tensor<1x1x!ttcore.tile<32x32, f32>>
+      %broadcast = ttl.tile_bcast %bcast_tile, %bcast_tile 1 : i32
+          into dst[%zero]
+          : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>)
+            -> !ttcore.tile<32x32, f32>
+      ttl.cb_pop %bcast_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// Disjoint launch-node domains still permit DFBs with identical static
+// compute configurations to share one physical index.
+
+// REUSE-LABEL: func.func @disjoint_compatible_configuration
+// REUSE: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// REUSE-NEXT: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 3 : index}
+
+// REPORT-NOT: DFB conflict lhs=2 rhs=3 reason=static-configuration-mismatch
+
+// NO-REUSE-LABEL: func.func @disjoint_compatible_configuration
+// NO-REUSE: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// NO-REUSE-NEXT: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 3 : index}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @disjoint_compatible_configuration()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 3 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %node_x = ttl.core_x : index
+    %first_node = arith.cmpi eq, %node_x, %zero : index
+    scf.if %first_node {
+      %first_wait = ttl.cb_wait %first_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %first_attached = ttl.attach_cb %first_wait, %first_dfb
+          : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %first_tile = tensor.extract %first_attached[%zero, %zero]
+          : tensor<1x1x!ttcore.tile<32x32, f32>>
+      %first_exp = ttl.tile_exp %first_tile into dst[%zero]
+          : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+      ttl.cb_pop %first_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    }
+    %second_node = arith.cmpi eq, %node_x, %one : index
+    scf.if %second_node {
+      %second_wait = ttl.cb_wait %second_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %second_attached = ttl.attach_cb %second_wait, %second_dfb
+          : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %second_tile = tensor.extract %second_attached[%zero, %zero]
+          : tensor<1x1x!ttcore.tile<32x32, f32>>
+      %second_exp = ttl.tile_exp %second_tile into dst[%zero]
+          : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+      ttl.cb_pop %second_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// An incompatible operation in a zero-trip loop does not constrain a physical
+// DFB used by active operations.
+
+// REUSE-LABEL: func.func @exact_empty_configuration_is_ignored
+// REUSE: %[[ACTIVE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 4 : index}
+// REUSE-NEXT: %[[INACTIVE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 5 : index}
+
+// CONFIG-LABEL: func.func @exact_empty_configuration_is_ignored
+// CONFIG: ttl.tile_add {{.*}}ttl.tile_execution_strategy = #ttl.tile_execution_strategy<fpu>
+
+// REPORT-NOT: DFB conflict lhs=4 rhs=5 reason=static-configuration-mismatch
+
+// NO-REUSE-LABEL: func.func @exact_empty_configuration_is_ignored
+// NO-REUSE: %[[ACTIVE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 4 : index}
+// NO-REUSE-NEXT: %[[INACTIVE:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 5 : index}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @exact_empty_configuration_is_ignored()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %active_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 4 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %inactive_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 5 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %active_wait = ttl.cb_wait %active_dfb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %active_attached = ttl.attach_cb %active_wait, %active_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %active_tile = tensor.extract %active_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, f32>>
+    %active_exp = ttl.tile_exp %active_tile into dst[%zero]
+        : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    ttl.cb_pop %active_dfb
+        : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %node_x = ttl.core_x : index
+    %outside_launch_grid = arith.cmpi eq, %node_x, %two : index
+    scf.if %outside_launch_grid {
+      %inactive_wait = ttl.cb_wait %inactive_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %inactive_attached = ttl.attach_cb %inactive_wait, %inactive_dfb
+          : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %inactive_tile = tensor.extract %inactive_attached[%zero, %zero]
+          : tensor<1x1x!ttcore.tile<32x32, f32>>
+      %inactive_add = ttl.tile_add %inactive_tile, %inactive_tile into dst[%zero]
+          : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+            -> !ttcore.tile<32x32, f32>
+      ttl.cb_pop %inactive_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_static_configuration_noncompute.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_static_configuration_noncompute.mlir
@@ -1,0 +1,21 @@
+// Tests that DFB static-configuration analysis ignores non-compute kernels.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// A NOC-only module does not require a compute-target environment. Quasar
+// allocation analysis therefore remains independent of unsupported compute
+// configuration and launch APIs.
+
+// CHECK-LABEL: func.func @noc_only
+// CHECK: %[[DFB:.*]] = ttl.bind_cb{cb_index = 0, block_count = 1}
+
+module attributes {ttl.target_arch = #ttcore.arch<quasar>} {
+  func.func @noc_only()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 1 : i32,
+                  ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_before_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_before_config.mlir
@@ -1,6 +1,6 @@
 // Summary: Verify compute configuration captures finalized physical DFB indices.
 //
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false},func.func(ttl-set-compute-kernel-config))' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false},ttl-set-compute-kernel-config)' | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_order_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_order_invalid.mlir
@@ -1,6 +1,6 @@
 // Verifies that DFB finalization rejects attributes containing copied
 // provisional indices from passes that must run after finalization.
-// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config),ttl-finalize-dfb-indices)'
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-set-compute-kernel-config,ttl-finalize-dfb-indices)'
 
 // Compute configuration copies an f32 input DFB index to the kernel.
 // expected-error @below {{'func.func' op contains derived DFB-index attribute 'ttl.unpack_to_dest_fp32' before DFB index finalization}}

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_compute_edge_cases.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_compute_edge_cases.mlir
@@ -1,6 +1,6 @@
 // Tests for subblock compute edge cases not covered by the main subblock test.
 //
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=4},ttl-subblock-compute-for-dst))' --split-input-file | FileCheck %s --check-prefix=TILED
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=4},ttl-subblock-compute-for-dst))' --split-input-file | FileCheck %s --check-prefix=TILED
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_compute_for_dst.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_compute_for_dst.mlir
@@ -3,11 +3,11 @@
 // ttl-subblock-compute-for-dst partitions the compute into subblocks.
 // Multi-dimensional tensors are tiled across multiple dimensions.
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8}))' --split-input-file | FileCheck %s --check-prefix=ASSIGN
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=8},ttl-subblock-compute-for-dst,canonicalize,cse))' --split-input-file | FileCheck %s --check-prefix=TILED
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8}))' --split-input-file | FileCheck %s --check-prefix=ASSIGN
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=8},ttl-subblock-compute-for-dst,canonicalize,cse))' --split-input-file | FileCheck %s --check-prefix=TILED
 // Actual DST capacity (no override) for tests where strategy selection matters:
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst))' --split-input-file | FileCheck %s --check-prefix=BCAST-ASSIGN
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst,ttl-subblock-compute-for-dst,canonicalize,cse))' --split-input-file | FileCheck %s --check-prefix=BCAST-TILED
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst))' --split-input-file | FileCheck %s --check-prefix=BCAST-ASSIGN
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,canonicalize,cse))' --split-input-file | FileCheck %s --check-prefix=BCAST-TILED
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_matmul.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_matmul.mlir
@@ -3,7 +3,7 @@
 // tiles count toward the DST budget. Subblocking partitions the M*N output
 // space while keeping K whole in each subblock.
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute, ttl-set-compute-kernel-config, ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-subblock-compute-for-dst))' --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst))' --split-input-file | FileCheck %s
 
 // -----
 

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_multi_output.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_multi_output.mlir
@@ -5,7 +5,7 @@
 // Shape: 4x4 bf16 (capacity=8). Multi-dim tiling: tileSizes=[2,4], product=8.
 // Loop on dim 0 (0 to 4 step 2). Stride 4 for dim 0 offset.
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config,ttl-assign-dst,ttl-subblock-compute-for-dst,canonicalize,cse))' | FileCheck %s --check-prefix=SUBBLOCK
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config,func.func(ttl-assign-dst,ttl-subblock-compute-for-dst,canonicalize,cse))' | FileCheck %s --check-prefix=SUBBLOCK
 
 // SUBBLOCK-LABEL: func.func @fused_compute
 // Verify three separate scf.for loops with inner ttl.compute ops (one per

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_multi_reserve_skip.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_multi_reserve_skip.mlir
@@ -2,9 +2,7 @@
 // multiple reserves or multiple pushes. The subblock tiling itself should still
 // happen, but the original reserve/push ops must be preserved.
 //
-// RUN: ttlang-opt %s \
-// RUN:   --pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst{dst-capacity=4},ttl-subblock-compute-for-dst{subblock-sync=true}))' \
-// RUN:   --split-input-file | FileCheck %s
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst{dst-capacity=4},ttl-subblock-compute-for-dst{subblock-sync=true}))' --split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_remainder.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_remainder.mlir
@@ -4,7 +4,7 @@
 // Multi-dim tiling finds tileSizes=[1,3] (product=3), producing 3 subblocks
 // of 3 tiles each with constant loop bounds. Loop on dim 0 (0 to 3 step 1).
 
-// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config,ttl-assign-dst,ttl-subblock-compute-for-dst),canonicalize,cse)' | FileCheck %s --check-prefix=SUBBLOCK
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config,func.func(ttl-assign-dst,ttl-subblock-compute-for-dst),canonicalize,cse)' | FileCheck %s --check-prefix=SUBBLOCK
 
 // SUBBLOCK-LABEL: func.func @remainder_3x3
 // SUBBLOCK-DAG:     %[[C0:.*]] = arith.constant 0 : index

--- a/test/ttlang/Dialect/TTL/Transforms/subblock_strict_f32_acc_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/subblock_strict_f32_acc_invalid.mlir
@@ -3,12 +3,7 @@
 // output requires subblocking, because bf16 L1 intermediates truncate f32
 // DST partial sums per K step.
 
-// RUN: ttlang-opt %s \
-// RUN:   --pass-pipeline='builtin.module(func.func( \
-// RUN:     ttl-annotate-l1-acc-loops, convert-ttl-to-compute, \
-// RUN:     ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, \
-// RUN:     ttl-subblock-compute-for-dst{strict-f32-acc=true}))' \
-// RUN:   --verify-diagnostics --split-input-file
+// RUN: ttlang-opt %s --pass-pipeline='builtin.module(func.func(ttl-annotate-l1-acc-loops,convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-subblock-compute-for-dst{strict-f32-acc=true}))' --verify-diagnostics --split-input-file
 
 // bf16 output 3x3 = 9 tiles exceeds f32 DST capacity (4): should error.
 

--- a/test/ttlang/Translate/TTLToCpp/compute_fused_chain_to_cpp.mlir
+++ b/test/ttlang/Translate/TTLToCpp/compute_fused_chain_to_cpp.mlir
@@ -1,15 +1,11 @@
 // FPU path (default): add uses add_tiles (reads from CB), mul uses SFPU.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' \
-// RUN:   -o %t.ttkernel.mlir
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' -o %t.ttkernel.mlir
 // RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.ttkernel.mlir -o %t.emitc.mlir
 // RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
 // RUN: FileCheck %s --input-file=%t.cpp --check-prefix=FPU
 
 // SFPU path: all binary ops use copy_tile + SFPU binary ops.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' \
-// RUN:   -o %t.sfpu.ttkernel.mlir
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' -o %t.sfpu.ttkernel.mlir
 // RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.sfpu.ttkernel.mlir -o %t.sfpu.emitc.mlir
 // RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.sfpu.cpp %t.sfpu.emitc.mlir
 // RUN: FileCheck %s --input-file=%t.sfpu.cpp --check-prefix=SFPU

--- a/test/ttlang/Translate/TTLToCpp/compute_with_data_movement.mlir
+++ b/test/ttlang/Translate/TTLToCpp/compute_with_data_movement.mlir
@@ -1,15 +1,11 @@
 // FPU path (default): add uses add_tiles (reads from CB), no copy_tile for add.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,canonicalize,cse,lower-affine)' \
-// RUN:   -o %t.ttkernel.mlir
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=1 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,canonicalize,cse,lower-affine)' -o %t.ttkernel.mlir
 // RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.ttkernel.mlir -o %t.emitc.mlir
 // RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
 // RUN: FileCheck %s --input-file=%t.cpp --check-prefix=FPU
 
 // SFPU path: all binary ops use copy_tile + SFPU binary ops.
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,canonicalize,cse,lower-affine)' \
-// RUN:   -o %t.sfpu.ttkernel.mlir
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,canonicalize,cse,lower-affine)' -o %t.sfpu.ttkernel.mlir
 // RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.sfpu.ttkernel.mlir -o %t.sfpu.emitc.mlir
 // RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.sfpu.cpp %t.sfpu.emitc.mlir
 // RUN: FileCheck %s --input-file=%t.sfpu.cpp --check-prefix=SFPU

--- a/test/ttlang/Translate/TTLToCpp/exp_scaled_to_cpp.mlir
+++ b/test/ttlang/Translate/TTLToCpp/exp_scaled_to_cpp.mlir
@@ -1,6 +1,4 @@
-// RUN: ttlang-opt %s \
-// RUN:   -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute,ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0}, ttl-assign-dst, ttl-lower-to-loops, ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' \
-// RUN:   -o %t.ttkernel.mlir
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' -o %t.ttkernel.mlir
 // RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.ttkernel.mlir -o %t.emitc.mlir
 // RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
 // RUN: FileCheck %s --input-file=%t.cpp


### PR DESCRIPTION
### Problem description

Two disjoint DFB lifecycles can require incompatible compute-kernel configuration when assigned one physical DFB index. The allocator previously ignored destination-width and unpack-mode requirements, so a valid lifetime coloring could fail during compute configuration. Compute configuration also ran module analysis from concurrent function passes, allowing one function to mutate the module while another traversed it.

### What's changed

~425 LOC implementation.

Derive typed static-configuration conflicts for supported destination-width and unpack-mode combinations before physical coloring. Operations proven never to execute are excluded from allocation compatibility while retaining their compute strategy metadata.

Resolve compute-kernel configuration at module scope from one immutable launch-domain snapshot, then apply every function plan after all resolutions succeed. DFB configuration operands are resolved once and returned through a typed result.

For example, these DFBs execute on disjoint worker nodes but require different FP32 unpack modes, so they retain distinct physical indices:

```python
if node_x == 0:
    output_block.store(ttl.exp(first_input_block))
if node_x == 1:
    output_block.store(
        ttl.block.broadcast(second_input_block, dims=[0], shape=(1, 1))
    )
```

### Validation

- New FP32 device regression covers incompatible disjoint-node configurations with DRAM and L1 tensors.
- New MLIR tests cover compatible and incompatible configurations, exact-empty domains, and non-compute owners.

### Checklist

- [x] New/Existing tests provide coverage for changes
