### PR TITLE
[ci] Run Galaxy tests on shared Exabox

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,4 +6,5 @@ self-hosted-runner:
     - mlir-large-runner-lang
     - n150
     - bh-loudbox-viommu
+    - exabox-multihost-ci-sc1
     - tt-ubuntu-2204-*-stable

--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -40,6 +40,12 @@ SHELL ["/bin/bash", "-c"]
 
 ENV TTLANG_TOOLCHAIN_DIR=/opt/ttlang-toolchain
 ENV DEBIAN_FRONTEND=noninteractive
+ENV OMPI_TAG=v5.0.7
+ENV OMPI_PREFIX=/opt/openmpi-v5.0.7-ulfm
+ENV PATH=$OMPI_PREFIX/bin:$PATH
+ENV LD_LIBRARY_PATH=$OMPI_PREFIX/lib
+ENV CPATH=$OMPI_PREFIX/include
+ENV PKG_CONFIG_PATH=$OMPI_PREFIX/lib/pkgconfig
 
 COPY --from=tt-triage-python /opt/ttlang-toolchain/tt-triage-venv $TTLANG_TOOLCHAIN_DIR/tt-triage-venv/
 
@@ -60,17 +66,18 @@ COPY --from=ird-toolchain --chmod=777 /src $TTLANG_TOOLCHAIN_DIR/src/
 # `-r requirements-runtime.txt`, so all three sibling files must be copied.
 COPY requirements.txt requirements-runtime.txt dev-requirements.txt /tmp/
 COPY docs/requirements.txt /tmp/docs/requirements.txt
+COPY .github/containers/install-exabox-worker.sh /tmp/install-exabox-worker.sh
 RUN $TTLANG_TOOLCHAIN_DIR/venv/bin/python -m pip install -r /tmp/dev-requirements.txt tt-smi --no-cache-dir && \
     rm -rf /tmp/requirements.txt /tmp/requirements-runtime.txt /tmp/docs /tmp/dev-requirements.txt && \
     apt-get update && apt-get install -y \
-    ssh \
-    sudo \
     vim \
     nano \
     tmux \
     psmisc \
     bash-completion \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* && \
+    /tmp/install-exabox-worker.sh && \
+    rm /tmp/install-exabox-worker.sh
 
 # Setup entrypoint
 COPY .github/containers/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/.github/containers/README.md
+++ b/.github/containers/README.md
@@ -20,8 +20,14 @@ text editors
 Interactive Research & Development image. Contains the toolchain but *not*
 tt-lang -- developers clone and build tt-lang themselves.
 
-**Contents:** LLVM + tt-metal toolchain + dev tools (ssh, sudo, tmux, vim,
-black, sphinx)
+**Contents:** LLVM + tt-metal toolchain + dev tools (SSH server, sudo, tmux,
+vim, black, sphinx)
+
+The image is also an Exabox worker image. It provides the fixed UID 1001
+`user` account, passwordless sudo, `sshd`, and a system `tt-smi` launcher
+required by the shared Exabox runner. It also installs the controller-matched
+OpenMPI 5.0.7/ULFM runtime under `/opt/openmpi-v5.0.7-ulfm` and provides
+worker-writable tt-metal profiler directories.
 
 ## Building Images Locally
 

