### PR TITLE
[TTL] Pack static DFB descriptors within L1

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -151,11 +151,15 @@ conservatively and reports the best candidate's overflow; this does not prove
 that every possible order exceeds L1.
 
 The runtime computes static DFB bytes independently for every selected core and
-compares them with that core's remaining L1. Tensor-backed and already
-allocated computed-address storage are excluded from the static sum. The
-correctness invariant is that every surviving DFB access has one compatible
-descriptor on its launch core; conservative metadata preserves the
-whole-program descriptor behavior when this cannot be proved.
+compares them with that core's remaining L1 interval. Static descriptors grow
+from the configured DFB allocator base, while tensor allocations grow from
+higher addresses. The lowest live L1 tensor page therefore bounds the interval;
+subtracting only allocated page sizes would ignore allocator gaps and could
+overestimate the available range. Tensor-backed and already allocated
+computed-address storage are excluded from the static sum. The correctness
+invariant is that every surviving DFB access has one compatible descriptor on
+its launch core; conservative metadata preserves the whole-program descriptor
+behavior when this cannot be proved.
 
 `ttl-verify-dfb-spsc` must run after `ttl-finalize-dfb-indices` so every
 `bind_cb` carries its final `cb_index` and module-wide logical `dfb_id`. The

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -156,10 +156,13 @@ from the configured DFB allocator base, while tensor allocations grow from
 higher addresses. The lowest live L1 tensor page therefore bounds the interval;
 subtracting only allocated page sizes would ignore allocator gaps and could
 overestimate the available range. Tensor-backed and already allocated
-computed-address storage are excluded from the static sum. The correctness
-invariant is that every surviving DFB access has one compatible descriptor on
-its launch core; conservative metadata preserves the whole-program descriptor
-behavior when this cannot be proved.
+computed-address storage are excluded from the static sum. For a multi-device
+mesh, tensor and runtime-resource allocations use common L1 addresses, while
+harvested worker mappings can differ. The runtime therefore applies the
+reference allocator's global minimum remaining interval to every logical core.
+The correctness invariant is that every surviving DFB access has one compatible
+descriptor on its launch core; conservative metadata preserves the
+whole-program descriptor behavior when this cannot be proved.
 
 `ttl-verify-dfb-spsc` must run after `ttl-finalize-dfb-indices` so every
 `bind_cb` carries its final `cb_index` and module-wide logical `dfb_id`. The

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -134,12 +134,21 @@ access that physical index. A computed-address DFB with an empty effective
 domain retains one hidden backing shard because the PipeNet ABI still requires
 a receiver address, but no launch core installs its descriptor.
 
-Descriptor construction partitions launch nodes by their complete DFB storage
-signature. Every node in one partition receives the same ordered descriptor
-sequence; different partitions receive disjoint descriptors. This preserves
-TT-Metal's static allocation cursor invariant while allowing each partition to
-omit unused allocations. Sparse partitions allocate one tensor shard per
-selected core rather than the area of their bounding rectangle.
+Descriptor construction creates one descriptor for each physical DFB storage
+source and restricts it to the exact launch nodes using that source. Sparse
+domains allocate one tensor shard per selected core rather than the area of
+their bounding rectangle.
+
+TT-Metal allocates static descriptor storage in descriptor order. It maintains
+one allocation frontier per core, and a descriptor shared by several cores
+starts at the greatest frontier among those cores. The runtime simulates these
+frontiers with TT-Metal's address alignment and the remaining L1 on each core.
+It preserves the physical-index order when that order fits. Otherwise, it
+evaluates deterministic node-count orders and improving pairwise exchanges.
+Only an order whose simulated allocation fits every selected core is emitted.
+If the bounded candidate set finds no fitting order, program construction fails
+conservatively and reports the best candidate's overflow; this does not prove
+that every possible order exceeds L1.
 
 The runtime computes static DFB bytes independently for every selected core and
 compares them with that core's remaining L1. Tensor-backed and already

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -57,6 +57,27 @@ class _DFBAllocation:
     total_size: int
 
 
+@dataclass(frozen=True)
+class _DFBDescriptorPlan:
+    """Runtime descriptor plus the metadata needed to model static storage."""
+
+    descriptor: Any
+    physical_index: int
+    total_size: int
+    nodes: Tuple[Tuple[int, int], ...]
+    has_static_storage: bool
+
+
+@dataclass(frozen=True)
+class _StaticDFBPackingResult:
+    """Predicted TT-Metal placement for one static descriptor order."""
+
+    packed_bytes: int
+    maximum_overflow_bytes: int
+    overflow_core: Optional[Tuple[int, int]]
+    required_bytes_on_overflow_core: int
+
+
 def _validate_physical_dfb_config(
     config: PhysicalDFBConfig, physical_index: int
 ) -> None:
