### PR TITLE
[ci] Keep :latest tracking main, reset Galaxy cards, and document uplift tagging

### DIFF
--- a/.github/scripts/reset-tt-cards.sh
+++ b/.github/scripts/reset-tt-cards.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reset the runner's cards and verify tt-smi answers afterwards.
+#
+# A degraded cluster reports as unrelated failures in every device test rather
+# than as a device error, so fail here instead. -glx_reset is Galaxy-specific;
+# -r covers boards that do not implement it.
+#
+# Env: TT_RESET_MAX_ATTEMPTS (10), TT_RESET_RETRY_SECONDS (30).
+#
+# Usage: reset-tt-cards.sh
+
+set -uo pipefail
+
+MAX_ATTEMPTS="${TT_RESET_MAX_ATTEMPTS:-10}"
+RETRY_SECONDS="${TT_RESET_RETRY_SECONDS:-30}"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    echo "=== Reset attempt $attempt of $MAX_ATTEMPTS ==="
+
+    if ! tt-smi -glx_reset && ! tt-smi -r; then
+        echo "reset failed on attempt $attempt"
+        sleep "$RETRY_SECONDS"
+        continue
+    fi
+
+    # Links and services settle after the reset returns.
+    sleep 5
+
+    if tt-smi --snapshot_no_tty --snapshot; then
+        echo "reset and health check passed on attempt $attempt"
+        exit 0
+    fi
+
+    echo "health check failed on attempt $attempt"
+    sleep "$RETRY_SECONDS"
+done
+
+echo "::error::Card reset or health check failed after $MAX_ATTEMPTS attempts"
+exit 1

--- a/.github/scripts/retag-docker-latest.sh
+++ b/.github/scripts/retag-docker-latest.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Point the dist and ird :latest tags at an already-published image.
+#
+# build-docker pushes :latest but runs only when the image is missing, so an
+# image published before the main push leaves :latest stale. Copies the manifest
+# rather than rebuilding.
+#
+# Usage: retag-docker-latest.sh <tag>
+
+set -euo pipefail
+
+TAG="${1:?usage: retag-docker-latest.sh <tag>}"
+REPO="${GITHUB_REPOSITORY:-tenstorrent/tt-lang}"
+REGISTRY="${TTLANG_REGISTRY:-ghcr.io}"
+
+for name in tt-lang-dist-ubuntu-24-04 tt-lang-ird-ubuntu-24-04; do
+    image="${REGISTRY}/${REPO}/${name}"
+    if ! docker manifest inspect "${image}:${TAG}" >/dev/null 2>&1; then
+        echo "::error::${image}:${TAG} is missing from the registry; refusing to move :latest" >&2
+        exit 1
+    fi
+    docker buildx imagetools create --tag "${image}:latest" "${image}:${TAG}"
+    echo "Pointed ${image}:latest at ${TAG}"
+done