--- a/.github/containers/install-exabox-worker.sh
+++ b/.github/containers/install-exabox-worker.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install the account and services required by Exabox worker pods.
+
+set -euo pipefail
+
+TOOLCHAIN_DIR="${TTLANG_TOOLCHAIN_DIR:-/opt/ttlang-toolchain}"
+OMPI_TAG="${OMPI_TAG:-v5.0.7}"
+OMPI_PREFIX="${OMPI_PREFIX:-/opt/openmpi-${OMPI_TAG}-ulfm}"
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    flex \
+    libtool \
+    openssh-server \
+    sudo \
+    libatomic1
+rm -rf /var/lib/apt/lists/*
+
+if [ ! -x "$OMPI_PREFIX/bin/prted" ]; then
+    ompi_source_dir="$(mktemp -d)"
+    trap 'rm -rf "$ompi_source_dir"' EXIT
+    git clone --branch "$OMPI_TAG" --depth 1 \
+        https://github.com/open-mpi/ompi.git "$ompi_source_dir"
+    cd "$ompi_source_dir"
+    git submodule update --init --recursive
+    grep -rl 'req_complete = false;' --include='*.h' --include='*.c' . | \
+        xargs -r sed -i \
+            's/req_complete = false;/req_complete = REQUEST_PENDING;/g'
+    ./autogen.pl
+    ./configure \
+        --prefix="$OMPI_PREFIX" \
+        --with-ft=ulfm \
+        --enable-wrapper-rpath \
+        --enable-mpirun-prefix-by-default \
+        --disable-mca-dso \
+        --disable-dlopen
+    make -j"$(nproc)"
+    make install
+    cd /
+    rm -rf "$ompi_source_dir"
+    trap - EXIT
+fi
+
+if id -u user > /dev/null 2>&1; then
+    [ "$(id -u user)" = "1001" ] || {
+        echo "Existing user account must have UID 1001." >&2
+        exit 1
+    }
+elif getent passwd 1001 > /dev/null; then
+    echo "UID 1001 is already assigned to another account." >&2
+    exit 1
+else
+    useradd --uid 1001 --create-home --shell /bin/bash user
+fi
+
+usermod -aG sudo user
+echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+chmod 0440 /etc/sudoers.d/user
+mkdir -p /run/sshd
+grep -q '^StrictModes no$' /etc/ssh/sshd_config || \
+    echo 'StrictModes no' >> /etc/ssh/sshd_config
+
+ln -sf "$TOOLCHAIN_DIR/venv/bin/tt-smi" /usr/local/bin/tt-smi
+
+install -d -m 0777 \
+    "$TOOLCHAIN_DIR/tt-metal/build" \
+    "$TOOLCHAIN_DIR/tt-metal/build/profiler" \
+    "$TOOLCHAIN_DIR/tt-metal/build/profiler/build_wasm" \
+    "$TOOLCHAIN_DIR/tt-metal/build/profiler/build_wasm/traces" \
+    "$TOOLCHAIN_DIR/tt-metal/generated" \
+    "$TOOLCHAIN_DIR/tt-metal/generated/profiler"
+
+test -x /usr/sbin/sshd
+test -x /usr/local/bin/tt-smi
+test -x "$OMPI_PREFIX/bin/prted"

--- a/.github/scripts/prepare-exabox-workspace.sh
+++ b/.github/scripts/prepare-exabox-workspace.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copy the Actions checkout to Exabox shared storage and then to every worker.
+#
+# Env: STAGE_DIR and WORKER_SRC are required. GITHUB_WORKSPACE is required by
+# the stage operation. EXABOX_REPORT_DIR optionally selects a shared report
+# directory that every worker can write.
+# Usage: prepare-exabox-workspace.sh <stage|install>
+
+set -euo pipefail
+
+MODE="${1:?usage: prepare-exabox-workspace.sh <stage|install>}"
+: "${STAGE_DIR:?STAGE_DIR is required}"
+: "${WORKER_SRC:?WORKER_SRC is required}"
+
+validate_target() {
+    local name="$1"
+    local target="$2"
+    case "$target" in
+        / | '')
+            echo "$name must not be / or empty" >&2
+            return 2
+            ;;
+        /*) ;;
+        *)
+            echo "$name must be absolute: $target" >&2
+            return 2
+            ;;
+    esac
+}
+
+validate_target STAGE_DIR "$STAGE_DIR"
+validate_target WORKER_SRC "$WORKER_SRC"
+[ "$STAGE_DIR" != "$WORKER_SRC" ] || {
+    echo "STAGE_DIR and WORKER_SRC must differ" >&2
+    exit 2
+}
+if [ -n "${EXABOX_REPORT_DIR:-}" ]; then
+    validate_target EXABOX_REPORT_DIR "$EXABOX_REPORT_DIR"
+fi
+
+case "$MODE" in
+    stage)
+        : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+        [ -d "$GITHUB_WORKSPACE" ] || {
+            echo "GITHUB_WORKSPACE is not a directory: $GITHUB_WORKSPACE" >&2
+            exit 2
+        }
+        [ "$GITHUB_WORKSPACE" != "$STAGE_DIR" ] || {
+            echo "GITHUB_WORKSPACE and STAGE_DIR must differ" >&2
+            exit 2
+        }
+
+        rm -rf -- "$STAGE_DIR"
+        mkdir -p "$(dirname "$STAGE_DIR")"
+        cp -r "$GITHUB_WORKSPACE" "$STAGE_DIR"
+        if [ -n "${EXABOX_REPORT_DIR:-}" ]; then
+            mkdir -p "$EXABOX_REPORT_DIR"
+            chmod 0777 "$EXABOX_REPORT_DIR"
+        fi
+        mpirun --pernode --tag-output \
+            bash "$STAGE_DIR/.github/scripts/prepare-exabox-workspace.sh" install
+        ;;
+    install)
+        [ -d "$STAGE_DIR" ] || {
+            echo "STAGE_DIR is not a directory: $STAGE_DIR" >&2
+            exit 2
+        }
+        rm -rf -- "$WORKER_SRC"
+        mkdir -p "$(dirname "$WORKER_SRC")"
+        cp -r "$STAGE_DIR" "$WORKER_SRC"
+        echo "$(hostname): workspace installed at $WORKER_SRC"
+        ;;
+    *)
+        echo "Unknown Exabox workspace operation: $MODE" >&2
+        exit 2
+        ;;
+esac

--- a/.github/scripts/run-exabox-hardware-phase.sh
+++ b/.github/scripts/run-exabox-hardware-phase.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run one hardware test phase on every Exabox worker host.
+#
+# Env: WORKER_SRC is required.
+# Usage: run-exabox-hardware-phase.sh <phase>
+
+set -euo pipefail
+
+PHASE="${1:?usage: run-exabox-hardware-phase.sh <phase>}"
+: "${WORKER_SRC:?WORKER_SRC is required}"
+
+case "$WORKER_SRC" in
+    /*) ;;
+    *)
+        echo "WORKER_SRC must be absolute: $WORKER_SRC" >&2
+        exit 2
+        ;;
+esac
+
+exec mpirun --pernode --tag-output \
+    bash "$WORKER_SRC/.github/scripts/run-hardware-test-phase.sh" "$PHASE"

--- a/.github/scripts/run-hardware-pytests.sh
+++ b/.github/scripts/run-hardware-pytests.sh
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Run the hardware Python pytest suite, parallelizing single-device tests across
-# every available chip and running multi_device (fabric mesh) tests serially.
+# every available chip and running compile_only and multi_device tests serially.
 #
 # Chip count is the number of digit-named nodes under /dev/tenstorrent (matching
 # test/lit.cfg.py). With more than one chip, single-device tests run under
 # pytest-xdist (-n <chips>) with each worker restricted to one chip through
-# TT_VISIBLE_DEVICES. The multi_device tests then run serially. With one chip the
-# whole suite runs serially.
+# TT_VISIBLE_DEVICES. Compile-only tests then run without xdist so concurrent
+# compiler subprocesses do not contend for host resources. The multi_device
+# tests run serially after that. With one chip the whole suite runs serially.
 #
 # Env: HW_PYTEST_CHIPS overrides the detected chip count.
 # Env: HW_SERIAL_TEST_VISIBLE_DEVICES restricts device visibility for serial
@@ -64,7 +65,7 @@ run_multi_device_phase() {
 }
 
 if [ "$chips" -gt 1 ]; then
-    echo "Detected ${chips} chips: single-device tests in parallel (-n ${chips}), multi_device serial"
+    echo "Detected ${chips} chips: single-device tests in parallel (-n ${chips}), compile_only and multi_device serial"
     unset TT_VISIBLE_DEVICES
     cache_root="$(absolute_path "${TT_METAL_CACHE:-${REPORT_PREFIX}-tt-metal-cache}")"
     rc=0
@@ -74,13 +75,15 @@ if [ "$chips" -gt 1 ]; then
     # one crash into a flood of "Invalid device ID" errors.
     TTLANG_PIN_XDIST_WORKERS_TO_DEVICES=1 \
         TTLANG_XDIST_TT_METAL_CACHE_ROOT="$cache_root" \
-        run_pytest_phase "$TEST_DIR" -m "not multi_device" -n "$chips" \
+        run_pytest_phase "$TEST_DIR" -m "not multi_device and not compile_only" -n "$chips" \
         --max-worker-restart=0 "${common[@]}" \
         --junitxml="${REPORT_PREFIX}-parallel.xml" || rc=1
+    run_pytest_phase "$TEST_DIR" -m compile_only \
+        "${common[@]}" --junitxml="${REPORT_PREFIX}-compile-only.xml" || rc=1
     run_multi_device_phase "$TEST_DIR" -m multi_device \
         "${common[@]}" --junitxml="${REPORT_PREFIX}-multidevice.xml" || rc=1
     if [ "$selected_phase_count" -eq 0 ]; then
-        echo "No tests selected by either hardware pytest phase" >&2
+        echo "No tests selected by any hardware pytest phase" >&2
         exit 5
     fi
     exit "$rc"

--- a/.github/scripts/run-hardware-test-phase.sh
+++ b/.github/scripts/run-hardware-test-phase.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run one hardware-CI phase from a tt-lang source checkout.
+#
+# Env:
+#   RUNS_ON identifies the hardware configuration (default: n150).
+#   EXABOX_WORKER_HOME selects the valid home directory in an Exabox worker.
+#   EXABOX_REPORT_DIR receives reports copied from an Exabox worker.
+#
+# Usage: run-hardware-test-phase.sh <phase>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PHASE="${1:?usage: run-hardware-test-phase.sh <phase>}"
+
+cd "$REPO_ROOT"
+
+if [ -n "${EXABOX_WORKER_HOME:-}" ]; then
+    export HOME="$EXABOX_WORKER_HOME"
+    # Exabox orchestration values refer to the CPU runner and would override
+    # the tt-metal installation selected by build/env/activate.
+    unset TT_METAL_RUNTIME_ROOT TT_METAL_HOME LD_LIBRARY_PATH
+fi
+
+activate_build() {
+    set +u
+    # shellcheck disable=SC1091
+    source build/env/activate
+    set -u
+}
+
+collect_exabox_reports() {
+    local report_root="${EXABOX_REPORT_DIR:?EXABOX_REPORT_DIR is required}"
+    local host_report_dir
+    case "$report_root" in
+        / | '')
+            echo "EXABOX_REPORT_DIR must not be / or empty" >&2
+            return 2
+            ;;
+        /*) ;;
+        *)
+            echo "EXABOX_REPORT_DIR must be absolute: $report_root" >&2
+            return 2
+            ;;
+    esac
+
+    host_report_dir="${report_root}/$(hostname)"
+    rm -rf -- "$host_report_dir"
+    mkdir -p "$host_report_dir"
+
+    if [ ! -d build/test ]; then
+        echo "No hardware test reports found."
+        return 0
+    fi
+
+    local report relative_report copied=0
+    while IFS= read -r -d '' report; do
+        relative_report="${report#build/test/}"
+        mkdir -p "$host_report_dir/$(dirname "$relative_report")"
+        cp "$report" "$host_report_dir/$relative_report"
+        copied=$((copied + 1))
+    done < <(find build/test -type f -name '*report*.xml' -print0)
+    echo "Copied $copied hardware test report(s) to $host_report_dir."
+}
+
+case "$PHASE" in
+    configure)
+        cmake -G Ninja -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DTTLANG_USE_TOOLCHAIN=ON \
+            -DTTLANG_ENABLE_PERF_TRACE=ON
+        ;;
+    build)
+        activate_build
+        cmake --build build
+        cmake --build build --target ttlang-test-tools
+        ;;
+    install-dependencies)
+        activate_build
+        python3 -m pip install -r dev-requirements.txt
+        ;;
+    reset)
+        activate_build
+        .github/scripts/reset-tt-cards.sh
+        ;;
+    smoketest)
+        activate_build
+        python3 test/python/smoketest.py
+        ;;
+    simple-add)
+        activate_build
+        if [ "${RUNS_ON:-n150}" = "galaxy-bh" ]; then
+            TT_VISIBLE_DEVICES=0 python test/python/simple_add.py
+        else
+            python test/python/simple_add.py
+        fi
+        ;;
+    simulator)
+        activate_build
+        python3 -m pytest test/sim -m requires_ttnn -v -n auto \
+            --tb=short --timeout=60 --timeout-method=signal \
+            --junitxml=build/test/sim-report.xml
+        ;;
+    python-lit)
+        activate_build
+        .github/scripts/run-hardware-lit.sh \
+            build/test/python build/test/python-lit-report
+        ;;
+    python-pytests)
+        activate_build
+        .github/scripts/run-hardware-pytests.sh \
+            test/python build/test/pytest-report
+        ;;
+    me2e)
+        activate_build
+        .github/scripts/run-hardware-pytests.sh \
+            test/me2e build/test/me2e-report
+        ;;
+    examples)
+        activate_build
+        bash .github/scripts/compile-and-run-examples.sh
+        ;;
+    tutorials)
+        activate_build
+        .github/scripts/run-hardware-pytests.sh \
+            test/tutorial build/test/tutorial-report
+        ;;
+    collect-exabox-reports)
+        collect_exabox_reports
+        ;;
+    *)
+        echo "Unknown hardware test phase: $PHASE" >&2
+        exit 2
+        ;;
+esac

--- a/.github/scripts/tests/test_prepare_exabox_workspace.bats
+++ b/.github/scripts/tests/test_prepare_exabox_workspace.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/prepare-exabox-workspace.sh.
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/prepare-exabox-workspace.sh"
+    GITHUB_WORKSPACE="$BATS_TEST_TMPDIR/source"
+    STAGE_DIR="$BATS_TEST_TMPDIR/shared/tt-lang"
+    WORKER_SRC="$BATS_TEST_TMPDIR/worker/tt-lang"
+    EXABOX_REPORT_DIR="$BATS_TEST_TMPDIR/shared/reports"
+    MPIRUN_CALLS="$BATS_TEST_TMPDIR/mpirun.calls"
+    export GITHUB_WORKSPACE STAGE_DIR WORKER_SRC EXABOX_REPORT_DIR MPIRUN_CALLS
+
+    mkdir -p "$GITHUB_WORKSPACE/.github/scripts" "$BATS_TEST_TMPDIR/bin"
+    cp "$SCRIPT" "$GITHUB_WORKSPACE/.github/scripts/"
+    chmod +x "$GITHUB_WORKSPACE/.github/scripts/prepare-exabox-workspace.sh"
+    echo source > "$GITHUB_WORKSPACE/source.txt"
+
+    cat > "$BATS_TEST_TMPDIR/bin/mpirun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$MPIRUN_CALLS"
+shift 2
+exec "$@"
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/mpirun"
+    PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+    export PATH
+}
+
+@test "stage copies the checkout through shared storage to the worker" {
+    mkdir -p "$WORKER_SRC"
+    echo stale > "$WORKER_SRC/stale.txt"
+
+    run -0 "$SCRIPT" stage
+
+    assert_output --partial "workspace installed at $WORKER_SRC"
+    [ -f "$STAGE_DIR/source.txt" ]
+    [ -f "$WORKER_SRC/source.txt" ]
+    [ ! -e "$WORKER_SRC/stale.txt" ]
+    [ "$(stat -c '%a' "$EXABOX_REPORT_DIR")" = 777 ]
+    run cat "$MPIRUN_CALLS"
+    assert_output "--pernode --tag-output bash $STAGE_DIR/.github/scripts/prepare-exabox-workspace.sh install"
+}
+
+@test "install does not require the CPU runner workspace" {
+    mkdir -p "$STAGE_DIR"
+    echo staged > "$STAGE_DIR/staged.txt"
+    unset GITHUB_WORKSPACE
+
+    run -0 "$SCRIPT" install
+
+    [ -f "$WORKER_SRC/staged.txt" ]
+}
+
+@test "destructive targets reject the filesystem root" {
+    STAGE_DIR=/ run -2 "$SCRIPT" install
+    assert_output --partial "STAGE_DIR must not be /"
+
+    WORKER_SRC=/ run -2 "$SCRIPT" install
+    assert_output --partial "WORKER_SRC must not be /"
+
+    EXABOX_REPORT_DIR=/ run -2 "$SCRIPT" stage
+    assert_output --partial "EXABOX_REPORT_DIR must not be /"
+}
+
+@test "stage and worker directories must differ" {
+    WORKER_SRC="$STAGE_DIR" run -2 "$SCRIPT" install
+    assert_output --partial "STAGE_DIR and WORKER_SRC must differ"
+}

--- a/.github/scripts/tests/test_run_exabox_hardware_phase.bats
+++ b/.github/scripts/tests/test_run_exabox_hardware_phase.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/run-exabox-hardware-phase.sh.
+
+load test_helper
+
+setup() {
+    SCRIPT="$SCRIPTS_DIR/run-exabox-hardware-phase.sh"
+    WORKER_SRC=/home/user/tt-lang
+    MPIRUN_CALLS="$BATS_TEST_TMPDIR/mpirun.calls"
+    export WORKER_SRC MPIRUN_CALLS
+
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/mpirun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$MPIRUN_CALLS"
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/mpirun"
+    PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+    export PATH
+}
+
+@test "phase execution uses every Exabox worker" {
+    run -0 "$SCRIPT" python-pytests
+
+    run cat "$MPIRUN_CALLS"
+    assert_output "--pernode --tag-output bash /home/user/tt-lang/.github/scripts/run-hardware-test-phase.sh python-pytests"
+}
+
+@test "worker source directory must be absolute" {
+    WORKER_SRC=relative run -2 "$SCRIPT" smoketest
+    assert_output --partial "WORKER_SRC must be absolute"
+}
+
+@test "phase is required" {
+    run "$SCRIPT"
+    assert_failure
+    assert_output --partial "usage: run-exabox-hardware-phase.sh <phase>"
+}

--- a/.github/scripts/tests/test_run_hardware_pytests.bats
+++ b/.github/scripts/tests/test_run_hardware_pytests.bats
@@ -35,6 +35,7 @@ EOF
 write_fake_python_sequence() {
     local first_exit="$1"
     local second_exit="$2"
+    local third_exit="$3"
     local count_file="$BATS_TEST_TMPDIR/python-call-count"
     cat > "$BIN/python3" <<EOF
 #!/usr/bin/env bash
@@ -45,13 +46,14 @@ printf '%s\n' "\$call_count" > "$count_file"
 printf 'env:%s cache-root:%s args:%s vis:%s\n' "\${TTLANG_PIN_XDIST_WORKERS_TO_DEVICES:-}" "\${TTLANG_XDIST_TT_METAL_CACHE_ROOT:-}" "\$*" "\${TT_VISIBLE_DEVICES:-}" >> "$CALLS"
 case "\$call_count" in
     1) exit $first_exit ;;
-    *) exit $second_exit ;;
+    2) exit $second_exit ;;
+    *) exit $third_exit ;;
 esac
 EOF
     chmod +x "$BIN/python3"
 }
 
-@test "multi-chip: parallel single-device run, then serial multi_device run" {
+@test "multi-chip: parallel device run, then serial compile-only and multi-device runs" {
     write_fake_python 0
 
     HW_PYTEST_CHIPS=4 run "$SCRIPT" test/python build/test/pytest-report
@@ -59,17 +61,19 @@ EOF
     assert_success
     run cat "$CALLS"
     assert_line --partial "env:1 cache-root:$PWD/build/test/pytest-report-tt-metal-cache args:-m pytest"
-    assert_line --partial "pytest test/python -m not multi_device -n 4"
+    assert_line --partial "pytest test/python -m not multi_device and not compile_only -n 4"
     # Crash-restart disabled and flaky-retry enabled on the parallel phase.
     assert_line --partial "-n 4 --max-worker-restart=0"
     assert_line --partial "--reruns 3"
     assert_line --partial "pytest-report-parallel.xml"
+    assert_line --partial "env: cache-root: args:-m pytest test/python -m compile_only"
+    assert_line --partial "pytest-report-compile-only.xml"
     assert_line --partial "env: cache-root: args:-m pytest test/python -m multi_device"
     assert_line --partial "pytest-report-multidevice.xml"
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 3 ]
 }
 
-@test "multi-chip: a preset TT_VISIBLE_DEVICES is cleared for both phases" {
+@test "multi-chip: a preset TT_VISIBLE_DEVICES is cleared for every phase" {
     write_fake_python 0
 
     TT_VISIBLE_DEVICES=2 HW_PYTEST_CHIPS=4 run "$SCRIPT" test/python build/test/pytest-report
@@ -77,7 +81,7 @@ EOF
     assert_success
     run cat "$CALLS"
     refute_output --partial "vis:2"
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 3 ]
 }
 
 @test "multi-chip: serial test visibility override applies to multi_device phase" {
@@ -88,11 +92,12 @@ EOF
     assert_success
     assert_output --partial "Restricting serial multi_device pytest phase to TT_VISIBLE_DEVICES=0,1"
     run cat "$CALLS"
-    assert_line --partial "pytest test/python -m not multi_device"
+    assert_line --partial "pytest test/python -m not multi_device and not compile_only"
     assert_line --partial "vis:"
+    assert_line --partial "pytest test/python -m compile_only"
     assert_line --partial "pytest test/python -m multi_device"
     assert_line --partial "vis:0,1"
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 3 ]
 }
 
 @test "single chip: one serial run over the whole suite" {
@@ -140,38 +145,48 @@ EOF
     [ "${#lines[@]}" -eq 1 ]
 }
 
-@test "multi-chip: both runs execute even when the parallel run fails" {
+@test "multi-chip: all runs execute even when the parallel run fails" {
     write_fake_python 1
 
     HW_PYTEST_CHIPS=4 run "$SCRIPT" test/python build/test/pytest-report
 
     assert_failure
     run cat "$CALLS"
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 3 ]
 }
 
 @test "multi-chip: empty parallel phase is allowed when multi_device tests run" {
-    write_fake_python_sequence 5 0
+    write_fake_python_sequence 5 5 0
 
     HW_PYTEST_CHIPS=4 run "$SCRIPT" test/python/only_multidevice.py build/test/pytest-report
 
     assert_success
     run cat "$CALLS"
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 3 ]
 }
 
 @test "multi-chip: empty multi_device phase is allowed when parallel tests run" {
-    write_fake_python_sequence 0 5
+    write_fake_python_sequence 0 5 5
 
     HW_PYTEST_CHIPS=4 run "$SCRIPT" test/python/only_single_device.py build/test/pytest-report
 
     assert_success
     run cat "$CALLS"
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 3 ]
 }
 
-@test "multi-chip: both phases empty is an error" {
-    write_fake_python_sequence 5 5
+@test "multi-chip: compile-only tests can be the only selected phase" {
+    write_fake_python_sequence 5 0 5
+
+    HW_PYTEST_CHIPS=4 run "$SCRIPT" test/python/only_compile.py build/test/pytest-report
+
+    assert_success
+    run cat "$CALLS"
+    [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "multi-chip: all phases empty is an error" {
+    write_fake_python_sequence 5 5 5
 
     HW_PYTEST_CHIPS=4 run "$SCRIPT" test/python/empty.py build/test/pytest-report
 

--- a/.github/scripts/tests/test_run_hardware_test_phase.bats
+++ b/.github/scripts/tests/test_run_hardware_test_phase.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for .github/scripts/run-hardware-test-phase.sh.
+
+load test_helper
+
+setup() {
+    TEST_REPO="$BATS_TEST_TMPDIR/repo"
+    SCRIPT_DIR="$TEST_REPO/.github/scripts"
+    SCRIPT="$SCRIPT_DIR/run-hardware-test-phase.sh"
+    BIN="$BATS_TEST_TMPDIR/bin"
+    CALLS="$BATS_TEST_TMPDIR/calls"
+    export CALLS
+
+    mkdir -p "$SCRIPT_DIR" "$TEST_REPO/build/env" "$TEST_REPO/build/test" "$BIN"
+    cp "$SCRIPTS_DIR/run-hardware-test-phase.sh" "$SCRIPT"
+    chmod +x "$SCRIPT"
+    cat > "$TEST_REPO/build/env/activate" <<'EOF'
+export BUILD_ENV_ACTIVE=1
+EOF
+
+    cat > "$BIN/cmake" <<'EOF'
+#!/usr/bin/env bash
+printf 'cmake active:%s args:%s\n' "${BUILD_ENV_ACTIVE:-}" "$*" >> "$CALLS"
+EOF
+    cat > "$BIN/python" <<'EOF'
+#!/usr/bin/env bash
+printf 'python active:%s visible:%s home:%s runtime:%s metal:%s ld:%s args:%s\n' \
+    "${BUILD_ENV_ACTIVE:-}" "${TT_VISIBLE_DEVICES:-}" "$HOME" \
+    "${TT_METAL_RUNTIME_ROOT:-}" "${TT_METAL_HOME:-}" \
+    "${LD_LIBRARY_PATH:-}" "$*" >> "$CALLS"
+EOF
+    cat > "$BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+printf 'python3 active:%s args:%s\n' "${BUILD_ENV_ACTIVE:-}" "$*" >> "$CALLS"
+EOF
+    cat > "$BIN/hostname" <<'EOF'
+#!/usr/bin/env bash
+echo worker-0
+EOF
+    chmod +x "$BIN/cmake" "$BIN/python" "$BIN/python3" "$BIN/hostname"
+    PATH="$BIN:$PATH"
+    export PATH
+    unset EXABOX_WORKER_HOME TT_METAL_RUNTIME_ROOT TT_METAL_HOME LD_LIBRARY_PATH
+    unset TT_VISIBLE_DEVICES
+}
+
+@test "configure uses the release toolchain configuration" {
+    run -0 "$SCRIPT" configure
+
+    run cat "$CALLS"
+    assert_output --partial "cmake active: args:-G Ninja -B build"
+    assert_output --partial "-DCMAKE_BUILD_TYPE=Release"
+    assert_output --partial "-DTTLANG_USE_TOOLCHAIN=ON"
+    assert_output --partial "-DTTLANG_ENABLE_PERF_TRACE=ON"
+}
+
+@test "build activates the environment and builds test tools" {
+    run -0 "$SCRIPT" build
+
+    run cat "$CALLS"
+    assert_line "cmake active:1 args:--build build"
+    assert_line "cmake active:1 args:--build build --target ttlang-test-tools"
+}
+
+@test "Galaxy simple-add exposes one device" {
+    RUNS_ON=galaxy-bh run -0 "$SCRIPT" simple-add
+
+    run cat "$CALLS"
+    assert_output --partial "python active:1 visible:0"
+    assert_output --partial "args:test/python/simple_add.py"
+}
+
+@test "N150 simple-add preserves device visibility" {
+    TT_VISIBLE_DEVICES=7 RUNS_ON=n150 run -0 "$SCRIPT" simple-add
+
+    run cat "$CALLS"
+    assert_output --partial "python active:1 visible:7"
+    assert_output --partial "args:test/python/simple_add.py"
+}
+
+@test "Exabox worker environment discards CPU runner tt-metal overrides" {
+    EXABOX_WORKER_HOME=/home/user \
+        TT_METAL_RUNTIME_ROOT=/cpu/runtime \
+        TT_METAL_HOME=/cpu/home \
+        LD_LIBRARY_PATH=/cpu/lib \
+        run -0 "$SCRIPT" simple-add
+
+    [ "$HOME" != /home/user ]
+    run cat "$CALLS"
+    assert_output --partial "home:/home/user runtime: metal: ld:"
+    assert_output --partial "args:test/python/simple_add.py"
+}
+
+@test "report collection preserves relative report names" {
+    mkdir -p "$TEST_REPO/build/test/nested"
+    echo report > "$TEST_REPO/build/test/pytest-report.xml"
+    echo nested > "$TEST_REPO/build/test/nested/me2e-report.xml"
+    EXABOX_REPORT_DIR="$BATS_TEST_TMPDIR/reports" run -0 "$SCRIPT" collect-exabox-reports
+
+    assert_output --partial "Copied 2 hardware test report(s)"
+    [ -f "$BATS_TEST_TMPDIR/reports/worker-0/pytest-report.xml" ]
+    [ -f "$BATS_TEST_TMPDIR/reports/worker-0/nested/me2e-report.xml" ]
+}
+
+@test "unknown phase fails" {
+    run -2 "$SCRIPT" unknown
+    assert_output --partial "Unknown hardware test phase: unknown"
+}

--- a/.github/scripts/uplift-paths.sh
+++ b/.github/scripts/uplift-paths.sh
@@ -33,6 +33,7 @@ UPLIFT_PATHS=(
     .github/containers/Dockerfile
     .github/containers/Dockerfile.base
     .github/containers/cleanup-toolchain.sh
+    .github/containers/install-exabox-worker.sh
     .github/scripts/normalize-toolchain-install.sh
     bin/tt-triage
     dev-requirements.txt

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -236,6 +236,22 @@ jobs:
             FileCheck --version
             python3 --version
             tt-triage --help
+            prted --version
+          '
+          docker run --rm --user 1001:1001 \
+            "${{ steps.build-ird.outputs.local-image }}" bash -c '
+            set -e
+            export HOME=/home/user
+            export PATH=/opt/ttlang-toolchain/venv/bin:/opt/ttlang-toolchain/bin:$PATH
+            export TT_METAL_HOME=/opt/ttlang-toolchain/tt-metal
+            export TT_METAL_RUNTIME_ROOT=$TT_METAL_HOME
+            export PYTHONPATH=$TT_METAL_HOME/python_packages/ttnn:$TT_METAL_HOME/python_packages/tools
+            export LD_LIBRARY_PATH=$TT_METAL_HOME/lib:${LD_LIBRARY_PATH:-}
+            test "$(id -u)" = 1001
+            test -w "$TT_METAL_HOME/build/profiler/build_wasm/traces"
+            test -w "$TT_METAL_HOME/generated/profiler"
+            prted --version
+            python3 -c "import ttnn"
           '
 
       # Push after the ird smoke test so the local image can be removed before

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -8,7 +8,7 @@ on:
                 type: boolean
                 default: false
             run_galaxy_tests:
-                description: "Run hardware tests on the Galaxy Blackhole runner."
+                description: "Run hardware tests on a shared Exabox Galaxy."
                 type: boolean
                 default: false
             docker_tag:
@@ -23,7 +23,7 @@ on:
                 required: false
                 default: false
             run_galaxy_tests:
-                description: "Run hardware tests on the Galaxy Blackhole runner."
+                description: "Run hardware tests on a shared Exabox Galaxy."
                 type: boolean
                 required: false
                 default: false
@@ -128,16 +128,19 @@ jobs:
                   path: ./build/docs/sphinx/_build/html
 
     test-hardware:
-        strategy:
-            fail-fast: false
-            matrix:
-                runner: ${{ inputs.run_galaxy_tests && fromJSON('["n150","galaxy-bh"]') || fromJSON('["n150"]') }}
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:
             defer_result_check: true
-            runs-on: ${{ matrix.runner }}
-            runner_labels: ${{ matrix.runner == 'galaxy-bh' && '["in-service", "galaxy-bh"]' || '["tt-ubuntu-2204-n150-stable"]' }}
+            timeout: 90
+            docker_tag: ${{ inputs.docker_tag }}
+
+    test-exabox:
+        if: ${{ inputs.run_galaxy_tests }}
+        uses: ./.github/workflows/call-test-exabox.yml
+        secrets: inherit
+        with:
+            defer_result_check: true
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}
 
@@ -148,12 +151,12 @@ jobs:
         timeout-minutes: 5
 
         steps:
-            - name: Report unavailable runner
-              run: echo "::warning::Galaxy hardware tests are disabled for this workflow run."
+            - name: Report skipped tests
+              run: echo "::warning::Exabox Galaxy hardware tests are disabled for this workflow run."
 
     check-hardware:
         name: "Check aggregate hardware result"
-        needs: test-hardware
+        needs: [test-hardware, test-exabox]
         if: ${{ !cancelled() }}
         runs-on: ubuntu-24.04
         timeout-minutes: 5

--- a/.github/workflows/call-test-exabox.yml
+++ b/.github/workflows/call-test-exabox.yml
@@ -1,0 +1,114 @@
+name: Exabox Hardware Tests
+
+on:
+  workflow_call:
+    inputs:
+      defer_result_check:
+        description: 'Allow the calling workflow to check the aggregate hardware result.'
+        required: false
+        type: boolean
+        default: false
+      timeout:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 90
+      docker_tag:
+        description: 'Docker image tag for the IRD worker container.'
+        required: true
+        type: string
+
+permissions:
+  checks: write
+  contents: read
+  packages: read
+
+jobs:
+  test-galaxy:
+    name: "Hardware Tests (galaxy-bh)"
+    runs-on: exabox-multihost-ci-sc1
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
+    continue-on-error: ${{ inputs.defer_result_check }}
+
+    # The shared runner provisions this image on the Galaxy worker and also
+    # executes the workflow steps in a CPU-side container.
+    container:
+      image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:${{ inputs.docker_tag }}
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      STAGE_DIR: /ci/tt-lang
+      WORKER_SRC: /home/user/tt-lang
+      EXABOX_WORKER_HOME: /home/user
+      EXABOX_REPORT_DIR: /ci/tt-lang-test-reports
+      RUNS_ON: galaxy-bh
+      PYTHONDONTWRITEBYTECODE: 1
+      TTLANG_TEST_SEED: 42
+      HW_SERIAL_TEST_VISIBLE_DEVICES: 0,1
+
+    steps:
+      - name: Checkout tt-lang
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Stage workspace on every host
+        id: stage
+        run: .github/scripts/prepare-exabox-workspace.sh stage
+
+      - name: Configure tt-lang
+        run: .github/scripts/run-exabox-hardware-phase.sh configure
+
+      - name: Build tt-lang
+        run: .github/scripts/run-exabox-hardware-phase.sh build
+
+      - name: Install test dependencies
+        run: .github/scripts/run-exabox-hardware-phase.sh install-dependencies
+
+      # Galaxy link failures otherwise appear as unrelated cluster lookup
+      # errors in every device test.
+      - name: Reset cards and check cluster health
+        timeout-minutes: 45
+        run: .github/scripts/run-exabox-hardware-phase.sh reset
+
+      - name: Smoketest
+        run: .github/scripts/run-exabox-hardware-phase.sh smoketest
+
+      - name: Single test (just python, Galaxy one chip)
+        run: .github/scripts/run-exabox-hardware-phase.sh simple-add
+
+      - name: Simulator tests
+        run: .github/scripts/run-exabox-hardware-phase.sh simulator
+
+      - name: Python lit tests
+        run: .github/scripts/run-exabox-hardware-phase.sh python-lit
+
+      - name: Pytests (Python DSL end-to-end tests)
+        run: .github/scripts/run-exabox-hardware-phase.sh python-pytests
+
+      - name: ME2E tests (MLIR input end-to-end tests)
+        run: .github/scripts/run-exabox-hardware-phase.sh me2e
+
+      - name: Hardware compiler example scripts
+        run: .github/scripts/run-exabox-hardware-phase.sh examples
+
+      - name: Tutorial examples
+        run: .github/scripts/run-exabox-hardware-phase.sh tutorials
+
+      - name: Collect test reports
+        if: ${{ always() && steps.stage.outcome == 'success' }}
+        run: .github/scripts/run-exabox-hardware-phase.sh collect-exabox-reports
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v7
+        if: ${{ always() && steps.stage.outcome == 'success' }}
+        with:
+          name: hardware-test-reports-galaxy-bh
+          path: /ci/tt-lang-test-reports/**/*.xml
+          retention-days: 7
+
+      - name: Mark hardware tests complete
+        run: echo "Hardware tests completed successfully."

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -1,18 +1,8 @@
-name: Hardware Tests
+name: N150 Hardware Tests
 
 on:
   workflow_dispatch:
     inputs:
