### PR TITLE
[TTL] Resolve static external DFB effect counts

### DIFF
--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -209,7 +209,8 @@ The supported actions are `ttl.DFBEffect.reserve`, `push`, `wait`, and `pop`.
 `ttl.DFBEffect.repeat(count, effects)` repeats a literal ordered effect list a
 nonnegative, statically resolvable number of times. The frontend expands the
 repeat before creating IR, so downstream analyses receive the same flat effect
-sequence as an explicitly written list:
+sequence as an explicitly written list. The expanded `dfb_effects` sequence is
+limited to 4096 actions per external call:
 
 ```python
 dfb_effects=[

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -223,6 +223,11 @@ dfb_effects=[
 ]
 ```
 
+Tile and repeat counts may use integer literals, integer captures, and
+module-level integer variables combined with unary `+` or `-` and the binary
+operators `+`, `-`, `*`, `//`, and `%`. Booleans and runtime SSA values are not
+static integer counts. Floor-division and modulo divisors must be nonzero.
+
 Every listed action occurs on every execution of the call, and list order is
 execution order. Conditional actions must use TTL control flow around both the
 matching acquisition and a call with an unconditional summary, execute

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -36,6 +36,22 @@ from .global_semaphore import (
 from .tensor_registry import get_tensor_global_index, get_tensor_source
 
 
+_MAX_EXPANDED_EXTERNAL_DFB_EFFECTS = 4096
+
+
+def _accumulate_expanded_dfb_effect_count(
+    current_effect_count: int, repeated_effect_count: int, repeat_count: int
+) -> int:
+    if current_effect_count > _MAX_EXPANDED_EXTERNAL_DFB_EFFECTS:
+        return _MAX_EXPANDED_EXTERNAL_DFB_EFFECTS + 1
+    if repeat_count == 0:
+        return current_effect_count
+    remaining_effect_count = _MAX_EXPANDED_EXTERNAL_DFB_EFFECTS - current_effect_count
+    if repeated_effect_count > remaining_effect_count // repeat_count:
+        return _MAX_EXPANDED_EXTERNAL_DFB_EFFECTS + 1
+    return current_effect_count + repeated_effect_count * repeat_count
+
+
 @dataclass(frozen=True)
 class _ExternalTemplateArg:
     """Separate compile-time payloads from DFB values needed by allocation."""
@@ -51,6 +67,14 @@ class _ExternalDFBEffect:
     kind: object
     dfb: object
     num_tiles: int
+
+
+@dataclass(frozen=True)
+class _ExternalDFBEffectRepeat:
+    """One parsed repeat whose body has not been materialized."""
+
+    count: int
+    effects: tuple[object, ...]
 
 
 def _make_file_loc(ctx, source_file: str, node, line_offset: int = 0) -> Location:
@@ -1849,8 +1873,8 @@ class TTLGenericCompiler(TTCompilerBase):
         )
         return (is_qualified_owner or is_direct_owner) and node.func.attr == "repeat"
 
-    def _resolve_dfb_effect_sequence(self, node):
-        """Resolve and flatten a literal ordered DFB-effect sequence."""
+    def _parse_dfb_effect_sequence(self, node):
+        """Parse an ordered DFB-effect sequence without expanding repeats."""
         if not isinstance(node, ast.List):
             self._raise_error(
                 node,
@@ -1858,10 +1882,14 @@ class TTLGenericCompiler(TTCompilerBase):
                 "ttl.DFBEffect.repeat() effects must be lists",
             )
 
-        resolved_effects = []
+        parsed_effects = []
+        expanded_effect_count = 0
         for element in node.elts:
             if not self._is_dfb_effect_repeat(element):
-                resolved_effects.append(self._resolve_dfb_effect(element))
+                parsed_effects.append(self._resolve_dfb_effect(element))
+                expanded_effect_count = _accumulate_expanded_dfb_effect_count(
+                    expanded_effect_count, 1, 1
+                )
                 continue
 
             if len(element.args) != 2 or element.keywords:
@@ -1877,14 +1905,43 @@ class TTLGenericCompiler(TTCompilerBase):
                     element.args[0],
                     "ttl.DFBEffect.repeat() count must be nonnegative",
                 )
-            repeated_effects = self._resolve_dfb_effect_sequence(element.args[1])
-            if not repeated_effects:
+            repeated_effects, repeated_effect_count = self._parse_dfb_effect_sequence(
+                element.args[1]
+            )
+            if repeated_effect_count == 0:
                 self._raise_error(
                     element.args[1],
                     "ttl.DFBEffect.repeat() effects must not be empty",
                 )
