### PR TITLE
[ttl] Reuse DFB allocations across reset epochs [dfb-reuse-14]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1429,9 +1429,9 @@ and the order of statically expanded transactions. Effects are synchronous
 facts about actions completed inside the external call; they do not emit
 lifecycle operations.
 
-An occurrence with no effect remains a possible read or write from call entry
-through completion. If operand adaptation aliases several occurrences to one
-DFB, every occurrence requires effects to eliminate that opaque interval.
+An occurrence with no effect remains a possible read or write from call entry.
+If operand adaptation aliases several occurrences to one DFB, every occurrence
+requires effects to eliminate that opaque interval.
 Ordinary storage accesses between summarized acquisitions and releases remain
 inside the corresponding lifetime. A partial summary supplies its listed
 events but cannot establish the complete reserve/push/wait/pop lifecycle for
@@ -1446,9 +1446,15 @@ listed DFBs, over the call's launch-node domain. Listed effects remain available
 to other verification. Unknown access applies only to user-managed DFBs;
 compiler-created DFB accesses require listed operands.
 
-The callee must complete every synchronous and asynchronous DFB access before
-returning. Work that remains active after return requires a separate explicit
-completion contract. The frontend and IR representation are described in
+Every declared effect action must complete before the callee returns. Associated
+interface work may remain active while the declared protocol retains ownership;
+it must complete before the terminal consumer release or a synchronized reset.
+For a named dependency with no effect summary, a synchronized reset ordered
+after the call may terminate the opaque access and canonicalize protocol state.
+The reset must complete earlier interface work before publishing arrival. This
+does not validate the callee's internal protocol. Unlisted access declared by
+`unknown_dfb_access` remains unbounded. The frontend and IR representation are
+described in
 [External Function Interop Lowering](ExternalFuncInteropLowering.md).
 
 An exact static `dfb_effects` sequence may describe cumulative queue state

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1811,15 +1811,22 @@ buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
       declarations and identity-preserving casts
 
   for each logical DFB pair A, B:
-    add descriptor mismatch if A.type != B.type
+    add descriptor mismatch if A.type != B.type, except for members of one
+        explicit allocation group without opaque external access
     add unknown-domain conflict unless both unknown domains are conditionally
       bounded
     for each node where A and B both execute:
-      add access-completion-not-proven conflict unless both node lifetimes are
-        proven
-      add transaction conflict unless their transaction tile-count sequences match
-      add pointer-owner conflict unless read and write owners match
-      add concurrent-lifetime conflict unless A precedes B or B precedes A
+      if A and B share an allocation group and either lifetime has reset epochs:
+        add access-completion-not-proven conflict unless every epoch completes
+        add concurrent-lifetime conflict unless every cross-member epoch pair
+            has exactly one proven order
+      else:
+        add access-completion-not-proven conflict unless both node lifetimes
+            are proven
+        add transaction conflict unless their transaction tile-count sequences
+            match
+        add pointer-owner conflict unless read and write owners match
+        add concurrent-lifetime conflict unless A precedes B or B precedes A
 
   for each typed allocation group:
     validate every member pair with descriptor equality disabled
@@ -1827,6 +1834,12 @@ buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
     reject any storage, static-configuration, protocol, owner, domain, or
       lifetime conflict
     compute the largest scratch byte capacity required by a member
+    for each launch node:
+      order every active member epoch by its proven event relation
+      require each adjacent handoff to preserve pointer owners or follow a
+          canonical reset
+      advance read and write cursors through every epoch in that order
+      reject unequal handoff offsets or a transaction that crosses the envelope
 
   if reuseUserDFBs:
     candidates = all logical DFBs in immutable declaration order

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1266,7 +1266,7 @@ Ordinary reuse requires identical `CircularBufferType` values (shape, element
 type, and block count). An explicit allocation group may combine scratch DFBs
 with different block shapes or block counts when their element types and page
 formats are identical. The physical descriptor then uses the largest total
-capacity. Both mechanisms require complete quiescent lifecycles. Ordinary reuse
+capacity. Both mechanisms require each lifecycle to complete. Ordinary reuse
 also requires matching write- and read-pointer runs unless a synchronized reset
 establishes canonical state. The matched sequences must remain boundary-safe
 when repeated from their terminal offsets. Allocation groups instead advance
@@ -1557,8 +1557,8 @@ unrelated third kernel adds no cross-kernel edge. A `B.wait` entered before
 The write- and read-pointer owners are also part of the allocation state. The
 owner is the launched node plus NOC0, NOC1, Pack, or Unpack and the pointer
 direction. Distinct kernel function symbols may share when they execute on the
-same hardware pointer processors. A quiescent handoff does not transfer pointer
-state between different processors.
+same hardware pointer processors. A completed lifecycle does not transfer
+pointer state between different processors.
 
 #### Relation to prior allocation models
 
@@ -1649,7 +1649,7 @@ analyzeConcurrentLifetimes(module, logicalIdentities):
       if every use completion precedes the final pop completion:
         DFB.nodeLifetime.earliestEvents = minimal entry events in uses
         DFB.nodeLifetime.terminalEvents = {final pop completion}
-        DFB.nodeLifetime.quiescence = proven
+        DFB.nodeLifetime.completionProof = proven
 
     build a second graph with every unknown access domain treated as possible
     prove conditionally bounded lifetimes only for one complete conditional
@@ -1658,7 +1658,7 @@ analyzeConcurrentLifetimes(module, logicalIdentities):
       identities at one launch coordinate
     retain possible-domain order separately from exact-domain order
 
