### PR TITLE
[ttl] Replace waited DFB blocks in place [dfb-reuse-10]

### DIFF
--- a/docs/development/ComputeOpCreation.md
+++ b/docs/development/ComputeOpCreation.md
@@ -7,14 +7,15 @@
 supported tensor expression into one `ttl.compute` so intermediate values can
 remain in DST instead of being stored to dataflow buffers (DFBs).
 
-Creating a `ComputeOp` may change both evaluation position and output
-publication. A tensor operation may be defined before a DFB release, used in
-another region, stored through several reserves, or shared by several
+Creating a `ComputeOp` may change both evaluation position and output DFB
+transactions. A tensor operation may be defined before a DFB release, used in
+another region, stored through several acquisitions, or shared by several
 consumers. Correctness therefore requires more than following SSA definitions.
 The compiler must prove:
 
 - every input DFB remains available where the `ttl.compute` executes;
-- the compute preserves each output reserve, store, and push transaction;
+- the compute preserves each output acquisition, store, and release
+  transaction;
 - the replacement result dominates every surviving use;
 - overlapping fusion candidates are applied in an order that preserves their
   recorded source operations;
@@ -28,7 +29,7 @@ are defined in [DFBManagement.md](DFBManagement.md).
 ## Design Motivation
 
 `ComputeOp` creation is a nonlocal transformation. Candidate legality depends
-on operations, uses, publication transactions, and DFB lifetimes throughout a
+on operations, uses, output DFB transactions, and DFB lifetimes throughout a
 kernel. Rewriting one candidate changes use lists, operation positions, and
 transactions that another candidate might inspect. Greedy rewrite order
 therefore cannot define semantic decisions without making legality depend on
@@ -67,7 +68,7 @@ The current conversion separates those responsibilities:
 analyze one immutable kernel:
   compute DFB value availability at every relevant program point
   construct complete typed direct, fused, and elision candidates
-  record reserve/store/push output transactions
+  record output DFB transactions and waited-block replacement proofs
   validate input lifetimes, result dominance, and instrumentation placement
   select non-conflicting candidates and order overlapping candidates
   assign every store or report why it remains unassigned
@@ -103,9 +104,12 @@ A **lifetime root input** is a root whose current storage remains an input
 after all planned materializations. Only lifetime roots constrain the
 `ComputeOp` insertion point through the DFB availability analysis.
 
-An **output publication transaction** contains one `cb_reserve`, every
-`ttl.store` using a view derived from that reserve, and the matching `cb_push`
-when one is present.
+An **output DFB transaction** contains one `cb_reserve` or `cb_wait` and every
+`ttl.store` using a view derived from that acquisition. A reserve-backed
+transaction records its matching `cb_push` when present. A wait-backed
+transaction retains its matching `cb_pop` and requires a separate proof that
+the store replaces the complete consumer-owned block without changing DFB
+occupancy or pointers.
 
 An **elision** replaces an operation without creating a `ttl.compute` or
 changing its evaluation position. Identity `ttl.typecast` is the current
@@ -124,7 +128,7 @@ ttl-create-producer-compute
 
 `ttl-create-producer-compute` applies creation plans that are legal in the
 original kernel. Rejected candidates remain unchanged so intermediate DFB insertion can
-repair storage or publication constraints. `ttl-insert-intermediate-dfbs`
+repair storage or output-transaction constraints. `ttl-insert-intermediate-dfbs`
 computes its own immutable plan, inserts the required storage, and rewrites the
 selected consumer operands. `convert-ttl-to-compute` then rebuilds creation
 and lifetime plans from the modified kernel and requires every output store to
@@ -203,10 +207,10 @@ planCandidate(source):
     kind = fused creation
 
   derive typed affine maps and iterator kinds
-  plan output publication transactions
+  plan output DFB transactions
   validate instrumentation placement
   find SSA boundaries needed to preserve instrumentation order
-  validate DFB input availability at the publication anchor
+  validate DFB input availability at the insertion anchor
   validate dominance of every surviving result use
 
   return the complete plan and its typed legality result
@@ -307,42 +311,48 @@ every region boundary as a storage requirement. Fusion is rejected when
 instrumentation around a cross-block producer cannot be placed relative to the
 consumer without changing observations.
 
-## Output Publication Planning
+## Output DFB Transaction Planning
 
-Creation replaces tensor stores with tile stores inside `ttl.compute` and may
-move an existing push after the new compute. Publication planning therefore
-records reserve-delimited transactions before mutation:
+Creation replaces tensor stores with tile stores inside `ttl.compute`.
+Reserve-backed stores may require an existing push to move after the new
+compute. Wait-backed stores require a complete consumer-owned replacement
+proof. Transaction planning records both forms before mutation:
 
 ```text
-planPublications(source):
+planOutputTransactions(source):
   collect every ttl.store of the source result
   require all stores to be in one block
 
   for each store:
-    trace the destination view to one cb_reserve
-    group stores by reserve identity
-    find the first matching cb_push after the stores and before another
-      reserve of the same DFB
+    trace the destination view to one cb_reserve or cb_wait
+    group stores by acquisition identity
+    for cb_reserve, find the first matching cb_push after the stores and
+      before another reserve of the same DFB
+    for cb_wait, prove complete one-block replacement and find the matching
+      cb_pop after all replacement-generation reads
 
-  require all stores in one transaction to precede the same push
+  require all reserve-backed stores in one transaction to precede the same push
   insertion anchor = final source-result store
-  record whether one DFB has more than one reserve transaction
+  record whether one DFB has more than one acquisition transaction
 ```
 
 Several reserves of different DFBs may become outputs of one compute. Several
 reserves of the same DFB cannot be combined because moving one publication to
 the final store would cross a later reserve of the same producer pointer. That
 case requires intermediate materialization so each original transaction can
-remain independent.
+remain independent. Several acquisitions of the same DFB are rejected for the
+same transformation because combining them would lose their transaction
+boundary.
 
-The final store is the insertion anchor. Every output reserve dominates its
-store, so all output views are available at that position. The planner rejects
-creation unless each lifetime root is definitely available there and the
-anchor dominates every result use not removed by the creation.
+The final store is the insertion anchor. Every output acquisition dominates
+its store, so all output views are available at that position. The planner
+rejects creation unless each lifetime root is definitely available there and
+the anchor dominates every result use not removed by the creation.
 
 Existing pushes are resolved again during application because an earlier
-creation may relocate a shared push. The reserve and store identities remain
-the analyzed ones; this limited resolution does not repeat semantic analysis.
+creation may relocate a shared push. The acquisition and store identities
+remain the analyzed ones; this limited resolution does not repeat semantic
+analysis.
 
 ## Instrumentation
 
@@ -367,8 +377,8 @@ the same boundary. Intermediate DFB planning materializes those uses, so each
 side receives an independent `ttl.compute`, and the instrumentation retains its
 original order.
 Pure tensor recomputation without movable instrumentation requires no split.
-Output reserves are excluded because they supply the formal output views and
-the compute must execute after them. `ttl.dprint` declares memory effects;
+Output acquisitions are excluded because they supply the formal output views
+and the compute must execute after them. `ttl.dprint` declares memory effects;
 scalar, DFB, and tensor prints stay outside the compute, while tile and DST
 prints use the explicit relocatable instrumentation plan.
 
