### PR TITLE
[TTL] Preserve exact DFB allocation domains

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -112,7 +112,12 @@ which assigns temporary IDs to compiler-created DFBs without modifying IR.
 Schedule verification uses exact transfer provenance and does not depend on DFB
 allocation.
 
-### Per-core descriptor specialization
+### Per-core descriptor allocation
+
+Physical allocation records the exact union of launch nodes that access each
+physical DFB index. The runtime restricts descriptors to this domain without
+requiring kernel specialization. An exact empty domain installs no descriptor;
+an unknown domain retains conservative whole-grid allocation.
 
 Per-core kernel specialization can remove different DFB operations on
 different launch nodes. Each final TTKernel function records the physical
@@ -121,12 +126,13 @@ indices still referenced by its compile-time arguments in
 An unresolved call or missing annotation is conservative and keeps every DFB
 available on the affected function's launch nodes.
 
-The runtime unions these sets for every kernel dispatched to a logical core.
-It then intersects the result with the finalized storage segments for each
-physical DFB. Static storage, tensor-backed ranges, and PipeNet
+The runtime unions these sets for every kernel dispatched to a logical core,
+then intersects the result with the physical allocation domain and finalized
+storage segments. Static storage, tensor-backed ranges, and PipeNet
 computed-address backing therefore use only cores where a surviving kernel can
-access that physical index. A tensor-backed or finalized static segment remains
-restricted to its allocation domain.
+access that physical index. A computed-address DFB with an empty effective
+domain retains one hidden backing shard because the PipeNet ABI still requires
+a receiver address, but no launch core installs its descriptor.
 
 Descriptor construction partitions launch nodes by their complete DFB storage
 signature. Every node in one partition receives the same ordered descriptor
@@ -1645,7 +1651,12 @@ non-DFB argument index.
 
 The plan contains one `ttl.dfb_allocations` descriptor per physical index.
 Each descriptor contains `dfb_index`, `num_tiles`, `element_type`, `page_size`,
-and `block_count`. The planner computes `page_size` with
+and `block_count`. When the compiler proves the exact union of launch nodes
+that access the physical index, the descriptor also contains
+`allocation_nodes`. An empty array records an unreachable allocation. Omitting
+the field retains conservative whole-grid allocation when the node domain is
+unknown. This metadata controls storage residency independently from optional
+per-core executable specialization. The planner computes `page_size` with
 `ttcore::getElementSizeBytes()` on the finalized element type, so subtile
 dimensions affect the physical allocation without requiring runtime device
 initialization.
@@ -1662,13 +1673,20 @@ buildRuntimeDescriptors(assignments):
           num_tiles = type.elementsPerBlock,
           element_type = type.elementType,
           page_size = byteSize(type.elementType),
-          block_count = type.blockCount}
+          block_count = type.blockCount,
+          allocation_nodes = exactUnionOrUnknown(launchDomains(index))}
 ```
 
 Every finalized declaration contributes to the table. Type equality makes
 each deduplicated descriptor valid for every declaration at that physical
 index, and deriving the page size from the same element type used by lowering
 keeps compiler and runtime allocation sizes equal.
+
+The runtime intersects `allocation_nodes` with final per-kernel DFB-use
+metadata when both are available. The allocation domain restricts an
+unspecialized grid-wide kernel, while specialized use metadata may remove
+additional DFBs after coordinate folding. Tensor-backed storage segments must
+cover the exact allocation nodes and retain their existing storage identity.
 
 The Python runtime validates that the descriptors form a dense index range and
 builds all `ttnn.CBDescriptor` objects from this final allocation table. It

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -90,7 +90,14 @@ ttl-annotate-cb-associations   (FuncOp)   Copy CB indices to tile ops
 ttl-verify-dfb-spsc            (Module)   Reject DFBs shared across threads
 convert-ttl-to-ttkernel        (Module)   Lower to TTKernel dialect
 ttkernel-insert-inits          (Module)   Insert hardware init calls
+ttkernel-specialize-cores      (Module)   Clone coordinate-dependent kernels
+canonicalize, cse              (Module)   Remove untaken coordinate branches
+ttkernel-annotate-dfb-use      (Module)   Record surviving physical DFB uses
 ```
+
+The final three entries run only when per-core specialization is enabled.
+Annotation follows canonicalization so an eliminated branch cannot keep an
+otherwise-unused DFB live on that clone's launch node.
 
 `ttl-finalize-dfb-indices` must precede
 `ttl-set-compute-kernel-config` and `ttl-annotate-cb-associations`.
@@ -104,6 +111,36 @@ finalization. Guard verification uses the read-only logical identity analysis,
 which assigns temporary IDs to compiler-created DFBs without modifying IR.
 Schedule verification uses exact transfer provenance and does not depend on DFB
 allocation.
+
+### Per-core descriptor specialization
+
+Per-core kernel specialization can remove different DFB operations on
+different launch nodes. Each final TTKernel function records the physical
+indices still referenced by its compile-time arguments in
+`ttl.used_dfb_indices`. Direct helper calls contribute their transitive uses.
+An unresolved call or missing annotation is conservative and keeps every DFB
+available on the affected function's launch nodes.
+
+The runtime unions these sets for every kernel dispatched to a logical core.
+It then intersects the result with the finalized storage segments for each
+physical DFB. Static storage, tensor-backed ranges, and PipeNet
+computed-address backing therefore use only cores where a surviving kernel can
+access that physical index. A tensor-backed or finalized static segment remains
+restricted to its allocation domain.
+
+Descriptor construction partitions launch nodes by their complete DFB storage
+signature. Every node in one partition receives the same ordered descriptor
+sequence; different partitions receive disjoint descriptors. This preserves
+TT-Metal's static allocation cursor invariant while allowing each partition to
+omit unused allocations. Sparse partitions allocate one tensor shard per
+selected core rather than the area of their bounding rectangle.
+
+The runtime computes static DFB bytes independently for every selected core and
+compares them with that core's remaining L1. Tensor-backed and already
+allocated computed-address storage are excluded from the static sum. The
+correctness invariant is that every surviving DFB access has one compatible
+descriptor on its launch core; conservative metadata preserves the
+whole-program descriptor behavior when this cannot be proved.
 
 `ttl-verify-dfb-spsc` must run after `ttl-finalize-dfb-indices` so every
 `bind_cb` carries its final `cb_index` and module-wide logical `dfb_id`. The

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -163,6 +163,10 @@ constexpr llvm::StringLiteral
 /// CTA layout is [CBs, TAs], so this equals the number of CBs.
 constexpr llvm::StringLiteral kBaseCTAIndexAttrName("ttl.base_cta_index");
 
+/// Function attribute recording physical DFB indices referenced by the final
+/// TTKernel body after per-core specialization and canonicalization.
+constexpr llvm::StringLiteral kUsedDFBIndicesAttrName("ttl.used_dfb_indices");
+
 /// Trait for data movement operations (copy_tile, copy_dst).
 template <typename ConcreteType>
 class TTLDataMovementOpTrait

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -942,7 +942,11 @@ def TTLFinalizeDFBIndices
     missing compiler-created logical IDs, and builds `ttl.dfb_allocations` for
     the Python runtime. The attribute contains one descriptor per physical
     index, including user-declared and compiler-created DFBs, and records the
-    page size computed from the finalized element type. See
+    page size computed from the finalized element type. A descriptor also
+    records the exact union of launch nodes that access its physical index when
+    that domain is known. An exact empty domain causes the runtime to install no
+    DFB descriptor; omitted domain metadata requires conservative whole-grid
+    allocation. See
     docs/development/DFBManagement.md.
   }];
 

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1201,6 +1201,28 @@ def TTKernelSpecializeCores
   ];
 }
 
+def TTKernelAnnotateDFBUse
+    : Pass<"ttkernel-annotate-dfb-use", "::mlir::ModuleOp"> {
+  let summary = "Record physical DFB indices used by each TTKernel function";
+  let description = [{
+    Records the physical dataflow buffer indices referenced by each TTKernel
+    function after per-core specialization and canonicalization. Each function
+    receives a sorted `ttl.used_dfb_indices` array. Direct calls contribute
+    their transitive uses. Functions that call an unresolved symbol or a
+    declaration conservatively record every DFB compile-time argument.
+
+    The TTKernel compile-time argument ABI places all DFB indices before tensor
+    accessor arguments. `ttl.base_cta_index` supplies the number of DFB
+    arguments for each function; the module-wide maximum is used when a helper
+    function has no local ABI boundary.
+  }];
+
+  let dependentDialects = [
+    "::mlir::func::FuncDialect",
+    "::mlir::tt::ttkernel::TTKernelDialect"
+  ];
+}
+
 def TTKernelCombinePackTiles
     : Pass<"ttkernel-combine-pack-tiles", "::mlir::func::FuncOp"> {
   let summary = "Combine consecutive pack_tile ops into pack_tile_block";

--- a/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(TTLangTTKernelTransforms
   TTKernelInsertInits.cpp
   TTKernelInsertL1Accumulation.cpp
   TTKernelLowerScalarFpTypes.cpp
+  TTKernelAnnotateDFBUse.cpp
   TTKernelSpecializeCores.cpp
 
   DEPENDS

--- a/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace ttk = mlir::tt::ttkernel;
+
+namespace mlir::tt::ttl {
+
+#define GEN_PASS_DEF_TTKERNELANNOTATEDFBUSE
+#include "ttlang/Dialect/TTL/Passes.h.inc"
+
+namespace {
+
+using DFBIndexSet = llvm::SmallDenseSet<int32_t, 8>;
+
+static int64_t getDFBCount(func::FuncOp function, int64_t moduleDFBCount) {
+  if (auto baseCTAIndex =
+          function->getAttrOfType<IntegerAttr>(kBaseCTAIndexAttrName)) {
+    return baseCTAIndex.getInt();
+  }
+  return moduleDFBCount;
+}
+
+struct TTKernelAnnotateDFBUsePass
+    : impl::TTKernelAnnotateDFBUseBase<TTKernelAnnotateDFBUsePass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    llvm::StringMap<Operation *> symbols;
+    llvm::DenseMap<Operation *, DFBIndexSet> usedDFBIndices;
+    llvm::DenseMap<Operation *, SmallVector<StringRef>> directCallees;
+    llvm::SmallDenseSet<Operation *> conservativelyAnnotated;
+    int64_t moduleDFBCount = 0;
+
+    for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+      symbols[function.getSymName()] = function.getOperation();
+      if (auto baseCTAIndex =
+              function->getAttrOfType<IntegerAttr>(kBaseCTAIndexAttrName)) {
+        moduleDFBCount = std::max(moduleDFBCount, baseCTAIndex.getInt());
+      }
+    }
+
+    for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+      Operation *functionOperation = function.getOperation();
+      int64_t dfbCount = getDFBCount(function, moduleDFBCount);
+      function.walk([&](ttk::GetCompileArgValOp compileArgument) {
+        int64_t argumentIndex =
+            static_cast<int64_t>(compileArgument.getArgIndex());
+        if (argumentIndex >= 0 && argumentIndex < dfbCount) {
+          usedDFBIndices[functionOperation].insert(
+              static_cast<int32_t>(argumentIndex));
+        }
+      });
+      function.walk([&](func::CallOp call) {
+        directCallees[functionOperation].push_back(call.getCallee());
+      });
+    }
+
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+        Operation *functionOperation = function.getOperation();
+        for (StringRef calleeName : directCallees[functionOperation]) {
+          auto calleeIterator = symbols.find(calleeName);
+          if (calleeIterator == symbols.end()) {
+            changed |= conservativelyAnnotated.insert(functionOperation).second;
+            continue;
+          }
+
+          Operation *calleeOperation = calleeIterator->second;
+          auto callee = cast<func::FuncOp>(calleeOperation);
+          if (callee.isDeclaration() ||
+              conservativelyAnnotated.contains(calleeOperation)) {
+            changed |= conservativelyAnnotated.insert(functionOperation).second;
+          }
+          for (int32_t dfbIndex : usedDFBIndices[calleeOperation]) {
+            changed |=
+                usedDFBIndices[functionOperation].insert(dfbIndex).second;
+          }
+        }
+      }
+    }
+
+    for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+      Operation *functionOperation = function.getOperation();
+      if (conservativelyAnnotated.contains(functionOperation)) {
+        int64_t dfbCount = getDFBCount(function, moduleDFBCount);
+        for (int64_t dfbIndex = 0; dfbIndex < dfbCount; ++dfbIndex) {
+          usedDFBIndices[functionOperation].insert(
+              static_cast<int32_t>(dfbIndex));
+        }
+      }
+
+      SmallVector<int32_t> sortedIndices(
+          usedDFBIndices[functionOperation].begin(),
+          usedDFBIndices[functionOperation].end());
+      llvm::sort(sortedIndices);
+      function->setAttr(
+          kUsedDFBIndicesAttrName,
+          DenseI32ArrayAttr::get(module.getContext(), sortedIndices));
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -97,6 +97,7 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
     pm.addPass(createTTKernelSpecializeCores());
     pm.addPass(createCanonicalizerPass());
     pm.addPass(createCSEPass());
