### PR TITLE
[ttl] Hoist resources introduced by operation composition [dfb-reuse-11]

### DIFF
--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -17,6 +17,8 @@ from ttl.dfb_reset import DFBReset
 from ttl.kernel import Kernel
 from ttl.scalar import ScalarType
 
+_INLINED_OPERATION_STATEMENT = "_ttl_inlined_operation_statement"
+
 _NESTED_SCOPES = (
     ast.FunctionDef,
     ast.AsyncFunctionDef,
@@ -387,6 +389,7 @@ def _expand_call(
         cloned_statement = copy.deepcopy(statement)
         inlined_statement = transformer.visit(cloned_statement)
         ast.fix_missing_locations(inlined_statement)
+        setattr(inlined_statement, _INLINED_OPERATION_STATEMENT, True)
         result.append(inlined_statement)
     return result
 

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -26,6 +26,7 @@ the explicit multi-kernel form.
 from __future__ import annotations
 
 import ast
+import builtins
 import copy
 import functools
 import hashlib
@@ -38,10 +39,15 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 import ttl as _ttl
 from ttl.pykernel._src.utils import _cleanup_source_code
 
-from ._src.atom_inline import inline_atom_calls
+from ._src.atom_inline import (
+    _INLINED_OPERATION_STATEMENT,
+    _collect_local_names,
+    inline_atom_calls,
+)
 from ._src.atom_rules import (
     defines_kernels_by_spelling,
     function_scope,
+    loaded_names_in,
     parse_function_definition,
     setup_assign_target,
     validate_operation_interface,
@@ -274,6 +280,7 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
         inlined_dispatch_conditions,
         inlined_dfb_resets,
     ) = inline_atom_calls(fn_def, scope, caller_name=name)
+    _hoist_inlined_resource_declarations(fn_def, scope, name)
     validate_resource_declarations(fn_def, name)
 
     loaded_names = set()
@@ -407,6 +414,121 @@ def _is_compile_time_literal(value: Any) -> bool:
     if isinstance(value, (tuple, list)):
         return all(_is_compile_time_literal(element) for element in value)
     return False
+
+
+class _OperationResourceNameCollector(ast.NodeVisitor):
+    def __init__(self):
+        self.names = set()
+
+    def visit_Assign(self, node):
+        resource_name = setup_assign_target(node)
+        if resource_name is not None:
+            self.names.add(resource_name)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        return
+
+    def visit_AsyncFunctionDef(self, node):
+        return
+
+    def visit_ClassDef(self, node):
+        return
+
+
+def _operation_resource_names(fn_def: ast.FunctionDef) -> set:
+    collector = _OperationResourceNameCollector()
+    for statement in fn_def.body:
+        collector.visit(statement)
+    return collector.names
+
+
+def _hoist_inlined_resource_declarations(
+    fn_def: ast.FunctionDef,
+    scope: Dict[str, Any],
+    operation_name: str,
+) -> None:
+    """Restore setup placement for resources introduced by composition."""
+
+    resource_names = _operation_resource_names(fn_def)
+    parameter_names = {
+        argument.arg
+        for argument in (
+            fn_def.args.posonlyargs + fn_def.args.args + fn_def.args.kwonlyargs
+        )
+    }
+    local_names = _collect_local_names(fn_def)
+    static_names = set(scope) | set(dir(builtins)) | resource_names | parameter_names
+    dynamic_local_names = local_names - resource_names - parameter_names
+
+    def rewrite_body(
+        statements: List[ast.stmt], *, operation_top_level: bool
+    ) -> Tuple[List[ast.stmt], List[ast.stmt]]:
+        rewritten = []
+        hoisted = []
+        for statement in statements:
+            if isinstance(
+                statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                rewritten.append(statement)
+                continue
+
+            nested_resources = []
+            for attribute in ("body", "orelse", "finalbody"):
+                body = getattr(statement, attribute, None)
+                if not isinstance(body, list):
+                    continue
+                if not body or not isinstance(body[0], ast.stmt):
+                    continue
+                rewritten_body, body_resources = rewrite_body(
+                    body, operation_top_level=False
+                )
+                if attribute == "body" and not rewritten_body:
+                    rewritten_body = [ast.copy_location(ast.Pass(), statement)]
+                setattr(statement, attribute, rewritten_body)
+                nested_resources.extend(body_resources)
+
+            handlers = getattr(statement, "handlers", None)
+            if isinstance(handlers, list):
+                for handler in handlers:
+                    if not isinstance(handler, ast.ExceptHandler):
+                        continue
+                    handler.body, handler_resources = rewrite_body(
+                        handler.body, operation_top_level=False
+                    )
+                    if not handler.body:
+                        handler.body = [ast.copy_location(ast.Pass(), handler)]
+                    nested_resources.extend(handler_resources)
+
+            if operation_top_level:
+                rewritten.extend(nested_resources)
+            else:
+                hoisted.extend(nested_resources)
+
+            is_inlined_resource = bool(
+                getattr(statement, _INLINED_OPERATION_STATEMENT, False)
+                and setup_assign_target(statement) is not None
+            )
+            if is_inlined_resource and not operation_top_level:
+                loaded_names = loaded_names_in(statement)
+                dependencies = (loaded_names & dynamic_local_names) | (
+                    loaded_names - static_names - local_names
+                )
+                if dependencies:
+                    raise ValueError(
+                        f"@ttl.operation {operation_name!r}: composed resource "
+                        "declaration cannot be hoisted because it depends on "
+                        f"operation-local values {sorted(dependencies)}"
+                    )
+                hoisted.append(statement)
+                continue
+            rewritten.append(statement)
+        return rewritten, hoisted
+
+    fn_def.body, unplaced_resources = rewrite_body(
+        fn_def.body, operation_top_level=True
+    )
+    assert not unplaced_resources
 
 
 def _lift_setup(

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -766,6 +766,8 @@ def test_global_dfb_reset_name_can_be_shadowed_by_parameter():
         pass
 
     assert shadowed_reset_operation._spec.params[0].name == "shadowed_dfb_reset"
+
+
 def test_composition_hoists_resources_from_control_flow():
     """Composed static resources remain operation-level declarations."""
 
@@ -781,12 +783,13 @@ def test_composition_hoists_resources_from_control_flow():
                 resource_helper()
 
     spec = composed_operation._spec
-    resource_statements = [
-        statement
+    resource_names = [
+        atom_rules.setup_assign_target(statement)
         for statement in spec.fn_ast.body
         if atom_rules.setup_assign_target(statement) is not None
     ]
-    assert len(resource_statements) == 2
+    assert resource_names[0].startswith("first_dfb__")
+    assert resource_names[1].startswith("second_dfb__")
 
     loop = next(
         statement for statement in spec.fn_ast.body if isinstance(statement, ast.For)
@@ -804,7 +807,7 @@ def test_composition_hoists_resources_from_control_flow():
         dict(spec.frozen_scope),
         spec.operation_identity,
     )
-    assert len(dfbs) == 2
+    assert tuple(dfbs) == tuple(resource_names)
 
 
 def test_composition_rejects_hoisted_resource_with_local_dependency():

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -20,6 +20,7 @@ import ttl
 import ttl.atom as atom_module
 import ttl.kernel as kernel_module
 
+from ttl._src import atom_rules
 from ttl._src.atom_split import split_function_body
 from ttl.atom import (
     _assign_backend_kernel_slots,
@@ -765,6 +766,116 @@ def test_global_dfb_reset_name_can_be_shadowed_by_parameter():
         pass
 
     assert shadowed_reset_operation._spec.params[0].name == "shadowed_dfb_reset"
+def test_composition_hoists_resources_from_control_flow():
+    """Composed static resources remain operation-level declarations."""
+
+    @ttl.operation()
+    def resource_helper():
+        first_dfb = ttl.make_dfb("bf16", shape=(1, 1))
+        second_dfb = ttl.make_dfb("bf16", shape=(1, 2))
+
+    @ttl.operation()
+    def composed_operation(enabled):
+        for iteration in range(2):
+            if enabled:
+                resource_helper()
+
+    spec = composed_operation._spec
+    resource_statements = [
+        statement
+        for statement in spec.fn_ast.body
+        if atom_rules.setup_assign_target(statement) is not None
+    ]
+    assert len(resource_statements) == 2
+
+    loop = next(
+        statement for statement in spec.fn_ast.body if isinstance(statement, ast.For)
+    )
+    assert not any(
+        isinstance(node, ast.Call)
+        and atom_rules.call_name(node) in atom_rules.SETUP_FACTORY_NAMES
+        for node in ast.walk(loop)
+    )
+    assert any(isinstance(node, ast.Pass) for node in ast.walk(loop))
+    ast.parse(ast.unparse(spec.fn_ast))
+
+    _, dfbs, _, _ = _lift_setup(
+        copy.deepcopy(spec.fn_ast),
+        dict(spec.frozen_scope),
+        spec.operation_identity,
+    )
+    assert len(dfbs) == 2
+
+
+def test_composition_rejects_hoisted_resource_with_local_dependency():
+    """A resource cannot move outside the scope of a required local value."""
+
+    @ttl.operation()
+    def resource_helper(blocks):
+        helper_dfb = ttl.make_dfb("bf16", shape=(1, blocks))
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "composed resource declaration cannot be hoisted because it depends "
+            "on operation-local values .*iteration"
+        ),
+    ):
+
+        @ttl.operation()
+        def composed_operation():
+            for iteration in range(2):
+                resource_helper(iteration)
+
+
+def test_composition_rejects_hoisted_resource_with_shadowed_builtin():
+    @ttl.operation()
+    def resource_helper(blocks):
+        helper_dfb = ttl.make_dfb("bf16", shape=(1, blocks))
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "composed resource declaration cannot be hoisted because it depends "
+            "on operation-local values .*max"
+        ),
+    ):
+
+        @ttl.operation()
+        def composed_operation():
+            max = 2
+            for iteration in range(2):
+                resource_helper(max)
+
+
+def test_composition_does_not_hoist_resources_from_nested_scope():
+    @ttl.operation()
+    def resource_helper():
+        helper_dfb = ttl.make_dfb("bf16", shape=(1, 1))
+
+    with pytest.raises(
+        ValueError,
+        match="resource declaration 'make_dfb' must be a simple top-level assignment",
+    ):
+
+        @ttl.operation()
+        def composed_operation():
+            def callback():
+                resource_helper()
+
+
+def test_resource_name_collection_excludes_nested_scopes():
+    function = _fn(
+        """
+        def operation():
+            operation_dfb = ttl.make_dfb("bf16", shape=(1, 1))
+
+            def callback():
+                callback_dfb = ttl.make_dfb("bf16", shape=(1, 1))
+        """
+    )
+
+    assert atom_module._operation_resource_names(function) == {"operation_dfb"}
 
 
 def test_composition_preserves_one_synchronized_dfb_reset_identity():

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -103,6 +103,26 @@ def _make_repeated_dfb_atom_kernel(data_format):
     return repeated_dfb_atom_kernel
 
 
+def _make_composed_control_resource_kernel(data_format):
+    @ttl.operation()
+    def copy_through_dfb(input_tensor, output_tensor):
+        transfer_dfb = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, 1), block_count=2
+        )
+
+        with transfer_dfb.reserve() as destination:
+            ttl.copy(input_tensor[0, 0], destination).wait()
+        with transfer_dfb.wait() as source:
+            ttl.copy(source, output_tensor[0, 0]).wait()
+
+    @ttl.operation(grid=(1, 1))
+    def composed_control_resource_kernel(input_tensor, output_tensor):
+        for iteration in range(2):
+            copy_through_dfb(input_tensor, output_tensor)
+
+    return composed_control_resource_kernel
+
+
 @ttl.operation()
 def _store_waited_block(state_dfb: ttl.DFB, output_dfb: ttl.DFB):
     with state_dfb.wait() as state_block:
