### PR TITLE
[TTL] Allow external DFB protocol overrides

### DIFF
--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -85,7 +85,7 @@ They are independent of the code generation flags above.
 | `TTLANG_DEBUG_LOCATIONS` | `0`/`1` | `0` | Include source locations in printed MLIR (locations are always tracked internally for error messages). |
 | `TTLANG_VERBOSE_ERRORS` | `0`/`1` | `0` | Include raw MLIR diagnostics in error output. |
 | `TTLANG_SIM_ONLY` | `0`/`1` | `0` | Force `import ttl` to skip loading the compiled MLIR extension. Used when running the simulator from a source tree without an installed `tt-lang-sim` wheel (which ships the same signal as a marker module). |
-| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Disable DFB producer and consumer launch-domain verification when external synchronization supplies the ownership proof. Finalized DFB identity, physical-index, and launch-grid checks remain enabled. |
+| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Disable DFB producer/consumer and wait/producer launch-domain verification when external synchronization supplies the ownership proof. Finalized DFB preconditions, PipeNet endpoint guards, transfer correspondence, and synchronization schedules remain enabled. |
 
 Profiling-related environment variables (`TTLANG_AUTO_PROFILE`,
 `TTLANG_PERF_DUMP`, `TTLANG_PERF_SERV`, `TTLANG_SIGNPOST_PROFILE`,

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -85,6 +85,7 @@ They are independent of the code generation flags above.
 | `TTLANG_DEBUG_LOCATIONS` | `0`/`1` | `0` | Include source locations in printed MLIR (locations are always tracked internally for error messages). |
 | `TTLANG_VERBOSE_ERRORS` | `0`/`1` | `0` | Include raw MLIR diagnostics in error output. |
 | `TTLANG_SIM_ONLY` | `0`/`1` | `0` | Force `import ttl` to skip loading the compiled MLIR extension. Used when running the simulator from a source tree without an installed `tt-lang-sim` wheel (which ships the same signal as a marker module). |
+| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Disable DFB producer and consumer launch-domain verification when external synchronization supplies the ownership proof. Finalized DFB identity, physical-index, and launch-grid checks remain enabled. |
 
 Profiling-related environment variables (`TTLANG_AUTO_PROFILE`,
 `TTLANG_PERF_DUMP`, `TTLANG_PERF_SERV`, `TTLANG_SIGNPOST_PROFILE`,

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -741,6 +741,10 @@ def TTLVerifyPipeNetGuards
     module-wide logical `dfb_id`; compiler-created DFBs receive analysis-only
     logical IDs until physical index finalization. DFB lifecycle operands used
     by the guard analysis must resolve to `ttl.bind_cb` declarations.
+
+    When `TTL_RELAX_DFB_SPSC` is set, external synchronization supplies the
+    wait-versus-producer domain proof. PipeNet endpoint guards, transfer
+    correspondence, and synchronization schedules remain mandatory.
   }];
 }
 

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -837,6 +837,12 @@ def TTLVerifyDFBSPSC
     `ttl-finalize-dfb-indices`, and every DFB declaration and lifecycle operand
     must resolve to a `ttl.bind_cb` with `dfb_id`. Modules with DFB acquire ops
     must also carry a valid `ttl.launch_grid` attribute.
+
+    Setting `TTL_RELAX_DFB_SPSC` disables producer and consumer launch-domain
+    analysis for externally synchronized programs whose ownership contract is
+    not represented in the IR. Finalized DFB identity, physical-index, and
+    launch-grid preconditions remain mandatory. Strict verification is the
+    default.
   }];
 
   let dependentDialects = [];

--- a/lib/Dialect/TTL/Transforms/DFBVerification.h
+++ b/lib/Dialect/TTL/Transforms/DFBVerification.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_LIB_DIALECT_TTL_TRANSFORMS_DFBVERIFICATION_H
+#define TTLANG_LIB_DIALECT_TTL_TRANSFORMS_DFBVERIFICATION_H
+
+#include <cstdlib>
+
+namespace mlir::tt::ttl {
+
+inline bool isDFBProtocolDomainVerificationRelaxed() {
+  return std::getenv("TTL_RELAX_DFB_SPSC") != nullptr;
+}
+
+} // namespace mlir::tt::ttl
+
+#endif // TTLANG_LIB_DIALECT_TTL_TRANSFORMS_DFBVERIFICATION_H

--- a/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
@@ -22,6 +22,8 @@
 #include "ttlang/Dialect/TTL/Passes.h"
 #include "ttlang/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.h"
 
+#include "DFBVerification.h"
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
@@ -232,6 +234,10 @@ struct TTLVerifyDFBSPSCPass
              "attribute (an i64 array of length 2 with positive entries) "
              "when verifying DFB acquire ops";
       signalPassFailure();