-      runs-on:
-        description: 'Hardware type to run on'
-        required: false
-        type: string
-        default: 'n150'
-      runner_labels:
-        description: 'JSON array of runner labels, e.g. ["in-service","qb2-blackhole"]'
-        required: false
-        type: string
-        default: '["tt-ubuntu-2204-n150-stable"]'
       timeout:
         description: 'Job timeout in minutes'
         required: false
@@ -29,16 +19,6 @@ on:
         required: false
         type: boolean
         default: false
-      runs-on:
-        description: 'Hardware type to run on'
-        required: false
-        type: string
-        default: 'n150'
-      runner_labels:
-        description: 'JSON array of runner labels, e.g. ["in-service","qb2-blackhole"]'
-        required: false
-        type: string
-        default: '["tt-ubuntu-2204-n150-stable"]'
       timeout:
         description: 'Job timeout in minutes'
         required: false
@@ -55,8 +35,8 @@ permissions:
 
 jobs:
   test-n150:
-    name: "Hardware Tests (${{ inputs.runs-on }})"
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    name: "Hardware Tests (n150)"
+    runs-on: tt-ubuntu-2204-n150-stable
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     continue-on-error: ${{ inputs.defer_result_check }}
 
@@ -74,10 +54,9 @@ jobs:
         shell: bash
 
     env:
