### PR TITLE
[ttl] Track and pack static DFB allocations

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -104,7 +104,14 @@ ttl-erase-pipenet-scopes       (Module)   Remove verified PipeNet markers
 ttl-validate-cb-budget         (Module)   Validate DFB/reset/reconfig L1 use
 convert-ttl-to-ttkernel        (Module)   Lower to TTKernel dialect
 ttkernel-insert-inits          (Module)   Insert hardware init calls
+ttkernel-specialize-cores      (Module)   Clone coordinate-dependent kernels
+canonicalize, cse              (Module)   Remove untaken coordinate branches
+ttkernel-annotate-dfb-use      (Module)   Record surviving physical DFB uses
 ```
+
+The final three entries run only when per-core specialization is enabled.
+Annotation follows canonicalization so an eliminated branch cannot keep an
+otherwise-unused DFB live on that clone's launch node.
 
 `ttl-finalize-dfb-indices` must precede
 `ttl-set-compute-kernel-config` and `ttl-annotate-cb-associations`.
@@ -123,6 +130,57 @@ physical index assignment. Finalization may use that reservation to select a
 lower-byte valid coloring. The budget pass validates finalized DFB and
 synchronized-reset and reconfiguration allocations. Conversion validates the
 exact combined allocation after PipeNet resource planning.
+
+### Per-core descriptor allocation
+
+Physical allocation records the exact union of launch nodes that access each
+physical DFB index. The runtime restricts descriptors to this domain without
+requiring kernel specialization. An exact empty domain installs no descriptor;
+an unknown domain retains conservative whole-grid allocation.
+
+Per-core kernel specialization can remove different DFB operations on
+different launch nodes. Each final TTKernel function records the physical
+indices still referenced by its compile-time arguments in
+`ttl.used_dfb_indices`. Direct helper calls contribute their transitive uses.
+An unresolved call or missing annotation is conservative and keeps every DFB
+available on the affected function's launch nodes.
+
+The runtime unions these sets for every kernel dispatched to a logical core,
+then intersects the result with the physical allocation domain and finalized
+storage segments. Static storage, tensor-backed ranges, and PipeNet
+computed-address backing therefore use only cores where a surviving kernel can
+access that physical index. A computed-address DFB with an empty effective
+domain retains one hidden backing shard because the PipeNet ABI still requires
+a receiver address, but no launch core installs its descriptor.
+
+Descriptor construction creates one descriptor for each physical DFB storage
+source and restricts it to the exact launch nodes using that source. Sparse
+domains allocate one tensor shard per selected core rather than the area of
+their bounding rectangle.
+
+TT-Metal allocates static descriptor storage in descriptor order. It maintains
+one allocation frontier per core, and a descriptor shared by several cores
+starts at the greatest frontier among those cores. The runtime simulates these
+frontiers with TT-Metal's address alignment and the remaining L1 on each core.
+It preserves the physical-index order when that order fits. Otherwise, it
+evaluates deterministic node-count orders and improving pairwise exchanges. If
+those orders do not fit, a bounded exact search prunes states whose per-core
+frontiers are dominated or whose remaining minimum allocation exceeds L1. Only
+an order whose simulated allocation fits every selected core is emitted. Search
+exhaustion proves that no order fits; reaching the state limit reports a
+conservative failure and the best candidate's overflow.
+
+The usable interval for each core begins at the configured DFB allocator base
+and ends at the lowest live L1 tensor page. Subtracting only allocated page
+sizes would ignore allocator gaps and could overestimate the available range.
+Tensor-backed and already allocated computed-address storage do not advance the
+static frontiers. For a multi-device mesh, tensor and runtime-resource
+allocations use common L1 addresses, while harvested worker mappings can
+differ. The runtime therefore applies the reference allocator's global minimum
+remaining interval to every logical core.
+The correctness invariant is that every surviving DFB access has one compatible
+descriptor on its launch core; conservative metadata preserves the
+whole-program descriptor behavior when this cannot be proved.
 
 `ttl-verify-dfb-spsc` must run after `ttl-finalize-dfb-indices` so every
 `bind_cb` carries its final `cb_index` and module-wide logical `dfb_id`. The
@@ -2195,7 +2253,12 @@ the first tensor-accessor argument index after these compiler-defined entries.
 
 The plan contains one `ttl.dfb_allocations` descriptor per physical index.
 Each descriptor contains `dfb_index`, `num_tiles`, `element_type`, `page_size`,
-and `block_count`. The planner computes `page_size` with
+and `block_count`. When the compiler proves the exact union of launch nodes
+that access the physical index, the descriptor also contains
+`allocation_nodes`. An empty array records an unreachable allocation. Omitting
+the field retains conservative whole-grid allocation when the node domain is
+unknown. This metadata controls storage residency independently from optional
+per-core executable specialization. The planner computes `page_size` with
 `ttcore::getElementSizeBytes()` on the finalized element type, so subtile
 dimensions affect the physical allocation without requiring runtime device
 initialization.
@@ -2203,6 +2266,7 @@ initialization.
 ```text
 buildRuntimeDescriptors(assignments, lifecycles, boundaryOrder):
   for physicalIndex in assignments grouped by index:
+    allocationDomain = exactUnionOrUnknown(physicalIndex.launchDomains)
     for assignment in physicalIndex.assignments:
       for active lifecycle epoch, or the initial epoch when none is recorded:
         configuration = configurations[epoch.entryBoundary]
@@ -2217,7 +2281,8 @@ buildRuntimeDescriptors(assignments, lifecycles, boundaryOrder):
     copy the initial configuration into the physical descriptor fields
     if the initial configuration is tensor-backed:
       add scratch placeholder segments for cores first active in later epochs