--- a/.github/scripts/tests/test_reset_tt_cards.bats
+++ b/.github/scripts/tests/test_reset_tt_cards.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/reset-tt-cards.sh.
+
+load test_helper
+
+# Fake tt-smi. Each subcommand's exit status comes from FAKE_TT_SMI_<NAME>_FAIL;
+# argv goes to $FAKE_TT_SMI_ARGS.
+make_tt_smi_mock() {
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/tt-smi" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_TT_SMI_ARGS"
+case "$1" in
+    -glx_reset) exit "${FAKE_TT_SMI_GLX_FAIL:-0}" ;;
+    -r)         exit "${FAKE_TT_SMI_R_FAIL:-0}" ;;
+    --snapshot_no_tty) exit "${FAKE_TT_SMI_SNAPSHOT_FAIL:-0}" ;;
+esac
+exit 0
+EOF
+    chmod +x "$bindir/tt-smi"
+    echo "$bindir"
+}
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../reset-tt-cards.sh"
+    FAKE_TT_SMI_ARGS="$BATS_TEST_TMPDIR/tt-smi-args"
+    : > "$FAKE_TT_SMI_ARGS"
+    export FAKE_TT_SMI_ARGS
+    PATH="$(make_tt_smi_mock):$PATH"
+    export PATH
+    export TT_RESET_RETRY_SECONDS=0
+}
+
+@test "glx reset succeeds and health check passes -> exit 0" {
+    run -0 "$SCRIPT"
+    assert_output --partial "reset and health check passed on attempt 1"
+    grep -q -- "-glx_reset" "$FAKE_TT_SMI_ARGS"
+    grep -q -- "--snapshot_no_tty" "$FAKE_TT_SMI_ARGS"
+}
+
+@test "glx reset unsupported -> falls back to tt-smi -r" {
+    FAKE_TT_SMI_GLX_FAIL=1 run -0 "$SCRIPT"
+    grep -q '^-r' "$FAKE_TT_SMI_ARGS"
+    assert_output --partial "reset and health check passed"
+}
+
+@test "successful glx reset does not also run tt-smi -r" {
+    run -0 "$SCRIPT"
+    run -1 grep -q '^-r$' "$FAKE_TT_SMI_ARGS"
+}
+
+@test "both resets fail -> retries then fails" {
+    TT_RESET_MAX_ATTEMPTS=2 FAKE_TT_SMI_GLX_FAIL=1 FAKE_TT_SMI_R_FAIL=1 run -1 "$SCRIPT"
+    assert_output --partial "Reset attempt 2 of 2"
+    assert_output --partial "failed after 2 attempts"
+}
+
+@test "health check keeps failing -> non-zero exit" {
+    TT_RESET_MAX_ATTEMPTS=2 FAKE_TT_SMI_SNAPSHOT_FAIL=1 run -1 "$SCRIPT"
+    assert_output --partial "health check failed on attempt 1"
+    assert_output --partial "failed after 2 attempts"
+}
+
+@test "health check recovers on a later attempt -> exit 0" {
+    # Snapshot fails once, then succeeds.
+    cat > "$BATS_TEST_TMPDIR/bin/tt-smi" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_TT_SMI_ARGS"
+if [[ "$1" == "--snapshot_no_tty" ]]; then
+    count=$(grep -c -- "--snapshot_no_tty" "$FAKE_TT_SMI_ARGS")
+    [[ "$count" -lt 2 ]] && exit 1
+fi
+exit 0
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/tt-smi"
+    TT_RESET_MAX_ATTEMPTS=3 run -0 "$SCRIPT"
+    assert_output --partial "reset and health check passed on attempt 2"
+}