-      RUNS_ON: ${{ inputs.runs-on }}
+      RUNS_ON: n150
       PYTHONDONTWRITEBYTECODE: 1
       TTLANG_TEST_SEED: 42
-      HW_SERIAL_TEST_VISIBLE_DEVICES: ${{ inputs.runs-on == 'galaxy-bh' && '0,1' || '' }}
 
     steps:
       - name: Checkout tt-lang
@@ -89,93 +68,49 @@ jobs:
         run: git config --global --add safe.directory "$(pwd)"
 
       - name: Configure tt-lang
-        run: |
-          cmake -G Ninja -B build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DTTLANG_USE_TOOLCHAIN=ON \
-              -DTTLANG_ENABLE_PERF_TRACE=ON
+        run: .github/scripts/run-hardware-test-phase.sh configure
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: Linux-ttlang-hw-${{ inputs.runs-on }}
+          key: Linux-ttlang-hw-n150
           max-size: 200M
 
       - name: Build tt-lang
-        run: |
-          source build/env/activate
-          cmake --build build
-          cmake --build build --target ttlang-test-tools
+        run: .github/scripts/run-hardware-test-phase.sh build
 
       - name: Install test dependencies
-        run: |
-          source build/env/activate
-          pip install -r dev-requirements.txt
-
-      # Galaxy links degrade across jobs and the failure reports as a cluster
-      # lookup error in every device test rather than as a device error.
-      - name: Reset cards and check cluster health
-        if: inputs.runs-on == 'galaxy-bh'
-        timeout-minutes: 45
-        run: |
-          source build/env/activate
-          .github/scripts/reset-tt-cards.sh
+        run: .github/scripts/run-hardware-test-phase.sh install-dependencies
 
       - name: Smoketest