-    emit the physical descriptor and its ordered epoch configurations
+    emit the physical descriptor with allocation_nodes = allocationDomain
+    emit its ordered epoch configurations
 ```
 
 Every finalized declaration contributes to the table. Exact-type reuse keeps
@@ -2237,6 +2302,12 @@ format except U8, whose compute passthrough is unsupported; U8 is qualified for
 the NoC interfaces. IEEE FP16 is rejected because TTNN does not expose a native
 FP16 tensor representation; its `float16` compatibility name resolves to BF16
 and does not represent IEEE FP16 storage.
+
+The runtime intersects `allocation_nodes` with final per-kernel DFB-use
+metadata when both are available. The allocation domain restricts an
+unspecialized grid-wide kernel, while specialized use metadata may remove
+additional DFBs after coordinate folding. Tensor-backed storage segments must
+cover the exact allocation nodes and retain their existing storage identity.
 
 The Python runtime validates that the descriptors form a dense index range and
 builds all `ttnn.CBDescriptor` objects from this final allocation table. It

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1136,7 +1136,11 @@ def TTLFinalizeDFBIndices
     missing compiler-created logical IDs, and builds `ttl.dfb_allocations` for
     the Python runtime. The attribute contains one descriptor per physical
     index, including user-declared and compiler-created DFBs, and records the
-    page size computed from the finalized element type. See
+    page size computed from the finalized element type. A descriptor also
+    records the exact union of launch nodes that access its physical index when
+    that domain is known. An exact empty domain causes the runtime to install no
+    DFB descriptor; omitted domain metadata requires conservative whole-grid
+    allocation. See
     docs/development/DFBManagement.md.
   }];
 

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -4997,6 +4997,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
 
   LivenessDomainState domainState;
   domainState.initialize(module);
+  exactLaunchGridAvailable = domainState.hasLaunchGrid;
   if (!domainState.hasLaunchGrid) {
     if (dependsOnLaunchNode) {
       for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -295,6 +295,10 @@ public:
 
   ArrayRef<LaunchNodeCoord> getLaunchNodes() const { return launchNodes; }
 
+  /// Returns whether launch nodes come from module metadata rather than the
+  /// representative domain used to analyze grid-independent lifetimes.
+  bool hasExactLaunchGrid() const { return exactLaunchGridAvailable; }
+
   ArrayRef<DFBResetAllocationConflict> getResetAllocationConflicts() const {
     return resetAllocationConflicts;
   }
@@ -361,6 +365,7 @@ private:
 
   SmallVector<DFBLogicalLifecycle, 0> logicalDFBs;
   SmallVector<LaunchNodeCoord> launchNodes;
+  bool exactLaunchGridAvailable = false;
   SmallVector<int64_t> reconfigurationBoundaryOrdinals;
   SmallVector<SmallVector<llvm::BitVector>> orderedBeforeByNode;
   SmallVector<SmallVector<llvm::BitVector>> conditionallyOrderedBeforeByNode;

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -1953,7 +1953,7 @@ static FailureOr<PhysicalAllocationCandidate> computeAllocationWithinL1(
 }
 
 /// Builds the dense runtime descriptor table without modifying IR.
-static FailureOr<SmallVector<DFBPhysicalAllocationDescriptor>>
+static FailureOr<DFBPhysicalAllocationDescriptorList>
 buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
                  const DFBConcurrentKernelLivenessAnalysis &liveness,
                  DFBAnalysisFailure &analysisFailure) {
@@ -1968,7 +1968,18 @@ buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
     lifecycleByLogicalId.try_emplace(logicalDFB.logicalId, &logicalDFB);
   }
   llvm::DenseMap<int32_t, const DFBPhysicalIndexAssignment *> uniqueByIndex;
+  llvm::DenseMap<int32_t, LaunchNodeDomain> allocationDomainByIndex;
+  llvm::DenseMap<int32_t, SmallVector<const DFBPhysicalIndexAssignment *, 0>>
+      assignmentsByIndex;
+  auto getRuntimeAllocationDomain = [&](const LaunchNodeDomain &domain) {
+    return liveness.hasExactLaunchGrid() ? domain : LaunchNodeDomain::unknown();
+  };
   for (const DFBPhysicalIndexAssignment &assignment : assignments) {
+    assignmentsByIndex[assignment.physicalIndex].push_back(&assignment);
+    LaunchNodeDomain &allocationDomain =
+        allocationDomainByIndex[assignment.physicalIndex];
+    allocationDomain = allocationDomain.unionWith(
+        getRuntimeAllocationDomain(assignment.launchDomain));
     auto [existingIt, inserted] =
         uniqueByIndex.try_emplace(assignment.physicalIndex, &assignment);
     if (inserted || existingIt->second->type == assignment.type) {
@@ -2020,7 +2031,7 @@ buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
     return lhs.first < rhs.first;
   });
 
-  SmallVector<DFBPhysicalAllocationDescriptor> descriptors;
+  DFBPhysicalAllocationDescriptorList descriptors;
   descriptors.reserve(sorted.size());
   for (auto [expectedIndex, indexedAssignment] : llvm::enumerate(sorted)) {
     int32_t physicalIndex = indexedAssignment.first;
@@ -2036,12 +2047,14 @@ buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
     }
     DFBPhysicalAllocationDescriptor descriptor;
     descriptor.physicalIndex = physicalIndex;
+    descriptor.allocationDomain = allocationDomainByIndex.lookup(physicalIndex);
     SmallVector<const DFBPhysicalIndexAssignment *>
         configurationRepresentatives;
     auto addConfiguration =
         [&](const DFBPhysicalIndexAssignment &candidate,
             std::optional<int64_t> entryReconfigurationOrdinal,
             LaunchNodeDomain activeDomain) -> LogicalResult {
+      activeDomain = getRuntimeAllocationDomain(activeDomain);
       auto dfbType = cast<CircularBufferType>(candidate.type);
       FailureOr<uint64_t> pagesPerBlock = getDFBPagesPerBlock(dfbType);
       FailureOr<uint64_t> pageSizeBytes = getDFBPageSizeBytes(dfbType);
@@ -2144,10 +2157,12 @@ buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
       return success();
     };
 
-    for (const DFBPhysicalIndexAssignment &candidate : assignments) {
-      if (candidate.physicalIndex != physicalIndex) {
-        continue;
-      }
+    auto assignmentsIt = assignmentsByIndex.find(physicalIndex);
+    assert(assignmentsIt != assignmentsByIndex.end() &&
+           "every physical index must have an assignment");
+    for (const DFBPhysicalIndexAssignment *indexedCandidate :
+         assignmentsIt->second) {
+      const DFBPhysicalIndexAssignment &candidate = *indexedCandidate;
       const DFBLogicalLifecycle *lifecycle =
           lifecycleByLogicalId.lookup(candidate.logicalId);
       assert(lifecycle && "every assignment must have a logical lifecycle");
@@ -2424,7 +2439,7 @@ DFBPhysicalAllocationPlanner::DFBPhysicalAllocationPlanner(
     return;
   }
 
-  FailureOr<SmallVector<DFBPhysicalAllocationDescriptor>> descriptors =
+  FailureOr<DFBPhysicalAllocationDescriptorList> descriptors =
       buildDescriptors(plan.assignments, liveness, analysisFailure);
   if (failed(descriptors)) {
     errorOperation = analysisFailure.operation;

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
@@ -60,9 +60,15 @@ struct DFBPhysicalAllocationDescriptor {
   Type elementType;
   int32_t pageSize = 0;
   int32_t blockCount = 0;
+  /// Exact union of nodes that access this index. An unknown domain requires
+  /// conservative whole-grid runtime allocation.
+  LaunchNodeDomain allocationDomain = LaunchNodeDomain::unknown();
   SmallVector<DFBPhysicalStorageSegment> storageSegments;
   SmallVector<DFBConfigurationEpochDescriptor> epochConfigurations;
 };
+
+using DFBPhysicalAllocationDescriptorList =
+    SmallVector<DFBPhysicalAllocationDescriptor, 0>;
 
 /// Final base CTA index for one kernel.
 struct DFBKernelBaseIndexAssignment {
@@ -197,7 +203,7 @@ private:
   friend class DFBPhysicalAllocationPlanner;
 
   SmallVector<DFBPhysicalIndexAssignment> assignments;
-  SmallVector<DFBPhysicalAllocationDescriptor> descriptors;
+  DFBPhysicalAllocationDescriptorList descriptors;
   SmallVector<DFBKernelBaseIndexAssignment> kernelBaseIndices;
   SmallVector<DFBAssumedAllocationGroup> assumedAllocationGroups;
   SmallVector<int64_t> reconfigurationBoundaryOrdinals;

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -104,19 +104,24 @@ applyPhysicalAllocationPlan(ModuleOp moduleOp, OpBuilder &builder,
                               builder.getI32IntegerAttr(baseIndex.baseIndex));
   }
 
+  auto buildLaunchNodeArrayAttr = [&](const LaunchNodeDomain &launchDomain) {
+    assert(launchDomain.known &&
+           "runtime metadata requires an exact launch domain");
+    SmallVector<Attribute> nodeAttributes;
+    for (LaunchNodeCoord node : launchDomain.nodes) {
+      nodeAttributes.push_back(
+          builder.getArrayAttr({builder.getI64IntegerAttr(node.x),
+                                builder.getI64IntegerAttr(node.y)}));
+    }
+    return builder.getArrayAttr(nodeAttributes);
+  };
   auto buildStorageSegmentAttributes =
       [&](ArrayRef<DFBPhysicalStorageSegment> storageSegments) {
         SmallVector<Attribute> storageSegmentAttributes;
         for (const DFBPhysicalStorageSegment &segment : storageSegments) {
-          SmallVector<Attribute> nodeAttributes;
-          for (LaunchNodeCoord node : segment.launchDomain.nodes) {
-            nodeAttributes.push_back(
-                builder.getArrayAttr({builder.getI64IntegerAttr(node.x),
-                                      builder.getI64IntegerAttr(node.y)}));
-          }
           SmallVector<NamedAttribute> segmentAttributes;
           segmentAttributes.push_back(builder.getNamedAttr(
-              "nodes", builder.getArrayAttr(nodeAttributes)));
+              "nodes", buildLaunchNodeArrayAttr(segment.launchDomain)));
           if (segment.tensorBacking) {
             segmentAttributes.push_back(
                 builder.getNamedAttr("tensor_backing", segment.tensorBacking));
@@ -142,6 +147,11 @@ applyPhysicalAllocationPlan(ModuleOp moduleOp, OpBuilder &builder,
         "page_size", builder.getI32IntegerAttr(descriptor.pageSize)));
     entryAttributes.push_back(builder.getNamedAttr(
         "block_count", builder.getI32IntegerAttr(descriptor.blockCount)));
+    if (descriptor.allocationDomain.known) {
+      entryAttributes.push_back(builder.getNamedAttr(
+          "allocation_nodes",
+          buildLaunchNodeArrayAttr(descriptor.allocationDomain)));
+    }
     if (!descriptor.storageSegments.empty()) {
       entryAttributes.push_back(builder.getNamedAttr(
           "storage_segments",

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -288,6 +288,8 @@ class PhysicalDFBConfig:
     independent of whether the allocation serves user-declared,
     compiler-created, or multiple non-overlapping logical DFBs.
     `tile` is present only when the DFB element type is a TTCore tile.
+    `allocation_nodes` distinguishes an unknown domain (`None`) from an exact,
+    possibly empty, launch-node set.
     """
 
     dfb_index: int
@@ -297,6 +299,7 @@ class PhysicalDFBConfig:
     page_size: int
     tile: Optional[Tuple[int, int]]
     storage_segments: Tuple["DFBStorageSegment", ...] = ()
+    allocation_nodes: Optional[Tuple[Tuple[int, int], ...]] = None
 
 
 @dataclass(frozen=True)

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -25,6 +25,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 
 ttnn = None  # Lazy-loaded via _ensure_ttnn()
 
+_STATIC_DFB_PACKING_SEARCH_STATE_LIMIT = 1_000_000
+
 
 def _ensure_ttnn():
     """Lazy import of ttnn."""
@@ -80,6 +82,27 @@ class _DFBAllocation:
     total_size: int
 
 
+@dataclass(frozen=True)
+class _DFBDescriptorPlan:
+    """Runtime descriptor plus the metadata needed to model static storage."""
+
+    descriptor: Any
+    physical_index: int
+    total_size: int
+    nodes: Tuple[Tuple[int, int], ...]
+    has_static_storage: bool
+
+
+@dataclass(frozen=True)
+class _StaticDFBPackingResult:
+    """Predicted TT-Metal placement for one static descriptor order."""
+
+    packed_bytes: int
+    maximum_overflow_bytes: int
+    overflow_core: Optional[Tuple[int, int]]
+    required_bytes_on_overflow_core: int
+
+
 def _validate_physical_dfb_config(
     config: PhysicalDFBConfig, physical_index: int
 ) -> None:
@@ -89,6 +112,25 @@ def _validate_physical_dfb_config(
             f"DFB config at physical index {physical_index} has dfb_index "
             f"{config.dfb_index}"
         )
+    allocation_nodes = None
+    if config.allocation_nodes is not None:
+        for node_position, node in enumerate(config.allocation_nodes):
+            if (
+                not isinstance(node, tuple)
+                or len(node) != 2
+                or any(type(coordinate) is not int for coordinate in node)
+                or node[0] < 0
+                or node[1] < 0
+            ):
+                raise ValueError(
+                    f"DFB[{config.dfb_index}] allocation node "
+                    f"{node_position} must be a nonnegative integer (x, y) tuple"
+                )
+        allocation_nodes = set(config.allocation_nodes)
+        if len(allocation_nodes) != len(config.allocation_nodes):
+            raise ValueError(
+                f"DFB[{config.dfb_index}] allocation_nodes contains duplicates"
+            )
     seen_nodes = set()
     for segment_position, segment in enumerate(config.storage_segments):
         if not segment.nodes:
@@ -103,6 +145,15 @@ def _validate_physical_dfb_config(
                     "multiple storage segments"
                 )
             seen_nodes.add(node)
+    if (
+        allocation_nodes is not None
+        and config.storage_segments
+        and seen_nodes != allocation_nodes
+    ):
+        raise ValueError(
+            f"DFB[{config.dfb_index}] storage segments must cover its exact "
+            "allocation nodes"
+        )
 
 
 def _get_dfb_allocation(config: PhysicalDFBConfig) -> _DFBAllocation:
@@ -163,28 +214,37 @@ def _get_l1_allocation_quantum_bytes(device) -> int:
     return 64
 
 
-def _device_l1_cb_usage(
+def _get_l1_remaining_bytes(
     device,
+    cores: Iterable[Tuple[int, int]],
     excluded_l1_buffer_addresses: Sequence[int] = (),
 ) -> Tuple[int, Dict[Tuple[int, int], int]]:
-    """Return ``(cb_limit, L1 bytes used per logical (x, y) core)``."""
+    """Return the global and requested per-core static DFB allocation bounds."""
     _ensure_ttnn()
     if ttnn is None:
         raise RuntimeError("ttnn is not available")
 
-    budget_bytes = ttnn._ttnn.reports.get_device_info(device).cb_limit
+    device_info = ttnn._ttnn.reports.get_device_info(device)
+    static_dfb_base_address = ttnn.get_allocator_base_address(
+        device, ttnn.BufferType.L1
+    )
+    remaining_bytes = {core: device_info.cb_limit for core in cores}
+    minimum_remaining_bytes = device_info.cb_limit
     excluded_addresses = frozenset(
         int(address) for address in excluded_l1_buffer_addresses
     )
-    used_bytes: Dict[Tuple[int, int], int] = {}
     for page in ttnn._ttnn.reports.get_buffer_pages(device):
         if page.buffer_type != ttnn.BufferType.L1:
             continue
-        if int(page.address) in excluded_addresses:
+        buffer_address = getattr(page, "address", None)
+        if buffer_address is not None and int(buffer_address) in excluded_addresses:
             continue
+        page_remaining_bytes = max(0, page.page_address - static_dfb_base_address)
+        minimum_remaining_bytes = min(minimum_remaining_bytes, page_remaining_bytes)
         core = (page.core_x, page.core_y)
-        used_bytes[core] = used_bytes.get(core, 0) + page.page_size
-    return budget_bytes, used_bytes
+        if core in remaining_bytes:
+            remaining_bytes[core] = min(remaining_bytes[core], page_remaining_bytes)
+    return minimum_remaining_bytes, remaining_bytes
 
 
 def get_min_remaining_l1_for_device(
@@ -193,35 +253,45 @@ def get_min_remaining_l1_for_device(
     """Return the minimum remaining L1 CB budget (bytes) across all cores.
 
     Accounts for reduced ``worker_l1_size`` and L1 tensor allocations.
-    Queries ``cb_limit`` (the hardware CB budget) and subtracts the maximum
-    per-core L1 buffer usage reported by the device.
+    TT-Metal allocates tensors from high L1 addresses and static DFBs from the
+    configured L1 allocator base. The usable interval therefore ends at the
+    lowest live tensor page address, not at the total allocated byte count.
 
-    ``get_buffer_pages`` is called on the original device rather than on
-    per-coordinate submeshes because ``create_submesh`` produces a new
-    device view that does not inherit buffer tracking from the parent.
-    For mesh devices this reports allocations for the first physical
-    device, which is representative because tt-lang distributes tensors
-    uniformly across the mesh. If individual physical devices need tracking,
-    ttnn.reports.get_buffer_pages would have to report allocations on the
-    parent mesh instead of the first device within the mesh.
+    For a MeshDevice, ``get_buffer_pages`` reports the reference allocator.
+    TT-Lang's multi-device tensors and runtime resources use common L1
+    addresses across their mesh, so its lowest live page is also a safe lower
+    bound for every physical device.
 
-    ``excluded_l1_buffer_addresses`` removes retained compiler-owned buffers
-    before computing the per-core maximum. This reconstructs the compilation
-    budget without changing the contribution of unrelated allocations.
+    ``excluded_l1_buffer_addresses`` omits retained compiler-owned buffers when
+    finding the lowest live page. This reconstructs the compilation budget
+    without changing the contribution of unrelated allocations.
     """
-    budget_bytes, bytes_per_core = _device_l1_cb_usage(
-        device, excluded_l1_buffer_addresses
+    minimum_remaining_bytes, _ = _get_l1_remaining_bytes(
+        device, (), excluded_l1_buffer_addresses
     )
-    max_core_bytes = max(bytes_per_core.values()) if bytes_per_core else 0
-    return max(0, budget_bytes - max_core_bytes)
+    return minimum_remaining_bytes
+
+
+def _requires_global_l1_floor(device) -> bool:
+    get_num_devices = getattr(device, "get_num_devices", None)
+    return get_num_devices is None or int(get_num_devices()) != 1
 
 
 def _get_remaining_l1_by_core_for_device(
     device, cores: set[tuple[int, int]]
 ) -> dict[tuple[int, int], int]:
-    """Return each requested logical core's remaining static DFB budget."""
-    budget_bytes, used_bytes = _device_l1_cb_usage(device)
-    return {core: max(0, budget_bytes - used_bytes.get(core, 0)) for core in cores}
+    """Return safe static DFB budgets for the requested logical cores."""
+    minimum_remaining_bytes, remaining_bytes = _get_l1_remaining_bytes(device, cores)
+
+    # Mesh and unrecognized device wrappers cannot prove that one reported
+    # allocator covers every worker. Common allocation addresses make the
+    # reference allocator's lowest live page safe for every worker.
+    if _requires_global_l1_floor(device):
+        remaining_bytes = {
+            core: min(core_remaining_bytes, minimum_remaining_bytes)
+            for core, core_remaining_bytes in remaining_bytes.items()
+        }
+    return remaining_bytes
 
 
 @dataclass
@@ -1537,19 +1607,39 @@ def build_pipe_computed_address_dfb_tensors(
         cb_configs, dfb_indices, dfb_reconfiguration_plan
     )
     used_by_core = _used_dfb_indices_by_core(kernel_specs, core_ranges, len(cb_configs))
+    program_cores = set(
+        _core_range_coordinates(core_ranges, label="program core ranges")
+    )
     backing_tensors = {}
     for dfb_index in dfb_indices:
-        backing_core_ranges = core_ranges
-        if used_by_core is not None:
-            backing_cores = tuple(
-                sorted(
-                    core
-                    for core, used_indices in used_by_core.items()
-                    if dfb_index in used_indices
-                )
+        if dfb_index < 0 or dfb_index >= len(cb_configs):
+            raise ValueError(
+                f"computed-address receiver DFB index {dfb_index} is invalid"
             )
-            if backing_cores:
-                backing_core_ranges = _make_singleton_core_ranges(backing_cores)
+        config = cb_configs[dfb_index]
+        _validate_physical_dfb_config(config, dfb_index)
+        backing_cores = (
+            set(program_cores)
+            if config.allocation_nodes is None
+            else set(config.allocation_nodes)
+        )
+        outside_program = backing_cores - program_cores
+        if outside_program:
+            raise ValueError(
+                f"DFB[{dfb_index}] allocation nodes {sorted(outside_program)} "
+                "are outside the program grid"
+            )
+        if used_by_core is not None:
+            backing_cores.intersection_update(
+                core
+                for core, used_indices in used_by_core.items()
+                if dfb_index in used_indices
+            )
+        if not backing_cores:
+            # The PipeNet ABI requires a receiver address even when analysis
+            # proves that no launch node installs the corresponding descriptor.
+            backing_cores = {min(program_cores, key=lambda core: (core[1], core[0]))}
+        backing_core_ranges = _make_singleton_core_ranges(tuple(sorted(backing_cores)))
         backing_tensors[dfb_index] = _allocate_l1_sharded_storage_tensor(
             backing_core_ranges, allocation_bytes_by_index[dfb_index], device
         )
@@ -2291,27 +2381,46 @@ def _validate_tensor_backing_aliases(
             bindings.append((config.dfb_index, nodes, absolute_start, absolute_end))
 
 
-def _specialized_dfb_placements(
+def _resolve_dfb_placements(
     cb_configs: List[PhysicalDFBConfig],
     core_ranges: Any,
     backing_tensors: Dict[int, Any],
     kernel_specs: Optional[List[KernelSpec]],
 ) -> Optional[List[Dict[Tuple[int, int], Tuple[str, Optional[int]]]]]:
-    """Resolve the storage source for each used ``(DFB, core)`` pair.
+    """Resolve the storage source for each allocated and used DFB/core pair.
 
     A DFB with ``storage_segments`` must cover every core that still uses it.
     """
     used_by_core = _used_dfb_indices_by_core(kernel_specs, core_ranges, len(cb_configs))
-    if used_by_core is None:
+    has_allocation_domains = any(
+        config.allocation_nodes is not None for config in cb_configs
+    )
+    if used_by_core is None and not has_allocation_domains:
         return None
 
-    program_cores = set(used_by_core)
+    program_cores = set(
+        _core_range_coordinates(core_ranges, label="program core ranges")
+    )
+    if used_by_core is None:
+        all_indices = set(range(len(cb_configs)))
+        used_by_core = {core: set(all_indices) for core in program_cores}
     placements = []
     for dfb_index, config in enumerate(cb_configs):
+        allocation_cores = (
+            program_cores
+            if config.allocation_nodes is None
+            else set(config.allocation_nodes)
+        )
+        outside_program = allocation_cores - program_cores
+        if outside_program:
+            raise ValueError(
+                f"DFB[{dfb_index}] allocation nodes {sorted(outside_program)} "
+                "are outside the program grid"
+            )
         candidates: Dict[Tuple[int, int], Tuple[str, Optional[int]]] = {}
         if not config.storage_segments:
             storage_kind = "backing" if dfb_index in backing_tensors else "static"
-            candidates = {core: (storage_kind, None) for core in program_cores}
+            candidates = {core: (storage_kind, None) for core in allocation_cores}
         else:
             for segment_index, segment in enumerate(config.storage_segments):
                 if segment.is_tensor_backed:
@@ -2334,7 +2443,9 @@ def _specialized_dfb_placements(
                         )
                     candidates[core] = source
         used_cores = {
-            core for core, indices in used_by_core.items() if dfb_index in indices
+            core
+            for core, indices in used_by_core.items()
+            if dfb_index in indices and core in allocation_cores
         }
         if config.storage_segments:
             uncovered = sorted(core for core in used_cores if core not in candidates)
@@ -2363,104 +2474,374 @@ def _cb_format_descriptor(cb_index: int, allocation: _DFBAllocation) -> Any:
     )
 
 
-def _build_specialized_dfb_descriptors(
+def _order_static_dfb_descriptor_plans(
+    descriptor_plans: List[_DFBDescriptorPlan],
+    remaining_bytes_by_core: Dict[Tuple[int, int], int],
+) -> List[_DFBDescriptorPlan]:
+    """Order static descriptors to fit TT-Metal's per-core L1 allocators."""
+    static_plan_indices = tuple(
+        plan_index
+        for plan_index, plan in enumerate(descriptor_plans)
+        if plan.has_static_storage
+    )
+    if not static_plan_indices:
+        return descriptor_plans
+
+    # TT-Metal's intersecting range allocators are equivalent to one frontier
+    # per selected core: a descriptor starts at the greatest covered frontier.
+    # Singleton input ranges preserve the exact node set when adjacent ranges
+    # are merged.
+    allocator_cores = tuple(
+        sorted(
+            {
+                node
+                for plan_index in static_plan_indices
+                for node in descriptor_plans[plan_index].nodes
+            }
+        )
+    )
+    allocator_index_by_core = {
+        node: allocator_index for allocator_index, node in enumerate(allocator_cores)
+    }
+    allocator_indices_by_plan = {
+        plan_index: tuple(
+            allocator_index_by_core[node] for node in descriptor_plans[plan_index].nodes
+        )
+        for plan_index in static_plan_indices
+    }
+    available_bytes_by_allocator = tuple(
+        remaining_bytes_by_core[node] for node in allocator_cores
+    )
+
+    # TT-Metal aligns both the allocator base and local DFB starts to DRAM
+    # alignment, so offset frontiers reproduce its absolute L1 addresses.
+    address_alignment = int(ttnn.get_dram_alignment())
+    if address_alignment <= 0:
+        raise ValueError("TT-Metal reported an invalid DFB address alignment")
+
+    def evaluate_order(order: Tuple[int, ...]) -> _StaticDFBPackingResult:
+        allocator_frontiers = [0] * len(allocator_cores)
+        for plan_index in order:
+            plan = descriptor_plans[plan_index]
+            allocator_indices = allocator_indices_by_plan[plan_index]
+            address = _align_up(
+                max(allocator_frontiers[index] for index in allocator_indices),
+                address_alignment,
+            )
+            end_address = address + plan.total_size
+            for allocator_index in allocator_indices:
+                allocator_frontiers[allocator_index] = end_address
+
+        overflow_records = [
+            (
+                frontier - available_bytes,
+                frontier,
+                allocator_cores[allocator_index],
+            )
+            for allocator_index, (frontier, available_bytes) in enumerate(
+                zip(allocator_frontiers, available_bytes_by_allocator)
+            )
+        ]
+        maximum_overflow, required_bytes, overflow_core = max(
+            overflow_records, default=(0, 0, None)
+        )
+        maximum_overflow = max(0, maximum_overflow)
+        return _StaticDFBPackingResult(
+            packed_bytes=max(allocator_frontiers, default=0),
+            maximum_overflow_bytes=maximum_overflow,
+            overflow_core=overflow_core if maximum_overflow else None,
+            required_bytes_on_overflow_core=(required_bytes if maximum_overflow else 0),
+        )
+
+    def packing_score(result: _StaticDFBPackingResult) -> Tuple[int, int]:
+        return result.maximum_overflow_bytes, result.packed_bytes
+
+    current_order = static_plan_indices
+    current_result = evaluate_order(current_order)
+    if current_result.maximum_overflow_bytes == 0:
+        return descriptor_plans
+
+    candidate_orders = [
+        tuple(
+            sorted(
+                static_plan_indices,
+                key=lambda plan_index: (
+                    len(descriptor_plans[plan_index].nodes),
+                    descriptor_plans[plan_index].physical_index,
+                    plan_index,
+                ),
+            )
+        ),
+        tuple(
+            sorted(
+                static_plan_indices,
+                key=lambda plan_index: (
+                    -len(descriptor_plans[plan_index].nodes),
+                    descriptor_plans[plan_index].physical_index,
+                    plan_index,
+                ),
+            )
+        ),
+    ]
+    evaluated_candidates = [
+        (packing_score(current_result), current_order, current_result)
+    ]
+    for candidate_order in dict.fromkeys(candidate_orders):
+        candidate_result = evaluate_order(candidate_order)
+        evaluated_candidates.append(
+            (packing_score(candidate_result), candidate_order, candidate_result)
+        )
+    current_score, current_order, current_result = min(evaluated_candidates)
+
+    while current_score[0] > 0:
+        next_candidate = None
+        for first_position in range(len(current_order)):
+            for second_position in range(first_position + 1, len(current_order)):
+                candidate_order_list = list(current_order)
+                (
+                    candidate_order_list[first_position],
+                    candidate_order_list[second_position],
+                ) = (
+                    candidate_order_list[second_position],
+                    candidate_order_list[first_position],
+                )
+                candidate_order = tuple(candidate_order_list)
+                candidate_result = evaluate_order(candidate_order)
+                candidate_score = packing_score(candidate_result)
+                if candidate_score >= current_score:
+                    continue
+                candidate = (candidate_score, candidate_order, candidate_result)
+                if next_candidate is None or candidate < next_candidate:
+                    next_candidate = candidate
+        if next_candidate is None:
+            break
+        current_score, current_order, current_result = next_candidate
+
+    def apply_order(order: Tuple[int, ...]) -> List[_DFBDescriptorPlan]:
+        ordered_plans = list(descriptor_plans)
+        for destination_index, source_index in zip(static_plan_indices, order):
+            ordered_plans[destination_index] = descriptor_plans[source_index]
+        return ordered_plans
+
+    if current_score[0] == 0:
+        return apply_order(current_order)
+
+    search_state_count = 0
+    search_limit_reached = False
+    nondominated_frontiers: Dict[int, List[Tuple[int, ...]]] = {}
+    plan_position_by_index = {
+        plan_index: plan_position
+        for plan_position, plan_index in enumerate(static_plan_indices)
+    }
+    plan_index_by_position = tuple(static_plan_indices)
+    allocator_indices_by_position = tuple(
+        allocator_indices_by_plan[plan_index] for plan_index in static_plan_indices
+    )
+    plan_sizes = tuple(
+        descriptor_plans[plan_index].total_size for plan_index in static_plan_indices
+    )
+    preferred_positions = tuple(
+        plan_position_by_index[plan_index] for plan_index in current_order
+    )
+    preferred_rank = {
+        plan_position: rank for rank, plan_position in enumerate(preferred_positions)
+    }
+
+    def remaining_allocation_exceeds_budget(
+        remaining_mask: int, allocator_frontiers: Tuple[int, ...]
+    ) -> bool:
+        for allocator_index, available_bytes in enumerate(available_bytes_by_allocator):
+            remaining_sizes = [
+                plan_sizes[plan_position]
+                for plan_position in range(len(plan_sizes))
+                if remaining_mask & (1 << plan_position)
+                and allocator_index in allocator_indices_by_position[plan_position]
+            ]
+            if not remaining_sizes:
+                continue
+            aligned_sizes = [
+                _align_up(size, address_alignment) for size in remaining_sizes
+            ]
+            maximum_final_padding = max(
+                aligned_size - size
+                for aligned_size, size in zip(aligned_sizes, remaining_sizes)
+            )
+            minimum_final_frontier = (
+                _align_up(allocator_frontiers[allocator_index], address_alignment)
+                + sum(aligned_sizes)
+                - maximum_final_padding
+            )
+            if minimum_final_frontier > available_bytes:
+                return True
+        return False
+
+    def is_dominated(remaining_mask: int, allocator_frontiers: Tuple[int, ...]) -> bool:
+        existing_frontiers = nondominated_frontiers.setdefault(remaining_mask, [])
+        if any(
+            all(
+                existing <= current
+                for existing, current in zip(existing_state, allocator_frontiers)
+            )
+            for existing_state in existing_frontiers
+        ):
+            return True
+        existing_frontiers[:] = [
+            existing_state
+            for existing_state in existing_frontiers
+            if not all(
+                current <= existing
+                for current, existing in zip(allocator_frontiers, existing_state)
+            )
+        ]
+        existing_frontiers.append(allocator_frontiers)
+        return False
+
+    def find_fitting_order(
+        remaining_mask: int, allocator_frontiers: Tuple[int, ...]
+    ) -> Optional[Tuple[int, ...]]:
+        nonlocal search_limit_reached, search_state_count
+        if remaining_mask == 0:
+            return ()
+        if search_state_count >= _STATIC_DFB_PACKING_SEARCH_STATE_LIMIT:
+            search_limit_reached = True
+            return None
+        search_state_count += 1
+        if is_dominated(remaining_mask, allocator_frontiers):
+            return None
+        if remaining_allocation_exceeds_budget(remaining_mask, allocator_frontiers):
+            return None
+
+        candidate_positions = [
+            plan_position
+            for plan_position in preferred_positions
+            if remaining_mask & (1 << plan_position)
+        ]
+        candidate_positions.sort(
+            key=lambda plan_position: (
+                -len(allocator_indices_by_position[plan_position]),
+                preferred_rank[plan_position],
+            )
+        )
+        seen_equivalent_plans = set()
+        for plan_position in candidate_positions:
+            allocator_indices = allocator_indices_by_position[plan_position]
+            equivalent_plan = (allocator_indices, plan_sizes[plan_position])
+            if equivalent_plan in seen_equivalent_plans:
+                continue
+            seen_equivalent_plans.add(equivalent_plan)
+            address = _align_up(
+                max(allocator_frontiers[index] for index in allocator_indices),
+                address_alignment,
+            )
+            end_address = address + plan_sizes[plan_position]
+            if any(
+                end_address > available_bytes_by_allocator[allocator_index]
+                for allocator_index in allocator_indices
+            ):
+                continue
+            next_frontiers = list(allocator_frontiers)
+            for allocator_index in allocator_indices:
+                next_frontiers[allocator_index] = end_address
+            suffix = find_fitting_order(
+                remaining_mask & ~(1 << plan_position), tuple(next_frontiers)
+            )
+            if suffix is not None:
+                return (plan_index_by_position[plan_position],) + suffix
+            if search_limit_reached:
+                return None
+        return None
+
+    fitting_order = find_fitting_order(
+        (1 << len(static_plan_indices)) - 1,
+        (0,) * len(allocator_cores),
+    )
+    if fitting_order is not None:
+        return apply_order(fitting_order)
+
+    overflow_core = current_result.overflow_core
+    assert overflow_core is not None
+    required_bytes = current_result.required_bytes_on_overflow_core
+    available_bytes = remaining_bytes_by_core[overflow_core]
+    search_context = (
+        "Static DFB descriptor packing reached its "
+        f"{_STATIC_DFB_PACKING_SEARCH_STATE_LIMIT}-state search limit;"
+        if search_limit_reached
+        else "No static DFB descriptor order fits;"
+    )
+    raise ValueError(
+        f"{search_context} the best candidate requires {required_bytes} bytes "
+        f"on core {overflow_core}, where {available_bytes} bytes remain, and "
+        f"exceeds the L1 budget by {required_bytes - available_bytes} bytes"
+    )
+
+
+def _build_dfb_descriptors(
     tensors: List[Any],
     cb_configs: List[PhysicalDFBConfig],
     allocations: List[_DFBAllocation],
-    allocation_bytes: List[int],
     placements: List[Dict[Tuple[int, int], Tuple[str, Optional[int]]]],
     backing_tensors: Dict[int, Any],
     remaining_bytes_by_core: Dict[Tuple[int, int], int],
 ) -> List[Any]:
-    """Build descriptors on disjoint core partitions after DFB-use filtering."""
-    all_cores = sorted({core for placement in placements for core in placement})
-    bytes_by_core = {core: 0 for core in all_cores}
+    """Build exact-source descriptors and order their static L1 storage."""
+
+    descriptor_plans = []
     for dfb_index, placement in enumerate(placements):
-        for core, (kind, _) in placement.items():
-            if kind == "static":
-                bytes_by_core[core] += allocation_bytes[dfb_index]
-
-    overflow_cores = [
-        core
-        for core, static_bytes in bytes_by_core.items()
-        if static_bytes > remaining_bytes_by_core[core]
-    ]
-    if overflow_cores:
-        core = max(
-            overflow_cores,
-            key=lambda item: bytes_by_core[item] - remaining_bytes_by_core[item],
+        cores_by_source: Dict[Tuple[str, Optional[int]], set[Tuple[int, int]]] = {}
+        for core, source in placement.items():
+            cores_by_source.setdefault(source, set()).add(core)
+        ordered_sources = sorted(
+            cores_by_source,
+            key=lambda source: (
+                -1 if source[1] is None else source[1],
+                source[0],
+            ),
         )
-        static_indices = [
-            dfb_index
-            for dfb_index, placement in enumerate(placements)
-            if placement.get(core, (None, None))[0] == "static"
-        ]
-        breakdown = "\n".join(
-            f"  DFB[{index}]: num_tiles={allocations[index].num_tiles} "
-            f"block_count={allocations[index].block_count} "
-            f"format={cb_configs[index].data_format} "
-            f"tile={allocations[index].tile} -> "
-            f"{allocation_bytes[index]} bytes"
-            for index in sorted(static_indices)
-        )
-        raise ValueError(
-            f"Per-core DFB allocation on core {core} ("
-            f"{bytes_by_core[core]} bytes) exceeds L1 budget "
-            f"({remaining_bytes_by_core[core]} bytes).\n"
-            + breakdown
-            + "\n  hint: reduce DFB shapes or block_count."
-        )
-
-    # Every descriptor uses one of these disjoint partitions. Equal ranges
-    # share TT-Metal's allocation cursor; disjoint ranges cannot overlap.
-    cores_by_signature: Dict[
-        Tuple[Optional[Tuple[str, Optional[int]]], ...],
-        set[Tuple[int, int]],
-    ] = {}
-    for core in all_cores:
-        signature = tuple(placement.get(core) for placement in placements)
-        cores_by_signature.setdefault(signature, set()).add(core)
-
-    descriptors = []
-    for signature, partition_cores in cores_by_signature.items():
-        partition_ranges = _make_singleton_core_ranges(sorted(partition_cores))
-        for dfb_index, source in enumerate(signature):
-            if source is None:
-                continue
+        for source in ordered_sources:
+            source_cores = cores_by_source[source]
             kind, segment_index = source
             allocation = allocations[dfb_index]
-            cb_format = _cb_format_descriptor(dfb_index, allocation)
+            format_descriptor = _cb_format_descriptor(dfb_index, allocation)
+            source_ranges = _make_singleton_core_ranges(sorted(source_cores))
             if kind == "tensor":
                 assert segment_index is not None
                 segment = cb_configs[dfb_index].storage_segments[segment_index]
                 tensor_index = segment.tensor_index
                 assert tensor_index is not None
-                descriptors.append(
-                    ttnn.cb_descriptor_from_sharded_tensor(
-                        dfb_index,
-                        tensors[tensor_index],
-                        address_offset=segment.byte_offset,
-                        total_size=allocation.total_size,
-                        core_ranges=partition_ranges,
-                    )
-                )
-                continue
-
-            descriptor = ttnn.CBDescriptor(
-                total_size=allocation.total_size,
-                core_ranges=partition_ranges,
-                format_descriptors=[cb_format],
-            )
-            if kind == "backing":
-                backing_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     dfb_index,
-                    backing_tensors[dfb_index],
+                    tensors[tensor_index],
+                    address_offset=segment.byte_offset,
                     total_size=allocation.total_size,
-                    core_ranges=partition_ranges,
+                    core_ranges=source_ranges,
                 )
-                descriptor.set_buffer_from_cb(backing_descriptor)
-            descriptors.append(descriptor)
-    return descriptors
+            else:
+                descriptor = ttnn.CBDescriptor(
+                    total_size=allocation.total_size,
+                    core_ranges=source_ranges,
+                    format_descriptors=[format_descriptor],
+                )
+                if kind == "backing":
+                    backing_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                        dfb_index,
+                        backing_tensors[dfb_index],
+                        total_size=allocation.total_size,
+                        core_ranges=source_ranges,
+                    )
+                    descriptor.set_buffer_from_cb(backing_descriptor)
+            descriptor_plans.append(
+                _DFBDescriptorPlan(
+                    descriptor=descriptor,
+                    physical_index=dfb_index,
+                    total_size=allocation.total_size,
+                    nodes=tuple(sorted(source_cores)),
+                    has_static_storage=kind == "static",
+                )
+            )
+    descriptor_plans = _order_static_dfb_descriptor_plans(
+        descriptor_plans, remaining_bytes_by_core
+    )
+    return [plan.descriptor for plan in descriptor_plans]
 
 
 def _validate_dfb_reconfiguration_plan(
@@ -2609,9 +2990,7 @@ def build_cb_descriptors(
             break
     allocation_quantum_bytes = _get_l1_allocation_quantum_bytes(device)
 
-    # Compute sizes first so overflow is diagnosed before creating descriptors.
     allocations = []
-    allocation_bytes = []
     static_cb_bytes = 0
     static_allocation_summaries = []
     for physical_index, config in enumerate(cb_configs):
@@ -2625,7 +3004,6 @@ def build_cb_descriptors(
             f"{aligned_bytes} bytes"
         )
         allocations.append(allocation)
-        allocation_bytes.append(aligned_bytes)
         has_static_storage = not config.storage_segments or any(
             not segment.is_tensor_backed for segment in config.storage_segments
         )
@@ -2633,7 +3011,7 @@ def build_cb_descriptors(
             static_cb_bytes += aligned_bytes
             static_allocation_summaries.append(allocation_summary)
 
-    placements = _specialized_dfb_placements(
+    placements = _resolve_dfb_placements(
         cb_configs, core_ranges, backing_tensors, kernel_specs
     )
     if placements is not None:
@@ -2645,11 +3023,10 @@ def build_cb_descriptors(
             if device is not None
             else {core: DEFAULT_L1_CB_BUDGET_BYTES for core in placement_cores}
         )
-        return _build_specialized_dfb_descriptors(
+        return _build_dfb_descriptors(
             tensors,
             cb_configs,
             allocations,
-            allocation_bytes,
             placements,
             backing_tensors,
             remaining_bytes_by_core,
@@ -3166,6 +3543,8 @@ def _append_physical_dfb_config_source(
     lines.append(f"{indent}    block_count={config.block_count},")
     lines.append(f"{indent}    page_size={config.page_size},")
     lines.append(f"{indent}    tile={config.tile!r},")
+    if config.allocation_nodes is not None:
+        lines.append(f"{indent}    allocation_nodes={config.allocation_nodes!r},")
     if config.storage_segments:
         lines.append(f"{indent}    storage_segments=(")
         for segment in config.storage_segments:

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1678,6 +1678,25 @@ def _parse_mlir_element_type(
     )
 
 
+def _extract_dfb_node_coordinates(
+    nodes_attr, *, context: str, allow_empty: bool
+) -> tuple[tuple[int, int], ...]:
+    nodes = []
+    for node_position, node_attr in enumerate(nodes_attr):
+        node = ArrayAttr(node_attr)
+        if len(node) != 2:
+            raise ValueError(f"{context}[{node_position}] must contain [x, y]")
+        coordinate = tuple(int(IntegerAttr(component).value) for component in node)
+        if coordinate[0] < 0 or coordinate[1] < 0:
+            raise ValueError(f"{context} contains negative coordinate {coordinate}")
+        if coordinate in nodes:
+            raise ValueError(f"{context} contains duplicate coordinate {coordinate}")
+        nodes.append(coordinate)
+    if not allow_empty and not nodes:
+        raise ValueError(f"{context} must not be empty")
+    return tuple(sorted(nodes))
+
+
 def _parse_physical_dfb_config(entry, *, dfb_index: int, context: str):
     """Parse and validate one compiler-emitted physical DFB configuration."""
     required_fields = ("num_tiles", "element_type", "block_count", "page_size")
@@ -1699,6 +1718,14 @@ def _parse_physical_dfb_config(entry, *, dfb_index: int, context: str):
         if value <= 0:
             raise ValueError(f"{context}.{field} must be positive, got {value}")
 
+    allocation_nodes = None
+    if "allocation_nodes" in entry:
+        allocation_nodes = _extract_dfb_node_coordinates(
+            entry["allocation_nodes"],
+            context=f"{context}.allocation_nodes",
+            allow_empty=True,
+        )
+
     storage_segments = []
     seen_nodes = set()
     storage_segment_entries = (
@@ -1708,24 +1735,17 @@ def _parse_physical_dfb_config(entry, *, dfb_index: int, context: str):
         segment_context = f"{context}.storage_segments[{segment_position}]"
         if "nodes" not in segment:
             raise ValueError(f"{segment_context} is missing 'nodes'")
-        nodes = []
-        for node_position, node_attr in enumerate(segment["nodes"]):
-            node = ArrayAttr(node_attr)
-            if len(node) != 2:
+        nodes = _extract_dfb_node_coordinates(
+            segment["nodes"],
+            context=f"{segment_context}.nodes",
+            allow_empty=False,
+        )
+        for coordinate in nodes:
+            if coordinate in seen_nodes:
                 raise ValueError(
-                    f"{segment_context}.nodes[{node_position}] must contain [x, y]"
+                    f"{context} assigns launch node {coordinate} to multiple segments"
                 )
-            coord = tuple(int(IntegerAttr(component).value) for component in node)
-            if coord[0] < 0 or coord[1] < 0:
-                raise ValueError(f"{context} contains negative launch node {coord}")
-            if coord in seen_nodes:
-                raise ValueError(
-                    f"{context} assigns launch node {coord} to multiple segments"
-                )
-            seen_nodes.add(coord)
-            nodes.append(coord)
-        if not nodes:
-            raise ValueError(f"{segment_context}.nodes must not be empty")
+            seen_nodes.add(coordinate)
 
         tensor_index = None
         byte_offset = 0
@@ -1747,7 +1767,7 @@ def _parse_physical_dfb_config(entry, *, dfb_index: int, context: str):
                 )
         storage_segments.append(
             DFBStorageSegment(
-                nodes=tuple(sorted(nodes)),
+                nodes=nodes,
                 tensor_index=tensor_index,
                 byte_offset=byte_offset,
                 byte_size=byte_size,
@@ -1761,6 +1781,7 @@ def _parse_physical_dfb_config(entry, *, dfb_index: int, context: str):
         page_size=page_size,
         tile=tile,
         storage_segments=tuple(storage_segments),
+        allocation_nodes=allocation_nodes,
     )
 
 

--- a/test/python/test_dfb_runtime_config.py
+++ b/test/python/test_dfb_runtime_config.py
@@ -96,6 +96,63 @@ def test_tensor_backing_segments_preserve_nodes_and_tensor_range():
         ]
 
 
+# Physical allocation metadata preserves exact and empty launch-node domains.
+@pytest.mark.parametrize(
+    ("allocation_nodes", "expected"),
+    [
+        ("[[1, 0], [0, 0]]", ((0, 0), (1, 0))),
+        ("[]", ()),
+    ],
+    ids=["exact", "empty"],
+)
+def test_allocation_nodes_preserve_exact_physical_domain(allocation_nodes, expected):
+    with Context():
+        module = Module.parse(
+            "module attributes {ttl.dfb_allocations = [{"
+            "block_count = 1 : i32, dfb_index = 0 : i32, "
+            "element_type = bf16, num_tiles = 1 : i32, "
+            "page_size = 2048 : i32, allocation_nodes = "
+            f"{allocation_nodes}"
+            "}]} {}"
+        )
+
+        assert _resolve_dfb_configs(module) == [
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                None,
+                allocation_nodes=expected,
+            )
+        ]
+
+
+# Malformed physical allocation domains are rejected during metadata parsing.
+@pytest.mark.parametrize(
+    ("allocation_nodes", "message"),
+    [
+        ("[[0, 0], [0, 0]]", "duplicate coordinate"),
+        ("[[-1, 0]]", "negative coordinate"),
+        ("[[0]]", "must contain \\[x, y\\]"),
+    ],
+)
+def test_invalid_allocation_nodes_are_rejected(allocation_nodes, message):
+    with Context():
+        module = Module.parse(
+            "module attributes {ttl.dfb_allocations = [{"
+            "block_count = 1 : i32, dfb_index = 0 : i32, "
+            "element_type = bf16, num_tiles = 1 : i32, "
+            "page_size = 2048 : i32, allocation_nodes = "
+            f"{allocation_nodes}"
+            "}]} {}"
+        )
+
+        with pytest.raises(ValueError, match=message):
+            _resolve_dfb_configs(module)
+
+
 @pytest.mark.parametrize(
     ("element_type", "data_format", "tile", "page_size"),
     [

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -387,6 +387,10 @@ class _FakeTTNN:
         return [_FakeTTNN.CoreCoord(0, 0), _FakeTTNN.CoreCoord(1, 0)]
 
     @staticmethod
+    def get_dram_alignment():
+        return 64
+
+    @staticmethod
     def generic_op(tensors, program):
         return {
             "tensors": tensors,
@@ -460,6 +464,7 @@ def test_cached_l1_budget_excludes_only_owned_buffer_pages(
             address=0x1000,
             core_x=0,
             core_y=0,
+            page_address=0x2100,
             page_size=32,
             buffer_type=l1_buffer_type,
         ),
@@ -467,6 +472,7 @@ def test_cached_l1_budget_excludes_only_owned_buffer_pages(
             address=0x1100,
             core_x=0,
             core_y=0,
+            page_address=0x2200,
             page_size=4,
             buffer_type=l1_buffer_type,
         ),
@@ -474,6 +480,7 @@ def test_cached_l1_budget_excludes_only_owned_buffer_pages(
             address=0x2000,
             core_x=1,
             core_y=0,
+            page_address=0x23D0,
             page_size=48,
             buffer_type=l1_buffer_type,
         ),
@@ -486,6 +493,7 @@ def test_cached_l1_budget_excludes_only_owned_buffer_pages(
         BufferType=SimpleNamespace(L1=l1_buffer_type),
         _ttnn=SimpleNamespace(reports=reports),
         corerange_to_cores=lambda core_ranges, row_wise: [_FakeCoreCoord(0, 0)],
+        get_allocator_base_address=lambda selected_device, buffer_type: 0x2000,
     )
     monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
     cache = kernel_runner.KernelRuntimeResourceCache(
@@ -560,6 +568,7 @@ def test_cached_scratch_budget_uses_reported_allocation_pages(
                 address=scratch_address,
                 core_x=0,
                 core_y=0,
+                page_address=0x2300,
                 page_size=32,
                 buffer_type=l1_buffer_type,
             )
@@ -569,6 +578,7 @@ def test_cached_scratch_budget_uses_reported_allocation_pages(
         BufferType=SimpleNamespace(L1=l1_buffer_type),
         _ttnn=SimpleNamespace(reports=reports),
         corerange_to_cores=lambda core_ranges, row_wise: [_FakeCoreCoord(0, 0)],
+        get_allocator_base_address=lambda selected_device, buffer_type: 0x2000,
     )
     monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
     monkeypatch.setattr(
@@ -616,6 +626,7 @@ def test_cached_global_semaphore_budget_uses_reported_allocation_pages(monkeypat
                 address=semaphore_address,
                 core_x=0,
                 core_y=0,
+                page_address=0x2300,
                 page_size=4,
                 buffer_type=l1_buffer_type,
             )
@@ -625,6 +636,7 @@ def test_cached_global_semaphore_budget_uses_reported_allocation_pages(monkeypat
         BufferType=SimpleNamespace(L1=l1_buffer_type),
         _ttnn=SimpleNamespace(reports=reports),
         corerange_to_cores=lambda core_ranges, row_wise: [_FakeCoreCoord(0, 0)],
+        get_allocator_base_address=lambda selected_device, buffer_type: 0x2000,
     )
     monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
     monkeypatch.setattr(
@@ -3468,7 +3480,8 @@ def _specialized_spec(core_ranges, used_dfb_indices):
     )
 
 
-def test_specialized_dfb_descriptors_partition_overlapping_use(monkeypatch):
+# Each physical index retains one descriptor across overlapping core domains.
+def test_specialized_dfb_descriptors_group_overlapping_use_by_index(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
     full_grid = _FakeExplicitCoreRanges((0, 0), (2, 0))
     core_0 = _FakeExplicitCoreRanges((0, 0), (0, 0))
@@ -3490,10 +3503,8 @@ def test_specialized_dfb_descriptors_partition_overlapping_use(monkeypatch):
     )
 
     assert {_descriptor_placement(descriptor) for descriptor in descriptors} == {
-        (0, frozenset({(0, 0)})),
-        (0, frozenset({(1, 0)})),
-        (1, frozenset({(1, 0)})),
-        (1, frozenset({(2, 0)})),
+        (0, frozenset({(0, 0), (1, 0)})),
+        (1, frozenset({(1, 0), (2, 0)})),
     }
 
 
@@ -3553,7 +3564,165 @@ def test_unannotated_kernel_remains_conservative_with_annotated_peer(monkeypatch
     assert _descriptor_cores(descriptors[0]) == {(1, 0)}
 
 
-def test_specialized_dfb_descriptors_allow_sparse_physical_ids(monkeypatch):
+# Exact allocation nodes restrict an otherwise unspecialized descriptor.
+def test_allocation_nodes_scope_unspecialized_dfb_descriptor(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=((1, 0),),
+            )
+        ],
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    assert len(descriptors) == 1
+    assert _descriptor_cores(descriptors[0]) == {(1, 0)}
+
+
+# An exact empty allocation domain installs no runtime descriptor.
+def test_empty_allocation_nodes_omit_dfb_descriptor(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=(),
+            )
+        ],
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    assert descriptors == []
+
+
+# Runtime validation rejects malformed allocation-node metadata.
+@pytest.mark.parametrize(
+    ("allocation_nodes", "message"),
+    [
+        (((0, 0), (0, 0)), "contains duplicates"),
+        (([0, 0],), "must be a nonnegative integer"),
+        (((True, 0),), "must be a nonnegative integer"),
+        (((-1, 0),), "must be a nonnegative integer"),
+    ],
+    ids=["duplicate", "non-tuple", "non-integer", "negative"],
+)
+def test_invalid_allocation_nodes_are_rejected(monkeypatch, allocation_nodes, message):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    config = PhysicalDFBConfig(
+        0,
+        1,
+        "bfloat16",
+        1,
+        2048,
+        (32, 32),
+        allocation_nodes=allocation_nodes,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=[config],
+            core_ranges=_FakeExplicitCoreRanges((0, 0), (1, 0)),
+        )
+
+
+# Storage segments must cover exactly the declared allocation domain.
+def test_allocation_nodes_must_cover_storage_segments(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    config = PhysicalDFBConfig(
+        0,
+        1,
+        "bfloat16",
+        1,
+        2048,
+        (32, 32),
+        (DFBStorageSegment(nodes=((0, 0),)),),
+        allocation_nodes=((1, 0),),
+    )
+
+    with pytest.raises(ValueError, match="must cover its exact allocation nodes"):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=[config],
+            core_ranges=full_grid,
+        )
+
+
+# Allocation nodes outside the operation grid are invalid.
+def test_allocation_nodes_outside_program_grid_are_rejected(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+
+    with pytest.raises(ValueError, match="outside the program grid"):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=[
+                PhysicalDFBConfig(
+                    0,
+                    1,
+                    "bfloat16",
+                    1,
+                    2048,
+                    (32, 32),
+                    allocation_nodes=((2, 0),),
+                )
+            ],
+            core_ranges=_FakeExplicitCoreRanges((0, 0), (1, 0)),
+        )
+
+
+# Disjoint allocation domains consume independent per-core L1 budgets.
+def test_allocation_nodes_compute_dfb_budget_per_core(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(kernel_runner, "DEFAULT_L1_CB_BUDGET_BYTES", 2048)
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[
+            PhysicalDFBConfig(
+                index,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=((index, 0),),
+            )
+            for index in range(2)
+        ],
+        core_ranges=full_grid,
+    )
+
+    assert len(descriptors) == 2
+    assert {_descriptor_cores(descriptor).pop() for descriptor in descriptors} == {
+        (0, 0),
+        (1, 0),
+    }
+
+
+# Use filtering may omit descriptors while retaining physical buffer indices.
+def test_specialized_dfb_descriptors_allow_sparse_physical_indices(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
     full_grid = _FakeExplicitCoreRanges((0, 0), (0, 0))
     configs = [
@@ -3598,7 +3767,8 @@ def test_specialized_dfb_budget_is_computed_per_core(monkeypatch):
     }
 
 
-def test_specialized_dfb_budget_aligns_blackhole_allocations(monkeypatch):
+# The final static DFB does not require trailing allocator padding.
+def test_specialized_dfb_budget_omits_final_alignment_padding(monkeypatch):
     class BlackholeDevice:
         def arch(self):
             return "blackhole"
@@ -3611,21 +3781,284 @@ def test_specialized_dfb_budget_aligns_blackhole_allocations(monkeypatch):
     )
     grid = _FakeExplicitCoreRanges((0, 0), (0, 0))
 
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensor(BlackholeDevice())],
+        cb_configs=[
+            PhysicalDFBConfig(index, 1, "bfloat4_b", 1, 24, (1, 16))
+            for index in range(2)
+        ],
+        core_ranges=grid,
+        kernel_specs=[_specialized_spec(grid, [0, 1])],
+    )
+
+    assert len(descriptors) == 2
+
+
+# Descriptor ordering avoids cross-core allocator-frontier inflation.
+@pytest.mark.parametrize(
+    ("budget_bytes", "expected_order"),
+    [(16000, [0, 2, 1]), (18000, [0, 1, 2])],
+    ids=["reordered", "already-fits"],
+)
+def test_static_dfb_descriptors_are_ordered_to_fit_l1(
+    monkeypatch, budget_bytes, expected_order
+):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(kernel_runner, "DEFAULT_L1_CB_BUDGET_BYTES", budget_bytes)
+    full_grid = _FakeExplicitCoreRanges((0, 0), (11, 9))
+    sparse_nodes = tuple(
+        (node_x, node_y)
+        for node_y, row_end_x in ((0, 7), (1, 7), (4, 7), (9, 0))
+        for node_x in range(row_end_x + 1)
+    )
+    configs = [
+        PhysicalDFBConfig(
+            0,
+            32,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=((0, 6),),
+        ),
+        PhysicalDFBConfig(
+            1,
+            128,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=tuple(
+                (node_x, node_y) for node_y in range(10) for node_x in range(12)
+            ),
+        ),
+        PhysicalDFBConfig(
+            2,
+            112,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=sparse_nodes,
+        ),
+    ]
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=configs,
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    # The physical order requires 17,408 bytes because the full-grid DFB
+    # inherits the singleton DFB frontier. Independent DFBs first need 15,360.
+    assert [
+        descriptor.format_descriptors[0].buffer_index for descriptor in descriptors
+    ] == expected_order
+    descriptors_by_index = {
+        descriptor.format_descriptors[0].buffer_index: descriptor
+        for descriptor in descriptors
+    }
+    assert _descriptor_cores(descriptors_by_index[0]) == {(0, 6)}
+    assert _descriptor_cores(descriptors_by_index[1]) == {
+        (node_x, node_y) for node_y in range(10) for node_x in range(12)
+    }
+    assert _descriptor_cores(descriptors_by_index[2]) == set(sparse_nodes)
+
+
+# Exact ordering finds a fitting permutation that local swaps cannot reach.
+def test_static_dfb_descriptor_exact_search_finds_nonlocal_reordering(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    plan_nodes = (
+        ((1, 0),),
+        ((0, 0), (3, 0)),
+        ((1, 0),),
+        ((0, 0), (1, 0)),
+        ((0, 0), (1, 0), (2, 0)),
+    )
+    plan_sizes = (96, 80, 256, 128, 24)
+    descriptor_plans = [
+        kernel_runner._DFBDescriptorPlan(
+            descriptor=object(),
+            physical_index=physical_index,
+            total_size=plan_sizes[physical_index],
+            nodes=plan_nodes[physical_index],
+            has_static_storage=True,
+        )
+        for physical_index in range(len(plan_nodes))
+    ]
+    remaining_bytes_by_core = {
+        (0, 0): 336,
+        (1, 0): 544,
+        (2, 0): 216,
+        (3, 0): 272,
+    }
+
+    ordered_plans = kernel_runner._order_static_dfb_descriptor_plans(
+        descriptor_plans, remaining_bytes_by_core
+    )
+
+    frontiers = {core: 0 for core in remaining_bytes_by_core}
+    for plan in ordered_plans:
+        address = kernel_runner._align_up(
+            max(frontiers[core] for core in plan.nodes), 64
+        )
+        for core in plan.nodes:
+            frontiers[core] = address + plan.total_size
+    assert all(
+        frontiers[core] <= remaining_bytes
+        for core, remaining_bytes in remaining_bytes_by_core.items()
+    )
+
+
+# A non-fitting static descriptor set reports the best deterministic order.
+def test_static_dfb_descriptor_order_reports_no_fitting_candidate(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(kernel_runner, "DEFAULT_L1_CB_BUDGET_BYTES", 10240)
+    full_grid = _FakeExplicitCoreRanges((0, 0), (2, 0))
+    configs = [
+        PhysicalDFBConfig(
+            physical_index,
+            64,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=allocation_nodes,
+        )
+        for physical_index, allocation_nodes in enumerate(
+            (
+                ((0, 0), (1, 0)),
+                ((1, 0), (2, 0)),
+                ((0, 0), (2, 0)),
+            )
+        )
+    ]
+
     with pytest.raises(
         ValueError,
-        match=r"core \(0, 0\).*128 bytes.*L1 budget \(100 bytes\)",
+        match=(
+            "the best candidate requires 12288 bytes on core .* where 10240 bytes "
+            "remain, and exceeds the L1 budget by 2048 bytes"
+        ),
     ):
         kernel_runner.build_cb_descriptors(
-            tensors=[_FakeTensor(BlackholeDevice())],
-            cb_configs=[
-                PhysicalDFBConfig(index, 1, "bfloat4_b", 1, 24, (1, 16))
-                for index in range(2)
-            ],
-            core_ranges=grid,
-            kernel_specs=[_specialized_spec(grid, [0, 1])],
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=configs,
+            core_ranges=full_grid,
+            kernel_specs=[_specialized_spec(full_grid, None)],
         )
 
 
+# The lowest live L1 tensor address bounds static DFB storage on each core.
+def test_remaining_l1_uses_lowest_live_tensor_address(monkeypatch):
+    l1_buffer_type = object()
+    dram_buffer_type = object()
+    device_info = SimpleNamespace(
+        address_at_first_l1_cb_buffer=0x1FC0,
+        cb_limit=0x1000,
+    )
+    buffer_pages = [
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=0,
+            core_y=0,
+            page_address=0x2900,
+            page_size=0x100,
+        ),
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=1,
+            core_y=0,
+            page_address=0x2C00,
+            page_size=0x400,
+        ),
+        SimpleNamespace(
+            buffer_type=dram_buffer_type,
+            core_x=0,
+            core_y=0,
+            page_address=0x2100,
+            page_size=0x800,
+        ),
+    ]
+    reports = SimpleNamespace(
+        get_device_info=lambda _device: device_info,
+        get_buffer_pages=lambda _device: buffer_pages,
+    )
+    monkeypatch.setattr(
+        kernel_runner,
+        "ttnn",
+        SimpleNamespace(
+            BufferType=SimpleNamespace(L1=l1_buffer_type),
+            get_allocator_base_address=lambda _device, _buffer_type: 0x2000,
+            _ttnn=SimpleNamespace(reports=reports),
+        ),
+    )
+
+    device = SimpleNamespace(get_num_devices=lambda: 1)
+    remaining_by_core = kernel_runner._get_remaining_l1_by_core_for_device(
+        device,
+        {(0, 0), (1, 0), (2, 0)},
+    )
+
+    assert remaining_by_core == {
+        (0, 0): 0x900,
+        (1, 0): 0xC00,
+        (2, 0): 0x1000,
+    }
+    assert kernel_runner.get_min_remaining_l1_for_device(device) == 0x900
+
+
+# Multi-device and opaque wrappers use one conservative global L1 floor.
+@pytest.mark.parametrize(
+    "device",
+    [SimpleNamespace(get_num_devices=lambda: 32), object()],
+    ids=["multiple-devices", "unknown-device-type"],
+)
+def test_global_remaining_l1_uses_reference_allocator_floor(monkeypatch, device):
+    l1_buffer_type = object()
+    device_info = SimpleNamespace(cb_limit=0x1000)
+    buffer_pages = [
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=0,
+            core_y=0,
+            page_address=0x2900,
+        ),
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=1,
+            core_y=0,
+            page_address=0x2C00,
+        ),
+    ]
+    reports = SimpleNamespace(
+        get_device_info=lambda _device: device_info,
+        get_buffer_pages=lambda _device: buffer_pages,
+    )
+    monkeypatch.setattr(
+        kernel_runner,
+        "ttnn",
+        SimpleNamespace(
+            BufferType=SimpleNamespace(L1=l1_buffer_type),
+            get_allocator_base_address=lambda _device, _buffer_type: 0x2000,
+            _ttnn=SimpleNamespace(reports=reports),
+        ),
+    )
+
+    remaining_by_core = kernel_runner._get_remaining_l1_by_core_for_device(
+        device,
+        {(0, 0), (1, 0), (2, 0)},
+    )
+
+    assert remaining_by_core == {
+        (0, 0): 0x900,
+        (1, 0): 0x900,
+        (2, 0): 0x900,
+    }
+
+
+# Exact packing reports the allocation deficit on the constrained core.
 def test_specialized_dfb_budget_uses_each_cores_remaining_l1(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
     monkeypatch.setattr(
@@ -3639,7 +4072,10 @@ def test_specialized_dfb_budget_uses_each_cores_remaining_l1(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match=r"core \(1, 0\).*2048 bytes.*L1 budget \(1024 bytes\)",
+        match=(
+            r"requires 2048 bytes on core \(1, 0\), where 1024 bytes remain, "
+            r"and exceeds the L1 budget by 1024 bytes"
+        ),
     ):
         kernel_runner.build_cb_descriptors(
             tensors=[_FakeTensor(object())],
@@ -3686,6 +4122,77 @@ def test_computed_address_backing_uses_specialized_dfb_cores(monkeypatch):
         type("Allocation", (), {"core_ranges": allocations[0][0]})()
     ) == {(0, 0)}
     assert allocations[0][1:] == (2048, device)
+
+
+# Each computed-address DFB uses only its proven allocation cores.
+def test_computed_address_backing_resolves_each_dfb_from_full_grid(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    allocations = []
+    monkeypatch.setattr(
+        kernel_runner,
+        "_allocate_l1_sharded_storage_tensor",
+        lambda ranges, size, device: allocations.append((ranges, size, device))
+        or object(),
+    )
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    core_0 = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    core_1 = _FakeExplicitCoreRanges((1, 0), (1, 0))
+
+    kernel_runner.build_pipe_computed_address_dfb_tensors(
+        tensors=[],
+        cb_configs=[
+            PhysicalDFBConfig(index, 1, "bfloat16", 1, 2048, (32, 32))
+            for index in range(2)
+        ],
+        core_ranges=full_grid,
+        pipe_computed_address_dfb_indices=[0, 1],
+        device=object(),
+        kernel_specs=[
+            _specialized_spec(core_0, [0]),
+            _specialized_spec(core_1, [1]),
+        ],
+    )
+
+    assert [
+        _descriptor_cores(type("Allocation", (), {"core_ranges": ranges})())
+        for ranges, _, _ in allocations
+    ] == [{(0, 0)}, {(1, 0)}]
+
+
+# Allocation-node metadata restricts computed-address backing storage.
+def test_computed_address_backing_uses_allocation_nodes(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    allocations = []
+    monkeypatch.setattr(
+        kernel_runner,
+        "_allocate_l1_sharded_storage_tensor",
+        lambda ranges, size, device: allocations.append((ranges, size, device))
+        or object(),
+    )
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    kernel_runner.build_pipe_computed_address_dfb_tensors(
+        tensors=[],
+        cb_configs=[
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=((1, 0),),
+            )
+        ],
+        core_ranges=full_grid,
+        pipe_computed_address_dfb_indices=[0],
+        device=object(),
+    )
+
+    allocated_ranges, _, _ = allocations[0]
+    assert _descriptor_cores(
+        type("Allocation", (), {"core_ranges": allocated_ranges})()
+    ) == {(1, 0)}
 
 
 def test_l1_sharded_storage_counts_sparse_cores(monkeypatch):
@@ -3741,6 +4248,32 @@ def test_specialized_dfb_use_intersects_storage_segments(monkeypatch):
             _specialized_spec(active, [0]),
             _specialized_spec(inactive, []),
         ],
+    )
+
+    assert len(descriptors) == 1
+    assert _descriptor_cores(descriptors[0]) == {(0, 0)}
+
+
+# Exact allocation nodes restrict conservative unspecialized DFB-use metadata.
+def test_allocation_nodes_intersect_storage_segment_coverage(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    config = PhysicalDFBConfig(
+        0,
+        1,
+        "bfloat16",
+        1,
+        2048,
+        (32, 32),
+        (DFBStorageSegment(nodes=((0, 0),)),),
+        allocation_nodes=((0, 0),),
+    )
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[config],
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
     )
 
     assert len(descriptors) == 1
@@ -4671,6 +5204,7 @@ def test_emit_runner_source_accepts_physical_dfb_configs(monkeypatch):
                 block_count=2,
                 page_size=32,
                 tile=(1, 16),
+                allocation_nodes=((0, 0),),
             )
         ],
         grid_cols=1,
@@ -4686,6 +5220,7 @@ def test_emit_runner_source_accepts_physical_dfb_configs(monkeypatch):
     assert "page_size=32" in source
     assert "tile=(1, 16)" in source
     assert "cb_configs=CB_CONFIGS" in source
+    assert "allocation_nodes=((0, 0),)" in source
     assert "for i, (num_tiles, block_count" not in source
 
 

--- a/test/python/test_static_dfb_descriptor_packing.py
+++ b/test/python/test_static_dfb_descriptor_packing.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device coverage for static DFB descriptor packing."""
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+from ttl import kernel_runner  # noqa: E402
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+TILE = 32
+
+
+def _make_static_dfb_packing_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(2, 1))
+    def static_dfb_packing_kernel(input_tensor, output_tensor):
+        first_node_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=1)
+        shared_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=4)
+        second_node_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=4)
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            pass
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            node_x, _node_y = ttl.node(dims=2)
+            if node_x == 0:
+                with first_node_dfb.reserve() as first_node_block:
+                    ttl.copy(input_tensor[0, 0], first_node_block).wait()
+            with shared_dfb.reserve() as shared_block:
+                ttl.copy(input_tensor[0, node_x], shared_block).wait()
+            if node_x == 1:
+                with second_node_dfb.reserve() as second_node_block:
+                    ttl.copy(input_tensor[0, 1], second_node_block).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            node_x, _node_y = ttl.node(dims=2)
+            if node_x == 0:
+                with first_node_dfb.wait():
+                    pass
+            with shared_dfb.wait() as shared_block:
+                ttl.copy(shared_block, output_tensor[0, node_x]).wait()
+            if node_x == 1:
+                with second_node_dfb.wait():
+                    pass
+
+    return static_dfb_packing_kernel
+
+
+# Device-reported tensor addresses determine the remaining static DFB interval.
+def test_remaining_l1_budget_matches_live_tensor_addresses(device):
+    input_host = torch.zeros((TILE, TILE), dtype=torch.bfloat16)
+    input_tensor = to_l1(input_host, device)
+    assert input_tensor is not None
+
+    static_dfb_base_address = ttnn.get_allocator_base_address(
+        device, ttnn.BufferType.L1
+    )
+    l1_pages = [
+        page
+        for page in ttnn._ttnn.reports.get_buffer_pages(device)
+        if page.buffer_type == ttnn.BufferType.L1
+    ]
+    assert l1_pages
+    cores = {(page.core_x, page.core_y) for page in l1_pages}
+    expected_remaining_by_core = {
+        core: min(
+            page.page_address for page in l1_pages if (page.core_x, page.core_y) == core
+        )
+        - static_dfb_base_address
+        for core in cores
+    }
+
+    assert (
+        kernel_runner._get_remaining_l1_by_core_for_device(device, cores)
+        == expected_remaining_by_core
+    )
+    assert kernel_runner.get_min_remaining_l1_for_device(device) == min(
+        expected_remaining_by_core.values()
+    )
+
+
+# Reordered static descriptors fit per-core L1 and preserve device results.
+@pytest.mark.parametrize(
+    ("data_format", "dtype", "dfb_page_size"),
+    [
+        ("bf16", torch.bfloat16, 2048),
+        ("float32", torch.float32, 4096),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize("to_device", [to_dram, to_l1], ids=["dram", "l1"])
+def test_static_dfb_descriptor_packing_fits_budget(
+    device,
+    data_format,
+    dtype,
+    dfb_page_size,
+    to_device,
+    monkeypatch,
+):
+    operation = _make_static_dfb_packing_kernel(data_format)
+    input_host = (
+        torch.arange(2 * TILE * TILE, dtype=torch.float32)
+        .reshape(TILE, 2 * TILE)
+        .to(dtype)
+    )
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+    descriptor_orders = []
+    original_ordering = kernel_runner._order_static_dfb_descriptor_plans
+
+    def record_descriptor_order(descriptor_plans, remaining_bytes_by_core):
+        plans_by_physical_index = {
+            plan.physical_index: plan for plan in descriptor_plans
+        }
+        over_budget_plans = [
+            plans_by_physical_index[physical_index] for physical_index in (0, 2, 1)
+        ]
+        ordered_plans = original_ordering(over_budget_plans, remaining_bytes_by_core)
+        descriptor_orders.append(
+            tuple(
+                plan.physical_index for plan in ordered_plans if plan.has_static_storage
+            )
+        )
+        return ordered_plans
+
+    monkeypatch.setattr(
+        kernel_runner,
+        "_get_remaining_l1_by_core_for_device",
+        lambda _device, cores: {core: (17 * dfb_page_size) // 2 for core in cores},
+    )
+    monkeypatch.setattr(
+        kernel_runner,
+        "_order_static_dfb_descriptor_plans",
+        record_descriptor_order,
+    )
+
+    operation(input_tensor, output_tensor, options="--no-ttl-specialize-cores")
+
+    assert descriptor_orders == [(0, 1, 2)]
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -309,6 +309,45 @@ def _make_exact_execution_domain_kernel(data_format):
     return exact_execution_domain_kernel
 
 
+def _make_node_scoped_allocation_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(2, 1))
+    def node_scoped_allocation_kernel(input_tensor, output_tensor):
+        input_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        first_node_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            node_x, _node_y = ttl.node(dims=2)
+            with input_dfb.wait() as input_block:
+                with output_dfb.reserve() as output_block:
+                    if node_x == 0:
+                        with first_node_scratch_dfb.reserve() as scratch_output:
+                            scratch_output.store(input_block)
+                        with first_node_scratch_dfb.wait() as scratch_input:
+                            output_block.store(scratch_input)
+                    else:
+                        output_block.store(input_block)
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            node_x, _node_y = ttl.node(dims=2)
+            with input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0, node_x], input_block).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            node_x, _node_y = ttl.node(dims=2)
+            with output_dfb.wait() as output_block:
+                ttl.copy(output_block, output_tensor[0, node_x]).wait()
+
+    return node_scoped_allocation_kernel
+
+
 @ttl.operation(grid=(2, 1))
 def _incompatible_static_configuration_kernel(input_tensor, output_tensor):
     first_input_dfb = ttl.make_dfb("float32", shape=(1, 1), block_count=2)
@@ -1476,6 +1515,8 @@ _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
 _in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
 _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
+_node_scoped_bf16_allocation_kernel = _make_node_scoped_allocation_kernel("bf16")
+_node_scoped_f32_allocation_kernel = _make_node_scoped_allocation_kernel("float32")
 _waited_mutation_bf16_store_kernel = _make_waited_block_store_kernel("bf16")
 _waited_mutation_f32_store_kernel = _make_waited_block_store_kernel("float32")
 _waited_mutation_bf16_two_tile_store_kernel = _make_waited_block_store_kernel(
@@ -1729,6 +1770,45 @@ def test_exact_disjoint_execution_domains_reuse_dfb(
     # scratch DFBs. The scratch DFBs share because their exact node domains are
     # disjoint, without requiring a local lifetime-order proof.
     assert _count_final_dfb_allocations(final_mlir_path) == 3
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+# Exact allocation domains execute correctly without kernel specialization.
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_node_scoped_bf16_allocation_kernel, torch.bfloat16),
+        (_node_scoped_f32_allocation_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_node_scoped_dfb_allocation_without_kernel_specialization(
+    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    element_indices = torch.arange(2 * TILE * TILE, dtype=torch.float32).reshape(
+        TILE, 2 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_file = tmp_path / "node_scoped_allocation.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_file))
+    operation(input_tensor, output_tensor, options="--no-ttl-specialize-cores")
+
+    final_mlir = final_mlir_file.read_text()
+    assert re.search(r"\{allocation_nodes = \[\[0, 0\]\], block_count", final_mlir)
 
     actual = ttnn.to_torch(output_tensor).float()
     expected = input_host.float()

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_group_epochs.mlir
@@ -7,7 +7,7 @@
 // compute, and NOC1. Native acquire operations in later epochs must retain the
 // next same-kind acquire as their ownership boundary.
 
-// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 3 : i32, dfb_index = 0 : i32
+// CHECK: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 3 : i32, dfb_index = 0 : i32
 // CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
 // CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
 // REPORT: DFB allocation group #ttl.dfb_allocation_group<0> launch_node=(0,0) epoch_order=[0:0, 1:0, 0:1, 1:1]

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_groups.mlir
@@ -114,7 +114,7 @@ module {
 // Group members on disjoint launch nodes share one index without a temporal
 // ordering relation. Each node retains its own tensor-backed storage segment.
 
-// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}, {nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
+// CHECK: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\], \[1, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}, {nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
 // CHECK-LABEL: func.func @disjoint_node_group
 // CHECK: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 6 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0
 // CHECK-NEXT: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 7 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 1

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_nodes.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_nodes.mlir
@@ -1,0 +1,71 @@
+// Verifies finalized DFB residency metadata independently from kernel specialization.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s
+
+// The first DFB is accessed only on core (0, 0), the second is unreachable on
+// the launch grid, and the third has a runtime-dependent domain. Exact domains
+// are serialized, including the empty domain; the unresolved domain omits
+// allocation_nodes so the runtime remains conservative.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {allocation_nodes = [], block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {block_count = 2 : i32, dfb_index = 2 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}], ttl.launch_grid = array<i64: 2, 1>}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @allocation_nodes(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %first_node = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %unreachable = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %runtime_dependent = ttl.bind_cb {cb_index = 2, block_count = 2}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %on_first_node = arith.cmpi eq, %core_x, %zero : index
+    %outside_grid = arith.cmpi eq, %core_x, %two : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+
+    scf.if %on_first_node {
+      ttl.opaque_call "first_node_access" (%first_node)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %outside_grid {
+      ttl.opaque_call "unreachable_access" (%unreachable)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %runtime_condition {
+      ttl.opaque_call "runtime_access" (%runtime_dependent)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Without a launch grid, the liveness proof uses one representative node but
+// runtime residency remains unknown and therefore omits allocation_nodes.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}]}
+
+module {
+  func.func @unknown_runtime_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    ttl.opaque_call "access" (%dfb)
+        {header = "effects.hpp"}
+        : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_inspect_access.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_inspect_access.mlir
@@ -3,7 +3,7 @@
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
 
-// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32
+// CHECK: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32
 // CHECK-LABEL: func.func @ordered_inspect_access
 // CHECK: %[[DESCRIPTOR:.*]] = ttl.bind_cb{cb_index = 0, block_count = 1} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
 // CHECK-NEXT: %[[QUEUE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reset_projected_access_order.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reset_projected_access_order.mlir
@@ -6,8 +6,8 @@
 // every reset. Its incomplete local ordering must not create reverse relations
 // between reset boundaries or prevent the interleaved group from sharing.
 
-// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 3 : i32, dfb_index = 0 : i32
-// CHECK-SAME: {block_count = 3 : i32, dfb_index = 1 : i32
+// CHECK: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 3 : i32, dfb_index = 0 : i32
+// CHECK-SAME: {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 3 : i32, dfb_index = 1 : i32
 // CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
 // CHECK: %{{.*}} = ttl.bind_cb{cb_index = 0, block_count = 3} {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
 // CHECK: %{{.*}} = ttl.bind_cb{cb_index = 1, block_count = 3} {dfb_id = 2 : index}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_reuse_debug.mlir
@@ -78,7 +78,7 @@ module {
 
 // -----
 
-module {
+module attributes {ttl.launch_grid = [1, 1]} {
   func.func @different_tensor_backing()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
                   ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {

--- a/test/ttlang/Dialect/TTL/Transforms/tensor_backing.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/tensor_backing.mlir
@@ -3,7 +3,7 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefixes=COMMON,DISTINCT
 // RUN: ttlang-opt %s --split-input-file --ttl-validate-cb-budget='l1-budget-override=1' -o /dev/null
 
-// COMMON: module attributes {ttl.dfb_allocations = [{block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32, storage_segments = [{nodes = {{\[\[0, 0\], \[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 2048>}]}], ttl.launch_grid = array<i64: 2, 1>}
+// COMMON: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\], \[1, 0\]\]}}, block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32, storage_segments = [{nodes = {{\[\[0, 0\], \[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 2048>}]}], ttl.launch_grid = array<i64: 2, 1>}
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   // COMMON-LABEL: func.func @publish_input
   func.func @publish_input()
@@ -21,12 +21,12 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 // DFBs with different tensor backing may share one hardware index when their
 // exact launch-node domains are disjoint.
 
-// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}, {nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
+// REUSE: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\], \[1, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}, {nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
 // REUSE-LABEL: func.func @per_node_backing
 // REUSE: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {{.*}}tensor_index = 0
 // REUSE: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {{.*}}tensor_index = 1
 
-// DISTINCT: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}, {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
+// DISTINCT: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[1, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}, {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
 // DISTINCT-LABEL: func.func @per_node_backing
 // DISTINCT: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {{.*}}tensor_index = 0
 // DISTINCT: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {{.*}}tensor_index = 1

--- a/test/ttlang/Dialect/TTL/Transforms/tensor_backing_allocation_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/tensor_backing_allocation_invalid.mlir
@@ -50,6 +50,24 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
 
 // -----
 
+// An analysis-only representative node cannot define tensor-backed residency.
+module {
+  func.func @unknown_grid_tensor_backing()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    // expected-error @below {{tensor-backed physical DFB requires an exact non-empty launch-node domain}}
+    %tensor_backed_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    ttl.opaque_call "access" (%tensor_backed_dfb)
+        {header = "access.hpp"}
+        : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    return
+  }
+}
+
+// -----
+
 // Partially overlapping ranges cannot describe distinct physical DFBs on one
 // launch node.
 module attributes {ttl.launch_grid = array<i64: 1, 1>} {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
@@ -7,7 +7,7 @@
 // DFBs cannot retain the same provisional physical index.
 
 // CHECK: module attributes {ttl.dfb_allocations = [
-// CHECK-SAME: {block_count = 2 : i32, dfb_index = 0 : i32,
+// CHECK-SAME: {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32,
 // CHECK-LABEL: func.func @producer_a
 // CHECK-SAME: ttl.base_cta_index = 2 : i32
 // CHECK: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}


### PR DESCRIPTION
### Problem description

Without kernel specialization, static DFB descriptors currently occupy every launch core even when compiler analysis proves a smaller access domain. This wastes L1 and can reject programs whose descriptors fit when assigned only to their actual launch nodes and ordered against per-core allocations.

### What's changed

~600 LOC implementation (tests and documentation excluded).

Record each physical DFB's exact launch-node domain and restrict runtime descriptors to cores with surviving accesses. Static descriptors use the available interval between TT-Metal's configured DFB allocator base and live L1 tensor allocations, with deterministic descriptor ordering when physical-index order does not fit.

```python
compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)