@@ -870,6 +890,8 @@ def _make_selected_reset_alias_domain_kernel(data_format):
 
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
+_composed_control_bf16_kernel = _make_composed_control_resource_kernel("bf16")
+_composed_control_f32_kernel = _make_composed_control_resource_kernel("float32")
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
 _in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
 _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
@@ -1579,6 +1601,39 @@ def test_repeated_dfb_declaring_atom_runtime(
             rtol=F32_REPEATED_EXP_RTOL,
             atol=F32_REPEATED_EXP_ATOL,
         )
+
+
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_composed_control_bf16_kernel, torch.bfloat16),
+        (_composed_control_f32_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+def test_composed_control_resource_runtime(
+    device, memory_config, to_device, operation, dtype
+):
+    input_host = torch.linspace(-1.0, 1.0, TILE * TILE, dtype=torch.float32).reshape(
+        TILE, TILE
+    )
+    input_host = input_host.to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    operation(input_tensor, output_tensor)
+    operation(input_tensor, output_tensor)
+
+    actual = ttnn.to_torch(output_tensor).float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, input_host.float(), rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, input_host.float(), rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -103,7 +103,7 @@ def _make_repeated_dfb_atom_kernel(data_format):
     return repeated_dfb_atom_kernel
 
 
-def _make_composed_control_resource_kernel(data_format):
+def _make_composed_control_resource_kernel():
     @ttl.operation()
     def copy_through_dfb(input_tensor, output_tensor):
         transfer_dfb = ttl.make_dataflow_buffer_like(
@@ -890,8 +890,7 @@ def _make_selected_reset_alias_domain_kernel(data_format):
 
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
-_composed_control_bf16_kernel = _make_composed_control_resource_kernel("bf16")
-_composed_control_f32_kernel = _make_composed_control_resource_kernel("float32")
+_composed_control_resource_kernel = _make_composed_control_resource_kernel()
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
 _in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
 _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
@@ -1609,16 +1608,11 @@ def test_repeated_dfb_declaring_atom_runtime(
     ids=["dram", "l1"],
 )
 @pytest.mark.parametrize(
-    ("operation", "dtype"),
-    [
-        (_composed_control_bf16_kernel, torch.bfloat16),
-        (_composed_control_f32_kernel, torch.float32),
-    ],
+    "dtype",
+    [torch.bfloat16, torch.float32],
     ids=["bf16", "f32"],
 )
-def test_composed_control_resource_runtime(
-    device, memory_config, to_device, operation, dtype
-):
+def test_composed_control_resource_runtime(device, memory_config, to_device, dtype):
     input_host = torch.linspace(-1.0, 1.0, TILE * TILE, dtype=torch.float32).reshape(
         TILE, TILE
     )
@@ -1626,8 +1620,8 @@ def test_composed_control_resource_runtime(
     input_tensor = to_device(input_host, device)
     output_tensor = to_device(torch.zeros_like(input_host), device)
 
-    operation(input_tensor, output_tensor)
-    operation(input_tensor, output_tensor)
+    _composed_control_resource_kernel(input_tensor, output_tensor)
+    _composed_control_resource_kernel(input_tensor, output_tensor)
 
     actual = ttnn.to_torch(output_tensor).float()
     if dtype == torch.bfloat16:


### PR DESCRIPTION
### Problem description

Operation composition expands a child body at its call site. When a resource-owning child is composed inside static control flow, its generated DFB declarations remain nested at the dynamic call site and fail resource validation even though they were valid top-level resources in the child operation. The complete KDA+MoE composition requires this form for resource-owning layer helpers.

### What's changed

~130 LOC implementation (tests and documentation excluded).

Mark statements introduced by composition and restore recognized static resource assignments to operation-level setup before resource validation and logical-kernel splitting. Generated declarations retain deterministic source and dependency order, while declarations that depend on operation-local control values receive a source diagnostic.

Only resources introduced by composition are moved. User-written declarations inside control flow, callbacks, or nested scopes remain invalid. This distinction preserves the public static-resource rule while allowing composition to retain the child's original semantics.

```python
@ttl.operation()
def child(input_tensor, output_tensor):
    staging = ttl.make_dataflow_buffer_like(
        input_tensor,
        shape=(1, 1),
        block_count=2,
    )
    with staging.reserve() as destination:
        ttl.copy(input_tensor[0, 0], destination).wait()
    with staging.wait() as source:
        ttl.copy(source, output_tensor[0, 0]).wait()

@ttl.operation(grid=(1, 1))
def parent(input_tensor, output_tensor):
    for _ in range(2):
        child(input_tensor, output_tensor)
```

### Validation

- A new device test composes a resource-owning child inside a static loop across BF16/FP32 and DRAM/L1 with two loop transactions and repeated dispatch.
- New composition tests cover deterministic ordering, lexical resource names, resource-only control bodies, nested DFB declarations, and control-local, shadowed, and callback-local declaration diagnostics.

### Stack

Builds on merged #891 and replaces historical #897.