@@ -396,9 +406,10 @@ ttl.store %second, %second_output : ...
 ```
 
 Both `ttl.exp` creation plans may absorb `ttl.add`, but `%sum` also requires an
-independent creation plan for its publication. The absorbing creations execute
-before the independent `%sum` creation. Each earlier creation removes only its
-own consumer; another use keeps `ttl.add` present until all absorbers have run.
+independent creation plan for its output transaction. The absorbing creations
+execute before the independent `%sum` creation. Each earlier creation removes
+only its own consumer; another use keeps `ttl.add` present until all absorbers
+have run.
 
 The selection algorithm is:
 
@@ -515,9 +526,11 @@ The design preserves these properties:
    operations whose SSA operands dominate the consumer. DFB availability is
    evaluated at the consumer position through MLIR control-flow dataflow.
 
-4. **Publication order.** Each tile store retains its reserve transaction.
-   Moving a push cannot cross another reserve of the same DFB because repeated
-   transactions of one DFB reject combined creation.
+4. **DFB transaction order.** Each tile store retains its acquisition
+   transaction. Moving a push cannot cross another reserve of the same DFB
+   because repeated transactions of one DFB reject combined creation. A
+   wait-backed store is selected only after proving one complete consumer-owned
+   replacement ending at the matching pop.
 
 5. **SSA uses.** The insertion anchor dominates every surviving result use.
    Uses that a preceding creation must erase are recorded and verified.
@@ -525,8 +538,8 @@ The design preserves these properties:
 6. **Instrumentation order.** Instrumentation does not move across an
    operation unless MLIR proves that operation pure. Intermediate DFB
    materialization splits the tensor SSA frontier when required. Output
-   reserves are recorded dependencies of the created `ttl.compute` and therefore
-   remain ordered before it.
+   acquisitions are recorded dependencies of the created `ttl.compute` and
+   therefore remain ordered before it.
 
 7. **Overlapping candidates.** An absorbed source is either erased by one
    selected creation or retained until every preceding absorber executes. A
@@ -575,7 +588,7 @@ Upstream does not model the TTL-specific relations required here. TT-Lang adds:
 
 - DFB FIFO acquisition identity and conservative release ownership;
 - DFB value availability at a creation position;
-- reserve/store/push publication transactions;
+- reserve/store/push transactions and waited-block replacement proofs;
 - direct and fused TTL tile recipes with hardware-specific affine roles;
 - overlapping-candidate selection and preservation records;
 - three-state planned, rejected, and invalid-IR results; and
@@ -626,7 +639,8 @@ operations and user DFB publications.
 ## Implementation Files
 
 - `lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.{h,cpp}` defines typed
-  recipes, publication plans, legality, overlap handling, and kernel order.
+  recipes, output transaction plans, legality, overlap handling, and kernel
+  order.
 - `lib/Dialect/TTL/IR/TTLOpsUtils.cpp` implements fusion tracing.
 - `lib/Dialect/TTL/Transforms/DFBValueLifetimeAnalysis.{h,cpp}` provides
   program-point storage availability.

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -278,6 +278,19 @@ the generated DFB lifecycle in write-then-publish order: `cb_reserve`,
 `ttl.compute` with `tile_store`, then `cb_push`. Both passes use the shared,
 read-only compute-op-creation analysis described below before modifying IR.
 
+A wait-backed `ttl.store` represents replacement of consumer-owned pages. The
+initial contract accepts one complete block from a one-block DFB, with the wait
+as the compute kernel's first access to that DFB. Analysis requires the
+replacement computation to read the original generation, requires values
+derived from the original contents to remain within that computation, excludes
+overlapping DFB access, and requires every replacement-generation read to
+precede the matching pop.
+Lowering emits `ttkernel.pack_waited_tile`, then converts it to the same
+`pack_tile` runtime call used for producer stores. It emits no reserve or push;
+the operation changes neither occupancy nor either DFB pointer. Full-ring
+acquisition and the absence of earlier producer-pointer access prove that the
+consumer read window and pack destination identify the same pages.
+
 After `cb_pop`, the producer may overwrite the released slot because its prior
 contents are no longer live. The DFB's backing storage remains statically
 allocated. Index reuse uses this release to prove that non-overlapping logical
@@ -540,11 +553,12 @@ materializations remain compute roots but are excluded from lifetime roots
 because their replacement DFB supplies new storage. If another unmaterialized
 occurrence reads the same SSA value, it remains a lifetime root.
 
-Output-store planning groups stores by their `cb_reserve` operations and
-prevents one compute from combining several reserve transactions of the same
-DFB. This preserves producer-pointer order when a push moves after the created
-`ttl.compute`. Kernel-wide selection and application ordering are described in
-`ComputeOpCreation.md`.
+Output-store planning groups stores by their `cb_reserve` or `cb_wait`
+acquisitions and prevents one compute from combining several transactions of
+the same DFB. Reserve-backed transactions preserve producer-pointer order when
+a push moves after the created `ttl.compute`. Wait-backed transactions require
+the complete consumer-owned replacement proof described above. Kernel-wide
+selection and application ordering are described in `ComputeOpCreation.md`.
 
 The analysis is kernel-local because creation moves operations only within
 one kernel. Producer and consumer pointer states are separate, and the
@@ -633,8 +647,8 @@ cannot reorder but the created `ttl.compute` would follow it, the query records
 tensor SSA uses from producers before that operation to consumers after it.
 Materialization replaces those uses, and the next fixed-point iteration creates
 an independent `ttl.compute` on each side. Uninstrumented pure tensor recomputation remains
-legal. Output reserves are part of the recorded output transaction and
-are not ordering boundaries; the created `ttl.compute` necessarily executes after
+legal. Output acquisitions are part of the recorded output transaction and are
+not ordering boundaries; the created `ttl.compute` necessarily executes after
 them.
 
 `ttl.compute` results preserve SSA dependencies, but the compute body publishes

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -133,6 +133,36 @@ def TTKernel_PackTileOp : TTKernel_Op<"pack_tile"> {
     }];
 }
 
+def TTKernel_PackWaitedTileOp : TTKernel_Op<"pack_waited_tile"> {
+    let summary = "Replace a tile in a waited full-ring DFB transaction.";
+    let description = [{
+      Copies one DST tile into a consumer-owned DFB page without reserving or
+      publishing producer space. `acquired_tiles` must equal the DFB capacity,
+      and `out_index` is relative to the acquired read window. The operation is
+      legal only when the producer write pointer and consumer read pointer are
+      separately proved to address the same ring position.
+
+      The operation changes neither occupancy nor either DFB pointer. A prior
+      consumer wait owns the pages until the corresponding pop. The compiler
+      must prove that the original page value is consumed before replacement
+      and that following accesses occur before the pop.
+    }];
+
+    let arguments = (ins
+      IndexLike:$dst_index,
+      TTKernel_CB:$out_cb,
+      IndexLike:$out_index,
+      DefaultValuedAttr<BoolAttr, "true">:$out_of_order,
+      ConfinedAttr<I64Attr, [IntPositive]>:$acquired_tiles
+    );
+
+    let assemblyFormat = [{
+      `(` $dst_index `,` $out_cb `,` $out_index `,` $out_of_order `)`
+      attr-dict `:` functional-type(operands, results)
+    }];
+    let hasVerifier = 1;
+}
+
 def TTKernel_PackTileBlockOp : TTKernel_Op<"pack_tile_block"> {
     let summary = "PackTileBlock op.";
     let description = [{

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1816,16 +1816,27 @@ def TTL_CBPopOp
 
 def TTL_StoreOp : TTL_ComputePrimitiveOp<"store", "Passthrough",
     [MemoryEffects<[MemWrite]>]> {
-  let summary = "Store a tensor to a circular buffer reserve view";
+  let summary = "Store a tensor to an acquired dataflow buffer view";
   let description = [{
     `ttl.store` represents the user's intent to store a computed tensor into
-    an output circular buffer.
+    an acquired dataflow buffer view. A reserve-backed destination writes a
+    producer-owned slot. A wait-backed destination replaces a consumer-owned
+    slot after the original value has been consumed.
 
-    Emitted by Python's `o.store(result)` (overwrite) or `o += result`
-    (accumulate). During `convert-ttl-to-compute`, this op is transformed
-    into a `ttl.tile_store` inside the compute body.
+    Python's `o.store(result)` emits an overwrite. `o += result` emits packer
+    accumulation for a reserve-backed destination or an explicit
+    read-add-replacement sequence for a wait-backed destination.
 
-    When `accumulate` is set, the enclosing loop is annotated for L1
+    Wait-backed replacement is valid only when compiler analysis proves that
+    the one-block DFB is acquired completely, so the read and write pointers
+    address the same pages. It does not advance either pointer and the existing
+    `ttl.cb_pop` remains the release operation. The replacement must execute
+    after a read of the acquired value, and its wait must be the first access
+    to that DFB in the compute kernel. Multi-block, partial-ring, conditional,
+    repeated, and otherwise unresolved mutations are rejected.
+
+    When `accumulate` is set, the destination must be reserve-backed. The
+    enclosing loop is annotated for L1
     packer accumulation so that each iteration adds to the existing L1
     value instead of overwriting.
 
@@ -2141,21 +2152,22 @@ def TTL_GetDfbIdOp : TTL_Op<"get_dfb_id", [Pure]> {
 def TTL_TileStoreOp : TTL_ComputePrimitiveOp<"tile_store", "Passthrough",
     [MemoryEffects<[MemWrite]>, TTL_DstResultOpTrait,
      TTL_DstAccessOpInterface, TTL_TileExecutionOpInterface]> {
-  let summary = "Store a tile into a circular buffer view";
+  let summary = "Store a tile into an acquired dataflow buffer view";
   let description = [{
-    `ttl.tile_store` packs a single tile from the DST register into a circular
-    buffer view obtained from `ttl.cb_reserve`. This is the tile-level form of
-    `ttl.store`, created by `convert-ttl-to-compute` from the tensor-level store.
+    `ttl.tile_store` packs a single tile from the DST register into a dataflow
+    buffer view obtained from `ttl.cb_reserve` or `ttl.cb_wait`. This is the
+    tile-level form of `ttl.store`.
 
-    The tile value typically comes from compute operations (e.g., tile_add,
-    tile_mul). The view must be from a prior `ttl.cb_reserve` call on the
-    same CB.
+    A `producer` store packs into producer-reserved pages. A
+    `consumer_replacement` store packs into waited pages without changing
+    occupancy or either dataflow buffer pointer. The latter is valid only when
+    the original generation has been read, the complete one-block DFB is
+    acquired, and all replacement reads precede the matching pop. `store_kind`
+    preserves this typed ownership decision when the view is replaced or
+    sliced.
 
-    The `indices` operands are multi-dimensional CB tile coordinates derived
-    from `ttl.iter_index` ops and the output indexing map. They are populated
-    by `ttl-assign-dst` inside the `ttl.compute` body and resolved to concrete
-    loop IVs by `ttl-lower-to-loops`. At `convert-ttl-to-ttkernel` time, the
-    indices are linearized to a flat CB tile index for `pack_tile`.
+    The `indices` operands are multi-dimensional DFB tile coordinates. The
+    `dst_index` operand identifies the source tile in the DST register.
 
     Example:
     ```mlir
@@ -2175,7 +2187,9 @@ def TTL_TileStoreOp : TTL_ComputePrimitiveOp<"tile_store", "Passthrough",
     AnyType:$tile,
     AnyRankedTensor:$view,
     Variadic<Index>:$indices,
-    Index:$dst_index
+    Index:$dst_index,
+    DefaultValuedAttr<TTL_DFBTileStoreKindAttr,
+      "::mlir::tt::ttl::DFBTileStoreKind::Producer">:$store_kind
   );
   let assemblyFormat = "$tile `,` $view `[` $indices `]` `from` `dst` `[` $dst_index `]` attr-dict `:` type($tile) `,` type($view)";
   let hasVerifier = 1;

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
@@ -88,6 +88,18 @@ def TTL_DFBProtocolEffectKind : I32EnumAttr<
   let genSpecializedAttr = 0;
 }
 
+def TTL_DFBTileStoreKind_Producer :
+    I32EnumAttrCase<"Producer", 0, "producer">;
+def TTL_DFBTileStoreKind_ConsumerReplacement :
+    I32EnumAttrCase<"ConsumerReplacement", 1, "consumer_replacement">;
+
+def TTL_DFBTileStoreKind : I32EnumAttr<
+    "DFBTileStoreKind", "Dataflow buffer tile-store ownership",
+    [TTL_DFBTileStoreKind_Producer,
+     TTL_DFBTileStoreKind_ConsumerReplacement]> {
+  let cppNamespace = "::mlir::tt::ttl";
+}
+
 def TTL_BcastType_Col    : I32EnumAttrCase<"Col",    1, "col">;
 def TTL_BcastType_Row    : I32EnumAttrCase<"Row",    2, "row">;
 def TTL_BcastType_Scalar : I32EnumAttrCase<"Scalar", 3, "scalar">;

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsTypes.td
@@ -102,6 +102,8 @@ def TTL_AccumulationInitialModeAttr
 def TTL_AccumulationCombinerAttr
     : EnumAttr<TTL_Dialect, TTL_AccumulationCombiner,
                "accumulation_combiner">;
+def TTL_DFBTileStoreKindAttr
+    : EnumAttr<TTL_Dialect, TTL_DFBTileStoreKind, "dfb_tile_store_kind">;
 def TTL_InputClampingAttr
     : EnumAttr<TTL_Dialect, TTL_InputClamping, "input_clamping">;
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -965,12 +965,11 @@ public:
       template_args.push_back(
           emitc::OpaqueAttr::get(op.getContext(), "true")); // default to DRAM
       return ArrayAttr::get(op.getContext(), template_args);