--- a/.github/scripts/tests/test_retag_docker_latest.bats
+++ b/.github/scripts/tests/test_retag_docker_latest.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/retag-docker-latest.sh.
+
+load test_helper
+
+IRD_IMAGE_BASE="ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04"
+DIST_IMAGE_BASE="ghcr.io/tenstorrent/tt-lang/tt-lang-dist-ubuntu-24-04"
+TAG="v99.99.99"
+
+# `manifest inspect` fails when FAKE_DOCKER_MISSING=1; argv goes to
+# $FAKE_DOCKER_ARGS.
+make_docker_mock() {
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${FAKE_DOCKER_ARGS:-}" ]]; then
+    printf '%s\n' "$*" >> "$FAKE_DOCKER_ARGS"
+fi
+if [[ "$1" == "manifest" && "$2" == "inspect" ]]; then
+    [[ "${FAKE_DOCKER_MISSING:-0}" == "1" ]] && exit 1
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$bindir/docker"
+    echo "$bindir"
+}
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../retag-docker-latest.sh"
+    FAKE_DOCKER_ARGS="$BATS_TEST_TMPDIR/docker-args"
+    : > "$FAKE_DOCKER_ARGS"
+    export FAKE_DOCKER_ARGS
+    PATH="$(make_docker_mock):$PATH"
+    export PATH
+    export GITHUB_REPOSITORY="tenstorrent/tt-lang"
+}
+
+@test "points both ird and dist :latest at the given tag" {
+    run -0 "$SCRIPT" "$TAG"
+    assert_output --partial "Pointed $IRD_IMAGE_BASE:latest at $TAG"
+    assert_output --partial "Pointed $DIST_IMAGE_BASE:latest at $TAG"
+}
+
+@test "copies the manifest instead of rebuilding" {
+    run -0 "$SCRIPT" "$TAG"
+    grep -q "buildx imagetools create --tag $IRD_IMAGE_BASE:latest $IRD_IMAGE_BASE:$TAG" \
+        "$FAKE_DOCKER_ARGS"
+    grep -q "buildx imagetools create --tag $DIST_IMAGE_BASE:latest $DIST_IMAGE_BASE:$TAG" \
+        "$FAKE_DOCKER_ARGS"
+}
+
+@test "verifies the source image exists before moving the tag" {
+    run -0 "$SCRIPT" "$TAG"
+    grep -q "manifest inspect $DIST_IMAGE_BASE:$TAG" "$FAKE_DOCKER_ARGS"
+}
+
+@test "missing source image -> refuse without moving :latest" {
+    FAKE_DOCKER_MISSING=1 run -1 "$SCRIPT" "$TAG"
+    assert_output --partial "refusing to move :latest"
+    run -1 grep -q "imagetools create" "$FAKE_DOCKER_ARGS"
+}
+
+@test "no tag argument -> non-zero exit" {
+    run -1 "$SCRIPT"
+}

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -112,6 +112,15 @@ jobs:
           source build/env/activate
           pip install -r dev-requirements.txt
 
+      # Galaxy links degrade across jobs and the failure reports as a cluster
+      # lookup error in every device test rather than as a device error.
+      - name: Reset cards and check cluster health
+        if: inputs.runs-on == 'galaxy-bh'
+        timeout-minutes: 45
+        run: |
+          source build/env/activate
+          .github/scripts/reset-tt-cards.sh
+
       - name: Smoketest
         run: |
           source build/env/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,30 @@ jobs:
     with:
       push: true
 
+  # build-docker pushes :latest but runs only when the image is missing, which
+  # leaves :latest stale for images published before the main push.
+  retag-latest:
+    name: Point :latest at the resolved image
+    needs: resolve-docker-tag
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.resolve-docker-tag.outputs.needs_rebuild == 'false' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Move :latest
+        run: .github/scripts/retag-docker-latest.sh "${{ needs.resolve-docker-tag.outputs.docker_tag }}"
+
   # Manylinux wheel-builder images are independent of the IRD image. Build them
   # alongside build-docker so hardware tests do not wait for toolchain caches.
   build-wheel-images:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -80,18 +80,10 @@ jobs:
     with:
       ttlang_sha_override: ${{ inputs.ttlang_sha }}
 
-  # Release-tag pushes publish the dist and IRD images under the release tag.
-  # ci.yml's probe requires the IRD image to exist at that tag, and rebuilding it
-  # from a PR or main commit would overwrite the release with newer content.
-  #
-  # Deliberately does not depend on preflight. preflight decides whether the
-  # release is publishable to public PyPI, which an S3-only pin fails by design;
-  # gating image publication on it would leave those releases without the image
-  # ci.yml needs. The image tag comes from get-version-tag.sh at checkout, not
-  # from preflight, and on.push.tags already restricts this event to release tags.
-  #
-  # No ttlang_sha_override: on a tag push github.sha is already the tagged commit,
-  # and the reusable workflow resolves from the same ref as this caller.
+  # Publishes the dist and IRD images ci.yml's probe requires at the release tag.
+  # No needs: preflight -- it fails the PyPI alignment check on S3-only pins,
+  # which would skip image publication for exactly those releases. No
+  # ttlang_sha_override: github.sha is already the tagged commit.
   build-docker:
     if: ${{ github.event_name == 'push' }}
     permissions:

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -397,6 +397,30 @@ the `build-docker` job builds and pushes it before any other downstream
 job consumes it. Subsequent pushes of the same submodule SHA set reuse
 the cached image.
 