@@ -896,7 +917,165 @@ def _dfb_format_descriptor(dfb_index: int, allocation: _DFBAllocation) -> Any:
     )
 
 
-def _build_partitioned_dfb_descriptors(
+def _order_static_dfb_descriptor_plans(
+    descriptor_plans: List[_DFBDescriptorPlan],
+    remaining_bytes_by_core: Dict[Tuple[int, int], int],
+) -> List[_DFBDescriptorPlan]:
+    """Order static descriptors to fit TT-Metal's per-core L1 allocators."""
+    static_plan_indices = tuple(
+        plan_index
+        for plan_index, plan in enumerate(descriptor_plans)
+        if plan.has_static_storage
+    )
+    if not static_plan_indices:
+        return descriptor_plans
+
+    # ProgramDescriptor preserves the singleton CoreRanges produced by
+    # _make_node_core_ranges. TT-Metal keeps one frontier per core and assigns
+    # each descriptor the maximum frontier across its cores.
+    allocator_cores = tuple(
+        sorted(
+            {
+                node
+                for plan_index in static_plan_indices
+                for node in descriptor_plans[plan_index].nodes
+            }
+        )
+    )
+    allocator_index_by_core = {
+        node: allocator_index for allocator_index, node in enumerate(allocator_cores)
+    }
+    allocator_indices_by_plan = {
+        plan_index: tuple(
+            allocator_index_by_core[node] for node in descriptor_plans[plan_index].nodes
+        )
+        for plan_index in static_plan_indices
+    }
+    available_bytes_by_allocator = tuple(
+        remaining_bytes_by_core[node] for node in allocator_cores
+    )
+
+    address_alignment = int(ttnn.get_dram_alignment())
+    if address_alignment <= 0:
+        raise ValueError("TT-Metal reported an invalid DFB address alignment")
+
+    def evaluate_order(order: Tuple[int, ...]) -> _StaticDFBPackingResult:
+        allocator_frontiers = [0] * len(allocator_cores)
+        for plan_index in order:
+            plan = descriptor_plans[plan_index]
+            allocator_indices = allocator_indices_by_plan[plan_index]
+            address = _align_up(
+                max(allocator_frontiers[index] for index in allocator_indices),
+                address_alignment,
+            )
+            end_address = address + plan.total_size
+            for allocator_index in allocator_indices:
+                allocator_frontiers[allocator_index] = end_address
+
+        overflow_records = [
+            (
+                frontier - available_bytes,
+                frontier,
+                allocator_cores[allocator_index],
+            )
+            for allocator_index, (frontier, available_bytes) in enumerate(
+                zip(allocator_frontiers, available_bytes_by_allocator)
+            )
+        ]
+        maximum_overflow, required_bytes, overflow_core = max(
+            overflow_records, default=(0, 0, None)
+        )
+        maximum_overflow = max(0, maximum_overflow)
+        return _StaticDFBPackingResult(
+            packed_bytes=max(allocator_frontiers, default=0),
+            maximum_overflow_bytes=maximum_overflow,
+            overflow_core=overflow_core if maximum_overflow else None,
+            required_bytes_on_overflow_core=(required_bytes if maximum_overflow else 0),
+        )
+
+    def packing_score(result: _StaticDFBPackingResult) -> Tuple[int, int]:
+        return result.maximum_overflow_bytes, result.packed_bytes
+
+    current_order = static_plan_indices
+    current_result = evaluate_order(current_order)
+    if current_result.maximum_overflow_bytes == 0:
+        return descriptor_plans
+
+    candidate_orders = [
+        tuple(
+            sorted(
+                static_plan_indices,
+                key=lambda plan_index: (
+                    len(descriptor_plans[plan_index].nodes),
+                    descriptor_plans[plan_index].physical_index,
+                    plan_index,
+                ),
+            )
+        ),
+        tuple(
+            sorted(
+                static_plan_indices,
+                key=lambda plan_index: (
+                    -len(descriptor_plans[plan_index].nodes),
+                    descriptor_plans[plan_index].physical_index,
+                    plan_index,
+                ),
+            )
+        ),
+    ]
+    evaluated_candidates = [
+        (packing_score(current_result), current_order, current_result)
+    ]
+    for candidate_order in dict.fromkeys(candidate_orders):
+        candidate_result = evaluate_order(candidate_order)
+        evaluated_candidates.append(
+            (packing_score(candidate_result), candidate_order, candidate_result)
+        )
+    current_score, current_order, current_result = min(evaluated_candidates)
+
+    while current_score[0] > 0:
+        next_candidate = None
+        for first_position in range(len(current_order)):
+            for second_position in range(first_position + 1, len(current_order)):
+                candidate_order_list = list(current_order)
+                (
+                    candidate_order_list[first_position],
+                    candidate_order_list[second_position],
+                ) = (
+                    candidate_order_list[second_position],
+                    candidate_order_list[first_position],
+                )
+                candidate_order = tuple(candidate_order_list)
+                candidate_result = evaluate_order(candidate_order)
+                candidate_score = packing_score(candidate_result)
+                if candidate_score >= current_score:
+                    continue
+                candidate = (candidate_score, candidate_order, candidate_result)
+                if next_candidate is None or candidate < next_candidate:
+                    next_candidate = candidate
+        if next_candidate is None:
+            break
+        current_score, current_order, current_result = next_candidate
+
+    if current_score[0] > 0:
+        overflow_core = current_result.overflow_core
+        assert overflow_core is not None
+        required_bytes = current_result.required_bytes_on_overflow_core
+        available_bytes = remaining_bytes_by_core[overflow_core]
+        raise ValueError(
+            "Static DFB descriptor packing did not find a fitting deterministic "
+            f"order; the best candidate requires {required_bytes} bytes on core "
+            f"{overflow_core}, where {available_bytes} bytes remain, and exceeds "
+            f"the L1 budget by {required_bytes - available_bytes} bytes"
+        )
+
+    ordered_plans = list(descriptor_plans)
+    for destination_index, source_index in zip(static_plan_indices, current_order):
+        ordered_plans[destination_index] = descriptor_plans[source_index]
+    return ordered_plans
+
+
+def _build_dfb_descriptors(
     tensors: List[Any],
     cb_configs: List[PhysicalDFBConfig],
     allocations: List[_DFBAllocation],
@@ -904,7 +1083,7 @@ def _build_partitioned_dfb_descriptors(
     backing_tensors: Dict[int, Any],
     remaining_bytes_by_core: Dict[Tuple[int, int], int],
 ) -> List[Any]:
-    """Build descriptors on disjoint core partitions after DFB-use filtering."""
+    """Build descriptors by physical DFB storage source after use filtering."""
     active_cores = sorted({core for placement in placements for core in placement})
     static_bytes_by_core = {core: 0 for core in active_cores}
     for dfb_index, placement in enumerate(placements):
@@ -945,56 +1124,55 @@ def _build_partitioned_dfb_descriptors(
             + "\n  hint: reduce DFB dimensions or block_count."
         )
 
-    # A descriptor partition must have one consistent allocation sequence on
-    # every core because TT-Metal advances one static DFB allocation cursor.
-    cores_by_signature: Dict[
-        Tuple[Optional[Tuple[str, Optional[int]]], ...],
-        set[Tuple[int, int]],
-    ] = {}
-    for core in active_cores:
-        signature = tuple(placement.get(core) for placement in placements)
-        cores_by_signature.setdefault(signature, set()).add(core)
-
-    descriptors = []
-    for signature, partition_cores in cores_by_signature.items():
-        partition_ranges = _make_node_core_ranges(tuple(sorted(partition_cores)))
-        for dfb_index, source in enumerate(signature):
-            if source is None:
-                continue
+    descriptor_plans = []
+    for dfb_index, placement in enumerate(placements):
+        cores_by_source: Dict[Tuple[str, Optional[int]], set[Tuple[int, int]]] = {}
+        for core, source in placement.items():
+            cores_by_source.setdefault(source, set()).add(core)
+        for source, source_cores in cores_by_source.items():
             storage_kind, segment_index = source
             allocation = allocations[dfb_index]
             format_descriptor = _dfb_format_descriptor(dfb_index, allocation)
+            source_ranges = _make_node_core_ranges(tuple(sorted(source_cores)))
             if storage_kind == "tensor":
                 assert segment_index is not None
                 segment = cb_configs[dfb_index].storage_segments[segment_index]
                 tensor_index = segment.tensor_index
                 assert tensor_index is not None
-                descriptors.append(
-                    ttnn.cb_descriptor_from_sharded_tensor(
-                        dfb_index,
-                        tensors[tensor_index],
-                        address_offset=segment.byte_offset,
-                        total_size=allocation.total_size,
-                        core_ranges=partition_ranges,
-                    )
-                )
-                continue
-
-            descriptor = ttnn.CBDescriptor(
-                total_size=allocation.total_size,
-                core_ranges=partition_ranges,
-                format_descriptors=[format_descriptor],
-            )
-            if storage_kind == "computed":
-                backing_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     dfb_index,
-                    backing_tensors[dfb_index],
+                    tensors[tensor_index],
+                    address_offset=segment.byte_offset,
                     total_size=allocation.total_size,
-                    core_ranges=partition_ranges,
+                    core_ranges=source_ranges,
                 )
-                descriptor.set_buffer_from_cb(backing_descriptor)
-            descriptors.append(descriptor)
-    return descriptors
+            else:
+                descriptor = ttnn.CBDescriptor(
+                    total_size=allocation.total_size,
+                    core_ranges=source_ranges,
+                    format_descriptors=[format_descriptor],
+                )
+                if storage_kind == "computed":
+                    backing_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                        dfb_index,
+                        backing_tensors[dfb_index],
+                        total_size=allocation.total_size,
+                        core_ranges=source_ranges,
+                    )
+                    descriptor.set_buffer_from_cb(backing_descriptor)
+            descriptor_plans.append(
+                _DFBDescriptorPlan(
+                    descriptor=descriptor,
+                    physical_index=dfb_index,
+                    total_size=allocation.total_size,
+                    nodes=tuple(sorted(source_cores)),
+                    has_static_storage=storage_kind == "static",
+                )
+            )
+    descriptor_plans = _order_static_dfb_descriptor_plans(
+        descriptor_plans, remaining_bytes_by_core
+    )
+    return [plan.descriptor for plan in descriptor_plans]
 
 
 def build_cb_descriptors(
@@ -1078,7 +1256,7 @@ def build_cb_descriptors(
             if device is not None
             else {core: DEFAULT_L1_CB_BUDGET_BYTES for core in placement_cores}
         )
-        return _build_partitioned_dfb_descriptors(
+        return _build_dfb_descriptors(
             tensors,
             cb_configs,
             allocations,

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -161,8 +161,9 @@ def get_min_remaining_l1_for_device(device):
     """Return the minimum remaining L1 CB budget (bytes) across all cores.
 
     Accounts for reduced ``worker_l1_size`` and L1 tensor allocations.
-    Queries ``cb_limit`` (the hardware CB budget) and subtracts the maximum
-    per-core L1 buffer usage reported by the device.
+    TT-Metal allocates tensors from high L1 addresses and static DFBs from
+    ``address_at_first_l1_cb_buffer``. The usable interval therefore ends at
+    the lowest live tensor page address, not at the total allocated byte count.
 
     ``get_buffer_pages`` is called on the original device rather than on
     per-coordinate submeshes because ``create_submesh`` produces a new
@@ -177,17 +178,16 @@ def get_min_remaining_l1_for_device(device):
     if ttnn is None:
         raise RuntimeError("ttnn is not available")
 
-    info = ttnn._ttnn.reports.get_device_info(device)
-    budget_bytes = info.cb_limit
-
-    bytes_per_core: dict[tuple[int, int], int] = {}
+    device_info = ttnn._ttnn.reports.get_device_info(device)
+    static_dfb_base_address = device_info.address_at_first_l1_cb_buffer
+    minimum_remaining_bytes = device_info.cb_limit
     for page in ttnn._ttnn.reports.get_buffer_pages(device):
         if page.buffer_type == ttnn.BufferType.L1:
-            key = (page.core_y, page.core_x)
-            bytes_per_core[key] = bytes_per_core.get(key, 0) + page.page_size
-
-    max_core_bytes = max(bytes_per_core.values()) if bytes_per_core else 0
-    return max(0, budget_bytes - max_core_bytes)
+            minimum_remaining_bytes = min(
+                minimum_remaining_bytes,
+                max(0, page.page_address - static_dfb_base_address),
+            )
+    return minimum_remaining_bytes
 
 
 def _get_remaining_l1_by_core_for_device(
@@ -198,16 +198,17 @@ def _get_remaining_l1_by_core_for_device(
     if ttnn is None:
         raise RuntimeError("ttnn is not available")
 
-    budget_bytes = ttnn._ttnn.reports.get_device_info(device).cb_limit
-    used_bytes = {core: 0 for core in cores}
+    device_info = ttnn._ttnn.reports.get_device_info(device)
+    static_dfb_base_address = device_info.address_at_first_l1_cb_buffer
+    remaining_bytes = {core: device_info.cb_limit for core in cores}
     for page in ttnn._ttnn.reports.get_buffer_pages(device):
         core = (page.core_x, page.core_y)
-        if page.buffer_type == ttnn.BufferType.L1 and core in used_bytes:
-            used_bytes[core] += page.page_size
-    return {
-        core: max(0, budget_bytes - core_used_bytes)
-        for core, core_used_bytes in used_bytes.items()
-    }
+        if page.buffer_type == ttnn.BufferType.L1 and core in remaining_bytes:
+            remaining_bytes[core] = min(
+                remaining_bytes[core],
+                max(0, page.page_address - static_dfb_base_address),
+            )
+    return remaining_bytes
 
 
 @dataclass

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -161,9 +161,9 @@ def get_min_remaining_l1_for_device(device):
     """Return the minimum remaining L1 CB budget (bytes) across all cores.
 
     Accounts for reduced ``worker_l1_size`` and L1 tensor allocations.
-    TT-Metal allocates tensors from high L1 addresses and static DFBs from
-    ``address_at_first_l1_cb_buffer``. The usable interval therefore ends at
-    the lowest live tensor page address, not at the total allocated byte count.
+    TT-Metal allocates tensors from high L1 addresses and static DFBs from the
+    configured L1 allocator base. The usable interval therefore ends at the
+    lowest live tensor page address, not at the total allocated byte count.
 
     ``get_buffer_pages`` is called on the original device rather than on
     per-coordinate submeshes because ``create_submesh`` produces a new
@@ -179,7 +179,9 @@ def get_min_remaining_l1_for_device(device):
         raise RuntimeError("ttnn is not available")
 
     device_info = ttnn._ttnn.reports.get_device_info(device)
-    static_dfb_base_address = device_info.address_at_first_l1_cb_buffer
+    static_dfb_base_address = ttnn.get_allocator_base_address(
+        device, ttnn.BufferType.L1
+    )
     minimum_remaining_bytes = device_info.cb_limit
     for page in ttnn._ttnn.reports.get_buffer_pages(device):
         if page.buffer_type == ttnn.BufferType.L1:
@@ -199,7 +201,9 @@ def _get_remaining_l1_by_core_for_device(
         raise RuntimeError("ttnn is not available")
 
     device_info = ttnn._ttnn.reports.get_device_info(device)
-    static_dfb_base_address = device_info.address_at_first_l1_cb_buffer
+    static_dfb_base_address = ttnn.get_allocator_base_address(
+        device, ttnn.BufferType.L1
+    )
     remaining_bytes = {core: device_info.cb_limit for core in cores}
     for page in ttnn._ttnn.reports.get_buffer_pages(device):
         core = (page.core_x, page.core_y)

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -165,14 +165,10 @@ def get_min_remaining_l1_for_device(device):
     configured L1 allocator base. The usable interval therefore ends at the
     lowest live tensor page address, not at the total allocated byte count.
 
-    ``get_buffer_pages`` is called on the original device rather than on
-    per-coordinate submeshes because ``create_submesh`` produces a new
-    device view that does not inherit buffer tracking from the parent.
-    For mesh devices this reports allocations for the first physical
-    device, which is representative because tt-lang distributes tensors
-    uniformly across the mesh. If individual physical devices need tracking,
-    ttnn.reports.get_buffer_pages would have to report allocations on the
-    parent mesh instead of the first device within the mesh.
+    For a MeshDevice, ``get_buffer_pages`` reports the reference allocator.
+    TT-Lang's multi-device tensors and runtime resources use common L1
+    addresses across their mesh, so its lowest live page is also a safe lower
+    bound for every physical device.
     """
     _ensure_ttnn()
     if ttnn is None:
@@ -192,10 +188,15 @@ def get_min_remaining_l1_for_device(device):
     return minimum_remaining_bytes
 
 
+def _contains_multiple_physical_devices(device) -> bool:
+    get_num_devices = getattr(device, "get_num_devices", None)
+    return get_num_devices is not None and int(get_num_devices()) > 1
+
+
 def _get_remaining_l1_by_core_for_device(
     device, cores: set[tuple[int, int]]
 ) -> dict[tuple[int, int], int]:
-    """Return each requested logical core's remaining static DFB budget."""
+    """Return safe static DFB budgets for the requested logical cores."""
     _ensure_ttnn()
     if ttnn is None:
         raise RuntimeError("ttnn is not available")
@@ -205,13 +206,26 @@ def _get_remaining_l1_by_core_for_device(
         device, ttnn.BufferType.L1
     )
     remaining_bytes = {core: device_info.cb_limit for core in cores}
+    minimum_remaining_bytes = device_info.cb_limit
     for page in ttnn._ttnn.reports.get_buffer_pages(device):
+        if page.buffer_type != ttnn.BufferType.L1:
+            continue
+        page_remaining_bytes = max(0, page.page_address - static_dfb_base_address)
+        minimum_remaining_bytes = min(minimum_remaining_bytes, page_remaining_bytes)
         core = (page.core_x, page.core_y)
-        if page.buffer_type == ttnn.BufferType.L1 and core in remaining_bytes:
-            remaining_bytes[core] = min(
-                remaining_bytes[core],
-                max(0, page.page_address - static_dfb_base_address),
-            )
+        if core in remaining_bytes:
+            remaining_bytes[core] = min(remaining_bytes[core], page_remaining_bytes)
+
+    # TTNN reports one physical allocator for a MeshDevice, while the same
+    # logical program executes on devices with potentially different harvested
+    # worker mappings. Common tensor and runtime-resource addresses make the
+    # reference allocator's lowest live page a conservative bound for every
+    # worker.
+    if _contains_multiple_physical_devices(device):
+        remaining_bytes = {
+            core: min(core_remaining_bytes, minimum_remaining_bytes)
+            for core, core_remaining_bytes in remaining_bytes.items()
+        }
     return remaining_bytes
 
 

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -916,7 +916,7 @@ def test_remaining_l1_uses_lowest_live_tensor_address(monkeypatch):
     l1_buffer_type = object()
     dram_buffer_type = object()
     device_info = SimpleNamespace(
-        address_at_first_l1_cb_buffer=0x2000,
+        address_at_first_l1_cb_buffer=0x1FC0,
         cb_limit=0x1000,
     )
     buffer_pages = [
@@ -951,6 +951,7 @@ def test_remaining_l1_uses_lowest_live_tensor_address(monkeypatch):
         "ttnn",
         SimpleNamespace(
             BufferType=SimpleNamespace(L1=l1_buffer_type),
+            get_allocator_base_address=lambda _device, _buffer_type: 0x2000,
             _ttnn=SimpleNamespace(reports=reports),
         ),
     )

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -173,6 +173,10 @@ class _FakeTTNN:
         return [_FakeTTNN.CoreCoord(0, 0), _FakeTTNN.CoreCoord(1, 0)]
 
     @staticmethod
+    def get_dram_alignment():
+        return 64
+
+    @staticmethod
     def generic_op(tensors, program):
         return {
             "tensors": tensors,
@@ -795,6 +799,115 @@ def test_specialized_dfb_budget_is_computed_per_core(monkeypatch):
         (0, 0),
         (1, 0),
     }
+
+
+@pytest.mark.parametrize(
+    ("budget_bytes", "expected_order"),
+    [(16000, [0, 2, 1]), (18000, [0, 1, 2])],
+    ids=["reordered", "already-fits"],
+)
+def test_static_dfb_descriptors_are_ordered_to_fit_l1(
+    monkeypatch, budget_bytes, expected_order
+):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(kernel_runner, "DEFAULT_L1_CB_BUDGET_BYTES", budget_bytes)
+    full_grid = _FakeExplicitCoreRanges((0, 0), (11, 9))
+    sparse_nodes = tuple(
+        (node_x, node_y)
+        for node_y, row_end_x in ((0, 7), (1, 7), (4, 7), (9, 0))
+        for node_x in range(row_end_x + 1)
+    )
+    configs = [
+        PhysicalDFBConfig(
+            0,
+            32,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=((0, 6),),
+        ),
+        PhysicalDFBConfig(
+            1,
+            128,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=tuple(
+                (node_x, node_y) for node_y in range(10) for node_x in range(12)
+            ),
+        ),
+        PhysicalDFBConfig(
+            2,
+            112,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=sparse_nodes,
+        ),
+    ]
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=configs,
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    # The physical order requires 17,408 bytes because the full-grid DFB
+    # inherits the singleton DFB frontier. Independent DFBs first need 15,360.
+    assert [
+        descriptor.format_descriptors[0].buffer_index for descriptor in descriptors
+    ] == expected_order
+    descriptors_by_index = {
+        descriptor.format_descriptors[0].buffer_index: descriptor
+        for descriptor in descriptors
+    }
+    assert _descriptor_cores(descriptors_by_index[0]) == {(0, 6)}
+    assert _descriptor_cores(descriptors_by_index[1]) == {
+        (node_x, node_y) for node_y in range(10) for node_x in range(12)
+    }
+    assert _descriptor_cores(descriptors_by_index[2]) == set(sparse_nodes)
+
+
+def test_static_dfb_descriptor_order_reports_no_fitting_candidate(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(kernel_runner, "DEFAULT_L1_CB_BUDGET_BYTES", 10240)
+    full_grid = _FakeExplicitCoreRanges((0, 0), (2, 0))
+    configs = [
+        PhysicalDFBConfig(
+            physical_index,
+            64,
+            "bfloat16",
+            1,
+            64,
+            (1, 32),
+            allocation_nodes=allocation_nodes,
+        )
+        for physical_index, allocation_nodes in enumerate(
+            (
+                ((0, 0), (1, 0)),
+                ((1, 0), (2, 0)),
+                ((0, 0), (2, 0)),
+            )
+        )
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "the best candidate requires 12288 bytes on core .* where 10240 bytes "
+            "remain, and exceeds the L1 budget by 2048 bytes"
+        ),
+    ):
+        kernel_runner.build_cb_descriptors(
+            tensors=[_FakeTensorWithoutDevice()],
+            cb_configs=configs,
+            core_ranges=full_grid,
+            kernel_specs=[_specialized_spec(full_grid, None)],
+        )
 
 
 def test_specialized_dfb_budget_uses_each_cores_remaining_l1(monkeypatch):

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -970,6 +970,50 @@ def test_remaining_l1_uses_lowest_live_tensor_address(monkeypatch):
     assert kernel_runner.get_min_remaining_l1_for_device(device) == 0x900
 
 
+def test_mesh_remaining_l1_uses_reference_allocator_global_floor(monkeypatch):
+    l1_buffer_type = object()
+    device_info = SimpleNamespace(cb_limit=0x1000)
+    buffer_pages = [
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=0,
+            core_y=0,
+            page_address=0x2900,
+        ),
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=1,
+            core_y=0,
+            page_address=0x2C00,
+        ),
+    ]
+    reports = SimpleNamespace(
+        get_device_info=lambda _device: device_info,
+        get_buffer_pages=lambda _device: buffer_pages,
+    )
+    monkeypatch.setattr(
+        kernel_runner,
+        "ttnn",
+        SimpleNamespace(
+            BufferType=SimpleNamespace(L1=l1_buffer_type),
+            get_allocator_base_address=lambda _device, _buffer_type: 0x2000,
+            _ttnn=SimpleNamespace(reports=reports),
+        ),
+    )
+
+    device = SimpleNamespace(get_num_devices=lambda: 32)
+    remaining_by_core = kernel_runner._get_remaining_l1_by_core_for_device(
+        device,
+        {(0, 0), (1, 0), (2, 0)},
+    )
+
+    assert remaining_by_core == {
+        (0, 0): 0x900,
+        (1, 0): 0x900,
+        (2, 0): 0x900,
+    }
+
+
 def test_specialized_dfb_budget_uses_each_cores_remaining_l1(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
     monkeypatch.setattr(

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -4,6 +4,8 @@
 
 """Python-only tests for ttl.kernel_runner resource allocation helpers."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from ttl import kernel_runner
@@ -908,6 +910,63 @@ def test_static_dfb_descriptor_order_reports_no_fitting_candidate(monkeypatch):
             core_ranges=full_grid,
             kernel_specs=[_specialized_spec(full_grid, None)],
         )
+
+
+def test_remaining_l1_uses_lowest_live_tensor_address(monkeypatch):
+    l1_buffer_type = object()
+    dram_buffer_type = object()
+    device_info = SimpleNamespace(
+        address_at_first_l1_cb_buffer=0x2000,
+        cb_limit=0x1000,
+    )
+    buffer_pages = [
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=0,
+            core_y=0,
+            page_address=0x2900,
+            page_size=0x100,
+        ),
+        SimpleNamespace(
+            buffer_type=l1_buffer_type,
+            core_x=1,
+            core_y=0,
+            page_address=0x2C00,
+            page_size=0x400,
+        ),
+        SimpleNamespace(
+            buffer_type=dram_buffer_type,
+            core_x=0,
+            core_y=0,
+            page_address=0x2100,
+            page_size=0x800,
+        ),
+    ]
+    reports = SimpleNamespace(
+        get_device_info=lambda _device: device_info,
+        get_buffer_pages=lambda _device: buffer_pages,
+    )
+    monkeypatch.setattr(
+        kernel_runner,
+        "ttnn",
+        SimpleNamespace(
+            BufferType=SimpleNamespace(L1=l1_buffer_type),
+            _ttnn=SimpleNamespace(reports=reports),
+        ),
+    )
+
+    device = object()
+    remaining_by_core = kernel_runner._get_remaining_l1_by_core_for_device(
+        device,
+        {(0, 0), (1, 0), (2, 0)},
+    )
+
+    assert remaining_by_core == {
+        (0, 0): 0x900,
+        (1, 0): 0xC00,
+        (2, 0): 0x1000,
+    }
+    assert kernel_runner.get_min_remaining_l1_for_device(device) == 0x900
 
 
 def test_specialized_dfb_budget_uses_each_cores_remaining_l1(monkeypatch):

--- a/test/python/test_static_dfb_descriptor_packing.py
+++ b/test/python/test_static_dfb_descriptor_packing.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device coverage for static DFB descriptor packing."""
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+from ttl import kernel_runner  # noqa: E402
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+TILE = 32
+
+
+def _make_static_dfb_packing_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+    @ttl.operation(grid=(2, 1))
+    def static_dfb_packing_kernel(input_tensor, output_tensor):
+        first_node_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=1)
+        shared_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=4)
+        second_node_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=4)
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            pass
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            node_x, _node_y = ttl.node(dims=2)
+            if node_x == 0:
+                with first_node_dfb.reserve() as first_node_block:
+                    ttl.copy(input_tensor[0, 0], first_node_block).wait()
+            with shared_dfb.reserve() as shared_block:
+                ttl.copy(input_tensor[0, node_x], shared_block).wait()
+            if node_x == 1:
+                with second_node_dfb.reserve() as second_node_block:
+                    ttl.copy(input_tensor[0, 1], second_node_block).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            node_x, _node_y = ttl.node(dims=2)
+            if node_x == 0:
+                with first_node_dfb.wait():
+                    pass
+            with shared_dfb.wait() as shared_block:
+                ttl.copy(shared_block, output_tensor[0, node_x]).wait()
+            if node_x == 1:
+                with second_node_dfb.wait():
+                    pass
+
+    return static_dfb_packing_kernel
+
+
+@pytest.mark.parametrize(
+    ("data_format", "dtype", "dfb_page_size"),
+    [
+        ("bf16", torch.bfloat16, 2048),
+        ("float32", torch.float32, 4096),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize("to_device", [to_dram, to_l1], ids=["dram", "l1"])
+def test_static_dfb_descriptor_packing_fits_budget(
+    device,
+    data_format,
+    dtype,
+    dfb_page_size,
+    to_device,
+    monkeypatch,
+):
+    operation = _make_static_dfb_packing_kernel(data_format)
+    input_host = (
+        torch.arange(2 * TILE * TILE, dtype=torch.float32)
+        .reshape(TILE, 2 * TILE)
+        .to(dtype)
+    )
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+    descriptor_orders = []
+    original_ordering = kernel_runner._order_static_dfb_descriptor_plans
+
+    def record_descriptor_order(descriptor_plans, remaining_bytes_by_core):
+        plans_by_physical_index = {
+            plan.physical_index: plan for plan in descriptor_plans
+        }
+        over_budget_plans = [
+            plans_by_physical_index[physical_index] for physical_index in (0, 2, 1)
+        ]
+        ordered_plans = original_ordering(over_budget_plans, remaining_bytes_by_core)
+        descriptor_orders.append(
+            tuple(
+                plan.physical_index for plan in ordered_plans if plan.has_static_storage
+            )
+        )
+        return ordered_plans
+
+    monkeypatch.setattr(
+        kernel_runner,
+        "_get_remaining_l1_by_core_for_device",
+        lambda _device, cores: {core: (17 * dfb_page_size) // 2 for core in cores},
+    )
+    monkeypatch.setattr(
+        kernel_runner,
+        "_order_static_dfb_descriptor_plans",
+        record_descriptor_order,
+    )
+
+    operation(input_tensor, output_tensor, options="--no-ttl-specialize-cores")
+
+    assert descriptor_orders == [(0, 1, 2)]
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)

--- a/test/python/test_static_dfb_descriptor_packing.py
+++ b/test/python/test_static_dfb_descriptor_packing.py
@@ -66,8 +66,9 @@ def test_remaining_l1_budget_matches_live_tensor_addresses(device):
     input_tensor = to_l1(input_host, device)
     assert input_tensor is not None
 
-    device_info = ttnn._ttnn.reports.get_device_info(device)
-    static_dfb_base_address = device_info.address_at_first_l1_cb_buffer
+    static_dfb_base_address = ttnn.get_allocator_base_address(
+        device, ttnn.BufferType.L1
+    )
     l1_pages = [
         page
         for page in ttnn._ttnn.reports.get_buffer_pages(device)

--- a/test/python/test_static_dfb_descriptor_packing.py
+++ b/test/python/test_static_dfb_descriptor_packing.py
@@ -61,6 +61,37 @@ def _make_static_dfb_packing_kernel(data_format):
     return static_dfb_packing_kernel
 
 
+def test_remaining_l1_budget_matches_live_tensor_addresses(device):
+    input_host = torch.zeros((TILE, TILE), dtype=torch.bfloat16)
+    input_tensor = to_l1(input_host, device)
+    assert input_tensor is not None
+
+    device_info = ttnn._ttnn.reports.get_device_info(device)
+    static_dfb_base_address = device_info.address_at_first_l1_cb_buffer
+    l1_pages = [
+        page
+        for page in ttnn._ttnn.reports.get_buffer_pages(device)
+        if page.buffer_type == ttnn.BufferType.L1
+    ]
+    assert l1_pages
+    cores = {(page.core_x, page.core_y) for page in l1_pages}
+    expected_remaining_by_core = {
+        core: min(
+            page.page_address for page in l1_pages if (page.core_x, page.core_y) == core
+        )
+        - static_dfb_base_address
+        for core in cores
+    }
+
+    assert (
+        kernel_runner._get_remaining_l1_by_core_for_device(device, cores)
+        == expected_remaining_by_core
+    )
+    assert kernel_runner.get_min_remaining_l1_for_device(device) == min(
+        expected_remaining_by_core.values()
+    )
+
+
 @pytest.mark.parametrize(
     ("data_format", "dtype", "dfb_page_size"),
     [


### PR DESCRIPTION
## Overview

- Improve static DFB descriptor allocation.
- Account for current L1 availability.

## Testing

- 11 focused Blackhole device tests passed.
- 72 focused host tests passed.
- Focused pre-commit hooks passed.