### PR TITLE
[ci][fix] CI precheck bats test fix

### DIFF
--- a/.github/scripts/tests/test_check_public_content.bats
+++ b/.github/scripts/tests/test_check_public_content.bats
@@ -13,8 +13,13 @@ setup() {
         "$RESTRICTED_TEXT")
 }
 
+# Empty the environment: a pull_request workflow run exports GITHUB_BASE_REF
+# naming a base branch the fixture repository does not have, and an allow-list
+# also excludes inputs the script reads later. Each test's own `env` runs after
+# this one, so its values take precedence.
 run_check() {
-    run env TTLANG_PUBLIC_CONTENT_SIGNATURES="$TEST_SIGNATURE" "$@"
+    run env -i PATH="$PATH" HOME="$HOME" \
+        TTLANG_PUBLIC_CONTENT_SIGNATURES="$TEST_SIGNATURE" "$@"
 }
 
 @test "accepts an ordinary branch and diff" {


### PR DESCRIPTION
### Problem description

`run_check()` in `.github/scripts/tests/test_check_public_content.bats` forwarded the ambient environment to `check-public-content.py`. On a `pull_request` run `GITHUB_BASE_REF` resolves to `refs/remotes/origin/<base>`, which the fixture repository lacks, so `check_branch_diff()` fails with `cannot resolve required diff base` in 8 of 18 tests. A base of `main` resolves to the fixture's one remote ref, so only stacked pull requests fail. Observed on #864.

### What's changed

`run_check()` runs under `env -i` with `PATH` and `HOME` allow-listed, neither of which the script reads. An allow-list also excludes inputs the script reads later, unlike unsetting the current eight one by one. Per-test `env` invocations run after it and take precedence, so no test body changed. `check-public-content.py` is unchanged.

### Testing

18 of 18 pass with a base ref absent from the fixture (8 failures before this change), with `GITHUB_BASE_REF=main`, with it unset, and with all eight of the script's inputs set to values that would break the checks.

### Checklist

- [x] New/Existing tests provide coverage for changes