-            resolved_effects.extend(repeated_effects * repeat_count)
+            parsed_effects.append(
+                _ExternalDFBEffectRepeat(repeat_count, repeated_effects)
+            )
+            expanded_effect_count = _accumulate_expanded_dfb_effect_count(
+                expanded_effect_count, repeated_effect_count, repeat_count
+            )
 
+        return tuple(parsed_effects), expanded_effect_count
+
+    def _append_dfb_effect_sequence(self, parsed_effects, resolved_effects):
+        for effect in parsed_effects:
+            if isinstance(effect, _ExternalDFBEffectRepeat):
+                for _repeat_index in range(effect.count):
+                    self._append_dfb_effect_sequence(effect.effects, resolved_effects)
+                continue
+            resolved_effects.append(effect)
+
+    def _resolve_dfb_effect_sequence(self, node):
+        """Resolve and flatten a literal ordered DFB-effect sequence."""
+        parsed_effects, expanded_effect_count = self._parse_dfb_effect_sequence(node)
+        if expanded_effect_count > _MAX_EXPANDED_EXTERNAL_DFB_EFFECTS:
+            self._raise_error(
+                node,
+                "ttl.call_extern_func() dfb_effects may contain at most "
+                f"{_MAX_EXPANDED_EXTERNAL_DFB_EFFECTS} expanded effects",
+            )
+
+        resolved_effects = []
+        self._append_dfb_effect_sequence(parsed_effects, resolved_effects)
         return resolved_effects
 
     def _visit_get_dfb_id(self, node):

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -1718,14 +1718,37 @@ class TTLGenericCompiler(TTCompilerBase):
 
     def _resolve_static_int(self, node, param_name):
         """Resolve a statically known Python integer without emitting SSA."""
-        literal = self._signed_int_literal(node)
-        if literal is not None:
-            return literal
+        if isinstance(node, ast.Constant) and type(node.value) is int:
+            return node.value
         if isinstance(node, ast.Name):
             for namespace in (self.captures, self.fn_globals):