+(tagging-after-an-uplift-merge)=
+### Tagging after an uplift merge
+
+Wait for the merge's CI run on `main` to finish building the toolchain before
+pushing the release tag. A run reads caches only from its own ref and the
+default branch, and the uplift PR's cache lives under `refs/pull/<N>/merge`, so
+a tag pushed before `main` has cached the toolchain rebuilds it from source --
+about an hour and a half, concurrent with the identical build on `main`.
+
+The tag run cannot skip it: `call-build-docker.yml`'s `build-images` restores
+the toolchain with `fail-on-cache-miss: true` and bakes it into the IRD image.
+Dispatching `call-build-docker.yml` separately resolves the same cache scopes
+and rebuilds too.
+
+Confirm the cache exists first; the key uses seven-character submodule SHAs:
+
+```bash
+gh api "repos/tenstorrent/tt-lang/actions/caches?per_page=100" \
+  --jq '.actions_caches[] | select(.key | startswith("Linux-toolchain")) | "\(.ref)  \(.key)"'
+```
+
+Look for `Linux-toolchain_llvm-<llvm7>_ttmetal-<ttmetal7>` at
+`ref=refs/heads/main` matching the uplifted submodules, then push the tag.
+
 ### CI: toolchain cache and Docker images
 
 CI uses two caching layers that must be rebuilt when submodule SHAs change:
@@ -506,11 +530,18 @@ Push policy across events:
 | PR (uplift)                            | refused by probe     | yes                            | no                           |
 | PR (non-uplift, container content)     | no (dryrun)          | n/a                            | no                           |
 | Main push (uplift)                     | refused by probe     | yes                            | yes                          |
-| Main push (non-uplift)                 | n/a (image exists)   | n/a                            | no (`build-docker` skipped)  |
+| Main push (non-uplift)                 | n/a (image exists)   | n/a                            | yes (`retag-latest`)         |
 | Tag push (release, via publish-pypi)   | yes                  | n/a                            | no                           |
 | `workflow_dispatch`                    | only if `push: true` | only if `push: true`           | only if `push: true` on main |
 