-  return logical DFB lifecycles, per-node quiescence, pointer owners,
+  return logical DFB lifecycles, per-node lifecycle completion, pointer owners,
          conditional boundedness, source evidence, and pairwise per-node
          exact and possible-domain lifetime order
 ```

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1270,10 +1270,11 @@ capacity. Both mechanisms require complete quiescent lifecycles. Ordinary reuse
 also requires matching write- and read-pointer runs unless a synchronized reset
 establishes canonical state. The matched sequences must remain boundary-safe
 when repeated from their terminal offsets. Allocation groups instead advance
-independent write and read cursors through each ordered member and require equal
-offsets at every handoff. Any pointer movement that crosses the shared physical
-envelope is rejected. These conditions retain one page format, sufficient
-storage, and legal ring-pointer progression.
+independent write and read cursors through each ordered member. A terminal
+synchronized reset establishes equal canonical offsets before the next
+handoff; otherwise the offsets must already be equal. Any pointer movement that
+crosses the shared physical envelope is rejected. These conditions retain one
+page format, sufficient storage, and legal ring-pointer progression.
 `CircularBufferType` is an MLIR-uniqued type, so exact ordinary compatibility
 is a pointer comparison.
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1829,7 +1829,8 @@ buildPhysicalAllocationPlan(module, logicalIdentities, perNodeLifetimes):
         add concurrent-lifetime conflict unless A precedes B or B precedes A
 
   for each typed allocation group:
-    validate every member pair with descriptor equality disabled
+    validate every member pair with descriptor equality disabled unless either
+        member has opaque external access
     reject incompatible element types or tensor-backed capacity envelopes
     reject any storage, static-configuration, protocol, owner, domain, or
       lifetime conflict

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -7,12 +7,14 @@ compiler preserves argument order, emits the header before the call, and lowers
 each argument according to its source category. It does not inspect the C++
 body or validate the foreign function signature.
 
-External code must complete all synchronous and asynchronous resource accesses
-before returning. DFB behavior is declared rather than inferred:
-`ttl.opaque_call` exposes dependencies, ordered protocol effects, and unknown
-access through `DFBAccessOpInterface`. A dependency occurrence with no listed
-effect remains an opaque access for the call duration. A complete effect summary
-can establish the lifecycle facts required for physical-index reuse.
+DFB behavior is declared rather than inferred: `ttl.opaque_call` exposes
+dependencies, ordered protocol effects, and unknown access through
+`DFBAccessOpInterface`. Every declared effect action completes before return,
+but associated asynchronous interface work may remain live until the terminal
+consumer release or a synchronized reset. A dependency occurrence with no
+listed effect remains opaque until a synchronized reset proves completion. A
+complete effect summary can establish the lifecycle facts required for
+physical-index reuse.
 
 The Python interface currently supports void calls.
 
@@ -230,9 +232,9 @@ selects allocation metadata or an integer index.
 The [external-functions reference](../sphinx/reference/external-functions.md)
 defines the Python API and static-expression rules. Every statically known DFB
 accessed by external code must be declared as a dependency. The `dfb_effects`
-summary is optional: without it, each dependency remains an opaque access for
-the call duration. A complete, accurate summary can prove a bounded lifecycle
-and permit physical-index reuse.
+summary is optional: without it, each dependency remains an opaque access until
+a synchronized reset proves completion. A complete, accurate summary can prove
+a bounded lifecycle and permit physical-index reuse.
 
 `OpaqueCallOp::getDFBDependencyOperands()` returns dependency occurrences in
 this order:
@@ -341,15 +343,19 @@ An effect summary describes actions performed by external C++; it does not
 create executable TTL operations. Every listed action must execute on every
 execution of the call and complete before return. Conditional external actions
 require corresponding TTL control flow around a call with an unconditional
-summary. Work that remains active after return requires a separate completion
-contract and cannot be represented by these effects.
+summary. The effect list does not state when associated hardware interface work
+completes; the declared protocol terminal or a synchronized reset must complete
+that work before storage reuse.
 
-An occurrence with no effect is a possible read and write for the complete
-call. Ordinary storage accesses between summarized acquisitions and releases
-remain inside the corresponding lifetime. A partial effect sequence is valid
-metadata but cannot prove a bounded lifecycle for that DFB. When the same DFB
-has multiple dependency occurrences, every occurrence requires effects to
-eliminate the opaque call-duration access. For allocation,
+An occurrence with no effect is a possible read and write beginning at call
+entry. A synchronized reset ordered after the call through the same
+participating logical kernel terminates a named opaque access and canonicalizes
+its protocol state. The reset implementation must complete earlier interface
+work before publishing arrival. Ordinary storage accesses between summarized
+acquisitions and releases remain inside the corresponding lifetime. A partial
+effect sequence is valid metadata but cannot prove a bounded lifecycle for that
+DFB. When the same DFB has multiple dependency occurrences, every occurrence
+requires effects to eliminate the opaque access without a reset. For allocation,
 `unknown_dfb_access` conservatively adds the call as an opaque occurrence on
 every user-managed DFB, including listed DFBs, in each affected allocation
 scope. The compiler does not infer facts from the callee name, header, emitted
@@ -462,9 +468,9 @@ alter the C++ call. TTKernel to EmitC resolves constants and descriptor types,
 and C++ emission inserts the required prelude and header during its existing
 operation scan.
 
-See `examples/external_dfb_reuse.py` for two external calls surrounded by
-visible TTL protocol operations. An acknowledgment proves that the result
-lifetimes do not overlap, while typed descriptor operands keep each opaque call
-inside the corresponding lifetime. See
+See `examples/external_dfb_descriptors.py` for two external calls surrounded by
+visible TTL protocol operations. Descriptor operands preserve each DFB's
+compile-time metadata but do not summarize storage behavior, so the two opaque
+result DFBs remain distinct. See
 `test/python/call_extern_func_dfb_effects.py` for dependency-only operands,
 ordered effect expansion, unknown access, and generated-C++ invariance.

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -324,9 +324,16 @@ opaque. Repeated transactions retain every action and its position. A bounded
 lifecycle requires ordered reserve/push and wait/pop transactions with matching
 tile counts. A partial summary is valid but does not prove a bounded lifecycle
 for that dependency. A dependency occurrence with no listed effect is an opaque
-storage access for the complete call duration, including when operand adaptation
-aliases multiple occurrences to the same SSA DFB. Every aliased occurrence
-requires its own effects to avoid an opaque call-duration access.
+storage access beginning at call entry, including when operand adaptation aliases
+multiple occurrences to the same SSA DFB. Every aliased occurrence requires its
+own effects to avoid an opaque access without a reset.
+
+A named opaque dependency may retain protocol and asynchronous interface work
+after the call. A synchronized reset ordered after the call through the same
+participating logical kernel terminates that access and canonicalizes protocol
+state. The reset implementation must complete earlier interface work before
+publishing arrival. Storage reuse is permitted only after reset completion. This
+does not validate the external function's internal queue protocol.
 
 `unknown_dfb_access=True` declares that external C++ may access user-managed
 DFBs not present in the declared dependencies. This is distinct from malformed
@@ -334,10 +341,11 @@ metadata. For allocation, the call becomes an opaque occurrence on every
 user-managed DFB in each scope where it may execute, including listed DFBs.
 Listed dependencies and effects remain available to other verification.
 
-Every listed effect is complete when the external function returns. External
-work that continues after return requires separate explicit completion
-semantics and cannot be represented by this synchronous effect list. Effects
-describe external behavior; they do not emit reserve, push, wait, or pop calls.
+Every listed effect action is complete when the external function returns.
+Associated interface work may remain active while the declared protocol retains
+ownership; it must complete before the terminal consumer release or a
+synchronized reset. Effects describe external behavior; they do not emit
+reserve, push, wait, or pop calls.
 Dependency-only operands and all effect metadata leave the generated C++ call
 signature unchanged.
 
@@ -366,9 +374,12 @@ ttl.call_extern_func(
 
 ## DFB synchronization ownership
 
-External C++ must complete its resource accesses before returning. The compiler
-does not infer reserve, wait, push, or pop operations from the C++ body; the
-`dfb_effects` contract supplies those facts when required.
+Every `dfb_effects` action must complete before the external call returns. Its
+associated interface work must complete before the terminal consumer release or
+a synchronized reset. The compiler does not infer reserve, wait, push, or pop
+operations from the C++ body; the `dfb_effects` contract supplies those facts
+when required. A named dependency without effects remains opaque and requires a
+synchronized reset before storage reuse.
 
 `TensorBlock.push` and `TensorBlock.pop` accept one `kernel=` selector when a
 DFB transaction has no other use from which ownership can be inferred.

--- a/examples/external_dfb_descriptors.py
+++ b/examples/external_dfb_descriptors.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Use typed DFB descriptors in external functions while reusing an index.
+"""Use typed DFB descriptors in external functions.
 
 TTL operations declare each DFB transaction around the opaque C++ calls. An
-acknowledgment orders the first result's pop before the second result's reserve,
-which permits those two logical DFBs to use one physical index.
+acknowledgment orders the first result's pop before the second result's reserve.
+The calls do not summarize their storage behavior, so their result DFBs remain
+distinct despite that ordering.
 """
 
 import os
@@ -25,7 +26,7 @@ EXTERNAL_MULTIPLY_HEADER = os.path.join(
 
 
 @ttl.operation(grid=(1, 1))
-def external_dfb_reuse(lhs, rhs, result):
+def external_dfb_descriptors(lhs, rhs, result):
     lhs_dfb = ttl.make_dataflow_buffer_like(lhs, shape=(1, 1), block_count=2)
     rhs_dfb = ttl.make_dataflow_buffer_like(rhs, shape=(1, 1), block_count=2)
     first_result_dfb = ttl.make_dataflow_buffer_like(
@@ -142,7 +143,9 @@ def main() -> None:
             previous_final_mlir = os.environ.get("TTLANG_FINAL_MLIR")
             os.environ["TTLANG_FINAL_MLIR"] = str(final_mlir_path)
             try:
-                external_dfb_reuse(lhs, rhs, result, options="--ttl-reuse-user-dfbs")
+                external_dfb_descriptors(
+                    lhs, rhs, result, options="--ttl-reuse-user-dfbs"
+                )
             finally:
                 if previous_final_mlir is None:
                     del os.environ["TTLANG_FINAL_MLIR"]
@@ -150,7 +153,7 @@ def main() -> None:
                     os.environ["TTLANG_FINAL_MLIR"] = previous_final_mlir
 
             first_index, second_index = _descriptor_result_indices(final_mlir_path)
-            assert first_index == second_index
+            assert first_index != second_index
         torch.testing.assert_close(ttnn.to_torch(result), lhs_host * rhs_host)
     finally:
         ttnn.close_device(device)

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -2070,16 +2070,28 @@ def TTL_OpaqueCallOp : TTL_Op<"opaque_call",
     greater than the selected DFB's capacity. Every listed effect occurs on
     every execution of the call. Repeated effects retain list order. The summary
     does not emit protocol calls. Effects omitted for a dependency occurrence
-    leave its access opaque for the call duration. If one DFB occupies multiple
-    dependency occurrences, every occurrence requires its own effects to avoid
-    an opaque call-duration access. The
+    leave its access opaque. If one DFB occupies multiple dependency
+    occurrences, every occurrence requires its own effects to avoid an opaque
+    access. The
     `unknown_dfb_access` unit attribute declares that the callee may also access
     unlisted user-managed DFBs and disables physical-index reuse in affected
     allocation scopes.
 
-    Every asynchronous DFB access must also complete before the call returns.
-    A callee with outstanding asynchronous work requires a separate explicit
-    completion contract and cannot use this operation's synchronous summary.
+    A named DFB dependency occurrence without `dfb_effects` contributes an
+    opaque storage access that begins at call entry. Its protocol and
+    asynchronous interface work may remain live after the call. When the call
+    is ordered before a synchronized DFB reset through the same participating
+    logical kernel, reset completion terminates the access and canonicalizes
+    its unknown protocol state. The reset implementation must complete each
+    participant's earlier interface work before publishing arrival. Storage
+    reuse is permitted only after the reset. This does not validate the
+    callee's internal queue protocol.
+
+    Every action declared by `dfb_effects` must occur before the call returns.
+    Interface work still active after return must remain ordered by the
+    declared protocol and complete before its terminal consumer release or a
+    synchronized reset. Work that can outlive that terminal must leave the
+    affected DFB dependency opaque.
 
     `unsigned_arg_indices` identifies signless i32 operands that represent
     unsigned addresses at the C++ boundary. The lowering inserts explicit

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1012,6 +1012,16 @@ def TTLFinalizeDFBIndices
     DFB without a matched lifecycle or a proven lifetime order conflicts with
     every other DFB.
 
+    Explicit allocation groups may reuse one physical index across
+    reset-delimited epochs from different logical DFBs. Every pair of active
+    epochs on a launch node must have one strict proven order. Each adjacent
+    handoff must either follow a reset that establishes canonical pointer state
+    or preserve both pointer owners. The allocator simulates every epoch's
+    transaction sequence against the group's physical capacity envelope and
+    rejects boundary crossings or unequal read and write offsets. This
+    epoch-level contract applies only to explicit allocation groups; automatic
+    reuse continues to compare complete logical-DFB lifetimes.
+
     Two DFBs used by one compute kernel may share a physical index only when
     every target-supported destination width assigns compatible static unpack
     modes to that index. This constraint is added to the conflict graph before

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_dfb_reset.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_dfb_reset.h
@@ -36,7 +36,6 @@ constexpr uint32_t stateWordCount = 4;
 constexpr uint32_t participantCount = 3;
 constexpr uint32_t entryComplete = 1;
 constexpr uint32_t exitComplete = 2;
-constexpr uint32_t completionMarker = 0xDFB0;
 
 static_assert(releaseWord + 1 == stateWordCount);
 
@@ -75,20 +74,20 @@ participantsHaveState(volatile uint32_t tt_l1_ptr *synchronizationState,
   return true;
 }
 
-// The readback is ordered after prior engine work and therefore prevents an
-// interface owner from publishing arrival before its commands retire.
-FORCE_INLINE void drainComputeEngine() {
+// Every interface owner must complete earlier asynchronous work before a
+// reset participant publishes its arrival.
+FORCE_INLINE void completeInterfaceWork() {
+#if defined(TTL_DFB_RESET_DM0) || defined(TTL_DFB_RESET_DM1)
+  noc_async_full_barrier();
+#endif
 #if defined(TTL_DFB_RESET_UNPACK)
   constexpr uint32_t waitResources = p_stall::UNPACK;
-  constexpr uint32_t completionGpr = p_gpr_unpack::TMP0;
 #elif defined(TTL_DFB_RESET_PACK)
   constexpr uint32_t waitResources = p_stall::PACK;
-  constexpr uint32_t completionGpr = p_gpr_pack::TMP0;
 #endif
 #if defined(TTL_DFB_RESET_UNPACK) || defined(TTL_DFB_RESET_PACK)
   TTI_STALLWAIT(p_stall::STALL_TDMA, waitResources);
-  TTI_SETDMAREG(0, completionMarker, 0, LO_16(completionGpr));
-  sync_regfile_write(completionGpr);
+  tensix_sync();
 #endif
 }
 
@@ -100,18 +99,13 @@ FORCE_INLINE void enter(volatile uint32_t tt_l1_ptr *synchronizationState) {
 #elif defined(TTL_DFB_RESET_PACK)
   constexpr uint32_t arrivalWord = packStateWord;
 #endif
-#if defined(TTL_DFB_RESET_DM0)
-  noc_async_full_barrier();
-#elif defined(TTL_DFB_RESET_UNPACK) || defined(TTL_DFB_RESET_PACK)
-  drainComputeEngine();
-#endif
+  completeInterfaceWork();
 #if defined(TTL_DFB_RESET_DM0) || defined(TTL_DFB_RESET_UNPACK) ||             \
     defined(TTL_DFB_RESET_PACK)
   storeStateWord(&synchronizationState[arrivalWord], entryComplete);
   while (loadStateWord(&synchronizationState[releaseWord]) != entryComplete) {
   }
 #elif defined(TTL_DFB_RESET_DM1)
-  noc_async_full_barrier();
   while (!participantsHaveState(synchronizationState, entryComplete)) {
   }
   storeStateWord(&synchronizationState[releaseWord], entryComplete);
@@ -182,6 +176,11 @@ FORCE_INLINE void applyMask(uint32_t activeMask, uint32_t firstDFBIndex) {
 }
 
 } // namespace dfb_reset_detail
+
+// Custom resets must complete interface work before publishing arrival.
+FORCE_INLINE void complete_dfb_interface_work() {
+  dfb_reset_detail::completeInterfaceWork();
+}
 
 FORCE_INLINE void reset_dfb_interfaces(uint32_t synchronizationAddress,
                                        uint32_t lowMask, uint32_t highMask) {

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -148,7 +148,11 @@ static void printAccesses(llvm::raw_ostream &output,
       output << "none";
     }
     output << " tiles=" << access.numTiles
-           << " sequence=" << access.sequenceIndex << " domain=";
+           << " sequence=" << access.sequenceIndex;
+    if (access.opaqueExternalAccess) {
+      output << " opaque_external=1";
+    }
+    output << " domain=";
     printDomain(output, access.launchDomain);
     output << " operation=";
     printOperation(output, access.operation);
@@ -257,6 +261,9 @@ static void printResetEpochs(llvm::raw_ostream &output,
         } else {
           output << "none";
         }
+        if (epoch.resetCanonicalizedOpaqueProtocol) {
+          output << ",opaque_protocol_reset=1";
+        }
         output << ",terminal_state="
                << (epoch.terminalStateCanonical ? "canonical" : "protocol")
                << '}';
@@ -281,6 +288,8 @@ static bool hasEqualResetEpochs(ArrayRef<DFBLifecycleEpoch> lhs,
                lhsEpoch.terminalReadPointerOwner ==
                    rhsEpoch.terminalReadPointerOwner &&
                lhsEpoch.terminalResetOrdinal == rhsEpoch.terminalResetOrdinal &&
+               lhsEpoch.resetCanonicalizedOpaqueProtocol ==
+                   rhsEpoch.resetCanonicalizedOpaqueProtocol &&
                lhsEpoch.terminalStateCanonical ==
                    rhsEpoch.terminalStateCanonical &&
                lhsEpoch.quiescence.failure == rhsEpoch.quiescence.failure &&
@@ -307,6 +316,8 @@ hasEqualPossibleFacts(const DFBPerNodeLifetime &lhs,
       lhs.terminalReadCursorRuns != rhs.terminalReadCursorRuns ||
       lhs.terminalWritePointerOwner != rhs.terminalWritePointerOwner ||
       lhs.terminalReadPointerOwner != rhs.terminalReadPointerOwner ||
+      lhs.resetCanonicalizedOpaqueProtocol !=
+          rhs.resetCanonicalizedOpaqueProtocol ||
       lhs.terminalStateCanonical != rhs.terminalStateCanonical ||
       !hasEqualResetEpochs(lhs.resetEpochs, rhs.resetEpochs) ||
       !(lhsDiagnostics == rhsDiagnostics)) {
@@ -382,8 +393,11 @@ static void printPossibleLifetimes(
            << getQuiescenceFailureName(lifetime.quiescence.failure)
            << " domain_assumption=unknown-possible may_be_active="
            << lifetime.mayBeActive
-           << " conditional_execution=" << lifetime.conditionalExecutionProven
-           << " node_count=" << group.nodes.size();
+           << " conditional_execution=" << lifetime.conditionalExecutionProven;
+    if (lifetime.resetCanonicalizedOpaqueProtocol) {
+      output << " opaque_protocol_reset=1";
+    }
+    output << " node_count=" << group.nodes.size();
     if (group.nodes.size() <= 8) {
       output << " nodes={";
       llvm::interleaveComma(group.nodes, output, [&](LaunchNodeCoord node) {
@@ -420,6 +434,9 @@ static void printNodeLifetimes(llvm::raw_ostream &output,
            << getQuiescenceFailureName(lifetime.quiescence.failure)
            << " domain_assumption=exact conditional_execution="
            << lifetime.conditionalExecutionProven;
+    if (lifetime.resetCanonicalizedOpaqueProtocol) {
+      output << " opaque_protocol_reset=1";
+    }
     printLifetimeFacts(output, lifetime, diagnostics);
     output << '\n';
   }
@@ -458,8 +475,11 @@ void printDFBAllocationDebugReport(
     output << "DFB logical_id=" << logicalDFB.logicalId
            << " bounded=" << logicalDFB.bounded
            << " compiler_created=" << logicalDFB.compilerCreated
-           << " conditionally_bounded=" << logicalDFB.conditionallyBounded
-           << " allocation_group=";
+           << " conditionally_bounded=" << logicalDFB.conditionallyBounded;
+    if (logicalDFB.hasOpaqueExternalAccess) {
+      output << " opaque_external_access=1";
+    }
+    output << " allocation_group=";
     if (logicalDFB.allocationGroup) {
       Attribute allocationGroup = logicalDFB.allocationGroup;
       allocationGroup.print(output);

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -36,22 +36,22 @@ static llvm::StringRef getProtocolEffectName(DFBProtocolEffectKind effect) {
 }
 
 static llvm::StringRef
-getQuiescenceFailureName(DFBQuiescenceFailureReason failure) {
+getLifecycleCompletionName(DFBLifecycleCompletionFailureReason failure) {
   switch (failure) {
-  case DFBQuiescenceFailureReason::None:
-    return "none";
-  case DFBQuiescenceFailureReason::MissingProtocolEffect:
+  case DFBLifecycleCompletionFailureReason::None:
+    return "complete";
+  case DFBLifecycleCompletionFailureReason::MissingProtocolEffect:
     return "missing-protocol-effect";
-  case DFBQuiescenceFailureReason::UnsupportedControlFlow:
+  case DFBLifecycleCompletionFailureReason::UnsupportedControlFlow:
     return "unsupported-control-flow";
-  case DFBQuiescenceFailureReason::MismatchedTransaction:
+  case DFBLifecycleCompletionFailureReason::MismatchedTransaction:
     return "mismatched-transaction";
-  case DFBQuiescenceFailureReason::IncompleteUseOrder:
+  case DFBLifecycleCompletionFailureReason::IncompleteUseOrder:
     return "incomplete-use-order";
-  case DFBQuiescenceFailureReason::UnknownPointerOwner:
+  case DFBLifecycleCompletionFailureReason::UnknownPointerOwner:
     return "unknown-pointer-owner";
   }
-  llvm_unreachable("unknown DFB quiescence failure");
+  llvm_unreachable("unknown DFB lifecycle-completion failure");
 }
 
 static llvm::StringRef getPointerProcessorName(DFBPointerProcessor processor) {
@@ -292,8 +292,10 @@ static bool hasEqualResetEpochs(ArrayRef<DFBLifecycleEpoch> lhs,
                    rhsEpoch.resetCanonicalizedOpaqueProtocol &&
                lhsEpoch.terminalStateCanonical ==
                    rhsEpoch.terminalStateCanonical &&
-               lhsEpoch.quiescence.failure == rhsEpoch.quiescence.failure &&
-               lhsEpoch.quiescence.evidence == rhsEpoch.quiescence.evidence;
+               lhsEpoch.completionProof.failure ==
+                   rhsEpoch.completionProof.failure &&
+               lhsEpoch.completionProof.evidence ==
+                   rhsEpoch.completionProof.evidence;
       });
 }
 
@@ -302,8 +304,8 @@ hasEqualPossibleFacts(const DFBPerNodeLifetime &lhs,
                       const DFBPerNodeLifetimeDiagnostics &lhsDiagnostics,
                       const DFBPerNodeLifetime &rhs,
                       const DFBPerNodeLifetimeDiagnostics &rhsDiagnostics) {
-  if (lhs.quiescence.failure != rhs.quiescence.failure ||
-      lhs.quiescence.evidence != rhs.quiescence.evidence ||
+  if (lhs.completionProof.failure != rhs.completionProof.failure ||
+      lhs.completionProof.evidence != rhs.completionProof.evidence ||
       lhs.mayBeActive != rhs.mayBeActive ||
       lhs.conditionalExecutionProven != rhs.conditionalExecutionProven ||
       lhs.transactionRuns != rhs.transactionRuns ||
@@ -331,7 +333,7 @@ printLifetimeFacts(llvm::raw_ostream &output,
                    const DFBPerNodeLifetime &lifetime,
                    const DFBPerNodeLifetimeDiagnostics &diagnostics) {
   output << " evidence=";
-  printOperation(output, lifetime.quiescence.evidence);
+  printOperation(output, lifetime.completionProof.evidence);
   output << " occurrences=";
   printOccurrences(output, diagnostics);
   output << " transactions=";
@@ -389,8 +391,8 @@ static void printPossibleLifetimes(
     const DFBPerNodeLifetime &lifetime = *group.representative.lifetime;
     const DFBPerNodeLifetimeDiagnostics &diagnostics =
         *group.representative.diagnostics;
-    output << "  possible_nodes quiescence="
-           << getQuiescenceFailureName(lifetime.quiescence.failure)
+    output << "  possible_nodes lifecycle_completion="
+           << getLifecycleCompletionName(lifetime.completionProof.failure)
            << " domain_assumption=unknown-possible may_be_active="
            << lifetime.mayBeActive
            << " conditional_execution=" << lifetime.conditionalExecutionProven;
@@ -430,8 +432,8 @@ static void printNodeLifetimes(llvm::raw_ostream &output,
                        allocationDiagnostics.nodeLifetimeDiagnostics)) {
     output << "  node ";
     printNode(output, lifetime.node);
-    output << " quiescence="
-           << getQuiescenceFailureName(lifetime.quiescence.failure)
+    output << " lifecycle_completion="
+           << getLifecycleCompletionName(lifetime.completionProof.failure)
            << " domain_assumption=exact conditional_execution="
            << lifetime.conditionalExecutionProven;
     if (lifetime.resetCanonicalizedOpaqueProtocol) {

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -244,6 +244,13 @@ static void printResetEpochs(llvm::raw_ostream &output,
         printPointerOwner(output, epoch.writePointerOwner);
         output << ",read_owner=";
         printPointerOwner(output, epoch.readPointerOwner);
+        if (epoch.terminalWritePointerOwner != epoch.writePointerOwner ||
+            epoch.terminalReadPointerOwner != epoch.readPointerOwner) {
+          output << ",terminal_write_owner=";
+          printPointerOwner(output, epoch.terminalWritePointerOwner);
+          output << ",terminal_read_owner=";
+          printPointerOwner(output, epoch.terminalReadPointerOwner);
+        }
         output << ",terminal_reset=";
         if (epoch.terminalResetOrdinal) {
           output << *epoch.terminalResetOrdinal;
@@ -269,6 +276,10 @@ static bool hasEqualResetEpochs(ArrayRef<DFBLifecycleEpoch> lhs,
                lhsEpoch.readCursorRuns == rhsEpoch.readCursorRuns &&
                lhsEpoch.writePointerOwner == rhsEpoch.writePointerOwner &&
                lhsEpoch.readPointerOwner == rhsEpoch.readPointerOwner &&
+               lhsEpoch.terminalWritePointerOwner ==
+                   rhsEpoch.terminalWritePointerOwner &&
+               lhsEpoch.terminalReadPointerOwner ==
+                   rhsEpoch.terminalReadPointerOwner &&
                lhsEpoch.terminalResetOrdinal == rhsEpoch.terminalResetOrdinal &&
                lhsEpoch.terminalStateCanonical ==
                    rhsEpoch.terminalStateCanonical &&

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -228,7 +228,28 @@ static void printTransactions(llvm::raw_ostream &output,
   }
 }
 
+static bool resetCompletesOpaqueAccess(const DFBLogicalLifecycle &logicalDFB,
+                                       const DFBLifecycleEpoch &epoch) {
+  if (!epoch.terminalResetOrdinal) {
+    return false;
+  }
+  return llvm::any_of(epoch.accessOccurrenceIndices, [&](unsigned accessIndex) {
+    assert(accessIndex < logicalDFB.accesses.size());
+    return logicalDFB.accesses[accessIndex].opaqueExternalAccess;
+  });
+}
+
+static bool
+hasOpaqueAccessCompletedByReset(const DFBLogicalLifecycle &logicalDFB,
+                                const DFBPerNodeLifetime &lifetime) {
+  return llvm::any_of(lifetime.resetEpochs,
+                      [&](const DFBLifecycleEpoch &epoch) {
+                        return resetCompletesOpaqueAccess(logicalDFB, epoch);
+                      });
+}
+
 static void printResetEpochs(llvm::raw_ostream &output,
+                             const DFBLogicalLifecycle &logicalDFB,
                              const DFBPerNodeLifetime &lifetime) {
   output << '[';
   llvm::interleaveComma(
@@ -261,7 +282,7 @@ static void printResetEpochs(llvm::raw_ostream &output,
         } else {
           output << "none";
         }
-        if (epoch.resetCanonicalizedOpaqueProtocol) {
+        if (resetCompletesOpaqueAccess(logicalDFB, epoch)) {
           output << ",opaque_protocol_reset=1";
         }
         output << ",terminal_state="
@@ -288,8 +309,6 @@ static bool hasEqualResetEpochs(ArrayRef<DFBLifecycleEpoch> lhs,
                lhsEpoch.terminalReadPointerOwner ==
                    rhsEpoch.terminalReadPointerOwner &&
                lhsEpoch.terminalResetOrdinal == rhsEpoch.terminalResetOrdinal &&
-               lhsEpoch.resetCanonicalizedOpaqueProtocol ==
-                   rhsEpoch.resetCanonicalizedOpaqueProtocol &&
                lhsEpoch.terminalStateCanonical ==
                    rhsEpoch.terminalStateCanonical &&
                lhsEpoch.completionProof.failure ==
@@ -318,8 +337,6 @@ hasEqualPossibleFacts(const DFBPerNodeLifetime &lhs,
       lhs.terminalReadCursorRuns != rhs.terminalReadCursorRuns ||
       lhs.terminalWritePointerOwner != rhs.terminalWritePointerOwner ||
       lhs.terminalReadPointerOwner != rhs.terminalReadPointerOwner ||
-      lhs.resetCanonicalizedOpaqueProtocol !=
-          rhs.resetCanonicalizedOpaqueProtocol ||
       lhs.terminalStateCanonical != rhs.terminalStateCanonical ||
       !hasEqualResetEpochs(lhs.resetEpochs, rhs.resetEpochs) ||
       !(lhsDiagnostics == rhsDiagnostics)) {
@@ -330,6 +347,7 @@ hasEqualPossibleFacts(const DFBPerNodeLifetime &lhs,
 
 static void
 printLifetimeFacts(llvm::raw_ostream &output,
+                   const DFBLogicalLifecycle &logicalDFB,
                    const DFBPerNodeLifetime &lifetime,
                    const DFBPerNodeLifetimeDiagnostics &diagnostics) {
   output << " evidence=";
@@ -348,7 +366,7 @@ printLifetimeFacts(llvm::raw_ostream &output,
   printValues(output, diagnostics.terminalAccessOccurrenceIndices);
   if (!lifetime.resetEpochs.empty()) {
     output << " reset_epochs=";
-    printResetEpochs(output, lifetime);
+    printResetEpochs(output, logicalDFB, lifetime);
   }
 }
 
@@ -396,7 +414,7 @@ static void printPossibleLifetimes(
            << " domain_assumption=unknown-possible may_be_active="
            << lifetime.mayBeActive
            << " conditional_execution=" << lifetime.conditionalExecutionProven;
-    if (lifetime.resetCanonicalizedOpaqueProtocol) {
+    if (hasOpaqueAccessCompletedByReset(logicalDFB, lifetime)) {
       output << " opaque_protocol_reset=1";
     }
     output << " node_count=" << group.nodes.size();
@@ -410,7 +428,7 @@ static void printPossibleLifetimes(
       output << " exemplar=";
       printNode(output, lifetime.node);
     }
-    printLifetimeFacts(output, lifetime, diagnostics);
+    printLifetimeFacts(output, logicalDFB, lifetime, diagnostics);
     output << '\n';
   }
 }
@@ -436,10 +454,10 @@ static void printNodeLifetimes(llvm::raw_ostream &output,
            << getLifecycleCompletionName(lifetime.completionProof.failure)
            << " domain_assumption=exact conditional_execution="
            << lifetime.conditionalExecutionProven;
-    if (lifetime.resetCanonicalizedOpaqueProtocol) {
+    if (hasOpaqueAccessCompletedByReset(logicalDFB, lifetime)) {
       output << " opaque_protocol_reset=1";
     }
-    printLifetimeFacts(output, lifetime, diagnostics);
+    printLifetimeFacts(output, logicalDFB, lifetime, diagnostics);
     output << '\n';
   }
   printPossibleLifetimes(output, logicalDFB, allocationDiagnostics);

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -3513,6 +3513,24 @@ static bool proveOrderedBefore(const DFBPerNodeLifetime &before,
   });
 }
 
+static SmallVector<llvm::BitVector>
+buildLogicalOrdering(ArrayRef<const DFBPerNodeLifetime *> lifetimes,
+                     const HappensBeforeGraph &graph) {
+  SmallVector<llvm::BitVector> ordering(lifetimes.size(),
+                                        llvm::BitVector(lifetimes.size()));
+  for (auto [beforeIndex, before] : llvm::enumerate(lifetimes)) {
+    if (!before) {
+      continue;
+    }
+    for (auto [afterIndex, after] : llvm::enumerate(lifetimes)) {
+      if (after && proveOrderedBefore(*before, *after, graph)) {
+        ordering[beforeIndex].set(afterIndex);
+      }
+    }
+  }
+  return ordering;
+}
+
 static bool intervalIsOutsideReset(ArrayRef<unsigned> earliestEntryEvents,
                                    ArrayRef<unsigned> terminalCompletionEvents,
                                    EventPair resetEvents,
@@ -3686,6 +3704,7 @@ static Operation *getResetOverlapEvidence(
 
 static void collectResetAllocationConflicts(
     ArrayRef<DFBLogicalLifecycle> logicalDFBs,
+    ArrayRef<const DFBPerNodeLifetime *> lifetimes,
     ArrayRef<ValidatedSynchronizedReset> synchronizedResets,
     const ResetBoundaryEvents &resetBoundaryEvents,
     const HappensBeforeGraph &graph, LaunchNodeCoord node,
@@ -3696,6 +3715,7 @@ static void collectResetAllocationConflicts(
     const AccessRuns &accessRuns, const LaunchNodeDomainState &domainState,
     bool usePossibleLifetimes,
     SmallVectorImpl<DFBResetAllocationConflict> &conflicts) {
+  assert(lifetimes.size() == logicalDFBs.size());
   for (const ValidatedSynchronizedReset &reset : synchronizedResets) {
     auto resetEvents = resetBoundaryEvents.find(reset.reset);
     if (resetEvents == resetBoundaryEvents.end()) {
@@ -3718,9 +3738,7 @@ static void collectResetAllocationConflicts(
             !sharesAllocationGroup) {
           continue;
         }
-        const DFBPerNodeLifetime *lifetime =
-            usePossibleLifetimes ? logicalDFB.findPossibleNodeLifetime(node)
-                                 : logicalDFB.findNodeLifetime(node);
+        const DFBPerNodeLifetime *lifetime = lifetimes[overlappingLogicalIndex];
         if (!lifetime || !lifetime->mayBeActive) {
           continue;
         }
@@ -3762,15 +3780,6 @@ static unsigned getLifecycleEpochCount(const DFBPerNodeLifetime *lifetime) {
     return 0;
   }
   return std::max<unsigned>(1, lifetime->resetEpochs.size());
-}
-
-static const DFBPerNodeLifetime *
-getEpochOrderingLifetime(const DFBLogicalLifecycle &logicalDFB,
-                         LaunchNodeCoord node, bool includeUnknownDomains) {
-  if (includeUnknownDomains && !logicalDFB.launchDomain.known) {
-    return logicalDFB.findPossibleNodeLifetime(node);
-  }
-  return logicalDFB.findNodeLifetime(node);
 }
 
 static ArrayRef<unsigned>
@@ -3867,7 +3876,8 @@ static void appendInconsistentEpochAccessEvents(
 }
 
 static void buildEpochOrdering(
-    ArrayRef<DFBLogicalLifecycle> logicalDFBs, LaunchNodeCoord node,
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs,
+    ArrayRef<const DFBPerNodeLifetime *> lifetimes, LaunchNodeCoord node,
     const HappensBeforeGraph &graph,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
@@ -3875,15 +3885,21 @@ static void buildEpochOrdering(
     SmallVectorImpl<unsigned> &logicalOffsets,
     SmallVectorImpl<llvm::BitVector> &orderedBefore,
     SmallVectorImpl<llvm::BitVector> &inconsistent) {
-  SmallVector<std::pair<unsigned, unsigned>> epochIdentities;
+  struct LifecycleEpochIdentity {
+    unsigned logicalIndex;
+    unsigned epochIndex;
+    const DFBPerNodeLifetime *lifetime;
+  };
+
+  assert(lifetimes.size() == logicalDFBs.size());
+  SmallVector<LifecycleEpochIdentity> epochIdentities;
   logicalOffsets.reserve(logicalDFBs.size() + 1);
   logicalOffsets.push_back(0);
-  for (auto [logicalIndex, logicalDFB] : llvm::enumerate(logicalDFBs)) {
-    const DFBPerNodeLifetime *lifetime =
-        getEpochOrderingLifetime(logicalDFB, node, includeUnknownDomains);
+  for (auto [logicalIndex, lifetime] : llvm::enumerate(lifetimes)) {
     unsigned epochCount = getLifecycleEpochCount(lifetime);
     for (unsigned epochIndex = 0; epochIndex < epochCount; ++epochIndex) {
-      epochIdentities.emplace_back(logicalIndex, epochIndex);
+      epochIdentities.push_back(
+          {static_cast<unsigned>(logicalIndex), epochIndex, lifetime});
     }
     logicalOffsets.push_back(epochIdentities.size());
   }
@@ -3894,11 +3910,11 @@ static void buildEpochOrdering(
       epochIdentities.size());
   for (auto [beforeFlatIndex, beforeIdentity] :
        llvm::enumerate(epochIdentities)) {
-    auto [beforeLogicalIndex, beforeEpochIndex] = beforeIdentity;
+    unsigned beforeLogicalIndex = beforeIdentity.logicalIndex;
+    unsigned beforeEpochIndex = beforeIdentity.epochIndex;
     const DFBLogicalLifecycle &beforeLogicalDFB =
         logicalDFBs[beforeLogicalIndex];
-    const DFBPerNodeLifetime *beforeLifetime =
-        getEpochOrderingLifetime(beforeLogicalDFB, node, includeUnknownDomains);
+    const DFBPerNodeLifetime *beforeLifetime = beforeIdentity.lifetime;
     assert(beforeLifetime && "flattened epoch must have a lifetime");
     appendInconsistentEpochAccessEvents(
         beforeLogicalDFB, *beforeLifetime, beforeEpochIndex, node, graph,
@@ -3906,11 +3922,8 @@ static void buildEpochOrdering(
         inconsistentEventsByEpoch[beforeFlatIndex]);
     for (auto [afterFlatIndex, afterIdentity] :
          llvm::enumerate(epochIdentities)) {
-      auto [afterLogicalIndex, afterEpochIndex] = afterIdentity;
-      const DFBLogicalLifecycle &afterLogicalDFB =
-          logicalDFBs[afterLogicalIndex];
-      const DFBPerNodeLifetime *afterLifetime = getEpochOrderingLifetime(
-          afterLogicalDFB, node, includeUnknownDomains);
+      unsigned afterEpochIndex = afterIdentity.epochIndex;
+      const DFBPerNodeLifetime *afterLifetime = afterIdentity.lifetime;
       assert(afterLifetime && "flattened epoch must have a lifetime");
       if (proveEpochOrderedBefore(*beforeLifetime, beforeEpochIndex,
                                   *afterLifetime, afterEpochIndex, graph)) {
@@ -4185,6 +4198,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
                                     node, domainState, structuralOrder,
                                     /*includeUnknownDomains=*/false);
 
+    SmallVector<const DFBPerNodeLifetime *> nodeLifetimes(logicalDFBs.size());
     for (auto [logicalIndex, logicalDFB] : llvm::enumerate(logicalDFBs)) {
       if (!knownLaunchNodeDomainContains(logicalDFB.launchDomain, node)) {
         continue;
@@ -4200,39 +4214,22 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           operationEvents, accessEvents, executionCounts, accessRuns,
           domainState);
       logicalDFB.nodeLifetimes.back().quiescence = proof;
+      nodeLifetimes[logicalIndex] = &logicalDFB.nodeLifetimes.back();
     }
 
     collectResetAllocationConflicts(
-        logicalDFBs, validatedResets, resetBoundaryEvents, graph, node,
-        structuralOrder, executionCounts, operationEvents, accessEvents,
+        logicalDFBs, nodeLifetimes, validatedResets, resetBoundaryEvents, graph,
+        node, structuralOrder, executionCounts, operationEvents, accessEvents,
         accessRuns, domainState, /*usePossibleLifetimes=*/false,
         resetAllocationConflicts);
 
-    SmallVector<llvm::BitVector> nodeOrdering(
-        logicalDFBs.size(), llvm::BitVector(logicalDFBs.size()));
-    for (unsigned beforeIndex = 0; beforeIndex < logicalDFBs.size();
-         ++beforeIndex) {
-      const DFBPerNodeLifetime *before =
-          logicalDFBs[beforeIndex].findNodeLifetime(node);
-      if (!before) {
-        continue;
-      }
-      for (unsigned afterIndex = 0; afterIndex < logicalDFBs.size();
-           ++afterIndex) {
-        const DFBPerNodeLifetime *after =
-            logicalDFBs[afterIndex].findNodeLifetime(node);
-        if (after && proveOrderedBefore(*before, *after, graph)) {
-          nodeOrdering[beforeIndex].set(afterIndex);
-        }
-      }
-    }
-    orderedBeforeByNode.push_back(std::move(nodeOrdering));
+    orderedBeforeByNode.push_back(buildLogicalOrdering(nodeLifetimes, graph));
     inconsistentOrderByNode.push_back(collectInconsistentAccessOrder(
         logicalDFBs, node, graph, operationEvents, accessEvents,
         executionCounts, /*includeUnknownDomains=*/false));
     EpochOrdering epochOrdering;
-    buildEpochOrdering(logicalDFBs, node, graph, operationEvents, accessEvents,
-                       executionCounts,
+    buildEpochOrdering(logicalDFBs, nodeLifetimes, node, graph, operationEvents,
+                       accessEvents, executionCounts,
                        /*includeUnknownDomains=*/false,
                        epochOrdering.logicalOffsets,
                        epochOrdering.orderedBefore, epochOrdering.inconsistent);
@@ -4265,6 +4262,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
         logicalDFBs, possibleGraph, possibleOperationEvents,
         possibleAccessEvents, executionCounts, *possibleAccessRuns, node,
         domainState, structuralOrder, /*includeUnknownDomains=*/true);
+    SmallVector<const DFBPerNodeLifetime *> possibleNodeLifetimes(
+        logicalDFBs.size());
     for (auto [logicalIndex, logicalDFB] : llvm::enumerate(logicalDFBs)) {
       if (logicalDFB.launchDomain.known) {
         continue;
@@ -4281,44 +4280,37 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           executionCounts, *possibleAccessRuns, domainState,
           /*includeUnknownDomains=*/true);
       logicalDFB.possibleNodeLifetimes.back().quiescence = proof;
+      possibleNodeLifetimes[logicalIndex] =
+          &logicalDFB.possibleNodeLifetimes.back();
     }
 
     collectResetAllocationConflicts(
-        logicalDFBs, validatedResets, possibleResetBoundaryEvents,
-        possibleGraph, node, structuralOrder, executionCounts,
-        possibleOperationEvents, possibleAccessEvents, *possibleAccessRuns,
-        domainState,
-        /*usePossibleLifetimes=*/true, resetAllocationConflicts);
+        logicalDFBs, possibleNodeLifetimes, validatedResets,
+        possibleResetBoundaryEvents, possibleGraph, node, structuralOrder,
+        executionCounts, possibleOperationEvents, possibleAccessEvents,
+        *possibleAccessRuns, domainState, /*usePossibleLifetimes=*/true,
+        resetAllocationConflicts);
 
-    SmallVector<llvm::BitVector> conditionalNodeOrdering(
-        logicalDFBs.size(), llvm::BitVector(logicalDFBs.size()));
-    for (unsigned beforeIndex = 0; beforeIndex < logicalDFBs.size();
-         ++beforeIndex) {
-      const DFBPerNodeLifetime *before =
-          logicalDFBs[beforeIndex].findPossibleNodeLifetime(node);
-      if (!before) {
-        continue;
-      }
-      for (unsigned afterIndex = 0; afterIndex < logicalDFBs.size();
-           ++afterIndex) {
-        const DFBPerNodeLifetime *after =
-            logicalDFBs[afterIndex].findPossibleNodeLifetime(node);
-        if (after && proveOrderedBefore(*before, *after, possibleGraph)) {
-          conditionalNodeOrdering[beforeIndex].set(afterIndex);
-        }
-      }
-    }
     conditionallyOrderedBeforeByNode.push_back(
-        std::move(conditionalNodeOrdering));
+        buildLogicalOrdering(possibleNodeLifetimes, possibleGraph));
     conditionallyInconsistentOrderByNode.push_back(
         collectInconsistentAccessOrder(logicalDFBs, node, possibleGraph,
                                        possibleOperationEvents,
                                        possibleAccessEvents, executionCounts,
                                        /*includeUnknownDomains=*/true));
     EpochOrdering conditionalEpochOrdering;
+    SmallVector<const DFBPerNodeLifetime *> conditionalEpochLifetimes;
+    conditionalEpochLifetimes.reserve(logicalDFBs.size());
+    for (unsigned logicalIndex = 0; logicalIndex < logicalDFBs.size();
+         ++logicalIndex) {
+      conditionalEpochLifetimes.push_back(
+          logicalDFBs[logicalIndex].launchDomain.known
+              ? nodeLifetimes[logicalIndex]
+              : possibleNodeLifetimes[logicalIndex]);
+    }
     buildEpochOrdering(
-        logicalDFBs, node, possibleGraph, possibleOperationEvents,
-        possibleAccessEvents, executionCounts,
+        logicalDFBs, conditionalEpochLifetimes, node, possibleGraph,
+        possibleOperationEvents, possibleAccessEvents, executionCounts,
         /*includeUnknownDomains=*/true, conditionalEpochOrdering.logicalOffsets,
         conditionalEpochOrdering.orderedBefore,
         conditionalEpochOrdering.inconsistent);

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -3002,7 +3002,6 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
             static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data()));
       }
     }
-    lifetime.resetCanonicalizedOpaqueProtocol = true;
     return {};
   }
 
@@ -3539,8 +3538,6 @@ static DFBLifecycleCompletionProof computePerNodeLifetime(
     epoch.readCursorRuns = epochLifetime.readCursorRuns;
     epoch.writePointerOwner = epochLifetime.writePointerOwner;
     epoch.readPointerOwner = epochLifetime.readPointerOwner;
-    epoch.resetCanonicalizedOpaqueProtocol =
-        epochLifetime.resetCanonicalizedOpaqueProtocol;
     epoch.completionProof = proof;
     if (resetTerminated) {
       const OrderedResetBoundary &boundary = boundaries[epochIndex];
@@ -3570,8 +3567,6 @@ static DFBLifecycleCompletionProof computePerNodeLifetime(
       lifetime.readCursorRuns = epochLifetime.readCursorRuns;
       lifetime.writePointerOwner = epochLifetime.writePointerOwner;
       lifetime.readPointerOwner = epochLifetime.readPointerOwner;
-      lifetime.resetCanonicalizedOpaqueProtocol =
-          epochLifetime.resetCanonicalizedOpaqueProtocol;
       hasActiveEpoch = true;
     }
     lifetime.conditionalExecutionProven |=
@@ -3587,8 +3582,6 @@ static DFBLifecycleCompletionProof computePerNodeLifetime(
     lifetime.terminalWritePointerOwner =
         epochLifetime.terminalWritePointerOwner;
     lifetime.terminalReadPointerOwner = epochLifetime.terminalReadPointerOwner;
-    lifetime.resetCanonicalizedOpaqueProtocol |=
-        epochLifetime.resetCanonicalizedOpaqueProtocol;
     lifetime.terminalStateCanonical = epochLifetime.terminalStateCanonical;
   }
 

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1879,6 +1879,12 @@ static void addSynchronizedResetAccessEdges(
         if (!localReset) {
           continue;
         }
+        if (!accessEvents.contains(&access) &&
+            structuralOrder.getTopLevelOperation(access.operation) ==
+                structuralOrder.getTopLevelOperation(localReset)) {
+          // The enclosing event spans both operations and cannot order them.
+          continue;
+        }
         if (structuralOrder.precedes(access.operation, localReset)) {
           graph.addEdge(events->last.completion, boundaryEvents.entry);
         } else if (structuralOrder.precedes(localReset, access.operation)) {
@@ -3041,14 +3047,26 @@ static DFBQuiescenceProof computeProtocolLifetime(
   if (!useCumulativeQueueProof) {
     SmallVector<Operation *> nativeReserves;
     SmallVector<Operation *> nativeWaits;
-    for (const AccessRun *reserve : reserves) {
-      if (isa<CBReserveOp>(reserve->access->operation)) {
-        nativeReserves.push_back(reserve->access->operation);
+    // Acquire ownership ends at the next same-kind acquire in the complete
+    // kernel. Restricting these boundaries to one reset epoch makes an earlier
+    // acquisition incorrectly own direct DFB uses in subsequent epochs.
+    for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+      if (!mayContainLaunchNode(access.launchDomain, node,
+                                includeUnknownDomains)) {
+        continue;
       }
-    }
-    for (const AccessRun *wait : waits) {
-      if (isa<CBWaitOp>(wait->access->operation)) {
-        nativeWaits.push_back(wait->access->operation);
+      auto executionCountIt = executionCounts.find(&access);
+      assert(executionCountIt != executionCounts.end() &&
+             "every DFB access must have an execution-count fact");
+      if (executionCountIt->second && *executionCountIt->second == 0) {
+        continue;
+      }
+      if (access.protocolEffect == DFBProtocolEffectKind::Reserve &&
+          isa<CBReserveOp>(access.operation)) {
+        nativeReserves.push_back(access.operation);
+      } else if (access.protocolEffect == DFBProtocolEffectKind::Wait &&
+                 isa<CBWaitOp>(access.operation)) {
+        nativeWaits.push_back(access.operation);
       }
     }
     for (auto [reserve, push] : llvm::zip_equal(reserves, pushes)) {
@@ -3222,16 +3240,21 @@ static DFBQuiescenceProof computeProtocolLifetime(
   lifetime.earliestEntryEvents = findMinimalEntryEvents(
       activeAccesses, graph, operationEvents, accessEvents);
   lifetime.terminalCompletionEvents = {terminalEvents->last.completion};
-  if (diagnostics) {
-    for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
-      std::optional<AccessEventSpan> activeEvents =
-          getAccessEventSpan(*activeAccess, operationEvents, accessEvents);
-      if (activeEvents && llvm::is_contained(lifetime.earliestEntryEvents,
-                                             activeEvents->first.entry)) {
+  for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
+    std::optional<AccessEventSpan> activeEvents =
+        getAccessEventSpan(*activeAccess, operationEvents, accessEvents);
+    if (activeEvents && llvm::is_contained(lifetime.earliestEntryEvents,
+                                           activeEvents->first.entry)) {
+      if (!lifetime.entryEvidence) {
+        lifetime.entryEvidence = activeAccess->operation;
+      }
+      if (diagnostics) {
         diagnostics->earliestAccessOccurrenceIndices.push_back(
             static_cast<unsigned>(activeAccess - logicalDFB.accesses.data()));
       }
     }
+  }
+  if (diagnostics) {
     diagnostics->terminalAccessOccurrenceIndices = {
         static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data())};
   }
@@ -3421,8 +3444,6 @@ static DFBQuiescenceProof computePerNodeLifetime(
     epoch.writePointerOwner = epochLifetime.writePointerOwner;
     epoch.readPointerOwner = epochLifetime.readPointerOwner;
     epoch.quiescence = proof;
-    epoch.earliestEntryEvents = epochLifetime.earliestEntryEvents;
-    epoch.terminalCompletionEvents = epochLifetime.terminalCompletionEvents;
     if (resetTerminated) {
       const OrderedResetBoundary &boundary = boundaries[epochIndex];
       epoch.terminalResetOrdinal = boundary.reset->reset.getOrdinal();
@@ -3430,10 +3451,15 @@ static DFBQuiescenceProof computePerNodeLifetime(
       epochLifetime.terminalCompletionEvents = {boundary.events.completion};
       epochLifetime.terminalStateCanonical = true;
     }
+    epoch.earliestEntryEvents = epochLifetime.earliestEntryEvents;
+    epoch.terminalCompletionEvents = epochLifetime.terminalCompletionEvents;
+    epoch.terminalWritePointerOwner = epochLifetime.terminalWritePointerOwner;
+    epoch.terminalReadPointerOwner = epochLifetime.terminalReadPointerOwner;
     lifetime.resetEpochs.push_back(std::move(epoch));
 
     if (!hasActiveEpoch) {
       lifetime.earliestEntryEvents = epochLifetime.earliestEntryEvents;
+      lifetime.entryEvidence = epochLifetime.entryEvidence;
       if (diagnostics) {
         diagnostics->earliestAccessOccurrenceIndices =
             epochDiagnostic->earliestAccessOccurrenceIndices;
@@ -3506,6 +3532,7 @@ static bool intervalIsOutsideReset(ArrayRef<unsigned> earliestEntryEvents,
 }
 
 static bool lifetimeIsOutsideReset(const DFBPerNodeLifetime &lifetime,
+                                   SynchronizedDFBResetAttr reset,
                                    EventPair resetEvents,
                                    const HappensBeforeGraph &graph) {
   if (lifetime.resetEpochs.empty()) {
@@ -3515,6 +3542,9 @@ static bool lifetimeIsOutsideReset(const DFBPerNodeLifetime &lifetime,
   }
   return llvm::all_of(
       lifetime.resetEpochs, [&](const DFBLifecycleEpoch &epoch) {
+        if (epoch.terminalResetOrdinal == reset.getOrdinal()) {
+          return true;
+        }
         return intervalIsOutsideReset(epoch.earliestEntryEvents,
                                       epoch.terminalCompletionEvents,
                                       resetEvents, graph);
@@ -3696,7 +3726,8 @@ static void collectResetAllocationConflicts(
         }
         bool outsideReset =
             lifetime->quiescence.proven()
-                ? lifetimeIsOutsideReset(*lifetime, resetEvents->second, graph)
+                ? lifetimeIsOutsideReset(*lifetime, reset.reset,
+                                         resetEvents->second, graph)
                 : unprovenLifecycleIsOutsideReset(
                       logicalDFB, node, executionCounts,
                       /*includeUnknownDomains=*/usePossibleLifetimes,
@@ -3721,6 +3752,188 @@ static void collectResetAllocationConflicts(
                                  logicalDFB, *lifetime, node, executionCounts,
                                  /*includeUnknownDomains=*/usePossibleLifetimes,
                                  operationEvents, accessEvents)});
+      }
+    }
+  }
+}
+
+static unsigned getLifecycleEpochCount(const DFBPerNodeLifetime *lifetime) {
+  if (!lifetime || !lifetime->mayBeActive) {
+    return 0;
+  }
+  return std::max<unsigned>(1, lifetime->resetEpochs.size());
+}
+
+static const DFBPerNodeLifetime *
+getEpochOrderingLifetime(const DFBLogicalLifecycle &logicalDFB,
+                         LaunchNodeCoord node, bool includeUnknownDomains) {
+  if (includeUnknownDomains && !logicalDFB.launchDomain.known) {
+    return logicalDFB.findPossibleNodeLifetime(node);
+  }
+  return logicalDFB.findNodeLifetime(node);
+}
+
+static ArrayRef<unsigned>
+getEpochEarliestEntryEvents(const DFBPerNodeLifetime &lifetime,
+                            unsigned epochIndex) {
+  if (lifetime.resetEpochs.empty()) {
+    assert(epochIndex == 0 && "complete lifetime has one epoch");
+    return lifetime.earliestEntryEvents;
+  }
+  assert(epochIndex < lifetime.resetEpochs.size());
+  return lifetime.resetEpochs[epochIndex].earliestEntryEvents;
+}
+
+static ArrayRef<unsigned>
+getEpochTerminalCompletionEvents(const DFBPerNodeLifetime &lifetime,
+                                 unsigned epochIndex) {
+  if (lifetime.resetEpochs.empty()) {
+    assert(epochIndex == 0 && "complete lifetime has one epoch");
+    return lifetime.terminalCompletionEvents;
+  }
+  assert(epochIndex < lifetime.resetEpochs.size());
+  return lifetime.resetEpochs[epochIndex].terminalCompletionEvents;
+}
+
+static const DFBQuiescenceProof &
+getEpochQuiescence(const DFBPerNodeLifetime &lifetime, unsigned epochIndex) {
+  if (lifetime.resetEpochs.empty()) {
+    assert(epochIndex == 0 && "complete lifetime has one epoch");
+    return lifetime.quiescence;
+  }
+  assert(epochIndex < lifetime.resetEpochs.size());
+  return lifetime.resetEpochs[epochIndex].quiescence;
+}
+
+static bool proveEpochOrderedBefore(const DFBPerNodeLifetime &before,
+                                    unsigned beforeEpochIndex,
+                                    const DFBPerNodeLifetime &after,
+                                    unsigned afterEpochIndex,
+                                    const HappensBeforeGraph &graph) {
+  if (!getEpochQuiescence(before, beforeEpochIndex).proven() ||
+      !getEpochQuiescence(after, afterEpochIndex).proven()) {
+    return false;
+  }
+  return llvm::all_of(
+      getEpochTerminalCompletionEvents(before, beforeEpochIndex),
+      [&](unsigned terminal) {
+        return llvm::all_of(getEpochEarliestEntryEvents(after, afterEpochIndex),
+                            [&](unsigned earliest) {
+                              return graph.strictlyPrecedes(terminal, earliest);
+                            });
+      });
+}
+
+static void appendInconsistentEpochAccessEvents(
+    const DFBLogicalLifecycle &logicalDFB, const DFBPerNodeLifetime &lifetime,
+    unsigned epochIndex, LaunchNodeCoord node, const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
+    const AccessExecutionCounts &executionCounts, bool includeUnknownDomains,
+    SmallVectorImpl<unsigned> &inconsistentEvents) {
+  auto appendAccess = [&](const DFBAccessOccurrence &access) {
+    std::optional<AccessEventSpan> span =
+        getAccessEventSpan(access, operationEvents, accessEvents);
+    if (!span) {
+      return;
+    }
+    unsigned candidates[] = {span->first.entry, span->first.completion,
+                             span->last.entry, span->last.completion};
+    for (unsigned event : candidates) {
+      if (graph.eventParticipatesInInconsistentOrder(event) &&
+          !llvm::is_contained(inconsistentEvents, event)) {
+        inconsistentEvents.push_back(event);
+      }
+    }
+  };
+
+  if (!lifetime.resetEpochs.empty()) {
+    assert(epochIndex < lifetime.resetEpochs.size());
+    for (unsigned accessIndex :
+         lifetime.resetEpochs[epochIndex].accessOccurrenceIndices) {
+      assert(accessIndex < logicalDFB.accesses.size());
+      appendAccess(logicalDFB.accesses[accessIndex]);
+    }
+    return;
+  }
+
+  assert(epochIndex == 0 && "complete lifetime has one epoch");
+  for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+    if (mayAccessLaunchNode(access, node, executionCounts,
+                            includeUnknownDomains)) {
+      appendAccess(access);
+    }
+  }
+}
+
+static void buildEpochOrdering(
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs, LaunchNodeCoord node,
+    const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
+    const AccessExecutionCounts &executionCounts, bool includeUnknownDomains,
+    SmallVectorImpl<unsigned> &logicalOffsets,
+    SmallVectorImpl<llvm::BitVector> &orderedBefore,
+    SmallVectorImpl<llvm::BitVector> &inconsistent) {
+  SmallVector<std::pair<unsigned, unsigned>> epochIdentities;
+  logicalOffsets.reserve(logicalDFBs.size() + 1);
+  logicalOffsets.push_back(0);
+  for (auto [logicalIndex, logicalDFB] : llvm::enumerate(logicalDFBs)) {
+    const DFBPerNodeLifetime *lifetime =
+        getEpochOrderingLifetime(logicalDFB, node, includeUnknownDomains);
+    unsigned epochCount = getLifecycleEpochCount(lifetime);
+    for (unsigned epochIndex = 0; epochIndex < epochCount; ++epochIndex) {
+      epochIdentities.emplace_back(logicalIndex, epochIndex);
+    }
+    logicalOffsets.push_back(epochIdentities.size());
+  }
+
+  orderedBefore.assign(epochIdentities.size(),
+                       llvm::BitVector(epochIdentities.size()));
+  SmallVector<SmallVector<unsigned>> inconsistentEventsByEpoch(
+      epochIdentities.size());
+  for (auto [beforeFlatIndex, beforeIdentity] :
+       llvm::enumerate(epochIdentities)) {
+    auto [beforeLogicalIndex, beforeEpochIndex] = beforeIdentity;
+    const DFBLogicalLifecycle &beforeLogicalDFB =
+        logicalDFBs[beforeLogicalIndex];
+    const DFBPerNodeLifetime *beforeLifetime =
+        getEpochOrderingLifetime(beforeLogicalDFB, node, includeUnknownDomains);
+    assert(beforeLifetime && "flattened epoch must have a lifetime");
+    appendInconsistentEpochAccessEvents(
+        beforeLogicalDFB, *beforeLifetime, beforeEpochIndex, node, graph,
+        operationEvents, accessEvents, executionCounts, includeUnknownDomains,
+        inconsistentEventsByEpoch[beforeFlatIndex]);
+    for (auto [afterFlatIndex, afterIdentity] :
+         llvm::enumerate(epochIdentities)) {
+      auto [afterLogicalIndex, afterEpochIndex] = afterIdentity;
+      const DFBLogicalLifecycle &afterLogicalDFB =
+          logicalDFBs[afterLogicalIndex];
+      const DFBPerNodeLifetime *afterLifetime = getEpochOrderingLifetime(
+          afterLogicalDFB, node, includeUnknownDomains);
+      assert(afterLifetime && "flattened epoch must have a lifetime");
+      if (proveEpochOrderedBefore(*beforeLifetime, beforeEpochIndex,
+                                  *afterLifetime, afterEpochIndex, graph)) {
+        orderedBefore[beforeFlatIndex].set(afterFlatIndex);
+      }
+    }
+  }
+
+  inconsistent.assign(epochIdentities.size(),
+                      llvm::BitVector(epochIdentities.size()));
+  for (unsigned lhsIndex = 0; lhsIndex < epochIdentities.size(); ++lhsIndex) {
+    for (unsigned rhsIndex = lhsIndex; rhsIndex < epochIdentities.size();
+         ++rhsIndex) {
+      bool inconsistentOrder = llvm::any_of(
+          inconsistentEventsByEpoch[lhsIndex], [&](unsigned lhsEvent) {
+            return llvm::any_of(
+                inconsistentEventsByEpoch[rhsIndex], [&](unsigned rhsEvent) {
+                  return graph.hasInconsistentOrder(lhsEvent, rhsEvent);
+                });
+          });
+      if (inconsistentOrder) {
+        inconsistent[lhsIndex].set(rhsIndex);
+        inconsistent[rhsIndex].set(lhsIndex);
       }
     }
   }
@@ -3896,6 +4109,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   conditionallyOrderedBeforeByNode.reserve(launchNodes.size());
   inconsistentOrderByNode.reserve(launchNodes.size());
   conditionallyInconsistentOrderByNode.reserve(launchNodes.size());
+  epochOrderedBeforeByNode.reserve(launchNodes.size());
+  conditionallyEpochOrderedBeforeByNode.reserve(launchNodes.size());
   bool collectAllocationDiagnostics = false;
   LLVM_DEBUG(collectAllocationDiagnostics = true);
   if (collectAllocationDiagnostics) {
@@ -4015,6 +4230,13 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     inconsistentOrderByNode.push_back(collectInconsistentAccessOrder(
         logicalDFBs, node, graph, operationEvents, accessEvents,
         executionCounts, /*includeUnknownDomains=*/false));
+    EpochOrdering epochOrdering;
+    buildEpochOrdering(logicalDFBs, node, graph, operationEvents, accessEvents,
+                       executionCounts,
+                       /*includeUnknownDomains=*/false,
+                       epochOrdering.logicalOffsets,
+                       epochOrdering.orderedBefore, epochOrdering.inconsistent);
+    epochOrderedBeforeByNode.push_back(std::move(epochOrdering));
 
     // Possible-domain reachability cannot affect exact-domain reuse.
     if (!hasUnknownDFBLaunchDomain) {
@@ -4093,6 +4315,15 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
                                        possibleOperationEvents,
                                        possibleAccessEvents, executionCounts,
                                        /*includeUnknownDomains=*/true));
+    EpochOrdering conditionalEpochOrdering;
+    buildEpochOrdering(
+        logicalDFBs, node, possibleGraph, possibleOperationEvents,
+        possibleAccessEvents, executionCounts,
+        /*includeUnknownDomains=*/true, conditionalEpochOrdering.logicalOffsets,
+        conditionalEpochOrdering.orderedBefore,
+        conditionalEpochOrdering.inconsistent);
+    conditionallyEpochOrderedBeforeByNode.push_back(
+        std::move(conditionalEpochOrdering));
   }
 
   assert(orderedBeforeByNode.size() == launchNodes.size() &&
@@ -4168,6 +4399,61 @@ bool DFBConcurrentKernelLivenessAnalysis::hasConditionallyInconsistentOrder(
          rhsIndex < conditionallyInconsistentOrderByNode[nodeIndex].size());
   return conditionallyInconsistentOrderByNode[nodeIndex][lhsIndex].test(
       rhsIndex);
+}
+
+bool DFBConcurrentKernelLivenessAnalysis::isEpochOrderedBefore(
+    unsigned beforeIndex, unsigned beforeEpochIndex, unsigned afterIndex,
+    unsigned afterEpochIndex, LaunchNodeCoord node) const {
+  return queryEpochRelation(epochOrderedBeforeByNode, beforeIndex,
+                            beforeEpochIndex, afterIndex, afterEpochIndex, node,
+                            /*inconsistent=*/false);
+}
+
+bool DFBConcurrentKernelLivenessAnalysis::isConditionallyEpochOrderedBefore(
+    unsigned beforeIndex, unsigned beforeEpochIndex, unsigned afterIndex,
+    unsigned afterEpochIndex, LaunchNodeCoord node) const {
+  return queryEpochRelation(conditionallyEpochOrderedBeforeByNode, beforeIndex,
+                            beforeEpochIndex, afterIndex, afterEpochIndex, node,
+                            /*inconsistent=*/false);
+}
+
+bool DFBConcurrentKernelLivenessAnalysis::hasInconsistentEpochOrder(
+    unsigned lhsIndex, unsigned lhsEpochIndex, unsigned rhsIndex,
+    unsigned rhsEpochIndex, LaunchNodeCoord node) const {
+  return queryEpochRelation(epochOrderedBeforeByNode, lhsIndex, lhsEpochIndex,
+                            rhsIndex, rhsEpochIndex, node,
+                            /*inconsistent=*/true);
+}
+
+bool DFBConcurrentKernelLivenessAnalysis::
+    hasConditionallyInconsistentEpochOrder(unsigned lhsIndex,
+                                           unsigned lhsEpochIndex,
+                                           unsigned rhsIndex,
+                                           unsigned rhsEpochIndex,
+                                           LaunchNodeCoord node) const {
+  return queryEpochRelation(conditionallyEpochOrderedBeforeByNode, lhsIndex,
+                            lhsEpochIndex, rhsIndex, rhsEpochIndex, node,
+                            /*inconsistent=*/true);
+}
+
+bool DFBConcurrentKernelLivenessAnalysis::queryEpochRelation(
+    ArrayRef<EpochOrdering> orderings, unsigned lhsIndex,
+    unsigned lhsEpochIndex, unsigned rhsIndex, unsigned rhsEpochIndex,
+    LaunchNodeCoord node, bool inconsistent) const {
+  auto nodeIt = llvm::find(launchNodes, node);
+  assert(nodeIt != launchNodes.end() && "node must be in the launch grid");
+  unsigned nodeIndex = nodeIt - launchNodes.begin();
+  assert(nodeIndex < orderings.size());
+  const EpochOrdering &ordering = orderings[nodeIndex];
+  assert(lhsIndex + 1 < ordering.logicalOffsets.size() &&
+         rhsIndex + 1 < ordering.logicalOffsets.size());
+  unsigned lhsFlatIndex = ordering.logicalOffsets[lhsIndex] + lhsEpochIndex;
+  unsigned rhsFlatIndex = ordering.logicalOffsets[rhsIndex] + rhsEpochIndex;
+  assert(lhsFlatIndex < ordering.logicalOffsets[lhsIndex + 1] &&
+         rhsFlatIndex < ordering.logicalOffsets[rhsIndex + 1]);
+  ArrayRef<llvm::BitVector> relation =
+      inconsistent ? ordering.inconsistent : ordering.orderedBefore;
+  return relation[lhsFlatIndex].test(rhsFlatIndex);
 }
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -886,15 +886,15 @@ static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
 // Requires a release to follow every use owned by its acquisition; textual
 // acquire/release order alone does not prove that those uses have completed.
 // `sameKindAcquires` contains every same-DFB acquisition of the same kind.
-static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release,
-                                    ArrayRef<Operation *> sameKindAcquires) {
-  if (acquire->getBlock() != release->getBlock()) {
-    return false;
-  }
+static bool
+releaseFollowsOwnedUses(Operation *acquire, Operation *release,
+                        ArrayRef<Operation *> sameKindAcquires,
+                        const StructuralOperationOrder &structuralOrder) {
   DFBAcquireInterval interval =
       makeDFBAcquireInterval(acquire, sameKindAcquires);
   Operation *lastOwnedUse = findLastDFBAcquireOwnedUse(interval);
-  return lastOwnedUse == acquire || lastOwnedUse->isBeforeInBlock(release);
+  return lastOwnedUse == acquire ||
+         structuralOrder.precedes(lastOwnedUse, release);
 }
 
 // Finds every access without a proved predecessor so all possible lifetime
@@ -3182,7 +3182,8 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
       }
       if (isa<CBReserveOp>(reserve->access->operation) &&
           !releaseFollowsOwnedUses(reserve->access->operation,
-                                   push->access->operation, nativeReserves)) {
+                                   push->access->operation, nativeReserves,
+                                   structuralOrder)) {
         return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
                 push->access->operation};
       }
@@ -3204,7 +3205,8 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
       }
       if (isa<CBWaitOp>(wait->access->operation) &&
           !releaseFollowsOwnedUses(wait->access->operation,
-                                   pop->access->operation, nativeWaits)) {
+                                   pop->access->operation, nativeWaits,
+                                   structuralOrder)) {
         return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
                 pop->access->operation};
       }

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -884,7 +884,7 @@ static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
 }
 
 // Requires a release to follow every use owned by its acquisition; textual
-// acquire/release order alone does not prove storage quiescence.
+// acquire/release order alone does not prove that those uses have completed.
 // `sameKindAcquires` contains every same-DFB acquisition of the same kind.
 static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release,
                                     ArrayRef<Operation *> sameKindAcquires) {
@@ -2324,7 +2324,7 @@ struct CumulativeQueueSide {
 
 struct CumulativeQueueSideResult {
   std::optional<CumulativeQueueSide> side;
-  DFBQuiescenceProof failure;
+  DFBLifecycleCompletionProof failure;
 };
 
 static FailureOr<SmallVector<const AccessRun *>>
@@ -2390,7 +2390,7 @@ static CumulativeQueueSideResult proveCumulativeQueueSide(
       unorderedRuns, graph, structuralOrder, operationEvents, accessEvents);
   if (failed(orderedRuns)) {
     return {std::nullopt,
-            {DFBQuiescenceFailureReason::IncompleteUseOrder,
+            {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
              unorderedRuns.front()->access->operation}};
   }
 
@@ -2404,20 +2404,20 @@ static CumulativeQueueSideResult proveCumulativeQueueSide(
         run->access->numTiles > physicalTileCount ||
         !run->access->protocolEffect) {
       return {std::nullopt,
-              {DFBQuiescenceFailureReason::MismatchedTransaction,
+              {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                run->access->operation}};
     }
     DFBProtocolEffectKind effect = *run->access->protocolEffect;
     if (effect != acquireKind && effect != releaseKind) {
       return {std::nullopt,
-              {DFBQuiescenceFailureReason::MismatchedTransaction,
+              {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                run->access->operation}};
     }
     std::optional<DFBPointerOwner> owner =
         getPointerOwner(run->access->operation, node, effect);
     if (!owner || (result.owner && *result.owner != *owner)) {
       return {std::nullopt,
-              {DFBQuiescenceFailureReason::UnknownPointerOwner,
+              {DFBLifecycleCompletionFailureReason::UnknownPointerOwner,
                run->access->operation}};
     }
     result.owner = owner;
@@ -2436,7 +2436,7 @@ static CumulativeQueueSideResult proveCumulativeQueueSide(
           static_cast<std::uint64_t>(run->access->numTiles));
       if (!acquiredLimit) {
         return {std::nullopt,
-                {DFBQuiescenceFailureReason::MismatchedTransaction,
+                {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                  run->access->operation}};
       }
       readinessLimit = std::max(readinessLimit.value_or(0), *acquiredLimit);
@@ -2445,7 +2445,7 @@ static CumulativeQueueSideResult proveCumulativeQueueSide(
 
     if (activeAcquires.empty() || !readinessLimit) {
       return {std::nullopt,
-              {DFBQuiescenceFailureReason::IncompleteUseOrder,
+              {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
                run->access->operation}};
     }
     std::optional<std::uint64_t> nextMovement = llvm::checkedAddUnsigned(
@@ -2453,7 +2453,7 @@ static CumulativeQueueSideResult proveCumulativeQueueSide(
         static_cast<std::uint64_t>(run->access->numTiles));
     if (!nextMovement || *nextMovement > *readinessLimit) {
       return {std::nullopt,
-              {DFBQuiescenceFailureReason::MismatchedTransaction,
+              {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                run->access->operation}};
     }
     result.totalMovement = *nextMovement;
@@ -2462,7 +2462,7 @@ static CumulativeQueueSideResult proveCumulativeQueueSide(
   }
   if (activeAcquires.empty() || !lastRelease) {
     return {std::nullopt,
-            {DFBQuiescenceFailureReason::IncompleteUseOrder,
+            {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
              unorderedRuns.front()->access->operation}};
   }
   for (const AccessRun *activeAcquire : activeAcquires) {
@@ -2860,7 +2860,7 @@ namespace {
 
 // Derives exact-domain or possible-domain per-node lifetime facts. Possible
 // facts control reuse only after proving conditional boundedness.
-static DFBQuiescenceProof computeProtocolLifetime(
+static DFBLifecycleCompletionProof computeProtocolLifetime(
     DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
     SmallVectorImpl<DFBPerNodeLifetime> &lifetimes,
     SmallVectorImpl<DFBPerNodeLifetimeDiagnostics> *lifetimeDiagnostics,
@@ -2961,7 +2961,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
       });
   if (opaqueExternalAccess != activeAccesses.end()) {
     if (!hasCanonicalResetTerminator) {
-      return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+      return {DFBLifecycleCompletionFailureReason::MissingProtocolEffect,
               (*opaqueExternalAccess)->operation};
     }
     auto unscopedOpaqueAccess =
@@ -2971,7 +2971,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
                  !access->opaqueExternalAccess;
         });
     if (unscopedOpaqueAccess != activeAccesses.end()) {
-      return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+      return {DFBLifecycleCompletionFailureReason::MissingProtocolEffect,
               (*unscopedOpaqueAccess)->operation};
     }
 
@@ -2981,7 +2981,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
         findMaximalCompletionAccesses(activeAccesses, graph, operationEvents,
                                       accessEvents);
     if (lifetime.earliestEntryEvents.empty() || terminalAccesses.empty()) {
-      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+      return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
               activeAccesses.front()->operation};
     }
     recordEntryFrontierEvidence(lifetime, diagnostics, activeAccesses,
@@ -2990,7 +2990,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
       std::optional<AccessEventSpan> events =
           getAccessEventSpan(*terminalAccess, operationEvents, accessEvents);
       if (!events) {
-        return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+        return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
                 terminalAccess->operation};
       }
       if (!llvm::is_contained(lifetime.terminalCompletionEvents,
@@ -3010,13 +3010,13 @@ static DFBQuiescenceProof computeProtocolLifetime(
                                  hasPush && !hasWait && !hasPop;
   if ((!hasReserve || !hasPush || !hasWait || !hasPop) &&
       !resetTerminatedProducer) {
-    return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+    return {DFBLifecycleCompletionFailureReason::MissingProtocolEffect,
             activeAccesses.empty() ? logicalDFB.declarations.front()
                                    : activeAccesses.front()->operation};
   }
 
   if (unsupportedAccess) {
-    return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+    return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
             unsupportedAccess->operation};
   }
   assert(!reserves.empty() && !pushes.empty() &&
@@ -3039,7 +3039,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
                                             reference, *run, node, domainState);
                                       });
     if (!sameCondition) {
-      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+      return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
               reference.access->operation};
     }
     lifetime.conditionalExecutionProven = true;
@@ -3066,7 +3066,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
   int64_t physicalTileCount =
       cast<CircularBufferType>(logicalDFB.type).getTotalElements();
   if (physicalTileCount <= 0) {
-    return {DFBQuiescenceFailureReason::MismatchedTransaction,
+    return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
             reserves.front()->access->operation};
   }
   bool alignedTransactions =
@@ -3086,11 +3086,11 @@ static DFBQuiescenceProof computeProtocolLifetime(
       supportsCumulativeQueueProof(producerProtocolRuns) &&
       supportsCumulativeQueueProof(consumerProtocolRuns);
   if (!countsMatch && !useCumulativeQueueProof) {
-    return {DFBQuiescenceFailureReason::MismatchedTransaction,
+    return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
             activeAccesses.front()->operation};
   }
   if (!alignedTransactions && !useCumulativeQueueProof) {
-    return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+    return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
             activeAccesses.front()->operation};
   }
 
@@ -3126,7 +3126,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
         failed(advanceDFBTransactionCursor(
             consumer.side->cursorRuns,
             static_cast<std::uint64_t>(physicalTileCount)))) {
-      return {DFBQuiescenceFailureReason::MismatchedTransaction,
+      return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
               activeAccesses.front()->operation};
     }
     FailureOr<SmallVector<std::pair<unsigned, unsigned>>> synchronizationEdges =
@@ -3137,7 +3137,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
         !llvm::all_of(*synchronizationEdges, [&](auto edge) {
           return graph.strictlyPrecedes(edge.first, edge.second);
         })) {
-      return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+      return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
               activeAccesses.front()->operation};
     }
     lifetime.transactionRuns = std::move(*normalized);
@@ -3177,13 +3177,13 @@ static DFBQuiescenceProof computeProtocolLifetime(
     }
     for (auto [reserve, push] : llvm::zip_equal(reserves, pushes)) {
       if (reserve->access->numTiles <= 0) {
-        return {DFBQuiescenceFailureReason::MismatchedTransaction,
+        return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                 reserve->access->operation};
       }
       if (isa<CBReserveOp>(reserve->access->operation) &&
           !releaseFollowsOwnedUses(reserve->access->operation,
                                    push->access->operation, nativeReserves)) {
-        return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+        return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
                 push->access->operation};
       }
       std::optional<DFBPointerOwner> reserveOwner = getPointerOwner(
@@ -3192,20 +3192,20 @@ static DFBQuiescenceProof computeProtocolLifetime(
           push->access->operation, node, DFBProtocolEffectKind::Push);
       if (!reserveOwner || !pushOwner || *reserveOwner != *pushOwner ||
           (writeOwner && *writeOwner != *reserveOwner)) {
-        return {DFBQuiescenceFailureReason::UnknownPointerOwner,
+        return {DFBLifecycleCompletionFailureReason::UnknownPointerOwner,
                 reserve->access->operation};
       }
       writeOwner = reserveOwner;
     }
     for (auto [wait, pop] : llvm::zip_equal(waits, pops)) {
       if (wait->access->numTiles <= 0) {
-        return {DFBQuiescenceFailureReason::MismatchedTransaction,
+        return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                 wait->access->operation};
       }
       if (isa<CBWaitOp>(wait->access->operation) &&
           !releaseFollowsOwnedUses(wait->access->operation,
                                    pop->access->operation, nativeWaits)) {
-        return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+        return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
                 pop->access->operation};
       }
       std::optional<DFBPointerOwner> waitOwner = getPointerOwner(
@@ -3214,7 +3214,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
           pop->access->operation, node, DFBProtocolEffectKind::Pop);
       if (!waitOwner || !popOwner || *waitOwner != *popOwner ||
           (readOwner && *readOwner != *waitOwner)) {
-        return {DFBQuiescenceFailureReason::UnknownPointerOwner,
+        return {DFBLifecycleCompletionFailureReason::UnknownPointerOwner,
                 wait->access->operation};
       }
       readOwner = waitOwner;
@@ -3227,14 +3227,14 @@ static DFBQuiescenceProof computeProtocolLifetime(
             reserve->executionCount,
             static_cast<std::uint64_t>(reserve->access->numTiles));
         if (!runTiles) {
-          return {DFBQuiescenceFailureReason::MismatchedTransaction,
+          return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                   reserve->access->operation};
         }
         std::optional<std::uint64_t> updatedTiles =
             llvm::checkedAddUnsigned(occupiedTiles, *runTiles);
         if (!updatedTiles ||
             *updatedTiles > static_cast<std::uint64_t>(physicalTileCount)) {
-          return {DFBQuiescenceFailureReason::MismatchedTransaction,
+          return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                   reserve->access->operation};
         }
         occupiedTiles = *updatedTiles;
@@ -3257,7 +3257,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
             reserve.access->numTiles > physicalTileCount ||
             (!hasCanonicalResetTerminator &&
              physicalTileCount % reserve.access->numTiles != 0)) {
-          return {DFBQuiescenceFailureReason::MismatchedTransaction,
+          return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                   reserve.access->operation};
         }
         std::uint64_t matchedCount =
@@ -3277,7 +3277,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
         }
       }
       if (reserveIndex != reserves.size() || waitIndex != waits.size()) {
-        return {DFBQuiescenceFailureReason::MismatchedTransaction,
+        return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                 reserves.front()->access->operation};
       }
     }
@@ -3285,7 +3285,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
         failed(advanceDFBTransactionCursor(
             lifetime.transactionRuns,
             static_cast<std::uint64_t>(physicalTileCount)))) {
-      return {DFBQuiescenceFailureReason::MismatchedTransaction,
+      return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
               reserves.front()->access->operation};
     }
   }
@@ -3316,7 +3316,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
                                      operationEvents, accessEvents);
     }
     if (!covered) {
-      return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+      return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
               activeAccess->operation};
     }
   }
@@ -3329,7 +3329,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
   std::optional<AccessEventSpan> terminalEvents =
       getAccessEventSpan(*terminalAccess, operationEvents, accessEvents);
   if (!terminalEvents) {
-    return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+    return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
             terminalAccess->operation};
   }
   for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
@@ -3339,7 +3339,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
         (useEvents->last.completion != terminalEvents->last.completion &&
          !graph.strictlyPrecedes(useEvents->last.completion,
                                  terminalEvents->last.completion))) {
-      return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+      return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
               activeAccess->operation};
     }
   }
@@ -3353,7 +3353,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
         static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data())};
   }
   if (lifetime.earliestEntryEvents.empty()) {
-    return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+    return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
             terminalAccess->operation};
   }
   lifetime.terminalTransactionRuns.assign(lifetime.transactionRuns.begin(),
@@ -3383,7 +3383,7 @@ struct OrderedResetBoundary {
 // Partitions accesses by collective reset boundaries and proves every resulting
 // epoch independently. A reset restores canonical hardware state; it does not
 // make an otherwise blocking consumer epoch executable.
-static DFBQuiescenceProof computePerNodeLifetime(
+static DFBLifecycleCompletionProof computePerNodeLifetime(
     DFBLogicalLifecycle &logicalDFB, unsigned logicalIndex,
     LaunchNodeCoord node, SmallVectorImpl<DFBPerNodeLifetime> &lifetimes,
     SmallVectorImpl<DFBPerNodeLifetimeDiagnostics> *lifetimeDiagnostics,
@@ -3408,7 +3408,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
       if (lifetimeDiagnostics) {
         lifetimeDiagnostics->emplace_back();
       }
-      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+      return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
               reset.participantOperations.front()};
     }
     boundaries.push_back({&reset, eventsIt->second});
@@ -3435,7 +3435,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
         if (lifetimeDiagnostics) {
           lifetimeDiagnostics->emplace_back();
         }
-        return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+        return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
                 rhs.reset->participantOperations.front()};
       }
     }
@@ -3472,7 +3472,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
     std::optional<AccessEventSpan> events =
         getAccessEventSpan(access, operationEvents, accessEvents);
     if (!events) {
-      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+      return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
               access.operation};
     }
     unsigned epochIndex = 0;
@@ -3482,7 +3482,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
       bool afterReset = graph.strictlyPrecedes(boundary.events.completion,
                                                events->first.entry);
       if (beforeReset == afterReset) {
-        return {DFBQuiescenceFailureReason::IncompleteUseOrder,
+        return {DFBLifecycleCompletionFailureReason::IncompleteUseOrder,
                 access.operation};
       }
       if (boundary.reset->conditionalExecution) {
@@ -3492,7 +3492,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
                 access.operation, node,
                 boundary.reset->participantOperations.front(), node,
                 domainState)) {
-          return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+          return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
                   access.operation};
         }
       }
@@ -3509,7 +3509,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
     bool resetTerminated = epochIndex < boundaries.size();
     SmallVector<DFBPerNodeLifetime, 0> epochLifetimes;
     SmallVector<DFBPerNodeLifetimeDiagnostics, 0> epochDiagnostics;
-    DFBQuiescenceProof proof = computeProtocolLifetime(
+    DFBLifecycleCompletionProof proof = computeProtocolLifetime(
         logicalDFB, node, epochLifetimes,
         diagnostics ? &epochDiagnostics : nullptr, graph, structuralOrder,
         operationEvents, accessEvents, executionCounts, accessRuns, domainState,
@@ -3522,7 +3522,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
     DFBPerNodeLifetime &epochLifetime = epochLifetimes.front();
     const DFBPerNodeLifetimeDiagnostics *epochDiagnostic =
         diagnostics ? &epochDiagnostics.front() : nullptr;
-    epochLifetime.quiescence = proof;
+    epochLifetime.completionProof = proof;
     if (!proof.proven()) {
       return proof;
     }
@@ -3539,7 +3539,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
     epoch.readPointerOwner = epochLifetime.readPointerOwner;
     epoch.resetCanonicalizedOpaqueProtocol =
         epochLifetime.resetCanonicalizedOpaqueProtocol;
-    epoch.quiescence = proof;
+    epoch.completionProof = proof;
     if (resetTerminated) {
       const OrderedResetBoundary &boundary = boundaries[epochIndex];
       if (boundary.reset->conditionalExecution) {
@@ -3595,7 +3595,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
       lifetime.mayBeActive = false;
       return {};
     }
-    return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+    return {DFBLifecycleCompletionFailureReason::MissingProtocolEffect,
             logicalDFB.declarations.front()};
   }
   return {};
@@ -3606,7 +3606,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
 static bool proveOrderedBefore(const DFBPerNodeLifetime &before,
                                const DFBPerNodeLifetime &after,
                                const HappensBeforeGraph &graph) {
-  if (!before.quiescence.proven() || !after.quiescence.proven()) {
+  if (!before.completionProof.proven() || !after.completionProof.proven()) {
     return false;
   }
   return llvm::all_of(before.terminalCompletionEvents, [&](unsigned terminal) {
@@ -3787,8 +3787,8 @@ static Operation *getResetOverlapEvidence(
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
-  if (lifetime.quiescence.evidence) {
-    return lifetime.quiescence.evidence;
+  if (lifetime.completionProof.evidence) {
+    return lifetime.completionProof.evidence;
   }
   for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
     if (!mayAccessLaunchNode(access, node, executionCounts,
@@ -3846,7 +3846,7 @@ static void collectResetAllocationConflicts(
           continue;
         }
         bool outsideReset =
-            lifetime->quiescence.proven()
+            lifetime->completionProof.proven()
                 ? lifetimeIsOutsideReset(*lifetime, reset.reset,
                                          resetEvents->second, graph)
                 : unprovenLifecycleIsOutsideReset(
@@ -3907,14 +3907,15 @@ getEpochTerminalCompletionEvents(const DFBPerNodeLifetime &lifetime,
   return lifetime.resetEpochs[epochIndex].terminalCompletionEvents;
 }
 
-static const DFBQuiescenceProof &
-getEpochQuiescence(const DFBPerNodeLifetime &lifetime, unsigned epochIndex) {
+static const DFBLifecycleCompletionProof &
+getEpochCompletionProof(const DFBPerNodeLifetime &lifetime,
+                        unsigned epochIndex) {
   if (lifetime.resetEpochs.empty()) {
     assert(epochIndex == 0 && "complete lifetime has one epoch");
-    return lifetime.quiescence;
+    return lifetime.completionProof;
   }
   assert(epochIndex < lifetime.resetEpochs.size());
-  return lifetime.resetEpochs[epochIndex].quiescence;
+  return lifetime.resetEpochs[epochIndex].completionProof;
 }
 
 static bool proveEpochOrderedBefore(const DFBPerNodeLifetime &before,
@@ -3922,8 +3923,8 @@ static bool proveEpochOrderedBefore(const DFBPerNodeLifetime &before,
                                     const DFBPerNodeLifetime &after,
                                     unsigned afterEpochIndex,
                                     const HappensBeforeGraph &graph) {
-  if (!getEpochQuiescence(before, beforeEpochIndex).proven() ||
-      !getEpochQuiescence(after, afterEpochIndex).proven()) {
+  if (!getEpochCompletionProof(before, beforeEpochIndex).proven() ||
+      !getEpochCompletionProof(after, afterEpochIndex).proven()) {
     return false;
   }
   return llvm::all_of(
@@ -4308,7 +4309,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
       }
       DFBLogicalLifecycleDiagnostics *allocationDiagnostics =
           logicalDFB.allocationDiagnostics.get();
-      DFBQuiescenceProof proof = computePerNodeLifetime(
+      DFBLifecycleCompletionProof proof = computePerNodeLifetime(
           logicalDFB, logicalIndex, node, logicalDFB.nodeLifetimes,
           allocationDiagnostics
               ? &allocationDiagnostics->nodeLifetimeDiagnostics
@@ -4316,7 +4317,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           validatedResets, resetBoundaryEvents, graph, structuralOrder,
           operationEvents, accessEvents, executionCounts, accessRuns,
           domainState);
-      logicalDFB.nodeLifetimes.back().quiescence = proof;
+      logicalDFB.nodeLifetimes.back().completionProof = proof;
       nodeLifetimes[logicalIndex] = &logicalDFB.nodeLifetimes.back();
     }
 
@@ -4373,7 +4374,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
       }
       DFBLogicalLifecycleDiagnostics *allocationDiagnostics =
           logicalDFB.allocationDiagnostics.get();
-      DFBQuiescenceProof proof = computePerNodeLifetime(
+      DFBLifecycleCompletionProof proof = computePerNodeLifetime(
           logicalDFB, logicalIndex, node, logicalDFB.possibleNodeLifetimes,
           allocationDiagnostics
               ? &allocationDiagnostics->possibleNodeLifetimeDiagnostics
@@ -4382,7 +4383,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           structuralOrder, possibleOperationEvents, possibleAccessEvents,
           executionCounts, *possibleAccessRuns, domainState,
           /*includeUnknownDomains=*/true);
-      logicalDFB.possibleNodeLifetimes.back().quiescence = proof;
+      logicalDFB.possibleNodeLifetimes.back().completionProof = proof;
       possibleNodeLifetimes[logicalIndex] =
           &logicalDFB.possibleNodeLifetimes.back();
     }
@@ -4428,18 +4429,18 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
          "per-node order relations must cover the launch grid");
 
   for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
-    logicalDFB.bounded = logicalDFB.launchDomain.known &&
-                         !logicalDFB.nodeLifetimes.empty() &&
-                         llvm::all_of(logicalDFB.nodeLifetimes,
-                                      [](const DFBPerNodeLifetime &lifetime) {
-                                        return lifetime.quiescence.proven();
-                                      });
+    logicalDFB.bounded =
+        logicalDFB.launchDomain.known && !logicalDFB.nodeLifetimes.empty() &&
+        llvm::all_of(logicalDFB.nodeLifetimes,
+                     [](const DFBPerNodeLifetime &lifetime) {
+                       return lifetime.completionProof.proven();
+                     });
     bool hasProvenConditionalLifecycle =
         llvm::any_of(logicalDFB.possibleNodeLifetimes,
                      [](const DFBPerNodeLifetime &lifetime) {
                        return lifetime.mayBeActive &&
                               lifetime.conditionalExecutionProven &&
-                              lifetime.quiescence.proven();
+                              lifetime.completionProof.proven();
                      });
     logicalDFB.conditionallyBounded =
         !logicalDFB.launchDomain.known && hasProvenConditionalLifecycle &&
@@ -4447,7 +4448,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
                      [](const DFBPerNodeLifetime &lifetime) {
                        return !lifetime.mayBeActive ||
                               (lifetime.conditionalExecutionProven &&
-                               lifetime.quiescence.proven());
+                               lifetime.completionProof.proven());
                      });
   }
 }

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -927,6 +927,58 @@ static SmallVector<unsigned> findMinimalEntryEvents(
   return minimal;
 }
 
+static void recordEntryFrontierEvidence(
+    DFBPerNodeLifetime &lifetime, DFBPerNodeLifetimeDiagnostics *diagnostics,
+    ArrayRef<const DFBAccessOccurrence *> accesses,
+    const DFBLogicalLifecycle &logicalDFB,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
+  for (const DFBAccessOccurrence *access : accesses) {
+    std::optional<AccessEventSpan> events =
+        getAccessEventSpan(*access, operationEvents, accessEvents);
+    if (!events || !llvm::is_contained(lifetime.earliestEntryEvents,
+                                       events->first.entry)) {
+      continue;
+    }
+    if (!lifetime.entryEvidence) {
+      lifetime.entryEvidence = access->operation;
+    }
+    if (diagnostics) {
+      diagnostics->earliestAccessOccurrenceIndices.push_back(
+          static_cast<unsigned>(access - logicalDFB.accesses.data()));
+    }
+  }
+}
+
+// Retains every possible lifetime end so each one constrains storage reuse.
+static SmallVector<const DFBAccessOccurrence *> findMaximalCompletionAccesses(
+    ArrayRef<const DFBAccessOccurrence *> accesses,
+    const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
+  SmallVector<const DFBAccessOccurrence *> maximal;
+  for (const DFBAccessOccurrence *candidate : accesses) {
+    std::optional<AccessEventSpan> candidateEvents =
+        getAccessEventSpan(*candidate, operationEvents, accessEvents);
+    if (!candidateEvents) {
+      continue;
+    }
+    bool hasSuccessor = llvm::any_of(accesses, [&](const auto *otherAccess) {
+      std::optional<AccessEventSpan> otherEvents =
+          getAccessEventSpan(*otherAccess, operationEvents, accessEvents);
+      return otherEvents &&
+             graph.strictlyPrecedes(candidateEvents->last.completion,
+                                    otherEvents->last.completion);
+    });
+    if (!hasSuccessor) {
+      maximal.push_back(candidate);
+    }
+  }
+  return maximal;
+}
+
 // Requires a custom function that consumes a physical index to name the same
 // logical DFB as a direct storage dependency.
 static LogicalResult verifyCustomFunctionIndexDependency(
@@ -1230,8 +1282,8 @@ static LogicalResult collectLogicalDFBs(
     }
 
     // Preserve dependency occurrences because aliased operands may have
-    // different summaries. An occurrence without an effect remains opaque for
-    // the operation's complete duration.
+    // different summaries. An occurrence without an effect remains opaque
+    // until a synchronized reset proves that its lifetime terminates.
     llvm::BitVector effectedDependencies(dfbOperands.size());
     for (const DFBProtocolEffect &effect : access.getDFBProtocolEffects()) {
       assert(effect.dependencyIndex < dependencyLogicalIndices.size() &&
@@ -1255,9 +1307,12 @@ static LogicalResult collectLogicalDFBs(
       std::optional<unsigned> logicalIndex =
           dependencyLogicalIndices[dependencyIndex];
       assert(logicalIndex && "DFB dependencies were validated above");
-      logicalDFBs[*logicalIndex].accesses.push_back(
-          {operation, std::nullopt, 0, 0, LaunchNodeDomain::unknown(),
-           nullptr});
+      DFBLogicalLifecycle &logicalDFB = logicalDFBs[*logicalIndex];
+      bool opaqueExternalAccess = isa<OpaqueCallOp>(operation);
+      logicalDFB.accesses.push_back({operation, std::nullopt, 0, 0,
+                                     LaunchNodeDomain::unknown(), nullptr,
+                                     opaqueExternalAccess});
+      logicalDFB.hasOpaqueExternalAccess |= opaqueExternalAccess;
     }
     return WalkResult::advance();
   });
@@ -2900,6 +2955,57 @@ static DFBQuiescenceProof computeProtocolLifetime(
     return {};
   }
 
+  auto opaqueExternalAccess =
+      llvm::find_if(activeAccesses, [](const DFBAccessOccurrence *access) {
+        return access->opaqueExternalAccess;
+      });
+  if (opaqueExternalAccess != activeAccesses.end()) {
+    if (!hasCanonicalResetTerminator) {
+      return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+              (*opaqueExternalAccess)->operation};
+    }
+    auto unscopedOpaqueAccess =
+        llvm::find_if(activeAccesses, [](const DFBAccessOccurrence *access) {
+          return !access->protocolEffect &&
+                 isa<OpaqueCallOp>(access->operation) &&
+                 !access->opaqueExternalAccess;
+        });
+    if (unscopedOpaqueAccess != activeAccesses.end()) {
+      return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+              (*unscopedOpaqueAccess)->operation};
+    }
+
+    lifetime.earliestEntryEvents = findMinimalEntryEvents(
+        activeAccesses, graph, operationEvents, accessEvents);
+    SmallVector<const DFBAccessOccurrence *> terminalAccesses =
+        findMaximalCompletionAccesses(activeAccesses, graph, operationEvents,
+                                      accessEvents);
+    if (lifetime.earliestEntryEvents.empty() || terminalAccesses.empty()) {
+      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+              activeAccesses.front()->operation};
+    }
+    recordEntryFrontierEvidence(lifetime, diagnostics, activeAccesses,
+                                logicalDFB, operationEvents, accessEvents);
+    for (const DFBAccessOccurrence *terminalAccess : terminalAccesses) {
+      std::optional<AccessEventSpan> events =
+          getAccessEventSpan(*terminalAccess, operationEvents, accessEvents);
+      if (!events) {
+        return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+                terminalAccess->operation};
+      }
+      if (!llvm::is_contained(lifetime.terminalCompletionEvents,
+                              events->last.completion)) {
+        lifetime.terminalCompletionEvents.push_back(events->last.completion);
+      }
+      if (diagnostics) {
+        diagnostics->terminalAccessOccurrenceIndices.push_back(
+            static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data()));
+      }
+    }
+    lifetime.resetCanonicalizedOpaqueProtocol = true;
+    return {};
+  }
+
   bool resetTerminatedProducer = hasCanonicalResetTerminator && hasReserve &&
                                  hasPush && !hasWait && !hasPop;
   if ((!hasReserve || !hasPush || !hasWait || !hasPop) &&
@@ -3240,20 +3346,8 @@ static DFBQuiescenceProof computeProtocolLifetime(
   lifetime.earliestEntryEvents = findMinimalEntryEvents(
       activeAccesses, graph, operationEvents, accessEvents);
   lifetime.terminalCompletionEvents = {terminalEvents->last.completion};
-  for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
-    std::optional<AccessEventSpan> activeEvents =
-        getAccessEventSpan(*activeAccess, operationEvents, accessEvents);
-    if (activeEvents && llvm::is_contained(lifetime.earliestEntryEvents,
-                                           activeEvents->first.entry)) {
-      if (!lifetime.entryEvidence) {
-        lifetime.entryEvidence = activeAccess->operation;
-      }
-      if (diagnostics) {
-        diagnostics->earliestAccessOccurrenceIndices.push_back(
-            static_cast<unsigned>(activeAccess - logicalDFB.accesses.data()));
-      }
-    }
-  }
+  recordEntryFrontierEvidence(lifetime, diagnostics, activeAccesses, logicalDFB,
+                              operationEvents, accessEvents);
   if (diagnostics) {
     diagnostics->terminalAccessOccurrenceIndices = {
         static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data())};
@@ -3443,9 +3537,14 @@ static DFBQuiescenceProof computePerNodeLifetime(
     epoch.readCursorRuns = epochLifetime.readCursorRuns;
     epoch.writePointerOwner = epochLifetime.writePointerOwner;
     epoch.readPointerOwner = epochLifetime.readPointerOwner;
+    epoch.resetCanonicalizedOpaqueProtocol =
+        epochLifetime.resetCanonicalizedOpaqueProtocol;
     epoch.quiescence = proof;
     if (resetTerminated) {
       const OrderedResetBoundary &boundary = boundaries[epochIndex];
+      if (boundary.reset->conditionalExecution) {
+        epochLifetime.conditionalExecutionProven = true;
+      }
       epoch.terminalResetOrdinal = boundary.reset->reset.getOrdinal();
       epoch.terminalStateCanonical = true;
       epochLifetime.terminalCompletionEvents = {boundary.events.completion};
@@ -3469,6 +3568,8 @@ static DFBQuiescenceProof computePerNodeLifetime(
       lifetime.readCursorRuns = epochLifetime.readCursorRuns;
       lifetime.writePointerOwner = epochLifetime.writePointerOwner;
       lifetime.readPointerOwner = epochLifetime.readPointerOwner;
+      lifetime.resetCanonicalizedOpaqueProtocol =
+          epochLifetime.resetCanonicalizedOpaqueProtocol;
       hasActiveEpoch = true;
     }
     lifetime.conditionalExecutionProven |=
@@ -3484,6 +3585,8 @@ static DFBQuiescenceProof computePerNodeLifetime(
     lifetime.terminalWritePointerOwner =
         epochLifetime.terminalWritePointerOwner;
     lifetime.terminalReadPointerOwner = epochLifetime.terminalReadPointerOwner;
+    lifetime.resetCanonicalizedOpaqueProtocol |=
+        epochLifetime.resetCanonicalizedOpaqueProtocol;
     lifetime.terminalStateCanonical = epochLifetime.terminalStateCanonical;
   }
 

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -164,7 +164,6 @@ struct DFBLifecycleEpoch {
   std::optional<DFBPointerOwner> terminalWritePointerOwner;
   std::optional<DFBPointerOwner> terminalReadPointerOwner;
   std::optional<int64_t> terminalResetOrdinal;
-  bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
   DFBLifecycleCompletionProof completionProof;
 };
@@ -208,7 +207,6 @@ struct DFBPerNodeLifetime {
   SmallVector<DFBTransactionRun, 0> terminalReadCursorRuns;
   std::optional<DFBPointerOwner> terminalWritePointerOwner;
   std::optional<DFBPointerOwner> terminalReadPointerOwner;
-  bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
   SmallVector<DFBLifecycleEpoch, 0> resetEpochs;
   DFBLifecycleCompletionProof completionProof;

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -71,12 +71,13 @@ struct DFBQuiescenceProof {
 /// A concrete lifecycle operation contributes one occurrence. An operation
 /// with a protocol summary contributes one occurrence per effect, preserving
 /// actions on different DFBs as distinct events. A dependency occurrence with
-/// no effect contributes an opaque call-duration access.
+/// no effect contributes an opaque access whose completion may require a
+/// synchronized reset.
 struct DFBAccessOccurrence {
   /// Operation that performs the access; several occurrences may share it.
   Operation *operation = nullptr;
 
-  /// Null for an opaque call-duration storage access.
+  /// Null for an access without an explicit protocol effect.
   std::optional<DFBProtocolEffectKind> protocolEffect;
 
   /// Positive for protocol effects and zero for opaque accesses.
@@ -90,6 +91,9 @@ struct DFBAccessOccurrence {
 
   /// Operation that prevented a precise launch domain, or null when precise.
   Operation *unanalyzableDomainOperation = nullptr;
+
+  /// Whether this occurrence is a named opaque external DFB dependency.
+  bool opaqueExternalAccess = false;
 };
 
 /// Execution count retained for one access in the allocation report.
@@ -157,6 +161,7 @@ struct DFBLifecycleEpoch {
   std::optional<DFBPointerOwner> terminalWritePointerOwner;
   std::optional<DFBPointerOwner> terminalReadPointerOwner;
   std::optional<int64_t> terminalResetOrdinal;
+  bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
   DFBQuiescenceProof quiescence;
 };
@@ -200,6 +205,7 @@ struct DFBPerNodeLifetime {
   SmallVector<DFBTransactionRun, 0> terminalReadCursorRuns;
   std::optional<DFBPointerOwner> terminalWritePointerOwner;
   std::optional<DFBPointerOwner> terminalReadPointerOwner;
+  bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
   SmallVector<DFBLifecycleEpoch, 0> resetEpochs;
   DFBQuiescenceProof quiescence;
@@ -220,6 +226,7 @@ struct DFBLogicalLifecycle {
   bool compilerCreated = false;
   SmallVector<BindCBOp> declarations;
   SmallVector<DFBAccessOccurrence> accesses;
+  bool hasOpaqueExternalAccess = false;
   LaunchNodeDomain launchDomain;
   SmallVector<DFBPerNodeLifetime, 0> nodeLifetimes;
   SmallVector<DFBPerNodeLifetime, 0> possibleNodeLifetimes;

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -48,8 +48,8 @@ struct DFBPointerOwner {
   bool operator!=(const DFBPointerOwner &rhs) const { return !(*this == rhs); }
 };
 
-/// Reason that a per-node lifetime did not prove a quiescent handoff.
-enum class DFBQuiescenceFailureReason {
+/// Reason DFB lifecycle completion was not proven for one launch node.
+enum class DFBLifecycleCompletionFailureReason {
   None,
   MissingProtocolEffect,
   UnsupportedControlFlow,
@@ -58,12 +58,15 @@ enum class DFBQuiescenceFailureReason {
   UnknownPointerOwner,
 };
 
-/// Typed quiescence result retained for conflict evidence.
-struct DFBQuiescenceProof {
-  DFBQuiescenceFailureReason failure = DFBQuiescenceFailureReason::None;
+/// Result of proving lifecycle completion, with evidence for a failed proof.
+struct DFBLifecycleCompletionProof {
+  DFBLifecycleCompletionFailureReason failure =
+      DFBLifecycleCompletionFailureReason::None;
   Operation *evidence = nullptr;
 
-  bool proven() const { return failure == DFBQuiescenceFailureReason::None; }
+  bool proven() const {
+    return failure == DFBLifecycleCompletionFailureReason::None;
+  }
 };
 
 /// One access event consumed by concurrent-liveness analysis.
@@ -163,7 +166,7 @@ struct DFBLifecycleEpoch {
   std::optional<int64_t> terminalResetOrdinal;
   bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
-  DFBQuiescenceProof quiescence;
+  DFBLifecycleCompletionProof completionProof;
 };
 
 /// A selected reset write that overlaps a non-target logical DFB lifecycle.
@@ -192,7 +195,7 @@ struct DFBPerNodeLifetime {
   /// First active access on the minimal entry frontier, retained as evidence.
   Operation *entryEvidence = nullptr;
 
-  /// Completion event IDs after which the DFB is quiescent.
+  /// Event IDs after which every access in the DFB lifecycle has completed.
   SmallVector<unsigned> terminalCompletionEvents;
   /// Normalized transaction runs in occurrence order.
   SmallVector<DFBTransactionRun> transactionRuns;
@@ -208,7 +211,7 @@ struct DFBPerNodeLifetime {
   bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
   SmallVector<DFBLifecycleEpoch, 0> resetEpochs;
-  DFBQuiescenceProof quiescence;
+  DFBLifecycleCompletionProof completionProof;
 };
 
 /// Allocation-report data omitted from normal liveness analysis.
@@ -242,7 +245,7 @@ struct DFBLogicalLifecycle {
   findPossibleNodeLifetime(LaunchNodeCoord node) const;
 };
 
-/// Builds per-node cross-kernel happens-before and DFB quiescence facts.
+/// Builds per-node cross-kernel happens-before and lifecycle completion facts.
 class DFBConcurrentKernelLivenessAnalysis {
 public:
   DFBConcurrentKernelLivenessAnalysis(Operation *operation,

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -154,6 +154,8 @@ struct DFBLifecycleEpoch {
   SmallVector<DFBTransactionRun> readCursorRuns;
   std::optional<DFBPointerOwner> writePointerOwner;
   std::optional<DFBPointerOwner> readPointerOwner;
+  std::optional<DFBPointerOwner> terminalWritePointerOwner;
+  std::optional<DFBPointerOwner> terminalReadPointerOwner;
   std::optional<int64_t> terminalResetOrdinal;
   bool terminalStateCanonical = false;
   DFBQuiescenceProof quiescence;
@@ -181,6 +183,9 @@ struct DFBPerNodeLifetime {
 
   /// Minimal access-entry event IDs under the proved happens-before relation.
   SmallVector<unsigned> earliestEntryEvents;
+
+  /// First active access on the minimal entry frontier, retained as evidence.
+  Operation *entryEvidence = nullptr;
 
   /// Completion event IDs after which the DFB is quiescent.
   SmallVector<unsigned> terminalCompletionEvents;
@@ -271,7 +276,42 @@ public:
   bool hasConditionallyInconsistentOrder(unsigned lhsIndex, unsigned rhsIndex,
                                          LaunchNodeCoord node) const;
 
+  /// Returns true when one reset-delimited epoch ends before another.
+  bool isEpochOrderedBefore(unsigned beforeIndex, unsigned beforeEpochIndex,
+                            unsigned afterIndex, unsigned afterEpochIndex,
+                            LaunchNodeCoord node) const;
+
+  /// Returns epoch ordering while treating unknown domains as possible.
+  bool isConditionallyEpochOrderedBefore(unsigned beforeIndex,
+                                         unsigned beforeEpochIndex,
+                                         unsigned afterIndex,
+                                         unsigned afterEpochIndex,
+                                         LaunchNodeCoord node) const;
+
+  /// Returns true when two epochs contain mutually reachable access events.
+  bool hasInconsistentEpochOrder(unsigned lhsIndex, unsigned lhsEpochIndex,
+                                 unsigned rhsIndex, unsigned rhsEpochIndex,
+                                 LaunchNodeCoord node) const;
+
+  /// Returns inconsistent epoch order with unknown domains included.
+  bool hasConditionallyInconsistentEpochOrder(unsigned lhsIndex,
+                                              unsigned lhsEpochIndex,
+                                              unsigned rhsIndex,
+                                              unsigned rhsEpochIndex,
+                                              LaunchNodeCoord node) const;
+
 private:
+  struct EpochOrdering {
+    SmallVector<unsigned> logicalOffsets;
+    SmallVector<llvm::BitVector> orderedBefore;
+    SmallVector<llvm::BitVector> inconsistent;
+  };
+
+  bool queryEpochRelation(ArrayRef<EpochOrdering> orderings, unsigned lhsIndex,
+                          unsigned lhsEpochIndex, unsigned rhsIndex,
+                          unsigned rhsEpochIndex, LaunchNodeCoord node,
+                          bool inconsistent) const;
+
   void analyze(Operation *operation,
                const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis);
 
@@ -283,6 +323,8 @@ private:
   SmallVector<SmallVector<llvm::BitVector>> inconsistentOrderByNode;
   SmallVector<SmallVector<llvm::BitVector>>
       conditionallyInconsistentOrderByNode;
+  SmallVector<EpochOrdering> epochOrderedBeforeByNode;
+  SmallVector<EpochOrdering> conditionallyEpochOrderedBeforeByNode;
   Operation *errorOperation = nullptr;
   std::string errorMessage;
 };

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -262,8 +262,13 @@ public:
         DFBAllocationGroupAttr lhsGroup = logicalDFBs[lhsIndex].allocationGroup;
         DFBAllocationGroupAttr rhsGroup = logicalDFBs[rhsIndex].allocationGroup;
         bool sameAllocationGroup = lhsGroup && lhsGroup == rhsGroup;
+        bool opaqueAccessRequiresExactDescriptor =
+            logicalDFBs[lhsIndex].hasOpaqueExternalAccess ||
+            logicalDFBs[rhsIndex].hasOpaqueExternalAccess;
         addPairConflicts(model, liveness, lhsIndex, rhsIndex,
-                         /*requireExactDescriptor=*/!sameAllocationGroup,
+                         /*requireExactDescriptor=*/
+                         !sameAllocationGroup ||
+                             opaqueAccessRequiresExactDescriptor,
                          /*requireMatchingTransactions=*/!sameAllocationGroup,
                          /*useAllocationGroupEpochs=*/sameAllocationGroup);
       }
@@ -309,7 +314,8 @@ public:
       return model;
     }
     addPairConflicts(model, liveness, lhsIndex, rhsIndex,
-                     /*requireExactDescriptor=*/false,
+                     /*requireExactDescriptor=*/lhs.hasOpaqueExternalAccess ||
+                         rhs.hasOpaqueExternalAccess,
                      /*requireMatchingTransactions=*/false,
                      /*useAllocationGroupEpochs=*/true);
     addResetAllocationConflicts(model, liveness,

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -86,8 +86,8 @@ namespace {
 // Preserves failed-proof evidence before using the caller-selected fallback.
 static Operation *getLifetimeEvidence(const DFBPerNodeLifetime *lifetime,
                                       Operation *fallbackEvidence) {
-  if (lifetime && lifetime->quiescence.evidence) {
-    return lifetime->quiescence.evidence;
+  if (lifetime && lifetime->completionProof.evidence) {
+    return lifetime->completionProof.evidence;
   }
   return fallbackEvidence;
 }
@@ -156,8 +156,8 @@ struct AllocationGroupNodeEpoch {
   const DFBLifecycleEpoch *epoch = nullptr;
   bool possibleDomain = false;
 
-  const DFBQuiescenceProof &getQuiescence() const {
-    return epoch ? epoch->quiescence : lifetime->quiescence;
+  const DFBLifecycleCompletionProof &getCompletionProof() const {
+    return epoch ? epoch->completionProof : lifetime->completionProof;
   }
 
   ArrayRef<DFBTransactionRun> getWriteCursorRuns() const {
@@ -235,8 +235,8 @@ getAllocationGroupEpochEvidence(const AllocationGroupNodeEpoch &epoch,
                                       : logicalDFB.declarations.front();
     return getLifetimeEvidence(epoch.lifetime, fallbackEvidence);
   }
-  if (epoch.getQuiescence().evidence) {
-    return epoch.getQuiescence().evidence;
+  if (epoch.getCompletionProof().evidence) {
+    return epoch.getCompletionProof().evidence;
   }
   assert(!epoch.epoch->accessOccurrenceIndices.empty() &&
          "active lifecycle epoch must contain an access");
@@ -451,11 +451,11 @@ private:
                                         useConditionalProof);
         auto unprovenLhsEpoch =
             llvm::find_if(lhsEpochs, [](const AllocationGroupNodeEpoch &epoch) {
-              return !epoch.getQuiescence().proven();
+              return !epoch.getCompletionProof().proven();
             });
         auto unprovenRhsEpoch =
             llvm::find_if(rhsEpochs, [](const AllocationGroupNodeEpoch &epoch) {
-              return !epoch.getQuiescence().proven();
+              return !epoch.getCompletionProof().proven();
             });
         if (unprovenLhsEpoch != lhsEpochs.end() ||
             unprovenRhsEpoch != rhsEpochs.end()) {
@@ -488,8 +488,8 @@ private:
         }
         continue;
       }
-      if (!lhsLifetime->quiescence.proven() ||
-          !rhsLifetime->quiescence.proven()) {
+      if (!lhsLifetime->completionProof.proven() ||
+          !rhsLifetime->completionProof.proven()) {
         addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
                     DFBConflictReason::AccessCompletionNotProven, node,
                     getLifetimeEvidence(lhsLifetime, lhs),
@@ -788,7 +788,7 @@ static LogicalResult validateAllocationGroupCursor(
                             messageStream.str());
         return failure();
       }
-      if (epoch.getQuiescence().proven() || unsafeAssumeAllocationGroups) {
+      if (epoch.getCompletionProof().proven() || unsafeAssumeAllocationGroups) {
         continue;
       }
       std::string message;
@@ -796,7 +796,7 @@ static LogicalResult validateAllocationGroupCursor(
       messageStream << "DFB allocation group ";
       printAllocationGroup(messageStream, allocationGroup, members,
                            logicalDFBs);
-      messageStream << " has unproved protocol quiescence for ";
+      messageStream << " does not have proven lifecycle completion for ";
       printAllocationGroupNodeEpoch(messageStream, epoch, logicalDFBs);
       messageStream << " on launch node (" << node.x << ',' << node.y << ')';
       analysisFailure.set(getAllocationGroupEpochEvidence(

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -83,14 +83,18 @@ StringRef getDFBAllocationGroupAssumptionReasonName(
 
 namespace {
 
-/// Preserves the operation that made a proof conservative, falling back to the
-/// declaration only when no more specific evidence exists.
+// Preserves failed-proof evidence before using the caller-selected fallback.
 static Operation *getLifetimeEvidence(const DFBPerNodeLifetime *lifetime,
-                                      const DFBLogicalLifecycle &logicalDFB) {
+                                      Operation *fallbackEvidence) {
   if (lifetime && lifetime->quiescence.evidence) {
     return lifetime->quiescence.evidence;
   }
-  return logicalDFB.declarations.front();
+  return fallbackEvidence;
+}
+
+static Operation *getLifetimeEvidence(const DFBPerNodeLifetime *lifetime,
+                                      const DFBLogicalLifecycle &logicalDFB) {
+  return getLifetimeEvidence(lifetime, logicalDFB.declarations.front());
 }
 
 static bool cursorRunsCanRepeat(ArrayRef<DFBTransactionRun> cursorRuns,
@@ -145,6 +149,101 @@ static bool haveCompatibleCursorRuns(const DFBPerNodeLifetime &before,
          cursorRunsCanRepeat(before.terminalReadCursorRuns, physicalTileCount);
 }
 
+struct AllocationGroupNodeEpoch {
+  unsigned logicalIndex = 0;
+  unsigned epochIndex = 0;
+  const DFBPerNodeLifetime *lifetime = nullptr;
+  const DFBLifecycleEpoch *epoch = nullptr;
+  bool possibleDomain = false;
+
+  const DFBQuiescenceProof &getQuiescence() const {
+    return epoch ? epoch->quiescence : lifetime->quiescence;
+  }
+
+  ArrayRef<DFBTransactionRun> getWriteCursorRuns() const {
+    if (epoch) {
+      return epoch->writeCursorRuns;
+    }
+    return lifetime->writeCursorRuns;
+  }
+
+  ArrayRef<DFBTransactionRun> getReadCursorRuns() const {
+    if (epoch) {
+      return epoch->readCursorRuns;
+    }
+    return lifetime->readCursorRuns;
+  }
+
+  std::optional<DFBPointerOwner> getWritePointerOwner() const {
+    return epoch ? epoch->writePointerOwner : lifetime->writePointerOwner;
+  }
+
+  std::optional<DFBPointerOwner> getReadPointerOwner() const {
+    return epoch ? epoch->readPointerOwner : lifetime->readPointerOwner;
+  }
+
+  std::optional<DFBPointerOwner> getTerminalWritePointerOwner() const {
+    return epoch ? epoch->terminalWritePointerOwner
+                 : lifetime->terminalWritePointerOwner;
+  }
+
+  std::optional<DFBPointerOwner> getTerminalReadPointerOwner() const {
+    return epoch ? epoch->terminalReadPointerOwner
+                 : lifetime->terminalReadPointerOwner;
+  }
+
+  bool hasCanonicalTerminalState() const {
+    return epoch ? epoch->terminalStateCanonical
+                 : lifetime->terminalStateCanonical;
+  }
+};
+
+static void appendAllocationGroupNodeEpochs(
+    SmallVectorImpl<AllocationGroupNodeEpoch> &epochs, unsigned logicalIndex,
+    const DFBPerNodeLifetime &lifetime, bool possibleDomain) {
+  if (lifetime.resetEpochs.empty()) {
+    epochs.push_back({logicalIndex, 0, &lifetime, nullptr, possibleDomain});
+    return;
+  }
+  for (auto [epochIndex, epoch] : llvm::enumerate(lifetime.resetEpochs)) {
+    epochs.push_back({logicalIndex, static_cast<unsigned>(epochIndex),
+                      &lifetime, &epoch, possibleDomain});
+  }
+}
+
+static bool isAllocationGroupEpochOrderedBefore(
+    const DFBConcurrentKernelLivenessAnalysis &liveness,
+    const AllocationGroupNodeEpoch &before,
+    const AllocationGroupNodeEpoch &after, LaunchNodeCoord node) {
+  if (before.possibleDomain || after.possibleDomain) {
+    return before.possibleDomain && after.possibleDomain &&
+           liveness.isConditionallyEpochOrderedBefore(
+               before.logicalIndex, before.epochIndex, after.logicalIndex,
+               after.epochIndex, node);
+  }
+  return liveness.isEpochOrderedBefore(before.logicalIndex, before.epochIndex,
+                                       after.logicalIndex, after.epochIndex,
+                                       node);
+}
+
+static Operation *
+getAllocationGroupEpochEvidence(const AllocationGroupNodeEpoch &epoch,
+                                const DFBLogicalLifecycle &logicalDFB) {
+  if (!epoch.epoch) {
+    Operation *fallbackEvidence = epoch.lifetime->entryEvidence
+                                      ? epoch.lifetime->entryEvidence
+                                      : logicalDFB.declarations.front();
+    return getLifetimeEvidence(epoch.lifetime, fallbackEvidence);
+  }
+  if (epoch.getQuiescence().evidence) {
+    return epoch.getQuiescence().evidence;
+  }
+  assert(!epoch.epoch->accessOccurrenceIndices.empty() &&
+         "active lifecycle epoch must contain an access");
+  return logicalDFB.accesses[epoch.epoch->accessOccurrenceIndices.front()]
+      .operation;
+}
+
 } // namespace
 
 class DFBPhysicalConflictModelBuilder {
@@ -165,7 +264,8 @@ public:
         bool sameAllocationGroup = lhsGroup && lhsGroup == rhsGroup;
         addPairConflicts(model, liveness, lhsIndex, rhsIndex,
                          /*requireExactDescriptor=*/!sameAllocationGroup,
-                         /*requireMatchingTransactions=*/!sameAllocationGroup);
+                         /*requireMatchingTransactions=*/!sameAllocationGroup,
+                         /*useAllocationGroupEpochs=*/sameAllocationGroup);
       }
     }
     addResetAllocationConflicts(model, liveness);
@@ -210,7 +310,8 @@ public:
     }
     addPairConflicts(model, liveness, lhsIndex, rhsIndex,
                      /*requireExactDescriptor=*/false,
-                     /*requireMatchingTransactions=*/false);
+                     /*requireMatchingTransactions=*/false,
+                     /*useAllocationGroupEpochs=*/true);
     addResetAllocationConflicts(model, liveness,
                                 std::make_pair(lhsIndex, rhsIndex));
     return model;
@@ -267,7 +368,8 @@ private:
                    const DFBConcurrentKernelLivenessAnalysis &liveness,
                    unsigned lhsIndex, unsigned rhsIndex,
                    bool requireExactDescriptor = true,
-                   bool requireMatchingTransactions = true) {
+                   bool requireMatchingTransactions = true,
+                   bool useAllocationGroupEpochs = false) {
     ArrayRef<DFBLogicalLifecycle> logicalDFBs =
         liveness.getLogicalDFBLifecycles();
     const DFBLogicalLifecycle &lhs = logicalDFBs[lhsIndex];
@@ -326,7 +428,61 @@ private:
                     lhs.declarations.front(), rhs.declarations.front());
         continue;
       }
-      if (!lhsLifetime || !rhsLifetime || !lhsLifetime->quiescence.proven() ||
+      if (!lhsLifetime || !rhsLifetime) {
+        addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                    DFBConflictReason::AccessCompletionNotProven, node,
+                    getLifetimeEvidence(lhsLifetime, lhs),
+                    getLifetimeEvidence(rhsLifetime, rhs));
+        continue;
+      }
+      if (useAllocationGroupEpochs && (!lhsLifetime->resetEpochs.empty() ||
+                                       !rhsLifetime->resetEpochs.empty())) {
+        SmallVector<AllocationGroupNodeEpoch> lhsEpochs;
+        SmallVector<AllocationGroupNodeEpoch> rhsEpochs;
+        appendAllocationGroupNodeEpochs(lhsEpochs, lhsIndex, *lhsLifetime,
+                                        useConditionalProof);
+        appendAllocationGroupNodeEpochs(rhsEpochs, rhsIndex, *rhsLifetime,
+                                        useConditionalProof);
+        auto unprovenLhsEpoch =
+            llvm::find_if(lhsEpochs, [](const AllocationGroupNodeEpoch &epoch) {
+              return !epoch.getQuiescence().proven();
+            });
+        auto unprovenRhsEpoch =
+            llvm::find_if(rhsEpochs, [](const AllocationGroupNodeEpoch &epoch) {
+              return !epoch.getQuiescence().proven();
+            });
+        if (unprovenLhsEpoch != lhsEpochs.end() ||
+            unprovenRhsEpoch != rhsEpochs.end()) {
+          const AllocationGroupNodeEpoch &lhsEvidence =
+              unprovenLhsEpoch != lhsEpochs.end() ? *unprovenLhsEpoch
+                                                  : lhsEpochs.front();
+          const AllocationGroupNodeEpoch &rhsEvidence =
+              unprovenRhsEpoch != rhsEpochs.end() ? *unprovenRhsEpoch
+                                                  : rhsEpochs.front();
+          addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                      DFBConflictReason::AccessCompletionNotProven, node,
+                      getAllocationGroupEpochEvidence(lhsEvidence, lhs),
+                      getAllocationGroupEpochEvidence(rhsEvidence, rhs));
+          continue;
+        }
+        for (const AllocationGroupNodeEpoch &lhsEpoch : lhsEpochs) {
+          for (const AllocationGroupNodeEpoch &rhsEpoch : rhsEpochs) {
+            bool lhsBeforeRhs = isAllocationGroupEpochOrderedBefore(
+                liveness, lhsEpoch, rhsEpoch, node);
+            bool rhsBeforeLhs = isAllocationGroupEpochOrderedBefore(
+                liveness, rhsEpoch, lhsEpoch, node);
+            if (lhsBeforeRhs != rhsBeforeLhs) {
+              continue;
+            }
+            addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
+                        DFBConflictReason::ConcurrentLifetime, node,
+                        getAllocationGroupEpochEvidence(lhsEpoch, lhs),
+                        getAllocationGroupEpochEvidence(rhsEpoch, rhs));
+          }
+        }
+        continue;
+      }
+      if (!lhsLifetime->quiescence.proven() ||
           !rhsLifetime->quiescence.proven()) {
         addEvidence(model, lhs, rhs, lhsIndex, rhsIndex,
                     DFBConflictReason::AccessCompletionNotProven, node,
@@ -446,34 +602,27 @@ static LogicalResult validateAllocationGroupTypes(
   return success();
 }
 
-struct AllocationGroupNodeMember {
-  unsigned logicalIndex = 0;
-  const DFBPerNodeLifetime *lifetime = nullptr;
-  bool possibleDomain = false;
-};
-
-static bool isAllocationGroupMemberOrderedBefore(
-    const DFBConcurrentKernelLivenessAnalysis &liveness,
-    const AllocationGroupNodeMember &lhs, const AllocationGroupNodeMember &rhs,
-    LaunchNodeCoord node) {
-  if (lhs.possibleDomain || rhs.possibleDomain) {
-    return lhs.possibleDomain && rhs.possibleDomain &&
-           liveness.isConditionallyOrderedBefore(lhs.logicalIndex,
-                                                 rhs.logicalIndex, node);
+static void
+printAllocationGroupNodeEpoch(raw_ostream &output,
+                              const AllocationGroupNodeEpoch &epoch,
+                              ArrayRef<DFBLogicalLifecycle> logicalDFBs) {
+  output << "logical DFB " << logicalDFBs[epoch.logicalIndex].logicalId;
+  if (epoch.epoch) {
+    output << " epoch " << epoch.epochIndex;
   }
-  return liveness.isOrderedBefore(lhs.logicalIndex, rhs.logicalIndex, node);
 }
 
-static bool hasAllocationGroupMemberInconsistentOrder(
+static bool hasAllocationGroupEpochInconsistentOrder(
     const DFBConcurrentKernelLivenessAnalysis &liveness,
-    const AllocationGroupNodeMember &lhs, const AllocationGroupNodeMember &rhs,
+    const AllocationGroupNodeEpoch &lhs, const AllocationGroupNodeEpoch &rhs,
     LaunchNodeCoord node) {
   if (lhs.possibleDomain || rhs.possibleDomain) {
-    return liveness.hasConditionallyInconsistentOrder(lhs.logicalIndex,
-                                                      rhs.logicalIndex, node);
+    return liveness.hasConditionallyInconsistentEpochOrder(
+        lhs.logicalIndex, lhs.epochIndex, rhs.logicalIndex, rhs.epochIndex,
+        node);
   }
-  return liveness.hasInconsistentOrder(lhs.logicalIndex, rhs.logicalIndex,
-                                       node);
+  return liveness.hasInconsistentEpochOrder(
+      lhs.logicalIndex, lhs.epochIndex, rhs.logicalIndex, rhs.epochIndex, node);
 }
 
 struct AllocationGroupCursorState {
@@ -481,39 +630,77 @@ struct AllocationGroupCursorState {
   std::uint64_t readPointerOffset = 0;
 };
 
+enum class AllocationGroupCursorFailure {
+  None,
+  RingBoundary,
+  UnequalOffsets,
+};
+
+static LogicalResult advanceAllocationGroupCursorRuns(
+    ArrayRef<DFBTransactionRun> writeCursorRuns,
+    ArrayRef<DFBTransactionRun> readCursorRuns, std::uint64_t physicalTileCount,
+    AllocationGroupCursorState &cursorState, bool terminalStateCanonical,
+    AllocationGroupCursorFailure *failureReason = nullptr) {
+  FailureOr<std::uint64_t> writePointerOffset = advanceDFBTransactionCursor(
+      writeCursorRuns, physicalTileCount, cursorState.writePointerOffset);
+  FailureOr<std::uint64_t> readPointerOffset = advanceDFBTransactionCursor(
+      readCursorRuns, physicalTileCount, cursorState.readPointerOffset);
+  if (failed(writePointerOffset) || failed(readPointerOffset)) {
+    if (failureReason) {
+      *failureReason = AllocationGroupCursorFailure::RingBoundary;
+    }
+    return failure();
+  }
+  cursorState = {*writePointerOffset, *readPointerOffset};
+  if (terminalStateCanonical) {
+    cursorState = {};
+    if (failureReason) {
+      *failureReason = AllocationGroupCursorFailure::None;
+    }
+    return success();
+  }
+  if (*writePointerOffset != *readPointerOffset) {
+    if (failureReason) {
+      *failureReason = AllocationGroupCursorFailure::UnequalOffsets;
+    }
+    return failure();
+  }
+  if (failureReason) {
+    *failureReason = AllocationGroupCursorFailure::None;
+  }
+  return success();
+}
+
 static FailureOr<AllocationGroupCursorState> advanceAllocationGroupMemberCursor(
     const DFBPerNodeLifetime &lifetime, std::uint64_t physicalTileCount,
     AllocationGroupCursorState cursorState = {}) {
-  auto advanceRuns = [&](ArrayRef<DFBTransactionRun> transactionRuns,
-                         std::uint64_t &pointerOffset) {
-    FailureOr<std::uint64_t> nextOffset = advanceDFBTransactionCursor(
-        transactionRuns, physicalTileCount, pointerOffset);
-    if (succeeded(nextOffset)) {
-      pointerOffset = *nextOffset;
-    }
-    return nextOffset;
-  };
   if (lifetime.resetEpochs.empty()) {
-    if (failed(advanceRuns(lifetime.writeCursorRuns,
-                           cursorState.writePointerOffset)) ||
-        failed(advanceRuns(lifetime.readCursorRuns,
-                           cursorState.readPointerOffset))) {
+    if (failed(advanceAllocationGroupCursorRuns(
+            lifetime.writeCursorRuns, lifetime.readCursorRuns,
+            physicalTileCount, cursorState,
+            /*terminalStateCanonical=*/false))) {
       return failure();
     }
   } else {
     for (const DFBLifecycleEpoch &epoch : lifetime.resetEpochs) {
-      if (failed(advanceRuns(epoch.writeCursorRuns,
-                             cursorState.writePointerOffset)) ||
-          failed(advanceRuns(epoch.readCursorRuns,
-                             cursorState.readPointerOffset))) {
+      if (failed(advanceAllocationGroupCursorRuns(
+              epoch.writeCursorRuns, epoch.readCursorRuns, physicalTileCount,
+              cursorState, epoch.terminalStateCanonical))) {
         return failure();
-      }
-      if (epoch.terminalStateCanonical) {
-        cursorState = {};
       }
     }
   }
-  if (cursorState.writePointerOffset != cursorState.readPointerOffset) {
+  return cursorState;
+}
+
+static FailureOr<AllocationGroupCursorState> advanceAllocationGroupEpochCursor(
+    const AllocationGroupNodeEpoch &epoch, std::uint64_t physicalTileCount,
+    AllocationGroupCursorState cursorState = {},
+    AllocationGroupCursorFailure *failureReason = nullptr) {
+  if (failed(advanceAllocationGroupCursorRuns(
+          epoch.getWriteCursorRuns(), epoch.getReadCursorRuns(),
+          physicalTileCount, cursorState, epoch.hasCanonicalTerminalState(),
+          failureReason))) {
     return failure();
   }
   return cursorState;
@@ -564,7 +751,7 @@ static LogicalResult validateAllocationGroupCursor(
   ArrayRef<DFBLogicalLifecycle> logicalDFBs =
       liveness.getLogicalDFBLifecycles();
   for (LaunchNodeCoord node : liveness.getLaunchNodes()) {
-    SmallVector<AllocationGroupNodeMember> activeMembers;
+    SmallVector<AllocationGroupNodeEpoch> activeEpochs;
     for (unsigned logicalIndex : members) {
       const DFBLogicalLifecycle &logicalDFB = logicalDFBs[logicalIndex];
       bool possibleDomain = !logicalDFB.launchDomain.known;
@@ -574,44 +761,60 @@ static LogicalResult validateAllocationGroupCursor(
       if (!lifetime || !lifetime->mayBeActive) {
         continue;
       }
-      activeMembers.push_back({logicalIndex, lifetime, possibleDomain});
+      appendAllocationGroupNodeEpochs(activeEpochs, logicalIndex, *lifetime,
+                                      possibleDomain);
     }
 
-    for (const AllocationGroupNodeMember &member : activeMembers) {
-      if (!hasAllocationGroupMemberInconsistentOrder(liveness, member, member,
-                                                     node)) {
+    bool hasUnprovenOrder = false;
+    for (const AllocationGroupNodeEpoch &epoch : activeEpochs) {
+      if (hasAllocationGroupEpochInconsistentOrder(liveness, epoch, epoch,
+                                                   node)) {
+        std::string message;
+        llvm::raw_string_ostream messageStream(message);
+        messageStream << "DFB allocation group ";
+        printAllocationGroup(messageStream, allocationGroup, members,
+                             logicalDFBs);
+        messageStream << " has contradictory cursor order involving ";
+        printAllocationGroupNodeEpoch(messageStream, epoch, logicalDFBs);
+        messageStream << " on launch node (" << node.x << ',' << node.y << ')';
+        analysisFailure.set(getAllocationGroupEpochEvidence(
+                                epoch, logicalDFBs[epoch.logicalIndex]),
+                            messageStream.str());
+        return failure();
+      }
+      if (epoch.getQuiescence().proven() || unsafeAssumeAllocationGroups) {
         continue;
       }
-      const DFBLogicalLifecycle &logicalDFB = logicalDFBs[member.logicalIndex];
       std::string message;
       llvm::raw_string_ostream messageStream(message);
       messageStream << "DFB allocation group ";
       printAllocationGroup(messageStream, allocationGroup, members,
                            logicalDFBs);
-      messageStream << " has contradictory cursor order involving logical DFB "
-                    << logicalDFB.logicalId << " on launch node (" << node.x
-                    << ',' << node.y << ')';
-      analysisFailure.set(logicalDFB.declarations.front(), messageStream.str());
+      messageStream << " has unproved protocol quiescence for ";
+      printAllocationGroupNodeEpoch(messageStream, epoch, logicalDFBs);
+      messageStream << " on launch node (" << node.x << ',' << node.y << ')';
+      analysisFailure.set(getAllocationGroupEpochEvidence(
+                              epoch, logicalDFBs[epoch.logicalIndex]),
+                          messageStream.str());
       return failure();
     }
 
-    bool hasUnprovenOrder = false;
-    SmallVector<unsigned> predecessorCounts(activeMembers.size());
-    for (auto [lhsPosition, lhs] : llvm::enumerate(activeMembers)) {
+    SmallVector<unsigned> predecessorCounts(activeEpochs.size());
+    for (auto [lhsPosition, lhs] : llvm::enumerate(activeEpochs)) {
       for (unsigned rhsPosition = lhsPosition + 1;
-           rhsPosition < activeMembers.size(); ++rhsPosition) {
-        const AllocationGroupNodeMember &rhs = activeMembers[rhsPosition];
+           rhsPosition < activeEpochs.size(); ++rhsPosition) {
+        const AllocationGroupNodeEpoch &rhs = activeEpochs[rhsPosition];
         bool lhsBeforeRhs =
-            isAllocationGroupMemberOrderedBefore(liveness, lhs, rhs, node);
+            isAllocationGroupEpochOrderedBefore(liveness, lhs, rhs, node);
         bool rhsBeforeLhs =
-            isAllocationGroupMemberOrderedBefore(liveness, rhs, lhs, node);
+            isAllocationGroupEpochOrderedBefore(liveness, rhs, lhs, node);
         if (lhsBeforeRhs != rhsBeforeLhs) {
           unsigned afterPosition = lhsBeforeRhs ? rhsPosition : lhsPosition;
           ++predecessorCounts[afterPosition];
           continue;
         }
         bool inconsistentOrder =
-            hasAllocationGroupMemberInconsistentOrder(liveness, lhs, rhs, node);
+            hasAllocationGroupEpochInconsistentOrder(liveness, lhs, rhs, node);
         if (!inconsistentOrder && unsafeAssumeAllocationGroups) {
           addAllocationGroupAssumption(
               assumptions,
@@ -629,24 +832,26 @@ static LogicalResult validateAllocationGroupCursor(
         messageStream << (inconsistentOrder
                               ? " has inconsistent cursor order for "
                               : " has no proven cursor order for ")
-                      << "logical DFBs "
-                      << logicalDFBs[lhs.logicalIndex].logicalId << " and "
-                      << logicalDFBs[rhs.logicalIndex].logicalId
-                      << " on launch node (" << node.x << ',' << node.y << ')';
-        analysisFailure.set(logicalDFBs[rhs.logicalIndex].declarations.front(),
-                            messageStream.str());
+                      << "epochs ";
+        printAllocationGroupNodeEpoch(messageStream, lhs, logicalDFBs);
+        messageStream << " and ";
+        printAllocationGroupNodeEpoch(messageStream, rhs, logicalDFBs);
+        messageStream << " on launch node (" << node.x << ',' << node.y << ')';
+        analysisFailure.set(
+            getAllocationGroupEpochEvidence(rhs, logicalDFBs[rhs.logicalIndex]),
+            messageStream.str());
         return failure();
       }
     }
-
     if (hasUnprovenOrder) {
-      for (const AllocationGroupNodeMember &member : activeMembers) {
-        if (succeeded(advanceAllocationGroupMemberCursor(*member.lifetime,
+      DenseSet<unsigned> validatedLogicalIndices;
+      for (const AllocationGroupNodeEpoch &epoch : activeEpochs) {
+        if (!validatedLogicalIndices.insert(epoch.logicalIndex).second ||
+            succeeded(advanceAllocationGroupMemberCursor(*epoch.lifetime,
                                                          physicalTileCount))) {
           continue;
         }
-        const DFBLogicalLifecycle &logicalDFB =
-            logicalDFBs[member.logicalIndex];
+        const DFBLogicalLifecycle &logicalDFB = logicalDFBs[epoch.logicalIndex];
         std::string message;
         llvm::raw_string_ostream messageStream(message);
         messageStream << "DFB allocation group ";
@@ -656,66 +861,138 @@ static LogicalResult validateAllocationGroupCursor(
                       << " tiles makes logical DFB " << logicalDFB.logicalId
                       << " cross the ring boundary on launch node (" << node.x
                       << ',' << node.y << ')';
-        analysisFailure.set(logicalDFB.declarations.front(),
+        analysisFailure.set(getAllocationGroupEpochEvidence(epoch, logicalDFB),
                             messageStream.str());
         return failure();
       }
       continue;
     }
-    SmallVector<AllocationGroupNodeMember> orderedMembers(activeMembers.size());
-    llvm::BitVector occupiedRanks(activeMembers.size());
-    for (auto [memberPosition, member] : llvm::enumerate(activeMembers)) {
-      unsigned rank = predecessorCounts[memberPosition];
-      if (rank < orderedMembers.size() && !occupiedRanks.test(rank)) {
-        orderedMembers[rank] = member;
+    SmallVector<AllocationGroupNodeEpoch> orderedEpochs(activeEpochs.size());
+    llvm::BitVector occupiedRanks(activeEpochs.size());
+    for (auto [epochPosition, epoch] : llvm::enumerate(activeEpochs)) {
+      unsigned rank = predecessorCounts[epochPosition];
+      if (rank < orderedEpochs.size() && !occupiedRanks.test(rank)) {
+        orderedEpochs[rank] = epoch;
         occupiedRanks.set(rank);
         continue;
       }
-      const DFBLogicalLifecycle &logicalDFB = logicalDFBs[member.logicalIndex];
       std::string message;
       llvm::raw_string_ostream messageStream(message);
       messageStream << "DFB allocation group ";
       printAllocationGroup(messageStream, allocationGroup, members,
                            logicalDFBs);
-      messageStream << " has inconsistent cursor order for logical DFB "
-                    << logicalDFB.logicalId << " on launch node (" << node.x
-                    << ',' << node.y << ')';
-      analysisFailure.set(logicalDFB.declarations.front(), messageStream.str());
+      messageStream << " has inconsistent cursor order for ";
+      printAllocationGroupNodeEpoch(messageStream, epoch, logicalDFBs);
+      messageStream << " on launch node (" << node.x << ',' << node.y << ')';
+      analysisFailure.set(getAllocationGroupEpochEvidence(
+                              epoch, logicalDFBs[epoch.logicalIndex]),
+                          messageStream.str());
       return failure();
     }
-    activeMembers = std::move(orderedMembers);
+    activeEpochs = std::move(orderedEpochs);
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "DFB allocation group " << allocationGroup
+                   << " launch_node=(" << node.x << ',' << node.y
+                   << ") epoch_order=[";
+      llvm::interleaveComma(activeEpochs, llvm::dbgs(),
+                            [&](const AllocationGroupNodeEpoch &epoch) {
+                              llvm::dbgs()
+                                  << logicalDFBs[epoch.logicalIndex].logicalId
+                                  << ':' << epoch.epochIndex;
+                            });
+      llvm::dbgs() << "]\n";
+    });
 
     AllocationGroupCursorState cursorState;
-    for (const AllocationGroupNodeMember &member : activeMembers) {
-      const DFBPerNodeLifetime &lifetime = *member.lifetime;
-      FailureOr<AllocationGroupCursorState> nextOffset =
-          advanceAllocationGroupMemberCursor(lifetime, physicalTileCount,
-                                             cursorState);
-      if (succeeded(nextOffset)) {
-        cursorState = *nextOffset;
+    const AllocationGroupNodeEpoch *previousEpoch = nullptr;
+    for (const AllocationGroupNodeEpoch &epoch : activeEpochs) {
+      bool pointerOwnersCompatible =
+          !previousEpoch || previousEpoch->hasCanonicalTerminalState() ||
+          (previousEpoch->getTerminalWritePointerOwner() ==
+               epoch.getWritePointerOwner() &&
+           previousEpoch->getTerminalReadPointerOwner() ==
+               epoch.getReadPointerOwner());
+      AllocationGroupCursorFailure cursorFailure =
+          AllocationGroupCursorFailure::None;
+      FailureOr<AllocationGroupCursorState> nextState = failure();
+      if (pointerOwnersCompatible) {
+        nextState = advanceAllocationGroupEpochCursor(
+            epoch, physicalTileCount, cursorState, &cursorFailure);
+      }
+      if (succeeded(nextState)) {
+        cursorState = *nextState;
+        previousEpoch = &epoch;
         continue;
       }
 
-      const DFBLogicalLifecycle &logicalDFB = logicalDFBs[member.logicalIndex];
-      FailureOr<AllocationGroupCursorState> resetState =
-          advanceAllocationGroupMemberCursor(lifetime, physicalTileCount);
-      if (unsafeAssumeAllocationGroups && succeeded(resetState)) {
-        addAllocationGroupAssumption(
-            assumptions, DFBAllocationGroupAssumptionReason::EpochReset,
-            logicalDFB.logicalId);
-        cursorState = *resetState;
-        continue;
+      bool differentLogicalMember =
+          previousEpoch && previousEpoch->logicalIndex != epoch.logicalIndex;
+      if (unsafeAssumeAllocationGroups && differentLogicalMember) {
+        AllocationGroupCursorFailure resetFailure =
+            AllocationGroupCursorFailure::None;
+        FailureOr<AllocationGroupCursorState> resetState =
+            advanceAllocationGroupEpochCursor(epoch, physicalTileCount, {},
+                                              &resetFailure);
+        if (succeeded(resetState)) {
+          const DFBLogicalLifecycle &logicalDFB =
+              logicalDFBs[epoch.logicalIndex];
+          addAllocationGroupAssumption(
+              assumptions, DFBAllocationGroupAssumptionReason::EpochReset,
+              logicalDFB.logicalId);
+          cursorState = *resetState;
+          previousEpoch = &epoch;
+          continue;
+        }
+        cursorFailure = resetFailure;
       }
+
+      const DFBLogicalLifecycle &logicalDFB = logicalDFBs[epoch.logicalIndex];
+      if (!pointerOwnersCompatible &&
+          cursorFailure == AllocationGroupCursorFailure::None) {
+        std::string message;
+        llvm::raw_string_ostream messageStream(message);
+        messageStream << "DFB allocation group ";
+        printAllocationGroup(messageStream, allocationGroup, members,
+                             logicalDFBs);
+        messageStream << " cannot alias logical DFBs "
+                      << logicalDFBs[previousEpoch->logicalIndex].logicalId
+                      << " and " << logicalDFB.logicalId << ": "
+                      << getDFBConflictReasonName(
+                             DFBConflictReason::PointerOwnerMismatch);
+        analysisFailure.set(getAllocationGroupEpochEvidence(epoch, logicalDFB),
+                            messageStream.str());
+        return failure();
+      }
+
+      if (cursorFailure == AllocationGroupCursorFailure::UnequalOffsets) {
+        std::string message;
+        llvm::raw_string_ostream messageStream(message);
+        messageStream << "DFB allocation group ";
+        printAllocationGroup(messageStream, allocationGroup, members,
+                             logicalDFBs);
+        messageStream << " leaves unequal write and read offsets after ";
+        printAllocationGroupNodeEpoch(messageStream, epoch, logicalDFBs);
+        messageStream << " on launch node (" << node.x << ',' << node.y << ')';
+        analysisFailure.set(getAllocationGroupEpochEvidence(epoch, logicalDFB),
+                            messageStream.str());
+        return failure();
+      }
+
       std::string message;
       llvm::raw_string_ostream messageStream(message);
       messageStream << "DFB allocation group ";
       printAllocationGroup(messageStream, allocationGroup, members,
                            logicalDFBs);
       messageStream << " physical envelope of " << physicalTileCount
-                    << " tiles makes logical DFB " << logicalDFB.logicalId
-                    << " cross the ring boundary on launch node (" << node.x
+                    << " tiles makes logical DFB " << logicalDFB.logicalId;
+      if (epoch.epoch) {
+        messageStream << " epoch " << epoch.epochIndex;
+      }
+      messageStream << " cross the ring boundary on launch node (" << node.x
                     << ',' << node.y << ')';
-      analysisFailure.set(logicalDFB.declarations.front(), messageStream.str());
+      analysisFailure.set(getAllocationGroupEpochEvidence(epoch, logicalDFB),
+                          messageStream.str());
       return failure();
     }
   }

--- a/test/python/test_external_dfb_reuse.py
+++ b/test/python/test_external_dfb_reuse.py
@@ -19,6 +19,7 @@ import torch
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 import ttl  # noqa: E402
+from ttl import ttl_api  # noqa: E402
 from ttlang_test_utils import to_dram, to_l1, to_l1_sharded  # noqa: E402
 from utils.correctness import assert_allclose  # noqa: E402
 
@@ -77,6 +78,72 @@ def _make_external_multiply_kernel(data_format):
         result_source.pop()
 
     return external_multiply_kernel
+
+
+def _make_external_reset_kernel(data_format, distinct_logical_dfbs):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    reset = ttl.DFBReset(
+        participants=(compute_kernel, reader_kernel, writer_kernel),
+    )
+
+    @ttl.operation(grid=(1, 1))
+    def external_reset_kernel(lhs, rhs, result):
+        lhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        rhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        if distinct_logical_dfbs:
+            shared_allocation = ttl.make_dfb_allocation_group()
+            stale_result = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=2,
+                allocation_group=shared_allocation,
+            )
+            current_result = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=2,
+                allocation_group=shared_allocation,
+            )
+        else:
+            stale_result = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=2,
+            )
+            current_result = stale_result
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            ttl.call_extern_func(
+                EXTERNAL_MULTIPLY_HEADER,
+                "ttl_external_eltwise_mul",
+                template_args=[
+                    ttl.dfb_descriptor(lhs_dfb),
+                    ttl.dfb_descriptor(rhs_dfb),
+                    ttl.dfb_descriptor(stale_result),
+                ],
+            )
+            ttl.reset_dfbs(reset, dfbs=[stale_result])
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            with lhs_dfb.reserve() as lhs_destination:
+                ttl.copy(lhs[0, 0], lhs_destination).wait()
+            with rhs_dfb.reserve() as rhs_destination:
+                ttl.copy(rhs[0, 0], rhs_destination).wait()
+            ttl.reset_dfbs(reset, dfbs=[stale_result])
+            with current_result.reserve() as current_destination:
+                ttl.copy(rhs[0, 0], current_destination).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            ttl.reset_dfbs(reset, dfbs=[stale_result])
+            with current_result.wait() as current_source:
+                ttl.copy(current_source, result[0, 0]).wait()
+
+    return external_reset_kernel
 
 
 def _make_nested_copy_atom(data_format, level_count):
@@ -183,6 +250,8 @@ def _make_external_composition_kernel(data_format, tensor_backed):
 
 _external_bf16_multiply = _make_external_multiply_kernel("bf16")
 _external_f32_multiply = _make_external_multiply_kernel("float32")
+_external_bf16_reset_same_dfb = _make_external_reset_kernel("bf16", False)
+_external_f32_reset_same_dfb = _make_external_reset_kernel("float32", False)
 _external_bf16_composition = _make_external_composition_kernel("bf16", False)
 _external_f32_composition = _make_external_composition_kernel("float32", False)
 _tensor_backed_bf16_composition = _make_external_composition_kernel("bf16", True)
@@ -194,6 +263,47 @@ assert EXTERNAL_COMPOSITION_LOGICAL_DFBS > 64
 def _count_final_dfb_allocations(final_mlir_path):
     final_mlir = final_mlir_path.read_text()
     return final_mlir.count("dfb_index =")
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_external_bf16_reset_same_dfb, torch.bfloat16),
+        (_external_f32_reset_same_dfb, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    "to_device",
+    [to_dram, to_l1],
+    ids=["dram", "l1"],
+)
+def test_external_protocol_state_reset_drains_compute_interfaces(
+    device, operation, dtype, to_device
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
+    rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)
+    lhs = to_device(lhs_host, device)
+    rhs = to_device(rhs_host, device)
+    result = to_device(torch.zeros_like(rhs_host), device)
+
+    for _invocation_index in range(2):
+        operation(
+            lhs,
+            rhs,
+            result,
+            options="--ttl-reuse-user-dfbs --ttl-specialize-cores",
+        )
+
+    actual = ttnn.to_torch(result).float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, rhs_host.float(), rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, rhs_host.float(), rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -249,6 +359,51 @@ def test_external_multiply_with_dfb_allocation(
             rtol=F32_EXTERNAL_MULTIPLY_RTOL,
             atol=F32_EXTERNAL_MULTIPLY_ATOL,
         )
+
+
+@pytest.mark.parametrize(
+    ("data_format", "dtype"),
+    [
+        ("bf16", torch.bfloat16),
+        ("float32", torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    "to_device",
+    [to_dram, to_l1],
+    ids=["dram", "l1"],
+)
+def test_external_protocol_state_reset_allows_group_reuse(
+    device, data_format, dtype, to_device, monkeypatch, tmp_path
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    operation = _make_external_reset_kernel(data_format, True)
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
+    rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)
+    lhs = to_device(lhs_host, device)
+    rhs = to_device(rhs_host, device)
+    result = to_device(torch.zeros_like(rhs_host), device)
+    final_mlir_path = tmp_path / "external_reset_reuse.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+
+    for _invocation_index in range(2):
+        operation(
+            lhs,
+            rhs,
+            result,
+            options="--ttl-reuse-user-dfbs --ttl-specialize-cores",
+        )
+
+    assert _count_final_dfb_allocations(final_mlir_path) == 3
+    actual = ttnn.to_torch(result).float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, rhs_host.float(), rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, rhs_host.float(), rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -1403,8 +1403,8 @@ def _distinct_noc_owner_kernel(first, second, out):
         with first_dfb.wait():
             pass
 
-        # The acknowledgment proves that the first DFB is quiescent before
-        # NOC1 produces the second DFB.
+        # The acknowledgment proves that every first-DFB access completes
+        # before NOC1 produces the second DFB.
         with acknowledgment_dfb.reserve() as acknowledgment:
             acknowledgment.store(
                 ttl.block.fill(

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -1291,8 +1291,6 @@ _waited_mutation_f32_two_tile_store_kernel = _make_waited_block_store_kernel(
 )
 _waited_mutation_bf16_iadd_kernel = _make_waited_block_iadd_kernel("bf16")
 _waited_mutation_f32_iadd_kernel = _make_waited_block_iadd_kernel("float32")
-_exact_bf16_execution_domain_kernel = _make_exact_execution_domain_kernel("bf16")
-_exact_f32_execution_domain_kernel = _make_exact_execution_domain_kernel("float32")
 _conditional_bf16_true_lifecycle_kernel = _make_conditional_lifecycle_kernel(
     "bf16", True
 )
@@ -1503,10 +1501,10 @@ def test_ordered_dfbs_with_distinct_noc_owners(
 
 
 @pytest.mark.parametrize(
-    ("operation", "dtype"),
+    ("data_format", "dtype"),
     [
-        (_exact_bf16_execution_domain_kernel, torch.bfloat16),
-        (_exact_f32_execution_domain_kernel, torch.float32),
+        ("bf16", torch.bfloat16),
+        ("float32", torch.float32),
     ],
     ids=["bf16", "f32"],
 )
@@ -1516,8 +1514,9 @@ def test_ordered_dfbs_with_distinct_noc_owners(
     ids=["dram", "l1"],
 )
 def test_exact_disjoint_execution_domains_reuse_dfb(
-    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+    device, data_format, dtype, memory_config, to_device, monkeypatch, tmp_path
 ):
+    operation = _make_exact_execution_domain_kernel(data_format)
     element_indices = torch.arange(2 * TILE * TILE, dtype=torch.float32).reshape(
         TILE, 2 * TILE
     )

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -1034,6 +1034,187 @@ def _make_selected_reset_alias_domain_kernel(data_format):
     return selected_reset_alias_domain_kernel
 
 
+def _make_interleaved_allocation_group_epochs_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    reset_participants = (
+        compute_kernel,
+        reader_kernel,
+        writer_kernel,
+    )
+    reset_first_epoch = ttl.DFBReset(participants=reset_participants)
+    reset_second_epoch = ttl.DFBReset(participants=reset_participants)
+    reset_third_epoch = ttl.DFBReset(participants=reset_participants)
+
+    @ttl.operation(grid=(1, 1))
+    def interleaved_allocation_group_epochs_kernel(input_tensor, output_tensor):
+        shared_allocation = ttl.make_dfb_allocation_group()
+        noc_stream = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=3,
+            allocation_group=shared_allocation,
+        )
+        pack_stream = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=3,
+            allocation_group=shared_allocation,
+        )
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            with noc_stream.reserve() as first_noc_destination:
+                ttl.copy(input_tensor[0, 0], first_noc_destination).wait()
+            ttl.reset_dfbs(reset_first_epoch, dfbs=[noc_stream])
+            ttl.reset_dfbs(reset_second_epoch, dfbs=[pack_stream])
+            with noc_stream.reserve() as second_noc_destination:
+                ttl.copy(input_tensor[0, 1], second_noc_destination).wait()
+            ttl.reset_dfbs(reset_third_epoch, dfbs=[noc_stream])
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            with noc_stream.wait():
+                pass
+            ttl.reset_dfbs(reset_first_epoch, dfbs=[noc_stream])
+            with pack_stream.reserve() as first_pack_destination:
+                first_pack_destination.store(
+                    ttl.block.fill(
+                        3,
+                        shape=first_pack_destination.shape,
+                        dtype=first_pack_destination.dtype,
+                    )
+                )
+            ttl.reset_dfbs(reset_second_epoch, dfbs=[pack_stream])
+            with noc_stream.wait():
+                pass
+            ttl.reset_dfbs(reset_third_epoch, dfbs=[noc_stream])
+            with pack_stream.reserve() as second_pack_destination:
+                second_pack_destination.store(
+                    ttl.block.fill(
+                        7,
+                        shape=second_pack_destination.shape,
+                        dtype=second_pack_destination.dtype,
+                    )
+                )
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            ttl.reset_dfbs(reset_first_epoch, dfbs=[noc_stream])
+            with pack_stream.wait() as first_pack_source:
+                ttl.copy(first_pack_source, output_tensor[0, 0]).wait()
+            ttl.reset_dfbs(reset_second_epoch, dfbs=[pack_stream])
+            ttl.reset_dfbs(reset_third_epoch, dfbs=[noc_stream])
+            with pack_stream.wait() as second_pack_source:
+                ttl.copy(second_pack_source, output_tensor[0, 1]).wait()
+
+    return interleaved_allocation_group_epochs_kernel
+
+
+def _make_nested_reset_target_access_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    reset_participants = (
+        compute_kernel,
+        reader_kernel,
+        writer_kernel,
+    )
+    reset_first_epoch = ttl.DFBReset(participants=reset_participants)
+    reset_second_epoch = ttl.DFBReset(participants=reset_participants)
+    reset_third_epoch = ttl.DFBReset(participants=reset_participants)
+
+    @ttl.operation(grid=(1, 1))
+    def nested_reset_target_access_kernel(input_tensor, output_tensor):
+        shared_allocation = ttl.make_dfb_allocation_group()
+        noc_stream = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=3,
+            allocation_group=shared_allocation,
+        )
+        pack_stream = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=3,
+            allocation_group=shared_allocation,
+        )
+        dynamic_scratch = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=3,
+        )
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            for _outer_iteration in range(1):
+                with noc_stream.reserve() as first_noc_destination:
+                    ttl.copy(input_tensor[0, 0], first_noc_destination).wait()
+                ttl.reset_all_dfbs(reset_first_epoch)
+                ttl.reset_all_dfbs(reset_second_epoch)
+                with noc_stream.reserve() as second_noc_destination:
+                    ttl.copy(input_tensor[0, 1], second_noc_destination).wait()
+                ttl.reset_all_dfbs(reset_third_epoch)
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            for _outer_iteration in range(1):
+                with noc_stream.wait():
+                    pass
+                ttl.reset_all_dfbs(reset_first_epoch)
+                with pack_stream.reserve() as first_pack_destination:
+                    first_pack_destination.store(
+                        ttl.block.fill(
+                            3,
+                            shape=first_pack_destination.shape,
+                            dtype=first_pack_destination.dtype,
+                        )
+                    )
+                ttl.reset_all_dfbs(reset_second_epoch)
+                dynamic_count = ttl.call_extern_func(
+                    SCALAR_RESULT_HEADER,
+                    "scalar_result",
+                    template_args=[32],
+                    result_type=ttl.ScalarType.I32,
+                )
+                for _scratch_iteration in range(dynamic_count):
+                    with dynamic_scratch.reserve() as scratch_destination:
+                        scratch_destination.store(
+                            ttl.block.fill(
+                                11,
+                                shape=scratch_destination.shape,
+                                dtype=scratch_destination.dtype,
+                            )
+                        )
+                    with dynamic_scratch.wait():
+                        pass
+                with noc_stream.wait():
+                    pass
+                ttl.reset_all_dfbs(reset_third_epoch)
+                with pack_stream.reserve() as second_pack_destination:
+                    second_pack_destination.store(
+                        ttl.block.fill(
+                            7,
+                            shape=second_pack_destination.shape,
+                            dtype=second_pack_destination.dtype,
+                        )
+                    )
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            for _outer_iteration in range(1):
+                ttl.reset_all_dfbs(reset_first_epoch)
+                with pack_stream.wait() as first_pack_source:
+                    ttl.copy(first_pack_source, output_tensor[0, 0]).wait()
+                ttl.reset_all_dfbs(reset_second_epoch)
+                ttl.reset_all_dfbs(reset_third_epoch)
+                with pack_stream.wait() as second_pack_source:
+                    ttl.copy(second_pack_source, output_tensor[0, 1]).wait()
+
+    return nested_reset_target_access_kernel
+
+
 def _make_allocation_group_kernel(data_format):
     reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
     compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
@@ -1719,6 +1900,94 @@ def test_selected_reset_preserves_non_target_live_aliases(
         rtol=0.05,
         atol=1.0,
     )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_allocation_group_reuses_interleaved_reset_epochs(
+    device, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    data_format = "bf16" if dtype == torch.bfloat16 else "float32"
+    operation = _make_interleaved_allocation_group_epochs_kernel(data_format)
+
+    element_indices = torch.arange(2 * TILE * TILE, dtype=torch.float32).reshape(
+        TILE, 2 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_path = tmp_path / "interleaved_allocation_group_epochs.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    for _ in range(2):
+        operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+
+    physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
+    assert physical_dfb_count == 1
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = torch.cat(
+        (
+            torch.full((TILE, TILE), 3, dtype=torch.float32),
+            torch.full((TILE, TILE), 7, dtype=torch.float32),
+        ),
+        dim=1,
+    )
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_nested_unknown_reset_target_does_not_reverse_reset_order(
+    device, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    data_format = "bf16" if dtype == torch.bfloat16 else "float32"
+    operation = _make_nested_reset_target_access_kernel(data_format)
+
+    element_indices = torch.arange(2 * TILE * TILE, dtype=torch.float32).reshape(
+        TILE, 2 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_path = tmp_path / "nested_reset_target_access.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    for _dispatch_iteration in range(2):
+        operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+
+    # The interleaved group uses one index. The unresolved dynamic scratch
+    # remains separate rather than creating a global reverse reset relation.
+    physical_dfb_count = final_mlir_path.read_text().count("dfb_index =")
+    assert physical_dfb_count == 2
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = torch.cat(
+        (
+            torch.full((TILE, TILE), 3, dtype=torch.float32),
+            torch.full((TILE, TILE), 7, dtype=torch.float32),
+        ),
+        dim=1,
+    )
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs.mlir
@@ -1,0 +1,91 @@
+// Tests allocation groups whose members alternate across synchronized reset epochs.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// The group alternates A0, B0, A1, B1 across three logical kernels. Each
+// reset establishes canonical state before ownership changes between NOC0,
+// compute, and NOC1. Native acquire operations in later epochs must retain the
+// next same-kind acquire as their ownership boundary.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 3 : i32, dfb_index = 0 : i32
+// CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+// CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+// REPORT: DFB allocation group #ttl.dfb_allocation_group<0> launch_node=(0,0) epoch_order=[0:0, 1:0, 0:1, 1:1]
+// REPORT: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// REPORT: Total DFB count: 1
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "allocation_group_epochs">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = [0 : i32]} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %a0 = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    ttl.reset_dfbs <1, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %a1 = ttl.cb_reserve %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <2, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+
+  func.func @compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "allocation_group_epochs">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %a0 = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %b0 = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <1, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %a1 = ttl.cb_wait %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %a : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <2, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %b1 = ttl.cb_reserve %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "allocation_group_epochs">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = [1 : i32]} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %b0 = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <1, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    ttl.reset_dfbs <2, participants[<kind = compute, identity = "compute", operation = "allocation_group_epochs">, <kind = data_movement, identity = "reader", operation = "allocation_group_epochs">, <kind = data_movement, identity = "writer", operation = "allocation_group_epochs">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %b1 = ttl.cb_wait %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %b : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs_assume_safe.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs_assume_safe.mlir
@@ -1,0 +1,72 @@
+// Tests unsafe handoff between interleaved allocation-group epochs.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true unsafe-assume-allocation-groups=true})' 2>%t.warning | FileCheck %s
+// RUN: FileCheck %s --check-prefix=WARNING < %t.warning
+
+// A0 resets at offset one. B0 then leaves offset two in the three-tile
+// envelope, so A1's two-tile transaction requires an assumed epoch reset.
+
+// CHECK: module attributes {ttl.assumed_dfb_allocation_groups = [{allocation_group = #ttl.dfb_allocation_group<0>, assumptions = [{lhs = 0 : i64, reason = "epoch-reset"}], members = [0, 1]}]
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+// WARNING: warning: unsafe DFB allocation-group policy accepted #ttl.dfb_allocation_group<0> members=[0, 1] without compiler proof: epoch-reset(0)
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @interleaved_epoch_reset()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "interleaved_epoch_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "a0"
+        dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>,
+                     #ttl.dfb_protocol_effect<push, 0, 1>,
+                     #ttl.dfb_protocol_effect<wait, 0, 1>,
+                     #ttl.dfb_protocol_effect<pop, 0, 1>]
+        () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "interleaved_epoch_reset">, <kind = data_movement, identity = "reader", operation = "interleaved_epoch_reset">, <kind = data_movement, identity = "writer", operation = "interleaved_epoch_reset">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    ttl.opaque_call "b0"
+        dfb_dependencies(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+        dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 2>,
+                     #ttl.dfb_protocol_effect<push, 0, 2>,
+                     #ttl.dfb_protocol_effect<wait, 0, 2>,
+                     #ttl.dfb_protocol_effect<pop, 0, 2>]
+        () {header = "effects.hpp"} : () -> ()
+    ttl.opaque_call "a1"
+        dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+        dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 2>,
+                     #ttl.dfb_protocol_effect<push, 0, 2>,
+                     #ttl.dfb_protocol_effect<wait, 0, 2>,
+                     #ttl.dfb_protocol_effect<pop, 0, 2>]
+        () {header = "effects.hpp"} : () -> ()
+    return
+  }
+
+  func.func @reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "interleaved_epoch_reset">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "interleaved_epoch_reset">, <kind = data_movement, identity = "reader", operation = "interleaved_epoch_reset">, <kind = data_movement, identity = "writer", operation = "interleaved_epoch_reset">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "interleaved_epoch_reset">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "interleaved_epoch_reset">, <kind = data_movement, identity = "reader", operation = "interleaved_epoch_reset">, <kind = data_movement, identity = "writer", operation = "interleaved_epoch_reset">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs_invalid.mlir
@@ -1,0 +1,167 @@
+// Tests rejected reset-epoch allocation-group contracts.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})'
+
+// Without the reset between B0 and A1, B's complete lifetime overlaps A1.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @missing_reset_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "producer", operation = "missing_reset">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "produce_a0" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "consumer", operation = "missing_reset">, <kind = data_movement, identity = "producer", operation = "missing_reset">, <kind = data_movement, identity = "writer", operation = "missing_reset">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] cannot alias logical DFBs 0 and 1: concurrent-lifetime}}
+    ttl.opaque_call "produce_b" dfb_dependencies(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.opaque_call "produce_a1" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+
+  func.func @missing_reset_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "consumer", operation = "missing_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "consume_a0" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "consumer", operation = "missing_reset">, <kind = data_movement, identity = "producer", operation = "missing_reset">, <kind = data_movement, identity = "writer", operation = "missing_reset">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    ttl.opaque_call "consume_a1" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.opaque_call "consume_b" dfb_dependencies(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+
+  func.func @missing_reset_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "missing_reset">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "consumer", operation = "missing_reset">, <kind = data_movement, identity = "producer", operation = "missing_reset">, <kind = data_movement, identity = "writer", operation = "missing_reset">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+}
+
+// -----
+
+// A noncanonical A1 epoch cannot hand the physical index from NOC0 to NOC1.
+// Resets of the control DFB establish ordering without resetting A1.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @owner_noc0()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "noc0", operation = "owner_handoff">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 3 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %control = ttl.bind_cb {cb_index = 2, block_count = 1}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    ttl.opaque_call "a0" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "owner_handoff">, <kind = data_movement, identity = "noc0", operation = "owner_handoff">, <kind = data_movement, identity = "noc1", operation = "owner_handoff">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    ttl.opaque_call "a1" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <1, participants[<kind = compute, identity = "compute", operation = "owner_handoff">, <kind = data_movement, identity = "noc0", operation = "owner_handoff">, <kind = data_movement, identity = "noc1", operation = "owner_handoff">]>(%control : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    return
+  }
+
+  func.func @owner_noc1()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "noc1", operation = "owner_handoff">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 3 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %control = ttl.bind_cb {cb_index = 2, block_count = 1}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "owner_handoff">, <kind = data_movement, identity = "noc0", operation = "owner_handoff">, <kind = data_movement, identity = "noc1", operation = "owner_handoff">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    ttl.reset_dfbs <1, participants[<kind = compute, identity = "compute", operation = "owner_handoff">, <kind = data_movement, identity = "noc0", operation = "owner_handoff">, <kind = data_movement, identity = "noc1", operation = "owner_handoff">]>(%control : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<1> members=[0, 1] cannot alias logical DFBs 0 and 1: pointer-owner-mismatch}}
+    ttl.opaque_call "b0" dfb_dependencies(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+
+  func.func @owner_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "owner_handoff">,
+                  ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %control = ttl.bind_cb {cb_index = 2, block_count = 1}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "owner_handoff">, <kind = data_movement, identity = "noc0", operation = "owner_handoff">, <kind = data_movement, identity = "noc1", operation = "owner_handoff">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    ttl.reset_dfbs <1, participants[<kind = compute, identity = "compute", operation = "owner_handoff">, <kind = data_movement, identity = "noc0", operation = "owner_handoff">, <kind = data_movement, identity = "noc1", operation = "owner_handoff">]>(%control : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    return
+  }
+}
+
+// -----
+
+// A0 resets at offset one. B0 leaves offset two in the three-tile envelope,
+// so A1's two-tile transaction would straddle the physical ring boundary.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @epoch_envelope_crossing()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "epoch_envelope_crossing">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %b = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "a0" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "epoch_envelope_crossing">, <kind = data_movement, identity = "reader", operation = "epoch_envelope_crossing">, <kind = data_movement, identity = "writer", operation = "epoch_envelope_crossing">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    ttl.opaque_call "b0" dfb_dependencies(%b : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 2>, #ttl.dfb_protocol_effect<push, 0, 2>, #ttl.dfb_protocol_effect<wait, 0, 2>, #ttl.dfb_protocol_effect<pop, 0, 2>] () {header = "effects.hpp"} : () -> ()
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<2> members=[0, 1] physical envelope of 3 tiles makes logical DFB 0 epoch 1 cross the ring boundary on launch node (0,0)}}
+    ttl.opaque_call "a1" dfb_dependencies(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 2>, #ttl.dfb_protocol_effect<push, 0, 2>, #ttl.dfb_protocol_effect<wait, 0, 2>, #ttl.dfb_protocol_effect<pop, 0, 2>] () {header = "effects.hpp"} : () -> ()
+    return
+  }
+
+  func.func @epoch_envelope_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "epoch_envelope_crossing">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "epoch_envelope_crossing">, <kind = data_movement, identity = "reader", operation = "epoch_envelope_crossing">, <kind = data_movement, identity = "writer", operation = "epoch_envelope_crossing">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @epoch_envelope_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "epoch_envelope_crossing">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %a = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "epoch_envelope_crossing">, <kind = data_movement, identity = "reader", operation = "epoch_envelope_crossing">, <kind = data_movement, identity = "writer", operation = "epoch_envelope_crossing">]>(%a : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_reset_terminal_state.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_reset_terminal_state.mlir
@@ -1,0 +1,63 @@
+// Tests allocation-group handoff from a reset-terminated producer epoch.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s
+
+// The first epoch has advanced only the write pointer when the synchronized
+// reset establishes canonical state. The second DFB may then use the group.
+// CHECK: DFB allocation group #ttl.dfb_allocation_group<0> launch_node=(0,0) epoch_order=[0:0, 1:0]
+// CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// CHECK: Total DFB count: 1
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "reset_terminal">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %stale = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %stale_slot = ttl.cb_reserve %stale
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %stale : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_terminal">, <kind = data_movement, identity = "reader", operation = "reset_terminal">, <kind = data_movement, identity = "writer", operation = "reset_terminal">]>(%stale : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %current_slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "reset_terminal">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %stale = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_terminal">, <kind = data_movement, identity = "reader", operation = "reset_terminal">, <kind = data_movement, identity = "writer", operation = "reset_terminal">]>(%stale : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %current_slot = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "reset_terminal">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %stale = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_terminal">, <kind = data_movement, identity = "reader", operation = "reset_terminal">, <kind = data_movement, identity = "writer", operation = "reset_terminal">]>(%stale : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_assume_safe_hard_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_assume_safe_hard_invalid.mlir
@@ -89,13 +89,13 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "first", operation = "cyclic_order">,
                   ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
                   ttl.crta_indices = []} {
-    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<5> members=[10, 11] has contradictory cursor order involving logical DFB 10 on launch node (0,0)}}
     %first = ttl.bind_cb {cb_index = 0, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<5>, dfb_id = 10 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %second = ttl.bind_cb {cb_index = 1, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<5>, dfb_id = 11 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<5> members=[10, 11] has contradictory cursor order involving logical DFB 10 on launch node (0,0)}}
     %first_read = ttl.cb_wait %first
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
           -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -188,7 +188,6 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>,
                   ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
                   ttl.crta_indices = []} {
-    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<2> members=[4, 5] physical envelope of 3 tiles makes logical DFB 4 cross the ring boundary on launch node (0,0)}}
     %first = ttl.bind_cb {cb_index = 0, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 4 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -199,6 +198,7 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
     %upper = arith.constant 2 : index
     %step = arith.constant 1 : index
     scf.for %transaction = %lower to %upper step %step {
+      // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<2> members=[4, 5] physical envelope of 3 tiles makes logical DFB 4 cross the ring boundary on launch node (0,0)}}
       ttl.opaque_call "produce_two" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 2>, #ttl.dfb_protocol_effect<push, 0, 2>] () {header = "producer.hpp"} : () -> ()
     }
     %second_slot = ttl.cb_reserve %second

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_grouped_reset_assume_safe.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_grouped_reset_assume_safe.mlir
@@ -1,18 +1,18 @@
-// Tests assumable incomplete lifecycles that remain wholly on one reset side.
+// Tests grouped reset completion and unsafe assumptions for unresolved
+// allocation-group lifecycles.
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true unsafe-assume-allocation-groups=true})' > %t.output 2> %t.warning
 // RUN: FileCheck %s --check-prefix=OUTPUT < %t.output
 // RUN: FileCheck %s --check-prefix=WARNING < %t.warning
 
-// An exact untyped access before the reset is incomplete but does not cross
-// the reset boundary.
+// A reset expanded to every allocation-group member completes an exact untyped
+// access before the reset without an unsafe assumption.
 
 // OUTPUT-LABEL: func.func @exact_reader
 // OUTPUT: %[[EXACT_SELECTED:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
 // OUTPUT-NEXT: %[[EXACT_BEFORE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
 
 // WARNING-NOT: reset-domain-write
-// WARNING: warning: unsafe DFB allocation-group policy accepted #ttl.dfb_allocation_group<0> members=[0, 1] without compiler proof: {{.*}}access-completion-not-proven(0,1)
-// WARNING-NOT: reset-domain-write
+// WARNING-NOT: #ttl.dfb_allocation_group<0>
 
 module attributes {
   ttl.launch_grid = array<i64: 1, 1>,
@@ -20,7 +20,7 @@ module attributes {
 } {
   func.func @exact_reader()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
-                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "exact_incomplete_before">,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "exact_reset_completed">,
                   ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
                   ttl.crta_indices = []} {
     %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
@@ -30,7 +30,7 @@ module attributes {
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.opaque_call "untyped_access" dfb_dependencies(%before : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "effects.hpp"} : () -> ()
-    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "exact_incomplete_before">, <kind = data_movement, identity = "reader", operation = "exact_incomplete_before">, <kind = data_movement, identity = "writer", operation = "exact_incomplete_before">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "exact_reset_completed">, <kind = data_movement, identity = "reader", operation = "exact_reset_completed">, <kind = data_movement, identity = "writer", operation = "exact_reset_completed">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
     %selected_slot = ttl.cb_reserve %selected
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
           -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -41,12 +41,12 @@ module attributes {
 
   func.func @exact_compute()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "exact_incomplete_before">,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "exact_reset_completed">,
                   ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
     %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "exact_incomplete_before">, <kind = data_movement, identity = "reader", operation = "exact_incomplete_before">, <kind = data_movement, identity = "writer", operation = "exact_incomplete_before">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "exact_reset_completed">, <kind = data_movement, identity = "reader", operation = "exact_reset_completed">, <kind = data_movement, identity = "writer", operation = "exact_reset_completed">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
     %selected_slot = ttl.cb_wait %selected
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
           -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -57,13 +57,13 @@ module attributes {
 
   func.func @exact_writer()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
-                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "exact_incomplete_before">,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "exact_reset_completed">,
                   ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
                   ttl.crta_indices = []} {
     %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "exact_incomplete_before">, <kind = data_movement, identity = "reader", operation = "exact_incomplete_before">, <kind = data_movement, identity = "writer", operation = "exact_incomplete_before">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "exact_reset_completed">, <kind = data_movement, identity = "reader", operation = "exact_reset_completed">, <kind = data_movement, identity = "writer", operation = "exact_reset_completed">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_invalid.mlir
@@ -46,7 +46,6 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "envelope_cursor">,
                   ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
                   ttl.crta_indices = []} {
-    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<6> members=[11, 12] physical envelope of 3 tiles makes logical DFB 11 cross the ring boundary on launch node (0,0)}}
     %first = ttl.bind_cb {cb_index = 0, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<6>, dfb_id = 11 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -57,6 +56,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
     %upper = arith.constant 2 : index
     %step = arith.constant 1 : index
     scf.for %transaction = %lower to %upper step %step {
+      // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<6> members=[11, 12] physical envelope of 3 tiles makes logical DFB 11 epoch 0 cross the ring boundary on launch node (0,0)}}
       ttl.opaque_call "produce_two" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 2>, #ttl.dfb_protocol_effect<push, 0, 2>] () {header = "producer.hpp"} : () -> ()
     }
     ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "envelope_cursor">, <kind = data_movement, identity = "reader", operation = "envelope_cursor">, <kind = data_movement, identity = "writer", operation = "envelope_cursor">]>(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
@@ -367,7 +367,7 @@ func.func @loop_lifecycle()
 // -----
 
 // Ordered lifetimes cannot share when the producer pointer changes from NOC0
-// to Pack. Quiescence does not transfer write-pointer ownership.
+// to Pack. Lifecycle completion does not transfer write-pointer ownership.
 
 // REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
 // REUSE-LABEL: func.func @producer_transition_dm

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
@@ -2,22 +2,21 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
 
 // A descriptor reference keeps A live through the external call without a
-// runtime DFB argument. The call completes before A's pop, so the
-// acknowledgment still orders B after A and permits A and B to share physical
-// index 0. The index query after the pop does not access physical storage and
-// does not extend A's lifetime.
+// runtime DFB argument. The unsummarized call may change A's protocol state,
+// so A remains unbounded and cannot share with B. The index query after the pop
+// does not access physical storage and does not extend A's lifetime.
 
-// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}]}
 // CHECK-LABEL: func.func @external_use_before_release_dm
-// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK-SAME: ttl.base_cta_index = 3 : i32
 // CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
-// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
 // CHECK-LABEL: func.func @external_use_before_release_compute
-// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK-SAME: ttl.base_cta_index = 3 : i32
 // CHECK-DAG: %[[A:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
-// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
 // CHECK: ttl.opaque_call "inspect_dfb" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%[[A]] : !ttl.cb<{{.*}}>) () {header = "inspect_dfb.hpp"}
 // CHECK: ttl.cb_pop %[[A]]
 // CHECK: ttl.get_dfb_id %[[A]]

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
@@ -58,37 +58,6 @@ module {
 
 // -----
 
-// An acquisition nested in a separate region from its release is not a valid
-// automatic synchronization interval.
-
-// CHECK-LABEL: func.func @nested_reserve
-// CHECK-SAME: ttl.base_cta_index = 2 : i32
-// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
-
-module {
-  func.func @nested_reserve()
-      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
-    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %first_reserved = scf.execute_region -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
-      %nested_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      scf.yield %nested_reserved : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    }
-    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    return
-  }
-}
-
-// -----
-
 // A multi-block function has no modeled linear program order.
 
 // CHECK-LABEL: func.func @multiple_blocks

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_conditional_lifecycle.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_conditional_lifecycle.mlir
@@ -4,8 +4,8 @@
 
 // REPORT: DFB logical_id=0 bounded=0 compiler_created=0 conditionally_bounded=1
 // REPORT-SAME: domain=unknown
-// REPORT: possible_nodes quiescence=none domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(0,0)}
-// REPORT: possible_nodes quiescence=none domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(1,0)}
+// REPORT: possible_nodes lifecycle_completion=complete domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(0,0)}
+// REPORT: possible_nodes lifecycle_completion=complete domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(1,0)}
 // REPORT: DFB logical_id=1 bounded=0 compiler_created=0 conditionally_bounded=1
 // REPORT-SAME: domain=unknown
 // REPORT: DFB assignment: logical DFB 0 -> physical index 0 (bounded)
@@ -158,7 +158,7 @@ module {
 
 // -----
 
-// A complete conditional transaction is quiescent before a later exact-count
+// A complete conditional transaction finishes before a later exact-count
 // transaction whether its condition is false or true.
 // CHECK-LABEL: func.func @conditional_and_exact_domains
 // CHECK-SAME: ttl.base_cta_index = 1 : i32
@@ -416,7 +416,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 
 // Equal affine operands do not establish condition identity when the
 // immutable IntegerSets differ.
-// REPORT: possible_nodes quiescence=unsupported-control-flow {{.*}} kernel=@different_affine_predicates
+// REPORT: possible_nodes lifecycle_completion=unsupported-control-flow {{.*}} kernel=@different_affine_predicates
 // CHECK-LABEL: func.func @different_affine_predicates
 // CHECK-SAME: ttl.base_cta_index = 2 : i32
 // CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_cumulative_queue_state.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_cumulative_queue_state.mlir
@@ -6,7 +6,7 @@
 // reservations depend on consumer progress because the DFB holds 12 tiles.
 
 // CHECK: DFB logical_id=0 bounded=1
-// CHECK: node (0,0) quiescence=none
+// CHECK: node (0,0) lifecycle_completion=complete
 // CHECK-SAME: transactions=[4, 4, 4, 4]
 
 module {
@@ -64,7 +64,7 @@ module {
 // ALLOC-NEXT: ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
 // CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=24576 handoff=proven
 // CHECK: DFB logical_id=0 bounded=1
-// CHECK: node (0,0) quiescence=none
+// CHECK: node (0,0) lifecycle_completion=complete
 // CHECK-SAME: transactions=[4, 4] write_cursor_runs=[8] read_cursor_runs=[4, 4]
 
 module {
@@ -104,7 +104,7 @@ module {
 // moves once by eight tiles.
 
 // CHECK: DFB logical_id=0 bounded=1
-// CHECK: node (0,0) quiescence=none
+// CHECK: node (0,0) lifecycle_completion=complete
 // CHECK-SAME: transactions=[4, 4] write_cursor_runs=[8] read_cursor_runs=[4, 4]
 
 module {
@@ -146,7 +146,7 @@ module {
 // One high-water wait may protect two smaller pointer advancements.
 
 // CHECK: DFB logical_id=0 bounded=1
-// CHECK: node (0,0) quiescence=none
+// CHECK: node (0,0) lifecycle_completion=complete
 // CHECK-SAME: transactions=[4, 4]
 
 module {
@@ -190,7 +190,7 @@ module {
 // prove differently partitioned producer and consumer cursor movement.
 
 // CHECK: DFB logical_id=0 bounded=1
-// CHECK: node (0,0) quiescence=none
+// CHECK: node (0,0) lifecycle_completion=complete
 // CHECK-SAME: transactions=[4, 4, 4] write_cursor_runs=[4, 8] read_cursor_runs=[8, 4]
 
 module {
@@ -236,7 +236,7 @@ module {
 // cumulative DFB has the lower logical identity.
 
 // CHECK: DFB logical_id=0 bounded=1
-// CHECK: node (0,0) quiescence=none
+// CHECK: node (0,0) lifecycle_completion=complete
 // CHECK-SAME: transactions=[4, 4, 4] write_cursor_runs=[4, 8] read_cursor_runs=[8, 4]
 
 module {

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_cumulative_queue_state_allocation_group_assume_safe_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_cumulative_queue_state_allocation_group_assume_safe_invalid.mlir
@@ -10,13 +10,13 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.noc_index = 0 : i32,
                   ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
-    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] has contradictory cursor order involving logical DFB 0 on launch node (0,0)}}
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
         : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
     %other = ttl.bind_cb {cb_index = 1, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
         : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] has contradictory cursor order involving logical DFB 0 on launch node (0,0)}}
     ttl.opaque_call "producer"
         dfb_dependencies(%dfb : !ttl.cb<[1, 4], !ttcore.tile<32x32, bf16>, 2>)
         dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 8>,

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_cumulative_queue_state_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_cumulative_queue_state_conservative.mlir
@@ -1,7 +1,7 @@
 // Tests conservative rejection of unsupported cumulative DFB queue state.
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s
 
-// CHECK: quiescence=mismatched-transaction {{.*}} kernel=@total_mismatch
+// CHECK: lifecycle_completion=mismatched-transaction {{.*}} kernel=@total_mismatch
 
 module {
   func.func @total_mismatch()
@@ -31,7 +31,7 @@ module {
 
 // -----
 
-// CHECK: quiescence=mismatched-transaction {{.*}} kernel=@pop_exceeds_wait
+// CHECK: lifecycle_completion=mismatched-transaction {{.*}} kernel=@pop_exceeds_wait
 
 module {
   func.func @pop_exceeds_wait()
@@ -61,7 +61,7 @@ module {
 
 // -----
 
-// CHECK: quiescence=mismatched-transaction {{.*}} kernel=@push_exceeds_reserve
+// CHECK: lifecycle_completion=mismatched-transaction {{.*}} kernel=@push_exceeds_reserve
 
 module {
   func.func @push_exceeds_reserve()
@@ -91,7 +91,7 @@ module {
 
 // -----
 
-// CHECK: quiescence=incomplete-use-order {{.*}} kernel=@unpublished_wait
+// CHECK: lifecycle_completion=incomplete-use-order {{.*}} kernel=@unpublished_wait
 
 module {
   func.func @unpublished_wait()
@@ -127,7 +127,7 @@ module {
 // Waiting for the second publication before the pop that enables its reserve
 // would introduce a cycle, so no synchronization relation is proved.
 
-// CHECK: quiescence=incomplete-use-order {{.*}} kernel=@cyclic_capacity_producer
+// CHECK: lifecycle_completion=incomplete-use-order {{.*}} kernel=@cyclic_capacity_producer
 
 module {
   func.func @cyclic_capacity_producer()
@@ -164,7 +164,7 @@ module {
 
 // -----
 
-// CHECK: quiescence=mismatched-transaction {{.*}} kernel=@cursor_crossing
+// CHECK: lifecycle_completion=mismatched-transaction {{.*}} kernel=@cursor_crossing
 
 module {
   func.func @cursor_crossing()

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
@@ -250,7 +250,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // REPORT: DFB logical_id=18 bounded=1 compiler_created=0
 // REPORT-SAME: domain={(0,0), (1,0)}
-// REPORT: node (0,0) quiescence=none
+// REPORT: node (0,0) lifecycle_completion=complete
 // REPORT-SAME: occurrences=[0:2, 1:2, 2:2, 3:2]
 // REPORT-SAME: transactions=[1, 1]
 // REPORT: DFB conflict lhs=18 rhs=19 reason=transaction-mismatch node=(0,0)

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
@@ -11,7 +11,7 @@
 
 // REPORT: DFB logical_id=0 bounded=0 compiler_created=0
 // REPORT-SAME: domain={}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={}
 // REPORT: DFB logical_id=1 bounded=0 compiler_created=0
 // REPORT-SAME: domain=unknown
 // REPORT-NOT: DFB conflict lhs=0 rhs=1
@@ -101,7 +101,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // REPORT: DFB logical_id=12 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(0,0), (1,0)}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0), (1,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={(0,0), (1,0)}
 // REPORT: DFB conflict lhs=12 rhs=13 reason=unknown-launch-node-domain
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
@@ -146,7 +146,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // REPORT: DFB logical_id=14 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(0,0)}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={(0,0)}
 // REPORT: DFB logical_id=15 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(1,0)}
 // REPORT-NOT: DFB conflict lhs=14 rhs=15
@@ -202,7 +202,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 // REPORT: DFB logical_id=16 bounded=0 compiler_created=0
 // REPORT-SAME: domain=unknown
 // REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(0,0), (1,0)}
-// REPORT: access 4 effect=none tiles=0 sequence=0 domain=unknown
+// REPORT: access 4 effect=none tiles=0 sequence=0 opaque_external=1 domain=unknown
 // REPORT: DFB logical_id=17 bounded=1 compiler_created=0
 // REPORT-SAME: domain={(0,0), (1,0)}
 // REPORT: DFB conflict lhs=16 rhs=17 reason=unknown-launch-node-domain
@@ -323,7 +323,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // REPORT: DFB logical_id=24 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(0,0)}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={(0,0)}
 // REPORT: access 1 effect=none tiles=0 sequence=0 domain={(0,0)}
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
@@ -1,0 +1,154 @@
+// Tests storage reuse after a synchronized reset canonicalizes protocol state
+// following named opaque external DFB accesses.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s
+
+// Reader and compute execute runtime-dependent external protocols on `old`.
+// Their collective reset establishes canonical protocol state without
+// asserting internal transaction counts, then permits `current` to reuse the
+// physical DFB.
+
+// CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// CHECK: DFB logical_id=0 bounded=1{{.*}}opaque_external_access=1
+// CHECK: opaque_protocol_reset=1
+// CHECK: reset_epochs=[{accesses=[0, 1],transactions=[],write_owner=unknown,read_owner=unknown,terminal_reset=0,opaque_protocol_reset=1,terminal_state=canonical}]
+// CHECK: DFB logical_id=1 bounded=1{{.*}}allocation_group=#ttl.dfb_allocation_group<0>
+// CHECK: Total DFB count: 1
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @opaque_reset_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "opaque_reset">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "runtime_chunk_reader" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "opaque_reset">, <kind = data_movement, identity = "reader", operation = "opaque_reset">, <kind = data_movement, identity = "writer", operation = "opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @opaque_reset_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "opaque_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "runtime_chunk_compute" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "opaque_reset">, <kind = data_movement, identity = "reader", operation = "opaque_reset">, <kind = data_movement, identity = "writer", operation = "opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %slot = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @opaque_reset_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "opaque_reset">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "opaque_reset">, <kind = data_movement, identity = "reader", operation = "opaque_reset">, <kind = data_movement, identity = "writer", operation = "opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+}
+
+// -----
+
+// Equal typed predicates prove that the opaque access, matching reset, and
+// following lifecycle execute together on each possible launch node.
+
+// CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// CHECK: DFB logical_id=0 bounded=1 compiler_created=0 conditionally_bounded=0 opaque_external_access=1
+// CHECK: node (0,0) quiescence=none domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
+// CHECK: node (1,0) quiescence=none domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
+// CHECK: DFB logical_id=1 bounded=1 compiler_created=0 conditionally_bounded=0
+// CHECK: Total DFB count: 1
+
+module attributes {ttl.launch_grid = [2, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @conditional_opaque_reset_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : i64
+    %value = ttl.opaque_call "reader_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+    %active = arith.cmpi ne, %value, %zero : i64
+    scf.if %active {
+      ttl.opaque_call "runtime_chunk_reader" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+      %slot = ttl.cb_reserve %current
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    }
+    return
+  }
+
+  func.func @conditional_opaque_reset_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "conditional_opaque_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : i64
+    %value = ttl.opaque_call "compute_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+    %active = arith.cmpi ne, %value, %zero : i64
+    scf.if %active {
+      ttl.opaque_call "runtime_chunk_compute" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+      %slot = ttl.cb_wait %current
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    }
+    return
+  }
+
+  func.func @conditional_opaque_reset_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : i64
+    %value = ttl.opaque_call "writer_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+    %active = arith.cmpi ne, %value, %zero : i64
+    scf.if %active {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
@@ -77,8 +77,8 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 
 // CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
 // CHECK: DFB logical_id=0 bounded=1 compiler_created=0 conditionally_bounded=0 opaque_external_access=1
-// CHECK: node (0,0) quiescence=none domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
-// CHECK: node (1,0) quiescence=none domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
+// CHECK: node (0,0) lifecycle_completion=complete domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
+// CHECK: node (1,0) lifecycle_completion=complete domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
 // CHECK: DFB logical_id=1 bounded=1 compiler_created=0 conditionally_bounded=0
 // CHECK: Total DFB count: 1
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime_invalid.mlir
@@ -1,0 +1,262 @@
+// Tests rejected opaque external DFB lifetime contracts.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})'
+
+// A named opaque dependency remains unproved without a synchronized reset.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @missing_reset()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "missing_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] cannot alias logical DFBs 0 and 1: access-completion-not-proven}}
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "opaque" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A partial explicit effect summary remains subject to transaction analysis.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @explicit_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "explicit">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "reserve_only" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "explicit">, <kind = data_movement, identity = "reader", operation = "explicit">, <kind = data_movement, identity = "writer", operation = "explicit">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<4> members=[0, 1] cannot alias logical DFBs 0 and 1: access-completion-not-proven}}
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @explicit_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "explicit">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "explicit">, <kind = data_movement, identity = "reader", operation = "explicit">, <kind = data_movement, identity = "writer", operation = "explicit">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @explicit_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "explicit">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "explicit">, <kind = data_movement, identity = "reader", operation = "explicit">, <kind = data_movement, identity = "writer", operation = "explicit">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}
+
+// -----
+
+// Two opaque lifetimes before the same reset cannot share storage.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @same_epoch_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "same_epoch">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<1> members=[0, 1] cannot alias logical DFBs 0 and 1: concurrent-lifetime}}
+    ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "same_epoch">, <kind = data_movement, identity = "reader", operation = "same_epoch">, <kind = data_movement, identity = "writer", operation = "same_epoch">]>(%first, %second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @same_epoch_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "same_epoch">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "same_epoch">, <kind = data_movement, identity = "reader", operation = "same_epoch">, <kind = data_movement, identity = "writer", operation = "same_epoch">]>(%first, %second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @same_epoch_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "same_epoch">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "same_epoch">, <kind = data_movement, identity = "reader", operation = "same_epoch">, <kind = data_movement, identity = "writer", operation = "same_epoch">]>(%first, %second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}
+
+// -----
+
+// A reset does not reconfigure an opaque external DFB descriptor.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @descriptor_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "descriptor">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<2> members=[0, 1] cannot alias logical DFBs 0 and 1: descriptor-mismatch}}
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "opaque" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "descriptor">, <kind = data_movement, identity = "reader", operation = "descriptor">, <kind = data_movement, identity = "writer", operation = "descriptor">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @descriptor_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "descriptor">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "descriptor">, <kind = data_movement, identity = "reader", operation = "descriptor">, <kind = data_movement, identity = "writer", operation = "descriptor">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+
+  func.func @descriptor_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "descriptor">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "descriptor">, <kind = data_movement, identity = "reader", operation = "descriptor">, <kind = data_movement, identity = "writer", operation = "descriptor">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+}
+
+// -----
+
+// Unlisted DFB access remains unproved even when named DFBs are reset.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @unknown_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "unknown">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<3> members=[0, 1] cannot alias logical DFBs 0 and 1: access-completion-not-proven}}
+    ttl.opaque_call "opaque" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp", unknown_dfb_access} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "unknown">, <kind = data_movement, identity = "reader", operation = "unknown">, <kind = data_movement, identity = "writer", operation = "unknown">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @unknown_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "unknown">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "unknown">, <kind = data_movement, identity = "reader", operation = "unknown">, <kind = data_movement, identity = "writer", operation = "unknown">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @unknown_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "unknown">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "unknown">, <kind = data_movement, identity = "reader", operation = "unknown">, <kind = data_movement, identity = "writer", operation = "unknown">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_per_node_liveness.mlir
@@ -83,7 +83,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 // -----
 
 // Distinct function symbols may share when their per-node pointer processors
-// match and both producer and consumer entries follow a quiescent handoff.
+// match and both producer and consumer entries follow lifecycle completion.
 
 // CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}]}
 // CHECK-LABEL: func.func @first_owner_producer
@@ -185,8 +185,8 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // -----
 
-// Missing NOC ownership information prevents a quiescence proof and therefore
-// prevents otherwise ordered lifetimes from sharing one physical index.
+// Missing NOC ownership information prevents proving lifecycle completion, so
+// otherwise ordered lifetimes cannot share one physical index.
 
 // CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
 // CHECK-LABEL: func.func @unknown_noc_owner
@@ -228,7 +228,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // -----
 
-// Quiescent lifetimes with different transaction sizes retain separate ring
+// Completed lifecycles with different transaction sizes retain separate ring
 // pointer progressions and therefore cannot share a physical index.
 
 // CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
@@ -293,3 +293,67 @@ module {
     return
   }
 }
+
+// -----
+
+// Ordered sibling regions preserve native producer and consumer acquisition
+// intervals, including acquired-tensor uses before each release.
+
+// REPORT: operation=ttl.cb_reserve kernel=@sibling_region_acquire_release
+// REPORT: node (0,0) lifecycle_completion=complete
+// REPORT-SAME: transactions=[1]
+
+module {
+  func.func @sibling_region_acquire_release()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %enabled = arith.constant true
+    scf.if %enabled {
+      %reserved = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %producer_use = tensor.extract_slice %reserved[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    scf.if %enabled {
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.if %enabled {
+      %waited = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %consumer_use = tensor.extract_slice %waited[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    scf.if %enabled {
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// An acquisition in an at-most-once region precedes its release after the
+// region, so both complete lifecycles may share one physical index.
+
+// REUSE-LABEL: func.func @nested_reserve
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @nested_reserve()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = scf.execute_region -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+      %nested_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      scf.yield %nested_reserved : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
@@ -42,7 +42,7 @@ module {
 // size in the allocation report.
 
 // REPORT: operation=ttl.cb_reserve kernel=@large_static_run
-// REPORT: node (0,0) quiescence=none
+// REPORT: node (0,0) lifecycle_completion=complete
 // REPORT-SAME: transactions=[run(count=1000,tiles=1)]
 
 module {
@@ -74,15 +74,15 @@ module {
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
 // REPORT: operation=ttl.cb_reserve kernel=@nested_explicit_consumer
-// REPORT: node (0,0) quiescence=none
+// REPORT: node (0,0) lifecycle_completion=complete
 // REPORT-SAME: occurrences=[0:4, 1:4, 2:1, 3:1, 4:1, 5:1, 6:1, 7:1, 8:1, 9:1]
 // REPORT-SAME: transactions=[4, 4, 4, 4]
-// REPORT: node (1,0) quiescence=none
+// REPORT: node (1,0) lifecycle_completion=complete
 // REPORT-SAME: transactions=[4, 4, 4, 4]
 // REPORT: operation=ttl.cb_reserve kernel=@nested_explicit_consumer
-// REPORT: node (0,0) quiescence=none
+// REPORT: node (0,0) lifecycle_completion=complete
 // REPORT-SAME: transactions=[4, 4, 4, 4]
-// REPORT: node (1,0) quiescence=none
+// REPORT: node (1,0) lifecycle_completion=complete
 // REPORT-SAME: transactions=[4, 4, 4, 4]
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
@@ -161,10 +161,10 @@ module {
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
 // REPORT: operation=ttl.cb_reserve kernel=@loop_to_loop
-// REPORT: node (0,0) quiescence=none
+// REPORT: node (0,0) lifecycle_completion=complete
 // REPORT-SAME: transactions=[4, 4, 4, 4]
 // REPORT: operation=ttl.cb_reserve kernel=@loop_to_loop
-// REPORT: node (0,0) quiescence=none
+// REPORT: node (0,0) lifecycle_completion=complete
 // REPORT-SAME: transactions=[4, 4, 4, 4]
 
 module {
@@ -208,7 +208,7 @@ module {
 // REUSE-SAME: ttl.base_cta_index = 1 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // REPORT: DFB logical_id=0 bounded=0
-// REPORT: node (0,0) quiescence=missing-protocol-effect
+// REPORT: node (0,0) lifecycle_completion=missing-protocol-effect
 // REPORT-SAME: evidence=ttl.opaque_call kernel=@straight_line_producer
 // REPORT-SAME: transactions=[]
 
@@ -246,7 +246,7 @@ module {
 // Two transactions in each loop iteration form one complete protocol run.
 
 // REPORT: operation=ttl.cb_reserve kernel=@two_transactions_per_iteration_producer
-// REPORT: node (0,0) quiescence=none
+// REPORT: node (0,0) lifecycle_completion=complete
 // REPORT-SAME: transactions=[1, 1, 1, 1, 1, 1, 1, 1]
 
 module {

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
@@ -3,12 +3,13 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
 
 // A loop producer and an explicit external consumer describe the same four
-// transactions. The non-protocol producer access executes in the same loop.
+// transactions, but the unsummarized producer access may change protocol state.
+// Both DFBs therefore remain distinct.
 
 // REUSE-LABEL: func.func @loop_to_explicit
-// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
 
 module {
   func.func @loop_to_explicit()
@@ -76,6 +77,13 @@ module {
 // REPORT: node (0,0) quiescence=none
 // REPORT-SAME: occurrences=[0:4, 1:4, 2:1, 3:1, 4:1, 5:1, 6:1, 7:1, 8:1, 9:1]
 // REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: node (1,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: operation=ttl.cb_reserve kernel=@nested_explicit_consumer
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: node (1,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @nested_explicit_consumer()
@@ -109,12 +117,14 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// An explicit producer summary and a loop consumer normalize identically.
+// An explicit producer summary and a loop consumer describe matching
+// transactions, but the unsummarized consumer access may change protocol
+// state. Both DFBs therefore remain distinct.
 
 // REUSE-LABEL: func.func @explicit_to_loop
-// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
 
 module {
   func.func @explicit_to_loop()
@@ -150,7 +160,12 @@ module {
 // REUSE-SAME: ttl.base_cta_index = 1 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
-// REPORT-COUNT-6: transactions=[4, 4, 4, 4]
+// REPORT: operation=ttl.cb_reserve kernel=@loop_to_loop
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: operation=ttl.cb_reserve kernel=@loop_to_loop
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
 
 module {
   func.func @loop_to_loop()
@@ -183,8 +198,8 @@ module {
 
 // -----
 
-// Each straight-line acquisition owns only the direct DFB accesses before the
-// next same-kind acquisition. Both producer and consumer runs remain bounded.
+// Unsummarized accesses in the straight-line producer and consumer may change
+// protocol state, so the combined DFB lifetime remains unbounded.
 
 // REUSE-LABEL: func.func @straight_line_producer
 // REUSE-SAME: ttl.base_cta_index = 1 : i32
@@ -192,9 +207,10 @@ module {
 // REUSE-LABEL: func.func @straight_line_consumer
 // REUSE-SAME: ttl.base_cta_index = 1 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// REPORT: DFB logical_id=0 bounded=1
-// REPORT: node (0,0) quiescence=none
-// REPORT-SAME: transactions=[1, 1]
+// REPORT: DFB logical_id=0 bounded=0
+// REPORT: node (0,0) quiescence=missing-protocol-effect
+// REPORT-SAME: evidence=ttl.opaque_call kernel=@straight_line_producer
+// REPORT-SAME: transactions=[]
 
 module {
   func.func @straight_line_producer()

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
@@ -2,13 +2,14 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=ALLOC
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
 
-// ALLOC-COUNT-10: ttl.base_cta_index = 2 : i32
+// ALLOC-COUNT-11: ttl.base_cta_index = 2 : i32
 // REPORT: lifecycle_completion=mismatched-transaction {{.*}} kernel=@mismatched_count
 // REPORT: lifecycle_completion=mismatched-transaction {{.*}} kernel=@overlapping_consumer_acquires
 // REPORT: lifecycle_completion=mismatched-transaction {{.*}} kernel=@mismatched_tiles
 // REPORT: lifecycle_completion=unsupported-control-flow {{.*}} kernel=@dynamic_trip_count
 // REPORT: lifecycle_completion=incomplete-use-order {{.*}} kernel=@differing_iteration_domains
 // REPORT: lifecycle_completion=unsupported-control-flow {{.*}} kernel=@conditional_iteration
+// REPORT: lifecycle_completion=unsupported-control-flow {{.*}} kernel=@sibling_region_predicate_mismatch
 // REPORT: lifecycle_completion=unsupported-control-flow {{.*}} kernel=@nonuniform_exact_selection
 // REPORT: lifecycle_completion=missing-protocol-effect {{.*}} kernel=@access_outside_interval
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch
@@ -161,6 +162,38 @@ module {
     ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
     %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
     ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// Structural order between sibling regions does not establish matching
+// executions when their runtime predicates differ.
+
+module {
+  func.func @sibling_region_predicate_mismatch(%acquire_enabled: i1,
+                                                %release_enabled: i1)
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    scf.if %acquire_enabled {
+      %reserved = ttl.cb_reserve %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    scf.if %release_enabled {
+      ttl.cb_push %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.if %acquire_enabled {
+      %waited = ttl.cb_wait %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    scf.if %release_enabled {
+      ttl.cb_pop %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    %second_reserved = ttl.cb_reserve %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
@@ -3,16 +3,16 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
 
 // ALLOC-COUNT-10: ttl.base_cta_index = 2 : i32
-// REPORT: quiescence=mismatched-transaction {{.*}} kernel=@mismatched_count
-// REPORT: quiescence=mismatched-transaction {{.*}} kernel=@overlapping_consumer_acquires
-// REPORT: quiescence=mismatched-transaction {{.*}} kernel=@mismatched_tiles
-// REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@dynamic_trip_count
-// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@differing_iteration_domains
-// REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@conditional_iteration
-// REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@nonuniform_exact_selection
-// REPORT: quiescence=missing-protocol-effect {{.*}} kernel=@access_outside_interval
+// REPORT: lifecycle_completion=mismatched-transaction {{.*}} kernel=@mismatched_count
+// REPORT: lifecycle_completion=mismatched-transaction {{.*}} kernel=@overlapping_consumer_acquires
+// REPORT: lifecycle_completion=mismatched-transaction {{.*}} kernel=@mismatched_tiles
+// REPORT: lifecycle_completion=unsupported-control-flow {{.*}} kernel=@dynamic_trip_count
+// REPORT: lifecycle_completion=incomplete-use-order {{.*}} kernel=@differing_iteration_domains
+// REPORT: lifecycle_completion=unsupported-control-flow {{.*}} kernel=@conditional_iteration
+// REPORT: lifecycle_completion=unsupported-control-flow {{.*}} kernel=@nonuniform_exact_selection
+// REPORT: lifecycle_completion=missing-protocol-effect {{.*}} kernel=@access_outside_interval
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch
-// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@unrelated_opaque_access
+// REPORT: lifecycle_completion=incomplete-use-order {{.*}} kernel=@unrelated_opaque_access
 
 // Producer and consumer transaction counts must match.
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
@@ -10,7 +10,7 @@
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@differing_iteration_domains
 // REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@conditional_iteration
 // REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@nonuniform_exact_selection
-// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@access_outside_interval
+// REPORT: quiescence=missing-protocol-effect {{.*}} kernel=@access_outside_interval
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@unrelated_opaque_access
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reset_alias_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reset_alias_domain.mlir
@@ -110,9 +110,9 @@ module attributes {
 // on node (0,0) while DFB 1 is active there. A zero-trip wait shares DFB 1's
 // projected producer event but cannot supply evidence.
 // CHECK: DFB logical_id=0 bounded=0 compiler_created=0 conditionally_bounded=1
-// CHECK: possible_nodes quiescence=none domain_assumption=unknown-possible
+// CHECK: possible_nodes lifecycle_completion=complete domain_assumption=unknown-possible
 // CHECK: DFB logical_id=1 bounded=0 compiler_created=0 conditionally_bounded=1
-// CHECK: possible_nodes quiescence=none domain_assumption=unknown-possible
+// CHECK: possible_nodes lifecycle_completion=complete domain_assumption=unknown-possible
 // CHECK: DFB conflict lhs=0 rhs=1 reason=reset-domain-write node=(0,0)
 // CHECK-SAME: lhs_operation=ttl.reset_dfbs
 // CHECK-SAME: rhs_operation=ttl.cb_reserve

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reset_projected_access_order.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reset_projected_access_order.mlir
@@ -1,0 +1,101 @@
+// Tests reset ordering when a nested access lacks a dedicated event span.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
+
+// The dynamic scratch access projects to the outer loop, which also contains
+// every reset. Its incomplete local ordering must not create reverse relations
+// between reset boundaries or prevent the interleaved group from sharing.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 3 : i32, dfb_index = 0 : i32
+// CHECK-SAME: {block_count = 3 : i32, dfb_index = 1 : i32
+// CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+// CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+// CHECK: %{{.*}} = ttl.bind_cb{cb_index = 1, block_count = 3} {dfb_id = 2 : index}
+// REPORT: DFB allocation group #ttl.dfb_allocation_group<0> launch_node=(0,0) epoch_order=[0:0, 1:0, 0:1, 1:1]
+// REPORT: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// REPORT: Total DFB count: 2
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @nested_reset_target_access()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "nested_reset_target_access">,
+                  ttl.base_cta_index = 3 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %dynamic_scratch = ttl.bind_cb {cb_index = 2, block_count = 3}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %dynamic_count = ttl.opaque_call "dynamic_count" () {header = "count.hpp"} : () -> i32
+    %dynamic_upper_bound = arith.index_cast %dynamic_count : i32 to index
+    scf.for %outer = %zero to %one step %one {
+      ttl.opaque_call "first_epoch_0" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+      ttl.opaque_call "second_epoch_0" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+      ttl.reset_all_dfbs <1, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+      scf.for %scratch_iteration = %zero to %dynamic_upper_bound step %one {
+        %scratch_output = ttl.cb_reserve %dynamic_scratch : <[1, 1], !ttcore.tile<32x32, bf16>, 3> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        ttl.cb_push %dynamic_scratch : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+        %scratch_input = ttl.cb_wait %dynamic_scratch : <[1, 1], !ttcore.tile<32x32, bf16>, 3> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        ttl.cb_pop %dynamic_scratch : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+      }
+      ttl.opaque_call "first_epoch_1" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+      ttl.reset_all_dfbs <2, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+      ttl.opaque_call "second_epoch_1" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    }
+    return
+  }
+
+  func.func @reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "nested_reset_target_access">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 3 : i32,
+                  ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %dynamic_scratch = ttl.bind_cb {cb_index = 2, block_count = 3}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    scf.for %outer = %zero to %one step %one {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+      ttl.reset_all_dfbs <1, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+      ttl.reset_all_dfbs <2, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+    }
+    return
+  }
+
+  func.func @writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "nested_reset_target_access">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 3 : i32,
+                  ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %dynamic_scratch = ttl.bind_cb {cb_index = 2, block_count = 3}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    scf.for %outer = %zero to %one step %one {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+      ttl.reset_all_dfbs <1, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+      ttl.reset_all_dfbs <2, participants[<kind = compute, identity = "compute", operation = "nested_reset_target_access">, <kind = data_movement, identity = "reader", operation = "nested_reset_target_access">, <kind = data_movement, identity = "writer", operation = "nested_reset_target_access">]>
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
@@ -54,7 +54,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 // A selected reset partitions tensor-backed interface state. Payload bytes
 // remain allocated, but reset occupancy makes pre-reset payload unavailable.
 // CHECK: DFB logical_id=0 bounded=0
-// CHECK: quiescence=missing-protocol-effect
+// CHECK: lifecycle_completion=missing-protocol-effect
 // CHECK: reset_epochs=[{accesses=[0, 1],transactions=[1]
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
@@ -154,7 +154,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 // A fifth two-tile acquire would start at offset eight and cross the end of a
 // nine-tile DFB. A later reset cannot make that transaction contiguous.
 // CHECK: DFB logical_id=0 bounded=0
-// CHECK: quiescence=mismatched-transaction
+// CHECK: lifecycle_completion=mismatched-transaction
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @straddling_nondividing_run_producer()
@@ -204,9 +204,9 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 // A conditional reset cannot order unconditional accesses across logical
 // kernels because the synchronization does not execute on the disabled branch.
 // CHECK: DFB logical_id=0 bounded=0
-// CHECK: quiescence=unsupported-control-flow
+// CHECK: lifecycle_completion=unsupported-control-flow
 // CHECK: DFB logical_id=1 bounded=0
-// CHECK: quiescence=unsupported-control-flow
+// CHECK: lifecycle_completion=unsupported-control-flow
 // CHECK: Total DFB count: 2
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
@@ -364,7 +364,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 // A payload access after reset belongs to a new epoch and cannot consume the
 // preceding epoch's produced data.
 // CHECK: DFB logical_id=0 bounded=0
-// CHECK: quiescence=incomplete-use-order{{.*}}evidence=ttl.cb_push
+// CHECK: lifecycle_completion=incomplete-use-order{{.*}}evidence=ttl.cb_push
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @payload_crosses_reset()
@@ -405,7 +405,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 // Access in a logical kernel outside the participant set is unordered with
 // the reset and leaves the complete lifecycle conservative.
 // CHECK: DFB logical_id=0 bounded=0
-// CHECK: quiescence=incomplete-use-order
+// CHECK: lifecycle_completion=incomplete-use-order
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @concurrent_access_producer()
@@ -651,7 +651,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 
 // Opposite reset polarity cannot prove one dynamic reset instance.
 // CHECK: DFB logical_id=0 bounded=0
-// CHECK: quiescence=unsupported-control-flow
+// CHECK: lifecycle_completion=unsupported-control-flow
 // CHECK: DFB logical_id=1 bounded=1
 // CHECK: Total DFB count: 2
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
@@ -11,7 +11,7 @@
 // REPORT: DFB allocation liveness report
 // REPORT: DFB logical_id=0 bounded=1 compiler_created=0
 // REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(0,0)} operation=ttl.cb_reserve kernel=@producer
-// REPORT: node (0,0) quiescence=none domain_assumption=exact conditional_execution=0 evidence=none occurrences=[0:1, 1:1, 2:1, 3:1] transactions=[1] write_owner=(0,0):noc0:write read_owner=(0,0):unpack:read
+// REPORT: node (0,0) lifecycle_completion=complete domain_assumption=exact conditional_execution=0 evidence=none occurrences=[0:1, 1:1, 2:1, 3:1] transactions=[1] write_owner=(0,0):noc0:write read_owner=(0,0):unpack:read
 // REPORT-SAME: earliest_accesses=[0, 2] terminal_accesses=[3]
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch node=(0,0)
 // REPORT: DFB allocation liveness report end

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
@@ -15,21 +15,21 @@
 // CHECK: access 4 effect=none tiles=0 sequence=0 opaque_external=1 domain=unknown
 // CHECK-SAME: operation=ttl.opaque_call kernel=@unknown_domain
 // CHECK-SAME: unresolved_at=arith.cmpi kernel=@unknown_domain
-// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
+// CHECK: possible_nodes lifecycle_completion=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
 // CHECK: DFB logical_id=1 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
+// CHECK: possible_nodes lifecycle_completion=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved]
 // CHECK: DFB logical_id=2 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=1 nodes={(0,0)}
+// CHECK: possible_nodes lifecycle_completion=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=1 nodes={(0,0)}
 // CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved]
-// CHECK: possible_nodes quiescence=none domain_assumption=unknown-possible may_be_active=0 conditional_execution=0 node_count=9 exemplar=(1,0)
+// CHECK: possible_nodes lifecycle_completion=complete domain_assumption=unknown-possible may_be_active=0 conditional_execution=0 node_count=9 exemplar=(1,0)
 // CHECK-SAME: occurrences=[0:0, 1:0, 2:0, 3:0]
 // CHECK: DFB logical_id=3 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
+// CHECK: possible_nodes lifecycle_completion=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
 // CHECK-SAME: transactions=[]
 // CHECK: DFB conflict lhs=0 rhs=1 reason=unknown-launch-node-domain node=none

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
@@ -12,12 +12,10 @@
 // CHECK: DFB logical_id=0 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
 // CHECK: access 0 effect=reserve tiles=1 sequence=0 domain=unknown
-// CHECK: access 4 effect=none tiles=0 sequence=0 domain=unknown
+// CHECK: access 4 effect=none tiles=0 sequence=0 opaque_external=1 domain=unknown
 // CHECK-SAME: operation=ttl.opaque_call kernel=@unknown_domain
 // CHECK-SAME: unresolved_at=arith.cmpi kernel=@unknown_domain
-// CHECK: possible_nodes quiescence=incomplete-use-order domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(0,0)}
-// CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
-// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=9 exemplar=(1,0)
+// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
 // CHECK: DFB logical_id=1 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
@@ -31,7 +29,7 @@
 // CHECK-SAME: occurrences=[0:0, 1:0, 2:0, 3:0]
 // CHECK: DFB logical_id=3 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
+// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
 // CHECK-SAME: transactions=[]
 // CHECK: DFB conflict lhs=0 rhs=1 reason=unknown-launch-node-domain node=none

--- a/test/ttlang/Translate/TTLToCpp/dfb_reset.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dfb_reset.mlir
@@ -6,11 +6,12 @@
 // CHECK: constexpr uint32_t stateWordCount = 4;
 // CHECK: constexpr uint32_t participantCount = 3;
 // CHECK: static_assert(releaseWord + 1 == stateWordCount);
-// CHECK: FORCE_INLINE void drainComputeEngine()
-// CHECK: TTI_STALLWAIT(p_stall::STALL_TDMA, waitResources);
-// CHECK: sync_regfile_write(completionGpr);
-// CHECK: FORCE_INLINE void enter(volatile uint32_t tt_l1_ptr *synchronizationState)
+// CHECK: FORCE_INLINE void completeInterfaceWork()
 // CHECK: noc_async_full_barrier();
+// CHECK: TTI_STALLWAIT(p_stall::STALL_TDMA, waitResources);
+// CHECK-NEXT: tensix_sync();
+// CHECK: FORCE_INLINE void enter(volatile uint32_t tt_l1_ptr *synchronizationState)
+// CHECK: completeInterfaceWork();
 // CHECK: while (!participantsHaveState(synchronizationState, entryComplete))
 // CHECK: FORCE_INLINE void exit(volatile uint32_t tt_l1_ptr *synchronizationState)
 // CHECK: while (!participantsHaveState(synchronizationState, exitComplete))
@@ -21,6 +22,8 @@
 // CHECK: *get_cb_tiles_received_ptr(dfbIndex) = 0;
 // CHECK: *get_cb_tiles_acked_ptr(dfbIndex) = 0;
 // CHECK: interface.fifo_wr_tile_ptr = 0;
+// CHECK: FORCE_INLINE void complete_dfb_interface_work()
+// CHECK: dfb_reset_detail::completeInterfaceWork();
 // CHECK: FORCE_INLINE void reset_dfb_interfaces(uint32_t synchronizationAddress,
 // CHECK: dfb_reset_detail::applyMask(lowMask, 0);
 // CHECK: dfb_reset_detail::applyMask(highMask, 32);


### PR DESCRIPTION
### Problem description

An allocation group may reuse one physical DFB across reset-delimited epochs that interleave with epochs from other group members. Comparing each logical DFB as one continuous lifetime loses the ordering and canonical-state facts required to validate those handoffs.

### What's changed

~1,100 LOC implementation (tests and documentation excluded).

Preserve reset-delimited epochs as allocation facts with entry and completion events, queue cursors, terminal state, and pointer ownership. Group validation orders active epochs, checks cursor movement within the shared capacity, and applies a proved terminal synchronized reset before requiring the next epoch to begin from canonical state.

Cache exact and possible per-node lifetime tables while constructing logical and epoch ordering.

Treat opaque external DFB dependencies as active until a matching synchronized reset completes their lifecycle, require exact descriptor compatibility while they are active, and drain affected hardware interfaces before resetting them.

```python
scratch_storage = ttl.make_dfb_allocation_group()
first_epoch = ttl.make_dataflow_buffer_like(
    input_tensor,
    shape=(1, 1),
    block_count=8,
    allocation_group=scratch_storage,
)
second_epoch = ttl.make_dataflow_buffer_like(
    input_tensor,
    shape=(1, 1),
    block_count=16,
    allocation_group=scratch_storage,
)
reset = ttl.DFBReset(participants=(compute_kernel, reader_kernel, writer_kernel))

ttl.reset_dfbs(reset, dfbs=[first_epoch])
```

The compiler may assign `first_epoch` and `second_epoch` the same physical index because the reset proves canonical state at the handoff. The shared allocation uses the larger 16-block capacity.

### Validation

- New device tests cover interleaved and producer-only reset epochs across BF16/FP32 and DRAM/L1, including exact physical-index reuse.
- New analysis tests cover interleaved and nested-region epochs, canonical reset handoff, pointer ownership, ring boundaries, and rejection of contradictory or unresolved ordering.
- New opaque-access tests cover pre-reset retention, post-reset reuse, descriptor mismatch rejection, and generated interface-drain/reset ordering.

### Checklist

- [x] New tests provide coverage for the changes.