-        run: |
-          source build/env/activate
-          python3 test/python/smoketest.py
+        run: .github/scripts/run-hardware-test-phase.sh smoketest
 
       - name: Single test (just python)
-        if: inputs.runs-on != 'galaxy-bh'
-        run: |
-          source build/env/activate
-          python test/python/simple_add.py
-
-      - name: Single test (just python, Galaxy one chip)
-        if: inputs.runs-on == 'galaxy-bh'
-        env:
-          TT_VISIBLE_DEVICES: "0"
-        run: |
-          source build/env/activate
-          python test/python/simple_add.py
+        run: .github/scripts/run-hardware-test-phase.sh simple-add
 
       - name: Simulator tests
-        run: |
-          source build/env/activate
-          python3 -m pytest test/sim -m requires_ttnn -v -n auto --tb=short --timeout=60 --timeout-method=signal --junitxml=build/test/sim-report.xml
+        run: .github/scripts/run-hardware-test-phase.sh simulator
 
       - name: Python lit tests
-        run: |
-          source build/env/activate
-          .github/scripts/run-hardware-lit.sh build/test/python build/test/python-lit-report
+        run: .github/scripts/run-hardware-test-phase.sh python-lit
 
       - name: Pytests (Python DSL end-to-end tests)
-        run: |
-          source build/env/activate
-          .github/scripts/run-hardware-pytests.sh test/python build/test/pytest-report
+        run: .github/scripts/run-hardware-test-phase.sh python-pytests
 
       - name: ME2E tests (MLIR input end-to-end tests)