+    pm.addPass(createTTKernelAnnotateDFBUse());
   }
   if (options.lowerToEmitC) {
     pm.addPass(createLowerAffinePass());

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -710,6 +710,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
 
   LivenessDomainState domainState;
   domainState.initialize(module);
+  exactLaunchGrid = domainState.hasLaunchGrid;
   if (!domainState.hasLaunchGrid) {
     if (dependsOnLaunchNode) {
       for (DFBLogicalLifecycle &logicalDFB : logicalDFBs) {

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -124,6 +124,9 @@ public:
     return logicalDFBs;
   }
 
+  /// Return whether launch domains use the complete runtime launch grid.
+  bool hasExactLaunchGrid() const { return exactLaunchGrid; }
+
   ArrayRef<LaunchNodeCoord> getLaunchNodes() const { return launchNodes; }
 
   /// Returns true when one indexed lifetime ends before another on `node`.
@@ -135,6 +138,7 @@ private:
                const DFBLogicalIdentityAnalysis &logicalIdentityAnalysis);
 
   SmallVector<DFBLogicalLifecycle, 0> logicalDFBs;
+  bool exactLaunchGrid = false;
   SmallVector<LaunchNodeCoord> launchNodes;
   SmallVector<SmallVector<llvm::BitVector>> orderedBeforeByNode;
   Operation *errorOperation = nullptr;

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -404,9 +404,12 @@ static FailureOr<PhysicalAllocationCandidate> computeDistinctUserAllocation(
       physicalIndex = *logicalPhysicalIndex;
     }
 
+    LaunchNodeDomain allocationDomain = liveness.hasExactLaunchGrid()
+                                            ? logicalDFB.launchDomain
+                                            : LaunchNodeDomain::unknown();
     allocation.assignments.push_back(
         {logicalDFB.logicalId, physicalIndex, logicalDFB.type,
-         logicalDFB.tensorBacking, logicalDFB.launchDomain,
+         logicalDFB.tensorBacking, std::move(allocationDomain),
          logicalDFB.declarations, logicalDFB.bounded});
     allocation.physicalDFBCount =
         std::max(allocation.physicalDFBCount, physicalIndex + 1);
@@ -497,9 +500,12 @@ static FailureOr<PhysicalAllocationCandidate> computeReuseAllocation(
     int32_t physicalIndex = assignment->assignments[indexedLogicalDFB.index()];
     allocation.physicalDFBCount =
         std::max(allocation.physicalDFBCount, physicalIndex + 1);
+    LaunchNodeDomain allocationDomain = liveness.hasExactLaunchGrid()
+                                            ? logicalDFB.launchDomain
+                                            : LaunchNodeDomain::unknown();
     allocation.assignments.push_back(
         {logicalDFB.logicalId, physicalIndex, logicalDFB.type,
-         logicalDFB.tensorBacking, logicalDFB.launchDomain,
+         logicalDFB.tensorBacking, std::move(allocationDomain),
          logicalDFB.declarations, logicalDFB.bounded});
   }
 
@@ -675,7 +681,15 @@ buildDescriptors(ArrayRef<DFBPhysicalIndexAssignment> assignments,
         dfbType.getElementType(),
         static_cast<int32_t>(*pageSizeBytes),
         static_cast<int32_t>(dfbType.getBlockCount()),
+        LaunchNodeDomain{},
         {}};
+
+    for (const DFBPhysicalIndexAssignment &candidate : assignments) {
+      if (candidate.physicalIndex == physicalIndex) {
+        descriptor.allocationDomain =
+            descriptor.allocationDomain.unionWith(candidate.launchDomain);
+      }
+    }
 
     bool hasTensorBacking = llvm::any_of(
         assignments, [&](const DFBPhysicalIndexAssignment &candidate) {

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.h
@@ -49,6 +49,9 @@ struct DFBPhysicalAllocationDescriptor {
   Type elementType;
   int32_t pageSize = 0;
   int32_t blockCount = 0;
+  /// Exact union of nodes that access this index. An unknown domain requires
+  /// conservative whole-grid runtime allocation.
+  LaunchNodeDomain allocationDomain = LaunchNodeDomain::unknown();
   SmallVector<DFBPhysicalStorageSegment> storageSegments;
 };
 

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -28,6 +28,18 @@ namespace mlir::tt::ttl {
 
 namespace {
 
+static ArrayAttr buildLaunchNodeArray(OpBuilder &builder,
+                                      const LaunchNodeDomain &domain) {
+  assert(domain.known && "runtime metadata requires an exact launch domain");
+  SmallVector<Attribute> nodeAttributes;
+  for (LaunchNodeCoord node : domain.nodes) {
+    nodeAttributes.push_back(
+        builder.getArrayAttr({builder.getI64IntegerAttr(node.x),
+                              builder.getI64IntegerAttr(node.y)}));
+  }
+  return builder.getArrayAttr(nodeAttributes);
+}
+
 /// Materializes decisions already validated by physical allocation analysis.
 static void
 applyPhysicalAllocationPlan(ModuleOp moduleOp, OpBuilder &builder,
@@ -68,18 +80,17 @@ applyPhysicalAllocationPlan(ModuleOp moduleOp, OpBuilder &builder,
         "page_size", builder.getI32IntegerAttr(descriptor.pageSize)));
     entryAttributes.push_back(builder.getNamedAttr(
         "block_count", builder.getI32IntegerAttr(descriptor.blockCount)));
+    if (descriptor.allocationDomain.known) {
+      entryAttributes.push_back(builder.getNamedAttr(
+          "allocation_nodes",
+          buildLaunchNodeArray(builder, descriptor.allocationDomain)));
+    }
     SmallVector<Attribute> storageSegmentAttributes;
     for (const DFBPhysicalStorageSegment &segment :
          descriptor.storageSegments) {
-      SmallVector<Attribute> nodeAttributes;
-      for (LaunchNodeCoord node : segment.launchDomain.nodes) {
-        nodeAttributes.push_back(
-            builder.getArrayAttr({builder.getI64IntegerAttr(node.x),
-                                  builder.getI64IntegerAttr(node.y)}));
-      }
       SmallVector<NamedAttribute> segmentAttributes;
-      segmentAttributes.push_back(
-          builder.getNamedAttr("nodes", builder.getArrayAttr(nodeAttributes)));
+      segmentAttributes.push_back(builder.getNamedAttr(
+          "nodes", buildLaunchNodeArray(builder, segment.launchDomain)));
       if (segment.tensorBacking) {
         segmentAttributes.push_back(
             builder.getNamedAttr("tensor_backing", segment.tensorBacking));

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -271,6 +271,8 @@ class PhysicalDFBConfig:
     independent of whether the allocation serves user-declared,
     compiler-created, or multiple non-overlapping logical DFBs.
     `tile` is present only when the DFB element type is a TTCore tile.
+    `allocation_nodes` distinguishes an unknown domain (`None`) from an exact,
+    possibly empty, launch-node set.
     """
 
     dfb_index: int
@@ -280,6 +282,7 @@ class PhysicalDFBConfig:
     page_size: int
     tile: Optional[Tuple[int, int]]
     storage_segments: Tuple["DFBStorageSegment", ...] = ()
+    allocation_nodes: Optional[Tuple[Tuple[int, int], ...]] = None
 
 
 @dataclass(frozen=True)

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -66,6 +66,25 @@ def _validate_physical_dfb_config(
             f"DFB config at physical index {physical_index} has dfb_index "
             f"{config.dfb_index}"
         )
+    allocation_nodes = None
+    if config.allocation_nodes is not None:
+        for node_position, node in enumerate(config.allocation_nodes):
+            if (
+                not isinstance(node, tuple)
+                or len(node) != 2
+                or any(type(coordinate) is not int for coordinate in node)
+                or node[0] < 0
+                or node[1] < 0
+            ):
+                raise ValueError(
+                    f"DFB[{config.dfb_index}] allocation node "
+                    f"{node_position} must be a nonnegative integer (x, y) tuple"
+                )
+        allocation_nodes = set(config.allocation_nodes)
+        if len(allocation_nodes) != len(config.allocation_nodes):
+            raise ValueError(
+                f"DFB[{config.dfb_index}] allocation_nodes contains duplicates"
+            )
     seen_nodes = set()
     for segment_position, segment in enumerate(config.storage_segments):
         if not segment.nodes:
@@ -80,6 +99,15 @@ def _validate_physical_dfb_config(
                     "multiple storage segments"
                 )
             seen_nodes.add(node)
+    if (
+        allocation_nodes is not None
+        and config.storage_segments
+        and seen_nodes != allocation_nodes
+    ):
+        raise ValueError(
+            f"DFB[{config.dfb_index}] storage segments must cover its exact "
+            "allocation nodes"
+        )
 
 
 def _get_dfb_allocation(config: PhysicalDFBConfig) -> _DFBAllocation:
@@ -472,6 +500,9 @@ def build_pipe_computed_address_dfb_tensors(
 
     device = device if device is not None else _first_device(tensors)
     used_by_core = _used_dfb_indices_by_core(kernel_specs, core_ranges, len(cb_configs))
+    program_cores = set(
+        _core_range_coordinates(core_ranges, label="program core ranges")
+    )
     backing_tensors = {}
     for dfb_index in dfb_indices:
         if dfb_index < 0 or dfb_index >= len(cb_configs):
@@ -481,17 +512,28 @@ def build_pipe_computed_address_dfb_tensors(
         config = cb_configs[dfb_index]
         allocation = _get_dfb_allocation(config)
         _validate_physical_dfb_config(config, dfb_index)
-        backing_core_ranges = core_ranges
-        if used_by_core is not None:
-            backing_cores = tuple(
-                sorted(
-                    core
-                    for core, used_indices in used_by_core.items()
-                    if dfb_index in used_indices
-                )
+        backing_cores = (
+            set(program_cores)
+            if config.allocation_nodes is None
+            else set(config.allocation_nodes)
+        )
+        outside_program = backing_cores - program_cores
+        if outside_program:
+            raise ValueError(
+                f"DFB[{dfb_index}] allocation nodes {sorted(outside_program)} "
+                "are outside the program grid"
             )
-            if backing_cores:
-                backing_core_ranges = _make_node_core_ranges(backing_cores)
+        if used_by_core is not None:
+            backing_cores.intersection_update(
+                core
+                for core, used_indices in used_by_core.items()
+                if dfb_index in used_indices
+            )
+        if not backing_cores:
+            # The PipeNet ABI requires a receiver address even when analysis
+            # proves that no launch node installs the corresponding descriptor.
+            backing_cores = {min(program_cores, key=lambda core: (core[1], core[0]))}
+        backing_core_ranges = _make_node_core_ranges(tuple(sorted(backing_cores)))
         backing_tensors[dfb_index] = _allocate_l1_sharded_storage_tensor(
             backing_core_ranges, allocation.total_size, device
         )
@@ -769,20 +811,39 @@ def _validate_tensor_backing_aliases(
             bindings.append((config.dfb_index, nodes, absolute_start, absolute_end))
 
 
-def _specialized_dfb_placements(
+def _resolve_dfb_placements(
     cb_configs: List[PhysicalDFBConfig],
     core_ranges: Any,
     backing_tensors: Dict[int, Any],
     kernel_specs: Optional[List[KernelSpec]],
 ) -> Optional[List[Dict[Tuple[int, int], Tuple[str, Optional[int]]]]]:
-    """Resolve the storage source for each used DFB and logical core."""
+    """Resolve the storage source for each allocated DFB and logical core."""
     used_by_core = _used_dfb_indices_by_core(kernel_specs, core_ranges, len(cb_configs))
-    if used_by_core is None:
+    has_allocation_domains = any(
+        config.allocation_nodes is not None for config in cb_configs
+    )
+    if used_by_core is None and not has_allocation_domains:
         return None
 
-    program_cores = set(used_by_core)
+    program_cores = set(
+        _core_range_coordinates(core_ranges, label="program core ranges")
+    )
+    if used_by_core is None:
+        all_indices = set(range(len(cb_configs)))
+        used_by_core = {core: set(all_indices) for core in program_cores}
     placements = []
     for dfb_index, config in enumerate(cb_configs):
+        allocation_cores = (
+            program_cores
+            if config.allocation_nodes is None
+            else set(config.allocation_nodes)
+        )
+        outside_program = allocation_cores - program_cores
+        if outside_program:
+            raise ValueError(
+                f"DFB[{dfb_index}] allocation nodes {sorted(outside_program)} "
+                "are outside the program grid"
+            )
         candidates: Dict[Tuple[int, int], Tuple[str, Optional[int]]] = {}
         if dfb_index in backing_tensors:
             if config.storage_segments:
@@ -790,9 +851,9 @@ def _specialized_dfb_placements(
                     f"DFB[{dfb_index}] cannot combine PipeNet computed-address "
                     "storage with finalized storage segments"
                 )
-            candidates = {core: ("computed", None) for core in program_cores}
+            candidates = {core: ("computed", None) for core in allocation_cores}
         elif not config.storage_segments:
-            candidates = {core: ("static", None) for core in program_cores}
+            candidates = {core: ("static", None) for core in allocation_cores}
         else:
             for segment_index, segment in enumerate(config.storage_segments):
                 source = (
@@ -835,7 +896,7 @@ def _dfb_format_descriptor(dfb_index: int, allocation: _DFBAllocation) -> Any:
     )
 
 
-def _build_specialized_dfb_descriptors(
+def _build_partitioned_dfb_descriptors(
     tensors: List[Any],
     cb_configs: List[PhysicalDFBConfig],
     allocations: List[_DFBAllocation],
@@ -1005,7 +1066,7 @@ def build_cb_descriptors(
                 continue
             break
 
-    placements = _specialized_dfb_placements(
+    placements = _resolve_dfb_placements(
         cb_configs, core_ranges, backing_tensors, kernel_specs
     )
     if placements is not None:
@@ -1017,7 +1078,7 @@ def build_cb_descriptors(
             if device is not None
             else {core: DEFAULT_L1_CB_BUDGET_BYTES for core in placement_cores}
         )
-        return _build_specialized_dfb_descriptors(
+        return _build_partitioned_dfb_descriptors(
             tensors,
             cb_configs,
             allocations,
@@ -1420,6 +1481,8 @@ def emit_runner_source(
         lines.append(f"        block_count={config.block_count},")
         lines.append(f"        page_size={config.page_size},")
         lines.append(f"        tile={config.tile!r},")
+        if config.allocation_nodes is not None:
+            lines.append(f"        allocation_nodes={config.allocation_nodes!r},")
         if config.storage_segments:
             lines.append("        storage_segments=(")
             for segment in config.storage_segments:

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -141,6 +141,26 @@ def get_min_remaining_l1_for_device(device):
     return max(0, budget_bytes - max_core_bytes)
 
 
+def _get_remaining_l1_by_core_for_device(
+    device, cores: set[tuple[int, int]]
+) -> dict[tuple[int, int], int]:
+    """Return each requested logical core's remaining static DFB budget."""
+    _ensure_ttnn()
+    if ttnn is None:
+        raise RuntimeError("ttnn is not available")
+
+    budget_bytes = ttnn._ttnn.reports.get_device_info(device).cb_limit
+    used_bytes = {core: 0 for core in cores}
+    for page in ttnn._ttnn.reports.get_buffer_pages(device):
+        core = (page.core_x, page.core_y)
+        if page.buffer_type == ttnn.BufferType.L1 and core in used_bytes:
+            used_bytes[core] += page.page_size
+    return {
+        core: max(0, budget_bytes - core_used_bytes)
+        for core, core_used_bytes in used_bytes.items()
+    }
+
+
 @dataclass
 class KernelSpec:
     """Specification for a single kernel to execute.
@@ -160,6 +180,9 @@ class KernelSpec:
             specialized kernel binary is dispatched only to these cores. When None,
             the whole-grid core_ranges passed to build_kernel_descriptors is used.
         logical_kernel: Target-independent selector retained across kernel cloning.
+        used_dfb_indices: Physical DFB indices referenced by the final kernel.
+            None means metadata is unavailable and conservatively uses every
+            DFB; an empty list means the kernel uses no DFBs.
     """
 
     path: str
@@ -170,6 +193,7 @@ class KernelSpec:
     pipe_computed_address_dfb_indices: List[int] = field(default_factory=list)
     core_ranges: Optional[Any] = None
     logical_kernel: Optional[KernelSelector] = None
+    used_dfb_indices: Optional[List[int]] = None
 
 
 @dataclass
@@ -310,6 +334,35 @@ def _align_up(value: int, alignment: int) -> int:
     return ((value + alignment - 1) // alignment) * alignment
 
 
+def _core_range_coordinates(
+    core_ranges: Any, *, label: str = "core ranges"
+) -> Tuple[Tuple[int, int], ...]:
+    """Expand a CoreRangeSet-like object into canonical logical coordinates."""
+    if core_ranges is None or not hasattr(core_ranges, "ranges"):
+        raise ValueError(f"{label} must be a CoreRangeSet with ranges")
+    ranges = core_ranges.ranges
+    if callable(ranges):
+        ranges = ranges()
+
+    coordinates = set()
+    for core_range in ranges:
+        try:
+            start_x = int(core_range.start.x)
+            start_y = int(core_range.start.y)
+            end_x = int(core_range.end.x)
+            end_y = int(core_range.end.y)
+        except (AttributeError, TypeError, ValueError) as error:
+            raise ValueError(f"{label} contains an invalid core range") from error
+        if end_x < start_x or end_y < start_y:
+            raise ValueError(f"{label} contains an inverted core range")
+        for core_y in range(start_y, end_y + 1):
+            for core_x in range(start_x, end_x + 1):
+                coordinates.add((core_x, core_y))
+    if not coordinates:
+        raise ValueError(f"{label} must cover at least one core")
+    return tuple(sorted(coordinates))
+
+
 def _first_device(tensors: List[Any]) -> Any:
     for tensor in tensors:
         if tensor is not None and hasattr(tensor, "device"):
@@ -323,8 +376,13 @@ def _allocate_l1_sharded_storage_tensor(core_ranges: Any, num_bytes: int, device
     """Allocate row-major L1 storage with one 4-byte element per storage word."""
     aligned_bytes = _align_up(num_bytes, 32)
     elements_per_core = max(1, aligned_bytes // 4)
-    grid_size = core_ranges.bounding_box().grid_size()
-    num_cores = grid_size.x * grid_size.y
+    if hasattr(core_ranges, "ranges"):
+        num_cores = len(
+            _core_range_coordinates(core_ranges, label="L1 storage core ranges")
+        )
+    else:
+        grid_size = core_ranges.bounding_box().grid_size()
+        num_cores = grid_size.x * grid_size.y
     shard_spec = ttnn.ShardSpec(
         core_ranges,
         (1, elements_per_core),
@@ -401,6 +459,7 @@ def build_pipe_computed_address_dfb_tensors(
     core_ranges: Any,
     pipe_computed_address_dfb_indices: Optional[List[int]] = None,
     device: Optional[Any] = None,
+    kernel_specs: Optional[List[KernelSpec]] = None,
 ) -> Dict[int, Any]:
     """Allocate hidden L1 backing tensors for computed pipe receiver DFBs."""
     dfb_indices = sorted(set(pipe_computed_address_dfb_indices or []))
@@ -412,6 +471,7 @@ def build_pipe_computed_address_dfb_tensors(
         raise RuntimeError("ttnn is not available")
 
     device = device if device is not None else _first_device(tensors)
+    used_by_core = _used_dfb_indices_by_core(kernel_specs, core_ranges, len(cb_configs))
     backing_tensors = {}
     for dfb_index in dfb_indices:
         if dfb_index < 0 or dfb_index >= len(cb_configs):
@@ -421,8 +481,19 @@ def build_pipe_computed_address_dfb_tensors(
         config = cb_configs[dfb_index]
         allocation = _get_dfb_allocation(config)
         _validate_physical_dfb_config(config, dfb_index)
+        backing_core_ranges = core_ranges
+        if used_by_core is not None:
+            backing_cores = tuple(
+                sorted(
+                    core
+                    for core, used_indices in used_by_core.items()
+                    if dfb_index in used_indices
+                )
+            )
+            if backing_cores:
+                backing_core_ranges = _make_node_core_ranges(backing_cores)
         backing_tensors[dfb_index] = _allocate_l1_sharded_storage_tensor(
-            core_ranges, allocation.total_size, device
+            backing_core_ranges, allocation.total_size, device
         )
     return backing_tensors
 
@@ -435,6 +506,7 @@ def build_pipe_runtime_resources(
     num_pipe_global_semaphores: int = 0,
     pipe_computed_address_dfb_indices: Optional[List[int]] = None,
     device: Optional[Any] = None,
+    kernel_specs: Optional[List[KernelSpec]] = None,
 ) -> PipeRuntimeResources:
     """Allocate pipe resources and build their appended common runtime args."""
     computed_address_dfb_indices = list(pipe_computed_address_dfb_indices or [])
@@ -458,6 +530,7 @@ def build_pipe_runtime_resources(
             core_ranges=core_ranges,
             pipe_computed_address_dfb_indices=computed_address_dfb_indices,
             device=resource_device,
+            kernel_specs=kernel_specs,
         )
 
     scratch_tensors = build_pipe_sram_scratch_tensors(
@@ -531,6 +604,55 @@ def _make_node_core_ranges(nodes: Tuple[Tuple[int, int], ...]) -> Any:
             for node_x, node_y in nodes
         ]
     )
+
+
+def _used_dfb_indices_by_core(
+    kernel_specs: Optional[List[KernelSpec]],
+    program_core_ranges: Any,
+    num_dfbs: int,
+) -> Optional[Dict[Tuple[int, int], set[int]]]:
+    """Union specialized kernel DFB use on each logical core."""
+    if not kernel_specs or not any(
+        spec.used_dfb_indices is not None for spec in kernel_specs
+    ):
+        return None
+
+    program_cores = set(
+        _core_range_coordinates(program_core_ranges, label="program core ranges")
+    )
+    used_by_core = {core: set() for core in program_cores}
+    all_indices = set(range(num_dfbs))
+    for spec_index, spec in enumerate(kernel_specs):
+        spec_ranges = (
+            spec.core_ranges if spec.core_ranges is not None else program_core_ranges
+        )
+        spec_cores = set(
+            _core_range_coordinates(
+                spec_ranges, label=f"kernel spec {spec_index} core ranges"
+            )
+        )
+        outside_program = spec_cores - program_cores
+        if outside_program:
+            raise ValueError(
+                f"kernel spec {spec_index} claims cores outside the program "
+                f"grid: {sorted(outside_program)}"
+            )
+        indices = (
+            all_indices
+            if spec.used_dfb_indices is None
+            else {int(index) for index in spec.used_dfb_indices}
+        )
+        invalid_indices = sorted(
+            index for index in indices if index < 0 or index >= num_dfbs
+        )
+        if invalid_indices:
+            raise ValueError(
+                f"kernel spec {spec_index} uses DFB indices outside "
+                f"[0, {num_dfbs}): {invalid_indices}"
+            )
+        for core in spec_cores:
+            used_by_core[core].update(indices)
+    return used_by_core
 
 
 def _validate_tensor_backed_dfb_binding(
@@ -647,11 +769,179 @@ def _validate_tensor_backing_aliases(
             bindings.append((config.dfb_index, nodes, absolute_start, absolute_end))
 
 
+def _specialized_dfb_placements(
+    cb_configs: List[PhysicalDFBConfig],
+    core_ranges: Any,
+    backing_tensors: Dict[int, Any],
+    kernel_specs: Optional[List[KernelSpec]],
+) -> Optional[List[Dict[Tuple[int, int], Tuple[str, Optional[int]]]]]:
+    """Resolve the storage source for each used DFB and logical core."""
+    used_by_core = _used_dfb_indices_by_core(kernel_specs, core_ranges, len(cb_configs))
+    if used_by_core is None:
+        return None
+
+    program_cores = set(used_by_core)
+    placements = []
+    for dfb_index, config in enumerate(cb_configs):
+        candidates: Dict[Tuple[int, int], Tuple[str, Optional[int]]] = {}
+        if dfb_index in backing_tensors:
+            if config.storage_segments:
+                raise ValueError(
+                    f"DFB[{dfb_index}] cannot combine PipeNet computed-address "
+                    "storage with finalized storage segments"
+                )
+            candidates = {core: ("computed", None) for core in program_cores}
+        elif not config.storage_segments:
+            candidates = {core: ("static", None) for core in program_cores}
+        else:
+            for segment_index, segment in enumerate(config.storage_segments):
+                source = (
+                    "tensor" if segment.is_tensor_backed else "static",
+                    segment_index,
+                )
+                for core in segment.nodes:
+                    if core not in program_cores:
+                        raise ValueError(
+                            f"DFB[{dfb_index}] storage segment claims core "
+                            f"{core} outside the program grid"
+                        )
+                    if core in candidates:
+                        raise ValueError(
+                            f"DFB[{dfb_index}] has overlapping storage segments "
+                            f"on core {core}"
+                        )
+                    candidates[core] = source
+        placements.append(
+            {
+                core: source
+                for core, source in candidates.items()
+                if dfb_index in used_by_core[core]
+            }
+        )
+    return placements
+
+
+def _dfb_format_descriptor(dfb_index: int, allocation: _DFBAllocation) -> Any:
+    tile_descriptor = (
+        ttnn.TileDescriptor(ttnn.Tile(allocation.tile))
+        if allocation.tile is not None
+        else None
+    )
+    return ttnn.CBFormatDescriptor(
+        buffer_index=dfb_index,
+        data_format=allocation.data_format,
+        page_size=allocation.page_size,
+        **({"tile": tile_descriptor} if tile_descriptor is not None else {}),
+    )
+
+
+def _build_specialized_dfb_descriptors(
+    tensors: List[Any],
+    cb_configs: List[PhysicalDFBConfig],
+    allocations: List[_DFBAllocation],
+    placements: List[Dict[Tuple[int, int], Tuple[str, Optional[int]]]],
+    backing_tensors: Dict[int, Any],
+    remaining_bytes_by_core: Dict[Tuple[int, int], int],
+) -> List[Any]:
+    """Build descriptors on disjoint core partitions after DFB-use filtering."""
+    active_cores = sorted({core for placement in placements for core in placement})
+    static_bytes_by_core = {core: 0 for core in active_cores}
+    for dfb_index, placement in enumerate(placements):
+        for core, (storage_kind, _) in placement.items():
+            if storage_kind == "static":
+                static_bytes_by_core[core] += allocations[dfb_index].total_size
+
+    overflow_cores = [
+        core
+        for core, static_bytes in static_bytes_by_core.items()
+        if static_bytes > remaining_bytes_by_core[core]
+    ]
+    if overflow_cores:
+        overflow_core = max(
+            overflow_cores,
+            key=lambda core: (
+                static_bytes_by_core[core] - remaining_bytes_by_core[core]
+            ),
+        )
+        static_indices = [
+            dfb_index
+            for dfb_index, placement in enumerate(placements)
+            if placement.get(overflow_core, (None, None))[0] == "static"
+        ]
+        breakdown = "\n".join(
+            f"  DFB[{dfb_index}]: num_tiles={allocations[dfb_index].num_tiles} "
+            f"block_count={allocations[dfb_index].block_count} "
+            f"format={cb_configs[dfb_index].data_format} "
+            f"tile={allocations[dfb_index].tile} -> "
+            f"{allocations[dfb_index].total_size} bytes"
+            for dfb_index in sorted(static_indices)
+        )
+        raise ValueError(
+            f"Per-core DFB allocation on core {overflow_core} ("
+            f"{static_bytes_by_core[overflow_core]} bytes) exceeds L1 budget "
+            f"({remaining_bytes_by_core[overflow_core]} bytes).\n"
+            + breakdown
+            + "\n  hint: reduce DFB dimensions or block_count."
+        )
+
+    # A descriptor partition must have one consistent allocation sequence on
+    # every core because TT-Metal advances one static DFB allocation cursor.
+    cores_by_signature: Dict[
+        Tuple[Optional[Tuple[str, Optional[int]]], ...],
+        set[Tuple[int, int]],
+    ] = {}
+    for core in active_cores:
+        signature = tuple(placement.get(core) for placement in placements)
+        cores_by_signature.setdefault(signature, set()).add(core)
+
+    descriptors = []
+    for signature, partition_cores in cores_by_signature.items():
+        partition_ranges = _make_node_core_ranges(tuple(sorted(partition_cores)))
+        for dfb_index, source in enumerate(signature):
+            if source is None:
+                continue
+            storage_kind, segment_index = source
+            allocation = allocations[dfb_index]
+            format_descriptor = _dfb_format_descriptor(dfb_index, allocation)
+            if storage_kind == "tensor":
+                assert segment_index is not None
+                segment = cb_configs[dfb_index].storage_segments[segment_index]
+                tensor_index = segment.tensor_index
+                assert tensor_index is not None
+                descriptors.append(
+                    ttnn.cb_descriptor_from_sharded_tensor(
+                        dfb_index,
+                        tensors[tensor_index],
+                        address_offset=segment.byte_offset,
+                        total_size=allocation.total_size,
+                        core_ranges=partition_ranges,
+                    )
+                )
+                continue
+
+            descriptor = ttnn.CBDescriptor(
+                total_size=allocation.total_size,
+                core_ranges=partition_ranges,
+                format_descriptors=[format_descriptor],
+            )
+            if storage_kind == "computed":
+                backing_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    dfb_index,
+                    backing_tensors[dfb_index],
+                    total_size=allocation.total_size,
+                    core_ranges=partition_ranges,
+                )
+                descriptor.set_buffer_from_cb(backing_descriptor)
+            descriptors.append(descriptor)
+    return descriptors
+
+
 def build_cb_descriptors(
     tensors: List[Any],
     cb_configs: List[PhysicalDFBConfig],
     core_ranges: Any,
     pipe_computed_address_backing_tensors: Optional[Dict[int, Any]] = None,
+    kernel_specs: Optional[List[KernelSpec]] = None,
 ) -> List[Any]:
     """
     Build circular buffer descriptors for ttnn.generic_op.
@@ -664,6 +954,7 @@ def build_cb_descriptors(
         core_ranges: ttnn.CoreRangeSet for DFB allocation.
         pipe_computed_address_backing_tensors: Hidden L1 backing tensors for DFBs whose
             receiver base is passed as a common runtime argument.
+        kernel_specs: Final per-kernel launch ranges and surviving DFB-use sets.
 
     Returns:
         List of ttnn.CBDescriptor objects. A configuration with storage
@@ -706,14 +997,40 @@ def build_cb_descriptors(
             static_cb_bytes += allocation.total_size
             static_allocation_summaries.append(allocation_summary)
 
-    remaining_bytes = DEFAULT_L1_CB_BUDGET_BYTES
+    device = None
     for tensor in tensors:
         if tensor is not None and hasattr(tensor, "device"):
             device = tensor.device()
             if device is None:
                 continue
-            remaining_bytes = get_min_remaining_l1_for_device(device)
             break
+
+    placements = _specialized_dfb_placements(
+        cb_configs, core_ranges, backing_tensors, kernel_specs
+    )
+    if placements is not None:
+        placement_cores = {
+            core for placement in placements for core in placement.keys()
+        }
+        remaining_bytes_by_core = (
+            _get_remaining_l1_by_core_for_device(device, placement_cores)
+            if device is not None
+            else {core: DEFAULT_L1_CB_BUDGET_BYTES for core in placement_cores}
+        )
+        return _build_specialized_dfb_descriptors(
+            tensors,
+            cb_configs,
+            allocations,
+            placements,
+            backing_tensors,
+            remaining_bytes_by_core,
+        )
+
+    remaining_bytes = (
+        get_min_remaining_l1_for_device(device)
+        if device is not None
+        else DEFAULT_L1_CB_BUDGET_BYTES
+    )
 
     # Must stay aligned with MLIR ttl-validate-cb-budget and the finalized DFB
     # page-size metadata. Computed-address backing tensors are allocated
@@ -732,17 +1049,7 @@ def build_cb_descriptors(
     cb_descriptors = []
     for cb_index, allocation in enumerate(allocations):
         config = cb_configs[cb_index]
-        tile_descriptor = (
-            ttnn.TileDescriptor(ttnn.Tile(allocation.tile))
-            if allocation.tile is not None
-            else None
-        )
-        cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=cb_index,
-            data_format=allocation.data_format,
-            page_size=allocation.page_size,
-            **({"tile": tile_descriptor} if tile_descriptor is not None else {}),
-        )
+        cb_format = _dfb_format_descriptor(cb_index, allocation)
         if cb_index in backing_tensors:
             if config.storage_segments:
                 raise ValueError(
@@ -887,6 +1194,7 @@ def run_kernel_on_device(
                 for dfb_index in spec.pipe_computed_address_dfb_indices
             }
         ),
+        kernel_specs=kernel_specs,
     )
     if pipe_global_semaphore_lifetime is not None:
         pipe_global_semaphore_lifetime[:] = pipe_runtime_resources.global_semaphores
@@ -917,6 +1225,7 @@ def run_kernel_on_device(
         pipe_computed_address_backing_tensors=(
             pipe_runtime_resources.computed_address_dfb_tensors
         ),
+        kernel_specs=kernel_specs,
     )
 
     semaphore_descriptors = build_pipe_sync_semaphore_descriptors(
@@ -1076,6 +1385,12 @@ def emit_runner_source(
     lines.append("]")
     lines.append("")
 
+    lines.append("KERNEL_USED_DFB_INDICES = [")
+    for spec in kernel_specs:
+        lines.append(f"    {spec.used_dfb_indices!r},  # {spec.thread_type}")
+    lines.append("]")
+    lines.append("")
+
     # Per-kernel dispatch ranges from KernelSpec.core_ranges. None means use
     # the whole-grid core_ranges below; a list of ((sx, sy), (ex, ey)) pairs
     # rebuilds a CoreRangeSet for specialize-cores clones.
@@ -1137,17 +1452,6 @@ def emit_runner_source(
     lines.append("")
 
     lines.append("    tensor_accessor_args = build_tensor_accessor_args(tensors)")
-    lines.append("    pipe_resources = build_pipe_runtime_resources(")
-    lines.append("        tensors=tensors,")
-    lines.append("        core_ranges=core_ranges,")
-    lines.append("        cb_configs=CB_CONFIGS,")
-    lines.append("        pipe_sram_scratch_bytes=PIPE_SRAM_SCRATCH_BYTES,")
-    lines.append("        num_pipe_global_semaphores=NUM_PIPE_GLOBAL_SEMAPHORES,")
-    lines.append(
-        "        pipe_computed_address_dfb_indices=PIPE_COMPUTED_ADDRESS_DFB_INDICES,"
-    )
-    lines.append("        device=device,")
-    lines.append("    )")
     lines.append("")
 
     lines.append("    def _core_ranges_from_spec(ranges_spec):")
@@ -1186,8 +1490,24 @@ def emit_runner_source(
         "                core_ranges=_core_ranges_from_spec("
         "KERNEL_CORE_RANGES[kernel_idx]),"
     )
+    lines.append(
+        "                used_dfb_indices=KERNEL_USED_DFB_INDICES[kernel_idx],"
+    )
     lines.append("            )")
     lines.append("        )")
+    lines.append("    pipe_resources = build_pipe_runtime_resources(")
+    lines.append("        tensors=tensors,")
+    lines.append("        core_ranges=core_ranges,")
+    lines.append("        cb_configs=CB_CONFIGS,")
+    lines.append("        pipe_sram_scratch_bytes=PIPE_SRAM_SCRATCH_BYTES,")
+    lines.append("        num_pipe_global_semaphores=NUM_PIPE_GLOBAL_SEMAPHORES,")
+    lines.append(
+        "        pipe_computed_address_dfb_indices=PIPE_COMPUTED_ADDRESS_DFB_INDICES,"
+    )
+    lines.append("        device=device,")
+    lines.append("        kernel_specs=kernel_specs,")
+    lines.append("    )")
+    lines.append("")
     lines.append("    kernel_descriptors = build_kernel_descriptors(")
     lines.append("        kernel_specs=kernel_specs,")
     lines.append("        tensors=tensors,")
@@ -1215,6 +1535,7 @@ def emit_runner_source(
     lines.append(
         "        pipe_computed_address_backing_tensors=pipe_resources.computed_address_dfb_tensors,"
     )
+    lines.append("        kernel_specs=kernel_specs,")
     lines.append("    )")
     lines.append("")
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1575,6 +1575,25 @@ def _parse_mlir_element_type(
     )
 
 
+def _extract_dfb_node_coordinates(
+    nodes_attr, *, context: str, allow_empty: bool
+) -> tuple[tuple[int, int], ...]:
+    nodes = []
+    for node_position, node_attr in enumerate(nodes_attr):
+        node = ArrayAttr(node_attr)
+        if len(node) != 2:
+            raise ValueError(f"{context}[{node_position}] must contain [x, y]")
+        coordinate = tuple(int(IntegerAttr(component).value) for component in node)
+        if coordinate[0] < 0 or coordinate[1] < 0:
+            raise ValueError(f"{context} contains negative coordinate {coordinate}")
+        if coordinate in nodes:
+            raise ValueError(f"{context} contains duplicate coordinate {coordinate}")
+        nodes.append(coordinate)
+    if not allow_empty and not nodes:
+        raise ValueError(f"{context} must not be empty")
+    return tuple(sorted(nodes))
+
+
 def _extract_dfb_allocations(module):
     """Read `ttl.dfb_allocations` and require dense physical indices."""
     attribute_name = "ttl.dfb_allocations"
@@ -1631,6 +1650,14 @@ def _extract_dfb_allocations(module):
                 f"got {page_size}"
             )
 
+        allocation_nodes = None
+        if "allocation_nodes" in entry:
+            allocation_nodes = _extract_dfb_node_coordinates(
+                entry["allocation_nodes"],
+                context=f"{attribute_name}[{position}].allocation_nodes",
+                allow_empty=True,
+            )
+
         storage_segments = []
         seen_nodes = set()
         if "storage_segments" in entry:
@@ -1640,35 +1667,21 @@ def _extract_dfb_allocations(module):
                         f"{attribute_name}[{position}].storage_segments"
                         f"[{segment_position}] is missing 'nodes'"
                     )
-                nodes = []
-                for node_position, node_attr in enumerate(segment["nodes"]):
-                    node = ArrayAttr(node_attr)
-                    if len(node) != 2:
-                        raise ValueError(
-                            f"{attribute_name}[{position}].storage_segments"
-                            f"[{segment_position}].nodes[{node_position}] must "
-                            "contain [x, y]"
-                        )
-                    coord = tuple(
-                        int(IntegerAttr(component).value) for component in node
-                    )
-                    if coord[0] < 0 or coord[1] < 0:
-                        raise ValueError(
-                            f"{attribute_name}[{position}] contains negative "
-                            f"launch-node coordinate {coord}"
-                        )
-                    if coord in seen_nodes:
+                nodes = _extract_dfb_node_coordinates(
+                    segment["nodes"],
+                    context=(
+                        f"{attribute_name}[{position}].storage_segments"
+                        f"[{segment_position}].nodes"
+                    ),
+                    allow_empty=False,
+                )
+                for coordinate in nodes:
+                    if coordinate in seen_nodes:
                         raise ValueError(
                             f"{attribute_name}[{position}] assigns launch node "
-                            f"{coord} to multiple storage segments"
+                            f"{coordinate} to multiple storage segments"
                         )
-                    seen_nodes.add(coord)
-                    nodes.append(coord)
-                if not nodes:
-                    raise ValueError(
-                        f"{attribute_name}[{position}].storage_segments"
-                        f"[{segment_position}].nodes must not be empty"
-                    )
+                    seen_nodes.add(coordinate)
 
                 tensor_index = None
                 byte_offset = 0
@@ -1694,7 +1707,7 @@ def _extract_dfb_allocations(module):
                         )
                 storage_segments.append(
                     DFBStorageSegment(
-                        nodes=tuple(sorted(nodes)),
+                        nodes=nodes,
                         tensor_index=tensor_index,
                         byte_offset=byte_offset,
                         byte_size=byte_size,
@@ -1711,6 +1724,7 @@ def _extract_dfb_allocations(module):
                 page_size=page_size,
                 tile=tile,
                 storage_segments=tuple(storage_segments),
+                allocation_nodes=allocation_nodes,
             )
         )
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -734,6 +734,7 @@ class CompiledTTNNKernel:
         opaque_include_paths=None,
         kernel_pipe_computed_address_dfb_indices=None,
         kernel_logical_selectors=None,
+        kernel_used_dfb_indices=None,
     ):
         """
         Initialize with pre-compiled kernel artifacts.
@@ -764,6 +765,8 @@ class CompiledTTNNKernel:
             kernel_pipe_computed_address_dfb_indices: Per-kernel receiver DFB indices whose
                 L1 bases are supplied as common runtime args.
             kernel_logical_selectors: Logical selector for each compiled kernel.
+            kernel_used_dfb_indices: Physical DFB indices referenced by each
+                final specialized kernel. None entries are conservative.
         """
         self.kernel_paths = kernel_paths
         self.kernel_configs = kernel_configs
@@ -787,6 +790,11 @@ class CompiledTTNNKernel:
         self.kernel_logical_selectors = kernel_logical_selectors or [
             None for _ in kernel_paths
         ]
+        self.kernel_used_dfb_indices = (
+            kernel_used_dfb_indices
+            if kernel_used_dfb_indices is not None
+            else [None for _ in kernel_paths]
+        )
         self._pipe_global_semaphore_lifetime = []
         self.opaque_include_paths = opaque_include_paths or []
 
@@ -822,6 +830,7 @@ class CompiledTTNNKernel:
                 ],
                 core_ranges=self.kernel_core_ranges[kernel_idx],
                 logical_kernel=self.kernel_logical_selectors[kernel_idx],
+                used_dfb_indices=self.kernel_used_dfb_indices[kernel_idx],
             )
             kernel_specs.append(spec)
 
@@ -956,18 +965,24 @@ def _get_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
     return list(attr)
 
 
-def _get_optional_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
-    """Read an optional `DenseI32ArrayAttr` kernel attribute."""
+def _read_optional_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
+    """Read an optional `DenseI32ArrayAttr`, preserving a missing attribute."""
     operation = _lookup_kernel_func_op(module, kernel_name)
     attr = operation.attributes.get(attr_name, None)
     if attr is None:
-        return []
+        return None
     if not isinstance(attr, DenseI32ArrayAttr):
         raise ValueError(
             f"Expected DenseI32ArrayAttr for '{attr_name}' on kernel "
             f"'{kernel_name}', got {attr}"
         )
     return list(attr)
+
+
+def _get_optional_kernel_i32_array_attr(module, kernel_name: str, attr_name: str):
+    """Read an optional `DenseI32ArrayAttr`, returning empty when absent."""
+    values = _read_optional_kernel_i32_array_attr(module, kernel_name, attr_name)
+    return [] if values is None else values
 
 
 def _get_kernel_core_coords(module, kernel_name: str):
@@ -1229,6 +1244,7 @@ def _compile_ttnn_kernel(
     kernel_configs = []
     kernel_arg_specs = []
     kernel_pipe_computed_address_dfb_indices = []
+    kernel_used_dfb_indices = []
     # Per-kernel single-core ranges (specialization path) and tensor indices
     # read from ttl.crta_indices. Both stay aligned with kernel_info order.
     kernel_core_ranges = []
@@ -1257,6 +1273,9 @@ def _compile_ttnn_kernel(
             _get_optional_kernel_i32_array_attr(
                 module, name, _ttl_ir.PIPE_COMPUTED_ADDRESS_DFB_INDICES_ATTR
             )
+        )
+        kernel_used_dfb_indices.append(
+            _read_optional_kernel_i32_array_attr(module, name, "ttl.used_dfb_indices")
         )
 
         # The specialized clone's launch coordinates (None on the default,
@@ -1348,6 +1367,7 @@ def _compile_ttnn_kernel(
         opaque_include_paths=opaque_include_paths or [],
         kernel_pipe_computed_address_dfb_indices=kernel_pipe_computed_address_dfb_indices,
         kernel_logical_selectors=kernel_logical_selectors,
+        kernel_used_dfb_indices=kernel_used_dfb_indices,
     )
 
     if verbose:
@@ -1370,6 +1390,7 @@ def _compile_ttnn_kernel(
                 ],
                 core_ranges=kernel_core_ranges[kernel_idx],
                 logical_kernel=kernel_logical_selectors[kernel_idx],
+                used_dfb_indices=kernel_used_dfb_indices[kernel_idx],
             )
             kernel_specs_for_emit.append(spec)
 
@@ -2384,6 +2405,7 @@ def _lower_program_to_kernel(
                 "ttkernel-specialize-cores",
                 "canonicalize",
                 "cse",
+                "ttkernel-annotate-dfb-use",
             ]
         pipeline_passes += [
             "convert-ttkernel-to-emitc",

--- a/test/bindings/python/ttl_passes.py
+++ b/test/bindings/python/ttl_passes.py
@@ -40,6 +40,7 @@ def test_ttl_passes_registered():
         "ttl-verify-pipenet-guards",
         "ttl-verify-pipenet-schedule",
         "ttl-erase-pipenet-scopes",
+        "ttkernel-annotate-dfb-use",
     ]
     for pass_name in module_passes:
         PassManager.parse(f"builtin.module({pass_name})", context=ctx)
@@ -48,6 +49,7 @@ def test_ttl_passes_registered():
         # CHECK: ttl-verify-pipenet-guards pass registered
         # CHECK: ttl-verify-pipenet-schedule pass registered
         # CHECK: ttl-erase-pipenet-scopes pass registered
+        # CHECK: ttkernel-annotate-dfb-use pass registered
 
 
 if __name__ == "__main__":

--- a/test/python/test_dfb_runtime_config.py
+++ b/test/python/test_dfb_runtime_config.py
@@ -97,6 +97,61 @@ def test_tensor_backing_segments_preserve_nodes_and_tensor_range():
 
 
 @pytest.mark.parametrize(
+    ("allocation_nodes", "expected"),
+    [
+        ("[[1, 0], [0, 0]]", ((0, 0), (1, 0))),
+        ("[]", ()),
+    ],
+    ids=["exact", "empty"],
+)
+def test_allocation_nodes_preserve_exact_physical_domain(allocation_nodes, expected):
+    with Context():
+        module = Module.parse(
+            "module attributes {ttl.dfb_allocations = [{"
+            "block_count = 1 : i32, dfb_index = 0 : i32, "
+            "element_type = bf16, num_tiles = 1 : i32, "
+            "page_size = 2048 : i32, allocation_nodes = "
+            f"{allocation_nodes}"
+            "}]} {}"
+        )
+
+        assert _resolve_dfb_configs(module) == [
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                None,
+                allocation_nodes=expected,
+            )
+        ]
+
+
+@pytest.mark.parametrize(
+    ("allocation_nodes", "message"),
+    [
+        ("[[0, 0], [0, 0]]", "duplicate coordinate"),
+        ("[[-1, 0]]", "negative coordinate"),
+        ("[[0]]", "must contain \\[x, y\\]"),
+    ],
+)
+def test_invalid_allocation_nodes_are_rejected(allocation_nodes, message):
+    with Context():
+        module = Module.parse(
+            "module attributes {ttl.dfb_allocations = [{"
+            "block_count = 1 : i32, dfb_index = 0 : i32, "
+            "element_type = bf16, num_tiles = 1 : i32, "
+            "page_size = 2048 : i32, allocation_nodes = "
+            f"{allocation_nodes}"
+            "}]} {}"
+        )
+
+        with pytest.raises(ValueError, match=message):
+            _resolve_dfb_configs(module)
+
+
+@pytest.mark.parametrize(
     ("element_type", "data_format", "tile", "page_size"),
     [
         ("!ttcore.tile<32x32, bfp_bf4>", "bfloat4_b", (32, 32), 576),

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -600,6 +600,157 @@ def test_unannotated_kernel_is_conservative_with_annotated_peer(monkeypatch):
     assert _descriptor_cores(descriptors[0]) == {(1, 0)}
 
 
+def test_allocation_nodes_scope_unspecialized_dfb_descriptor(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=((1, 0),),
+            )
+        ],
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    assert len(descriptors) == 1
+    assert _descriptor_cores(descriptors[0]) == {(1, 0)}
+
+
+def test_empty_allocation_nodes_omit_dfb_descriptor(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=(),
+            )
+        ],
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    assert descriptors == []
+
+
+@pytest.mark.parametrize(
+    ("allocation_nodes", "message"),
+    [
+        (((0, 0), (0, 0)), "contains duplicates"),
+        (([0, 0],), "must be a nonnegative integer"),
+        (((True, 0),), "must be a nonnegative integer"),
+        (((-1, 0),), "must be a nonnegative integer"),
+    ],
+    ids=["duplicate", "non-tuple", "non-integer", "negative"],
+)
+def test_invalid_allocation_nodes_are_rejected(monkeypatch, allocation_nodes, message):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    config = PhysicalDFBConfig(
+        0,
+        1,
+        "bfloat16",
+        1,
+        2048,
+        (32, 32),
+        allocation_nodes=allocation_nodes,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=[config],
+            core_ranges=_FakeExplicitCoreRanges((0, 0), (1, 0)),
+        )
+
+
+def test_allocation_nodes_must_cover_storage_segments(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    config = PhysicalDFBConfig(
+        0,
+        1,
+        "bfloat16",
+        1,
+        2048,
+        (32, 32),
+        (DFBStorageSegment(nodes=((0, 0),)),),
+        allocation_nodes=((1, 0),),
+    )
+
+    with pytest.raises(ValueError, match="must cover its exact allocation nodes"):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=[config],
+            core_ranges=full_grid,
+        )
+
+
+def test_allocation_nodes_outside_program_grid_are_rejected(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+
+    with pytest.raises(ValueError, match="outside the program grid"):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=[
+                PhysicalDFBConfig(
+                    0,
+                    1,
+                    "bfloat16",
+                    1,
+                    2048,
+                    (32, 32),
+                    allocation_nodes=((2, 0),),
+                )
+            ],
+            core_ranges=_FakeExplicitCoreRanges((0, 0), (1, 0)),
+        )
+
+
+def test_allocation_nodes_compute_dfb_budget_per_core(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(kernel_runner, "DEFAULT_L1_CB_BUDGET_BYTES", 2048)
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[
+            PhysicalDFBConfig(
+                index,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=((index, 0),),
+            )
+            for index in range(2)
+        ],
+        core_ranges=full_grid,
+    )
+
+    assert len(descriptors) == 2
+    assert {_descriptor_cores(descriptor).pop() for descriptor in descriptors} == {
+        (0, 0),
+        (1, 0),
+    }
+
+
 def test_specialized_dfb_descriptors_allow_sparse_physical_indices(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
     full_grid = _FakeExplicitCoreRanges((0, 0), (0, 0))
@@ -708,6 +859,75 @@ def test_computed_address_backing_uses_specialized_dfb_cores(monkeypatch):
     ) == {(0, 0)}
     assert allocated_bytes == 2048
     assert allocated_device is device
+
+
+def test_computed_address_backing_resolves_each_dfb_from_full_grid(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    allocations = []
+    monkeypatch.setattr(
+        kernel_runner,
+        "_allocate_l1_sharded_storage_tensor",
+        lambda ranges, size, device: allocations.append((ranges, size, device))
+        or object(),
+    )
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    core_0 = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    core_1 = _FakeExplicitCoreRanges((1, 0), (1, 0))
+
+    kernel_runner.build_pipe_computed_address_dfb_tensors(
+        tensors=[],
+        cb_configs=[
+            PhysicalDFBConfig(index, 1, "bfloat16", 1, 2048, (32, 32))
+            for index in range(2)
+        ],
+        core_ranges=full_grid,
+        pipe_computed_address_dfb_indices=[0, 1],
+        device=object(),
+        kernel_specs=[
+            _specialized_spec(core_0, [0]),
+            _specialized_spec(core_1, [1]),
+        ],
+    )
+
+    assert [
+        _descriptor_cores(type("Allocation", (), {"core_ranges": ranges})())
+        for ranges, _, _ in allocations
+    ] == [{(0, 0)}, {(1, 0)}]
+
+
+def test_computed_address_backing_uses_allocation_nodes(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    allocations = []
+    monkeypatch.setattr(
+        kernel_runner,
+        "_allocate_l1_sharded_storage_tensor",
+        lambda ranges, size, device: allocations.append((ranges, size, device))
+        or object(),
+    )
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    kernel_runner.build_pipe_computed_address_dfb_tensors(
+        tensors=[],
+        cb_configs=[
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                allocation_nodes=((1, 0),),
+            )
+        ],
+        core_ranges=full_grid,
+        pipe_computed_address_dfb_indices=[0],
+        device=object(),
+    )
+
+    allocated_ranges, _, _ = allocations[0]
+    assert _descriptor_cores(
+        type("Allocation", (), {"core_ranges": allocated_ranges})()
+    ) == {(1, 0)}
 
 
 def test_l1_sharded_storage_counts_sparse_cores(monkeypatch):
@@ -1192,6 +1412,7 @@ def test_emit_runner_source_accepts_physical_dfb_configs():
                 block_count=2,
                 page_size=32,
                 tile=(1, 16),
+                allocation_nodes=((0, 0),),
             )
         ],
         grid_cols=1,
@@ -1206,6 +1427,7 @@ def test_emit_runner_source_accepts_physical_dfb_configs():
     assert "block_count=2" in source
     assert "page_size=32" in source
     assert "tile=(1, 16)" in source
+    assert "allocation_nodes=((0, 0),)" in source
     assert "cb_descriptors = build_cb_descriptors(" in source
     assert "for i, (num_tiles, block_count" not in source
 

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -68,6 +68,13 @@ class _FakeCoreRanges:
         return _FakeBoundingBox()
 
 
+class _FakeExplicitCoreRanges:
+    def __init__(self, start, end):
+        self.ranges = (
+            _FakeTTNN.CoreRange(_FakeTTNN.CoreCoord(*start), _FakeTTNN.CoreCoord(*end)),
+        )
+
+
 class _FakeTTNN:
     def __init__(self):
         self.create_calls = []
@@ -513,6 +520,254 @@ def test_build_cb_descriptors_preserves_subtile_geometry(monkeypatch):
     assert descriptor.total_size == 1024
     assert format_descriptor.page_size == 512
     assert format_descriptor.tile.tile.tile_shape == (16, 16)
+
+
+def _descriptor_cores(descriptor):
+    ranges = descriptor.core_ranges.ranges
+    if callable(ranges):
+        ranges = ranges()
+    return {
+        (core_x, core_y)
+        for core_range in ranges
+        for core_y in range(core_range.start.y, core_range.end.y + 1)
+        for core_x in range(core_range.start.x, core_range.end.x + 1)
+    }
+
+
+def _specialized_spec(core_ranges, used_dfb_indices):
+    return kernel_runner.KernelSpec(
+        path="/tmp/specialized.cpp",
+        thread_type="compute",
+        tensor_indices=[],
+        config=object(),
+        core_ranges=core_ranges,
+        used_dfb_indices=used_dfb_indices,
+    )
+
+
+def test_specialized_dfb_descriptor_follows_active_kernel_core(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    active = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    inactive = _FakeExplicitCoreRanges((1, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[PhysicalDFBConfig(0, 1, "bfloat16", 1, 2048, (32, 32))],
+        core_ranges=full_grid,
+        kernel_specs=[
+            _specialized_spec(active, [0]),
+            _specialized_spec(inactive, []),
+        ],
+    )
+
+    assert len(descriptors) == 1
+    assert _descriptor_cores(descriptors[0]) == {(0, 0)}
+
+
+def test_unannotated_kernel_keeps_whole_grid_dfb_descriptor(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[PhysicalDFBConfig(0, 1, "bfloat16", 1, 2048, (32, 32))],
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    assert len(descriptors) == 1
+    assert descriptors[0].core_ranges is full_grid
+
+
+def test_unannotated_kernel_is_conservative_with_annotated_peer(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    core_0 = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    core_1 = _FakeExplicitCoreRanges((1, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[PhysicalDFBConfig(0, 1, "bfloat16", 1, 2048, (32, 32))],
+        core_ranges=full_grid,
+        kernel_specs=[
+            _specialized_spec(core_0, []),
+            _specialized_spec(core_1, None),
+        ],
+    )
+
+    assert len(descriptors) == 1
+    assert _descriptor_cores(descriptors[0]) == {(1, 0)}
+
+
+def test_specialized_dfb_descriptors_allow_sparse_physical_indices(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    configs = [
+        PhysicalDFBConfig(index, 1, "bfloat16", 1, 2048, (32, 32)) for index in range(3)
+    ]
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=configs,
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, [2])],
+    )
+
+    assert [
+        descriptor.format_descriptors[0].buffer_index for descriptor in descriptors
+    ] == [2]
+
+
+def test_specialized_dfb_budget_is_computed_per_core(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(kernel_runner, "DEFAULT_L1_CB_BUDGET_BYTES", 2048)
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    core_0 = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    core_1 = _FakeExplicitCoreRanges((1, 0), (1, 0))
+    configs = [
+        PhysicalDFBConfig(index, 1, "bfloat16", 1, 2048, (32, 32)) for index in range(2)
+    ]
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=configs,
+        core_ranges=full_grid,
+        kernel_specs=[
+            _specialized_spec(core_0, [0]),
+            _specialized_spec(core_1, [1]),
+        ],
+    )
+
+    assert len(descriptors) == 2
+    assert {_descriptor_cores(descriptor).pop() for descriptor in descriptors} == {
+        (0, 0),
+        (1, 0),
+    }
+
+
+def test_specialized_dfb_budget_uses_each_cores_remaining_l1(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(
+        kernel_runner,
+        "_get_remaining_l1_by_core_for_device",
+        lambda _device, _cores: {(0, 0): 2048, (1, 0): 1024},
+    )
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    core_0 = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    core_1 = _FakeExplicitCoreRanges((1, 0), (1, 0))
+
+    with pytest.raises(
+        ValueError,
+        match=r"core \(1, 0\).*2048 bytes.*L1 budget \(1024 bytes\)",
+    ):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensor(object())],
+            cb_configs=[
+                PhysicalDFBConfig(index, 1, "bfloat16", 1, 2048, (32, 32))
+                for index in range(2)
+            ],
+            core_ranges=full_grid,
+            kernel_specs=[
+                _specialized_spec(core_0, [0]),
+                _specialized_spec(core_1, [1]),
+            ],
+        )
+
+
+def test_computed_address_backing_uses_specialized_dfb_cores(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    allocations = []
+    monkeypatch.setattr(
+        kernel_runner,
+        "_allocate_l1_sharded_storage_tensor",
+        lambda ranges, size, device: allocations.append((ranges, size, device))
+        or object(),
+    )
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    core_0 = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    core_1 = _FakeExplicitCoreRanges((1, 0), (1, 0))
+    device = object()
+
+    kernel_runner.build_pipe_computed_address_dfb_tensors(
+        tensors=[],
+        cb_configs=[PhysicalDFBConfig(0, 1, "bfloat16", 1, 2048, (32, 32))],
+        core_ranges=full_grid,
+        pipe_computed_address_dfb_indices=[0],
+        device=device,
+        kernel_specs=[
+            _specialized_spec(core_0, [0]),
+            _specialized_spec(core_1, []),
+        ],
+    )
+
+    assert len(allocations) == 1
+    allocated_ranges, allocated_bytes, allocated_device = allocations[0]
+    assert _descriptor_cores(
+        type("Allocation", (), {"core_ranges": allocated_ranges})()
+    ) == {(0, 0)}
+    assert allocated_bytes == 2048
+    assert allocated_device is device
+
+
+def test_l1_sharded_storage_counts_sparse_cores(monkeypatch):
+    fake_ttnn = _FakeTTNN()
+    fake_ttnn.ShardSpec = lambda *args: args
+    fake_ttnn.MemoryConfig = lambda *args: args
+    fake_ttnn.ShardOrientation = type("ShardOrientation", (), {"ROW_MAJOR": object()})
+    fake_ttnn.TensorMemoryLayout = type(
+        "TensorMemoryLayout", (), {"HEIGHT_SHARDED": object()}
+    )
+    fake_ttnn.BufferType = type("BufferType", (), {"L1": object()})
+    fake_ttnn.float32 = object()
+    fake_ttnn.ROW_MAJOR_LAYOUT = object()
+    empty_calls = []
+    fake_ttnn.empty = (
+        lambda tensor_shape, **kwargs: empty_calls.append((tensor_shape, kwargs))
+        or object()
+    )
+    monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
+    sparse_ranges = _FakeTTNN.CoreRangeSet(
+        (
+            _FakeTTNN.CoreRange(_FakeTTNN.CoreCoord(0, 0), _FakeTTNN.CoreCoord(0, 0)),
+            _FakeTTNN.CoreRange(_FakeTTNN.CoreCoord(2, 0), _FakeTTNN.CoreCoord(2, 0)),
+        )
+    )
+
+    kernel_runner._allocate_l1_sharded_storage_tensor(
+        sparse_ranges, num_bytes=2048, device=object()
+    )
+
+    assert empty_calls[0][0] == (2, 512)
+
+
+def test_specialized_dfb_use_intersects_storage_segments(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+    active = _FakeExplicitCoreRanges((0, 0), (0, 0))
+    inactive = _FakeExplicitCoreRanges((1, 0), (1, 0))
+    config = PhysicalDFBConfig(
+        0,
+        1,
+        "bfloat16",
+        1,
+        2048,
+        (32, 32),
+        (DFBStorageSegment(nodes=((0, 0), (1, 0))),),
+    )
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[config],
+        core_ranges=full_grid,
+        kernel_specs=[
+            _specialized_spec(active, [0]),
+            _specialized_spec(inactive, []),
+        ],
+    )
+
+    assert len(descriptors) == 1
+    assert _descriptor_cores(descriptors[0]) == {(0, 0)}
 
 
 def test_build_cb_descriptors_binds_tensor_on_exact_nodes(monkeypatch):
@@ -1087,6 +1342,31 @@ def test_emit_runner_source_omits_program_hash_by_default():
     )
 
     assert "PROGRAM_HASH = None" in source
+
+
+def test_emit_runner_source_preserves_specialized_dfb_use(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    source = kernel_runner.emit_runner_source(
+        kernel_specs=[
+            kernel_runner.KernelSpec(
+                path="/tmp/sparse.cpp",
+                thread_type="compute",
+                tensor_indices=[],
+                config=object(),
+                used_dfb_indices=[2],
+            )
+        ],
+        cb_configs=[],
+        grid_cols=1,
+        grid_rows=1,
+        num_tensors=1,
+    )
+
+    assert "KERNEL_USED_DFB_INDICES = [" in source
+    assert "    [2],  # compute" in source
+    assert "used_dfb_indices=KERNEL_USED_DFB_INDICES[kernel_idx]" in source
+    assert "kernel_specs=kernel_specs" in source
+    compile(source, "<emitted-runner>", "exec")
 
 
 def test_emit_runner_source_preserves_positional_options():

--- a/test/python/test_specialize_cores.py
+++ b/test/python/test_specialize_cores.py
@@ -43,7 +43,7 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 import torch
 
 import ttl
-from ttlang_test_utils import assert_pcc, to_dram
+from ttlang_test_utils import assert_pcc, to_dram, to_l1
 
 TILE_SIZE = 32
 
@@ -201,6 +201,90 @@ def _make_branch_swap_op():
 
 branch_swap_default = _make_branch_swap_op()
 branch_swap_specialized = _make_branch_swap_op()
+
+
+def _make_core_local_dfb_op():
+    @ttl.operation(grid=(2, 1))
+    def core_local_dfb(input_tensor, output_tensor):
+        left_input = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, 1), block_count=2
+        )
+        left_output = ttl.make_dataflow_buffer_like(
+            output_tensor, shape=(1, 1), block_count=2
+        )
+        right_input = ttl.make_dataflow_buffer_like(
+            input_tensor, shape=(1, 1), block_count=2
+        )
+        right_output = ttl.make_dataflow_buffer_like(
+            output_tensor, shape=(1, 1), block_count=2
+        )
+
+        @ttl.compute()
+        def compute_fn():
+            node_x, _node_y = ttl.node(dims=2)
+            if node_x == 0:
+                with (
+                    left_input.wait() as input_block,
+                    left_output.reserve() as output_block,
+                ):
+                    output_block.store(input_block)
+            else:
+                with (
+                    right_input.wait() as input_block,
+                    right_output.reserve() as output_block,
+                ):
+                    output_block.store(input_block)
+
+        @ttl.datamovement()
+        def dm_read():
+            node_x, _node_y = ttl.node(dims=2)
+            if node_x == 0:
+                with left_input.reserve() as input_block:
+                    ttl.copy(input_tensor[0, 0], input_block).wait()
+            else:
+                with right_input.reserve() as input_block:
+                    ttl.copy(input_tensor[0, 1], input_block).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            node_x, _node_y = ttl.node(dims=2)
+            if node_x == 0:
+                with left_output.wait() as output_block:
+                    ttl.copy(output_block, output_tensor[0, 0]).wait()
+            else:
+                with right_output.wait() as output_block:
+                    ttl.copy(output_block, output_tensor[0, 1]).wait()
+
+    return core_local_dfb
+
+
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_specialize_cores_scopes_dfb_descriptors(
+    device, memory_config, to_device, dtype
+):
+    """Each specialized core receives only the DFBs used by its kernels."""
+    element_indices = torch.arange(32 * 64, dtype=torch.float32).reshape(32, 64)
+    input_host = ((element_indices.remainder(127) - 63) / 32).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    _make_core_local_dfb_op()(
+        input_tensor,
+        output_tensor,
+        options="--ttl-specialize-cores --no-ttl-reuse-user-dfbs",
+    )
+
+    threshold = 0.999 if dtype == torch.bfloat16 else 0.999999
+    assert_pcc(
+        input_host.float(),
+        ttnn.to_torch(output_tensor).float(),
+        threshold=threshold,
+    )
 
 
 def _make_swap_inputs(device):

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -4,6 +4,8 @@
 
 """Runtime coverage for physical reuse of user-declared DFBs."""
 
+import re
+
 import pytest
 import torch
 
@@ -128,12 +130,53 @@ def _make_capacity_test_atom_kernel(data_format):
     return capacity_test_atom_kernel
 
 
+def _make_node_scoped_allocation_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(2, 1))
+    def node_scoped_allocation_kernel(input_tensor, output_tensor):
+        input_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        first_node_scratch_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        output_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            node_x, _ = ttl.node(dims=2)
+            with input_dfb.wait() as input_block:
+                with output_dfb.reserve() as output_block:
+                    if node_x == 0:
+                        with first_node_scratch_dfb.reserve() as scratch_output:
+                            scratch_output.store(input_block)
+                        with first_node_scratch_dfb.wait() as scratch_input:
+                            output_block.store(scratch_input)
+                    else:
+                        output_block.store(input_block)
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            node_x, _ = ttl.node(dims=2)
+            with input_dfb.reserve() as input_block:
+                ttl.copy(input_tensor[0, node_x], input_block).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            node_x, _ = ttl.node(dims=2)
+            with output_dfb.wait() as output_block:
+                ttl.copy(output_block, output_tensor[0, node_x]).wait()
+
+    return node_scoped_allocation_kernel
+
+
 _repeated_bf16_atom_kernel = _make_repeated_dfb_atom_kernel("bf16")
 _repeated_f32_atom_kernel = _make_repeated_dfb_atom_kernel("float32")
 _in_place_bf16_atom_kernel = _make_in_place_atom_kernel("bf16")
 _in_place_f32_atom_kernel = _make_in_place_atom_kernel("float32")
 _capacity_test_bf16_atom_kernel = _make_capacity_test_atom_kernel("bf16")
 _capacity_test_f32_atom_kernel = _make_capacity_test_atom_kernel("float32")
+_node_scoped_bf16_allocation_kernel = _make_node_scoped_allocation_kernel("bf16")
+_node_scoped_f32_allocation_kernel = _make_node_scoped_allocation_kernel("float32")
 
 assert CAPACITY_TEST_LOGICAL_DFBS == 33
 
@@ -482,3 +525,41 @@ def test_mixed_capacity_dfb_atoms_runtime(device, memory_config, to_device):
         expected = torch.exp(intermediate.float()).to(torch.bfloat16).float()
         actual = ttnn.to_torch(output_tensor).float()
         assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_node_scoped_bf16_allocation_kernel, torch.bfloat16),
+        (_node_scoped_f32_allocation_kernel, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    ("memory_config", "to_device"),
+    [("dram", to_dram), ("l1", to_l1)],
+    ids=["dram", "l1"],
+)
+def test_node_scoped_dfb_allocation_without_kernel_specialization(
+    device, operation, dtype, memory_config, to_device, monkeypatch, tmp_path
+):
+    element_indices = torch.arange(2 * TILE * TILE, dtype=torch.float32).reshape(
+        TILE, 2 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    final_mlir_file = tmp_path / "node_scoped_allocation.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_file))
+    operation(input_tensor, output_tensor, options="--no-ttl-specialize-cores")
+
+    final_mlir = final_mlir_file.read_text()
+    assert re.search(r"\{allocation_nodes = \[\[0, 0\]\], block_count", final_mlir)
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)

--- a/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use.mlir
@@ -1,0 +1,39 @@
+// Verifies direct, transitive, and conservative DFB-use annotations.
+// RUN: ttlang-opt %s -ttkernel-annotate-dfb-use | FileCheck %s
+
+// CHECK-LABEL: func.func private @unknown()
+// CHECK-SAME: ttl.used_dfb_indices = array<i32>
+
+// CHECK-LABEL: func.func @helper()
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 1, 2>
+
+// CHECK-LABEL: func.func @calls_helper()
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 1, 2>
+
+// CHECK-LABEL: func.func @calls_unknown()
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 0, 1>
+
+module {
+  func.func private @unknown()
+
+  func.func @helper() attributes {ttl.base_cta_index = 3 : i32} {
+    %scalar_dfb_id = ttkernel.get_compile_time_arg_val(1) : () -> i32
+    %dfb = ttkernel.get_compile_time_arg_val(2)
+        : () -> !ttkernel.cb<3, !ttcore.tile<32x32, bf16>>
+    %pages = arith.constant 1 : i32
+    %effective_pages = arith.addi %scalar_dfb_id, %pages : i32
+    ttkernel.cb_wait_front(%dfb, %effective_pages)
+        : (!ttkernel.cb<3, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    return
+  }
+
+  func.func @calls_helper() attributes {ttl.base_cta_index = 3 : i32} {
+    func.call @helper() : () -> ()
+    return
+  }
+
+  func.func @calls_unknown() attributes {ttl.base_cta_index = 2 : i32} {
+    func.call @unknown() : () -> ()
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_dfb_use_elision.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_dfb_use_elision.mlir
@@ -1,0 +1,38 @@
+// Verifies that DFB-use metadata reflects specialized branch elimination.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-cores,canonicalize,cse,ttkernel-annotate-dfb-use)' | FileCheck %s
+
+// Core (0, 0) retains the DFB use. Core (0, 1) has the complete
+// DFB-dependent branch removed before annotation.
+
+// CHECK-NOT: func.func @conditional_dfb_user()
+// CHECK-LABEL: func.func @conditional_dfb_user_c0_0
+// CHECK-SAME: ttl.core_coord = {{\[\[}}0, 0]]
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 0>
+// CHECK: ttkernel.get_compile_time_arg_val(0)
+// CHECK: ttkernel.cb_wait_front
+// CHECK-NOT: scf.if
+// CHECK-LABEL: func.func @conditional_dfb_user_c0_1
+// CHECK-SAME: ttl.core_coord = {{\[\[}}0, 1]]
+// CHECK-SAME: ttl.used_dfb_indices = array<i32>
+// CHECK-NOT: ttkernel.get_compile_time_arg_val
+// CHECK-NOT: ttkernel.cb_wait_front
+// CHECK-NOT: scf.if
+// CHECK: return
+
+module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
+  func.func @conditional_dfb_user() attributes {
+      ttl.base_cta_index = 1 : i32,
+      ttkernel.thread = #ttkernel.thread<noc>} {
+    %c0 = arith.constant 0 : index
+    %pages = arith.constant 3 : i32
+    %node_y = "ttkernel.my_logical_y_"() : () -> index
+    %is_active = arith.cmpi eq, %node_y, %c0 : index
+    scf.if %is_active {
+      %dfb = ttkernel.get_compile_time_arg_val(0)
+          : () -> !ttkernel.cb<3, !ttcore.tile<32x32, bf16>>
+      ttkernel.cb_wait_front(%dfb, %pages)
+          : (!ttkernel.cb<3, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    }
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_nodes.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_nodes.mlir
@@ -1,0 +1,71 @@
+// Verifies finalized DFB residency metadata independently from kernel specialization.
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s
+
+// The first DFB is accessed only on core (0, 0), the second is unreachable on
+// the launch grid, and the third has a runtime-dependent domain. Exact domains
+// are serialized, including the empty domain; the unresolved domain omits
+// allocation_nodes so the runtime remains conservative.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {allocation_nodes = [], block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {block_count = 2 : i32, dfb_index = 2 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}], ttl.launch_grid = array<i64: 2, 1>}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @allocation_nodes(%runtime_offset: index)
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %first_node = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %unreachable = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %runtime_dependent = ttl.bind_cb {cb_index = 2, block_count = 2}
+        {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %two = arith.constant 2 : index
+    %on_first_node = arith.cmpi eq, %core_x, %zero : index
+    %outside_grid = arith.cmpi eq, %core_x, %two : index
+    %runtime_sum = arith.addi %core_x, %runtime_offset : index
+    %runtime_condition = arith.cmpi eq, %runtime_sum, %zero : index
+
+    scf.if %on_first_node {
+      ttl.opaque_call "first_node_access" (%first_node)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %outside_grid {
+      ttl.opaque_call "unreachable_access" (%unreachable)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    scf.if %runtime_condition {
+      ttl.opaque_call "runtime_access" (%runtime_dependent)
+          {header = "effects.hpp"}
+          : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// Without a launch grid, the liveness proof uses one representative node but
+// runtime residency remains unknown and therefore omits allocation_nodes.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}]}
+
+module {
+  func.func @unknown_runtime_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    ttl.opaque_call "access" (%dfb)
+        {header = "effects.hpp"}
+        : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/tensor_backing.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/tensor_backing.mlir
@@ -3,7 +3,7 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=false})' | FileCheck %s --check-prefixes=COMMON,DISTINCT
 // RUN: ttlang-opt %s --split-input-file --ttl-validate-cb-budget='l1-budget-override=1' -o /dev/null
 
-// COMMON: module attributes {ttl.dfb_allocations = [{block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32, storage_segments = [{nodes = {{\[\[0, 0\], \[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 2048>}]}], ttl.launch_grid = array<i64: 2, 1>}
+// COMMON: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\], \[1, 0\]\]}}, block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32, storage_segments = [{nodes = {{\[\[0, 0\], \[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 2048>}]}], ttl.launch_grid = array<i64: 2, 1>}
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   // COMMON-LABEL: func.func @publish_input
   func.func @publish_input()
@@ -21,12 +21,12 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 // DFBs with different tensor backing may share one hardware index when their
 // exact launch-node domains are disjoint.
 
-// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}, {nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
+// REUSE: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[0, 0\], \[1, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}, {nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
 // REUSE-LABEL: func.func @per_node_backing
 // REUSE: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {{.*}}tensor_index = 0
 // REUSE: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {{.*}}tensor_index = 1
 
-// DISTINCT: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}, {block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
+// DISTINCT: module attributes {ttl.dfb_allocations = [{allocation_nodes = {{\[\[1, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[1, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 64>}]}, {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32, storage_segments = [{nodes = {{\[\[0, 0\]\]}}, tensor_backing = #ttl.tensor_backing<tensor_index = 1, byte_offset = 0, byte_size = 64>}]}], ttl.launch_grid = array<i64: 2, 1>}
 // DISTINCT-LABEL: func.func @per_node_backing
 // DISTINCT: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {{.*}}tensor_index = 0
 // DISTINCT: %[[SECOND:.*]] = ttl.bind_cb{cb_index = 1, block_count = 2} {{.*}}tensor_index = 1

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_after_finalize.mlir
@@ -7,7 +7,7 @@
 // DFBs cannot retain the same provisional physical index.
 
 // CHECK: module attributes {ttl.dfb_allocations = [
-// CHECK-SAME: {block_count = 2 : i32, dfb_index = 0 : i32,
+// CHECK-SAME: {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 2 : i32, dfb_index = 0 : i32,
 // CHECK-LABEL: func.func @producer_a
 // CHECK-SAME: ttl.base_cta_index = 2 : i32
 // CHECK: %[[FIRST:.*]] = ttl.bind_cb{cb_index = 0, {{.*}} {dfb_id = 0 : index}


### PR DESCRIPTION
### Problem description
DFB descriptors are allocated across the full launch grid when kernel specialization is disabled, even when accesses are node-scoped.

### What changed
Preserve finalized launch-node allocation domains and use them when building runtime DFB descriptors.

### Testing
- BF16/FP32 device tests on DRAM and L1
- 92 focused runtime tests
- 316 MLIR tests
- pre-commit