@ttl.operation(grid=(2, 1))
def core_local_scratch(input_tensor, output_tensor):
    input_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
    scratch_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)
    output_dfb = ttl.make_dfb("bf16", shape=(1, 1), block_count=2)

    @ttl.compute(kernel=compute_kernel)
    def compute():
        node_x, _node_y = ttl.node(dims=2)
        with input_dfb.wait() as input_block:
            with output_dfb.reserve() as output_block:
                if node_x == 0:
                    with scratch_dfb.reserve() as scratch_output:
                        scratch_output.store(input_block)
                    with scratch_dfb.wait() as scratch_input:
                        output_block.store(scratch_input)
                else:
                    output_block.store(input_block)

    @ttl.datamovement(kernel=reader_kernel)
    def read():
        node_x, _node_y = ttl.node(dims=2)
        with input_dfb.reserve() as input_block:
            ttl.copy(input_tensor[0, node_x], input_block).wait()

    @ttl.datamovement(kernel=writer_kernel)
    def write():
        node_x, _node_y = ttl.node(dims=2)
        with output_dfb.wait() as output_block:
            ttl.copy(output_block, output_tensor[0, node_x]).wait()
```

Even with `--no-ttl-specialize-cores`, `scratch_dfb` receives a descriptor only on launch node `(0, 0)`. The input and output DFBs remain available on both nodes.

### Validation

- New BF16/FP32 device tests cover exact node-scoped descriptors and static descriptor reordering with DRAM and L1 tensors.
- New runtime-planning tests cover exact, empty, sparse, and invalid domains; live L1 bounds; deterministic and exact ordering; and overflow diagnostics.
- New MLIR tests cover exact allocation metadata, conservative unknown-domain behavior, and tensor-backed domain diagnostics.