-        run: |
-          source build/env/activate
-          .github/scripts/run-hardware-pytests.sh test/me2e build/test/me2e-report
+        run: .github/scripts/run-hardware-test-phase.sh me2e
 
       - name: Hardware compiler example scripts
-        run: |
-          set -eo pipefail
-          source build/env/activate
-          bash .github/scripts/compile-and-run-examples.sh
+        run: .github/scripts/run-hardware-test-phase.sh examples
 
       - name: Tutorial examples
-        run: |
-          source build/env/activate
-          .github/scripts/run-hardware-pytests.sh test/tutorial build/test/tutorial-report
+        run: .github/scripts/run-hardware-test-phase.sh tutorials
 
       - name: Upload test reports
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: hardware-test-reports-${{ inputs.runs-on }}
+          name: hardware-test-reports-n150
           path: |
             build/test/me2e-report*.xml
             build/test/python-lit-report*.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,7 @@ jobs:
     secrets: inherit
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
-      # TODO: re-enable once the Galaxy Blackhole runner is available again.
-      run_galaxy_tests: false
+      run_galaxy_tests: true
 
   build-docs:
     name: Build documentation

--- a/.github/workflows/manual-test-exabox.yml
+++ b/.github/workflows/manual-test-exabox.yml
@@ -1,0 +1,32 @@
+name: Run Exabox Hardware Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      timeout:
+        description: 'Job timeout in minutes.'
+        required: false
+        type: number
+        default: 90
+
+permissions:
+  checks: write
+  contents: read
+  packages: write
+
+run-name: 'Exabox hardware tests (${{ github.ref_name }})'
+
+jobs:
+  build-image:
+    uses: ./.github/workflows/call-build-docker.yml
+    secrets: inherit
+    with:
+      push: true
+
+  test:
+    needs: build-image
+    uses: ./.github/workflows/call-test-exabox.yml
+    secrets: inherit
+    with:
+      docker_tag: ${{ needs.build-image.outputs.docker-tag }}
+      timeout: ${{ inputs.timeout }}

