### PR TITLE
[ttl] Model repeated reset lifetimes [dfb-reuse-16]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -171,9 +171,10 @@ reset_operation = make_reset_operation()
 The same `DFBReset` value identifies the three occurrences as one dynamic
 boundary. `ttl.reset_all_dfbs(reset_boundary)` provides the same boundary for
 every allocated physical DFB index. A declaration contains exactly one compute
-kernel and two data movement kernels, and it executes at most once per dispatch
-and launch node. Conditional occurrences must use equivalent structured
-conditions on all participants.
+kernel and two data movement kernels. It executes once per dispatch and launch
+node, or once per iteration of the same immutable sequential loop nest in all
+participants. Conditional occurrences must use equivalent structured conditions
+on all participants and cannot form a repeated reset run.
 
 The compiler treats the interval before the first reset, each interval between
 resets, and the interval after the last reset as separate allocation epochs.
@@ -185,8 +186,8 @@ selects the same DFB set. The reset discards producer-only occupancy and
 terminates the old lifecycle at canonical empty state. A later lifecycle can
 then reuse the physical index when its launch-node domain, storage, element
 type, and other allocation constraints are compatible. Missing participants,
-repeated dynamic instances, mismatched conditions or target sets, incomplete
-transactions, and unordered boundaries are compilation errors.
+nonuniform or mismatched repeated sequences, mismatched conditions or target
+sets, incomplete transactions, and unordered boundaries are compilation errors.
 
 On Blackhole, `convert-ttl-to-ttkernel` lowers each occurrence to
 `experimental::reset_dfb_interfaces(state_address, low_mask, high_mask)` from

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1279,6 +1279,29 @@ page format, sufficient storage, and legal ring-pointer progression.
 `CircularBufferType` is an MLIR-uniqued type, so exact ordinary compatibility
 is a pointer comparison.
 