-    } else if constexpr (std::is_same_v<SourceOp, ttkernel::PackTileOp>) {
+    } else if constexpr (std::is_same_v<SourceOp, ttkernel::PackTileOp> ||
+                         std::is_same_v<SourceOp, ttkernel::PackWaitedTileOp>) {
       SmallVector<Attribute, 1> template_args;
 
-      auto packTileOp = mlir::cast<ttkernel::PackTileOp>(op);
-
-      template_args.push_back(packTileOp.getOutOfOrderAttr());
+      template_args.push_back(op.getOutOfOrderAttr());
       return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp, ttkernel::AddIntTileOp> ||
                          std::is_same_v<SourceOp, ttkernel::SubIntTileOp> ||
@@ -3211,6 +3210,9 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetDataFormatOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TensorAccessorOp>>(
         typeConverter, context);
+
+    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::PackWaitedTileOp>>(
+        typeConverter, context, "pack_tile");
 
     patterns.add<GetDfbIdOpRewriter>(typeConverter, context);
     patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBPushBackOp>>(

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -126,6 +126,19 @@ static bool insideKernelFunction(mlir::Operation *op) {
   return success();
 }
 
+::mlir::LogicalResult PackWaitedTileOp::verify() {
+  if (!getOutOfOrder()) {
+    return emitOpError("requires out_of_order packing");
+  }
+  auto dfbType = getOutCb().getType();
+  uint64_t capacityTiles = static_cast<uint64_t>(dfbType.getNumElements());
+  if (getAcquiredTiles() != capacityTiles) {
+    return emitOpError() << "acquired_tiles must equal DFB capacity "
+                         << capacityTiles << ", got " << getAcquiredTiles();
+  }
+  return success();
+}
+
 static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
   if (mlir::isa<ttcore::TileType>(scalarCB.getElementType())) {
     return "Input to TilizeOp or Output to UntilizeOp must have scalar "

--- a/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelInsertInits.cpp
@@ -419,6 +419,8 @@ analyzeSyncRegion(ttk::TileRegsAcquireOp acquireOp, Value &inputCB,
       };
       if (auto pack = dyn_cast<ttk::PackTileOp>(inner)) {
         collectOutputCB(pack.getOutCb(), pack);
+      } else if (auto pack = dyn_cast<ttk::PackWaitedTileOp>(inner)) {
+        collectOutputCB(pack.getOutCb(), pack);
       } else if (auto packBlock = dyn_cast<ttk::PackTileBlockOp>(inner)) {
         collectOutputCB(packBlock.getOutCb(), packBlock);
       }

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1894,10 +1894,13 @@ mlir::LogicalResult mlir::tt::ttl::StoreOp::verify() {
     }
   }
 
-  // The view must ultimately come from a `ttl.cb_reserve`, possibly
-  // through intervening `tensor.extract_slice` ops.
-  if (!findCBReserveForView(getView())) {
-    return emitOpError() << "view must come from ttl.cb_reserve";
+  Operation *acquire = findCBAcquireOp(getView());
+  if (!acquire) {
+    return emitOpError() << "view must come from ttl.cb_reserve or ttl.cb_wait";
+  }
+  if (getAccumulate() && isa<CBWaitOp>(acquire)) {
+    return emitOpError()
+           << "wait-backed replacement does not support packer accumulation";
   }
 
   return success();
@@ -1915,6 +1918,18 @@ mlir::LogicalResult mlir::tt::ttl::TileStoreOp::verify() {
   if (viewElemTy != tileType) {
     return emitOpError() << "view element type (" << viewElemTy
                          << ") must match tile type (" << tileType << ")";
+  }
+
+  Operation *acquire = findCBAcquireOp(getView());
+  bool isWaitBacked = isa_and_nonnull<CBWaitOp>(acquire);
+  if (getStoreKind() == DFBTileStoreKind::ConsumerReplacement &&
+      !isWaitBacked) {
+    return emitOpError(
+        "consumer_replacement store requires a ttl.cb_wait-backed view");
+  }
+  if (getStoreKind() == DFBTileStoreKind::Producer && isWaitBacked) {
+    return emitOpError(
+        "ttl.cb_wait-backed view requires consumer_replacement store kind");
   }
 
   // Inside a compute body, indices must match the view rank (populated by

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -961,6 +961,17 @@ resolveTransactionPushes(OutputPublicationPlan plan) {
   plan.pushes.clear();
   for (OutputDFBTransaction &transaction : plan.transactions) {
     transaction.push.reset();
+    for (StoreOp store : transaction.stores) {
+      if (findCBAcquireOp(store.getView()) != transaction.acquire) {
+        return PlanningResult<OutputPublicationPlan>::invalidIR(
+            store, "output store acquisition changed after planning");
+      }
+    }
+    if (transaction.isWaitedMutation()) {
+      continue;
+    }
+    assert(isa<CBReserveOp>(transaction.acquire) &&
+           "output transaction requires a DFB acquisition");
     bool sawStoreWithoutPush = false;
     for (StoreOp store : transaction.stores) {
       std::optional<CBPushOp> push = findPushAfterStore(store, transaction.dfb);
@@ -1006,29 +1017,28 @@ buildOutputPublicationPlan(Operation *source) {
   assert(stores.isPlanned() && "store collection cannot report malformed IR");
 
   OutputPublicationPlan plan;
-  DenseMap<Operation *, unsigned> transactionByReserve;
-  DenseMap<Value, Operation *> firstReserveByDFB;
+  DenseMap<Operation *, unsigned> transactionByAcquire;
+  DenseMap<Value, Operation *> firstAcquireByDFB;
 
   for (StoreOp store : stores.getPlan()) {
-    CBReserveOp reserve = findCBReserveForView(store.getView());
-    if (!reserve) {
+    Operation *acquire = findCBAcquireOp(store.getView());
+    if (!acquire) {
       return PlanningResult<OutputPublicationPlan, OutputPublicationRejection>::
-          invalidIR(store,
-                    "output store view does not originate from ttl.cb_reserve");
+          invalidIR(store, "output store view does not originate from "
+                           "ttl.cb_reserve or ttl.cb_wait");
     }
 
-    Value dfb = reserve.getCb();
+    Value dfb = getDFBAcquireDFB(acquire);
     addUniqueValue(plan.dfbs, dfb);
     plan.stores.push_back(store);
 
-    auto [transactionIterator, inserted] = transactionByReserve.try_emplace(
-        reserve.getOperation(), plan.transactions.size());
+    auto [transactionIterator, inserted] =
+        transactionByAcquire.try_emplace(acquire, plan.transactions.size());
     if (inserted) {
-      plan.transactions.push_back({dfb, reserve, {}, std::nullopt});
-      auto [firstReserveIterator, insertedFirstReserve] =
-          firstReserveByDFB.try_emplace(dfb, reserve.getOperation());
-      if (!insertedFirstReserve &&
-          firstReserveIterator->second != reserve.getOperation()) {
+      plan.transactions.push_back({dfb, acquire, {}, std::nullopt});
+      auto [firstAcquireIterator, insertedFirstAcquire] =
+          firstAcquireByDFB.try_emplace(dfb, acquire);
+      if (!insertedFirstAcquire && firstAcquireIterator->second != acquire) {
         addUniqueValue(plan.multiTransactionDFBs, dfb);
       }
     }
@@ -1242,7 +1252,7 @@ collectInstrumentationBoundaries(
   }
   DenseSet<Operation *> outputReserves;
   for (const OutputDFBTransaction &transaction : outputs.transactions) {
-    outputReserves.insert(transaction.reserve);
+    outputReserves.insert(transaction.acquire);
   }
 
   auto firstMovedIterator =
@@ -1382,6 +1392,237 @@ rejectComputeOpCreation(
       rejected({source, kind, std::move(message), std::move(candidate)});
 }
 
+static bool isViewPreservingMutationUser(Operation *operation) {
+  return isa<AttachCBOp, tensor::ExtractSliceOp, tensor::ExtractOp,
+             UnrealizedConversionCastOp>(operation);
+}
+
+static LogicalResult collectWaitedMutationUsers(
+    Value acquiredView, StoreOp mutationStore, Operation *replacementSource,
+    const FusionTraceResult &replacementTrace,
+    SmallVectorImpl<Operation *> &replacementGenerationUsers,
+    std::string &failureReason) {
+  DenseSet<Value> visited;
+  SmallVector<Value> pending = {acquiredView};
+  while (!pending.empty()) {
+    Value value = pending.pop_back_val();
+    if (!visited.insert(value).second) {
+      continue;
+    }
+    for (Operation *user : value.getUsers()) {
+      if (isViewPreservingMutationUser(user)) {
+        llvm::append_range(pending, user->getResults());
+        continue;
+      }
+      if (user == mutationStore) {
+        continue;
+      }
+      bool readsOriginalGeneration = user == replacementSource ||
+                                     replacementTrace.opsInOrder.contains(user);
+      if (readsOriginalGeneration) {
+        continue;
+      }
+      if (auto followingStore = dyn_cast<StoreOp>(user);
+          followingStore && followingStore.getTensor() == value &&
+          followingStore->getBlock() == mutationStore->getBlock() &&
+          mutationStore->isBeforeInBlock(followingStore)) {
+        replacementGenerationUsers.push_back(user);
+        continue;
+      }
+      if (!isPure(user) || user->getNumRegions() != 0 ||
+          user->getNumResults() == 0 ||
+          user->getBlock() != mutationStore->getBlock() ||
+          !mutationStore->isBeforeInBlock(user)) {
+        failureReason =
+            "wait-backed replacement has an unsupported or unordered use of "
+            "the acquired generation";
+        return failure();
+      }
+      replacementGenerationUsers.push_back(user);
+    }
+  }
+  return success();
+}
+
+static bool mayAccessDFB(Operation *operation, Value dfb) {
+  auto access = dyn_cast<DFBAccessOpInterface>(operation);
+  return access && (access.hasUnknownDFBAccess() ||
+                    llvm::is_contained(access.getDFBDependencyOperands(), dfb));
+}
+
+static FailureOr<WaitedDFBMutationPlan> buildWaitedDFBMutationPlan(
+    Operation *replacementSource, const ComputeOpCreationPlan &creation,
+    const OutputDFBTransaction &transaction,
+    const DFBValueLifetimeAnalysis &lifetimes, std::string &failureReason) {
+  auto wait = dyn_cast<CBWaitOp>(transaction.acquire);
+  assert(wait && "waited mutation planning requires ttl.cb_wait");
+  if (transaction.stores.size() != 1) {
+    failureReason =
+        "wait-backed replacement requires exactly one store per acquisition";
+    return failure();
+  }
+  StoreOp store = transaction.stores.front();
+  if (store.getAccumulate()) {
+    failureReason =
+        "wait-backed replacement does not support packer accumulation";
+    return failure();
+  }
+
+  func::FuncOp kernel = store->getParentOfType<func::FuncOp>();
+  Block *entryBlock =
+      kernel && !kernel.getBody().empty() ? &kernel.getBody().front() : nullptr;
+  if (!kernel || !entryBlock || !kernel.getBody().hasOneBlock() ||
+      wait->getBlock() != entryBlock || store->getBlock() != entryBlock ||
+      replacementSource->getBlock() != entryBlock ||
+      !wait->isBeforeInBlock(store)) {
+    failureReason =
+        "wait-backed replacement requires one straight-line entry-block "
+        "execution";
+    return failure();
+  }
+
+  Value dfb = wait.getCb();
+  auto dfbType = cast<CircularBufferType>(dfb.getType());
+  int64_t transactionTiles = getDFBLifecycleTileCount(wait);
+  int64_t capacityTiles = dfbType.getTotalElements();
+  if (dfbType.getBlockCount() != 1 || transactionTiles != capacityTiles) {
+    failureReason = "wait-backed replacement requires one complete DFB block";
+    return failure();
+  }
+  if (traceUnrealizedCasts(store.getView()) != wait.getResult()) {
+    failureReason =
+        "wait-backed replacement requires the complete acquired view";
+    return failure();
+  }
+
+  WaitedDFBMutationPlan plan;
+  plan.store = store;
+  plan.wait = wait;
+  plan.dfb = dfb;
+  plan.transactionTiles = transactionTiles;
+  plan.capacityTiles = capacityTiles;
+  // A wait does not synchronize this thread's local producer pointer. Both
+  // local pointers remain at their common initialized position only when this
+  // is the compute kernel's first access to the DFB.
+  for (Operation &operation : *entryBlock) {
+    if (&operation == wait) {
+      break;
+    }
+    if (mayAccessDFB(&operation, dfb)) {
+      failureReason = "wait-backed replacement requires no earlier access to "
+                      "the same DFB in its compute kernel";
+      return failure();
+    }
+  }
+  for (Operation *operation = wait->getNextNode();
+       operation && operation != store; operation = operation->getNextNode()) {
+    if (auto reserve = dyn_cast<CBReserveOp>(operation);
+        reserve && reserve.getCb() == dfb) {
+      failureReason =
+          "wait-backed replacement cannot overlap a producer acquisition";
+      return failure();
+    }
+    if (auto pop = dyn_cast<CBPopOp>(operation); pop && pop.getCb() == dfb) {
+      failureReason =
+          "wait-backed replacement cannot execute after its consumer release";
+      return failure();
+    }
+  }
+
+  bool readsOriginalGeneration = false;
+  for (Value input : creation.inputs) {
+    if (findCBAcquireOp(input) != wait) {
+      continue;
+    }
+    if (lifetimes.getAvailability(input, store) !=
+        DFBValueAvailability::DefinitelyAvailable) {
+      failureReason =
+          "wait-backed replacement input may be released before the store";
+      return failure();
+    }
+    readsOriginalGeneration = true;
+  }
+  if (!readsOriginalGeneration) {
+    failureReason =
+        "wait-backed replacement must read the acquired value before writing";
+    return failure();
+  }
+
+  SmallVector<Operation *> replacementGenerationUsers;
+  if (failed(collectWaitedMutationUsers(
+          wait.getResult(), store, replacementSource, creation.trace,
+          replacementGenerationUsers, failureReason))) {
+    return failure();
+  }
+
+  CBPopOp release;
+  for (Operation *operation = wait->getNextNode(); operation;
+       operation = operation->getNextNode()) {
+    if (auto reserve = dyn_cast<CBReserveOp>(operation);
+        reserve && reserve.getCb() == dfb) {
+      failureReason =
+          "wait-backed replacement cannot overlap a producer acquisition";
+      return failure();
+    }
+    if (auto nextWait = dyn_cast<CBWaitOp>(operation);
+        nextWait && nextWait.getCb() == dfb) {
+      failureReason =
+          "wait-backed replacement cannot overlap another consumer acquisition";
+      return failure();
+    }
+    auto pop = dyn_cast<CBPopOp>(operation);
+    if (pop && pop.getCb() == dfb) {
+      if (!store->isBeforeInBlock(pop)) {
+        failureReason = "wait-backed replacement cannot execute after its "
+                        "consumer release";
+        return failure();
+      }
+      release = pop;
+      break;
+    }
+    if (mayAccessDFB(operation, dfb)) {
+      failureReason =
+          "wait-backed replacement cannot overlap another DFB access";
+      return failure();
+    }
+  }
+  if (!release) {
+    failureReason =
+        "wait-backed replacement requires a matching consumer release";
+    return failure();
+  }
+  if (getDFBLifecycleTileCount(release) != transactionTiles) {
+    failureReason =
+        "wait-backed replacement requires equal wait and pop tile counts";
+    return failure();
+  }
+  for (Operation *user : replacementGenerationUsers) {
+    if (!user->isBeforeInBlock(release)) {
+      failureReason = "wait-backed replacement value cannot be read after its "
+                      "consumer release";
+      return failure();
+    }
+  }
+  bool hasNestedDFBAccess = false;
+  kernel.walk([&](Operation *operation) {
+    if (operation->getBlock() == entryBlock) {
+      return WalkResult::advance();
+    }
+    if (mayAccessDFB(operation, dfb)) {
+      hasNestedDFBAccess = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  if (hasNestedDFBAccess) {
+    failureReason =
+        "wait-backed replacement cannot overlap a nested DFB access";
+    return failure();
+  }
+  plan.release = release;
+  return plan;
+}
+
 static PlanningResult<ComputeOpCreationPlan, ComputeOpCreationRejection>
 buildComputeOpCreationPlan(Operation *source,
                            const DFBValueLifetimeAnalysis &lifetimes,
@@ -1490,6 +1731,20 @@ buildComputeOpCreationPlan(Operation *source,
         outputs.getRejection().message);
   }
   plan.outputs = std::move(outputs).takePlan();
+
+  for (const OutputDFBTransaction &transaction : plan.outputs.transactions) {
+    if (!transaction.isWaitedMutation()) {
+      continue;
+    }
+    FailureOr<WaitedDFBMutationPlan> mutation = buildWaitedDFBMutationPlan(
+        source, plan, transaction, lifetimes, failureReason);
+    if (failed(mutation)) {
+      return rejectComputeOpCreation(
+          source, ComputeOpCreationRejectionKind::UnsupportedOutputPublication,
+          std::move(failureReason));
+    }
+    plan.waitedMutations.push_back(std::move(*mutation));
+  }
 
   ComputeOpMovement movement =
       collectComputeOpMovement(source, plan.kind, plan.trace);

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -1392,7 +1392,7 @@ rejectComputeOpCreation(
       rejected({source, kind, std::move(message), std::move(candidate)});
 }
 
-static bool isViewPreservingMutationUser(Operation *operation) {
+static bool propagatesWaitedMutationProvenance(Operation *operation) {
   return isa<AttachCBOp, tensor::ExtractSliceOp, tensor::ExtractOp,
              UnrealizedConversionCastOp>(operation);
 }
@@ -1402,28 +1402,52 @@ static LogicalResult collectWaitedMutationUsers(
     const FusionTraceResult &replacementTrace,
     SmallVectorImpl<Operation *> &replacementGenerationUsers,
     std::string &failureReason) {
-  DenseSet<Value> visited;
-  SmallVector<Value> pending = {acquiredView};
+  struct WaitedMutationValue {
+    Value value;
+    bool derivedFromOriginalGeneration = false;
+  };
+
+  DenseSet<Value> visitedViews;
+  DenseSet<Value> visitedOriginalValues;
+  SmallVector<WaitedMutationValue> pending = {{acquiredView, false}};
   while (!pending.empty()) {
-    Value value = pending.pop_back_val();
-    if (!visited.insert(value).second) {
+    WaitedMutationValue current = pending.pop_back_val();
+    DenseSet<Value> &visited = current.derivedFromOriginalGeneration
+                                   ? visitedOriginalValues
+                                   : visitedViews;
+    if (!visited.insert(current.value).second) {
       continue;
     }
-    for (Operation *user : value.getUsers()) {
-      if (isViewPreservingMutationUser(user)) {
-        llvm::append_range(pending, user->getResults());
+    for (Operation *user : current.value.getUsers()) {
+      if (propagatesWaitedMutationProvenance(user)) {
+        for (Value result : user->getResults()) {
+          pending.push_back({result, current.derivedFromOriginalGeneration});
+        }
         continue;
       }
       if (user == mutationStore) {
         continue;
       }
-      bool readsOriginalGeneration = user == replacementSource ||
-                                     replacementTrace.opsInOrder.contains(user);
-      if (readsOriginalGeneration) {
+      bool isReplacementSource = user == replacementSource;
+      bool isReplacementTraceOperation =
+          replacementTrace.opsInOrder.contains(user);
+      if (isReplacementSource || isReplacementTraceOperation) {
+        if (!isReplacementSource) {
+          for (Value result : user->getResults()) {
+            pending.push_back({result, true});
+          }
+        }
         continue;
       }
+      if (current.derivedFromOriginalGeneration) {
+        failureReason =
+            "wait-backed replacement requires values derived from the "
+            "original DFB contents to remain within the replacement "
+            "computation";
+        return failure();
+      }
       if (auto followingStore = dyn_cast<StoreOp>(user);
-          followingStore && followingStore.getTensor() == value &&
+          followingStore && followingStore.getTensor() == current.value &&
           followingStore->getBlock() == mutationStore->getBlock() &&
           mutationStore->isBeforeInBlock(followingStore)) {
         replacementGenerationUsers.push_back(user);

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -285,31 +285,34 @@ struct ComputeOpCreationUse {
   }
 };
 
-/// Stores and `ttl.cb_push` publication for one reserve of an output DFB.
+/// Stores and optional publication for one acquired output DFB view.
 ///
-/// Every store uses a view derived from `reserve`. When present, `push` is the
-/// first `ttl.cb_push` following every store without an intervening reserve.
-/// Automatic DFB synchronization may add an absent push later.
+/// Every store uses a view derived from `acquire`. Reserve-backed transactions
+/// may carry a following `ttl.cb_push`. Wait-backed transactions replace an
+/// occupied consumer slot and retain the existing `ttl.cb_pop` release.
 struct OutputDFBTransaction {
-  /// DFB whose producer pointer is advanced by the transaction.
+  /// DFB whose acquired pages are written by the transaction.
   Value dfb;
 
-  /// Acquisition that provides every store view in the transaction.
-  CBReserveOp reserve;
+  /// `ttl.cb_reserve` or `ttl.cb_wait` that provides every store view.
+  Operation *acquire = nullptr;
 
-  /// Stores using views derived from `reserve`, in block order.
+  /// Stores using views derived from `acquire`, in block order.
   SmallVector<StoreOp> stores;
 
-  /// First matching `ttl.cb_push` after every store, when one exists.
+  /// First matching `ttl.cb_push` after every reserve-backed store, when one
+  /// exists. Wait-backed transactions never publish.
   std::optional<CBPushOp> push;
+
+  bool isWaitedMutation() const { return isa<CBWaitOp>(acquire); }
 };
 
 /// Read-only plan for storing and pushing one created `ComputeOp` result.
 ///
 /// Stores, transactions, and pushes retain block order. `dfbs` contains each
 /// output DFB once in first-store order. A DFB in `multiTransactionDFBs` is
-/// written through more than one reserve; combining those transactions into
-/// one compute would move a publication across a later reserve.
+/// written through more than one acquisition; combining those transactions
+/// into one compute would lose the acquisition boundary.
 struct OutputPublicationPlan {
   /// Unique output DFBs in first-store order.
   SmallVector<Value> dfbs;
@@ -320,17 +323,17 @@ struct OutputPublicationPlan {
   /// Existing `ttl.cb_push` operations matched to transactions, in block order.
   SmallVector<CBPushOp> pushes;
 
-  /// Reserve-delimited output transactions in first-store order.
+  /// Acquire-delimited output transactions in first-store order.
   SmallVector<OutputDFBTransaction> transactions;
 
-  /// DFBs written through more than one reserve operation.
+  /// DFBs written through more than one acquisition operation.
   SmallVector<Value> multiTransactionDFBs;
 
   /// Operation immediately before which the created `ComputeOp` executes.
   ///
   /// The final store is selected because all output stores are in one block
-  /// and each reserve dominates its store. It is therefore dominated by every
-  /// reserve needed to create the `ComputeOp` outputs.
+  /// and each acquisition dominates its store. It is therefore dominated by
+  /// every acquisition needed to create the `ComputeOp` outputs.
   StoreOp insertionAnchor;
 
   bool hasMultipleTransactionsForOneDFB() const {
@@ -340,6 +343,29 @@ struct OutputPublicationPlan {
   bool hasMultipleTransactions(Value dfb) const {
     return llvm::is_contained(multiTransactionDFBs, dfb);
   }
+};
+
+/// Immutable proof for one straight-line replacement of a waited DFB block.
+///
+/// The initial contract accepts one complete one-block consumer acquisition
+/// whose original value is a direct input to the replacement compute. All
+/// fields refer to the unmodified kernel used to build the creation plan.
+struct WaitedDFBMutationPlan {
+  /// Tensor store that replaces the acquired pages.
+  StoreOp store;
+
+  /// Consumer acquisition that owns the destination pages.
+  CBWaitOp wait;
+
+  /// Consumer release after every read of the replacement generation.
+  CBPopOp release;
+
+  /// Logical DFB whose read and write cursors coincide while the ring is full.
+  Value dfb;
+
+  /// Complete-ring transaction and capacity, in tiles.
+  int64_t transactionTiles = 0;
+  int64_t capacityTiles = 0;
 };
 
 /// Reason output publication cannot be planned for a legal source operation.
@@ -395,10 +421,11 @@ bool hasStandaloneComputeOpCreationRecipe(Operation *source);
 ///
 /// `source` must have exactly one result with at least one `ttl.store` user,
 /// all stores must be in one block, and every store view must originate from
-/// `ttl.cb_reserve`. Valid SSA ensures each reserve dominates its stores. These
-/// conditions provide one insertion position and explicit transaction
-/// identities. Unsupported valid forms return a typed rejection. A malformed
-/// reserve/store/publication transaction returns an invalid-IR diagnostic.
+/// `ttl.cb_reserve` or `ttl.cb_wait`. Valid SSA ensures each acquisition
+/// dominates its stores. These conditions provide one insertion position and
+/// explicit transaction identities. Unsupported valid forms return a typed
+/// rejection. A malformed store/publication transaction returns an invalid-IR
+/// diagnostic.
 PlanningResult<OutputPublicationPlan, OutputPublicationRejection>
 buildOutputPublicationPlan(Operation *source);
 
@@ -555,6 +582,9 @@ struct ComputeOpCreationPlan {
 
   /// Reserve, store, and publication transactions affected by creation.
   OutputPublicationPlan outputs;
+
+  /// Consumer-owned DFB replacements proved before IR mutation.
+  SmallVector<WaitedDFBMutationPlan> waitedMutations;
 
   /// Typed reason for an unselected structurally complete creation.
   ComputeOpCreationRejectionKind rejectionKind =

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -344,7 +344,7 @@ static scf::LoopNest generateAccumulatingLoops(
                                                            storeInfo.dstIndex);
           TileStoreOp::create(storeBuilder, parLoc, placeholder,
                               storeInfo.store.getView(), storeIndices,
-                              dstIdxVal);
+                              dstIdxVal, storeInfo.store.getStoreKind());
         }
 
         return {};

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -178,7 +178,7 @@ static void insertAtCreationAnchor(PatternRewriter &rewriter,
 /// Creates one tile store using the output transaction selected by planning.
 static void emitTileStore(PatternRewriter &rewriter, Location loc,
                           Value tileResult, ComputeOp computeOp, StoreOp store,
-                          const OutputPublicationPlan &outputs) {
+                          const ComputeOpCreationPlan &creation) {
   SmallVector<Value> iterIndices = getOrCreateIterIndices(rewriter, computeOp);
   auto indexingMaps = computeOp.getIndexingMapsArray();
   size_t numInputs = computeOp.getNumInputs();
@@ -191,8 +191,35 @@ static void emitTileStore(PatternRewriter &rewriter, Location loc,
   SmallVector<Value> indices =
       applyIndexingMap(rewriter, loc, outputMap, iterIndices);
 
-  createTileOpWithPlaceholderDstIndex<TileStoreOp>(rewriter, loc, tileResult,
-                                                   store.getView(), indices);
+  TileStoreOp tileStore = createTileOpWithPlaceholderDstIndex<TileStoreOp>(
+      rewriter, loc, tileResult, store.getView(), indices);
+  const WaitedDFBMutationPlan *waitedMutation = nullptr;
+  for (const WaitedDFBMutationPlan &mutation : creation.waitedMutations) {
+    if (mutation.store != store) {
+      continue;
+    }
+    assert(!waitedMutation && "one store cannot replace two waited DFBs");
+    waitedMutation = &mutation;
+  }
+  bool isWaitedMutation = waitedMutation != nullptr;
+  assert(isWaitedMutation == isa<CBWaitOp>(findCBAcquireOp(store.getView())) &&
+         "wait-backed tile store must consume a proved mutation plan");
+  if (isWaitedMutation) {
+    CBWaitOp waitedAcquire = waitedMutation->wait;
+    CBPopOp waitedRelease = waitedMutation->release;
+    assert(waitedAcquire == findCBAcquireOp(store.getView()) &&
+           waitedAcquire.getCb() == waitedMutation->dfb &&
+           waitedRelease.getCb() == waitedMutation->dfb &&
+           waitedMutation->transactionTiles ==
+               getDFBLifecycleTileCount(waitedAcquire) &&
+           waitedMutation->transactionTiles ==
+               getDFBLifecycleTileCount(waitedRelease) &&
+           waitedMutation->capacityTiles ==
+               cast<CircularBufferType>(waitedMutation->dfb.getType())
+                   .getTotalElements() &&
+           "waited DFB mutation changed after planning");
+    tileStore.setStoreKind(DFBTileStoreKind::ConsumerReplacement);
+  }
 }
 
 static void
@@ -541,7 +568,7 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   // Output stores and their instrumentation retain their complete source
   // order, including distinct signpost scopes around multiple stores.
   for (StoreOp store : outputs.stores) {
-    emitTileStore(rewriter, loc, finalResult, computeOp, store, outputs);
+    emitTileStore(rewriter, loc, finalResult, computeOp, store, creation);
     instrumentationEmitter.emitAfter(store);
   }
   assert(instrumentationEmitter.emittedAll() &&
@@ -655,7 +682,7 @@ static LogicalResult buildComputeFromInputs(
       emitTileOp(rewriter, loc, creation->resultTileType, body, *creation);
   instrumentationEmitter.emitAfter(op);
   for (StoreOp store : outputs.stores) {
-    emitTileStore(rewriter, loc, result, computeOp, store, outputs);
+    emitTileStore(rewriter, loc, result, computeOp, store, *creation);
     instrumentationEmitter.emitAfter(store);
   }
   assert(instrumentationEmitter.emittedAll() &&

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -546,8 +546,15 @@ struct TileStoreLowering : OpConversionPattern<TileStoreOp> {
 
     Value dstIndex = adaptor.getDstIndex();
 
-    ttk::PackTileOp::create(rewriter, loc, dstIndex, *cb, cbTileIndex,
-                            /*out_of_order=*/true);
+    if (op.getStoreKind() == DFBTileStoreKind::ConsumerReplacement) {
+      uint64_t acquiredTiles = static_cast<uint64_t>(
+          cast<ttk::CBType>((*cb).getType()).getNumElements());
+      ttk::PackWaitedTileOp::create(rewriter, loc, dstIndex, *cb, cbTileIndex,
+                                    /*out_of_order=*/true, acquiredTiles);
+    } else {
+      ttk::PackTileOp::create(rewriter, loc, dstIndex, *cb, cbTileIndex,
+                              /*out_of_order=*/true);
+    }
 
     rewriter.eraseOp(op);
     return success();

--- a/lib/Dialect/TTL/Transforms/LowerMatmulCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/LowerMatmulCompute.cpp
@@ -52,6 +52,7 @@ struct PendingStore {
   Value view;
   SmallVector<Value> indices;
   Value dstIndex;
+  DFBTileStoreKind storeKind = DFBTileStoreKind::Producer;
 };
 
 /// Non-mutating preflight for one block matmul compute. Shared by the
@@ -524,14 +525,14 @@ LogicalResult generateMatmulCompute(PatternRewriter &rewriter, Location loc,
       }
       pendingStores.push_back(
           {storedTile, expansion.mapping.lookupOrDefault(store.getView()),
-           storeIndices,
-           createConstantIndex(secBuilder, loc, *storedDstIndex)});
+           storeIndices, createConstantIndex(secBuilder, loc, *storedDstIndex),
+           store.getStoreKind()});
     }
   }
 
   for (PendingStore &store : pendingStores) {
     TileStoreOp::create(secBuilder, loc, store.tile, store.view, store.indices,
-                        store.dstIndex);
+                        store.dstIndex, store.storeKind);
   }
 
   SmallVector<Value> replacements;

--- a/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLInsertIntermediateDFBs.cpp
@@ -103,6 +103,7 @@ static void cloneComputeBodyWithMaterializedStores(
           output.reserve.getResult(), clonedStore.getIndices(),
           clonedStore.getDstIndex());
       materializedStore->setAttrs(clonedStore->getAttrs());
+      materializedStore.setStoreKind(DFBTileStoreKind::Producer);
       ++output.storeCount;
     }
   }

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -347,42 +347,47 @@ class TensorBlock:
         return _build_matmul(ast_self, rhs, transpose_rhs=False)
 
     def store(ast_self: TensorBlock, rhs: TensorBlock) -> None:
-        """Store result tensor to the output CB reserve view (overwrite).
+        """Store a result into a reserved or previously read waited block.
 
-        Emits ttl.store with the result tensor and reserve view.
-        Always overwrites the CB slot. For accumulation, use ``+=``.
+        A waited destination represents ordered replacement of the acquired
+        pages. Compiler analysis accepts it only after proving the complete
+        consumer-owned mutation contract.
         """
         if not _is_block(ast_self):
             raise ValueError(
-                "store() must be called on a block acquired from reserve(), not a regular tensor"
+                "store() must be called on a block acquired from reserve() or wait()"
             )
-        reserve = _get_reserve_from_block(ast_self)
+        acquired_view = _get_acquired_view_from_block(ast_self)
         _require_matching_tile_shapes(
             rhs.type.element_type,
-            reserve.type.element_type,
+            acquired_view.type.element_type,
             "source",
-            "destination CB",
+            "destination DFB",
         )
-        ttl.store(rhs, reserve)
+        ttl.store(rhs, acquired_view)
 
     def __iadd__(ast_self: TensorBlock, rhs: TensorBlock) -> TensorBlock:
-        """Accumulate into a reserved block via L1 packer accumulation.
+        """Accumulate into a reserve or replace a previously read wait.
 
-        Emits ttl.store with the ``accumulate`` attribute. When used
-        inside a loop, the compiler inserts ``pack_reconfig_l1_acc``
-        guards so that each iteration adds to the existing L1 value
-        instead of overwriting.
+        A reserve-backed block uses L1 packer accumulation. A wait-backed block
+        reads the original value, adds ``rhs``, and stores the replacement
+        without changing dataflow buffer occupancy or pointers.
 
-        This is an interim mechanism; the spec's full pattern
-        (``fill`` + lazy ``BlockExpr`` ``+=`` + ``store``) is deferred
-        to the BlockExpr PR (#446).
+        The compiler accepts waited replacement only after proving the
+        complete consumer-owned mutation contract.
         """
         if not _is_block(ast_self):
             raise ValueError(
-                "+= must be called on a block acquired from reserve(), not a regular tensor"
+                "+= must be called on a block acquired from reserve() or wait()"
             )
-        reserve = _get_reserve_from_block(ast_self)
-        ttl.store(rhs, reserve, accumulate=True)
+        acquired_view = _get_acquired_view_from_block(ast_self)
+        acquisition = acquired_view.owner
+        if acquisition.name == "ttl.cb_wait":
+            ttl.store(ttl.add(ast_self, rhs), acquired_view)
+            return ast_self
+        if acquisition.name != "ttl.cb_reserve":
+            raise ValueError("block acquisition must be ttl.cb_reserve or ttl.cb_wait")
+        ttl.store(rhs, acquired_view, accumulate=True)
         return ast_self
 
     def push(
@@ -512,15 +517,20 @@ def _is_block(value) -> bool:
     return value.owner.name == "ttl.attach_cb"
 
 
-def _get_reserve_from_block(block):
-    """Extract the reserve view from a block (result of ttl.attach_cb).
+def _get_acquired_view_from_block(block):
+    """Extract the reserve or wait view from a block.
 
     The attach_cb op has signature: (tensor, cb) -> tensor
     So the reserve/wait tensor is operand[0].
     """
     if block.owner.name != "ttl.attach_cb":
         raise ValueError(f"expected block from ttl.attach_cb, got {block.owner.name}")
-    return block.owner.operands[0]
+    acquired_view = block.owner.operands[0]
+    if acquired_view.owner.name not in ("ttl.cb_reserve", "ttl.cb_wait"):
+        raise ValueError(
+            "ttl.attach_cb tensor must come from ttl.cb_reserve or ttl.cb_wait"
+        )
+    return acquired_view
 
 
 def _get_cb_from_block(block):

--- a/test/python/test_subtile_tensor_dm.py
+++ b/test/python/test_subtile_tensor_dm.py
@@ -236,7 +236,7 @@ def test_copy_rejects_mismatched_tile_shape(device):
 
 
 def test_store_rejects_mismatched_tile_shape(device):
-    """CB->CB store must reject source/destination tile HxW mismatch."""
+    """DFB-to-DFB store must reject source/destination tile HxW mismatch."""
     out = _to_device(
         torch.zeros((32, 32), dtype=torch.bfloat16),
         device,
@@ -246,7 +246,7 @@ def test_store_rejects_mismatched_tile_shape(device):
     )
     with pytest.raises(
         TTLangCompileError,
-        match=r"source tile shape 16x16 must match destination CB tile shape 32x32",
+        match=r"source tile shape 16x16 must match destination DFB tile shape 32x32",
     ):
         _store_cb_16_into_cb_32(out)
     ttnn.deallocate(out)

--- a/test/python/test_tensor_backed_dfb.py
+++ b/test/python/test_tensor_backed_dfb.py
@@ -12,6 +12,7 @@ import torch
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
+import ttl  # noqa: E402
 from conftest import temp_kernel_files
 from ttlang_test_utils import to_dram
 from utils.correctness import assert_allclose, assert_pcc
@@ -160,6 +161,33 @@ def _to_height_sharded(torch_tensor, device, node_count):
     return ttnn.to_memory_config(dram_tensor, memory_config=memory_config)
 
 
+@ttl.operation(grid=(1, 1))
+def _replace_waited_tensor_backed_state(state, output):
+    state_dfb = ttl.make_tensor_backed_dfb(state, shape=(1, 1), block_count=1)
+    output_dfb = ttl.make_dataflow_buffer_like(output, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def replace_state():
+        with state_dfb.wait() as state_block:
+            increment = ttl.block.fill(
+                1,
+                shape=state_block.shape,
+                dtype=state_block.dtype,
+            )
+            state_block.store(state_block + increment)
+            with output_dfb.reserve() as output_block:
+                output_block.store(state_block)
+
+    @ttl.datamovement()
+    def publish_state():
+        state_dfb.publish()
+
+    @ttl.datamovement()
+    def write_output():
+        with output_dfb.wait() as output_block:
+            ttl.copy(output_block, output[0, 0]).wait()
+
+
 @pytest.mark.requires_device
 @pytest.mark.parametrize(
     "torch_dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"]
@@ -218,6 +246,31 @@ def test_tensor_backed_dfb_block_count_two(device, torch_dtype):
 
         actual = ttnn.to_torch(out)
         assert_pcc(expected.float(), actual.float(), threshold=0.999)
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize(
+    "torch_dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"]
+)
+def test_tensor_backed_waited_block_replacement_persists(device, torch_dtype):
+    """Replacement updates tensor storage and remains reusable across dispatches."""
+    element_indices = torch.arange(32 * 32, dtype=torch.float32).reshape(32, 32)
+    state_host = ((element_indices.remainder(257) - 128) / 64).to(torch_dtype)
+    state = _to_height_sharded(state_host, device, node_count=1)
+    output = to_dram(torch.zeros_like(state_host), device)
+
+    _replace_waited_tensor_backed_state(state, output)
+    _replace_waited_tensor_backed_state(state, output)
+
+    actual_state = ttnn.to_torch(state).float()
+    actual_output = ttnn.to_torch(output).float()
+    expected = state_host.float() + 2
+    if torch_dtype == torch.bfloat16:
+        assert_allclose(actual_state, expected, rtol=0.05, atol=1.0)
+        assert_allclose(actual_output, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual_state, expected, rtol=1e-5, atol=1e-6)
+        assert_allclose(actual_output, expected, rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.requires_device

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -103,6 +103,74 @@ def _make_repeated_dfb_atom_kernel(data_format):
     return repeated_dfb_atom_kernel
 
 
+@ttl.operation()
+def _store_waited_block(state_dfb: ttl.DFB, output_dfb: ttl.DFB):
+    with state_dfb.wait() as state_block:
+        increment = ttl.block.fill(
+            1,
+            shape=state_block.shape,
+            dtype=state_block.dtype,
+        )
+        updated_state = ttl.add(state_block, increment)
+        state_block.store(updated_state)
+
+        with output_dfb.reserve() as output_block:
+            output_block.store(state_block)
+
+
+@ttl.operation()
+def _iadd_waited_block(state_dfb: ttl.DFB, output_dfb: ttl.DFB):
+    with state_dfb.wait() as state_block:
+        increment = ttl.block.fill(
+            1,
+            shape=state_block.shape,
+            dtype=state_block.dtype,
+        )
+        state_block += increment
+
+        with output_dfb.reserve() as output_block:
+            output_block.store(
+                ttl.add(
+                    state_block,
+                    ttl.block.fill(
+                        0,
+                        shape=state_block.shape,
+                        dtype=state_block.dtype,
+                    ),
+                )
+            )
+
+
+def _make_waited_block_store_kernel(data_format):
+    @ttl.operation(grid=(1, 1))
+    def waited_block_mutation_kernel(input_tensor, output_tensor):
+        state_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=1)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        with state_dfb.reserve() as state_destination:
+            ttl.copy(input_tensor[0, 0], state_destination).wait()
+        _store_waited_block(state_dfb, output_dfb)
+        with output_dfb.wait() as output_block:
+            ttl.copy(output_block, output_tensor[0, 0]).wait()
+
+    return waited_block_mutation_kernel
+
+
+def _make_waited_block_iadd_kernel(data_format):
+    @ttl.operation(grid=(1, 1))
+    def waited_block_mutation_kernel(input_tensor, output_tensor):
+        state_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=1)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        with state_dfb.reserve() as state_destination:
+            ttl.copy(input_tensor[0, 0], state_destination).wait()
+        _iadd_waited_block(state_dfb, output_dfb)
+        with output_dfb.wait() as output_block:
+            ttl.copy(output_block, output_tensor[0, 0]).wait()
+
+    return waited_block_mutation_kernel
+
+
 def _make_nested_copy_atom(data_format, level_count):
     @ttl.operation()
     def copy_stage(source: ttl.DFB, destination: ttl.DFB):
@@ -806,6 +874,10 @@ _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
 _in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
 _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
+_waited_mutation_bf16_store_kernel = _make_waited_block_store_kernel("bf16")
+_waited_mutation_f32_store_kernel = _make_waited_block_store_kernel("float32")
+_waited_mutation_bf16_iadd_kernel = _make_waited_block_iadd_kernel("bf16")
+_waited_mutation_f32_iadd_kernel = _make_waited_block_iadd_kernel("float32")
 _exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
 _exact_f32_execution_domain_kernel = _make_exact_execution_domain_kernel("float32")
 _conditional_bf16_true_lifecycle_kernel = _make_conditional_lifecycle_kernel(
@@ -1375,6 +1447,40 @@ def test_selected_reset_preserves_non_target_live_aliases(
         rtol=0.05,
         atol=1.0,
     )
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_waited_mutation_bf16_store_kernel, torch.bfloat16),
+        (_waited_mutation_f32_store_kernel, torch.float32),
+        (_waited_mutation_bf16_iadd_kernel, torch.bfloat16),
+        (_waited_mutation_f32_iadd_kernel, torch.float32),
+    ],
+    ids=["store-bf16", "store-f32", "iadd-bf16", "iadd-f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_waited_block_replacement_preserves_updated_value(
+    device, operation, dtype, memory_config, to_device
+):
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    operation(input_tensor, output_tensor)
+    operation(input_tensor, output_tensor)
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float() + 1
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -141,17 +141,17 @@ def _iadd_waited_block(state_dfb: ttl.DFB, output_dfb: ttl.DFB):
             )
 
 
-def _make_waited_block_store_kernel(data_format):
+def _make_waited_block_store_kernel(data_format, tile_columns=1):
     @ttl.operation(grid=(1, 1))
     def waited_block_mutation_kernel(input_tensor, output_tensor):
-        state_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=1)
-        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        state_dfb = ttl.make_dfb(data_format, shape=(1, tile_columns), block_count=1)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, tile_columns), block_count=2)
 
         with state_dfb.reserve() as state_destination:
-            ttl.copy(input_tensor[0, 0], state_destination).wait()
+            ttl.copy(input_tensor[0:1, 0:tile_columns], state_destination).wait()
         _store_waited_block(state_dfb, output_dfb)
         with output_dfb.wait() as output_block:
-            ttl.copy(output_block, output_tensor[0, 0]).wait()
+            ttl.copy(output_block, output_tensor[0:1, 0:tile_columns]).wait()
 
     return waited_block_mutation_kernel
 
@@ -876,6 +876,12 @@ _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
 _waited_mutation_bf16_store_kernel = _make_waited_block_store_kernel("bf16")
 _waited_mutation_f32_store_kernel = _make_waited_block_store_kernel("float32")
+_waited_mutation_bf16_two_tile_store_kernel = _make_waited_block_store_kernel(
+    "bf16", tile_columns=2
+)
+_waited_mutation_f32_two_tile_store_kernel = _make_waited_block_store_kernel(
+    "float32", tile_columns=2
+)
 _waited_mutation_bf16_iadd_kernel = _make_waited_block_iadd_kernel("bf16")
 _waited_mutation_f32_iadd_kernel = _make_waited_block_iadd_kernel("float32")
 _exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
@@ -1450,14 +1456,23 @@ def test_selected_reset_preserves_non_target_live_aliases(
 
 
 @pytest.mark.parametrize(
-    ("operation", "dtype"),
+    ("operation", "dtype", "tile_columns"),
     [
-        (_waited_mutation_bf16_store_kernel, torch.bfloat16),
-        (_waited_mutation_f32_store_kernel, torch.float32),
-        (_waited_mutation_bf16_iadd_kernel, torch.bfloat16),
-        (_waited_mutation_f32_iadd_kernel, torch.float32),
+        (_waited_mutation_bf16_store_kernel, torch.bfloat16, 1),
+        (_waited_mutation_f32_store_kernel, torch.float32, 1),
+        (_waited_mutation_bf16_iadd_kernel, torch.bfloat16, 1),
+        (_waited_mutation_f32_iadd_kernel, torch.float32, 1),
+        (_waited_mutation_bf16_two_tile_store_kernel, torch.bfloat16, 2),
+        (_waited_mutation_f32_two_tile_store_kernel, torch.float32, 2),
     ],
-    ids=["store-bf16", "store-f32", "iadd-bf16", "iadd-f32"],
+    ids=[
+        "store-bf16",
+        "store-f32",
+        "iadd-bf16",
+        "iadd-f32",
+        "store-two-tiles-bf16",
+        "store-two-tiles-f32",
+    ],
 )
 @pytest.mark.parametrize(
     ("memory_config", "to_device"),
@@ -1465,9 +1480,11 @@ def test_selected_reset_preserves_non_target_live_aliases(
     ids=["dram", "l1"],
 )
 def test_waited_block_replacement_preserves_updated_value(
-    device, operation, dtype, memory_config, to_device
+    device, operation, dtype, tile_columns, memory_config, to_device
 ):
-    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    element_indices = torch.arange(
+        TILE * TILE * tile_columns, dtype=torch.float32
+    ).reshape(TILE, TILE * tile_columns)
     input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
     input_tensor = to_device(input_host, device)
     output_tensor = to_device(torch.zeros_like(input_host), device)

--- a/test/ttlang/Conversion/TTLToTTKernel/cb_ops_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/cb_ops_invalid.mlir
@@ -2,9 +2,9 @@
 
 // -----
 
-// ttl.tile_store view must come from ttl.cb_reserve (not a function argument).
+// ttl.tile_store view must come from a DFB acquisition, not a function argument.
 // The conversion fails because getCBFromView cannot trace from a block argument
-// back to a CB - it expects a view from ttl.cb_reserve.
+// back to a DFB acquisition.
 // expected-error @below {{failed to legalize operation 'ttl.tile_store' that was explicitly marked illegal}}
 module {
   func.func @store_view_not_from_reserve(%tile: !ttcore.tile<32x32, bf16>, %view: tensor<1x1x!ttcore.tile<32x32, bf16>>) attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {

--- a/test/ttlang/Dialect/TTKernel/IR/pack_waited_tile_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/pack_waited_tile_invalid.mlir
@@ -1,0 +1,28 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics
+
+// Verify that waited packing carries the complete-ring proof.
+
+func.func @mismatched_proof_tile_count() {
+  %c0 = arith.constant 0 : index
+  %dfb = ttkernel.get_compile_time_arg_val(0)
+      : () -> !ttkernel.cb<2, !ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttkernel.pack_waited_tile' op acquired_tiles must equal DFB capacity 2, got 1}}
+  ttkernel.pack_waited_tile(%c0, %dfb, %c0, true)
+      {acquired_tiles = 1 : i64}
+      : (index, !ttkernel.cb<2, !ttcore.tile<32x32, bf16>>, index) -> ()
+  return
+}
+
+// -----
+
+// Verify that waited packing uses absolute output indexing.
+func.func @ordered_packing() {
+  %c0 = arith.constant 0 : index
+  %dfb = ttkernel.get_compile_time_arg_val(0)
+      : () -> !ttkernel.cb<1, !ttcore.tile<32x32, bf16>>
+  // expected-error @below {{'ttkernel.pack_waited_tile' op requires out_of_order packing}}
+  ttkernel.pack_waited_tile(%c0, %dfb, %c0, false)
+      {acquired_tiles = 1 : i64}
+      : (index, !ttkernel.cb<1, !ttcore.tile<32x32, bf16>>, index) -> ()
+  return
+}

--- a/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
@@ -549,7 +549,7 @@ func.func @compute_result_count_mismatch(
 
 // -----
 
-// Test: tile_store view not from cb_reserve inside compute body
+// Test: tile_store view not from a DFB acquisition inside compute body
 func.func @compute_tile_store_view_not_from_reserve(
     %a: tensor<2x2x!ttcore.tile<32x32, f32>>,
     %view: tensor<2x2x!ttcore.tile<32x32, f32>>,
@@ -579,6 +579,43 @@ func.func @compute_tile_store_view_not_from_reserve(
     ttl.yield
   } -> tensor<2x2x!ttcore.tile<32x32, f32>>
   func.return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Test: consumer replacement requires a waited view.
+func.func @consumer_replacement_from_reserve(
+    %tile: !ttcore.tile<32x32, f32>) {
+  %c0 = arith.constant 0 : index
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %view = ttl.cb_reserve %dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{'ttl.tile_store' op consumer_replacement store requires a ttl.cb_wait-backed view}}
+  ttl.tile_store %tile, %view[] from dst[%c0]
+      {store_kind = 1 : i32}
+      : !ttcore.tile<32x32, f32>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+  return
+}
+
+// -----
+
+// Test: waited views cannot use producer packing.
+func.func @producer_store_to_waited_view(
+    %tile: !ttcore.tile<32x32, f32>) {
+  %c0 = arith.constant 0 : index
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %view = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{'ttl.tile_store' op ttl.cb_wait-backed view requires consumer_replacement store kind}}
+  ttl.tile_store %tile, %view[] from dst[%c0]
+      : !ttcore.tile<32x32, f32>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+  return
 }
 
 // -----

--- a/test/ttlang/Dialect/TTL/IR/store_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/store_invalid.mlir
@@ -51,12 +51,30 @@ func.func @store_shape_mismatch(
 
 // -----
 
-// View not from cb_reserve.
-func.func @store_view_not_from_reserve(
+// View not from a typed DFB acquisition.
+func.func @store_view_not_from_acquisition(
     %tensor: tensor<2x2x!ttcore.tile<32x32, f32>>,
     %view: tensor<2x2x!ttcore.tile<32x32, f32>>) {
   %cb = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[2, 2], !ttcore.tile<32x32, f32>, 2>
-  // expected-error @below {{view must come from ttl.cb_reserve}}
+  // expected-error @below {{view must come from ttl.cb_reserve or ttl.cb_wait}}
   ttl.store %tensor, %view : tensor<2x2x!ttcore.tile<32x32, f32>>, tensor<2x2x!ttcore.tile<32x32, f32>>
   func.return
+}
+
+// -----
+
+// Waited replacement uses an ordinary expression and cannot enable the
+// reserve-backed packer accumulation mode.
+func.func @waited_store_with_packer_accumulation(
+    %tensor: tensor<1x1x!ttcore.tile<32x32, f32>>) {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %view = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{wait-backed replacement does not support packer accumulation}}
+  ttl.store %tensor, %view {accumulate}
+      : tensor<1x1x!ttcore.tile<32x32, f32>>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+  return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
@@ -10,6 +10,7 @@
 // TTKERNEL-NOT: ttkernel.cb_reserve_back(%[[STATE]],
 // TTKERNEL: ttkernel.pack_waited_tile({{.*}}, %[[STATE]], %[[ZERO]], true) {acquired_tiles = 2 : i64}
 // TTKERNEL-NEXT: ttkernel.pack_waited_tile({{.*}}, %[[STATE]], %[[ONE]], true) {acquired_tiles = 2 : i64}
+// TTKERNEL-NOT: ttkernel.pack_waited_tile
 // TTKERNEL-NOT: ttkernel.cb_push_back(%[[STATE]],
 // TTKERNEL: ttkernel.cb_reserve_back(%[[OUTPUT]],
 // TTKERNEL: ttkernel.pack_tile_block({{.*}}, %[[OUTPUT]],
@@ -20,6 +21,7 @@
 // absolute-index pack API and emits no reserve or push for the mutated DFB.
 // EMITC-LABEL: func.func @mutate
 // EMITC-COUNT-2: emitc.call_opaque "pack_tile"
+// EMITC-NOT: emitc.call_opaque "pack_tile"
 // EMITC-NOT: pack_waited_tile
 
 module attributes {

--- a/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
@@ -1,0 +1,66 @@
+// RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline | FileCheck %s --check-prefix=TTKERNEL
+// RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline --convert-ttkernel-to-emitc | FileCheck %s --check-prefix=EMITC
+
+// TTKERNEL-LABEL: func.func @mutate
+// TTKERNEL: %[[OUTPUT:.*]] = ttkernel.get_compile_time_arg_val(0)
+// TTKERNEL: %[[STATE:.*]] = ttkernel.get_compile_time_arg_val(1)
+// TTKERNEL: ttkernel.cb_wait_front(%[[STATE]],
+// TTKERNEL-NOT: ttkernel.cb_reserve_back(%[[STATE]],
+// TTKERNEL: ttkernel.pack_waited_tile({{.*}}, %[[STATE]], {{.*}}, true) {acquired_tiles = 1 : i64}
+// TTKERNEL-NOT: ttkernel.cb_push_back(%[[STATE]],
+// TTKERNEL: ttkernel.cb_reserve_back(%[[OUTPUT]],
+// TTKERNEL: ttkernel.pack_tile({{.*}}, %[[OUTPUT]],
+// TTKERNEL: ttkernel.cb_push_back(%[[OUTPUT]],
+// TTKERNEL: ttkernel.cb_pop_front(%[[STATE]],
+
+// The proof attribute is compiler-only. Runtime lowering uses the existing
+// absolute-index pack API and emits no reserve or push for the mutated DFB.
+// EMITC-LABEL: func.func @mutate
+// EMITC-COUNT-2: emitc.call_opaque "pack_tile"
+// EMITC-NOT: pack_waited_tile
+
+module attributes {
+  ttl.launch_grid = [1, 1],
+  ttl.target_arch = #ttcore.arch<blackhole>
+} {
+  func.func @mutate() attributes {
+    ttl.base_cta_index = 2 : i32,
+    ttl.crta_indices = [],
+    ttl.kernel_thread = #ttkernel.thread<compute>,
+    ttl.logical_kernel = #ttl.logical_kernel<kind = compute>
+  } {
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %state_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %wait = ttl.cb_wait %state_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %state = ttl.attach_cb %wait, %state_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %one = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %updated = ttl.add %state, %one
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.store %updated, %wait
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.store %state, %output
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %output_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.cb_pop %state_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
@@ -2,14 +2,17 @@
 // RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline --convert-ttkernel-to-emitc | FileCheck %s --check-prefix=EMITC
 
 // TTKERNEL-LABEL: func.func @mutate
+// TTKERNEL-DAG: %[[ONE:.*]] = arith.constant 1 : index
+// TTKERNEL-DAG: %[[ZERO:.*]] = arith.constant 0 : index
 // TTKERNEL: %[[OUTPUT:.*]] = ttkernel.get_compile_time_arg_val(0)
 // TTKERNEL: %[[STATE:.*]] = ttkernel.get_compile_time_arg_val(1)
 // TTKERNEL: ttkernel.cb_wait_front(%[[STATE]],
 // TTKERNEL-NOT: ttkernel.cb_reserve_back(%[[STATE]],
-// TTKERNEL: ttkernel.pack_waited_tile({{.*}}, %[[STATE]], {{.*}}, true) {acquired_tiles = 1 : i64}
+// TTKERNEL: ttkernel.pack_waited_tile({{.*}}, %[[STATE]], %[[ZERO]], true) {acquired_tiles = 2 : i64}
+// TTKERNEL-NEXT: ttkernel.pack_waited_tile({{.*}}, %[[STATE]], %[[ONE]], true) {acquired_tiles = 2 : i64}
 // TTKERNEL-NOT: ttkernel.cb_push_back(%[[STATE]],
 // TTKERNEL: ttkernel.cb_reserve_back(%[[OUTPUT]],
-// TTKERNEL: ttkernel.pack_tile({{.*}}, %[[OUTPUT]],
+// TTKERNEL: ttkernel.pack_tile_block({{.*}}, %[[OUTPUT]],
 // TTKERNEL: ttkernel.cb_push_back(%[[OUTPUT]],
 // TTKERNEL: ttkernel.cb_pop_front(%[[STATE]],
 
@@ -31,36 +34,36 @@ module attributes {
   } {
     %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
         {dfb_id = 1 : index}
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
     %state_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
         {dfb_id = 0 : index}
-        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
     %wait = ttl.cb_wait %state_dfb
-        : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
-          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+          -> tensor<1x2x!ttcore.tile<32x32, bf16>>
     %state = ttl.attach_cb %wait, %state_dfb
-        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
-           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
-          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+          -> tensor<1x2x!ttcore.tile<32x32, bf16>>
     %one = ttl.fill 1.000000e+00
-        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+        : tensor<1x2x!ttcore.tile<32x32, bf16>>
     %updated = ttl.add %state, %one
-        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-          tensor<1x1x!ttcore.tile<32x32, bf16>>
-          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+          tensor<1x2x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x2x!ttcore.tile<32x32, bf16>>
     ttl.store %updated, %wait
-        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-          tensor<1x1x!ttcore.tile<32x32, bf16>>
+        : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+          tensor<1x2x!ttcore.tile<32x32, bf16>>
     %output = ttl.cb_reserve %output_dfb
-        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x2x!ttcore.tile<32x32, bf16>>
     ttl.store %state, %output
-        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-          tensor<1x1x!ttcore.tile<32x32, bf16>>
+        : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+          tensor<1x2x!ttcore.tile<32x32, bf16>>
     ttl.cb_push %output_dfb
-        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
     ttl.cb_pop %state_dfb
-        : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation_invalid.mlir
@@ -185,6 +185,44 @@ func.func @live_old_generation()
 
 // -----
 
+// A replacement-trace intermediate still denotes the original generation and
+// cannot be recomputed after the in-place write for an independent store.
+func.func @original_generation_intermediate_escape()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %old_intermediate = ttl.exp %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %old_intermediate, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires values derived from the original DFB contents to remain within the replacement computation}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %old_intermediate, %output
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  return
+}
+
+// -----
+
 func.func @overlapping_producer_acquisition()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}

--- a/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation_invalid.mlir
@@ -1,0 +1,439 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute))'
+
+// Verify that waited-block replacement rejects every protocol or ordering case
+// for which the compiler cannot prove complete occupied-slot replacement.
+
+func.func @overwrite_before_read()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.fill 1.000000e+00
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement must read the acquired value before writing}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @multi_block_cursor_state()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires one complete DFB block}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @partial_one_block_acquisition()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
+  // expected-error @below {{'ttl.cb_wait' op result tensor has 2 tiles but num_tiles attribute is 1}}
+  %wait = ttl.cb_wait %dfb {num_tiles = 1 : i64}
+      : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.store %replacement, %wait
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @repeated_replacement()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires exactly one store per acquisition}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @conditional_replacement(%condition: i1)
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  scf.if %condition {
+    %replacement = ttl.add %block, %block
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires one straight-line entry-block execution}}
+    ttl.store %replacement, %wait
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  return
+}
+
+// -----
+
+func.func @iterated_replacement()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.for %iteration = %c0 to %c1 step %c1 {
+    %replacement = ttl.add %block, %block
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires one straight-line entry-block execution}}
+    ttl.store %replacement, %wait
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+  }
+  return
+}
+
+// -----
+
+func.func @live_old_generation()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %stale = ttl.exp %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement has an unsupported or unordered use of the acquired generation}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %stale, %output
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @overlapping_producer_acquisition()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %producer = ttl.cb_reserve %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement cannot overlap a producer acquisition}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @prior_partial_consumer_transaction()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
+  ttl.opaque_call "consume_one" dfb_dependencies(
+      %dfb : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+      dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>,
+                   #ttl.dfb_protocol_effect<pop, 0, 1>]
+      () {header = "consumer.hpp"} : () -> ()
+  %wait = ttl.cb_wait %dfb
+      : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires no earlier access to the same DFB in its compute kernel}}
+  ttl.store %replacement, %wait
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %dfb
+      : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+  return
+}
+
+// -----
+
+func.func @release_before_replacement()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement cannot execute after its consumer release}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @missing_release()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires a matching consumer release}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @mismatched_release_count()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement requires equal wait and pop tile counts}}
+  ttl.store %replacement, %wait
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %dfb {num_tiles = 1 : i64}
+      : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+  return
+}
+
+// -----
+
+func.func @replacement_read_after_release()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement value cannot be read after its consumer release}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %late = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %late, %output
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}
+
+// -----
+
+func.func @opaque_access_during_replacement()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement cannot overlap another DFB access}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.opaque_call "inspect" dfb_dependencies(
+      %dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      () {header = "inspect.hpp", unknown_dfb_access} : () -> ()
+  ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  return
+}
+
+// -----
+
+func.func @unknown_opaque_access_during_replacement()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement cannot overlap another DFB access}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.opaque_call "inspect" ()
+      {header = "inspect.hpp", unknown_dfb_access} : () -> ()
+  ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  return
+}
+
+// -----
+
+func.func @nested_dfb_access_during_replacement(%condition: i1)
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %block = ttl.attach_cb %wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %replacement = ttl.add %block, %block
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{cannot lower tensor store to ttl.compute: wait-backed replacement cannot overlap a nested DFB access}}
+  ttl.store %replacement, %wait
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  scf.if %condition {
+    ttl.opaque_call "inspect" dfb_dependencies(
+        %dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        () {header = "inspect.hpp"} : () -> ()
+  }
+  ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  return
+}


### PR DESCRIPTION
### Problem description

TT-Lang rejected every store to a block acquired by `wait`, even when the program reads the old value, replaces the complete acquired block, consumes the replacement, and then pops it. Kimi FlashKDA requires this ordered state update. Replacing it with `pop` followed by `reserve` would transfer ownership and may select a different ring slot.

### What's changed

~640 LOC implementation (tests and documentation excluded).

Plan the complete consumer-owned mutation interval before rewriting. A replacement is legal only for one complete one-block transaction with exact wait/pop counts, single straight-line execution, no earlier or overlapping access, no value derived from the original contents escaping the replacement computation, and a terminal pop.

Add `ttkernel.pack_waited_tile`, which packs into a compiler-proved waited slot without changing queue occupancy or pointers. It lowers to ordinary `pack_tile` only after proving that the acquired read window and destination coincide. Unsupported multi-block, repeated, conditional, asynchronous, or opaque lifecycles remain rejected. The simulator remains unchanged because it does not yet model consumer-owned replacement state.

```python
with state_dfb.wait() as state:
    increment = ttl.block.fill(1, shape=state.shape, dtype=state.dtype)
    state.store(state + increment)

    with output_dfb.reserve() as output:
        output.store(state)
```

### Validation

- New device tests verify explicit `store` and `+=` across BF16/FP32 and DRAM/L1, including repeated dispatch and two-tile full-ring replacement.
- New lowering coverage verifies both page indices for a two-tile replacement, and new invalid coverage rejects an original-generation intermediate used outside the replacement computation.
- New analysis tests reject overwrite-before-read, partial or multi-block acquisition, repeated or conditional execution, old-generation uses, overlapping access, premature release, and post-pop reads.
