### PR TITLE
[ttl][fix] Make DFB index capacity target-aware

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -6,11 +6,13 @@ This document describes how the tt-lang compiler manages dataflow buffers (DFBs)
 
 DFBs originate from two sources. User-declared DFBs are created explicitly in the DSL via `make_dataflow_buffer_like` and correspond to the programmer's data movement plan. Compiler-allocated DFBs are inserted automatically when the compiler needs concrete storage for a tensor SSA value: a tensor-level operation requires a CB-attached operand, a fused expression must be preserved before a source DFB release, or a computed value is stored by operations in multiple MLIR basic blocks.
 
-The hardware supports at most 32 DFBs per node (indices 0--31). User and
-compiler-allocated DFBs share this index space. Passes operating on individual
-kernels assign compiler DFBs kernel-local provisional indices. The module-level
-finalization pass assigns module-wide physical indices after the last
-user-declared DFB and applies lifetime-based index reuse.
+Blackhole supports 64 physical DFB indices per node (0--63). Wormhole B0 and
+Quasar support 32 (0--31). Compilation without target metadata uses the
+conservative 32-index capacity. User and compiler-allocated DFBs share this
+index space. Passes operating on individual kernels assign compiler DFBs
+kernel-local provisional indices. The module-level finalization pass assigns
+module-wide physical indices after the last user-declared DFB and applies
+lifetime-based index reuse.
 
 `ttl.bind_cb` separates logical and physical identity. `dfb_id` identifies one
 logical DFB across kernel functions, while `cb_index` names its assigned
@@ -634,8 +636,8 @@ Physical index reuse may later assign the same index to non-overlapping
 compiler DFB lifetimes of identical type. `ttl-validate-cb-budget` runs after
 index finalization and verifies the resulting static DFB storage against the
 device-specific remaining L1 budget. Materialization that is semantically
-required but exceeds either the 32-index limit or the L1 budget is rejected
-with a resource diagnostic.
+required but exceeds either the selected target's DFB-index capacity or the L1
+budget is rejected with a resource diagnostic.
 
 `test/python/test_recurrence_multi_output_dfb.py` exercises this behavior on
 hardware with several results materialized from the same compute, nested and
@@ -1573,19 +1575,20 @@ them different physical indices.
 atom with a three-level tree-reduction atom over eight nodes. The composed
 operation contains 36 logical DFBs across the compute and data movement
 kernels. Proven non-overlapping lifetimes reduce the allocation to 29 physical
-indices, below the hardware limit of 32. The device test compares the final
-result with PyTorch scaled dot-product attention.
+indices, within every supported target capacity. The device test compares the
+final result with PyTorch scaled dot-product attention.
 
 `test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir`
 isolates the cross-kernel ordering rules. The independent allocation-oracle
 test joins 30 DFBs that all conflict pairwise with the confirmed four-DFB
-order-sensitive case. First-fit uses 33 indices and the fixed-limit exact check
-finds a 32-index assignment. The invalid liveness test confirms that 33
-mutually conflicting lifetimes are rejected.
+order-sensitive case. First-fit uses 33 indices and the target-capacity exact
+check finds a 32-index assignment. The invalid liveness test confirms that 33
+mutually conflicting lifetimes are rejected without target metadata.
 
 `test/python/test_user_dfb_reuse.py` recursively composes copy atoms into an
-operation with 33 logical DFBs. The operation compiles and executes only when
-reuse reduces the physical allocation below the hardware limit.
+operation with 33 logical DFBs. Reuse reduces the physical allocation for all
+targets. A focused Blackhole case disables reuse and executes all 33 distinct
+indices.
 
 ### Module attribute and runtime integration
 
@@ -1594,8 +1597,9 @@ compiler-created DFBs after them. This removes gaps caused by DFBs that the
 frontend created but no kernel captured, without changing logical identity or
 existing physical-index sharing. Lifetime-based assignment may further reuse
 physical indices when enabled. The planned physical DFB count is one greater
-than the greatest assigned index, and the pass verifies this does not exceed
-`kMaxCircularBuffers` (32).
+than the greatest assigned index. The pass compares this count with
+`getTargetMaxDFBIndices()`, which returns 64 for Blackhole and 32 for Wormhole
+B0, Quasar, and absent target metadata.
 
 The allocation planner records the final `ttl.base_cta_index` for every kernel
 that has the attribute. Compile-time arguments to each kernel reserve

--- a/docs/development/PipeOptimizations.md
+++ b/docs/development/PipeOptimizations.md
@@ -26,11 +26,9 @@ Goals:
 3. Remove the limit on overlapping multicast width. Today, when `N`
    pipes target the same receiver and share its dataflow buffer, the
    receiver's `block_count` must be at least `N` because each pipe
-   gets its own dedicated slot in that buffer. With the tt-metal
-   per-Tensix CB cap of 32 (`NUM_CIRCULAR_BUFFERS` in
-   [`tt_metal/llrt/hal.hpp:409-411`][hal-num-cb]), this constrains
-   overlapping multicast to `N <= 32`. The compiler should let one
-   wide overlapping multicast lower without that constraint.
+   gets its own dedicated slot in that buffer. The resulting DFB allocation
+   grows with `N` until it exceeds available L1. The compiler should let one
+   wide overlapping multicast use bounded storage independent of `N`.
 
 ## 2. Background
 
@@ -51,12 +49,8 @@ requires multicast receivers to reserve the same slot for a given pipe
 because TT-Metal NoC multicast carries one destination address.
 `verifyReceiverDFBBlockCounts` then requires
 `block_count >= max_slot_idx + 1` per receiver. This
-makes overlapping multicast unrepresentable when more than 32 pipes
-target the same receiver: the tt-metal per-Tensix CB cap is 32
-(`NUM_CIRCULAR_BUFFERS` in
-[`tt_metal/llrt/hal.hpp:409-411`][hal-num-cb], enforced in tt-lang
-at `python/ttl/dataflow_buffer.py:66`), and the slot table requires
-the count to equal the number of pipes.
+makes the receiver's L1 allocation grow linearly with the number of pipes and
+eventually exceed the available L1 budget.
 
 ### Multicast handshake protocol
 
@@ -797,7 +791,7 @@ CCL receiver staging DFB feeding a matmul operand-reader DFB.
 operand-reader DFB occupies; the operand-reader waits on a semaphore
 (signaled by the multicast sender) instead of doing a
 `cb_wait_front` on the staging DFB. Saves one CB index (one of the
-32 per-Tensix tt-metal CB slots that DFBs lower to), one
+target-dependent physical slots that DFBs lower to), one
 `cb_push_back` / `cb_pop_front` pair, and the implicit L1 region
 reservation for the staging DFB.
 
@@ -808,9 +802,9 @@ DFB exists between gather and matmul-A. The companion compute
 kernel is
 [`bmm_large_block_zm_fused_bias_activation_gathered.cpp`][llama-compute].
 