--- a/docs/sphinx/build.md
+++ b/docs/sphinx/build.md
@@ -475,8 +475,9 @@ to query GHCR. If the image is present, `build-docker` is skipped and
 downstream jobs proceed immediately. If the image is missing and the
 resolved tag is the uplift form, `build-docker` runs `call-build-docker.yml`
 with `push: true` and uploads the rebuilt image so downstream jobs
-(`build`, `build-wheels`, `test-hardware`, `test-dist-tutorials`) can pull
-it. If the image is missing and the resolved tag is the bare release form
+(`build`, `build-wheels`, `test-hardware`, `test-exabox`,
+`test-dist-tutorials`) can pull it. If the image is missing and the resolved
+tag is the bare release form
 (e.g. `vX.Y.Z`), the probe step fails the job with an error directing the
 maintainer to run `call-build-docker.yml` with `push: true` at that exact
 release tag. Recovery uses that workflow rather than `publish-pypi.yml` so the
@@ -510,11 +511,28 @@ resolved tag.
 
 #### Hardware test timeouts
 
-`call-test-hardware.yml` and `call-test-dist-tutorials.yml` pass
-`--timeout=60 --timeout-method=signal` to every pytest invocation so a hung
-test exits within ~60 seconds instead of holding the single `n150` runner
-until the 90-minute job timeout. Tests that legitimately need longer should
-set their own `@pytest.mark.timeout(...)` override.
+`call-test-hardware.yml` and `call-test-exabox.yml` pass
+`--timeout=60 --timeout-method=signal` to simulator tests. Device suites run
+through `.github/scripts/run-hardware-pytests.sh`, which passes
+`--timeout=300 --timeout-method=thread`; the thread method interrupts C-level
+device deadlocks that `SIGALRM` cannot. `call-test-dist-tutorials.yml` uses the
+60-second signal timeout for its distribution tests. Tests that legitimately
+need longer set their own `@pytest.mark.timeout(...)` override. On multi-chip
+hosts, `compile_only` and `multi_device` tests execute serially while
+single-device tests execute in parallel with one worker per chip.
+
+#### Exabox Galaxy tests
+
+`call-build.yml` runs N150 tests through `call-test-hardware.yml` and Galaxy
+tests through `call-test-exabox.yml`. The Exabox job uses
+`exabox-multihost-ci-sc1`, which provisions a Galaxy allocation from the IRD
+image while Actions steps execute in a CPU-side container. The checkout is
+staged on `/ci`, copied to `/home/user/tt-lang` on every worker host, and reset,
+build, and test commands execute through `mpirun --pernode`.
+
+`manual-test-exabox.yml` builds and publishes the current revision's IRD image,
+then dispatches the same reusable workflow with the resulting tag. This keeps
+the worker toolchain and Exabox services aligned with the tested source.
 
 #### Rebuilding Docker images
 

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -223,16 +223,21 @@ pytest test/python/
 
 ### Pytest timeouts in CI
 
-`call-test-hardware.yml` bounds every pytest run so a hung test cannot hold the
-hardware runner until the job timeout. The simulator step passes
+`call-test-hardware.yml` and `call-test-exabox.yml` bound every pytest run so a
+hung test cannot hold the hardware allocation until the job timeout. The
+simulator step passes
 `--timeout=60 --timeout-method=signal`; the device suites (`test/python`,
 `test/me2e`, `test/tutorial`) run through
 `.github/scripts/run-hardware-pytests.sh`, which passes
-`--timeout=300 --timeout-method=thread` — the thread method interrupts C-level
+`--timeout=300 --timeout-method=thread`; the thread method interrupts C-level
 device deadlocks that `SIGALRM` cannot. Tests that legitimately need longer set
 their own `@pytest.mark.timeout(...)` override; the tutorial suite raises its
 backstop above the per-script subprocess timeout for this reason. Local runs use
 the default (no timeout) unless you pass `--timeout` yourself.