-                value = namespace.get(node.id)
-                if type(value) is int:
-                    return value
+                if node.id in namespace:
+                    value = namespace[node.id]
+                    if type(value) is int:
+                        return value
+                    break
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            operand = self._resolve_static_int(node.operand, param_name)
+            return operand if isinstance(node.op, ast.UAdd) else -operand
+        if isinstance(node, ast.BinOp) and isinstance(
+            node.op, (ast.Add, ast.Sub, ast.Mult, ast.FloorDiv, ast.Mod)
+        ):
+            lhs = self._resolve_static_int(node.left, param_name)
+            rhs = self._resolve_static_int(node.right, param_name)
+            if isinstance(node.op, (ast.FloorDiv, ast.Mod)) and rhs == 0:
+                self._raise_error(
+                    node.right,
+                    f"ttl.call_extern_func() {param_name} divisor must be nonzero",
+                )
+            if isinstance(node.op, ast.Add):
+                return lhs + rhs
+            if isinstance(node.op, ast.Sub):
+                return lhs - rhs
+            if isinstance(node.op, ast.Mult):
+                return lhs * rhs
+            if isinstance(node.op, ast.FloorDiv):
+                return lhs // rhs
+            return lhs % rhs
         self._raise_error(
             node,
             f"ttl.call_extern_func() {param_name} must be a statically "

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -53,7 +53,13 @@ def call_extern_func(
 
 
 class DFBEffect:
-    """Ordered synchronous DFB actions performed by an external call."""
+    """Ordered synchronous DFB actions performed by an external call.
+
+    Tile and repeat counts accept static integer expressions over literals,
+    integer captures, and module globals using ``+``, ``-``, ``*``, ``//``,
+    and ``%``. Runtime values and booleans are invalid counts. Floor-division
+    and modulo divisors must be nonzero.
+    """
 
     @staticmethod
     def repeat(count: int, effects, /):

--- a/test/python/call_extern_func_dfb_effects.py
+++ b/test/python/call_extern_func_dfb_effects.py
@@ -22,6 +22,7 @@ import ttnn
 
 
 FAKE_HEADER = "/dev/null/fake_shim.hpp"
+EFFECT_TILES = 5
 reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
 
 
@@ -36,18 +37,18 @@ def make_external_stage(transaction_count):
             dfb_dependencies=[destination],
             dfb_effects=[
                 ttl.DFBEffect.repeat(
-                    transaction_count,
+                    -(-transaction_count),
                     [
-                        ttl.DFBEffect.wait(source, tiles=2),
-                        ttl.DFBEffect.pop(source, tiles=2),
+                        ttl.DFBEffect.wait(source, tiles=(EFFECT_TILES + 1) // 3),
+                        ttl.DFBEffect.pop(source, tiles=EFFECT_TILES - 3),
                     ],
                 ),
                 ttl.DFBEffect.repeat(
                     0,
                     [ttl.DFBEffect.wait(destination, tiles=99)],
                 ),
-                ttl.DFBEffect.reserve(destination, tiles=1),
-                ttl.DFBEffect.push(destination, tiles=1),
+                ttl.DFBEffect.reserve(destination, tiles=(EFFECT_TILES * 2) % 3),
+                ttl.DFBEffect.push(destination, tiles=+(EFFECT_TILES % 2)),
             ],
             unknown_dfb_access=True,
             kernel=reader,

--- a/test/python/invalid/call_extern_func_dfb_effect_repeat_invalid.py
+++ b/test/python/invalid/call_extern_func_dfb_effect_repeat_invalid.py
@@ -59,7 +59,7 @@ def make_invalid_repeated_effect(mode):
                 dfb_dependencies=[source],
                 dfb_effects=[
                     ttl.DFBEffect.repeat(
-                        node_x,
+                        node_x + 1,
                         [ttl.DFBEffect.wait(source, tiles=1)],
                     )
                 ],

--- a/test/python/invalid/call_extern_func_dfb_effect_repeat_invalid.py
+++ b/test/python/invalid/call_extern_func_dfb_effect_repeat_invalid.py
@@ -7,8 +7,10 @@
 # RUN: not env TTLANG_COMPILE_ONLY=1 %python %s dynamic 2>&1 | FileCheck %s --check-prefix=DYNAMIC
 # RUN: not env TTLANG_COMPILE_ONLY=1 %python %s empty 2>&1 | FileCheck %s --check-prefix=EMPTY
 # RUN: not env TTLANG_COMPILE_ONLY=1 %python %s expression 2>&1 | FileCheck %s --check-prefix=EXPRESSION
+# RUN: not env TTLANG_COMPILE_ONLY=1 %python %s limit 2>&1 | FileCheck %s --check-prefix=LIMIT
+# RUN: not env TTLANG_COMPILE_ONLY=1 %python %s nested_limit 2>&1 | FileCheck %s --check-prefix=NESTED-LIMIT
 
-"""Verify that repeated external DFB effects require a static nonempty list."""
+"""Verify repeated external DFB effect syntax and expansion limits."""
 
 import os
 import sys
@@ -97,6 +99,51 @@ def make_invalid_repeated_effect(mode):
                 kernel=ttl.KernelKind.DATA_MOVEMENT,
             )
 
+    elif mode == "limit":
+
+        @ttl.operation(grid=(1, 1))
+        def invalid_repeated_effect(input_tensor):
+            source = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, 1), block_count=2
+            )
+            ttl.call_extern_func(
+                FAKE_HEADER,
+                "repeated_effect",
+                dfb_dependencies=[source],
+                dfb_effects=[
+                    ttl.DFBEffect.repeat(
+                        4097,
+                        [ttl.DFBEffect.wait(source, tiles=1)],
+                    )
+                ],
+                kernel=ttl.KernelKind.DATA_MOVEMENT,
+            )
+
+    elif mode == "nested_limit":
+
+        @ttl.operation(grid=(1, 1))
+        def invalid_repeated_effect(input_tensor):
+            source = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, 1), block_count=2
+            )
+            ttl.call_extern_func(
+                FAKE_HEADER,
+                "repeated_effect",
+                dfb_dependencies=[source],
+                dfb_effects=[
+                    ttl.DFBEffect.repeat(
+                        65,
+                        [
+                            ttl.DFBEffect.repeat(
+                                64,
+                                [ttl.DFBEffect.wait(source, tiles=1)],
+                            )
+                        ],
+                    )
+                ],
+                kernel=ttl.KernelKind.DATA_MOVEMENT,
+            )
+
     else:
         raise ValueError(f"unsupported mode: {mode}")
 
@@ -110,6 +157,8 @@ invalid_repeated_effect = make_invalid_repeated_effect(MODE)
 # DYNAMIC: TTLangCompileError: error: ttl.call_extern_func() effect repeat count must be a statically resolvable integer
 # EMPTY: TTLangCompileError: error: ttl.DFBEffect.repeat() effects must not be empty
 # EXPRESSION: TTLangCompileError: error: ttl.call_extern_func() dfb_effects and ttl.DFBEffect.repeat() effects must be lists
+# LIMIT: TTLangCompileError: error: ttl.call_extern_func() dfb_effects may contain at most 4096 expanded effects
+# NESTED-LIMIT: TTLangCompileError: error: ttl.call_extern_func() dfb_effects may contain at most 4096 expanded effects
 
 
 if __name__ == "__main__":