-**Why this is faster.** Frees one of the 32 per-Tensix CB indices
-that DFBs lower to and removes one push/pop pair per delivered
-tile. For kernels approaching the index ceiling (e.g.
+**Why this is faster.** Frees one physical DFB index and removes one push/pop
+pair per delivered tile. For kernels approaching the target's index capacity
+(e.g.
 `make_balanced_relu_kernel` in `test_mcast_matmul.py` already uses
 4-5 DFBs), the index headroom is the limiting factor.
 
@@ -821,8 +815,8 @@ needs a separate analysis pass.
 
 #### 3.2.6 Wave decomposition for wide overlapping multicast
 
-**Pattern.** A single PipeNet whose slot-per-pipe `block_count`
-exceeds the L1 budget or the tt-metal per-Tensix CB cap of 32.
+**Pattern.** A single PipeNet whose slot-per-pipe `block_count` exceeds the L1
+budget.
 
 **Rewrite.** The pass splits the PipeNet into `K` narrower PipeNets
 executed sequentially, each with `block_count = ceil(N/K)` where `N`
@@ -865,11 +859,6 @@ queries. At minimum the interface exposes:
 - `l1BandwidthPerCycle()`: per-Tensix L1 bandwidth in bytes per
   cycle, used to bound the receiver-side staging cost subtracted by
   3.2.5.
-- `dataflowBufferDepthCap()`: 32 on Wormhole and Blackhole, the
-  static maximum `block_count` enforced by `python/ttl/circular_buffer.py`.
-  3.2.6 applies only when the slot-per-pipe `block_count` would
-  exceed this value.
-
 Each rewrite then implements `costOfRewritten(pipeNet, ctx)` and
 `costOfFallback(pipeNet, ctx)` returning a comparable scalar; the
 rewrite applies when the difference exceeds a target-specific threshold.
@@ -1288,8 +1277,6 @@ tt-metal (at SHA `c296ef469fe6aab65ab0d359e164b14b62d92bfc`):
 - [`tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp`](https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp) — random-source-to-random-destination NoC sweep
 - [tt-benchmarking repository](https://github.com/tenstorrent/tt-benchmarking) — op-level perf harnesses
 - [`Kernel::compute_hash` (tt-metal JIT cache key)](https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/tt_metal/impl/kernels/kernel.cpp#L374-L399) — hashes emitted source, compile-time args, defines, and config
-- [`NUM_CIRCULAR_BUFFERS = 32` (tt-metal per-Tensix CB cap)](https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/tt_metal/llrt/hal.hpp#L409-L411) — the limit `block_count` is bounded by
-
 <!--
 The reference labels below back the in-text [text][label] links and
 should be left in place; markdown renders them as invisible link
@@ -1312,7 +1299,6 @@ definitions.
 [llvm-lv-force-ordered]: https://github.com/llvm/llvm-project/blob/705cdc3a9d0adb4c0667aa840a1f23165eca297b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp#L344
 [dm-in0-chain]: https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp#L287-L315
 [noc-mcast-docstring]: https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/tt_metal/hw/inc/api/dataflow/dataflow_api.h#L885-L924
-[hal-num-cb]: https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/tt_metal/llrt/hal.hpp#L409-L411
 [dm-in1-out]: https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
 [factory-in0-next]: https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp#L719-L722
 [factory-in1-next]: https://github.com/tenstorrent/tt-metal/blob/c296ef469fe6aab65ab0d359e164b14b62d92bfc/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp#L770-L773

--- a/docs/sphinx/specs/TTLangSpecification.externalized.md
+++ b/docs/sphinx/specs/TTLangSpecification.externalized.md
@@ -635,7 +635,7 @@ number of SFPU lane iterations and defaults to 8.
 | Tile size in scalar elements | 32, 32 | 32, 32 |
 | Maximum single chip grid size (unharvested) | 8, 9 | 13, 10 |
 | Size of L1 memory (KB) | 1464 | 1464 |
-| Maximum number of dataflow buffers | 32 | 32 |
+| Maximum number of dataflow buffers | 32 | 64 |
 
 
 [^1]: This is temporary requirement that will be removed in future versions. When removed the shape will be inferred.

--- a/docs/sphinx/specs/TTLangSpecification.md
+++ b/docs/sphinx/specs/TTLangSpecification.md
@@ -1638,7 +1638,7 @@ number of SFPU lane iterations and defaults to 8.
 | Tile size in scalar elements | 32, 32 | 32, 32 |
 | Maximum single chip grid size (unharvested) | 8, 9 | 13, 10 |
 | Size of L1 memory (KB) | 1464 | 1464 |
-| Maximum number of dataflow buffers | 32 | 32 |
+| Maximum number of dataflow buffers | 32 | 64 |
 
 
 [^1]: This is temporary requirement that will be removed in future versions. When removed the shape will be inferred.

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -24,8 +24,6 @@ namespace mlir::tt::ttl {
 /// Default tile dimensions used for TTL tensors.
 inline constexpr int32_t kDefaultTileHeight = 32;
 inline constexpr int32_t kDefaultTileWidth = 32;
-/// Physical DFB indices supported by TT kernel hardware.
-inline constexpr int32_t kMaxCircularBuffers = 32;
 /// TT kernel hardware semaphore id capacity. Mirrored by
 /// python/ttl/constants.py for simulator-side resource checks.
 inline constexpr int64_t kMaxHardwareSemaphoreIds = 16;

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -936,13 +936,14 @@ def TTLFinalizeDFBIndices
     legal and remains live through the end of its kernel.
 
     The pass rejects copied DFB-index attributes from later passes. It computes
-    all physical assignments and runtime metadata and validates the 32-index
-    hardware limit before modifying the IR. Applying the validated plan updates
-    physical indices and `ttl.base_cta_index`, assigns missing compiler-created
-    logical IDs, and builds `ttl.dfb_allocations` for the Python runtime. The
-    attribute contains one descriptor per physical index, including
-    user-declared and compiler-created DFBs, and records the page size computed
-    from the finalized element type. See docs/development/DFBManagement.md.
+    all physical assignments and runtime metadata and validates the selected
+    target's physical DFB-index capacity before modifying the IR. Applying the
+    validated plan updates physical indices and `ttl.base_cta_index`, assigns
+    missing compiler-created logical IDs, and builds `ttl.dfb_allocations` for
+    the Python runtime. The attribute contains one descriptor per physical
+    index, including user-declared and compiler-created DFBs, and records the
+    page size computed from the finalized element type. See
+    docs/development/DFBManagement.md.
   }];
 
   let options = [

--- a/include/ttlang/Dialect/TTL/Transforms/ComputeTarget.h
+++ b/include/ttlang/Dialect/TTL/Transforms/ComputeTarget.h
@@ -35,11 +35,6 @@ struct ReductionCapability {
   ttkernel::ReduceDim reduceDimension;
 };
 
-/// Resolve the optional architecture selected by the module attribute or
-/// default device. Both sources must agree when present.
-FailureOr<std::optional<ttcore::Arch>>
-resolveComputeTargetArch(Operation *operation, std::string &failureReason);
-
 /// Immutable LLK capabilities for one compute target.
 class ComputeTargetEnvironment {
 public:

--- a/include/ttlang/Dialect/TTL/Transforms/DFBMaterialization.h
+++ b/include/ttlang/Dialect/TTL/Transforms/DFBMaterialization.h
@@ -21,11 +21,12 @@ namespace mlir::tt::ttl {
 /// at kernel entry, where finalization can assign physical indices
 /// consistently. The provisional index is unique within the kernel;
 /// finalization assigns module-wide indices, performs lifetime-based reuse, and
-/// validates the hardware limit. The completed compiler pipeline emits a
-/// balanced reserve/push/wait/pop lifecycle whose pop executes before the same
-/// static reserve repeats, so one slot is sufficient. The builder's insertion
-/// point is left at the new `bind_cb`; callers that need to emit elsewhere
-/// should wrap the call in `OpBuilder::InsertionGuard`.
+/// validates the selected target's physical DFB-index capacity. The completed
+/// compiler pipeline emits a balanced reserve/push/wait/pop lifecycle whose
+/// pop executes before the same static reserve repeats, so one slot is
+/// sufficient. The builder's insertion point is left at the new `bind_cb`;
+/// callers that need to emit elsewhere should wrap the call in
+/// `OpBuilder::InsertionGuard`.
 BindCBOp createCompilerAllocatedDFB(RankedTensorType tensorType, Location loc,
                                     func::FuncOp kernel, OpBuilder &builder);
 

--- a/include/ttlang/Target/TargetInfo.h
+++ b/include/ttlang/Target/TargetInfo.h
@@ -5,13 +5,21 @@
 #ifndef TTLANG_TARGET_TARGETINFO_H
 #define TTLANG_TARGET_TARGETINFO_H
 
-#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttlang/Dialect/TTCore/IR/TTCoreOps.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Support/LogicalResult.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include <cassert>
 #include <cstdint>
+#include <optional>
+#include <string>
 
 namespace mlir::tt {
 
@@ -27,16 +35,168 @@ inline constexpr int64_t kWormholeB0NocMaxBurstBytes = 8192;
 inline constexpr int64_t kBlackholeNocMaxBurstBytes = 16384;
 inline constexpr int64_t kDefaultNocMaxBurstBytes = kWormholeB0NocMaxBurstBytes;
 
+/// Physical DFB-index capacity selected for a compilation target.
+struct TargetDFBIndexCapacity {
+  int32_t indexCount;
+  llvm::StringRef targetName;
+
+  bool contains(int64_t index) const {
+    return index >= 0 && index < indexCount;
+  }
+
+  std::string getDescription() const {
+    if (targetName.empty()) {
+      return "the conservative " + std::to_string(indexCount) +
+             "-DFB-index capacity used when target metadata is absent";
+    }
+    return "the " + std::to_string(indexCount) + "-DFB-index " +
+           targetName.str() + " target capacity";
+  }
+};
+
+namespace target_info_detail {
+
+inline FailureOr<std::optional<ttcore::Arch>>
+getDeviceArch(ModuleOp module, std::string &failureReason) {
+  Attribute rawSystemDesc = module->getAttr(ttcore::SystemDescAttr::name);
+  auto systemDesc = dyn_cast_or_null<ttcore::SystemDescAttr>(rawSystemDesc);
+  if (rawSystemDesc && !systemDesc) {
+    failureReason =
+        "ttcore.system_desc must be a #ttcore.system_desc attribute";
+    return failure();
+  }
+  auto device = ttcore::lookupDeviceOp(module, ttcore::getDefaultDeviceName());
+  if (!systemDesc || !device) {
+    return std::optional<ttcore::Arch>();
+  }
+
+  ArrayRef<unsigned> chipIds = device.getDeviceAttr().getChipIds();
+  if (chipIds.empty()) {
+    failureReason = "default device has no selected chip";
+    return failure();
+  }
+  auto invalidChip = llvm::find_if(chipIds, [&](unsigned chipId) {
+    return chipId >= systemDesc.getChipDescIndices().size();
+  });
+  if (invalidChip != chipIds.end()) {
+    failureReason = "default device selects chip " +
+                    std::to_string(*invalidChip) +
+                    " outside the system description";
+    return failure();
+  }
+  ttcore::Arch arch =
+      systemDesc.getChipDesc(chipIds.front()).getArch().getValue();
+  if (llvm::any_of(llvm::drop_begin(chipIds), [&](unsigned chipId) {
+        return systemDesc.getChipDesc(chipId).getArch().getValue() != arch;
+      })) {
+    failureReason = "default device selects chips with different architectures";
+    return failure();
+  }
+  return std::optional<ttcore::Arch>(arch);
+}
+
+} // namespace target_info_detail
+
+/// Resolve the optional architecture selected by the module attribute or
+/// default device. Both sources must agree when present.
+inline FailureOr<std::optional<ttcore::Arch>>
+resolveTargetArch(Operation *operation, std::string &failureReason) {
+  failureReason.clear();
+  ModuleOp module = dyn_cast<ModuleOp>(operation);
+  if (!module) {
+    module = operation->getParentOfType<ModuleOp>();
+  }
+  if (!module) {
+    failureReason = "operation is not nested in a module";
+    return failure();
+  }
+
+  std::optional<ttcore::Arch> attributeArch;
+  Attribute rawTargetArch = module->getAttr(kTargetArchAttrName);
+  auto targetArch = dyn_cast_or_null<ttcore::ArchAttr>(rawTargetArch);
+  if (rawTargetArch && !targetArch) {
+    failureReason =
+        (kTargetArchAttrName + " must be a #ttcore.arch attribute").str();
+    return failure();
+  }
+  if (targetArch) {
+    attributeArch = targetArch.getValue();
+  }
+
+  FailureOr<std::optional<ttcore::Arch>> deviceArch =
+      target_info_detail::getDeviceArch(module, failureReason);
+  if (failed(deviceArch)) {
+    return failure();
+  }
+  if (attributeArch && *deviceArch && *attributeArch != **deviceArch) {
+    failureReason =
+        (kTargetArchAttrName + " does not match the selected device arch")
+            .str();
+    return failure();
+  }
+  return attributeArch ? attributeArch : *deviceArch;
+}
+
+/// Return the DFB-index capacity for a resolved target architecture.
+inline TargetDFBIndexCapacity
+getTargetDFBIndexCapacity(ttcore::Arch targetArch) {
+  switch (targetArch) {
+  case ttcore::Arch::WormholeB0:
+    return {32, "Wormhole B0"};
+  case ttcore::Arch::Blackhole:
+    return {64, "Blackhole"};
+  case ttcore::Arch::Quasar:
+    return {32, "Quasar"};
+  }
+  llvm_unreachable("unhandled ttcore::Arch");
+}
+
+/// Return the conservative capacity used without target metadata.
+inline TargetDFBIndexCapacity getConservativeDFBIndexCapacity() {
+  return {32, {}};
+}
+
+/// Resolve and return the physical DFB-index capacity for an operation.
+inline FailureOr<TargetDFBIndexCapacity>
+resolveTargetDFBIndexCapacity(Operation *operation,
+                              std::string &failureReason) {
+  FailureOr<std::optional<ttcore::Arch>> targetArch =
+      resolveTargetArch(operation, failureReason);
+  if (failed(targetArch)) {
+    return failure();
+  }
+  return *targetArch ? getTargetDFBIndexCapacity(**targetArch)
+                     : getConservativeDFBIndexCapacity();
+}
+
+/// Return the physical DFB-index capacity after target metadata validation.
+inline int32_t getTargetMaxDFBIndices(Operation *operation) {
+  std::string failureReason;
+  FailureOr<TargetDFBIndexCapacity> capacity =
+      resolveTargetDFBIndexCapacity(operation, failureReason);
+  assert(succeeded(capacity) && "target metadata must be validated");
+  return capacity->indexCount;
+}
+
+/// Return target and limit text after target metadata validation.
+inline std::string getTargetDFBIndexCapacityDescription(Operation *operation) {
+  std::string failureReason;
+  FailureOr<TargetDFBIndexCapacity> capacity =
+      resolveTargetDFBIndexCapacity(operation, failureReason);
+  assert(succeeded(capacity) && "target metadata must be validated");
+  return capacity->getDescription();
+}
+
 /// Return the maximum one-packet NoC transfer size for the module target.
 ///
 /// Compile-only IR may omit `ttl.target_arch`; in that case this uses the
 /// minimum supported Wormhole B0/Blackhole value.
-inline int64_t getTargetNocMaxBurstBytes(Operation *op) {
-  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
-  auto targetArch =
-      moduleOp ? moduleOp->getAttrOfType<ttcore::ArchAttr>(kTargetArchAttrName)
-               : nullptr;
-  if (targetArch && targetArch.getValue() == ttcore::Arch::Blackhole) {
+inline int64_t getTargetNocMaxBurstBytes(Operation *operation) {
+  std::string failureReason;
+  FailureOr<std::optional<ttcore::Arch>> targetArch =
+      resolveTargetArch(operation, failureReason);
+  assert(succeeded(targetArch) && "target metadata must be validated");
+  if (*targetArch && **targetArch == ttcore::Arch::Blackhole) {
     return kBlackholeNocMaxBurstBytes;
   }
   return kDefaultNocMaxBurstBytes;

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -80,7 +80,7 @@ SystemDescAttr createDefaultBlackholeSystemDesc(
   constexpr auto dramUnreservedBase = 64;
   constexpr auto dramUnreservedEnd = 4276383744;
   constexpr auto dstPhysicalSizeTiles = 16;
-  constexpr auto numCBs = 32;
+  constexpr auto numCBs = 64;
   constexpr auto numComputeThreads = 1;
   constexpr auto numDatamovementThreads = 2;
 

--- a/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeKernelConfigAnalysis.cpp
@@ -73,13 +73,15 @@ getOptionalUnpackConstraint(func::FuncOp function) {
   }
 
   SmallVector<int32_t> dataflowBufferIndices(unpackAttribute.asArrayRef());
-  if (llvm::any_of(dataflowBufferIndices, [](int32_t index) {
-        return index < 0 || index >= kMaxCircularBuffers;
+  int32_t targetMaxDFBIndices = getTargetMaxDFBIndices(function);
+  if (llvm::any_of(dataflowBufferIndices, [&](int32_t index) {
+        return index < 0 || index >= targetMaxDFBIndices;
       })) {
     function.emitOpError()
         << kUnpackToDestFp32AttrName
         << " must contain dataflow buffer indices in range [0, "
-        << kMaxCircularBuffers - 1 << "]";
+        << targetMaxDFBIndices - 1 << "] for "
+        << getTargetDFBIndexCapacityDescription(function);
     return failure();
   }
   llvm::sort(dataflowBufferIndices);
@@ -117,10 +119,12 @@ resolveDataflowBufferIndex(Value value, Operation *consumer) {
       consumer->emitOpError("uses a dataflow buffer without a finalized index");
       return failure();
     }
-    if (*dfbIndex < 0 || *dfbIndex >= kMaxCircularBuffers) {
-      consumer->emitOpError() << "uses dataflow buffer index " << *dfbIndex
-                              << " outside the supported range [0, "
-                              << kMaxCircularBuffers - 1 << "]";
+    int32_t targetMaxDFBIndices = getTargetMaxDFBIndices(consumer);
+    if (*dfbIndex < 0 || *dfbIndex >= targetMaxDFBIndices) {
+      consumer->emitOpError()
+          << "uses dataflow buffer index " << *dfbIndex
+          << " outside the supported range [0, " << targetMaxDFBIndices - 1
+          << "] for " << getTargetDFBIndexCapacityDescription(consumer);
       return failure();
     }
     return dfbIndex;
@@ -760,7 +764,7 @@ KernelTargetEnvironment::get(func::FuncOp function) {
 
   std::string targetFailureReason;
   FailureOr<std::optional<ttcore::Arch>> targetArch =
-      resolveComputeTargetArch(function, targetFailureReason);
+      resolveTargetArch(function, targetFailureReason);
   if (failed(targetArch)) {
     module.emitOpError(targetFailureReason);
     return failure();

--- a/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeTarget.cpp
@@ -5,7 +5,6 @@
 #include "ttlang/Dialect/TTL/Transforms/ComputeTarget.h"
 
 #include "ttlang/Dialect/TTCore/IR/TTCoreOps.h"
-#include "ttlang/Dialect/TTCore/IR/Utils.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
@@ -472,40 +471,6 @@ std::unique_ptr<ComputeTargetEnvironment> createCommonTargetEnvironment() {
       std::move(environments));
 }
 
-FailureOr<std::optional<ttcore::Arch>>
-getDeviceArch(ModuleOp module, std::string &failureReason) {
-  auto systemDesc = module->getAttrOfType<ttcore::SystemDescAttr>(
-      ttcore::SystemDescAttr::name);
-  auto device = ttcore::lookupDeviceOp(module, ttcore::getDefaultDeviceName());
-  if (!systemDesc || !device) {
-    return std::optional<ttcore::Arch>();
-  }
-
-  ArrayRef<unsigned> chipIds = device.getDeviceAttr().getChipIds();
-  if (chipIds.empty()) {
-    failureReason = "default device has no selected chip";
-    return failure();
-  }
-  auto invalidChip = llvm::find_if(chipIds, [&](unsigned chipId) {
-    return chipId >= systemDesc.getChipDescIndices().size();
-  });
-  if (invalidChip != chipIds.end()) {
-    failureReason = "default device selects chip " +
-                    std::to_string(*invalidChip) +
-                    " outside the system description";
-    return failure();
-  }
-  ttcore::Arch arch =
-      systemDesc.getChipDesc(chipIds.front()).getArch().getValue();
-  if (llvm::any_of(llvm::drop_begin(chipIds), [&](unsigned chipId) {
-        return systemDesc.getChipDesc(chipId).getArch().getValue() != arch;
-      })) {
-    failureReason = "default device selects chips with different architectures";
-    return failure();
-  }
-  return std::optional<ttcore::Arch>(arch);
-}
-
 FailureOr<ttcore::TileType> getRequiredTileType(Type type, StringRef role,
                                                 std::string &failureReason) {
   FailureOr<ttcore::TileType> tileType = getTileType(type);
@@ -612,49 +577,11 @@ getReductionCapability(Operation *operation, std::string &failureReason) {
 
 } // namespace
 
-FailureOr<std::optional<ttcore::Arch>>
-resolveComputeTargetArch(Operation *operation, std::string &failureReason) {
-  failureReason.clear();
-  ModuleOp module = dyn_cast<ModuleOp>(operation);
-  if (!module) {
-    module = operation->getParentOfType<ModuleOp>();
-  }
-  if (!module) {
-    failureReason = "operation is not nested in a module";
-    return failure();
-  }
-
-  std::optional<ttcore::Arch> attributeArch;
-  Attribute rawTargetArch = module->getAttr(kTargetArchAttrName);
-  auto targetArch = dyn_cast_or_null<ttcore::ArchAttr>(rawTargetArch);
-  if (rawTargetArch && !targetArch) {
-    failureReason =
-        (kTargetArchAttrName + " must be a #ttcore.arch attribute").str();
-    return failure();
-  }
-  if (targetArch) {
-    attributeArch = targetArch.getValue();
-  }
-
-  FailureOr<std::optional<ttcore::Arch>> deviceArch =
-      getDeviceArch(module, failureReason);
-  if (failed(deviceArch)) {
-    return failure();
-  }
-  if (attributeArch && *deviceArch && *attributeArch != **deviceArch) {
-    failureReason =
-        (kTargetArchAttrName + " does not match the selected device arch")
-            .str();
-    return failure();
-  }
-  return attributeArch ? attributeArch : *deviceArch;
-}
-
 FailureOr<std::unique_ptr<ComputeTargetEnvironment>>
 ComputeTargetEnvironment::get(Operation *operation,
                               std::string &failureReason) {
   FailureOr<std::optional<ttcore::Arch>> arch =
-      resolveComputeTargetArch(operation, failureReason);
+      resolveTargetArch(operation, failureReason);
   if (failed(arch)) {
     return failure();
   }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -76,9 +76,8 @@ static Value lookupCBByIndex(Value src, Operation *funcOp) {
     if (computeOp) {
       unsigned argIdx = barg.getArgNumber();
       if (auto cbIndex = getCBIndexAttr(computeOp, argIdx)) {
-        // Validate cb_index is in valid range.
-        assert(*cbIndex >= 0 && *cbIndex < kMaxCircularBuffers &&
-               "cb_index must be in range [0, 31]");
+        assert(*cbIndex >= 0 && *cbIndex < getTargetMaxDFBIndices(computeOp) &&
+               "cb_index must be valid for the compilation target");
 
         // Find the bind_cb op with matching cb_index in the function.
         Value result;

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -227,9 +227,11 @@ static FailureOr<int32_t> getValidatedDFBIndex(Value dfb, Operation *op) {
   if (!dfbIndex) {
     return op->emitError("cannot resolve finalized DFB index");
   }
-  if (*dfbIndex < 0 || *dfbIndex >= kMaxCircularBuffers) {
+  int32_t targetMaxDFBIndices = getTargetMaxDFBIndices(op);
+  if (*dfbIndex < 0 || *dfbIndex >= targetMaxDFBIndices) {
     return op->emitError("finalized DFB index ")
-           << *dfbIndex << " is outside [0, " << kMaxCircularBuffers - 1 << "]";
+           << *dfbIndex << " is outside [0, " << targetMaxDFBIndices - 1
+           << "] for " << getTargetDFBIndexCapacityDescription(op);
   }
   return static_cast<int32_t>(*dfbIndex);
 }
@@ -316,10 +318,12 @@ struct BindCBLowering : OpConversionPattern<BindCBOp> {
 
     // Get the CB index from the bind_cb op attribute.
     int64_t cbIndex = op.getCbIndex().getSExtValue();
-    if (cbIndex < 0 || cbIndex >= kMaxCircularBuffers) {
+    int32_t targetMaxDFBIndices = getTargetMaxDFBIndices(op);
+    if (cbIndex < 0 || cbIndex >= targetMaxDFBIndices) {
       return rewriter.notifyMatchFailure(op, [&](Diagnostic &diag) {
         diag << "cb_index " << cbIndex << " out of valid range [0, "
-             << kMaxCircularBuffers - 1 << "]";
+             << targetMaxDFBIndices - 1 << "] for "
+             << getTargetDFBIndexCapacityDescription(op);
       });
     }
 

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
@@ -152,9 +152,9 @@ uint64_t DFBAllocationFootprint::getBytes(int64_t physicalIndex) const {
   return indexIt->second;
 }
 
-llvm::SmallVector<int64_t, kMaxCircularBuffers>
+llvm::SmallVector<int64_t>
 DFBAllocationFootprint::getSortedPhysicalIndices() const {
-  llvm::SmallVector<int64_t, kMaxCircularBuffers> physicalIndices;
+  llvm::SmallVector<int64_t> physicalIndices;
   physicalIndices.reserve(maxBytesByIndex.size());
   for (int64_t physicalIndex : llvm::make_first_range(maxBytesByIndex)) {
     physicalIndices.push_back(physicalIndex);

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.h
@@ -40,8 +40,7 @@ public:
   FailureOr<uint64_t> getTotalBytesWithMinimumAllocations(
       const llvm::DenseMap<int64_t, uint64_t> &minimumBytesByIndex) const;
   uint64_t getBytes(int64_t physicalIndex) const;
-  llvm::SmallVector<int64_t, kMaxCircularBuffers>
-  getSortedPhysicalIndices() const;
+  llvm::SmallVector<int64_t> getSortedPhysicalIndices() const;
 
 private:
   llvm::DenseMap<int64_t, uint64_t> maxBytesByIndex;

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -13,6 +13,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Transforms/DFBLogicalIdentityAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h"
+#include "ttlang/Target/TargetInfo.h"
 
 #include "mlir/IR/BuiltinOps.h"
 
@@ -279,12 +280,6 @@ setExactSearchLimitFailure(ModuleOp moduleOp, unsigned firstFitCount,
   analysisFailure.set(moduleOp, messageStream.str());
 }
 
-/// Derives capacity text from the enforced constant so diagnostics cannot
-/// report a stale limit.
-static std::string getPhysicalIndexLimitDescription() {
-  return "the " + std::to_string(kMaxCircularBuffers) + "-index hardware limit";
-}
-
 /// Maps provisional user indices to a dense physical index range.
 ///
 /// Frontend indices identify allocation groups before finalization but may
@@ -332,6 +327,7 @@ struct PhysicalAllocationCandidate {
 static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
     ModuleOp moduleOp, const DFBConcurrentKernelLivenessAnalysis &liveness,
     const DFBPhysicalConflictModel &conflictModel,
+    const TargetDFBIndexCapacity &targetCapacity,
     DFBAnalysisFailure &analysisFailure,
     std::uint64_t exactColoringSearchStateLimit, bool requireMinimum = false) {
   ArrayRef<DFBLogicalLifecycle> logicalDFBs =
@@ -340,6 +336,7 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
       computeCompactedUserIndices(logicalDFBs);
   int32_t firstCompilerIndex =
       static_cast<int32_t>(compactedUserIndices.size());
+  int32_t targetMaxDFBIndices = targetCapacity.indexCount;
   SmallVector<unsigned> compilerLogicalIndices;
   for (auto indexedLogicalDFB : llvm::enumerate(logicalDFBs)) {
     if (indexedLogicalDFB.value().compilerCreated) {
@@ -348,9 +345,9 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
   }
 
   unsigned availableCompilerIndices =
-      firstCompilerIndex >= kMaxCircularBuffers
+      firstCompilerIndex >= targetMaxDFBIndices
           ? 0
-          : static_cast<unsigned>(kMaxCircularBuffers - firstCompilerIndex);
+          : static_cast<unsigned>(targetMaxDFBIndices - firstCompilerIndex);
   FailureOr<ConcurrentAssignmentResult> compilerAssignment =
       computeConcurrentAssignments(
           moduleOp, compilerLogicalIndices, firstCompilerIndex, conflictModel,
@@ -441,12 +438,12 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
   }
 
   int32_t compilerSlotCount = allocation.physicalDFBCount - firstCompilerIndex;
-  if (allocation.physicalDFBCount > kMaxCircularBuffers) {
+  if (allocation.physicalDFBCount > targetMaxDFBIndices) {
     if (allocation.exactSearchLimitReached) {
       setExactSearchLimitFailure(
           moduleOp, allocation.physicalDFBCount,
           allocation.exactSearchStateCount, exactColoringSearchStateLimit,
-          getPhysicalIndexLimitDescription(), analysisFailure);
+          targetCapacity.getDescription(), analysisFailure);
       return failure();
     }
     std::string message;
@@ -459,8 +456,9 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
                            static_cast<int32_t>(
                                compilerAssignment->provenColorLowerBound);
     }
-    messageStream << " unspilled DFB indices but hardware supports at most "
-                  << kMaxCircularBuffers << " (" << compilerSlotCount
+    messageStream << " unspilled DFB indices, exceeding "
+                  << targetCapacity.getDescription() << " ("
+                  << compilerSlotCount
                   << " compiler-allocated after proven reuse)";
     analysisFailure.set(moduleOp, messageStream.str());
     return failure();
@@ -473,16 +471,18 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
 static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
     ModuleOp moduleOp, const DFBConcurrentKernelLivenessAnalysis &liveness,
     const DFBPhysicalConflictModel &conflictModel,
+    const TargetDFBIndexCapacity &targetCapacity,
     DFBAnalysisFailure &analysisFailure,
     std::uint64_t exactColoringSearchStateLimit, bool requireMinimum) {
   ArrayRef<DFBLogicalLifecycle> logicalDFBs =
       liveness.getLogicalDFBLifecycles();
   SmallVector<unsigned> logicalIndices =
       llvm::to_vector(llvm::seq<unsigned>(0, logicalDFBs.size()));
+  int32_t targetMaxDFBIndices = targetCapacity.indexCount;
   FailureOr<ConcurrentAssignmentResult> assignment =
       computeConcurrentAssignments(
           moduleOp, logicalIndices, /*firstPhysicalIndex=*/0, conflictModel,
-          kMaxCircularBuffers, exactColoringSearchStateLimit, analysisFailure,
+          targetMaxDFBIndices, exactColoringSearchStateLimit, analysisFailure,
           requireMinimum);
   if (failed(assignment)) {
     return failure();
@@ -503,13 +503,13 @@ static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
          logicalDFB.declarations, logicalDFB.bounded});
   }
 
-  if (allocation.physicalDFBCount <= kMaxCircularBuffers) {
+  if (allocation.physicalDFBCount <= targetMaxDFBIndices) {
     return allocation;
   }
   if (allocation.exactSearchLimitReached) {
     setExactSearchLimitFailure(
         moduleOp, allocation.physicalDFBCount, allocation.exactSearchStateCount,
-        exactColoringSearchStateLimit, getPhysicalIndexLimitDescription(),
+        exactColoringSearchStateLimit, targetCapacity.getDescription(),
         analysisFailure);
     return failure();
   }
@@ -522,8 +522,8 @@ static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
     messageStream << "DFB allocation needs at least "
                   << assignment->provenColorLowerBound;
   }
-  messageStream << " unspilled physical indices but hardware supports at most "
-                << kMaxCircularBuffers;
+  messageStream << " unspilled physical indices, exceeding "
+                << targetCapacity.getDescription();
   analysisFailure.set(moduleOp, messageStream.str());
   return failure();
 }
@@ -775,6 +775,14 @@ DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
     std::uint64_t exactColoringSearchStateLimit,
     AnalysisManager analysisManager) {
   ModuleOp moduleOp = cast<ModuleOp>(operation);
+  std::string targetFailureReason;
+  FailureOr<TargetDFBIndexCapacity> targetCapacity =
+      resolveTargetDFBIndexCapacity(moduleOp, targetFailureReason);
+  if (failed(targetCapacity)) {
+    errorOperation = moduleOp;
+    errorMessage = std::move(targetFailureReason);
+    return;
+  }
   const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis =
       analysisManager.getAnalysis<DFBLogicalIdentityAnalysis>();
   if (!logicalIdentityAnalysis.succeeded()) {
@@ -797,12 +805,12 @@ DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
       [&](bool requireMinimum) -> FailureOr<PhysicalAllocationCandidate> {
     if (reuseUserDFBs) {
       return computeReuseAllocation(
-          moduleOp, liveness, plan.conflictModel, analysisFailure,
-          exactColoringSearchStateLimit, requireMinimum);
+          moduleOp, liveness, plan.conflictModel, *targetCapacity,
+          analysisFailure, exactColoringSearchStateLimit, requireMinimum);
     }
     return computeDistinctUserAllocation(
-        moduleOp, liveness, plan.conflictModel, analysisFailure,
-        exactColoringSearchStateLimit, requireMinimum);
+        moduleOp, liveness, plan.conflictModel, *targetCapacity,
+        analysisFailure, exactColoringSearchStateLimit, requireMinimum);
   };
   FailureOr<PhysicalAllocationCandidate> allocation =
       computeAllocationWithinL1(moduleOp, exactColoringSearchStateLimit,

--- a/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLSetComputeKernelConfig.cpp
@@ -29,10 +29,14 @@ struct TTLSetComputeKernelConfigPass
     func::FuncOp function = getOperation();
     FailureOr<std::unique_ptr<KernelTargetEnvironment>> target =
         KernelTargetEnvironment::get(function);
+    if (failed(target)) {
+      signalPassFailure();
+      return;
+    }
     FailureOr<KernelConfigPolicy> policy = KernelConfigPolicy::get(
         function, fp32DestAccEn, dstFullSyncEn, reduceFullFp32, matmulFullFp32,
         enableFPUBinaryOps);
-    if (failed(target) || failed(policy)) {
+    if (failed(policy)) {
       signalPassFailure();
       return;
     }

--- a/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLValidateCBBudget.cpp
@@ -121,8 +121,7 @@ struct TTLValidateCBBudgetPass
       return;
     }
     uint64_t totalBytes = *maybeTotalBytes;
-    SmallVector<int64_t, kMaxCircularBuffers> sortedIndices =
-        footprint.getSortedPhysicalIndices();
+    SmallVector<int64_t> sortedIndices = footprint.getSortedPhysicalIndices();
 
     auto emitBreakdown = [&](InFlightDiagnostic &diag) {
       for (int64_t idx : sortedIndices) {

--- a/python/sim/program.py
+++ b/python/sim/program.py
@@ -198,14 +198,16 @@ def Program(*funcs: BindableTemplate, grid: Shape, pipenets: Any = None) -> Any:
         ) -> None:
             """Cooperative scheduling execution mode using greenlets."""
 
-            # Warn if the number of DataflowBuffers exceeds the hardware limit.
+            # Warn if the number of DataflowBuffers exceeds the configured limit.
             dfb_count = get_context().kernel_dfb_count
             max_dfbs = get_max_dfbs()
             if dfb_count > max_dfbs:
                 warnings.warn(
                     f"Kernel defines {dfb_count} dataflow buffers, "
-                    f"but the hardware limit is {max_dfbs}. "
-                    f"Reduce the number of ttl.make_dataflow_buffer_like() calls.",
+                    f"but the configured limit is {max_dfbs}. "
+                    f"Reduce the number of ttl.make_dataflow_buffer_like() calls, "
+                    f"or raise the limit with --max-dfbs. Blackhole supports 64 "
+                    f"physical DFB indices; Wormhole B0 and Quasar support 32.",
                     stacklevel=2,
                 )
 

--- a/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
+++ b/test/lib/Analysis/DFBAllocation/DFBAllocationOracleTest.cpp
@@ -7,8 +7,13 @@
 // assignment enumeration supplies expected results without calling the
 // production search.
 
+#include "ttlang/Dialect/TTCore/IR/TTCore.h"
 #include "ttlang/Dialect/TTL/Transforms/InterferenceGraphColoring.h"
+#include "ttlang/Target/TargetInfo.h"
 
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
@@ -27,6 +32,111 @@ using mlir::tt::ttl::InterferenceGraphColorLimitStatus;
 
 constexpr uint64_t kUnlimitedSearchStates =
     std::numeric_limits<uint64_t>::max();
+
+/// Verifies the target query and default system descriptor use the same
+/// architecture capacities.
+static bool verifyTargetDFBIndexCapacities() {
+  mlir::MLIRContext context;
+  context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+  mlir::OwningOpRef<mlir::ModuleOp> module =
+      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+
+  struct ExpectedCapacity {
+    mlir::tt::ttcore::Arch arch;
+    int32_t indexCount;
+  };
+  constexpr ExpectedCapacity expectedCapacities[] = {
+      {mlir::tt::ttcore::Arch::WormholeB0, 32},
+      {mlir::tt::ttcore::Arch::Blackhole, 64},
+      {mlir::tt::ttcore::Arch::Quasar, 32},
+  };
+  llvm::SmallVector<int32_t, 4> observedCapacities;
+  for (const ExpectedCapacity &expected : expectedCapacities) {
+    module->getOperation()->setAttr(
+        mlir::tt::kTargetArchAttrName,
+        mlir::tt::ttcore::ArchAttr::get(&context, expected.arch));
+    std::string failureReason;
+    mlir::FailureOr<mlir::tt::TargetDFBIndexCapacity> capacity =
+        mlir::tt::resolveTargetDFBIndexCapacity(*module, failureReason);
+    if (mlir::failed(capacity) || capacity->indexCount != expected.indexCount ||
+        !capacity->contains(expected.indexCount - 1) ||
+        capacity->contains(expected.indexCount)) {
+      llvm::errs() << "target DFB-index capacity mismatch\n";
+      return false;
+    }
+    observedCapacities.push_back(capacity->indexCount);
+  }
+  module->getOperation()->removeAttr(mlir::tt::kTargetArchAttrName);
+  std::string failureReason;
+  mlir::FailureOr<mlir::tt::TargetDFBIndexCapacity> missingTargetCapacity =
+      mlir::tt::resolveTargetDFBIndexCapacity(*module, failureReason);
+  if (mlir::failed(missingTargetCapacity) ||
+      missingTargetCapacity->indexCount != 32) {
+    llvm::errs() << "missing-target DFB-index capacity mismatch\n";
+    return false;
+  }
+  observedCapacities.push_back(missingTargetCapacity->indexCount);
+
+  module->getOperation()->setAttr(mlir::tt::kTargetArchAttrName,
+                                  mlir::StringAttr::get(&context, "blackhole"));
+  mlir::FailureOr<mlir::tt::TargetDFBIndexCapacity> malformedTargetCapacity =
+      mlir::tt::resolveTargetDFBIndexCapacity(*module, failureReason);
+  if (mlir::succeeded(malformedTargetCapacity) ||
+      failureReason != "ttl.target_arch must be a #ttcore.arch attribute") {
+    llvm::errs() << "malformed target architecture was not rejected\n";
+    return false;
+  }
+
+  struct ExpectedSystemDescCapacity {
+    mlir::tt::ttcore::Arch arch;
+    unsigned numCBs;
+    llvm::StringRef name;
+  };
+  const ExpectedSystemDescCapacity expectedSystemDescCapacities[] = {
+      {mlir::tt::ttcore::Arch::Blackhole, 64, "Blackhole"},
+      {mlir::tt::ttcore::Arch::WormholeB0, 32, "Wormhole B0"},
+  };
+  llvm::SmallVector<unsigned, 2> observedSystemDescCapacities;
+  for (const ExpectedSystemDescCapacity &expected :
+       expectedSystemDescCapacities) {
+    mlir::tt::ttcore::SystemDescAttr systemDesc =
+        mlir::tt::ttcore::SystemDescAttr::getDefault(&context, expected.arch);
+    if (systemDesc.getChipDescs().size() != 1 ||
+        systemDesc.getChipDescs().front().getNumCBs() != expected.numCBs) {
+      llvm::errs() << "default " << expected.name
+                   << " system descriptor reports the wrong DFB-index "
+                      "capacity\n";
+      return false;
+    }
+    observedSystemDescCapacities.push_back(
+        systemDesc.getChipDescs().front().getNumCBs());
+
+    mlir::OwningOpRef<mlir::ModuleOp> deviceModule =
+        mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
+    deviceModule->getOperation()->setAttr(
+        mlir::tt::ttcore::SystemDescAttr::name, systemDesc);
+    mlir::OpBuilder builder(&context);
+    builder.setInsertionPointToStart(deviceModule->getBody());
+    mlir::tt::ttcore::DeviceOp::create(
+        builder, deviceModule->getLoc(),
+        mlir::tt::ttcore::getDefaultDeviceName(),
+        mlir::tt::ttcore::DeviceAttr::get(&context, systemDesc));
+    mlir::FailureOr<mlir::tt::TargetDFBIndexCapacity> deviceCapacity =
+        mlir::tt::resolveTargetDFBIndexCapacity(*deviceModule, failureReason);
+    if (mlir::failed(deviceCapacity) ||
+        deviceCapacity->indexCount != static_cast<int32_t>(expected.numCBs)) {
+      llvm::errs() << "default device target resolution mismatch\n";
+      return false;
+    }
+  }
+
+  llvm::outs() << "target_capacities=";
+  llvm::interleaveComma(observedCapacities, llvm::outs());
+  llvm::outs() << "\nsystem_desc_num_cbs=";
+  llvm::interleaveComma(observedSystemDescCapacities, llvm::outs());
+  llvm::outs() << "\n";
+  return true;
+}
 
 /// Enumerates index choices in vertex order so expected results do not depend
 /// on the production search order.
@@ -371,6 +481,7 @@ int main() {
                  verifyGreedyCapacityReproducer() &&
                  verifySearchLimitOutcome() &&
                  verifyFixedLimitAvoidsMinimumSearch() &&
+                 verifyTargetDFBIndexCapacities() &&
                  compareAssignmentContracts()
              ? 0
              : 1;

--- a/test/python/invalid/invalid_dfb_capacity.py
+++ b/test/python/invalid/invalid_dfb_capacity.py
@@ -13,7 +13,7 @@ logical assignments and must report the Python-visible physical-index limit.
 """
 
 # REUSE: Compiled kernel ready
-# NOREUSE: need 33 unspilled DFB indices but hardware supports at most 32
+# NOREUSE: need 33 unspilled DFB indices, exceeding the conservative 32-DFB-index capacity used when target metadata is absent
 
 import os
 

--- a/test/python/test_external_dfb_reuse.py
+++ b/test/python/test_external_dfb_reuse.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.requires_device
 # TTNN interop rejects non-tilized tensors before DFB lowering, so TILE is the
 # only supported tensor layout for these runtime cases.
 TILE = 32
-OVER_CAPACITY_COMPOSITION_LEVELS = 5
+OVER_CAPACITY_COMPOSITION_LEVELS = 6
 EXTERNAL_COMPOSITION_LOGICAL_DFBS = (1 << OVER_CAPACITY_COMPOSITION_LEVELS) + 6
 EXTERNAL_COMPOSITION_PHYSICAL_DFBS = 8
 # The external fp32 pack step produces approximately 1/256 output increments.
@@ -188,7 +188,7 @@ _external_f32_composition = _make_external_composition_kernel("float32", False)
 _tensor_backed_bf16_composition = _make_external_composition_kernel("bf16", True)
 _tensor_backed_f32_composition = _make_external_composition_kernel("float32", True)
 
-assert EXTERNAL_COMPOSITION_LOGICAL_DFBS > 32
+assert EXTERNAL_COMPOSITION_LOGICAL_DFBS > 64
 
 
 def _count_final_dfb_allocations(final_mlir_path):
@@ -300,11 +300,14 @@ def test_external_composition_requires_dfb_reuse(
         else scratch_operation
     )
 
-    # The disabled mode requires one physical index for each of the 38 logical
-    # DFBs, proving that enabled execution cannot fit without index reuse.
+    # The disabled mode requires one physical index for each logical DFB,
+    # exceeding every supported target capacity.
     with pytest.raises(
         RuntimeError,
-        match=("need 38 unspilled DFB indices " "but hardware supports at most 32"),
+        match=(
+            "need 70 unspilled DFB indices, exceeding the "
+            "(?:64-DFB-index Blackhole|32-DFB-index Wormhole B0) target capacity"
+        ),
     ):
         operation(
             lhs,

--- a/test/python/test_flash_chain_8node.py
+++ b/test/python/test_flash_chain_8node.py
@@ -7,8 +7,8 @@
 Each node computes streaming-softmax state for its K/V shard. A binary tree
 combines the per-node states before node 0 normalizes and writes the result.
 Frontend composition inlines both atoms into one operation whose logical DFB
-count exceeds the hardware limit; concurrent-kernel liveness maps the logical DFBs
-to a legal set of physical indices.
+count exceeds the smallest supported target capacity; concurrent-kernel liveness
+maps the logical DFBs to a legal set of physical indices.
 """
 
 import math

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -10,6 +10,7 @@ import torch
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 import ttl  # noqa: E402
+from ttl import ttl_api  # noqa: E402
 from ttlang_test_utils import to_dram, to_l1  # noqa: E402
 from utils.correctness import assert_allclose  # noqa: E402
 
@@ -18,8 +19,8 @@ pytestmark = pytest.mark.requires_device
 # TTNN interop rejects non-tilized tensors before DFB lowering, so TILE is the
 # only supported tensor layout for these runtime cases.
 TILE = 32
-OVER_CAPACITY_COMPOSITION_LEVELS = 5
-OVER_CAPACITY_LOGICAL_DFBS = (1 << OVER_CAPACITY_COMPOSITION_LEVELS) + 1
+CAPACITY_TEST_COMPOSITION_LEVELS = 5
+CAPACITY_TEST_LOGICAL_DFBS = (1 << CAPACITY_TEST_COMPOSITION_LEVELS) + 1
 # Two approximate SFPU exponential evaluations need operation-level error
 # bounds; f32 data movement and addition tests retain 1e-5 relative tolerance.
 F32_REPEATED_EXP_RTOL = 2e-3
@@ -112,11 +113,11 @@ def _make_nested_copy_atom(data_format, level_count):
     return nested_copy
 
 
-def _make_over_capacity_atom_kernel(data_format):
-    nested_copy = _make_nested_copy_atom(data_format, OVER_CAPACITY_COMPOSITION_LEVELS)
+def _make_capacity_test_atom_kernel(data_format):
+    nested_copy = _make_nested_copy_atom(data_format, CAPACITY_TEST_COMPOSITION_LEVELS)
 
     @ttl.operation(grid=(1, 1))
-    def over_capacity_atom_kernel(input_tensor, output_tensor):
+    def capacity_test_atom_kernel(input_tensor, output_tensor):
         first_stage_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
         last_stage_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
 
@@ -124,17 +125,17 @@ def _make_over_capacity_atom_kernel(data_format):
         nested_copy(first_stage_dfb, last_stage_dfb)
         ttl.copy(last_stage_dfb.wait(), output_tensor[0, 0]).wait()
 
-    return over_capacity_atom_kernel
+    return capacity_test_atom_kernel
 
 
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
 _in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
-_over_capacity_bf16_atom_kernel = _make_over_capacity_atom_kernel("bf16")
-_over_capacity_f32_atom_kernel = _make_over_capacity_atom_kernel("float32")
+_capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
+_capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
 
-assert OVER_CAPACITY_LOGICAL_DFBS > 32
+assert CAPACITY_TEST_LOGICAL_DFBS == 33
 
 
 _exp_scalar_via_scratch = _make_exp_via_scratch_atom("bf16", shape=(1, 1))
@@ -402,12 +403,12 @@ def test_atom_accepts_same_dfb_as_source_and_result(
 @pytest.mark.parametrize(
     ("operation", "dtype"),
     [
-        (_over_capacity_bf16_atom_kernel, torch.bfloat16),
-        (_over_capacity_f32_atom_kernel, torch.float32),
+        (_capacity_test_bf16_atom_kernel, torch.bfloat16),
+        (_capacity_test_f32_atom_kernel, torch.float32),
     ],
     ids=["bf16", "f32"],
 )
-def test_over_capacity_atom_composition_requires_dfb_reuse(
+def test_33_dfb_atom_composition_with_reuse(
     device, memory_config, to_device, operation, dtype
 ):
     input_host = torch.linspace(-1.0, 1.0, TILE * TILE, dtype=torch.float32).reshape(
@@ -425,6 +426,26 @@ def test_over_capacity_atom_composition_requires_dfb_reuse(
         assert_allclose(actual, expected, rtol=0.05, atol=1.0)
     else:
         assert_allclose(actual, expected, rtol=1e-3, atol=1e-4)
+
+
+def test_blackhole_accepts_33_distinct_dfb_indices(device):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires the Blackhole 64-index DFB capacity")
+
+    input_host = torch.linspace(-1.0, 1.0, TILE * TILE, dtype=torch.bfloat16).reshape(
+        TILE, TILE
+    )
+    input_tensor = to_dram(input_host, device)
+    output_tensor = to_dram(torch.zeros_like(input_host), device)
+
+    _capacity_test_bf16_atom_kernel(
+        input_tensor,
+        output_tensor,
+        options="--no-ttl-reuse-user-dfbs",
+    )
+
+    actual = ttnn.to_torch(output_tensor).float()
+    assert_allclose(actual, input_host.float(), rtol=0.05, atol=1.0)
 
 
 @pytest.mark.parametrize(

--- a/test/sim/test_dfb.py
+++ b/test/sim/test_dfb.py
@@ -1022,7 +1022,7 @@ def test_per_node_dfb_limit_exceeds_max() -> None:
         def noop_dm1():
             pass
 
-    with pytest.warns(UserWarning, match="hardware limit"):
+    with pytest.warns(UserWarning, match="configured limit"):
         test_kernel(element)
 
 

--- a/test/sim/test_examples.py
+++ b/test/sim/test_examples.py
@@ -407,7 +407,7 @@ def test_max_dfbs_warning_warns_at_limit(scheduler: str) -> None:
     This example allocates 36 DataflowBuffers, exceeding the default limit of 32.
     The warning is issued at kernel definition time before any kernel execution.
     """
-    with pytest.warns(UserWarning, match="hardware limit is 32"):
+    with pytest.warns(UserWarning, match="configured limit is 32"):
         code, out = run_script_in_process(ERRORS_DIR / "max_dfbs_warning.py", scheduler)
     assert (
         code == 0

--- a/test/sim/test_ttlang_sim.py
+++ b/test/sim/test_ttlang_sim.py
@@ -474,7 +474,7 @@ if __name__ == "__main__":
                 result.returncode == 0
             ), f"Expected success with --max-dfbs 2, got stderr: {result.stderr}"
             assert (
-                "hardware limit is 2" in result.stderr
+                "configured limit is 2" in result.stderr
             ), f"Expected DFB limit warning in stderr, got: {result.stderr}"
         finally:
             script.unlink()
@@ -593,7 +593,7 @@ if __name__ == "__main__":
             assert (
                 result.returncode == 0
             ), f"Expected success with --max-dfbs 0, got stderr: {result.stderr}"
-            assert "hardware limit is 0" in result.stderr
+            assert "configured limit is 0" in result.stderr
         finally:
             script.unlink()
 

--- a/test/ttlang/Analysis/dfb_allocation_oracle.mlir
+++ b/test/ttlang/Analysis/dfb_allocation_oracle.mlir
@@ -8,6 +8,8 @@
 // CHECK-NEXT: bounded_search_states=1
 // CHECK-NEXT: fixed_limit_states={{[1-9][0-9]*}}
 // CHECK-NEXT: minimum_proof_states=100
+// CHECK-NEXT: target_capacities=32, 64, 32, 32
+// CHECK-NEXT: system_desc_num_cbs=64, 32
 // CHECK-NEXT: contract_cases=262144
 // CHECK-NEXT: per_node_improvements=149268
 // CHECK-NEXT: two_group_improvements=142536

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config.mlir
@@ -62,6 +62,32 @@ func.func @f32_auto_enable(%a: tensor<1x1x!ttcore.tile<32x32, f32>>,
 
 // -----
 
+// Blackhole accepts index 32 in both explicit unpack policy and attached DFB
+// validation.
+// DEFAULT-LABEL: func.func @blackhole_accepts_dfb_index_32
+// DEFAULT-SAME: ttl.unpack_to_dest_fp32 = array<i32: 32>
+// BLACKHOLE-LABEL: func.func @blackhole_accepts_dfb_index_32
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @blackhole_accepts_dfb_index_32(
+      %input: tensor<1x1x!ttcore.tile<32x32, f32>>)
+      attributes {ttl.unpack_to_dest_fp32 = array<i32: 32>} {
+    %input_dfb = ttl.bind_cb {cb_index = 32, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %input_attached = ttl.attach_cb %input, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    %zero = arith.constant 0 : index
+    %input_tile = tensor.extract %input_attached[%zero, %zero]
+        : tensor<1x1x!ttcore.tile<32x32, f32>>
+    %result = ttl.tile_exp %input_tile into dst[%zero]
+        : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+    return
+  }
+}
+
+// -----
+
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 // A bf16 kernel without an accumulation preference selects default DST mode.

--- a/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/SetComputeKernelConfig/set_compute_kernel_config_invalid.mlir
@@ -46,7 +46,7 @@ func.func @malformed_unpack_policy()
 
 // -----
 
-// expected-error @below {{'func.func' op ttl.unpack_to_dest_fp32 must contain dataflow buffer indices in range [0, 31]}}
+// expected-error @below {{'func.func' op ttl.unpack_to_dest_fp32 must contain dataflow buffer indices in range [0, 31] for the conservative 32-DFB-index capacity used when target metadata is absent}}
 func.func @out_of_range_unpack_policy()
     attributes {ttl.unpack_to_dest_fp32 = array<i32: 32>} {
   return
@@ -224,7 +224,7 @@ func.func @dataflow_buffer_index_out_of_range(
   %zero = arith.constant 0 : index
   %input_tile = tensor.extract %input_attached[%zero, %zero]
       : tensor<1x1x!ttcore.tile<32x32, f32>>
-  // expected-error @below {{'ttl.tile_exp' op uses dataflow buffer index 32 outside the supported range [0, 31]}}
+  // expected-error @below {{'ttl.tile_exp' op uses dataflow buffer index 32 outside the supported range [0, 31] for the conservative 32-DFB-index capacity used when target metadata is absent}}
   %exp = ttl.tile_exp %input_tile into dst[%zero]
       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   return

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocator_review_reproducers.mlir
@@ -41,8 +41,9 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // Each data DFB conflicts only with the next DFB in A-B-C-D order. Processing
 // them as A, D, B, C makes first-fit use three indices although two suffice.
-// This six-index result is valid and below the hardware limit, so proving the
-// smaller assignment would not change acceptance. The independent oracle adds
+// This six-index result is valid and below the conservative 32-index capacity
+// applied without target metadata, so proving the smaller assignment would not
+// change acceptance. The independent oracle adds
 // 30 DFBs that all conflict pairwise to verify the case where exact search must
 // reduce 33 first-fit indices to the available 32.
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_capacity.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_capacity.mlir
@@ -1,4 +1,4 @@
-// Tests physical DFB allocation at the 32-index hardware boundary.
+// Tests physical DFB allocation at the conservative 32-index boundary.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
 
 // Thirty-one unbounded DFBs interfere with every other DFB. The last three

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_invalid.mlir
@@ -165,7 +165,7 @@ module {
 // An unbounded lifetime conflicts with every other lifetime. Thirty-three
 // unbounded logical DFBs must be rejected rather than unsafely compacted.
 
-// expected-error @below {{DFB allocation needs 33 unspilled physical indices but hardware supports at most 32}}
+// expected-error @below {{DFB allocation needs 33 unspilled physical indices, exceeding the conservative 32-DFB-index capacity used when target metadata is absent}}
 module {
   func.func @unbounded_over_capacity()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_search_limit_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_coloring_search_limit_invalid.mlir
@@ -7,7 +7,7 @@
 // first-fit result uses 33 indices, but an exact assignment can use 32. A
 // one-state limit must report an inconclusive search, not a capacity failure.
 
-// expected-error @below {{'builtin.module' op deterministic first-fit uses 33 physical DFB indices; exact allocation search explored 1 states and reached the 1-state limit without proving whether the allocation fits the 32-index hardware limit; increase `exact-coloring-search-limit`}}
+// expected-error @below {{'builtin.module' op deterministic first-fit uses 33 physical DFB indices; exact allocation search explored 1 states and reached the 1-state limit without proving whether the allocation fits the conservative 32-DFB-index capacity used when target metadata is absent; increase `exact-coloring-search-limit`}}
 module {
   func.func @bounded_exact_search()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_target_capacity.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_target_capacity.mlir
@@ -1,0 +1,84 @@
+// Tests the Blackhole physical DFB-index capacity through a default device.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s
+
+// CHECK: ttl.dfb_allocations = [
+// CHECK-COUNT-64: dfb_index = {{[0-9]+}} : i32
+// CHECK-NOT: dfb_index
+// CHECK-LABEL: func.func @blackhole_accepts_64_indices
+// CHECK-SAME: ttl.base_cta_index = 64 : i32
+// CHECK: ttl.bind_cb{cb_index = 63, block_count = 1}
+
+module attributes {
+  ttcore.system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <blackhole>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 204800, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 0, erisc_l1_unreserved_base = 0, dram_unreserved_base = 0, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>], supported_tile_sizes = [32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(0, 0)], dram_bank_to_logical_worker_noc1 = [(0, 0)]}], [0], [1 : i32], [ 0x0x0x0]>
+} {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  func.func @blackhole_accepts_64_indices()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 64 : i32, ttl.crta_indices = []} {
+    %dfb0 = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb1 = ttl.bind_cb {cb_index = 1, block_count = 1} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb2 = ttl.bind_cb {cb_index = 2, block_count = 1} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb3 = ttl.bind_cb {cb_index = 3, block_count = 1} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb4 = ttl.bind_cb {cb_index = 4, block_count = 1} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb5 = ttl.bind_cb {cb_index = 5, block_count = 1} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb6 = ttl.bind_cb {cb_index = 6, block_count = 1} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb7 = ttl.bind_cb {cb_index = 7, block_count = 1} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb8 = ttl.bind_cb {cb_index = 8, block_count = 1} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb9 = ttl.bind_cb {cb_index = 9, block_count = 1} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb10 = ttl.bind_cb {cb_index = 10, block_count = 1} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb11 = ttl.bind_cb {cb_index = 11, block_count = 1} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb12 = ttl.bind_cb {cb_index = 12, block_count = 1} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb13 = ttl.bind_cb {cb_index = 13, block_count = 1} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb14 = ttl.bind_cb {cb_index = 14, block_count = 1} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb15 = ttl.bind_cb {cb_index = 15, block_count = 1} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb16 = ttl.bind_cb {cb_index = 16, block_count = 1} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb17 = ttl.bind_cb {cb_index = 17, block_count = 1} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb18 = ttl.bind_cb {cb_index = 18, block_count = 1} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb19 = ttl.bind_cb {cb_index = 19, block_count = 1} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb20 = ttl.bind_cb {cb_index = 20, block_count = 1} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb21 = ttl.bind_cb {cb_index = 21, block_count = 1} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb22 = ttl.bind_cb {cb_index = 22, block_count = 1} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb23 = ttl.bind_cb {cb_index = 23, block_count = 1} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb24 = ttl.bind_cb {cb_index = 24, block_count = 1} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb25 = ttl.bind_cb {cb_index = 25, block_count = 1} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb26 = ttl.bind_cb {cb_index = 26, block_count = 1} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb27 = ttl.bind_cb {cb_index = 27, block_count = 1} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb28 = ttl.bind_cb {cb_index = 28, block_count = 1} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb29 = ttl.bind_cb {cb_index = 29, block_count = 1} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb30 = ttl.bind_cb {cb_index = 30, block_count = 1} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb31 = ttl.bind_cb {cb_index = 31, block_count = 1} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb32 = ttl.bind_cb {cb_index = 32, block_count = 1} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb33 = ttl.bind_cb {cb_index = 33, block_count = 1} {dfb_id = 33 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb34 = ttl.bind_cb {cb_index = 34, block_count = 1} {dfb_id = 34 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb35 = ttl.bind_cb {cb_index = 35, block_count = 1} {dfb_id = 35 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb36 = ttl.bind_cb {cb_index = 36, block_count = 1} {dfb_id = 36 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb37 = ttl.bind_cb {cb_index = 37, block_count = 1} {dfb_id = 37 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb38 = ttl.bind_cb {cb_index = 38, block_count = 1} {dfb_id = 38 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb39 = ttl.bind_cb {cb_index = 39, block_count = 1} {dfb_id = 39 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb40 = ttl.bind_cb {cb_index = 40, block_count = 1} {dfb_id = 40 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb41 = ttl.bind_cb {cb_index = 41, block_count = 1} {dfb_id = 41 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb42 = ttl.bind_cb {cb_index = 42, block_count = 1} {dfb_id = 42 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb43 = ttl.bind_cb {cb_index = 43, block_count = 1} {dfb_id = 43 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb44 = ttl.bind_cb {cb_index = 44, block_count = 1} {dfb_id = 44 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb45 = ttl.bind_cb {cb_index = 45, block_count = 1} {dfb_id = 45 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb46 = ttl.bind_cb {cb_index = 46, block_count = 1} {dfb_id = 46 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb47 = ttl.bind_cb {cb_index = 47, block_count = 1} {dfb_id = 47 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb48 = ttl.bind_cb {cb_index = 48, block_count = 1} {dfb_id = 48 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb49 = ttl.bind_cb {cb_index = 49, block_count = 1} {dfb_id = 49 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb50 = ttl.bind_cb {cb_index = 50, block_count = 1} {dfb_id = 50 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb51 = ttl.bind_cb {cb_index = 51, block_count = 1} {dfb_id = 51 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb52 = ttl.bind_cb {cb_index = 52, block_count = 1} {dfb_id = 52 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb53 = ttl.bind_cb {cb_index = 53, block_count = 1} {dfb_id = 53 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb54 = ttl.bind_cb {cb_index = 54, block_count = 1} {dfb_id = 54 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb55 = ttl.bind_cb {cb_index = 55, block_count = 1} {dfb_id = 55 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb56 = ttl.bind_cb {cb_index = 56, block_count = 1} {dfb_id = 56 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb57 = ttl.bind_cb {cb_index = 57, block_count = 1} {dfb_id = 57 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb58 = ttl.bind_cb {cb_index = 58, block_count = 1} {dfb_id = 58 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb59 = ttl.bind_cb {cb_index = 59, block_count = 1} {dfb_id = 59 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb60 = ttl.bind_cb {cb_index = 60, block_count = 1} {dfb_id = 60 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb61 = ttl.bind_cb {cb_index = 61, block_count = 1} {dfb_id = 61 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb62 = ttl.bind_cb {cb_index = 62, block_count = 1} {dfb_id = 62 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb63 = ttl.bind_cb {cb_index = 63, block_count = 1} {dfb_id = 63 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_target_capacity_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_target_capacity_invalid.mlir
@@ -1,0 +1,237 @@
+// Tests target metadata validation and target-specific DFB capacity errors.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)'
+
+// Rejects malformed target metadata before allocation analysis.
+// expected-error @below {{'builtin.module' op ttl.target_arch must be a #ttcore.arch attribute}}
+module attributes {ttl.target_arch = "blackhole"} {
+}
+
+// -----
+
+// Rejects malformed system-description metadata before allocation analysis.
+// expected-error @below {{'builtin.module' op ttcore.system_desc must be a #ttcore.system_desc attribute}}
+module attributes {ttcore.system_desc = "blackhole"} {
+}
+
+// -----
+
+// Requires explicit target metadata and the selected device to agree.
+// expected-error @below {{'builtin.module' op ttl.target_arch does not match the selected device arch}}
+module attributes {
+  ttl.target_arch = #ttcore.arch<blackhole>,
+  ttcore.system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 204800, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 0, erisc_l1_unreserved_base = 0, dram_unreserved_base = 0, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>], supported_tile_sizes = [32x32], dst_physical_size_tiles = 16, num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(0, 0)], dram_bank_to_logical_worker_noc1 = [(0, 0)]}], [0], [1 : i32], [ 0x0x0x0]>
+} {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+}
+
+// -----
+
+// Rejects one more DFB than the Blackhole physical capacity.
+// expected-error @below {{DFB allocation needs 65 unspilled physical indices, exceeding the 64-DFB-index Blackhole target capacity}}
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @blackhole_rejects_65_indices()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 65 : i32, ttl.crta_indices = []} {
+    %dfb0 = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb1 = ttl.bind_cb {cb_index = 1, block_count = 1} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb2 = ttl.bind_cb {cb_index = 2, block_count = 1} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb3 = ttl.bind_cb {cb_index = 3, block_count = 1} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb4 = ttl.bind_cb {cb_index = 4, block_count = 1} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb5 = ttl.bind_cb {cb_index = 5, block_count = 1} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb6 = ttl.bind_cb {cb_index = 6, block_count = 1} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb7 = ttl.bind_cb {cb_index = 7, block_count = 1} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb8 = ttl.bind_cb {cb_index = 8, block_count = 1} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb9 = ttl.bind_cb {cb_index = 9, block_count = 1} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb10 = ttl.bind_cb {cb_index = 10, block_count = 1} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb11 = ttl.bind_cb {cb_index = 11, block_count = 1} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb12 = ttl.bind_cb {cb_index = 12, block_count = 1} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb13 = ttl.bind_cb {cb_index = 13, block_count = 1} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb14 = ttl.bind_cb {cb_index = 14, block_count = 1} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb15 = ttl.bind_cb {cb_index = 15, block_count = 1} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb16 = ttl.bind_cb {cb_index = 16, block_count = 1} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb17 = ttl.bind_cb {cb_index = 17, block_count = 1} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb18 = ttl.bind_cb {cb_index = 18, block_count = 1} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb19 = ttl.bind_cb {cb_index = 19, block_count = 1} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb20 = ttl.bind_cb {cb_index = 20, block_count = 1} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb21 = ttl.bind_cb {cb_index = 21, block_count = 1} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb22 = ttl.bind_cb {cb_index = 22, block_count = 1} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb23 = ttl.bind_cb {cb_index = 23, block_count = 1} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb24 = ttl.bind_cb {cb_index = 24, block_count = 1} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb25 = ttl.bind_cb {cb_index = 25, block_count = 1} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb26 = ttl.bind_cb {cb_index = 26, block_count = 1} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb27 = ttl.bind_cb {cb_index = 27, block_count = 1} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb28 = ttl.bind_cb {cb_index = 28, block_count = 1} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb29 = ttl.bind_cb {cb_index = 29, block_count = 1} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb30 = ttl.bind_cb {cb_index = 30, block_count = 1} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb31 = ttl.bind_cb {cb_index = 31, block_count = 1} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb32 = ttl.bind_cb {cb_index = 32, block_count = 1} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb33 = ttl.bind_cb {cb_index = 33, block_count = 1} {dfb_id = 33 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb34 = ttl.bind_cb {cb_index = 34, block_count = 1} {dfb_id = 34 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb35 = ttl.bind_cb {cb_index = 35, block_count = 1} {dfb_id = 35 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb36 = ttl.bind_cb {cb_index = 36, block_count = 1} {dfb_id = 36 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb37 = ttl.bind_cb {cb_index = 37, block_count = 1} {dfb_id = 37 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb38 = ttl.bind_cb {cb_index = 38, block_count = 1} {dfb_id = 38 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb39 = ttl.bind_cb {cb_index = 39, block_count = 1} {dfb_id = 39 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb40 = ttl.bind_cb {cb_index = 40, block_count = 1} {dfb_id = 40 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb41 = ttl.bind_cb {cb_index = 41, block_count = 1} {dfb_id = 41 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb42 = ttl.bind_cb {cb_index = 42, block_count = 1} {dfb_id = 42 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb43 = ttl.bind_cb {cb_index = 43, block_count = 1} {dfb_id = 43 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb44 = ttl.bind_cb {cb_index = 44, block_count = 1} {dfb_id = 44 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb45 = ttl.bind_cb {cb_index = 45, block_count = 1} {dfb_id = 45 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb46 = ttl.bind_cb {cb_index = 46, block_count = 1} {dfb_id = 46 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb47 = ttl.bind_cb {cb_index = 47, block_count = 1} {dfb_id = 47 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb48 = ttl.bind_cb {cb_index = 48, block_count = 1} {dfb_id = 48 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb49 = ttl.bind_cb {cb_index = 49, block_count = 1} {dfb_id = 49 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb50 = ttl.bind_cb {cb_index = 50, block_count = 1} {dfb_id = 50 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb51 = ttl.bind_cb {cb_index = 51, block_count = 1} {dfb_id = 51 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb52 = ttl.bind_cb {cb_index = 52, block_count = 1} {dfb_id = 52 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb53 = ttl.bind_cb {cb_index = 53, block_count = 1} {dfb_id = 53 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb54 = ttl.bind_cb {cb_index = 54, block_count = 1} {dfb_id = 54 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb55 = ttl.bind_cb {cb_index = 55, block_count = 1} {dfb_id = 55 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb56 = ttl.bind_cb {cb_index = 56, block_count = 1} {dfb_id = 56 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb57 = ttl.bind_cb {cb_index = 57, block_count = 1} {dfb_id = 57 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb58 = ttl.bind_cb {cb_index = 58, block_count = 1} {dfb_id = 58 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb59 = ttl.bind_cb {cb_index = 59, block_count = 1} {dfb_id = 59 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb60 = ttl.bind_cb {cb_index = 60, block_count = 1} {dfb_id = 60 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb61 = ttl.bind_cb {cb_index = 61, block_count = 1} {dfb_id = 61 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb62 = ttl.bind_cb {cb_index = 62, block_count = 1} {dfb_id = 62 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb63 = ttl.bind_cb {cb_index = 63, block_count = 1} {dfb_id = 63 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb64 = ttl.bind_cb {cb_index = 64, block_count = 1} {dfb_id = 64 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+}
+
+// -----
+
+// Rejects one more DFB than the Wormhole B0 physical capacity.
+// expected-error @below {{DFB allocation needs 33 unspilled physical indices, exceeding the 32-DFB-index Wormhole B0 target capacity}}
+module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
+  func.func @wormhole_rejects_33_indices()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 33 : i32, ttl.crta_indices = []} {
+    %dfb0 = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb1 = ttl.bind_cb {cb_index = 1, block_count = 1} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb2 = ttl.bind_cb {cb_index = 2, block_count = 1} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb3 = ttl.bind_cb {cb_index = 3, block_count = 1} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb4 = ttl.bind_cb {cb_index = 4, block_count = 1} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb5 = ttl.bind_cb {cb_index = 5, block_count = 1} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb6 = ttl.bind_cb {cb_index = 6, block_count = 1} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb7 = ttl.bind_cb {cb_index = 7, block_count = 1} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb8 = ttl.bind_cb {cb_index = 8, block_count = 1} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb9 = ttl.bind_cb {cb_index = 9, block_count = 1} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb10 = ttl.bind_cb {cb_index = 10, block_count = 1} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb11 = ttl.bind_cb {cb_index = 11, block_count = 1} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb12 = ttl.bind_cb {cb_index = 12, block_count = 1} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb13 = ttl.bind_cb {cb_index = 13, block_count = 1} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb14 = ttl.bind_cb {cb_index = 14, block_count = 1} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb15 = ttl.bind_cb {cb_index = 15, block_count = 1} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb16 = ttl.bind_cb {cb_index = 16, block_count = 1} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb17 = ttl.bind_cb {cb_index = 17, block_count = 1} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb18 = ttl.bind_cb {cb_index = 18, block_count = 1} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb19 = ttl.bind_cb {cb_index = 19, block_count = 1} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb20 = ttl.bind_cb {cb_index = 20, block_count = 1} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb21 = ttl.bind_cb {cb_index = 21, block_count = 1} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb22 = ttl.bind_cb {cb_index = 22, block_count = 1} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb23 = ttl.bind_cb {cb_index = 23, block_count = 1} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb24 = ttl.bind_cb {cb_index = 24, block_count = 1} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb25 = ttl.bind_cb {cb_index = 25, block_count = 1} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb26 = ttl.bind_cb {cb_index = 26, block_count = 1} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb27 = ttl.bind_cb {cb_index = 27, block_count = 1} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb28 = ttl.bind_cb {cb_index = 28, block_count = 1} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb29 = ttl.bind_cb {cb_index = 29, block_count = 1} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb30 = ttl.bind_cb {cb_index = 30, block_count = 1} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb31 = ttl.bind_cb {cb_index = 31, block_count = 1} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb32 = ttl.bind_cb {cb_index = 32, block_count = 1} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+}
+
+// -----
+
+// Rejects one more DFB than the Quasar physical capacity.
+// expected-error @below {{DFB allocation needs 33 unspilled physical indices, exceeding the 32-DFB-index Quasar target capacity}}
+module attributes {ttl.target_arch = #ttcore.arch<quasar>} {
+  func.func @quasar_rejects_33_indices()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 33 : i32, ttl.crta_indices = []} {
+    %dfb0 = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb1 = ttl.bind_cb {cb_index = 1, block_count = 1} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb2 = ttl.bind_cb {cb_index = 2, block_count = 1} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb3 = ttl.bind_cb {cb_index = 3, block_count = 1} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb4 = ttl.bind_cb {cb_index = 4, block_count = 1} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb5 = ttl.bind_cb {cb_index = 5, block_count = 1} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb6 = ttl.bind_cb {cb_index = 6, block_count = 1} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb7 = ttl.bind_cb {cb_index = 7, block_count = 1} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb8 = ttl.bind_cb {cb_index = 8, block_count = 1} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb9 = ttl.bind_cb {cb_index = 9, block_count = 1} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb10 = ttl.bind_cb {cb_index = 10, block_count = 1} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb11 = ttl.bind_cb {cb_index = 11, block_count = 1} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb12 = ttl.bind_cb {cb_index = 12, block_count = 1} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb13 = ttl.bind_cb {cb_index = 13, block_count = 1} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb14 = ttl.bind_cb {cb_index = 14, block_count = 1} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb15 = ttl.bind_cb {cb_index = 15, block_count = 1} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb16 = ttl.bind_cb {cb_index = 16, block_count = 1} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb17 = ttl.bind_cb {cb_index = 17, block_count = 1} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb18 = ttl.bind_cb {cb_index = 18, block_count = 1} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb19 = ttl.bind_cb {cb_index = 19, block_count = 1} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb20 = ttl.bind_cb {cb_index = 20, block_count = 1} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb21 = ttl.bind_cb {cb_index = 21, block_count = 1} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb22 = ttl.bind_cb {cb_index = 22, block_count = 1} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb23 = ttl.bind_cb {cb_index = 23, block_count = 1} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb24 = ttl.bind_cb {cb_index = 24, block_count = 1} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb25 = ttl.bind_cb {cb_index = 25, block_count = 1} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb26 = ttl.bind_cb {cb_index = 26, block_count = 1} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb27 = ttl.bind_cb {cb_index = 27, block_count = 1} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb28 = ttl.bind_cb {cb_index = 28, block_count = 1} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb29 = ttl.bind_cb {cb_index = 29, block_count = 1} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb30 = ttl.bind_cb {cb_index = 30, block_count = 1} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb31 = ttl.bind_cb {cb_index = 31, block_count = 1} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb32 = ttl.bind_cb {cb_index = 32, block_count = 1} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+}
+
+// -----
+
+// Uses the conservative capacity when no target metadata is available.
+// expected-error @below {{DFB allocation needs 33 unspilled physical indices, exceeding the conservative 32-DFB-index capacity used when target metadata is absent}}
+module {
+  func.func @missing_target_rejects_33_indices()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.base_cta_index = 33 : i32, ttl.crta_indices = []} {
+    %dfb0 = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb1 = ttl.bind_cb {cb_index = 1, block_count = 1} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb2 = ttl.bind_cb {cb_index = 2, block_count = 1} {dfb_id = 2 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb3 = ttl.bind_cb {cb_index = 3, block_count = 1} {dfb_id = 3 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb4 = ttl.bind_cb {cb_index = 4, block_count = 1} {dfb_id = 4 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb5 = ttl.bind_cb {cb_index = 5, block_count = 1} {dfb_id = 5 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb6 = ttl.bind_cb {cb_index = 6, block_count = 1} {dfb_id = 6 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb7 = ttl.bind_cb {cb_index = 7, block_count = 1} {dfb_id = 7 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb8 = ttl.bind_cb {cb_index = 8, block_count = 1} {dfb_id = 8 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb9 = ttl.bind_cb {cb_index = 9, block_count = 1} {dfb_id = 9 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb10 = ttl.bind_cb {cb_index = 10, block_count = 1} {dfb_id = 10 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb11 = ttl.bind_cb {cb_index = 11, block_count = 1} {dfb_id = 11 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb12 = ttl.bind_cb {cb_index = 12, block_count = 1} {dfb_id = 12 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb13 = ttl.bind_cb {cb_index = 13, block_count = 1} {dfb_id = 13 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb14 = ttl.bind_cb {cb_index = 14, block_count = 1} {dfb_id = 14 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb15 = ttl.bind_cb {cb_index = 15, block_count = 1} {dfb_id = 15 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb16 = ttl.bind_cb {cb_index = 16, block_count = 1} {dfb_id = 16 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb17 = ttl.bind_cb {cb_index = 17, block_count = 1} {dfb_id = 17 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb18 = ttl.bind_cb {cb_index = 18, block_count = 1} {dfb_id = 18 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb19 = ttl.bind_cb {cb_index = 19, block_count = 1} {dfb_id = 19 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb20 = ttl.bind_cb {cb_index = 20, block_count = 1} {dfb_id = 20 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb21 = ttl.bind_cb {cb_index = 21, block_count = 1} {dfb_id = 21 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb22 = ttl.bind_cb {cb_index = 22, block_count = 1} {dfb_id = 22 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb23 = ttl.bind_cb {cb_index = 23, block_count = 1} {dfb_id = 23 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb24 = ttl.bind_cb {cb_index = 24, block_count = 1} {dfb_id = 24 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb25 = ttl.bind_cb {cb_index = 25, block_count = 1} {dfb_id = 25 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb26 = ttl.bind_cb {cb_index = 26, block_count = 1} {dfb_id = 26 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb27 = ttl.bind_cb {cb_index = 27, block_count = 1} {dfb_id = 27 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb28 = ttl.bind_cb {cb_index = 28, block_count = 1} {dfb_id = 28 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb29 = ttl.bind_cb {cb_index = 29, block_count = 1} {dfb_id = 29 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb30 = ttl.bind_cb {cb_index = 30, block_count = 1} {dfb_id = 30 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb31 = ttl.bind_cb {cb_index = 31, block_count = 1} {dfb_id = 31 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %dfb32 = ttl.bind_cb {cb_index = 32, block_count = 1} {dfb_id = 32 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_atomic_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_atomic_invalid.mlir
@@ -2,7 +2,7 @@
 // indices and kernel configuration unchanged and creates no runtime metadata.
 // RUN: ttlang-opt %s --verify-diagnostics --mlir-print-ir-after=ttl-finalize-dfb-indices --mlir-print-ir-after-failure -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' 2>&1 | FileCheck %s --implicit-check-not=ttl.dfb_allocations
 
-// expected-error @below {{need 33 unspilled DFB indices but hardware supports at most 32 (1 compiler-allocated after proven reuse)}}
+// expected-error @below {{need 33 unspilled DFB indices, exceeding the conservative 32-DFB-index capacity used when target metadata is absent (1 compiler-allocated after proven reuse)}}
 module {
   func.func @all_user_indices()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_invalid.mlir
@@ -1,6 +1,6 @@
-// Negative test: exceeding maximum circular buffer count.
+// Negative test: exceeding the conservative DFB-index capacity.
 // The insert pass creates compiler-allocated DFBs without checking the limit;
-// the finalize pass enforces the hardware maximum after index reuse.
+// the finalize pass enforces target capacity after index reuse.
 // RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(func.func(ttl-insert-intermediate-dfbs,ttl-insert-cb-sync),ttl-finalize-dfb-indices{reuse-user-dfbs=false})'
 
 // -----
@@ -8,9 +8,9 @@
 // All 32 CB indices (0-31) are occupied by user DFBs. The add result
 // feeds reduce, which requires a compiler-allocated DFB at index 32.
 // After reuse (only one intermediate, nothing to reuse), the total DFB
-// count is 33, exceeding the hardware maximum of 32.
+// count is 33, exceeding the 32-index capacity used without target metadata.
 
-// expected-error @below {{need 33 unspilled DFB indices but hardware supports at most 32 (1 compiler-allocated after proven reuse)}}
+// expected-error @below {{need 33 unspilled DFB indices, exceeding the conservative 32-DFB-index capacity used when target metadata is absent (1 compiler-allocated after proven reuse)}}
 module {
 func.func @exceeds_max_cb_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {


### PR DESCRIPTION
### Problem description

TT-Lang applies a 32-index dataflow buffer limit to every target. This rejects valid Blackhole kernels that use indices 32 through 63 and can disagree with the architecture selected by the module default device.

### What's changed

- Centralizes target resolution across `ttl.target_arch` and `ttcore.system_desc` plus `@default_device`, with diagnostics for malformed or conflicting metadata.
- Defines one typed DFB-capacity query: 64 indices for Blackhole and 32 for Wormhole B0, Quasar, and compilation without target metadata.
- Uses the resolved capacity for physical allocation, compute-kernel configuration, and TTL-to-TTKernel lowering.
- Updates system descriptors and documentation, with compiler coverage for exact boundaries and a Blackhole device test using 33 distinct indices.

### Checklist

- [x] New/Existing tests provide coverage for changes