+      return;
+    }
+
+    if (isDFBProtocolDomainVerificationRelaxed()) {
       return;
     }
 

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -11,6 +11,8 @@
 // wait-for cycles in execution order.
 //===----------------------------------------------------------------------===//
 
+#include "DFBVerification.h"
+
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -2115,7 +2117,9 @@ struct TTLVerifyPipeNetGuardsPass
       }
     });
 
-    verifyCBWaits(state);
+    if (!isDFBProtocolDomainVerificationRelaxed()) {
+      verifyCBWaits(state);
+    }
     if (state.sawError) {
       signalPassFailure();
       return;

--- a/test/python/invalid/invalid_dfb_spsc_overlap.py
+++ b/test/python/invalid/invalid_dfb_spsc_overlap.py
@@ -4,12 +4,14 @@
 
 # REQUIRES: ttnn, tt-device
 # RUN: env TTLANG_COMPILE_ONLY=1 not %python %s 2>&1 | FileCheck %s
+# RUN: env TTLANG_COMPILE_ONLY=1 TTL_RELAX_DFB_SPSC=1 %python %s
 
 """Compile-only coverage for DFB SPSC rejection in frontend-generated IR.
 
 The program creates one DFB consumed by both a compute thread and a data
 movement thread over the full launch grid. The verifier must reject the shared
-DFB because the consumer launch-node domains overlap.
+DFB in strict mode because the consumer launch-node domains overlap. The
+relaxed RUN verifies the explicit external synchronization override.
 """
 
 # CHECK: logical DFB 0 has multiple consumer kernels active on the same launched node

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_preconditions_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_preconditions_invalid.mlir
@@ -1,6 +1,7 @@
-// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-dfb-spsc
+// Summary: Negative tests for finalized DFB verifier preconditions.
 
-// Summary: Negative tests for finalized DFB identity preconditions.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-dfb-spsc
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-dfb-spsc
 
 // SPSC verification requires the allocation metadata emitted by DFB
 // finalization, even when the frontend already assigned a logical ID.
@@ -31,6 +32,43 @@ module attributes {
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-error @below {{`ttl-verify-dfb-spsc` requires every `ttl.bind_cb` to have `dfb_id` after finalization}}
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Relaxed domain verification still requires a launch grid.
+
+// expected-error @below {{ttl-verify-dfb-spsc requires a `ttl.launch_grid` module attribute}}
+module attributes {ttl.dfb_allocations = []} {
+  func.func @missing_launch_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Relaxed domain verification still requires a valid launch grid.
+
+// expected-error @below {{ttl-verify-dfb-spsc requires a `ttl.launch_grid` module attribute}}
+module attributes {
+  ttl.dfb_allocations = [],
+  ttl.launch_grid = [0 : i64, 1 : i64]
+} {
+  func.func @malformed_launch_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %block = ttl.cb_wait %dfb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_relaxed.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_relaxed.mlir
@@ -1,0 +1,55 @@
+// Summary: Verifies the explicit external DFB domain proof override.
+
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' -o /dev/null
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @consumer_all_nodes()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @consumer_x0()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %zero = arith.constant 0 : index
+    %is_x0 = arith.cmpi eq, %core_x, %zero : index
+    scf.if %is_x0 {
+      %block = ttl.cb_wait %dfb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    func.return
+  }
+
+  func.func @producer_all_nodes()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @producer_x1()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %core_x = ttl.core_x : index
+    %one = arith.constant 1 : index
+    %is_x1 = arith.cmpi eq, %core_x, %one : index
+    scf.if %is_x1 {
+      %block = ttl.cb_reserve %dfb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed.mlir
@@ -1,0 +1,17 @@
+// Summary: Verifies the external DFB domain override in PipeNet guard analysis.
+
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s -ttl-verify-pipenet-guards -o /dev/null
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @wait_without_represented_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %pipe = ttl.create_pipe src(0, 0) dst(0, 0) to(0, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(0, 0) to(0, 0) net 0>
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed_invalid.mlir
@@ -1,0 +1,21 @@
+// Summary: Verifies PipeNet endpoint checks remain enabled in relaxed mode.
+
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-pipenet-guards
+
+module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @unguarded_pipe_source()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-note @below {{PipeNet net_0 declared here}}
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{this `ttl.copy(buffer, pipe)` sends data on PipeNet net_0 from a node that is not a source}}
+    // expected-note @below {{example node where the guard does not hold: core_x=1, core_y=0}}
+    %send = ttl.copy %dfb, %pipe
+        : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>,
+           !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>)
+        -> !ttl.transfer_handle<write>
+    func.return
+  }
+}


### PR DESCRIPTION
### Problem description

Some externally synchronized programs cannot express their ownership protocol in launch-domain analysis.

### What's changed

Add an explicit verifier override while preserving standard validation.

### Checklist

- [x] New/Existing tests provide coverage
