### PR TITLE
[ci] Disable automatic Galaxy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
     secrets: inherit
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
-      run_galaxy_tests: true
+      run_galaxy_tests: false
 
   build-docs:
     name: Build documentation

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -21,12 +21,12 @@ INSTALL_EXABOX_WORKER = (
 UPLIFT_PATHS = REPO_ROOT / ".github" / "scripts" / "uplift-paths.sh"
 
 
-def test_enabled_galaxy_tests_use_exabox_instead_of_legacy_runner() -> None:
+def test_disabled_galaxy_tests_retain_exabox_configuration() -> None:
     ci_workflow = CI_WORKFLOW.read_text()
     call_build = CALL_BUILD.read_text()
     n150_workflow = CALL_TEST_HARDWARE.read_text()
 
-    assert "run_galaxy_tests: true" in ci_workflow
+    assert "run_galaxy_tests: false" in ci_workflow
     assert "uses: ./.github/workflows/call-test-exabox.yml" in call_build
     assert "if: ${{ inputs.run_galaxy_tests }}" in call_build
     assert "needs: [test-hardware, test-exabox]" in call_build


### PR DESCRIPTION
### Problem description

The Exabox runner administrator hook currently rejects pull-request jobs before checkout, including same-repository PRs whose author association is `MEMBER`. This produces a red Galaxy sub-job without executing repository code or tests.

### What's changed

Set `run_galaxy_tests: false` in the automatic CI caller and update its packaging contract. The reusable and manual Exabox workflows remain available for explicit validation while runner authorization is corrected.

### Checklist

- [x] New/Existing tests provide coverage for changes