-For a final release:
+`build-docker` pushes `:latest`, but runs only when the probe reports the image
+missing. For an image published before the main push -- by an uplift PR's run or
+a release tag's `publish-pypi.yml` run -- the `retag-latest` job moves `:latest`
+onto the resolved tag instead, copying the manifest with
+`docker buildx imagetools create` rather than rebuilding.
+
+For a final release (see [Tagging after an uplift
+merge](#tagging-after-an-uplift-merge) before tagging an uplift):
 
 ```bash
 git tag vX.Y.Z

--- a/test/packaging/test_workflow_helper_scripts.py
+++ b/test/packaging/test_workflow_helper_scripts.py
@@ -471,6 +471,27 @@ def test_publish_pypi_supports_release_sha_from_main() -> None:
     assert "inputs.ttlang_sha" not in publish_job
 
 
+def test_main_push_moves_latest_when_the_image_already_exists() -> None:
+    """:latest must track main when build-docker is skipped as already-built."""
+    workflow = CI_WORKFLOW.read_text()
+    retag_job = workflow.split("\n  retag-latest:", 1)[1].split(
+        "\n  build-wheel-images:", 1
+    )[0]
+
+    assert "needs: resolve-docker-tag" in retag_job
+    assert "github.event_name == 'push'" in retag_job
+    assert "github.ref == 'refs/heads/main'" in retag_job
+    # Runs exactly when build-docker does not.
+    assert "needs.resolve-docker-tag.outputs.needs_rebuild == 'false'" in retag_job
+    assert "packages: write" in retag_job
+    assert ".github/scripts/retag-docker-latest.sh" in retag_job
+
+    script = (SCRIPTS_DIR / "retag-docker-latest.sh").read_text()
+    assert "docker buildx imagetools create" in script
+    assert "tt-lang-ird-ubuntu-24-04" in script
+    assert "tt-lang-dist-ubuntu-24-04" in script
+
+
 def test_release_tag_builds_ird_and_manylinux_images_independently() -> None:
     """A release-tag push must publish the IRD image ci.yml's probe requires.
 


### PR DESCRIPTION
### Problem description

The `v1.1.8` and `v1.1.9` releases exposed three CI problems, all of which cost time during the uplift.

`:latest` stopped tracking `main`. `build-docker` is what pushes `:latest`, but it runs only when the probe reports the image missing. An uplift PR's own run publishes the image before the merge reaches `main`, and a release tag's `publish-pypi.yml` run does the same, so the probe reports present, `build-docker` is skipped, and `:latest` keeps pointing at the previous image. Before this change `:latest` was three days and two uplifts stale.

Pushing a release tag immediately after the merge rebuilds the toolchain from source. A run reads caches only from its own ref and the default branch, and the uplift PR's cache lives under `refs/pull/<N>/merge`, so a tag pushed before `main` has cached the toolchain finds nothing to restore. For `v1.1.9` that meant two concurrent builds of the same toolchain, roughly an hour and a half each.

Galaxy hardware links degrade across jobs, and tt-metal reports the result as a cluster-type lookup failure rather than as a device error, so every device test fails in a way that points at the code under test.

### What's changed

- Add a `retag-latest` job to `ci.yml` that moves `:latest` onto the resolved tag when `build-docker` is skipped as already-built. It copies the published manifest with `docker buildx imagetools create` rather than rebuilding, and verifies the source image exists before moving the tag.
- Document waiting for the merge's own CI run on `main` to cache the toolchain before pushing a release tag, including the `gh api` command to confirm the cache exists. The key uses seven-character submodule SHAs. The tag run cannot skip the build: `call-build-docker.yml`'s `build-images` restores the toolchain with `fail-on-cache-miss: true` and bakes it into the IRD image, and dispatching `call-build-docker.yml` separately resolves the same cache scopes.
- Correct the push-policy table, which said a non-uplift push to `main` does not update `:latest`.
- Reset the Galaxy cards before hardware tests, following tt-xla's exabox workflow: `tt-smi -glx_reset` with a `tt-smi -r` fallback, retried, and a `tt-smi` snapshot afterwards to confirm the cluster answers. tt-lang runs single-host, so this omits tt-xla's `mpirun --pernode` fan-out; it also omits their `TT_METAL_HOME`/`LD_LIBRARY_PATH` unsets, which exist only because `mpirun` forwards the exabox runner's environment into worker pods where those paths dangle.
- Trim the `build-docker` comment in `publish-pypi.yml` to the two invariants that are not evident from the job body.

### Testing

The `.github/scripts/tests/` Bats suite passes 559 tests, including eleven new ones covering the retag and reset scripts: tag movement for both images, manifest copy rather than rebuild, refusal when the source image is absent, the `-glx_reset` to `-r` fallback, no redundant `-r` after a successful reset, retry exhaustion, and health-check recovery on a later attempt. The packaging workflow tests pass 63, including a contract test asserting `retag-latest` runs exactly when `build-docker` does not. `actionlint`, `shellcheck`, and `pre-commit run --all-files` are clean.

Traced against the live repository rather than assumed: `tt-smi` 5.0.0 accepts `-glx_reset`, `-r` with optional targets, and `--snapshot_no_tty`; the ird image ships `tt-smi` in the toolchain venv, which `env/activate` puts on `PATH`; this branch resolves to docker tag `v1.1.9`, where both the ird and dist images exist, so `retag-latest` has its precondition satisfied on the post-merge push. `retag-latest` is skipped on pull requests by design, so it first executes on the merge to `main`.

### Checklist

- [x] New/Existing tests provide coverage for changes