+### Repeated synchronized reset intervals
+
+A synchronized reset declaration in an immutable sequential `scf.for` or
+`affine.for` loop denotes one collective reset instance per iteration. Every
+participant must execute once in each iteration on the same launch node and
+must have the same nested trip-count sequence. Unknown counts, conditional
+iterations, non-sequential loops, participant-count differences, and target-set
+differences are rejected because they cannot establish corresponding collective
+instances.
+
+The liveness analysis represents the first and last reset instances without
+expanding the happens-before graph by the trip count. A DFB receives a repeated
+interval lifetime only when every active access executes once per iteration in
+the same local loop nest and completes before that iteration's reset. Protocol
+validation then normalizes each selected access to one representative interval.
+The reset supplies the terminal canonical pointer and occupancy state, and the
+lifecycle epoch records the number of represented intervals.
+
+This representative interval does not create a dispatch-wide allocation
+boundary between unrelated DFB declarations. Accesses outside the matching loop
+domain, consumer-only intervals that may block before the reset, and incomplete
+or conditionally mismatched protocols remain conservative.
+
 ### Logical identity
 
 The frontend assigns each user-declared DFB a module-wide logical `dfb_id` and

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1994,9 +1994,10 @@ def TTL_ResetDFBsOp : TTL_Op<"reset_dfbs", [MemoryEffects<[MemWrite]>]> {
   let description = [{
     `ttl.reset_dfbs` is one worker-local synchronization boundary shared by
     the three logical kernels named by `reset`. Each participant executes the
-    same zero-or-one dynamic instance per dispatch and launch node. Before any
-    participant returns, the operation completes prior DFB-interface work and
-    restores the listed DFBs to canonical empty protocol state without
+    same zero-or-one dynamic instance per dispatch and launch node, or one
+    instance per iteration of an equivalent immutable sequential loop nest.
+    Before any participant returns, the operation completes prior DFB-interface
+    work and restores the listed DFBs to canonical empty protocol state without
     changing descriptor configuration or payload storage.
 
     The operation resets read and write pointers, the packer write-tile

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -89,7 +89,8 @@ def TTL_SynchronizedDFBResetAttr
     order is canonical and otherwise semantically insignificant. The
     participant set contains one compute kernel and both data movement kernels
     that own DFB interface state. Each participant executes the declaration at
-    most once per enclosing loop iteration and launch node.
+    most once at each point in the enclosing nested iteration sequence and
+    launch node.
   }];
   let parameters = (ins
     "int64_t":$ordinal,

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -74,18 +74,22 @@ def TTL_SynchronizedDFBResetAttr
     : TTL_Attr<"SynchronizedDFBReset", "synchronized_dfb_reset"> {
   let summary = "Worker-local synchronized dataflow buffer reset identity";
   let description = [{
-    Identifies one dynamic reset instance and the complete set of logical
-    kernels that participate on each active worker. Every participant reaches
-    the same instance before any participant returns. The reset establishes
-    canonical read-pointer, write-pointer, occupancy, and initialization state
-    for each target declared by the operation.
+    Identifies one synchronized reset declaration and the complete set of
+    logical kernels that participate on each active worker. Every participant
+    reaches each corresponding dynamic instance before any participant
+    returns. A declaration in an immutable sequential structured loop denotes
+    one reset instance per iteration; participant loops must define the same
+    nested iteration sequence. The reset establishes canonical read-pointer,
+    write-pointer, occupancy, and initialization state for each target declared
+    by the operation.
 
     The ordinal is module-local and has no runtime meaning. Equal attributes
-    reference the same reset instance. Distinct ordinals identify independent
-    reset instances. Participant order is canonical and otherwise semantically
-    insignificant. The participant set contains one compute kernel and both
-    data movement kernels that own DFB interface state. Each participant
-    executes the declaration at most once per dispatch and launch node.
+    reference the same reset instance or statically repeated instance sequence.
+    Distinct ordinals identify independent reset declarations. Participant
+    order is canonical and otherwise semantically insignificant. The
+    participant set contains one compute kernel and both data movement kernels
+    that own DFB interface state. Each participant executes the declaration at
+    most once per enclosing loop iteration and launch node.
   }];
   let parameters = (ins
     "int64_t":$ordinal,

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -269,7 +269,11 @@ static void printResetEpochs(llvm::raw_ostream &output,
   output << '[';
   llvm::interleaveComma(
       lifetime.resetEpochs, output, [&](const DFBLifecycleEpoch &epoch) {
-        output << "{accesses=";
+        output << '{';
+        if (epoch.executionCount > 1) {
+          output << "executions=" << epoch.executionCount << ',';
+        }
+        output << "accesses=";
         printValues(output, epoch.accessOccurrenceIndices);
         output << ",transactions=";
         printTransactionRuns(output, epoch.transactionRuns);
@@ -315,7 +319,8 @@ static bool hasEqualResetEpochs(ArrayRef<DFBLifecycleEpoch> lhs,
   return llvm::equal(
       lhs, rhs,
       [](const DFBLifecycleEpoch &lhsEpoch, const DFBLifecycleEpoch &rhsEpoch) {
-        return lhsEpoch.accessOccurrenceIndices ==
+        return lhsEpoch.executionCount == rhsEpoch.executionCount &&
+               lhsEpoch.accessOccurrenceIndices ==
                    rhsEpoch.accessOccurrenceIndices &&
                lhsEpoch.transactionRuns == rhsEpoch.transactionRuns &&
                lhsEpoch.writeCursorRuns == rhsEpoch.writeCursorRuns &&

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -3982,25 +3982,27 @@ buildLogicalOrdering(ArrayRef<const DFBPerNodeLifetime *> lifetimes,
 
 static bool intervalIsOutsideReset(ArrayRef<unsigned> earliestEntryEvents,
                                    ArrayRef<unsigned> terminalCompletionEvents,
-                                   EventPair resetEvents,
+                                   const AccessEventSpan &resetEvents,
                                    const HappensBeforeGraph &graph) {
   if (earliestEntryEvents.empty() || terminalCompletionEvents.empty()) {
     return false;
   }
   bool beforeReset =
       llvm::all_of(terminalCompletionEvents, [&](unsigned terminalCompletion) {
-        return graph.strictlyPrecedes(terminalCompletion, resetEvents.entry);
+        return graph.strictlyPrecedes(terminalCompletion,
+                                      resetEvents.first.entry);
       });
   bool afterReset =
       llvm::all_of(earliestEntryEvents, [&](unsigned earliestEntry) {
-        return graph.strictlyPrecedes(resetEvents.completion, earliestEntry);
+        return graph.strictlyPrecedes(resetEvents.last.completion,
+                                      earliestEntry);
       });
   return beforeReset || afterReset;
 }
 
 static bool lifetimeIsOutsideReset(const DFBPerNodeLifetime &lifetime,
                                    SynchronizedDFBResetAttr reset,
-                                   EventPair resetEvents,
+                                   const AccessEventSpan &resetEvents,
                                    const HappensBeforeGraph &graph) {
   if (lifetime.resetEpochs.empty()) {
     return intervalIsOutsideReset(lifetime.earliestEntryEvents,

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -2990,7 +2990,10 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
     const LaunchNodeDomainState &domainState,
     bool includeUnknownDomains = false,
     ArrayRef<const DFBAccessOccurrence *> selectedAccesses = {},
-    bool hasCanonicalResetTerminator = false) {
+    bool hasCanonicalResetTerminator = false,
+    std::uint64_t executionCountDivisor = 1) {
+  assert(executionCountDivisor > 0 &&
+         "execution-count divisor must be positive");
   DFBPerNodeLifetime &lifetime = lifetimes.emplace_back();
   lifetime.node = node;
   DFBPerNodeLifetimeDiagnostics *diagnostics = nullptr;
@@ -3191,10 +3194,23 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
     }
     lifetime.conditionalExecutionProven = true;
   }
-  auto getTransactionCount = [](ArrayRef<const AccessRun *> runs) {
+  auto getIntervalExecutionCount =
+      [executionCountDivisor](
+          const AccessRun &run) -> std::optional<std::uint64_t> {
+    if (run.executionCount % executionCountDivisor != 0) {
+      return std::nullopt;
+    }
+    return run.executionCount / executionCountDivisor;
+  };
+  auto getTransactionCount = [&](ArrayRef<const AccessRun *> runs) {
     std::optional<std::uint64_t> total = 0;
     for (const AccessRun *run : runs) {
-      total = llvm::checkedAddUnsigned(*total, run->executionCount);
+      std::optional<std::uint64_t> intervalCount =
+          getIntervalExecutionCount(*run);
+      if (!intervalCount) {
+        return std::optional<std::uint64_t>();
+      }
+      total = llvm::checkedAddUnsigned(*total, *intervalCount);
       if (!total) {
         break;
       }
@@ -3229,7 +3245,7 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
   llvm::append_range(consumerProtocolRuns, waits);
   llvm::append_range(consumerProtocolRuns, pops);
   bool useCumulativeQueueProof =
-      !resetTerminatedProducer &&
+      executionCountDivisor == 1 && !resetTerminatedProducer &&
       supportsCumulativeQueueProof(producerProtocolRuns) &&
       supportsCumulativeQueueProof(consumerProtocolRuns);
   if (!countsMatch && !useCumulativeQueueProof) {
@@ -3372,8 +3388,14 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
     if (resetTerminatedProducer) {
       std::uint64_t occupiedTiles = 0;
       for (const AccessRun *reserve : reserves) {
+        std::optional<std::uint64_t> intervalCount =
+            getIntervalExecutionCount(*reserve);
+        if (!intervalCount) {
+          return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
+                  reserve->access->operation};
+        }
         std::optional<std::uint64_t> runTiles = llvm::checkedMulUnsigned(
-            reserve->executionCount,
+            *intervalCount,
             static_cast<std::uint64_t>(reserve->access->numTiles));
         if (!runTiles) {
           return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
@@ -3387,7 +3409,7 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
                   reserve->access->operation};
         }
         occupiedTiles = *updatedTiles;
-        appendTransactionRun(lifetime.transactionRuns, reserve->executionCount,
+        appendTransactionRun(lifetime.transactionRuns, *intervalCount,
                              reserve->access->numTiles);
       }
     } else {
@@ -3409,18 +3431,26 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
           return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                   reserve.access->operation};
         }
+        std::optional<std::uint64_t> reserveIntervalCount =
+            getIntervalExecutionCount(reserve);
+        std::optional<std::uint64_t> waitIntervalCount =
+            getIntervalExecutionCount(wait);
+        if (!reserveIntervalCount || !waitIntervalCount) {
+          return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
+                  reserve.access->operation};
+        }
         std::uint64_t matchedCount =
-            std::min(reserve.executionCount - reserveOffset,
-                     wait.executionCount - waitOffset);
+            std::min(*reserveIntervalCount - reserveOffset,
+                     *waitIntervalCount - waitOffset);
         appendTransactionRun(lifetime.transactionRuns, matchedCount,
                              reserve.access->numTiles);
         reserveOffset += matchedCount;
         waitOffset += matchedCount;
-        if (reserveOffset == reserve.executionCount) {
+        if (reserveOffset == *reserveIntervalCount) {
           ++reserveIndex;
           reserveOffset = 0;
         }
-        if (waitOffset == wait.executionCount) {
+        if (waitOffset == *waitIntervalCount) {
           ++waitIndex;
           waitOffset = 0;
         }
@@ -3524,6 +3554,174 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
   return {};
 }
 
+static std::optional<std::pair<Operation *, const StaticIterationDomain *>>
+getParticipantIteration(const ValidatedSynchronizedReset &reset,
+                        Operation *accessOperation) {
+  func::FuncOp accessFunction =
+      accessOperation->getParentOfType<func::FuncOp>();
+  if (!accessFunction) {
+    return std::nullopt;
+  }
+  for (auto [participant, iterationDomain] : llvm::zip_equal(
+           reset.participantOperations, reset.participantIterationDomains)) {
+    if (participant &&
+        participant->getParentOfType<func::FuncOp>() == accessFunction) {
+      return std::make_pair(participant, &iterationDomain);
+    }
+  }
+  return std::nullopt;
+}
+
+// Models one representative interval when every access and its terminating
+// collective reset execute once per iteration of the same sequential loop.
+// The reset restores canonical cursor state, so physical allocation validates
+// the per-iteration transactions rather than their dispatch-wide sum.
+static std::optional<DFBLifecycleCompletionProof>
+tryComputeRepeatedResetLifetime(
+    DFBLogicalLifecycle &logicalDFB, unsigned logicalIndex,
+    LaunchNodeCoord node, SmallVectorImpl<DFBPerNodeLifetime> &lifetimes,
+    SmallVectorImpl<DFBPerNodeLifetimeDiagnostics> *lifetimeDiagnostics,
+    ArrayRef<ValidatedSynchronizedReset> synchronizedResets,
+    const ResetBoundaryEvents &resetBoundaryEvents,
+    const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
+    const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
+    const LaunchNodeDomainState &domainState,
+    const StructuralOperationOrder &structuralOrder,
+    bool includeUnknownDomains) {
+  SmallVector<const DFBAccessOccurrence *> activeAccesses;
+  for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
+    if (!mayContainLaunchNode(access.launchDomain, node,
+                              includeUnknownDomains)) {
+      continue;
+    }
+    auto executionCountIt = executionCounts.find(&access);
+    assert(executionCountIt != executionCounts.end() &&
+           "every DFB access must have an execution-count fact");
+    if (executionCountIt->second && *executionCountIt->second == 0) {
+      continue;
+    }
+    activeAccesses.push_back(&access);
+  }
+  if (activeAccesses.empty()) {
+    return std::nullopt;
+  }
+
+  SmallVector<const ValidatedSynchronizedReset *> candidates;
+  for (const ValidatedSynchronizedReset &reset : synchronizedResets) {
+    if (reset.executionCount <= 1 || reset.conditionalExecution ||
+        !llvm::is_contained(reset.targetLogicalIndices, logicalIndex)) {
+      continue;
+    }
+    auto resetEventsIt = resetBoundaryEvents.find(reset.reset);
+    if (resetEventsIt == resetBoundaryEvents.end()) {
+      continue;
+    }
+    bool terminatesEveryAccess =
+        llvm::all_of(activeAccesses, [&](const DFBAccessOccurrence *access) {
+          auto runIt = accessRuns.find(access);
+          std::optional<std::pair<Operation *, const StaticIterationDomain *>>
+              participant = getParticipantIteration(reset, access->operation);
+          std::optional<AccessEventSpan> events =
+              getAccessEventSpan(*access, operationEvents, accessEvents);
+          if (runIt == accessRuns.end() || !participant || !events ||
+              runIt->second.conditionalExecution ||
+              runIt->second.executionCount != reset.executionCount ||
+              !(runIt->second.iterationDomain == *participant->second) ||
+              !structuralOrder.precedes(access->operation,
+                                        participant->first)) {
+            return false;
+          }
+          const AccessEventSpan &resetEvents = resetEventsIt->second;
+          return graph.strictlyPrecedes(events->first.completion,
+                                        resetEvents.first.entry) &&
+                 graph.strictlyPrecedes(events->last.completion,
+                                        resetEvents.last.entry);
+        });
+    if (terminatesEveryAccess) {
+      candidates.push_back(&reset);
+    }
+  }
+  if (candidates.empty()) {
+    return std::nullopt;
+  }
+
+  const ValidatedSynchronizedReset *terminator = nullptr;
+  for (const ValidatedSynchronizedReset *candidate : candidates) {
+    const AccessEventSpan &candidateEvents =
+        resetBoundaryEvents.at(candidate->reset);
+    bool precedesEveryOtherCandidate =
+        llvm::all_of(candidates, [&](const ValidatedSynchronizedReset *other) {
+          if (candidate == other) {
+            return true;
+          }
+          const AccessEventSpan &otherEvents =
+              resetBoundaryEvents.at(other->reset);
+          return graph.strictlyPrecedes(candidateEvents.first.completion,
+                                        otherEvents.first.entry) &&
+                 graph.strictlyPrecedes(candidateEvents.last.completion,
+                                        otherEvents.last.entry);
+        });
+    if (precedesEveryOtherCandidate) {
+      terminator = candidate;
+      break;
+    }
+  }
+  if (!terminator) {
+    return std::nullopt;
+  }
+
+  SmallVector<DFBPerNodeLifetime, 0> intervalLifetimes;
+  SmallVector<DFBPerNodeLifetimeDiagnostics, 0> intervalDiagnostics;
+  DFBLifecycleCompletionProof proof = computeProtocolLifetime(
+      logicalDFB, node, intervalLifetimes,
+      lifetimeDiagnostics ? &intervalDiagnostics : nullptr, graph,
+      structuralOrder, operationEvents, accessEvents, executionCounts,
+      accessRuns, domainState, includeUnknownDomains, activeAccesses,
+      /*hasCanonicalResetTerminator=*/true, terminator->executionCount);
+  assert(intervalLifetimes.size() == 1 &&
+         "one repeated interval must produce one protocol lifetime");
+  assert((!lifetimeDiagnostics || intervalDiagnostics.size() == 1) &&
+         "one repeated interval must produce one diagnostic lifetime");
+  lifetimes.push_back(std::move(intervalLifetimes.front()));
+  if (lifetimeDiagnostics) {
+    lifetimeDiagnostics->push_back(std::move(intervalDiagnostics.front()));
+  }
+  DFBPerNodeLifetime &lifetime = lifetimes.back();
+  lifetime.completionProof = proof;
+  if (!proof.proven()) {
+    return proof;
+  }
+
+  const AccessEventSpan &terminatorEvents =
+      resetBoundaryEvents.at(terminator->reset);
+  lifetime.terminalCompletionEvents = {terminatorEvents.last.completion};
+  lifetime.terminalStateCanonical = true;
+
+  DFBLifecycleEpoch epoch;
+  epoch.executionCount = terminator->executionCount;
+  for (const DFBAccessOccurrence *access : activeAccesses) {
+    epoch.accessOccurrenceIndices.push_back(
+        static_cast<unsigned>(access - logicalDFB.accesses.data()));
+  }
+  epoch.earliestEntryEvents = lifetime.earliestEntryEvents;
+  epoch.terminalCompletionEvents = lifetime.terminalCompletionEvents;
+  epoch.transactionRuns = lifetime.transactionRuns;
+  epoch.writeCursorRuns = lifetime.writeCursorRuns;
+  epoch.readCursorRuns = lifetime.readCursorRuns;
+  epoch.writePointerOwner = lifetime.writePointerOwner;
+  epoch.readPointerOwner = lifetime.readPointerOwner;
+  epoch.terminalWritePointerOwner = lifetime.terminalWritePointerOwner;
+  epoch.terminalReadPointerOwner = lifetime.terminalReadPointerOwner;
+  epoch.terminalResetOrdinal = terminator->reset.getOrdinal();
+  epoch.inspectionOnly = lifetime.inspectionOnly;
+  epoch.terminalStateCanonical = true;
+  epoch.completionProof = proof;
+  lifetime.resetEpochs.push_back(std::move(epoch));
+  return proof;
+}
+
 struct OrderedResetBoundary {
   const ValidatedSynchronizedReset *reset = nullptr;
   EventPair events;
@@ -3545,6 +3743,15 @@ static DFBLifecycleCompletionProof computePerNodeLifetime(
     const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
     const LaunchNodeDomainState &domainState,
     bool includeUnknownDomains = false) {
+  if (std::optional<DFBLifecycleCompletionProof> repeatedResetProof =
+          tryComputeRepeatedResetLifetime(
+              logicalDFB, logicalIndex, node, lifetimes, lifetimeDiagnostics,
+              synchronizedResets, resetBoundaryEvents, graph, operationEvents,
+              accessEvents, executionCounts, accessRuns, domainState,
+              structuralOrder, includeUnknownDomains)) {
+    return *repeatedResetProof;
+  }
+
   SmallVector<OrderedResetBoundary> boundaries;
   for (const ValidatedSynchronizedReset &reset : synchronizedResets) {
     if (!reset.isModeledLifetimeBoundary()) {

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -14,6 +14,7 @@
 
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -29,6 +30,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/CheckedArithmetic.h"
 #include "llvm/Support/Debug.h"
 
@@ -369,35 +371,61 @@ struct SynchronizedResetOccurrence {
   LaunchNodeDomain launchDomain = LaunchNodeDomain::unknown();
 };
 
-// One proved dynamic reset instance on one launch node.
-struct ValidatedSynchronizedReset {
-  SynchronizedDFBResetAttr reset;
-  SmallVector<Operation *> participantOperations;
-  SmallVector<unsigned> targetLogicalIndices;
-  bool conditionalExecution = false;
+// Structured loops whose Cartesian iteration space executes one operation once.
+// Local access ordering uses loop identity; cross-kernel reset matching uses
+// the constant trip-count sequence.
+struct StaticIterationDomain {
+  SmallVector<Operation *> loops;
+  SmallVector<std::uint64_t> tripCounts;
 
-  bool operator==(const ValidatedSynchronizedReset &rhs) const {
-    return std::tie(reset, participantOperations, targetLogicalIndices,
-                    conditionalExecution) ==
-           std::tie(rhs.reset, rhs.participantOperations,
-                    rhs.targetLogicalIndices, rhs.conditionalExecution);
+  bool operator==(const StaticIterationDomain &rhs) const {
+    return loops == rhs.loops && tripCounts == rhs.tripCounts;
   }
 };
 
-using ResetBoundaryEvents = DenseMap<SynchronizedDFBResetAttr, EventPair>;
+// One proved reset instance or uniform reset run on one launch node.
+struct ValidatedSynchronizedReset {
+  SynchronizedDFBResetAttr reset;
+  SmallVector<Operation *> participantOperations;
+  SmallVector<StaticIterationDomain, 0> participantIterationDomains;
+  SmallVector<unsigned> targetLogicalIndices;
+  std::uint64_t executionCount = 1;
+  bool conditionalExecution = false;
+
+  bool operator==(const ValidatedSynchronizedReset &rhs) const {
+    return std::tie(reset, participantOperations, participantIterationDomains,
+                    targetLogicalIndices, executionCount,
+                    conditionalExecution) ==
+           std::tie(rhs.reset, rhs.participantOperations,
+                    rhs.participantIterationDomains, rhs.targetLogicalIndices,
+                    rhs.executionCount, rhs.conditionalExecution);
+  }
+
+  // Dispatch-wide partitioning is valid only for a single reset instance.
+  bool isModeledLifetimeBoundary() const { return executionCount == 1; }
+};
+
+// First and last collective instances of one reset declaration. Equal events
+// represent a single reset instance.
+using ResetBoundaryEvents = DenseMap<SynchronizedDFBResetAttr, AccessEventSpan>;
 
 using AccessExecutionCounts =
     DenseMap<const DFBAccessOccurrence *, std::optional<std::uint64_t>>;
 
-// Structured loops whose Cartesian iteration space executes one access once.
-// Loop operation identity, rather than a numeric count, distinguishes domains.
-struct StaticIterationDomain {
-  SmallVector<Operation *> loops;
+// Compares dynamic iteration positions across different logical kernels. Equal
+// constant trip counts at each nesting depth define the same ordinal iteration
+// sequence without depending on unrelated loop operation identity.
+static bool hasEquivalentIterationSequence(const StaticIterationDomain &lhs,
+                                           const StaticIterationDomain &rhs) {
+  return lhs.tripCounts == rhs.tripCounts;
+}
 
-  bool operator==(const StaticIterationDomain &rhs) const {
-    return loops == rhs.loops;
-  }
-};
+static bool
+hasSequentialIterationOrder(const StaticIterationDomain &iterationDomain) {
+  return llvm::all_of(iterationDomain.loops, [](Operation *loop) {
+    return isa<affine::AffineForOp, scf::ForOp>(loop);
+  });
+}
 
 // One statically counted run of an access occurrence.
 struct AccessRun {
@@ -463,7 +491,7 @@ static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
   }
 
   StaticIterationDomain domain;
-  std::uint64_t domainExecutionCount = 1;
+  std::uint64_t nestedExecutionCount = executionCount;
   Operation *nestedOperation = operation;
   while (nestedOperation->getParentRegion() != &function.getBody()) {
     Region *region = nestedOperation->getParentRegion();
@@ -478,12 +506,8 @@ static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
           getExactExecutionCountAtLaunchNode(parent, node, domainState);
       // Equality proves that an at-most-once region was selected for every
       // parent invocation, including each enclosing-loop iteration.
-      std::optional<std::uint64_t> selectedExecutionCount =
-          parentExecutionCount ? llvm::checkedMulUnsigned(*parentExecutionCount,
-                                                          domainExecutionCount)
-                               : std::nullopt;
-      if (!executesRegionsAtMostOnce(parent) || !selectedExecutionCount ||
-          *selectedExecutionCount != executionCount) {
+      if (!executesRegionsAtMostOnce(parent) || !parentExecutionCount ||
+          *parentExecutionCount != nestedExecutionCount) {
         return std::nullopt;
       }
       nestedOperation = parent;
@@ -497,21 +521,29 @@ static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
     if (!tripCount || *tripCount == 0) {
       return std::nullopt;
     }
-    std::optional<std::uint64_t> product =
-        llvm::checkedMulUnsigned(domainExecutionCount, *tripCount);
-    if (!product) {
+    std::optional<std::uint64_t> parentExecutionCount =
+        getExactExecutionCountAtLaunchNode(parent, node, domainState);
+    if (!parentExecutionCount) {
       return std::nullopt;
     }
-    domainExecutionCount = *product;
+    std::optional<std::uint64_t> loopBodyExecutionCount =
+        llvm::checkedMulUnsigned(*parentExecutionCount, *tripCount);
+    if (!loopBodyExecutionCount ||
+        *loopBodyExecutionCount != nestedExecutionCount) {
+      return std::nullopt;
+    }
     domain.loops.push_back(parent);
+    domain.tripCounts.push_back(*tripCount);
+    nestedExecutionCount = *parentExecutionCount;
     nestedOperation = parent;
   }
 
   if (nestedOperation->getBlock() != &function.getBody().front() ||
-      domainExecutionCount != executionCount) {
+      nestedExecutionCount != 1) {
     return std::nullopt;
   }
   std::reverse(domain.loops.begin(), domain.loops.end());
+  std::reverse(domain.tripCounts.begin(), domain.tripCounts.end());
   return domain;
 }
 
@@ -875,6 +907,17 @@ static bool runPrecedesWithinEachIteration(
 
 // The middle edge preserves iteration-to-iteration order without one event per
 // execution.
+static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
+                                     const AccessEventSpan &before,
+                                     const AccessEventSpan &after) {
+  graph.addEdge(before.first.completion, after.first.entry);
+  graph.addEdge(after.first.completion, before.last.entry);
+  graph.addEdge(before.last.completion, after.last.entry);
+}
+
+// Orders first and last representatives of two equal sequential runs. The
+// middle edge establishes that the next execution of `before` follows the
+// current execution of `after` without creating one event per iteration.
 static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
                                      const AccessEventSpan &before,
                                      const AccessEventSpan &after) {
@@ -1606,6 +1649,8 @@ static LogicalResult validateSynchronizedResetsAtNode(
     bool allParticipantsExact = true;
     bool allParticipantsConditional = true;
     Operation *referenceConditionalOperation = nullptr;
+    std::optional<std::uint64_t> referenceExecutionCount;
+    std::optional<StaticIterationDomain> referenceIterationDomain;
     for (LogicalKernelAttr participant : reset.getParticipants()) {
       SmallVector<const SynchronizedResetOccurrence *> activeOccurrences;
       bool participantMayBeActive = false;
@@ -1622,19 +1667,13 @@ static LogicalResult validateSynchronizedResetsAtNode(
           continue;
         }
         participantMayBeActive = true;
-        if (executionCount && *executionCount != 1) {
-          analysisFailure.set(
-              occurrence->operation,
-              "synchronized DFB reset declaration must execute at most once "
-              "per dispatch and launch node");
-          return failure();
-        }
         if (!executionCount &&
             !structurallyExecutesAtMostOnce(occurrence->operation)) {
           analysisFailure.set(
               occurrence->operation,
-              "synchronized DFB reset requires an exact zero-or-one dynamic "
-              "instance count");
+              "synchronized DFB reset must execute at most once per dispatch "
+              "and launch node or once per iteration of an immutable "
+              "sequential structured loop nest");
           return failure();
         }
         activeOccurrences.push_back(occurrence);
@@ -1651,6 +1690,7 @@ static LogicalResult validateSynchronizedResetsAtNode(
       }
       if (activeOccurrences.empty()) {
         validated.participantOperations.push_back(nullptr);
+        validated.participantIterationDomains.emplace_back();
         continue;
       }
       const SynchronizedResetOccurrence &occurrence =
@@ -1665,11 +1705,41 @@ static LogicalResult validateSynchronizedResetsAtNode(
             "target sets");
         return failure();
       }
-      validated.participantOperations.push_back(occurrence.operation);
       std::optional<std::uint64_t> executionCount =
           getExactExecutionCountAtLaunchNode(occurrence.operation, node,
                                              domainState);
-      if (!executionCount) {
+      StaticIterationDomain iterationDomain;
+      if (executionCount) {
+        if (*executionCount > 1) {
+          std::optional<StaticIterationDomain> uniformDomain =
+              getUniformStaticIterationDomain(
+                  occurrence.operation, *executionCount, node, domainState);
+          if (!uniformDomain || uniformDomain->loops.empty() ||
+              !hasSequentialIterationOrder(*uniformDomain)) {
+            analysisFailure.set(
+                occurrence.operation,
+                ("repeated synchronized DFB reset with exact count " +
+                 llvm::Twine(*executionCount) +
+                 " must execute once in every iteration of an immutable "
+                 "sequential structured loop nest")
+                    .str());
+            return failure();
+          }
+          iterationDomain = std::move(*uniformDomain);
+        }
+        if (!referenceExecutionCount) {
+          referenceExecutionCount = executionCount;
+          referenceIterationDomain = iterationDomain;
+        } else if (*referenceExecutionCount != *executionCount ||
+                   !hasEquivalentIterationSequence(*referenceIterationDomain,
+                                                   iterationDomain)) {
+          analysisFailure.set(
+              occurrence.operation,
+              "synchronized DFB reset participants must execute in the same "
+              "structured iteration sequence");
+          return failure();
+        }
+      } else {
         if (referenceConditionalOperation &&
             !proveEquivalentConditionalExecutionAtLaunchNodes(
                 referenceConditionalOperation, node, occurrence.operation, node,
@@ -1682,6 +1752,9 @@ static LogicalResult validateSynchronizedResetsAtNode(
         }
         referenceConditionalOperation = occurrence.operation;
       }
+      validated.participantOperations.push_back(occurrence.operation);
+      validated.participantIterationDomains.push_back(
+          std::move(iterationDomain));
     }
     if (!anyParticipantActive) {
       continue;
@@ -1707,6 +1780,7 @@ static LogicalResult validateSynchronizedResetsAtNode(
       return failure();
     }
     validated.conditionalExecution = allParticipantsConditional;
+    validated.executionCount = referenceExecutionCount.value_or(1);
     validatedResets.push_back(std::move(validated));
   }
   return success();
@@ -1867,11 +1941,17 @@ static void buildProgramOrderTopology(
     if (participantEvents.size() != reset.participantOperations.size()) {
       continue;
     }
-    EventPair boundaryEvents = graph.addOperation();
-    resetBoundaryEvents.try_emplace(reset.reset, boundaryEvents);
+    EventPair firstEvents = graph.addOperation();
+    EventPair lastEvents = firstEvents;
+    if (reset.executionCount > 1) {
+      lastEvents = graph.addOperation();
+      graph.addEdge(firstEvents.completion, lastEvents.entry);
+    }
+    resetBoundaryEvents.try_emplace(reset.reset,
+                                    AccessEventSpan{firstEvents, lastEvents});
     for (const EventPair &participant : participantEvents) {
-      graph.addEdge(participant.entry, boundaryEvents.entry);
-      graph.addEdge(boundaryEvents.completion, participant.completion);
+      graph.addEdge(participant.entry, firstEvents.entry);
+      graph.addEdge(lastEvents.completion, participant.completion);
     }
   }
 
@@ -1893,8 +1973,18 @@ static void buildProgramOrderTopology(
         auto afterEvents = resetBoundaryEvents.find(after.reset);
         if (beforeEvents != resetBoundaryEvents.end() &&
             afterEvents != resetBoundaryEvents.end()) {
-          graph.addEdge(beforeEvents->second.completion,
-                        afterEvents->second.entry);
+          bool matchingRepeatedSequence =
+              before.executionCount > 1 &&
+              before.executionCount == after.executionCount &&
+              llvm::equal(before.participantIterationDomains,
+                          after.participantIterationDomains);
+          if (matchingRepeatedSequence) {
+            addPerIterationSpanOrder(graph, beforeEvents->second,
+                                     afterEvents->second);
+          } else if (before.executionCount == 1 && after.executionCount == 1) {
+            graph.addEdge(beforeEvents->second.last.completion,
+                          afterEvents->second.first.entry);
+          }
         }
       }
     }
@@ -1908,7 +1998,7 @@ static void addSynchronizedResetAccessEdges(
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const ResetBoundaryEvents &resetBoundaryEvents,
-    const AccessExecutionCounts &executionCounts,
+    const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
     const StructuralOperationOrder &structuralOrder,
     bool includeUnknownDomains) {
   for (const ValidatedSynchronizedReset &reset : synchronizedResets) {
@@ -1916,7 +2006,7 @@ static void addSynchronizedResetAccessEdges(
     if (boundaryIt == resetBoundaryEvents.end()) {
       continue;
     }
-    EventPair boundaryEvents = boundaryIt->second;
+    AccessEventSpan boundaryEvents = boundaryIt->second;
     for (unsigned logicalIndex : reset.targetLogicalIndices) {
       for (const DFBAccessOccurrence &access :
            logicalDFBs[logicalIndex].accesses) {
@@ -1932,25 +2022,46 @@ static void addSynchronizedResetAccessEdges(
         Operation *accessFunction =
             structuralOrder.getFunction(access.operation);
         Operation *localReset = nullptr;
-        for (Operation *participant : reset.participantOperations) {
+        const StaticIterationDomain *localResetDomain = nullptr;
+        for (auto [participantIndex, participant] :
+             llvm::enumerate(reset.participantOperations)) {
           if (structuralOrder.getFunction(participant) == accessFunction) {
             localReset = participant;
+            localResetDomain =
+                &reset.participantIterationDomains[participantIndex];
             break;
           }
         }
         if (!localReset) {
           continue;
         }
-        if (!accessEvents.contains(&access) &&
+        bool sameProjectedOperation =
             structuralOrder.getTopLevelOperation(access.operation) ==
-                structuralOrder.getTopLevelOperation(localReset)) {
+            structuralOrder.getTopLevelOperation(localReset);
+        if (!accessEvents.contains(&access) && sameProjectedOperation) {
           // The enclosing event spans both operations and cannot order them.
           continue;
         }
+        auto runIt = accessRuns.find(&access);
+        bool matchingRepeatedDomain =
+            reset.executionCount > 1 && runIt != accessRuns.end() &&
+            runIt->second.executionCount == reset.executionCount &&
+            runIt->second.iterationDomain == *localResetDomain;
+        if (matchingRepeatedDomain) {
+          if (structuralOrder.precedes(access.operation, localReset)) {
+            addPerIterationSpanOrder(graph, *events, boundaryEvents);
+          } else if (structuralOrder.precedes(localReset, access.operation)) {
+            addPerIterationSpanOrder(graph, boundaryEvents, *events);
+          }
+          continue;
+        }
+        if (reset.executionCount > 1 && sameProjectedOperation) {
+          continue;
+        }
         if (structuralOrder.precedes(access.operation, localReset)) {
-          graph.addEdge(events->last.completion, boundaryEvents.entry);
+          graph.addEdge(events->last.completion, boundaryEvents.first.entry);
         } else if (structuralOrder.precedes(localReset, access.operation)) {
-          graph.addEdge(boundaryEvents.completion, events->first.entry);
+          graph.addEdge(boundaryEvents.last.completion, events->first.entry);
         }
       }
     }
@@ -3436,6 +3547,9 @@ static DFBLifecycleCompletionProof computePerNodeLifetime(
     bool includeUnknownDomains = false) {
   SmallVector<OrderedResetBoundary> boundaries;
   for (const ValidatedSynchronizedReset &reset : synchronizedResets) {
+    if (!reset.isModeledLifetimeBoundary()) {
+      continue;
+    }
     if (!llvm::is_contained(reset.targetLogicalIndices, logicalIndex)) {
       continue;
     }
@@ -3449,7 +3563,9 @@ static DFBLifecycleCompletionProof computePerNodeLifetime(
       return {DFBLifecycleCompletionFailureReason::UnsupportedControlFlow,
               reset.participantOperations.front()};
     }
-    boundaries.push_back({&reset, eventsIt->second});
+    assert(eventsIt->second.first.entry == eventsIt->second.last.entry &&
+           "single reset instance must use one boundary event");
+    boundaries.push_back({&reset, eventsIt->second.first});
   }
   if (boundaries.empty()) {
     return computeProtocolLifetime(
@@ -4331,7 +4447,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     ResetBoundaryEvents &resetBoundaryEvents = graphState.resetBoundaryEvents;
     addSynchronizedResetAccessEdges(
         logicalDFBs, validatedResets, node, graph, operationEvents,
-        accessEvents, resetBoundaryEvents, executionCounts, structuralOrder,
+        accessEvents, resetBoundaryEvents, executionCounts, accessRuns,
+        structuralOrder,
         /*includeUnknownDomains=*/false);
     addProtocolSynchronizationEdges(logicalDFBs, graph, operationEvents,
                                     accessEvents, executionCounts, accessRuns,
@@ -4396,7 +4513,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     addSynchronizedResetAccessEdges(
         logicalDFBs, validatedResets, node, possibleGraph,
         possibleOperationEvents, possibleAccessEvents,
-        possibleResetBoundaryEvents, executionCounts, structuralOrder,
+        possibleResetBoundaryEvents, executionCounts, possibleAccessRuns,
+        structuralOrder,
         /*includeUnknownDomains=*/true);
     addProtocolSynchronizationEdges(
         logicalDFBs, possibleGraph, possibleOperationEvents,

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -911,17 +911,6 @@ static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
   graph.addEdge(before.last.completion, after.last.entry);
 }
 
-// Orders first and last representatives of two equal sequential runs. The
-// middle edge establishes that the next execution of `before` follows the
-// current execution of `after` without creating one event per iteration.
-static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
-                                     const AccessEventSpan &before,
-                                     const AccessEventSpan &after) {
-  graph.addEdge(before.first.completion, after.first.entry);
-  graph.addEdge(after.first.completion, before.last.entry);
-  graph.addEdge(before.last.completion, after.last.entry);
-}
-
 // Requires a release to follow every use owned by its acquisition; textual
 // acquire/release order alone does not prove that those uses have completed.
 // `sameKindAcquires` contains every same-DFB acquisition of the same kind.
@@ -4636,11 +4625,11 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents =
         graphState.accessEvents;
     ResetBoundaryEvents &resetBoundaryEvents = graphState.resetBoundaryEvents;
-    addSynchronizedResetAccessEdges(
-        logicalDFBs, validatedResets, node, graph, operationEvents,
-        accessEvents, resetBoundaryEvents, executionCounts, accessRuns,
-        structuralOrder,
-        /*includeUnknownDomains=*/false);
+    addSynchronizedResetAccessEdges(logicalDFBs, validatedResets, node, graph,
+                                    operationEvents, accessEvents,
+                                    resetBoundaryEvents, executionCounts,
+                                    accessRuns, structuralOrder,
+                                    /*includeUnknownDomains=*/false);
     addProtocolSynchronizationEdges(logicalDFBs, graph, operationEvents,
                                     accessEvents, executionCounts, accessRuns,
                                     node, domainState, structuralOrder,
@@ -4704,7 +4693,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     addSynchronizedResetAccessEdges(
         logicalDFBs, validatedResets, node, possibleGraph,
         possibleOperationEvents, possibleAccessEvents,
-        possibleResetBoundaryEvents, executionCounts, possibleAccessRuns,
+        possibleResetBoundaryEvents, executionCounts, *possibleAccessRuns,
         structuralOrder,
         /*includeUnknownDomains=*/true);
     addProtocolSynchronizationEdges(

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -420,13 +420,6 @@ static bool hasEquivalentIterationSequence(const StaticIterationDomain &lhs,
   return lhs.tripCounts == rhs.tripCounts;
 }
 
-static bool
-hasSequentialIterationOrder(const StaticIterationDomain &iterationDomain) {
-  return llvm::all_of(iterationDomain.loops, [](Operation *loop) {
-    return isa<affine::AffineForOp, scf::ForOp>(loop);
-  });
-}
-
 // One statically counted run of an access occurrence.
 struct AccessRun {
   const DFBAccessOccurrence *access = nullptr;
@@ -499,6 +492,9 @@ static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
     auto loop = dyn_cast_or_null<LoopLikeOpInterface>(parent);
     if (!parent || !region->hasOneBlock() ||
         nestedOperation->getBlock() != &region->front()) {
+      return std::nullopt;
+    }
+    if (loop && !isa<affine::AffineForOp, scf::ForOp>(parent)) {
       return std::nullopt;
     }
     if (!loop) {
@@ -1714,8 +1710,7 @@ static LogicalResult validateSynchronizedResetsAtNode(
           std::optional<StaticIterationDomain> uniformDomain =
               getUniformStaticIterationDomain(
                   occurrence.operation, *executionCount, node, domainState);
-          if (!uniformDomain || uniformDomain->loops.empty() ||
-              !hasSequentialIterationOrder(*uniformDomain)) {
+          if (!uniformDomain || uniformDomain->loops.empty()) {
             analysisFailure.set(
                 occurrence.operation,
                 ("repeated synchronized DFB reset with exact count " +

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -2991,9 +2991,11 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
     bool includeUnknownDomains = false,
     ArrayRef<const DFBAccessOccurrence *> selectedAccesses = {},
     bool hasCanonicalResetTerminator = false,
-    std::uint64_t executionCountDivisor = 1) {
-  assert(executionCountDivisor > 0 &&
-         "execution-count divisor must be positive");
+    std::optional<std::uint64_t> expectedSelectedExecutionCount =
+        std::nullopt) {
+  assert((!expectedSelectedExecutionCount ||
+          (*expectedSelectedExecutionCount > 0 && !selectedAccesses.empty())) &&
+         "normalized selected accesses require a positive execution count");
   DFBPerNodeLifetime &lifetime = lifetimes.emplace_back();
   lifetime.node = node;
   DFBPerNodeLifetimeDiagnostics *diagnostics = nullptr;
@@ -3194,23 +3196,18 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
     }
     lifetime.conditionalExecutionProven = true;
   }
-  auto getIntervalExecutionCount =
-      [executionCountDivisor](
-          const AccessRun &run) -> std::optional<std::uint64_t> {
-    if (run.executionCount % executionCountDivisor != 0) {
-      return std::nullopt;
+  auto getIntervalExecutionCount = [&](const AccessRun &run) {
+    if (expectedSelectedExecutionCount) {
+      assert(run.executionCount == *expectedSelectedExecutionCount &&
+             "selected repeated-reset accesses must execute once per interval");
+      return std::uint64_t{1};
     }
-    return run.executionCount / executionCountDivisor;
+    return run.executionCount;
   };
   auto getTransactionCount = [&](ArrayRef<const AccessRun *> runs) {
     std::optional<std::uint64_t> total = 0;
     for (const AccessRun *run : runs) {
-      std::optional<std::uint64_t> intervalCount =
-          getIntervalExecutionCount(*run);
-      if (!intervalCount) {
-        return std::optional<std::uint64_t>();
-      }
-      total = llvm::checkedAddUnsigned(*total, *intervalCount);
+      total = llvm::checkedAddUnsigned(*total, getIntervalExecutionCount(*run));
       if (!total) {
         break;
       }
@@ -3245,7 +3242,7 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
   llvm::append_range(consumerProtocolRuns, waits);
   llvm::append_range(consumerProtocolRuns, pops);
   bool useCumulativeQueueProof =
-      executionCountDivisor == 1 && !resetTerminatedProducer &&
+      !expectedSelectedExecutionCount && !resetTerminatedProducer &&
       supportsCumulativeQueueProof(producerProtocolRuns) &&
       supportsCumulativeQueueProof(consumerProtocolRuns);
   if (!countsMatch && !useCumulativeQueueProof) {
@@ -3388,14 +3385,9 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
     if (resetTerminatedProducer) {
       std::uint64_t occupiedTiles = 0;
       for (const AccessRun *reserve : reserves) {
-        std::optional<std::uint64_t> intervalCount =
-            getIntervalExecutionCount(*reserve);
-        if (!intervalCount) {
-          return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
-                  reserve->access->operation};
-        }
+        std::uint64_t intervalCount = getIntervalExecutionCount(*reserve);
         std::optional<std::uint64_t> runTiles = llvm::checkedMulUnsigned(
-            *intervalCount,
+            intervalCount,
             static_cast<std::uint64_t>(reserve->access->numTiles));
         if (!runTiles) {
           return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
@@ -3409,7 +3401,7 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
                   reserve->access->operation};
         }
         occupiedTiles = *updatedTiles;
-        appendTransactionRun(lifetime.transactionRuns, *intervalCount,
+        appendTransactionRun(lifetime.transactionRuns, intervalCount,
                              reserve->access->numTiles);
       }
     } else {
@@ -3431,26 +3423,20 @@ static DFBLifecycleCompletionProof computeProtocolLifetime(
           return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
                   reserve.access->operation};
         }
-        std::optional<std::uint64_t> reserveIntervalCount =
-            getIntervalExecutionCount(reserve);
-        std::optional<std::uint64_t> waitIntervalCount =
-            getIntervalExecutionCount(wait);
-        if (!reserveIntervalCount || !waitIntervalCount) {
-          return {DFBLifecycleCompletionFailureReason::MismatchedTransaction,
-                  reserve.access->operation};
-        }
+        std::uint64_t reserveIntervalCount = getIntervalExecutionCount(reserve);
+        std::uint64_t waitIntervalCount = getIntervalExecutionCount(wait);
         std::uint64_t matchedCount =
-            std::min(*reserveIntervalCount - reserveOffset,
-                     *waitIntervalCount - waitOffset);
+            std::min(reserveIntervalCount - reserveOffset,
+                     waitIntervalCount - waitOffset);
         appendTransactionRun(lifetime.transactionRuns, matchedCount,
                              reserve.access->numTiles);
         reserveOffset += matchedCount;
         waitOffset += matchedCount;
-        if (reserveOffset == *reserveIntervalCount) {
+        if (reserveOffset == reserveIntervalCount) {
           ++reserveIndex;
           reserveOffset = 0;
         }
-        if (waitOffset == *waitIntervalCount) {
+        if (waitOffset == waitIntervalCount) {
           ++waitIndex;
           waitOffset = 0;
         }
@@ -3679,7 +3665,8 @@ tryComputeRepeatedResetLifetime(
       lifetimeDiagnostics ? &intervalDiagnostics : nullptr, graph,
       structuralOrder, operationEvents, accessEvents, executionCounts,
       accessRuns, domainState, includeUnknownDomains, activeAccesses,
-      /*hasCanonicalResetTerminator=*/true, terminator->executionCount);
+      /*hasCanonicalResetTerminator=*/true,
+      /*expectedSelectedExecutionCount=*/terminator->executionCount);
   assert(intervalLifetimes.size() == 1 &&
          "one repeated interval must produce one protocol lifetime");
   assert((!lifetimeDiagnostics || intervalDiagnostics.size() == 1) &&

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -4063,7 +4063,7 @@ static bool protocolRunsCrossReset(
 static bool unprovenLifecycleIsOutsideReset(
     const DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
     const AccessExecutionCounts &executionCounts, bool includeUnknownDomains,
-    EventPair resetEvents, const HappensBeforeGraph &graph,
+    const AccessEventSpan &resetEvents, const HappensBeforeGraph &graph,
     const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
@@ -4079,10 +4079,10 @@ static bool unprovenLifecycleIsOutsideReset(
     if (!events) {
       return false;
     }
-    bool beforeReset =
-        graph.strictlyPrecedes(events->last.completion, resetEvents.entry);
-    bool afterReset =
-        graph.strictlyPrecedes(resetEvents.completion, events->first.entry);
+    bool beforeReset = graph.strictlyPrecedes(events->last.completion,
+                                              resetEvents.first.entry);
+    bool afterReset = graph.strictlyPrecedes(resetEvents.last.completion,
+                                             events->first.entry);
     if (beforeReset == afterReset) {
       return false;
     }

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -176,6 +176,7 @@ advanceDFBTransactionCursor(ArrayRef<DFBTransactionRun> transactionRuns,
 
 /// Access lifetime and queue state proved between synchronized resets.
 struct DFBLifecycleEpoch {
+  std::uint64_t executionCount = 1;
   SmallVector<unsigned> accessOccurrenceIndices;
   SmallVector<unsigned> earliestEntryEvents;
   SmallVector<unsigned> terminalCompletionEvents;

--- a/python/ttl/_src/atom_inline.py
+++ b/python/ttl/_src/atom_inline.py
@@ -494,13 +494,14 @@ def _add_logical_kernel_bindings(
     selected_kernels: Dict[int, Kernel] = {}
     reset_participant_ids = {
         id(participant)
-        for reset in spec.dfb_resets.values()
+        for reset_name, reset in spec.dfb_resets.items()
+        if reset_name in loaded_names
         for participant in reset.participants
     }
     for name, kernel in spec.logical_kernels.items():
-        if (
-            name not in loaded_names and id(kernel) not in reset_participant_ids
-        ) or name in bindings:
+        if name in bindings:
+            continue
+        if name not in loaded_names and id(kernel) not in reset_participant_ids:
             continue
         existing_name = next(
             (

--- a/python/ttl/atom.py
+++ b/python/ttl/atom.py
@@ -61,7 +61,12 @@ from .condition import (
     _bind_dispatch_conditions,
     _dispatch_condition_topology,
 )
-from .dfb_reset import DFBReset, _bind_dfb_resets, _dfb_reset_topology
+from .dfb_reset import (
+    DFBReset,
+    _bind_dfb_resets,
+    _dfb_reset_topology,
+    _transitive_participant_kernels,
+)
 from .dfb_allocation_group import (
     DFBAllocationGroup,
     _bind_dfb_allocation_groups,
@@ -333,17 +338,6 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
             allocation_groups[capture_name] = value
         elif isinstance(value, DFBReset):
             dfb_resets[capture_name] = value
-            for participant_index, participant in enumerate(value.participants):
-                if any(
-                    participant is kernel
-                    for kernel in (
-                        *logical_kernels.values(),
-                        *captured_logical_kernels.values(),
-                    )
-                ):
-                    continue
-                participant_name = f"{capture_name}__participant_{participant_index}"
-                captured_logical_kernels[participant_name] = participant
         elif _is_compile_time_literal(value):
             compile_time_captures[capture_name] = copy.deepcopy(value)
         elif not isinstance(value, types.ModuleType) and not callable(value):
@@ -352,6 +346,13 @@ def _build_atom_spec(fn: Callable) -> _AtomSpec:
                 f"{capture_name!r} has unsupported type "
                 f"{type(value).__name__}"
             )
+
+    transitive_participant_kernels = _transitive_participant_kernels(
+        dfb_resets,
+        {**logical_kernels, **captured_logical_kernels},
+        loaded_names,
+    )
+    captured_logical_kernels.update(transitive_participant_kernels)
 
     operation_identity = _operation_identity(fn)
     allocation_group_topology = _dfb_allocation_group_topology(allocation_groups)

--- a/python/ttl/dfb_reset.py
+++ b/python/ttl/dfb_reset.py
@@ -16,7 +16,7 @@ from .kernel import Kernel, KernelKind
 
 @dataclass(frozen=True, eq=False)
 class DFBReset:
-    """One worker-local synchronized DFB reset instance.
+    """One worker-local synchronized DFB reset declaration.
 
     ``participants`` contains one compute ``Kernel`` and two data movement
     ``Kernel`` handles created in the same enclosing operation factory. A call

--- a/python/ttl/dfb_reset.py
+++ b/python/ttl/dfb_reset.py
@@ -154,7 +154,6 @@ def _transitive_participant_kernels(
                 suffix_index += 1
                 participant_name = f"{name_stem}_{suffix_index}"
             used_names.add(participant_name)
-            participant_names[id(participant)] = participant_name
             transitive_kernels[participant_name] = participant
     return transitive_kernels
 

--- a/python/ttl/dfb_reset.py
+++ b/python/ttl/dfb_reset.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Iterator, Mapping
+from typing import Collection, Iterator, Mapping
 
 from .kernel import Kernel, KernelKind
 
@@ -21,8 +21,9 @@ class DFBReset:
     ``participants`` contains one compute ``Kernel`` and two data movement
     ``Kernel`` handles created in the same enclosing operation factory. A call
     to ``ttl.reset_dfbs`` or ``ttl.reset_all_dfbs`` is replicated to those
-    three logical kernels. One declaration may execute at most once per
-    dispatch and launch node. Runtime lowering is supported only on Blackhole.
+    three logical kernels. A declaration may execute once or once per iteration
+    of the same immutable sequential loop nest in every participant. Runtime
+    lowering is supported only on Blackhole.
     """
 
     participants: tuple[Kernel, ...]
@@ -100,12 +101,70 @@ def _bind_dfb_resets(resets: Mapping[str, DFBReset]) -> dict[str, _BoundDFBReset
     return {name: binder.bind(reset) for name, reset in resets.items()}
 
 
+def _transitive_participant_kernels(
+    resets: Mapping[str, DFBReset],
+    logical_kernels: Mapping[str, Kernel],
+    reserved_names: Collection[str] = (),
+) -> dict[str, Kernel]:
+    """Name Kernel resources referenced only through reset metadata."""
+    participant_names = {id(kernel): name for name, kernel in logical_kernels.items()}
+    used_names = set(reserved_names) | set(logical_kernels)
+    reset_ordinals: dict[int, int] = {}
+    participants: dict[int, Kernel] = {}
+    participant_memberships: dict[int, set[int]] = {}
+    for reset_name in sorted(resets):
+        reset = resets[reset_name]
+        reset_ordinal = reset_ordinals.setdefault(id(reset), len(reset_ordinals))
+        for participant in reset.participants:
+            if not isinstance(participant, Kernel):
+                continue
+            if (
+                participant._implicit_role is not None
+                or participant._identity is not None
+                or id(participant) in participant_names
+            ):
+                continue
+            participant_identity = id(participant)
+            participants[participant_identity] = participant
+            participant_memberships.setdefault(participant_identity, set()).add(
+                reset_ordinal
+            )
+
+    participant_groups: dict[tuple[str, tuple[int, ...]], list[Kernel]] = {}
+    for participant_identity, participant in participants.items():
+        signature = (
+            participant.kind.name,
+            tuple(sorted(participant_memberships[participant_identity])),
+        )
+        participant_groups.setdefault(signature, []).append(participant)
+
+    transitive_kernels: dict[str, Kernel] = {}
+    for (kernel_kind, reset_membership), participant_group in sorted(
+        participant_groups.items()
+    ):
+        membership_name = "_".join(str(ordinal) for ordinal in reset_membership)
+        for group_index, participant in enumerate(participant_group):
+            name_stem = (
+                f"dfb_reset_participant_{kernel_kind.lower()}_"
+                f"{membership_name}_{group_index}"
+            )
+            participant_name = name_stem
+            suffix_index = 0
+            while participant_name in used_names:
+                suffix_index += 1
+                participant_name = f"{name_stem}_{suffix_index}"
+            used_names.add(participant_name)
+            participant_names[id(participant)] = participant_name
+            transitive_kernels[participant_name] = participant
+    return transitive_kernels
+
+
 def _participant_topology(
     participant: Kernel, logical_kernels: Mapping[str, Kernel]
 ) -> tuple[str, str]:
     for name, kernel in logical_kernels.items():
         if participant is kernel:
-            return ("kernel", name)
+            return ("kernel", f"{participant.kind.name}:{name}")
     if participant._identity is not None:
         return (
             "kernel",

--- a/python/ttl/kernel.py
+++ b/python/ttl/kernel.py
@@ -274,7 +274,7 @@ def _encode_identity_capture(
 def _operation_identity_impl(function: Callable, active_functions: set[int]) -> str:
     # Local import avoids the dfb_reset -> kernel import cycle during module
     # initialization while retaining a typed resource check.
-    from .dfb_reset import DFBReset
+    from .dfb_reset import DFBReset, _transitive_participant_kernels
 
     function_id = id(function)
     if function_id in active_functions:
@@ -313,6 +313,24 @@ def _operation_identity_impl(function: Callable, active_functions: set[int]) -> 
             for name, value in nonlocal_captures.items()
             if isinstance(value, Kernel)
         }
+        reset_captures = {
+            name: value
+            for name, value in nonlocal_captures.items()
+            if isinstance(value, DFBReset)
+        }
+        direct_kernels = {
+            name: value
+            for name, value in nonlocal_captures.items()
+            if isinstance(value, Kernel)
+        }
+        transitive_kernels = _transitive_participant_kernels(
+            reset_captures,
+            direct_kernels,
+            nonlocal_captures.keys(),
+        )
+        kernel_capture_names.update(
+            {id(kernel): name for name, kernel in transitive_kernels.items()}
+        )
         for name, value in sorted(nonlocal_captures.items()):
             if isinstance(value, DispatchCondition):
                 binding = bound_conditions[name]
@@ -327,7 +345,7 @@ def _operation_identity_impl(function: Callable, active_functions: set[int]) -> 
                 reset_identity = id(value)
                 ordinal = reset_ordinals.setdefault(reset_identity, len(reset_ordinals))
                 participant_tokens = []
-                for participant_index, participant in enumerate(value.participants):
+                for participant in value.participants:
                     if participant._implicit_role is not None:
                         participant_tokens.append(
                             "role:"
@@ -337,12 +355,18 @@ def _operation_identity_impl(function: Callable, active_functions: set[int]) -> 
                         continue
                     participant_name = kernel_capture_names.get(id(participant))
                     if participant_name is None:
-                        participant_tokens.append(
-                            "reset-kernel:"
-                            f"{participant_index}:{participant.kind.name}"
+                        if participant._identity is not None:
+                            raise TypeError(
+                                "DFBReset participant Kernel is already bound to "
+                                f"operation {participant._operation_identity!r}"
+                            )
+                        raise TypeError(
+                            "DFBReset participant Kernel must be captured by "
+                            "the enclosing @ttl.operation"
                         )
-                    else:
-                        participant_tokens.append(f"kernel:{participant_name}")
+                    participant_tokens.append(
+                        f"kernel:{participant.kind.name}:{participant_name}"
+                    )
                 encoded = (
                     f"dfb-reset:{ordinal}:" + ",".join(sorted(participant_tokens))
                 ).encode("utf-8")

--- a/test/python/atom/test_atom_split.py
+++ b/test/python/atom/test_atom_split.py
@@ -201,6 +201,92 @@ def test_captured_kernel_cannot_bind_to_two_operations():
         _build_atom_spec(second_operation)
 
 
+def test_reset_owned_kernel_cannot_bind_to_two_operations():
+    """Reset metadata cannot transfer a bound kernel to another operation."""
+    compute_kernel = Kernel(KernelKind.COMPUTE)
+    reader_kernel = Kernel(KernelKind.DATA_MOVEMENT)
+    writer_kernel = Kernel(KernelKind.DATA_MOVEMENT)
+    reset = ttl.DFBReset(participants=(compute_kernel, reader_kernel, writer_kernel))
+
+    @ttl.operation()
+    def first_operation():
+        ttl.reset_all_dfbs(reset)
+
+    with pytest.raises(TypeError, match="already bound to operation"):
+
+        @ttl.operation()
+        def second_operation():
+            ttl.reset_all_dfbs(reset)
+
+
+def test_reset_participant_membership_changes_operation_identity():
+    """Anonymous reset participant membership contributes to identity."""
+
+    def make_reset_operation(shared_participants):
+        first_participants = (
+            Kernel(KernelKind.COMPUTE),
+            Kernel(KernelKind.DATA_MOVEMENT),
+            Kernel(KernelKind.DATA_MOVEMENT),
+        )
+        second_participants = (
+            first_participants
+            if shared_participants
+            else (
+                Kernel(KernelKind.COMPUTE),
+                Kernel(KernelKind.DATA_MOVEMENT),
+                Kernel(KernelKind.DATA_MOVEMENT),
+            )
+        )
+        first_reset = ttl.DFBReset(participants=first_participants)
+        second_reset = ttl.DFBReset(participants=second_participants)
+
+        @ttl.operation()
+        def reset_operation():
+            ttl.reset_all_dfbs(first_reset)
+            ttl.reset_all_dfbs(second_reset)
+
+        return reset_operation
+
+    shared_operation = make_reset_operation(shared_participants=True)
+    independent_operation = make_reset_operation(shared_participants=False)
+
+    assert (
+        shared_operation._spec.operation_identity
+        != independent_operation._spec.operation_identity
+    )
+
+
+def test_reset_only_kernel_names_ignore_participant_order():
+    """Reset participant tuples represent sets in operation identity."""
+
+    def make_reset_operation(reverse_participants):
+        compute_participant = Kernel(KernelKind.COMPUTE)
+        reader_participant = Kernel(KernelKind.DATA_MOVEMENT)
+        writer_participant = Kernel(KernelKind.DATA_MOVEMENT)
+        participants = (
+            compute_participant,
+            reader_participant,
+            writer_participant,
+        )
+        if reverse_participants:
+            participants = tuple(reversed(participants))
+        first_reset = ttl.DFBReset(participants=participants)
+
+        @ttl.operation()
+        def reset_operation():
+            ttl.reset_all_dfbs(first_reset)
+
+        return reset_operation
+
+    forward_operation = make_reset_operation(False)
+    reversed_operation = make_reset_operation(True)
+
+    assert (
+        forward_operation._spec.operation_identity
+        == reversed_operation._spec.operation_identity
+    )
+
+
 def test_captured_kernel_cannot_have_two_names():
     """Alias validation completes before the handle is bound."""
     reader = Kernel(KernelKind.DATA_MOVEMENT)
@@ -1069,6 +1155,11 @@ def test_composition_preserves_one_synchronized_dfb_reset_identity():
 
     spec = composed_reset._spec
     assert len(spec.dfb_resets) == 1
+    assert set(spec.logical_kernels.values()) == {
+        compute_kernel,
+        reader_kernel,
+        writer_kernel,
+    }
     composed_reset_identity = next(iter(spec.dfb_resets.values()))
     assert composed_reset_identity is not reset
     assert composed_reset_identity.participants == reset.participants

--- a/test/python/synchronized_dfb_reset.py
+++ b/test/python/synchronized_dfb_reset.py
@@ -56,17 +56,17 @@ synchronized_reset_operation = make_reset_operation()
 # One source call is replicated to exactly its three logical-kernel
 # participants. Participant representation is canonical despite source order.
 # INITIAL-LABEL: func.func @synchronized_reset_operation__trisc
-# INITIAL-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "all_reset__participant_0"
-# INITIAL: ttl.reset_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "all_reset__participant_0"
-# INITIAL-NEXT: ttl.reset_all_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "all_reset__participant_0"
+# INITIAL-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "dfb_reset_participant_compute_0_1_0"
+# INITIAL: ttl.reset_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "dfb_reset_participant_compute_0_1_0"
+# INITIAL-NEXT: ttl.reset_all_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "dfb_reset_participant_compute_0_1_0"
 # INITIAL-LABEL: func.func @synchronized_reset_operation__ncrisc
-# INITIAL-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "all_reset__participant_1"
-# INITIAL: ttl.reset_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "all_reset__participant_0"
-# INITIAL-NEXT: ttl.reset_all_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "all_reset__participant_0"
+# INITIAL-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "dfb_reset_participant_data_movement_0_1_0"
+# INITIAL: ttl.reset_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "dfb_reset_participant_compute_0_1_0"
+# INITIAL-NEXT: ttl.reset_all_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "dfb_reset_participant_compute_0_1_0"
 # INITIAL-LABEL: func.func @synchronized_reset_operation__brisc
-# INITIAL-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "all_reset__participant_2"
-# INITIAL: ttl.reset_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "all_reset__participant_0"
-# INITIAL-NEXT: ttl.reset_all_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "all_reset__participant_0"
+# INITIAL-SAME: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "dfb_reset_participant_data_movement_0_1_1"
+# INITIAL: ttl.reset_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "dfb_reset_participant_compute_0_1_0"
+# INITIAL-NEXT: ttl.reset_all_dfbs <{{[0-9]+}}, participants[<kind = compute, identity = "dfb_reset_participant_compute_0_1_0"
 
 # The built-in lowering supplies the shared state address and physical-index
 # masks; no user reset helper is required.

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -832,6 +832,67 @@ def _make_synchronized_reset_kernel(
     return synchronized_reset_kernel
 
 
+def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    reset = ttl.DFBReset(
+        participants=(compute_kernel, reader_kernel, writer_kernel),
+    )
+
+    @ttl.operation(grid=(1, 1))
+    def repeated_synchronized_reset_kernel(input_tensor, output_tensor):
+        reset_allocation = ttl.make_dfb_allocation_group()
+        stale_dfb = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=1,
+            allocation_group=reset_allocation,
+        )
+        current_dfb = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=1,
+            allocation_group=reset_allocation,
+        )
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=1)
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            for _reset_iteration in range(4):
+                if reset_all:
+                    ttl.reset_all_dfbs(reset)
+                else:
+                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+            with current_dfb.wait() as current_source:
+                with output_dfb.reserve() as output_destination:
+                    output_destination.store(current_source)
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            for _reset_iteration in range(4):
+                with stale_dfb.reserve() as stale_destination:
+                    ttl.copy(input_tensor[0, 0], stale_destination).wait()
+                if reset_all:
+                    ttl.reset_all_dfbs(reset)
+                else:
+                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+            with current_dfb.reserve() as current_destination:
+                ttl.copy(input_tensor[0, 1], current_destination).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            for _reset_iteration in range(4):
+                if reset_all:
+                    ttl.reset_all_dfbs(reset)
+                else:
+                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+            with output_dfb.wait() as output_source:
+                ttl.copy(output_source, output_tensor[0, 0]).wait()
+
+    return repeated_synchronized_reset_kernel
+
+
 def _make_compute_interface_reset_kernel(data_format, tile):
     compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
     reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
@@ -1819,6 +1880,58 @@ def test_synchronized_reset_terminates_producer_epoch(
         assert_allclose(actual, expected, rtol=0.05, atol=1.0)
     else:
         assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize("reset_all", [False, True], ids=["selected", "all"])
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_repeated_synchronized_reset_run(
+    device,
+    dtype,
+    reset_all,
+    memory_config,
+    to_device,
+    monkeypatch,
+    tmp_path,
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    data_format = "bf16" if dtype == torch.bfloat16 else "float32"
+    operation = _make_repeated_synchronized_reset_kernel(data_format, reset_all)
+    final_mlir_path = tmp_path / "repeated_synchronized_reset.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+
+    for invocation_index in range(2):
+        element_indices = torch.arange(
+            2 * TILE * TILE, dtype=torch.float32
+        ).reshape(TILE, 2 * TILE)
+        input_host = (
+            (element_indices.remainder(257) - 128) / 64 + invocation_index
+        ).to(dtype)
+        input_tensor = to_device(input_host, device)
+        output_tensor = to_device(torch.zeros(TILE, TILE, dtype=dtype), device)
+        operation(
+            input_tensor,
+            output_tensor,
+            options=(
+                "--ttl-reuse-user-dfbs "
+                "--ttl-unsafe-assume-dfb-allocation-groups"
+            ),
+        )
+
+        actual = ttnn.to_torch(output_tensor).float()
+        expected = input_host[:, TILE:].float()
+        if dtype == torch.bfloat16:
+            assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+        else:
+            assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+    assert _count_final_dfb_allocations(final_mlir_path) == 2
 
 
 def test_synchronized_reset_executes_above_physical_index_31(

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -711,6 +711,8 @@ def _make_synchronized_reset_kernel(
         participants=(compute_kernel, reader_kernel, writer_kernel),
     )
 
+    # The frontend traces both branches of closure-dependent conditionals, so
+    # selected and all-interface reset operations need separate definitions.
     if reset_all:
 
         @ttl.operation(grid=(grid_cols, 1))
@@ -840,55 +842,91 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
         participants=(compute_kernel, reader_kernel, writer_kernel),
     )
 
-    @ttl.operation(grid=(1, 1))
-    def repeated_synchronized_reset_kernel(input_tensor, output_tensor):
-        reset_allocation = ttl.make_dfb_allocation_group()
-        stale_dfb = ttl.make_dfb(
-            data_format,
-            shape=(1, 2),
-            block_count=1,
-            allocation_group=reset_allocation,
-        )
-        current_dfb = ttl.make_dfb(
-            data_format,
-            shape=(1, 1),
-            block_count=3,
-            allocation_group=reset_allocation,
-        )
-        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
+    if reset_all:
 
-        @ttl.compute(kernel=compute_kernel)
-        def compute():
-            for _reset_iteration in range(4):
-                if reset_all:
-                    ttl.reset_all_dfbs(reset)
-                else:
-                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
-            with current_dfb.wait() as current_source:
-                with output_dfb.reserve() as output_destination:
-                    output_destination.store(current_source)
+        @ttl.operation(grid=(1, 1))
+        def repeated_synchronized_reset_kernel(input_tensor, output_tensor):
+            reset_allocation = ttl.make_dfb_allocation_group()
+            stale_dfb = ttl.make_dfb(
+                data_format,
+                shape=(1, 2),
+                block_count=1,
+                allocation_group=reset_allocation,
+            )
+            current_dfb = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=3,
+                allocation_group=reset_allocation,
+            )
+            output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
 
-        @ttl.datamovement(kernel=reader_kernel)
-        def read():
-            for _reset_iteration in range(4):
-                with stale_dfb.reserve() as stale_destination:
-                    ttl.copy(input_tensor[0:1, 0:2], stale_destination).wait()
-                if reset_all:
+            @ttl.compute(kernel=compute_kernel)
+            def compute():
+                for _reset_iteration in range(4):
                     ttl.reset_all_dfbs(reset)
-                else:
-                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
-            with current_dfb.reserve() as current_destination:
-                ttl.copy(input_tensor[0, 0], current_destination).wait()
+                with current_dfb.wait() as current_source:
+                    with output_dfb.reserve() as output_destination:
+                        output_destination.store(current_source)
 
-        @ttl.datamovement(kernel=writer_kernel)
-        def write():
-            for _reset_iteration in range(4):
-                if reset_all:
+            @ttl.datamovement(kernel=reader_kernel)
+            def read():
+                for _reset_iteration in range(4):
+                    with stale_dfb.reserve() as stale_destination:
+                        ttl.copy(input_tensor[0:1, 0:2], stale_destination).wait()
                     ttl.reset_all_dfbs(reset)
-                else:
+                with current_dfb.reserve() as current_destination:
+                    ttl.copy(input_tensor[0, 0], current_destination).wait()
+
+            @ttl.datamovement(kernel=writer_kernel)
+            def write():
+                for _reset_iteration in range(4):
+                    ttl.reset_all_dfbs(reset)
+                with output_dfb.wait() as output_source:
+                    ttl.copy(output_source, output_tensor[0, 0]).wait()
+
+    else:
+
+        @ttl.operation(grid=(1, 1))
+        def repeated_synchronized_reset_kernel(input_tensor, output_tensor):
+            reset_allocation = ttl.make_dfb_allocation_group()
+            stale_dfb = ttl.make_dfb(
+                data_format,
+                shape=(1, 2),
+                block_count=1,
+                allocation_group=reset_allocation,
+            )
+            current_dfb = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=3,
+                allocation_group=reset_allocation,
+            )
+            output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
+
+            @ttl.compute(kernel=compute_kernel)
+            def compute():
+                for _reset_iteration in range(4):
                     ttl.reset_dfbs(reset, dfbs=[stale_dfb])
-            with output_dfb.wait() as output_source:
-                ttl.copy(output_source, output_tensor[0, 0]).wait()
+                with current_dfb.wait() as current_source:
+                    with output_dfb.reserve() as output_destination:
+                        output_destination.store(current_source)
+
+            @ttl.datamovement(kernel=reader_kernel)
+            def read():
+                for _reset_iteration in range(4):
+                    with stale_dfb.reserve() as stale_destination:
+                        ttl.copy(input_tensor[0:1, 0:2], stale_destination).wait()
+                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+                with current_dfb.reserve() as current_destination:
+                    ttl.copy(input_tensor[0, 0], current_destination).wait()
+
+            @ttl.datamovement(kernel=writer_kernel)
+            def write():
+                for _reset_iteration in range(4):
+                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+                with output_dfb.wait() as output_source:
+                    ttl.copy(output_source, output_tensor[0, 0]).wait()
 
     return repeated_synchronized_reset_kernel
 
@@ -1907,9 +1945,9 @@ def test_repeated_synchronized_reset_run(
     monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
 
     for invocation_index in range(2):
-        element_indices = torch.arange(
-            2 * TILE * TILE, dtype=torch.float32
-        ).reshape(TILE, 2 * TILE)
+        element_indices = torch.arange(2 * TILE * TILE, dtype=torch.float32).reshape(
+            TILE, 2 * TILE
+        )
         input_host = (
             (element_indices.remainder(257) - 128) / 64 + invocation_index
         ).to(dtype)

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -845,17 +845,17 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
         reset_allocation = ttl.make_dfb_allocation_group()
         stale_dfb = ttl.make_dfb(
             data_format,
-            shape=(1, 1),
+            shape=(1, 2),
             block_count=1,
             allocation_group=reset_allocation,
         )
         current_dfb = ttl.make_dfb(
             data_format,
             shape=(1, 1),
-            block_count=1,
+            block_count=3,
             allocation_group=reset_allocation,
         )
-        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=1)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
 
         @ttl.compute(kernel=compute_kernel)
         def compute():
@@ -872,13 +872,13 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
         def read():
             for _reset_iteration in range(4):
                 with stale_dfb.reserve() as stale_destination:
-                    ttl.copy(input_tensor[0, 0], stale_destination).wait()
+                    ttl.copy(input_tensor[0:1, 0:2], stale_destination).wait()
                 if reset_all:
                     ttl.reset_all_dfbs(reset)
                 else:
                     ttl.reset_dfbs(reset, dfbs=[stale_dfb])
             with current_dfb.reserve() as current_destination:
-                ttl.copy(input_tensor[0, 1], current_destination).wait()
+                ttl.copy(input_tensor[0, 0], current_destination).wait()
 
         @ttl.datamovement(kernel=writer_kernel)
         def write():
@@ -1918,14 +1918,11 @@ def test_repeated_synchronized_reset_run(
         operation(
             input_tensor,
             output_tensor,
-            options=(
-                "--ttl-reuse-user-dfbs "
-                "--ttl-unsafe-assume-dfb-allocation-groups"
-            ),
+            options="--ttl-reuse-user-dfbs",
         )
 
         actual = ttnn.to_torch(output_tensor).float()
-        expected = input_host[:, TILE:].float()
+        expected = input_host[:, :TILE].float()
         if dtype == torch.bfloat16:
             assert_allclose(actual, expected, rtol=0.05, atol=1.0)
         else:

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -845,7 +845,9 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
     if reset_all:
 
         @ttl.operation(grid=(1, 1))
-        def repeated_synchronized_reset_kernel(input_tensor, output_tensor):
+        def repeated_synchronized_reset_kernel(
+            input_tensor, output_tensor, balanced_output_tensor
+        ):
             reset_allocation = ttl.make_dfb_allocation_group()
             stale_dfb = ttl.make_dfb(
                 data_format,
@@ -860,10 +862,15 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
                 allocation_group=reset_allocation,
             )
             output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
+            compute_source_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
+            compute_output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
 
             @ttl.compute(kernel=compute_kernel)
             def compute():
                 for _reset_iteration in range(4):
+                    with compute_source_dfb.wait() as compute_source:
+                        with compute_output_dfb.reserve() as compute_output:
+                            compute_output.store(compute_source)
                     ttl.reset_all_dfbs(reset)
                 with current_dfb.wait() as current_source:
                     with output_dfb.reserve() as output_destination:
@@ -874,6 +881,8 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
                 for _reset_iteration in range(4):
                     with stale_dfb.reserve() as stale_destination:
                         ttl.copy(input_tensor[0:1, 0:2], stale_destination).wait()
+                    with compute_source_dfb.reserve() as compute_source:
+                        ttl.copy(input_tensor[0, 0], compute_source).wait()
                     ttl.reset_all_dfbs(reset)
                 with current_dfb.reserve() as current_destination:
                     ttl.copy(input_tensor[0, 0], current_destination).wait()
@@ -881,6 +890,8 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
             @ttl.datamovement(kernel=writer_kernel)
             def write():
                 for _reset_iteration in range(4):
+                    with compute_output_dfb.wait() as compute_output:
+                        ttl.copy(compute_output, balanced_output_tensor[0, 0]).wait()
                     ttl.reset_all_dfbs(reset)
                 with output_dfb.wait() as output_source:
                     ttl.copy(output_source, output_tensor[0, 0]).wait()
@@ -888,7 +899,9 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
     else:
 
         @ttl.operation(grid=(1, 1))
-        def repeated_synchronized_reset_kernel(input_tensor, output_tensor):
+        def repeated_synchronized_reset_kernel(
+            input_tensor, output_tensor, balanced_output_tensor
+        ):
             reset_allocation = ttl.make_dfb_allocation_group()
             stale_dfb = ttl.make_dfb(
                 data_format,
@@ -903,11 +916,19 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
                 allocation_group=reset_allocation,
             )
             output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
+            compute_source_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
+            compute_output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=3)
 
             @ttl.compute(kernel=compute_kernel)
             def compute():
                 for _reset_iteration in range(4):
-                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+                    with compute_source_dfb.wait() as compute_source:
+                        with compute_output_dfb.reserve() as compute_output:
+                            compute_output.store(compute_source)
+                    ttl.reset_dfbs(
+                        reset,
+                        dfbs=[stale_dfb, compute_source_dfb, compute_output_dfb],
+                    )
                 with current_dfb.wait() as current_source:
                     with output_dfb.reserve() as output_destination:
                         output_destination.store(current_source)
@@ -917,14 +938,24 @@ def _make_repeated_synchronized_reset_kernel(data_format, reset_all):
                 for _reset_iteration in range(4):
                     with stale_dfb.reserve() as stale_destination:
                         ttl.copy(input_tensor[0:1, 0:2], stale_destination).wait()
-                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+                    with compute_source_dfb.reserve() as compute_source:
+                        ttl.copy(input_tensor[0, 0], compute_source).wait()
+                    ttl.reset_dfbs(
+                        reset,
+                        dfbs=[stale_dfb, compute_source_dfb, compute_output_dfb],
+                    )
                 with current_dfb.reserve() as current_destination:
                     ttl.copy(input_tensor[0, 0], current_destination).wait()
 
             @ttl.datamovement(kernel=writer_kernel)
             def write():
                 for _reset_iteration in range(4):
-                    ttl.reset_dfbs(reset, dfbs=[stale_dfb])
+                    with compute_output_dfb.wait() as compute_output:
+                        ttl.copy(compute_output, balanced_output_tensor[0, 0]).wait()
+                    ttl.reset_dfbs(
+                        reset,
+                        dfbs=[stale_dfb, compute_source_dfb, compute_output_dfb],
+                    )
                 with output_dfb.wait() as output_source:
                     ttl.copy(output_source, output_tensor[0, 0]).wait()
 
@@ -1953,20 +1984,25 @@ def test_repeated_synchronized_reset_run(
         ).to(dtype)
         input_tensor = to_device(input_host, device)
         output_tensor = to_device(torch.zeros(TILE, TILE, dtype=dtype), device)
+        balanced_output_tensor = to_device(torch.zeros(TILE, TILE, dtype=dtype), device)
         operation(
             input_tensor,
             output_tensor,
+            balanced_output_tensor,
             options="--ttl-reuse-user-dfbs",
         )
 
         actual = ttnn.to_torch(output_tensor).float()
+        balanced_actual = ttnn.to_torch(balanced_output_tensor).float()
         expected = input_host[:, :TILE].float()
         if dtype == torch.bfloat16:
             assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+            assert_allclose(balanced_actual, expected, rtol=0.05, atol=1.0)
         else:
             assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+            assert_allclose(balanced_actual, expected, rtol=1e-5, atol=1e-6)
 
-    assert _count_final_dfb_allocations(final_mlir_path) == 2
+    assert _count_final_dfb_allocations(final_mlir_path) == 3
 
 
 def test_synchronized_reset_executes_above_physical_index_31(

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_grouped_reset_assume_safe.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_grouped_reset_assume_safe.mlir
@@ -70,6 +70,85 @@ module attributes {
 
 // -----
 
+// Incomplete access operations that execute before the first reset or after
+// the last reset do not overlap any repeated interface write.
+
+// OUTPUT-LABEL: func.func @repeated_outside_reader
+// OUTPUT: %[[REPEATED_SELECTED_READER:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 6 : index}
+// OUTPUT-NEXT: %[[REPEATED_BEFORE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 7 : index}
+// OUTPUT-LABEL: func.func @repeated_outside_writer
+// OUTPUT: %[[REPEATED_SELECTED_WRITER:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 6 : index}
+// OUTPUT-NEXT: %[[REPEATED_AFTER:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 8 : index}
+
+// WARNING: warning: unsafe DFB allocation-group policy accepted #ttl.dfb_allocation_group<3> members=[6, 7, 8] without compiler proof:
+// WARNING-SAME: access-completion-not-proven
+// WARNING-NOT: reset-domain-write
+
+module attributes {
+  ttl.launch_grid = array<i64: 1, 1>,
+  ttl.target_arch = #ttcore.arch<blackhole>
+} {
+  func.func @repeated_outside_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "repeated_unproven_outside">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 6 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %before = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 7 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "untyped_access" dfb_dependencies(%before : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "effects.hpp"} : () -> ()
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <3, participants[<kind = compute, identity = "compute", operation = "repeated_unproven_outside">, <kind = data_movement, identity = "reader", operation = "repeated_unproven_outside">, <kind = data_movement, identity = "writer", operation = "repeated_unproven_outside">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    }
+    return
+  }
+
+  func.func @repeated_outside_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "repeated_unproven_outside">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 6 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <3, participants[<kind = compute, identity = "compute", operation = "repeated_unproven_outside">, <kind = data_movement, identity = "reader", operation = "repeated_unproven_outside">, <kind = data_movement, identity = "writer", operation = "repeated_unproven_outside">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    }
+    return
+  }
+
+  func.func @repeated_outside_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "repeated_unproven_outside">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 6 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %after = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 8 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <3, participants[<kind = compute, identity = "compute", operation = "repeated_unproven_outside">, <kind = data_movement, identity = "reader", operation = "repeated_unproven_outside">, <kind = data_movement, identity = "writer", operation = "repeated_unproven_outside">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    }
+    ttl.opaque_call "untyped_access" dfb_dependencies(%after : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "effects.hpp"} : () -> ()
+    return
+  }
+}
+
+// -----
+
 // A runtime predicate makes the untyped-access domain possible rather than exact.
 // Its activity still remains before the reset on every possible launch node.
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_grouped_reset_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups_grouped_reset_invalid.mlir
@@ -50,6 +50,73 @@ module attributes {
 
 // -----
 
+// An unmatched reserve repeated before each reset overlaps the interval from
+// the first reset through the last reset and cannot be assumed safe.
+
+module attributes {
+  ttl.launch_grid = array<i64: 1, 1>,
+  ttl.target_arch = #ttcore.arch<blackhole>
+} {
+  func.func @repeated_overlap_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "repeated_unproven_overlap">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 8 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %overlapping = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 9 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<4> members=[8, 9] cannot alias logical DFBs 8 and 9: reset-domain-write}}
+      %overlapping_slot = ttl.cb_reserve %overlapping
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.reset_dfbs <4, participants[<kind = compute, identity = "compute", operation = "repeated_unproven_overlap">, <kind = data_movement, identity = "reader", operation = "repeated_unproven_overlap">, <kind = data_movement, identity = "writer", operation = "repeated_unproven_overlap">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    }
+    return
+  }
+
+  func.func @repeated_overlap_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "repeated_unproven_overlap">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 8 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <4, participants[<kind = compute, identity = "compute", operation = "repeated_unproven_overlap">, <kind = data_movement, identity = "reader", operation = "repeated_unproven_overlap">, <kind = data_movement, identity = "writer", operation = "repeated_unproven_overlap">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    }
+    return
+  }
+
+  func.func @repeated_overlap_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "repeated_unproven_overlap">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %selected = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 8 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <4, participants[<kind = compute, identity = "compute", operation = "repeated_unproven_overlap">, <kind = data_movement, identity = "reader", operation = "repeated_unproven_overlap">, <kind = data_movement, identity = "writer", operation = "repeated_unproven_overlap">]>(%selected : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    }
+    return
+  }
+}
+
+// -----
+
 // A reserve cannot be separated from its matching push by a reset.
 
 module attributes {

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
@@ -51,6 +51,95 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 
 // -----
 
+// One selected reset declaration may execute once per iteration of equivalent
+// immutable sequential loops in all three participants.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @repeated_selected_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "repeated_selected">} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_selected">, <kind = data_movement, identity = "reader", operation = "repeated_selected">, <kind = data_movement, identity = "writer", operation = "repeated_selected">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    return
+  }
+
+  func.func @repeated_selected_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "repeated_selected">,
+                  ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    affine.for %iteration = 0 to 4 {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_selected">, <kind = data_movement, identity = "reader", operation = "repeated_selected">, <kind = data_movement, identity = "writer", operation = "repeated_selected">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    return
+  }
+
+  func.func @repeated_selected_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "repeated_selected">,
+                  ttl.noc_index = 1 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_selected">, <kind = data_movement, identity = "reader", operation = "repeated_selected">, <kind = data_movement, identity = "writer", operation = "repeated_selected">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    return
+  }
+}
+
+// -----
+
+// Repeated all-interface resets use the same participant-loop contract.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @repeated_all_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "repeated_all">} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_all">, <kind = data_movement, identity = "reader", operation = "repeated_all">, <kind = data_movement, identity = "writer", operation = "repeated_all">]>
+    }
+    return
+  }
+
+  func.func @repeated_all_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "repeated_all">,
+                  ttl.noc_index = 0 : i32} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_all">, <kind = data_movement, identity = "reader", operation = "repeated_all">, <kind = data_movement, identity = "writer", operation = "repeated_all">]>
+    }
+    return
+  }
+
+  func.func @repeated_all_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "repeated_all">,
+                  ttl.noc_index = 1 : i32} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_all">, <kind = data_movement, identity = "reader", operation = "repeated_all">, <kind = data_movement, identity = "writer", operation = "repeated_all">]>
+    }
+    return
+  }
+}
+
+// -----
+
 // A selected reset partitions tensor-backed interface state. Payload bytes
 // remain allocated, but reset occupancy makes pre-reset payload unavailable.
 // CHECK: DFB logical_id=0 bounded=0

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
@@ -102,6 +102,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
   func.func @repeated_all_compute()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "repeated_all">} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 4 : index
     %step = arith.constant 1 : index
@@ -115,6 +116,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "repeated_all">,
                   ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 4 : index
     %step = arith.constant 1 : index
@@ -128,6 +130,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "repeated_all">,
                   ttl.noc_index = 1 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 4 : index
     %step = arith.constant 1 : index

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs.mlir
@@ -801,3 +801,82 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
     return
   }
 }
+
+// -----
+
+// Each iteration completes one two-tile transaction before the same reset.
+// Per-iteration cursor normalization permits the allocation group to reuse one
+// three-tile physical allocation.
+// CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// CHECK: DFB logical_id=0 bounded=1
+// CHECK: reset_epochs=[{executions=4,accesses=[0, 1, 2, 3],transactions=[2]
+// CHECK: DFB logical_id=1 bounded=1
+// CHECK: Total DFB count: 1
+// CHECK: DFB assignment: logical DFB 0 -> physical index 0 allocation_group=#ttl.dfb_allocation_group<0> (bounded)
+// CHECK: DFB assignment: logical DFB 1 -> physical index 0 allocation_group=#ttl.dfb_allocation_group<0> (bounded)
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @repeated_reset_lifetime_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "repeated_lifetime">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 1}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      %old_block = ttl.cb_wait %old : <[1, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %old : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_lifetime">, <kind = data_movement, identity = "reader", operation = "repeated_lifetime">, <kind = data_movement, identity = "writer", operation = "repeated_lifetime">]>(%old : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    %current_block = ttl.cb_wait %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @repeated_reset_lifetime_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "repeated_lifetime">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 1}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      %old_block = ttl.cb_reserve %old : <[1, 2], !ttcore.tile<32x32, bf16>, 1> -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %old : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_lifetime">, <kind = data_movement, identity = "reader", operation = "repeated_lifetime">, <kind = data_movement, identity = "writer", operation = "repeated_lifetime">]>(%old : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    %current_block = ttl.cb_reserve %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @repeated_reset_lifetime_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "repeated_lifetime">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 1}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "repeated_lifetime">, <kind = data_movement, identity = "reader", operation = "repeated_lifetime">, <kind = data_movement, identity = "writer", operation = "repeated_lifetime">]>(%old : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs_invalid.mlir
@@ -141,6 +141,69 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
 
 // -----
 
+// A conditional reset cannot define one reset instance per loop interval.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @conditional_repeated_reset_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "conditional_repeated_reset">} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    scf.for %iteration = %lower to %upper step %step {
+      %value = ttl.opaque_call "compute_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+      %active = arith.cmpi ne, %value, %zero : i64
+      scf.if %active {
+        // expected-error @below {{'ttl.reset_dfbs' op synchronized DFB reset must execute at most once per dispatch and launch node or once per iteration of an immutable sequential structured loop nest}}
+        ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_repeated_reset">, <kind = data_movement, identity = "reader", operation = "conditional_repeated_reset">, <kind = data_movement, identity = "writer", operation = "conditional_repeated_reset">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      }
+    }
+    return
+  }
+
+  func.func @conditional_repeated_reset_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "conditional_repeated_reset">,
+                  ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    scf.for %iteration = %lower to %upper step %step {
+      %value = ttl.opaque_call "reader_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+      %active = arith.cmpi ne, %value, %zero : i64
+      scf.if %active {
+        ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_repeated_reset">, <kind = data_movement, identity = "reader", operation = "conditional_repeated_reset">, <kind = data_movement, identity = "writer", operation = "conditional_repeated_reset">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      }
+    }
+    return
+  }
+
+  func.func @conditional_repeated_reset_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "conditional_repeated_reset">,
+                  ttl.noc_index = 1 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    %zero = arith.constant 0 : i64
+    scf.for %iteration = %lower to %upper step %step {
+      %value = ttl.opaque_call "writer_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+      %active = arith.cmpi ne, %value, %zero : i64
+      scf.if %active {
+        ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_repeated_reset">, <kind = data_movement, identity = "reader", operation = "conditional_repeated_reset">, <kind = data_movement, identity = "writer", operation = "conditional_repeated_reset">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      }
+    }
+    return
+  }
+}
+
+// -----
+
 // All participants must execute the same number of reset instances.
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
@@ -195,6 +258,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
   func.func @sequence_mismatch_compute()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "sequence_mismatch">} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 4 : index
     %step = arith.constant 1 : index
@@ -208,6 +272,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "sequence_mismatch">,
                   ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 4 : index
     %step = arith.constant 1 : index
@@ -221,6 +286,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "sequence_mismatch">,
                   ttl.noc_index = 1 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 2 : index
     %step = arith.constant 1 : index
@@ -236,17 +302,18 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 
 // -----
 
-// Parallel iterations have no shared sequential reset ordinal.
+// Parallel iterations do not have an exact sequential reset count.
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @parallel_reset_compute()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "parallel_reset">} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 2 : index
     %step = arith.constant 1 : index
     scf.parallel (%iteration) = (%lower) to (%upper) step (%step) {
-      // expected-error @below {{'ttl.reset_all_dfbs' op repeated synchronized DFB reset with exact count 2 must execute once in every iteration of an immutable sequential structured loop nest}}
+      // expected-error @below {{'ttl.reset_all_dfbs' op synchronized DFB reset must execute at most once per dispatch and launch node or once per iteration of an immutable sequential structured loop nest}}
       ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "parallel_reset">, <kind = data_movement, identity = "reader", operation = "parallel_reset">, <kind = data_movement, identity = "writer", operation = "parallel_reset">]>
     }
     return
@@ -256,6 +323,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "parallel_reset">,
                   ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 2 : index
     %step = arith.constant 1 : index
@@ -269,6 +337,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "parallel_reset">,
                   ttl.noc_index = 1 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     %lower = arith.constant 0 : index
     %upper = arith.constant 2 : index
     %step = arith.constant 1 : index

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_synchronized_reset_epochs_invalid.mlir
@@ -47,42 +47,6 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 // -----
 
 module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
-  func.func @repeated_reset_reader()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
-                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "reset_test">,
-                  ttl.noc_index = 0 : i32} {
-    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %lower = arith.constant 0 : index
-    %upper = arith.constant 2 : index
-    %step = arith.constant 1 : index
-    scf.for %iteration = %lower to %upper step %step {
-      // expected-error @below {{'ttl.reset_dfbs' op synchronized DFB reset declaration must execute at most once per dispatch and launch node}}
-      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_test">, <kind = data_movement, identity = "reader", operation = "reset_test">, <kind = data_movement, identity = "writer", operation = "reset_test">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-    }
-    return
-  }
-
-  func.func @repeated_reset_compute()
-      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "reset_test">} {
-    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_test">, <kind = data_movement, identity = "reader", operation = "reset_test">, <kind = data_movement, identity = "writer", operation = "reset_test">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-    return
-  }
-
-  func.func @repeated_reset_writer()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
-                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "reset_test">,
-                  ttl.noc_index = 1 : i32} {
-    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_test">, <kind = data_movement, identity = "reader", operation = "reset_test">, <kind = data_movement, identity = "writer", operation = "reset_test">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-    return
-  }
-}
-
-// -----
-
-module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @condition_mismatch_compute()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                   ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "reset_test">} {
@@ -171,6 +135,146 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     // expected-error @below {{'ttl.reset_dfbs' op is supported only for Blackhole; selected target is #ttcore.arch<wormhole_b0>}}
     ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_test">, <kind = data_movement, identity = "reader", operation = "reset_test">, <kind = data_movement, identity = "writer", operation = "reset_test">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    return
+  }
+}
+
+// -----
+
+// All participants must execute the same number of reset instances.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @count_mismatch_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "count_mismatch">} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "count_mismatch">, <kind = data_movement, identity = "reader", operation = "count_mismatch">, <kind = data_movement, identity = "writer", operation = "count_mismatch">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    return
+  }
+
+  func.func @count_mismatch_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "count_mismatch">,
+                  ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "count_mismatch">, <kind = data_movement, identity = "reader", operation = "count_mismatch">, <kind = data_movement, identity = "writer", operation = "count_mismatch">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    return
+  }
+
+  func.func @count_mismatch_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "count_mismatch">,
+                  ttl.noc_index = 1 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 3 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      // expected-error @below {{'ttl.reset_dfbs' op synchronized DFB reset participants must execute in the same structured iteration sequence}}
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "count_mismatch">, <kind = data_movement, identity = "reader", operation = "count_mismatch">, <kind = data_movement, identity = "writer", operation = "count_mismatch">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+    }
+    return
+  }
+}
+
+// -----
+
+// Equal total counts do not match different nested iteration sequences.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @sequence_mismatch_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "sequence_mismatch">} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "sequence_mismatch">, <kind = data_movement, identity = "reader", operation = "sequence_mismatch">, <kind = data_movement, identity = "writer", operation = "sequence_mismatch">]>
+    }
+    return
+  }
+
+  func.func @sequence_mismatch_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "sequence_mismatch">,
+                  ttl.noc_index = 0 : i32} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "sequence_mismatch">, <kind = data_movement, identity = "reader", operation = "sequence_mismatch">, <kind = data_movement, identity = "writer", operation = "sequence_mismatch">]>
+    }
+    return
+  }
+
+  func.func @sequence_mismatch_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "sequence_mismatch">,
+                  ttl.noc_index = 1 : i32} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.for %outer = %lower to %upper step %step {
+      scf.for %inner = %lower to %upper step %step {
+        // expected-error @below {{'ttl.reset_all_dfbs' op synchronized DFB reset participants must execute in the same structured iteration sequence}}
+        ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "sequence_mismatch">, <kind = data_movement, identity = "reader", operation = "sequence_mismatch">, <kind = data_movement, identity = "writer", operation = "sequence_mismatch">]>
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Parallel iterations have no shared sequential reset ordinal.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @parallel_reset_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "parallel_reset">} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.parallel (%iteration) = (%lower) to (%upper) step (%step) {
+      // expected-error @below {{'ttl.reset_all_dfbs' op repeated synchronized DFB reset with exact count 2 must execute once in every iteration of an immutable sequential structured loop nest}}
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "parallel_reset">, <kind = data_movement, identity = "reader", operation = "parallel_reset">, <kind = data_movement, identity = "writer", operation = "parallel_reset">]>
+    }
+    return
+  }
+
+  func.func @parallel_reset_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "parallel_reset">,
+                  ttl.noc_index = 0 : i32} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.parallel (%iteration) = (%lower) to (%upper) step (%step) {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "parallel_reset">, <kind = data_movement, identity = "reader", operation = "parallel_reset">, <kind = data_movement, identity = "writer", operation = "parallel_reset">]>
+    }
+    return
+  }
+
+  func.func @parallel_reset_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "parallel_reset">,
+                  ttl.noc_index = 1 : i32} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    scf.parallel (%iteration) = (%lower) to (%upper) step (%step) {
+      ttl.reset_all_dfbs <0, participants[<kind = compute, identity = "compute", operation = "parallel_reset">, <kind = data_movement, identity = "reader", operation = "parallel_reset">, <kind = data_movement, identity = "writer", operation = "parallel_reset">]>
+    }
     return
   }
 }


### PR DESCRIPTION
### Problem description

Repeated synchronized reset declarations in immutable sequential loops could not delimit per-iteration DFB lifetimes. Treating the loop as one continuous lifetime prevents valid physical reuse; accepting an unproved repeated boundary can alias active queue state.

### What's changed

~510 LOC implementation (tests and documentation excluded).

Model uniform repeated synchronized resets as canonical per-iteration DFB lifetimes. All participants must execute the same reset sequence under equivalent conditions on every iteration. Mismatched participants, reset order, predicates, trip counts, and unsupported loop constructs are rejected.

```python
reset_boundary = ttl.DFBReset(
    participants=(compute_kernel, reader_kernel, writer_kernel)
)

@ttl.compute(kernel=compute_kernel)
def compute():
    for _iteration in range(4):
        consume(scratch)
        ttl.reset_dfbs(reset_boundary, dfbs=[scratch])

@ttl.datamovement(kernel=reader_kernel)
def read():
    for _iteration in range(4):
        produce(scratch)
        ttl.reset_dfbs(reset_boundary, dfbs=[scratch])

@ttl.datamovement(kernel=writer_kernel)
def write():
    for _iteration in range(4):
        finish_output()
        ttl.reset_dfbs(reset_boundary, dfbs=[scratch])
```

The compiler analyzes each iteration as one epoch and may reuse the allocation after the reset proves canonical interface state. The loop itself remains ordinary generated control flow; no runtime epoch object is created.

### Validation

- New device tests cover selected and all-DFB repeated resets across BF16/FP32, DRAM/L1, and repeated dispatch.
- New frontend and analysis tests cover constant loop expansion, per-iteration lifecycle reuse, reset-interval access conflicts, and rejection of participant, sequence, predicate, and trip-count mismatches.