--- a/test/python/invalid/call_extern_func_dfb_effect_static_int_invalid.py
+++ b/test/python/invalid/call_extern_func_dfb_effect_static_int_invalid.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify diagnostics for invalid external DFB effect integer expressions.
+# REQUIRES: ttnn
+# RUN: not env TTLANG_COMPILE_ONLY=1 %python %s boolean 2>&1 | FileCheck %s --check-prefix=BOOLEAN
+# RUN: not env TTLANG_COMPILE_ONLY=1 %python %s zero-divisor 2>&1 | FileCheck %s --check-prefix=ZERO-DIVISOR
+# RUN: not env TTLANG_COMPILE_ONLY=1 %python %s zero-modulo 2>&1 | FileCheck %s --check-prefix=ZERO-MODULO
+# RUN: not env TTLANG_COMPILE_ONLY=1 %python %s unsupported 2>&1 | FileCheck %s --check-prefix=OPERATOR
+
+import os
+import sys
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+
+FAKE_HEADER = "/dev/null/static_effect.hpp"
+MODE = sys.argv[1]
+
+
+def make_invalid_static_effect(mode):
+    if mode == "boolean":
+
+        @ttl.operation(grid=(1, 1))
+        def invalid_static_effect(input_tensor):
+            source = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, 1), block_count=2
+            )
+            ttl.call_extern_func(
+                FAKE_HEADER,
+                "static_effect",
+                dfb_dependencies=[source],
+                dfb_effects=[ttl.DFBEffect.wait(source, tiles=True)],
+                kernel=ttl.KernelKind.DATA_MOVEMENT,
+            )
+
+    elif mode == "zero-divisor":
+
+        @ttl.operation(grid=(1, 1))
+        def invalid_static_effect(input_tensor):
+            source = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, 1), block_count=2
+            )
+            ttl.call_extern_func(
+                FAKE_HEADER,
+                "static_effect",
+                dfb_dependencies=[source],
+                dfb_effects=[ttl.DFBEffect.wait(source, tiles=1 // 0)],
+                kernel=ttl.KernelKind.DATA_MOVEMENT,
+            )
+
+    elif mode == "zero-modulo":
+
+        @ttl.operation(grid=(1, 1))
+        def invalid_static_effect(input_tensor):
+            source = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, 1), block_count=2
+            )
+            ttl.call_extern_func(
+                FAKE_HEADER,
+                "static_effect",
+                dfb_dependencies=[source],
+                dfb_effects=[ttl.DFBEffect.wait(source, tiles=1 % 0)],
+                kernel=ttl.KernelKind.DATA_MOVEMENT,
+            )
+
+    elif mode == "unsupported":
+
+        @ttl.operation(grid=(1, 1))
+        def invalid_static_effect(input_tensor):
+            source = ttl.make_dataflow_buffer_like(
+                input_tensor, shape=(1, 1), block_count=2
+            )
+            ttl.call_extern_func(
+                FAKE_HEADER,
+                "static_effect",
+                dfb_dependencies=[source],
+                dfb_effects=[ttl.DFBEffect.wait(source, tiles=2**0)],
+                kernel=ttl.KernelKind.DATA_MOVEMENT,
+            )
+
+    else:
+        raise ValueError(f"unsupported mode: {mode}")
+
+    return invalid_static_effect
+
+
+invalid_static_effect = make_invalid_static_effect(MODE)
+
+
+# BOOLEAN: TTLangCompileError: error: ttl.call_extern_func() effect tiles must be a statically resolvable integer
+# ZERO-DIVISOR: TTLangCompileError: error: ttl.call_extern_func() effect tiles divisor must be nonzero
+# ZERO-MODULO: TTLangCompileError: error: ttl.call_extern_func() effect tiles divisor must be nonzero
+# OPERATOR: TTLangCompileError: error: ttl.call_extern_func() effect tiles must be a statically resolvable integer
+
+
+if __name__ == "__main__":
+    input_tensor = ttnn.from_torch(
+        torch.zeros((32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    invalid_static_effect(input_tensor)

--- a/test/python/test_external_dfb_effects.py
+++ b/test/python/test_external_dfb_effects.py
@@ -48,7 +48,7 @@ def external_effect_operation(lhs, rhs, result):
             ttl.DFBEffect.repeat(
                 1,
                 [
-                    ttl.DFBEffect.reserve(result_dfb, tiles=1),
+                    ttl.DFBEffect.reserve(result_dfb, tiles=TILE // TILE),
                     ttl.DFBEffect.wait(lhs_dfb, tiles=1),
                     ttl.DFBEffect.wait(rhs_dfb, tiles=1),
                     ttl.DFBEffect.pop(lhs_dfb, tiles=1),


### PR DESCRIPTION
### Problem description

External DFB effect counts cannot use static arithmetic expressions.

### What's changed

Resolve supported integer expressions, bound expanded repeated effects, and report invalid counts directly.

### Checklist

- [x] New/Existing tests provide coverage