+
+On multi-chip hosts, tests marked `compile_only` execute serially without
+xdist, single-device tests execute in parallel with one worker per chip, and
+tests marked `multi_device` execute serially with the required device set.
 
 Middle end-to-end tests (requires ttnn and a TT device or simulator):
 ```bash

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workflow contracts for shared Exabox Galaxy testing."""
+
+from __future__ import annotations
+
+from conftest import REPO_ROOT
+
+CALL_BUILD = REPO_ROOT / ".github" / "workflows" / "call-build.yml"
+CALL_BUILD_DOCKER = REPO_ROOT / ".github" / "workflows" / "call-build-docker.yml"
+CALL_TEST_EXABOX = REPO_ROOT / ".github" / "workflows" / "call-test-exabox.yml"
+CALL_TEST_HARDWARE = REPO_ROOT / ".github" / "workflows" / "call-test-hardware.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+MANUAL_TEST_EXABOX = REPO_ROOT / ".github" / "workflows" / "manual-test-exabox.yml"
+IRD_DOCKERFILE = REPO_ROOT / ".github" / "containers" / "Dockerfile"
+INSTALL_EXABOX_WORKER = (
+    REPO_ROOT / ".github" / "containers" / "install-exabox-worker.sh"
+)
+UPLIFT_PATHS = REPO_ROOT / ".github" / "scripts" / "uplift-paths.sh"
+
+
+def test_enabled_galaxy_tests_use_exabox_instead_of_legacy_runner() -> None:
+    ci_workflow = CI_WORKFLOW.read_text()
+    call_build = CALL_BUILD.read_text()
+    n150_workflow = CALL_TEST_HARDWARE.read_text()
+
+    assert "run_galaxy_tests: true" in ci_workflow
+    assert "uses: ./.github/workflows/call-test-exabox.yml" in call_build
+    assert "if: ${{ inputs.run_galaxy_tests }}" in call_build
+    assert "needs: [test-hardware, test-exabox]" in call_build
+    assert '"in-service", "galaxy-bh"' not in call_build
+    assert "galaxy-bh" not in n150_workflow
+
+
+def test_exabox_workflow_dispatches_all_worker_operations_through_scripts() -> None:
+    workflow = CALL_TEST_EXABOX.read_text()
+
+    assert "runs-on: exabox-multihost-ci-sc1" in workflow
+    assert "image: ghcr.io/tenstorrent/tt-lang/tt-lang-ird-ubuntu-24-04:" in workflow
+    assert "run: |" not in workflow
+    assert ".github/scripts/prepare-exabox-workspace.sh stage" in workflow
+    assert workflow.count(".github/scripts/run-exabox-hardware-phase.sh") == 13
+    assert workflow.count("steps.stage.outcome == 'success'") == 2
+    assert "options: --device /dev/tenstorrent" not in workflow
+
+
+def test_manual_workflow_calls_the_reusable_exabox_workflow() -> None:
+    workflow = MANUAL_TEST_EXABOX.read_text()
+
+    assert "workflow_dispatch:" in workflow
+    assert "uses: ./.github/workflows/call-build-docker.yml" in workflow
+    assert "push: true" in workflow
+    assert "uses: ./.github/workflows/call-test-exabox.yml" in workflow
+    assert "docker_tag: ${{ needs.build-image.outputs.docker-tag }}" in workflow
+
+
+def test_ird_image_installs_versioned_exabox_worker_support() -> None:
+    dockerfile = IRD_DOCKERFILE.read_text()
+    installer = INSTALL_EXABOX_WORKER.read_text()
+    build_workflow = CALL_BUILD_DOCKER.read_text()
+    uplift_paths = UPLIFT_PATHS.read_text()
+
+    assert "install-exabox-worker.sh" in dockerfile
+    assert "OMPI_TAG=v5.0.7" in dockerfile
+    assert 'test -x "$OMPI_PREFIX/bin/prted"' in installer
+    assert "build/profiler/build_wasm/traces" in installer
+    assert "prted --version" in build_workflow
+    assert "docker run --rm --user 1001:1001" in build_workflow
+    assert "export HOME=/home/user" in build_workflow
+    assert "export TT_METAL_HOME=/opt/ttlang-toolchain/tt-metal" in build_workflow
+    assert "export PYTHONPATH=$TT_METAL_HOME/python_packages/ttnn" in build_workflow
+    assert 'test -w "$TT_METAL_HOME/build/profiler/build_wasm/traces"' in build_workflow
+    assert 'test -w "$TT_METAL_HOME/generated/profiler"' in build_workflow
+    assert 'python3 -c "import ttnn"' in build_workflow
+    assert ".github/containers/install-exabox-worker.sh" in uplift_paths

--- a/test/packaging/test_hardware_job_results.py
+++ b/test/packaging/test_hardware_job_results.py
@@ -48,9 +48,9 @@ def _hardware_job(
             }
         )
 
+    caller_job = "test-exabox" if runner_name == "galaxy-bh" else "test-hardware"
     return {
-        "name": f'build / test-hardware ({runner_name}, ["label"]) / '
-        f"Hardware Tests ({runner_name})",
+        "name": f"build / {caller_job} / Hardware Tests ({runner_name})",
         "steps": steps,
     }
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -83,6 +83,11 @@ def pytest_configure(config):
         "multi_device: needs a fabric mesh; excluded from the "
         "per-chip parallel run and executed serially",
     )
+    config.addinivalue_line(
+        "markers",
+        "compile_only: does not execute on a device; executed serially on "
+        "multi-chip hosts",
+    )
 
 
 # =============================================================================

--- a/test/python/test_bcast_ops.py
+++ b/test/python/test_bcast_ops.py
@@ -1039,6 +1039,7 @@ kern(inp, out)
     return result.stderr
 
 
+@pytest.mark.compile_only
 class TestBcastDimsValidation:
     """Test that out-of-range dims are rejected at compile time."""
 


### PR DESCRIPTION
### Problem description

Galaxy hardware CI still schedules the legacy `galaxy-bh` runner directly. This can leave jobs queued for many hours and does not use the shared Exabox controller and worker execution contract.

### What's changed

- Route enabled Galaxy tests through a dedicated reusable workflow on `exabox-multihost-ci-sc1` while retaining the existing N150 workflow.
- Make the IRD container a valid Exabox worker image with the fixed UID account, SSH server, `tt-smi` launcher, controller-matched OpenMPI 5.0.7/ULFM runtime, and worker-writable profiler directories.
- Stage the checkout through shared storage and execute reset, build, and test phases on every Galaxy worker host with `mpirun --pernode`.
- Move hardware phase logic into shared shell scripts covered by Bats tests.
- Execute compile-only validation tests serially on multi-chip hosts while retaining per-chip parallel device tests and serial fabric tests.
- Add a manual Exabox workflow that builds the current revision's IRD image before testing.
- Re-enable Galaxy tests in CI and preserve aggregate hardware-result checking.
- Skip report collection when runner admission or checkout fails before workspace staging.

### Validation

- Exact-head workflow dispatch [31865688044](https://github.com/tenstorrent/tt-lang/actions/runs/31865688044) at `dfa438f31`: N150, Exabox Galaxy, and aggregate hardware result passed.
- Galaxy execution passed container initialization, MPI staging, configure/build, dependency installation, reset/health check, smoketest, one-chip test, simulator, Python lit, Python DSL, ME2E, compiler examples, tutorials, and report upload.
- The Galaxy artifact contains 43 XML reports with no failure or error elements.
- PR CI [31865663790](https://github.com/tenstorrent/tt-lang/actions/runs/31865663790): N150 and the aggregate hardware result passed. The Exabox job is rejected by the internal-runner admission policy before container initialization; report cleanup remains skipped, and the aggregate checker treats this setup-only rejection as infrastructure.
- Actionlint, ShellCheck, repository-wide pre-commit, 579 Bats tests, and 168 packaging/workflow tests passed.

### Checklist
- [x] New/Existing tests provide coverage for changes
