### PR TITLE
[TTL] Bind external fabric managers to launch domains

### DIFF
--- a/docs/development/PipesOnFabric.md
+++ b/docs/development/PipesOnFabric.md
@@ -613,6 +613,14 @@ not interpret or modify the external manager's runtime arguments. The complete
 plan is validated before program descriptors, semaphores, or runtime arguments
 are modified.
 
+An external scoped manager call inside structured control flow records its
+compiler-proven launch-node domain. Runtime binding resolves each kernel
+descriptor independently, verifies that the recorded nodes are contained by
+that descriptor, and unions the per-descriptor domains for the claim. An absent
+domain means the complete descriptor executes the interval; a present empty
+domain means no node executes it. The external binding must cover the resulting
+node set exactly.
+
 The compiler serializes an ordered sequence of generated receiver and sender
 manager intervals only when corresponding intervals each contain one protocol
 operation, implement the same transfers at the same device and TENSIX node,

--- a/docs/sphinx/reference/operation-runtime-resources.md
+++ b/docs/sphinx/reference/operation-runtime-resources.md
@@ -125,8 +125,10 @@ execute on the compiler-owned PipeNet source kernel.
 Ownership begins at entry to the acquire call because that opaque call may open
 connections. It ends after the release call returns. Every `use()` must occur
 strictly between one acquire and release. `scoped()` declares one opaque call
-that acquires, uses, and releases the manager. Effects must occur in the
-selected logical kernel's straight-line entry block.
+that acquires, uses, and releases the manager. Acquire, use, and release
+effects must occur in the selected logical kernel's straight-line entry block.
+A scoped effect may occur in structured control flow when the compiler proves
+its exact launch-node domain.
 
 An expand-only operation forwards captured claims to the final grid-bearing
 operation. Acquire, use, and release effects may therefore reside in separate
@@ -135,12 +137,15 @@ reusing the same claim in two independent grid-bearing operations is invalid.
 
 The runtime resource factory supplies one `FabricConnectionBinding` for every
 captured claim. Its requirements must cover every active logical-device and
-worker-node instance of the selected kernel. `fixed_link_index` is an external
-ABI constraint, not a preference; target binding rejects it when the active
-control plane does not expose that link for the destination. The compiler
-places external and generated manager intervals in one interference graph,
-validates every link assignment before descriptor mutation, and reserves the
-external link without interpreting or modifying external runtime arguments.
+worker-node instance of the selected kernel. A conditional scoped effect uses
+its proven launch-node domain instead of the complete executable descriptor;
+a proven empty domain requires no worker binding. `fixed_link_index` is an
+external ABI constraint, not a preference; target binding rejects it when the
+active control plane does not expose that link for the destination. The
+compiler places external and generated manager intervals in one interference
+graph, validates every link assignment before descriptor mutation, and
+reserves the external link without interpreting or modifying external runtime
+arguments.
 
 The claim identity, `abi_identity`, logical endpoints, worker nodes, and fixed
 links participate in program-cache identity. Objects in the binding's

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -228,14 +228,18 @@ def TTL_FabricManagerIntervalAttr
     Identifies one generated or external manager ownership interval in a
     logical kernel. Generated intervals reference the function's fabric route
     indices. External intervals reference an operation-local claim. The
-    interference list contains interval identities whose lifetimes may overlap.
+    optional launch-node list records the exact nodes that execute an external
+    interval. An absent list uses the enclosing kernel descriptor; a present
+    empty list means no node executes the interval. The interference list
+    contains interval identities whose lifetimes may overlap.
   }];
   let parameters = (ins
     "StringAttr":$identity,
     "FabricManagerIntervalKind":$kind,
     OptionalParameter<"StringAttr">:$claim,
     "DenseI64ArrayAttr":$routeIndices,
-    ArrayRefParameter<"StringAttr">:$interferingIntervals
+    ArrayRefParameter<"StringAttr">:$interferingIntervals,
+    OptionalParameter<"DenseI64ArrayAttr">:$launchNodes
   );
   let assemblyFormat = "`<` struct(params) `>`";
 }

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -2473,7 +2473,10 @@ lowerTTLOpsToTTKernel(ModuleOp mod, MLIRContext &ctx,
       PipeGraph::build(mod, transferIndex, foreachLoweringInfo,
                        mod->hasAttr(kDFBAllocationsAttrName)
                            ? PipeDFBIndexMode::Finalized
-                           : PipeDFBIndexMode::DeclaredPhysical);
+                           : PipeDFBIndexMode::DeclaredPhysical,
+                       externalManagerIntervals->empty()
+                           ? PipeGraphLaunchDomainMode::WhenPipesPresent
+                           : PipeGraphLaunchDomainMode::Required);
   if (failed(pipeGraphOrErr)) {
     return failure();
   }

--- a/lib/Dialect/TTL/Transforms/FabricManagerLifetimeAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/FabricManagerLifetimeAnalysis.cpp
@@ -25,9 +25,11 @@ appendClaimEffect(OpaqueCallOp call, FabricManagerEffectAttr effect,
     return call.emitError("fabric manager effects require an enclosing logical "
                           "kernel function");
   }
-  if (call->getBlock() != &function.getBody().front()) {
+  if (call->getBlock() != &function.getBody().front() &&
+      effect.getKind() != FabricManagerEffectKind::Scoped) {
     return call.emitError("fabric manager effects must be in the logical "
-                          "kernel's straight-line entry block");
+                          "kernel's straight-line entry block unless the "
+                          "effect is scoped");
   }
   if (claimEffects.function && claimEffects.function != function) {
     return call.emitError("fabric manager claim '")

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -95,6 +95,11 @@ static LogicalResult collectLaunchNodeDomains(ModuleOp mod,
       return failure();
     }
   }
+  return success();
+}
+
+static LogicalResult collectDFBLifecycles(ModuleOp mod,
+                                          PipeGraphAnalysisState &state) {
   for (func::FuncOp function : mod.getOps<func::FuncOp>()) {
     PlanningResult<std::unique_ptr<DFBAcquireReleaseIndex>> lifecycleResult =
         DFBAcquireReleaseIndex::create(function);
@@ -2240,7 +2245,8 @@ PipeGraph::addPipeReceiver(Operation *op, PipeTransferCreateOp transferCreateOp,
 FailureOr<PipeGraph>
 PipeGraph::build(ModuleOp mod, const PipeTransferIndex &transferIndex,
                  const PipeForeachLoweringInfo &foreachLoweringInfo,
-                 PipeDFBIndexMode dfbIndexMode) {
+                 PipeDFBIndexMode dfbIndexMode,
+                 PipeGraphLaunchDomainMode launchDomainMode) {
   PipeGraph graph;
   PipeGraphAnalysisState analysisState;
   WalkResult protocolSearch = mod.walk([&](Operation *operation) {
@@ -2249,7 +2255,18 @@ PipeGraph::build(ModuleOp mod, const PipeTransferIndex &transferIndex,
                ? WalkResult::interrupt()
                : WalkResult::advance();
   });
+  if (!protocolSearch.wasInterrupted() &&
+      launchDomainMode == PipeGraphLaunchDomainMode::WhenPipesPresent) {
+    return std::move(graph);
+  }
+  analysisState.pipeRecordIfThenDomains = foreachLoweringInfo.ifThenDomains;
   if (!protocolSearch.wasInterrupted()) {
+    if (failed(collectLaunchNodeDomains(mod, analysisState))) {
+      return failure();
+    }
+    graph.hasAnalyzedLaunchGrid = analysisState.hasLaunchGrid;
+    graph.operationLaunchDomains =
+        std::move(analysisState.operationLaunchDomains);
     return std::move(graph);
   }
   analysisState.dfbLogicalIdentities =
@@ -2267,7 +2284,6 @@ PipeGraph::build(ModuleOp mod, const PipeTransferIndex &transferIndex,
   analysisState.pipeRecordControlOps.insert(
       foreachLoweringInfo.controlOps.begin(),
       foreachLoweringInfo.controlOps.end());
-  analysisState.pipeRecordIfThenDomains = foreachLoweringInfo.ifThenDomains;
   analysisState.pipeRecordLoops = foreachLoweringInfo.recordLoops;
 
   for (PipeTransferPostOp postOp : analysisState.receiverPosts) {
@@ -2279,6 +2295,9 @@ PipeGraph::build(ModuleOp mod, const PipeTransferIndex &transferIndex,
     }
   }
   if (failed(collectLaunchNodeDomains(mod, analysisState))) {
+    return failure();
+  }
+  if (failed(collectDFBLifecycles(mod, analysisState))) {
     return failure();
   }
 

--- a/lib/Dialect/TTL/Transforms/PipeGraph.h
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.h
@@ -62,6 +62,13 @@ enum class PipeDFBIndexMode {
   Finalized,
 };
 
+/// Controls whether launch-node domains are required when the module contains
+/// no pipe-transfer protocol operations.
+enum class PipeGraphLaunchDomainMode {
+  WhenPipesPresent,
+  Required,
+};
+
 //===----------------------------------------------------------------------===//
 // Pipe Graph: Tracks static transfers, receiver endpoints, logical receiver
 // DFB lifecycles, physical allocation, and endpoint address sequences.
@@ -467,7 +474,8 @@ public:
   static FailureOr<PipeGraph>
   build(ModuleOp mod, const PipeTransferIndex &transferIndex,
         const PipeForeachLoweringInfo &foreachLoweringInfo,
-        PipeDFBIndexMode dfbIndexMode);
+        PipeDFBIndexMode dfbIndexMode,
+        PipeGraphLaunchDomainMode launchDomainMode);
 
   /// Check if any pipes were found.
   bool hasPipes() const { return !pipeTransferNodes.empty(); }

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -411,7 +411,19 @@ static bool intervalRoutesEqual(const FabricManagerIntervalPlan &lhs,
          });
 }
 
-static void planGeneratedFabricManagerOwnership(
+static bool
+externalManagerIntervalsAreSequential(const FabricManagerIntervalPlan &lhs,
+                                      const FabricManagerIntervalPlan &rhs) {
+  if (lhs.kind != FabricManagerIntervalKind::External ||
+      rhs.kind != FabricManagerIntervalKind::External ||
+      lhs.function != rhs.function ||
+      lhs.releaseBoundary->getBlock() != rhs.acquireBoundary->getBlock()) {
+    return false;
+  }
+  return lhs.releaseBoundary->isBeforeInBlock(rhs.acquireBoundary);
+}
+
+static void planFabricManagerOwnership(
     FabricRoutePlan &plan, const PipeGraph &pipeGraph,
     const llvm::SmallPtrSetImpl<Operation *> &generatedControlOps,
     bool enableLocalOwnership) {
@@ -553,6 +565,14 @@ static void planGeneratedFabricManagerOwnership(
               ownershipGroupByManager[rhsIndex]) {
         continue;
       }
+      if (externalManagerIntervalsAreSequential(
+              plan.managerIntervals[lhsIndex],
+              plan.managerIntervals[rhsIndex]) ||
+          externalManagerIntervalsAreSequential(
+              plan.managerIntervals[rhsIndex],
+              plan.managerIntervals[lhsIndex])) {
+        continue;
+      }
       plan.managerIntervals[lhsIndex].interferingIntervals.push_back(rhsIndex);
       plan.managerIntervals[rhsIndex].interferingIntervals.push_back(lhsIndex);
     }
@@ -690,17 +710,33 @@ LogicalResult buildFabricRoutePlan(
         getIntervalTransferNodes(operations, pipeGraph),
         scope,
         scope,
-        {}});
+        {},
+        std::nullopt});
     plan.runtimeIntervals.push_back(FabricRuntimeIntervalPlan{
         managerIntervalIndex, scope, std::move(operations), std::nullopt, false,
         0, 0});
   }
 
-  for (const ExternalFabricManagerInterval &externalInterval :
+  for (ExternalFabricManagerInterval externalInterval :
        externalManagerIntervals) {
+    LaunchNodeDomain launchDomain =
+        pipeGraph.getOperationLaunchDomain(externalInterval.acquire);
+    if (!launchDomain.known) {
+      externalInterval.acquire.emitError(
+          "cannot prove the exact launch-node domain for external fabric "
+          "manager claim '")
+          << externalInterval.claim.getValue() << "'";
+      result = failure();
+      continue;
+    }
     StringAttr identity = StringAttr::get(
         module.getContext(),
         (Twine("external.") + externalInterval.claim.getValue()).str());
+    std::optional<SmallVector<LaunchNodeCoord>> launchNodes;
+    if (externalInterval.acquire->getBlock() !=
+        &externalInterval.function.getBody().front()) {
+      launchNodes.emplace(launchDomain.nodes.begin(), launchDomain.nodes.end());
+    }
     plan.managerIntervals.push_back(
         FabricManagerIntervalPlan{identity,
                                   FabricManagerIntervalKind::External,
@@ -711,11 +747,12 @@ LogicalResult buildFabricRoutePlan(
                                   {},
                                   externalInterval.acquire,
                                   externalInterval.release,
-                                  {}});
+                                  {},
+                                  std::move(launchNodes)});
   }
 
-  planGeneratedFabricManagerOwnership(plan, pipeGraph, generatedControlOps,
-                                      enableLocalManagerOwnership);
+  planFabricManagerOwnership(plan, pipeGraph, generatedControlOps,
+                             enableLocalManagerOwnership);
   return result;
 }
 
@@ -761,11 +798,22 @@ void applyFabricRoutePlan(ModuleOp mod, const FabricRoutePlan &plan) {
     }
     SmallVector<int64_t> routeIndices(interval.routeIndices.begin(),
                                       interval.routeIndices.end());
+    DenseI64ArrayAttr launchNodes;
+    if (interval.launchNodes) {
+      SmallVector<int64_t> nodeCoordinates;
+      nodeCoordinates.reserve(2 * interval.launchNodes->size());
+      for (LaunchNodeCoord node : *interval.launchNodes) {
+        nodeCoordinates.push_back(node.x);
+        nodeCoordinates.push_back(node.y);
+      }
+      launchNodes = builder.getDenseI64ArrayAttr(nodeCoordinates);
+    }
     intervalsByFunction[interval.function].push_back(
         FabricManagerIntervalAttr::get(
             mod.getContext(), interval.identity, interval.kind,
             interval.claim.value_or(StringAttr()),
-            builder.getDenseI64ArrayAttr(routeIndices), interferingIntervals));
+            builder.getDenseI64ArrayAttr(routeIndices), interferingIntervals,
+            launchNodes));
   }
   for (auto &[function, intervals] : intervalsByFunction) {
     function->setAttr(kFabricManagerIntervalsAttrName,

--- a/lib/Dialect/TTL/Transforms/PipeLowering.h
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.h
@@ -71,6 +71,7 @@ struct FabricManagerIntervalPlan {
   Operation *acquireBoundary;
   Operation *releaseBoundary;
   SmallVector<std::size_t> interferingIntervals;
+  std::optional<SmallVector<LaunchNodeCoord>> launchNodes;
 };
 
 /// Fabric routes and transfer associations derived before PipeNet lowering.

--- a/lib/Dialect/TTL/Transforms/TTLFormPipeTransports.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFormPipeTransports.cpp
@@ -764,7 +764,8 @@ struct TTLFormPipeTransportsPass
     PipeForeachLoweringInfo foreachLoweringInfo;
     FailureOr<PipeGraph> maybePipeGraph =
         PipeGraph::build(module, transferIndex, foreachLoweringInfo,
-                         PipeDFBIndexMode::Provisional);
+                         PipeDFBIndexMode::Provisional,
+                         PipeGraphLaunchDomainMode::WhenPipesPresent);
     if (failed(maybePipeGraph)) {
       signalPassFailure();
       return;

--- a/python/ttl/_fabric_target.py
+++ b/python/ttl/_fabric_target.py
@@ -36,6 +36,7 @@ class FabricManagerIntervalSpec:
     claim: Optional[str]
     route_indices: Tuple[int, ...]
     interfering_intervals: Tuple[str, ...]
+    launch_nodes: Optional[Tuple[Tuple[int, int], ...]] = None
 
 
 @dataclass(frozen=True)
@@ -822,14 +823,38 @@ def build_fabric_target_binding_plan(
                 "to one manager interval"
             )
         interval_identity = next(iter(interval_identities))
-        expected_external_nodes.setdefault(interval_identity, set()).update(
-            (node_x, node_y)
-            for kernel_index, _ in interval_matches
-            for node_y in range(grid_rows)
-            for node_x in range(grid_cols)
-            if program_descriptor.kernels[kernel_index].core_ranges.contains(
-                ttnn_api.CoreCoord(node_x, node_y)
+        descriptor_nodes = set()
+        explicit_launch_domains = set()
+        for kernel_index, interval in interval_matches:
+            descriptor_nodes.update(
+                (node_x, node_y)
+                for node_y in range(grid_rows)
+                for node_x in range(grid_cols)
+                if program_descriptor.kernels[kernel_index].core_ranges.contains(
+                    ttnn_api.CoreCoord(node_x, node_y)
+                )
             )
+            if interval.launch_nodes is not None:
+                explicit_launch_domains.add(frozenset(interval.launch_nodes))
+        if len(explicit_launch_domains) > 1:
+            raise ValueError(
+                f"external fabric interval {interval_identity!r} has "
+                "inconsistent launch-node domains across kernel descriptors"
+            )
+        interval_nodes = (
+            descriptor_nodes
+            if not explicit_launch_domains
+            else set(next(iter(explicit_launch_domains)))
+        )
+        outside_nodes = interval_nodes - descriptor_nodes
+        if outside_nodes:
+            raise ValueError(
+                f"external fabric interval {interval_identity!r} has launch "
+                "nodes outside its kernel descriptors: "
+                f"{tuple(sorted(outside_nodes))}"
+            )
+        expected_external_nodes.setdefault(interval_identity, set()).update(
+            interval_nodes
         )
         for requirement in binding.connections:
             local_device = tuple(
@@ -933,7 +958,7 @@ def build_fabric_target_binding_plan(
             extra_nodes = tuple(sorted(provided_nodes - expected_nodes))
             raise ValueError(
                 f"external fabric interval {interval_identity!r} does not "
-                f"cover its kernel range; missing nodes {missing_nodes}, "
+                f"cover its launch-node domain; missing nodes {missing_nodes}, "
                 f"extra nodes {extra_nodes}"
             )
 

--- a/python/ttl/_fabric_target.py
+++ b/python/ttl/_fabric_target.py
@@ -524,11 +524,20 @@ def _assign_fabric_links(
 def _build_interval_interference(
     kernel_intervals: List[Tuple[FabricManagerIntervalSpec, ...]],
 ) -> Dict[str, frozenset[str]]:
+    def specialization_invariant(interval: FabricManagerIntervalSpec):
+        return (
+            interval.identity,
+            interval.kind,
+            interval.claim,
+            interval.route_indices,
+            interval.interfering_intervals,
+        )
+
     intervals_by_identity = {}
     for intervals in kernel_intervals:
         for interval in intervals:
             existing = intervals_by_identity.setdefault(interval.identity, interval)
-            if existing != interval:
+            if specialization_invariant(existing) != specialization_invariant(interval):
                 raise ValueError(
                     f"fabric manager interval {interval.identity!r} has "
                     "inconsistent specialized records"
@@ -823,36 +832,29 @@ def build_fabric_target_binding_plan(
                 "to one manager interval"
             )
         interval_identity = next(iter(interval_identities))
-        descriptor_nodes = set()
-        explicit_launch_domains = set()
+        interval_nodes = set()
         for kernel_index, interval in interval_matches:
-            descriptor_nodes.update(
+            descriptor_nodes = {
                 (node_x, node_y)
                 for node_y in range(grid_rows)
                 for node_x in range(grid_cols)
                 if program_descriptor.kernels[kernel_index].core_ranges.contains(
                     ttnn_api.CoreCoord(node_x, node_y)
                 )
+            }
+            descriptor_interval_nodes = (
+                descriptor_nodes
+                if interval.launch_nodes is None
+                else set(interval.launch_nodes)
             )
-            if interval.launch_nodes is not None:
-                explicit_launch_domains.add(frozenset(interval.launch_nodes))
-        if len(explicit_launch_domains) > 1:
-            raise ValueError(
-                f"external fabric interval {interval_identity!r} has "
-                "inconsistent launch-node domains across kernel descriptors"
-            )
-        interval_nodes = (
-            descriptor_nodes
-            if not explicit_launch_domains
-            else set(next(iter(explicit_launch_domains)))
-        )
-        outside_nodes = interval_nodes - descriptor_nodes
-        if outside_nodes:
-            raise ValueError(
-                f"external fabric interval {interval_identity!r} has launch "
-                "nodes outside its kernel descriptors: "
-                f"{tuple(sorted(outside_nodes))}"
-            )
+            outside_nodes = descriptor_interval_nodes - descriptor_nodes
+            if outside_nodes:
+                raise ValueError(
+                    f"external fabric interval {interval_identity!r} has "
+                    f"launch nodes outside kernel descriptor {kernel_index}: "
+                    f"{tuple(sorted(outside_nodes))}"
+                )
+            interval_nodes.update(descriptor_interval_nodes)
         expected_external_nodes.setdefault(interval_identity, set()).update(
             interval_nodes
         )

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -2464,7 +2464,7 @@ def _fabric_manager_intervals_to_source(kernel_specs: List[KernelSpec]) -> str:
             f"{interval.identity!r}, "
             f"FabricManagerIntervalKind({interval.kind.value!r}), "
             f"{interval.claim!r}, {interval.route_indices!r}, "
-            f"{interval.interfering_intervals!r})"
+            f"{interval.interfering_intervals!r}, {interval.launch_nodes!r})"
             for interval in spec.fabric_manager_intervals
         ]
         suffix = "," if interval_sources else ""

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -1288,6 +1288,11 @@ def _get_kernel_fabric_manager_intervals(module, kernel_name: str):
                 claim=interval.claim,
                 route_indices=tuple(interval.route_indices),
                 interfering_intervals=tuple(interval.interfering_intervals),
+                launch_nodes=(
+                    None
+                    if interval.launch_nodes is None
+                    else tuple(tuple(node) for node in interval.launch_nodes)
+                ),
             )
         )
     return tuple(intervals)

--- a/python/ttlang/TTLModule.cpp
+++ b/python/ttlang/TTLModule.cpp
@@ -12,9 +12,12 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/Location.h"
 
+#include <nanobind/stl/array.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
+
+#include <array>
 
 namespace nb = nanobind;
 using namespace mlir;
@@ -177,14 +180,34 @@ void populateTTLModule(nb::module_ &m) {
                                                  routeIndices.end());
                    })
       .def_prop_ro(
-          "interfering_intervals", [](FabricManagerIntervalAttr attribute) {
+          "interfering_intervals",
+          [](FabricManagerIntervalAttr attribute) {
             std::vector<std::string> identities;
             identities.reserve(attribute.getInterferingIntervals().size());
             for (StringAttr identity : attribute.getInterferingIntervals()) {
               identities.push_back(identity.getValue().str());
             }
             return identities;
-          });
+          })
+      .def_prop_ro("launch_nodes",
+                   [](FabricManagerIntervalAttr attribute)
+                       -> std::optional<std::vector<std::array<int64_t, 2>>> {
+                     DenseI64ArrayAttr launchNodes = attribute.getLaunchNodes();
+                     if (!launchNodes) {
+                       return std::nullopt;
+                     }
+                     ArrayRef<int64_t> coordinates = launchNodes.asArrayRef();
+                     assert(coordinates.size() % 2 == 0 &&
+                            "launch-node coordinates must contain x/y pairs");
+                     std::vector<std::array<int64_t, 2>> nodes;
+                     nodes.reserve(coordinates.size() / 2);
+                     for (std::size_t index = 0; index < coordinates.size();
+                          index += 2) {
+                       nodes.push_back(
+                           {coordinates[index], coordinates[index + 1]});
+                     }
+                     return nodes;
+                   });
 
   //===--------------------------------------------------------------------===//
   // Device-domain attributes

--- a/test/python/atom/test_kernel_spec_identity.py
+++ b/test/python/atom/test_kernel_spec_identity.py
@@ -149,6 +149,88 @@ def test_external_fabric_manager_can_select_pipe_source_kernel(monkeypatch):
     assert interval.claim == manager.identity
 
 
+def test_scoped_external_managers_retain_conditional_launch_domain(monkeypatch):
+    """Sequential coordinator calls can reuse one physical manager."""
+    monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")
+    pre_manager = ttl.FabricManagerClaim("pre", kernel=ttl.PIPE_SOURCE_KERNEL)
+    post_manager = ttl.FabricManagerClaim("post", kernel=ttl.PIPE_SOURCE_KERNEL)
+
+    @ttl.operation(grid=(3, 2))
+    def conditional_managers(inp):
+        core_x, core_y = ttl.node(dims=2)
+        if core_x == 1:
+            if core_y == 0:
+                ttl.call_extern_func(
+                    HEADER,
+                    "pre",
+                    kernel=ttl.PIPE_SOURCE_KERNEL,
+                    fabric_manager_effects=(pre_manager.scoped(),),
+                )
+                ttl.call_extern_func(
+                    HEADER,
+                    "post",
+                    kernel=ttl.PIPE_SOURCE_KERNEL,
+                    fabric_manager_effects=(post_manager.scoped(),),
+                )
+
+    conditional_managers(
+        ttnn.from_torch(
+            torch.zeros((32, 32), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+    )
+
+    selected_spec = next(
+        spec
+        for spec in _kernel_specs(_compiled_kernel(conditional_managers))
+        if spec.logical_kernel == ttl.PIPE_SOURCE_KERNEL
+    )
+    assert len(selected_spec.fabric_manager_intervals) == 2
+    intervals_by_claim = {
+        interval.claim: interval for interval in selected_spec.fabric_manager_intervals
+    }
+    assert set(intervals_by_claim) == {pre_manager.identity, post_manager.identity}
+    assert all(
+        interval.launch_nodes == ((1, 0),) and interval.interfering_intervals == ()
+        for interval in intervals_by_claim.values()
+    )
+
+
+def test_scoped_external_manager_retains_empty_launch_domain(monkeypatch):
+    """An unreachable scoped call must not acquire on the full kernel range."""
+    monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")
+    manager = ttl.FabricManagerClaim("empty", kernel=ttl.PIPE_SOURCE_KERNEL)
+
+    @ttl.operation(grid=(3, 2))
+    def unreachable_manager(inp):
+        core_x, core_y = ttl.node(dims=2)
+        if core_x == 99:
+            if core_y == 99:
+                ttl.call_extern_func(
+                    HEADER,
+                    "unreachable",
+                    kernel=ttl.PIPE_SOURCE_KERNEL,
+                    fabric_manager_effects=(manager.scoped(),),
+                )
+
+    unreachable_manager(
+        ttnn.from_torch(
+            torch.zeros((32, 32), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+    )
+
+    selected_spec = next(
+        spec
+        for spec in _kernel_specs(_compiled_kernel(unreachable_manager))
+        if spec.logical_kernel == ttl.PIPE_SOURCE_KERNEL
+    )
+    assert len(selected_spec.fabric_manager_intervals) == 1
+    assert selected_spec.fabric_manager_intervals[0].launch_nodes == ()
+
+
 def test_composed_fabric_manager_lifetime_reaches_selected_kernel(monkeypatch):
     """Composed acquire, use, and release produce one ownership interval."""
     monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -3338,6 +3338,75 @@ def test_routing_plane_uses_external_interval_launch_nodes(monkeypatch):
     assert program.semaphores == []
 
 
+def test_routing_plane_unions_per_descriptor_external_launch_nodes(monkeypatch):
+    fake_ttnn = _FakeTTNN()
+    monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
+    program = _make_fake_fabric_program_at_node(2)
+    program.kernels[0].core_ranges = _FakeTTNN.CoreRangeSet(
+        [
+            _FakeTTNN.CoreRange(
+                _FakeTTNN.CoreCoord(0, 0),
+                _FakeTTNN.CoreCoord(0, 0),
+            )
+        ]
+    )
+    program.kernels[1].core_ranges = _FakeTTNN.CoreRangeSet(
+        [
+            _FakeTTNN.CoreRange(
+                _FakeTTNN.CoreCoord(1, 0),
+                _FakeTTNN.CoreCoord(2, 0),
+            )
+        ]
+    )
+    claim = _bound_fabric_claim()
+    external_binding = FabricConnectionBinding(
+        claim=claim,
+        connections=(
+            FabricConnectionRequirement(
+                local_device=DeviceRef(0, 0),
+                remote_device=DeviceRef(0, 1),
+                worker_nodes=((2, 0),),
+                fixed_link_index=1,
+            ),
+        ),
+        abi_identity="external-v1",
+    )
+
+    kernel_runner.configure_routing_plane_runtime_args(
+        program_descriptor=program,
+        kernel_fabric_routes=[[], []],
+        kernel_fabric_runtime_arg_base_common_indices=[None, None],
+        kernel_fabric_manager_intervals=[
+            (
+                _fabric_manager_interval(
+                    "external.external",
+                    kind=kernel_runner.FabricManagerIntervalKind.EXTERNAL,
+                    claim="external",
+                    route_indices=(),
+                    launch_nodes=(),
+                ),
+            ),
+            (
+                _fabric_manager_interval(
+                    "external.external",
+                    kind=kernel_runner.FabricManagerIntervalKind.EXTERNAL,
+                    claim="external",
+                    route_indices=(),
+                    launch_nodes=((2, 0),),
+                ),
+            ),
+        ],
+        external_fabric_connections=(external_binding,),
+        mesh_device=_FakeMeshDevice(),
+        device_coordinates=(0, 0),
+        grid_cols=3,
+        grid_rows=1,
+    )
+
+    assert fake_ttnn.fabric_setup_calls == []
+    assert program.semaphores == []
+
+
 def test_routing_plane_rejects_launch_nodes_outside_kernel_descriptor(monkeypatch):
     fake_ttnn = _FakeTTNN()
     monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
@@ -3356,7 +3425,10 @@ def test_routing_plane_rejects_launch_nodes_outside_kernel_descriptor(monkeypatc
         abi_identity="external-v1",
     )
 
-    with pytest.raises(ValueError, match=r"outside.*\(\(2, 0\),\)"):
+    with pytest.raises(
+        ValueError,
+        match=r"outside kernel descriptor 0.*\(\(2, 0\),\)",
+    ):
         kernel_runner.configure_routing_plane_runtime_args(
             program_descriptor=program,
             kernel_fabric_routes=[[]],

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -481,6 +481,7 @@ def _fabric_manager_interval(
     claim=None,
     route_indices=(0,),
     interfering_intervals=(),
+    launch_nodes=None,
 ):
     return kernel_runner.FabricManagerIntervalSpec(
         identity=identity,
@@ -488,6 +489,7 @@ def _fabric_manager_interval(
         claim=claim,
         route_indices=route_indices,
         interfering_intervals=interfering_intervals,
+        launch_nodes=launch_nodes,
     )
 
 
@@ -3282,6 +3284,139 @@ def test_routing_plane_rejects_incomplete_external_node_coverage(monkeypatch):
         )
 
     assert fake_ttnn.fabric_setup_calls == []
+
+
+def test_routing_plane_uses_external_interval_launch_nodes(monkeypatch):
+    fake_ttnn = _FakeTTNN()
+    monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
+    program = _make_fake_fabric_program_at_node(1)
+    program.kernels[0].core_ranges = _FakeTTNN.CoreRangeSet(
+        [
+            _FakeTTNN.CoreRange(
+                _FakeTTNN.CoreCoord(1, 0),
+                _FakeTTNN.CoreCoord(2, 0),
+            )
+        ]
+    )
+    claim = _bound_fabric_claim()
+    external_binding = FabricConnectionBinding(
+        claim=claim,
+        connections=(
+            FabricConnectionRequirement(
+                local_device=DeviceRef(0, 0),
+                remote_device=DeviceRef(0, 1),
+                worker_nodes=((1, 0),),
+                fixed_link_index=1,
+            ),
+        ),
+        abi_identity="external-v1",
+    )
+
+    kernel_runner.configure_routing_plane_runtime_args(
+        program_descriptor=program,
+        kernel_fabric_routes=[[]],
+        kernel_fabric_runtime_arg_base_common_indices=[None],
+        kernel_fabric_manager_intervals=[
+            (
+                _fabric_manager_interval(
+                    "external.external",
+                    kind=kernel_runner.FabricManagerIntervalKind.EXTERNAL,
+                    claim="external",
+                    route_indices=(),
+                    launch_nodes=((1, 0),),
+                ),
+            )
+        ],
+        external_fabric_connections=(external_binding,),
+        mesh_device=_FakeMeshDevice(),
+        device_coordinates=(0, 0),
+        grid_cols=3,
+        grid_rows=1,
+    )
+
+    assert fake_ttnn.fabric_setup_calls == []
+    assert program.semaphores == []
+
+
+def test_routing_plane_rejects_launch_nodes_outside_kernel_descriptor(monkeypatch):
+    fake_ttnn = _FakeTTNN()
+    monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
+    program = _make_fake_fabric_program_at_node(1)
+    claim = _bound_fabric_claim()
+    external_binding = FabricConnectionBinding(
+        claim=claim,
+        connections=(
+            FabricConnectionRequirement(
+                local_device=DeviceRef(0, 0),
+                remote_device=DeviceRef(0, 1),
+                worker_nodes=((1, 0),),
+                fixed_link_index=1,
+            ),
+        ),
+        abi_identity="external-v1",
+    )
+
+    with pytest.raises(ValueError, match=r"outside.*\(\(2, 0\),\)"):
+        kernel_runner.configure_routing_plane_runtime_args(
+            program_descriptor=program,
+            kernel_fabric_routes=[[]],
+            kernel_fabric_runtime_arg_base_common_indices=[None],
+            kernel_fabric_manager_intervals=[
+                (
+                    _fabric_manager_interval(
+                        "external.external",
+                        kind=kernel_runner.FabricManagerIntervalKind.EXTERNAL,
+                        claim="external",
+                        route_indices=(),
+                        launch_nodes=((2, 0),),
+                    ),
+                )
+            ],
+            external_fabric_connections=(external_binding,),
+            mesh_device=_FakeMeshDevice(),
+            device_coordinates=(0, 0),
+            grid_cols=3,
+            grid_rows=1,
+        )
+
+    assert fake_ttnn.fabric_setup_calls == []
+
+
+def test_routing_plane_distinguishes_empty_launch_domain_from_absent(monkeypatch):
+    fake_ttnn = _FakeTTNN()
+    monkeypatch.setattr(kernel_runner, "ttnn", fake_ttnn)
+    program = _make_fake_fabric_program_at_node(1)
+    claim = _bound_fabric_claim()
+    external_binding = FabricConnectionBinding(
+        claim=claim,
+        connections=(),
+        abi_identity="external-v1",
+    )
+
+    kernel_runner.configure_routing_plane_runtime_args(
+        program_descriptor=program,
+        kernel_fabric_routes=[[]],
+        kernel_fabric_runtime_arg_base_common_indices=[None],
+        kernel_fabric_manager_intervals=[
+            (
+                _fabric_manager_interval(
+                    "external.external",
+                    kind=kernel_runner.FabricManagerIntervalKind.EXTERNAL,
+                    claim="external",
+                    route_indices=(),
+                    launch_nodes=(),
+                ),
+            )
+        ],
+        external_fabric_connections=(external_binding,),
+        mesh_device=_FakeMeshDevice(),
+        device_coordinates=(0, 0),
+        grid_cols=3,
+        grid_rows=1,
+    )
+
+    assert fake_ttnn.fabric_setup_calls == []
+    assert program.semaphores == []
 
 
 def test_device_domain_plans_all_fabric_bindings_before_setup(monkeypatch):

--- a/test/ttlang/Dialect/TTL/Transforms/fabric_manager_lifetime.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/fabric_manager_lifetime.mlir
@@ -10,7 +10,7 @@
 // Acquire ownership starts at call entry and release ownership ends when its
 // call returns. Uses within that interval do not create additional intervals.
 // CHECK-LABEL: func.func @explicit_interval
-// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.explicit", kind = external, claim = "explicit", routeIndices = [], interferingIntervals = "external.scoped">]
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.explicit", kind = external, claim = "explicit", routeIndices = [], interferingIntervals = ["external.scoped", "external.conditional"]>]
 // CHECK-NEXT: ttkernel.opaque_call "acquire"
 // CHECK-NEXT: ttkernel.opaque_call "use"
 // CHECK-NEXT: ttkernel.opaque_call "release"
@@ -18,9 +18,15 @@
 
 // A scoped claim owns its manager for one opaque call.
 // CHECK-LABEL: func.func @scoped_interval
-// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.scoped", kind = external, claim = "scoped", routeIndices = [], interferingIntervals = "external.explicit">]
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.scoped", kind = external, claim = "scoped", routeIndices = [], interferingIntervals = ["external.explicit", "external.conditional"]>]
 // CHECK-NEXT: ttkernel.opaque_call "run"
 // CHECK-NEXT: return
+
+// A nested scoped claim records the exact launch nodes that execute it.
+// CHECK-LABEL: func.func @conditional_scoped_interval
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.conditional", kind = external, claim = "conditional", routeIndices = [], interferingIntervals = ["external.explicit", "external.scoped"], launchNodes = [1, 0]>]
+// CHECK: scf.if
+// CHECK: ttkernel.opaque_call "run_conditional"
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @explicit_interval() attributes {
@@ -48,6 +54,21 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
         fabric_manager_effects = [#ttl.fabric_manager_effect<
             claim = "scoped", kind = scoped>],
         header = "fabric.hpp"} : () -> ()
+    return
+  }
+
+  func.func @conditional_scoped_interval() attributes {
+      ttl.kernel_thread = #ttkernel.thread<noc>,
+      ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
+    %node_x = ttl.core_x : index
+    %selected_x = arith.constant 1 : index
+    %selected = arith.cmpi eq, %node_x, %selected_x : index
+    scf.if %selected {
+      ttl.opaque_call "run_conditional" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "conditional", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/fabric_manager_lifetime_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/fabric_manager_lifetime_invalid.mlir
@@ -27,10 +27,10 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
       ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
     %condition = arith.constant true
     scf.if %condition {
-      // expected-error @below {{fabric manager effects must be in the logical kernel's straight-line entry block}}
+      // expected-error @below {{fabric manager effects must be in the logical kernel's straight-line entry block unless the effect is scoped}}
       ttl.opaque_call "run" () {
           fabric_manager_effects = [#ttl.fabric_manager_effect<
-              claim = "manager", kind = scoped>],
+              claim = "manager", kind = acquire>],
           header = "fabric.hpp"} : () -> ()
     }
     return

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_multiple_intervals.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_multiple_intervals.mlir
@@ -14,8 +14,8 @@
 // CHECK-SAME: ttl.pipe_sync_semaphore_count = 1 : i64
 // CHECK-LABEL: func.func @sender_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "generated.0", kind = generated_sender,
-// CHECK-SAME: interferingIntervals = >, #ttl.fabric_manager_interval<identity = "generated.2", kind = generated_sender,
-// CHECK-SAME: interferingIntervals = >]
+// CHECK-SAME: interferingIntervals = []>, #ttl.fabric_manager_interval<identity = "generated.2", kind = generated_sender,
+// CHECK-SAME: interferingIntervals = []>]
 // CHECK: %[[SENDER_COUNTER:.*]] = memref.alloca() : memref<1xi32>
 // CHECK: memref.store {{.*}}, %[[SENDER_COUNTER]]
 // CHECK: memref.load %[[SENDER_COUNTER]]
@@ -24,8 +24,8 @@
 // CHECK: memref.store {{.*}}, %[[SENDER_COUNTER]]
 // CHECK-LABEL: func.func @receiver_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "generated.1", kind = generated_receiver,
-// CHECK-SAME: interferingIntervals = >, #ttl.fabric_manager_interval<identity = "generated.3", kind = generated_receiver,
-// CHECK-SAME: interferingIntervals = >]
+// CHECK-SAME: interferingIntervals = []>, #ttl.fabric_manager_interval<identity = "generated.3", kind = generated_receiver,
+// CHECK-SAME: interferingIntervals = []>]
 // CHECK: %[[RECEIVER_COUNTER:.*]] = memref.alloca() : memref<1xi32>
 // CHECK: memref.store {{.*}}, %[[RECEIVER_COUNTER]]
 // CHECK: memref.load %[[RECEIVER_COUNTER]]

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_ownership.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_ownership.mlir
@@ -20,16 +20,16 @@
 // GLOBAL-SAME: ttl.pipe_sync_semaphore_count = 0 : i64
 // GLOBAL-LABEL: func.func @sender_node
 // GLOBAL-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "generated.0", kind = generated_sender,
-// GLOBAL-SAME: interferingIntervals = "generated.1">]
+// GLOBAL-SAME: interferingIntervals = ["generated.1"]>]
 // GLOBAL-LABEL: func.func @receiver_node
 // GLOBAL-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "generated.1", kind = generated_receiver,
-// GLOBAL-SAME: interferingIntervals = "generated.0">]
+// GLOBAL-SAME: interferingIntervals = ["generated.0"]>]
 
 // The sender waits for the receiver to release the manager, sends the payload,
 // closes the manager, and publishes the pair's completed generation.
 // CHECK-LABEL: func.func @sender_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "generated.0", kind = generated_sender,
-// CHECK-SAME: interferingIntervals = >]
+// CHECK-SAME: interferingIntervals = []>]
 // CHECK-DAG: %[[SENDER_GENERATION_1:.*]] = arith.constant 1 : i32
 // CHECK-DAG: %[[SENDER_GENERATION_2:.*]] = arith.constant 2 : i32
 // CHECK-DAG: %[[SENDER_INDEX_0:.*]] = arith.constant 0 : index
@@ -47,7 +47,7 @@
 // ownership wait.
 // CHECK-LABEL: func.func @receiver_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "generated.1", kind = generated_receiver,
-// CHECK-SAME: interferingIntervals = >]
+// CHECK-SAME: interferingIntervals = []>]
 // CHECK-DAG: %[[RECEIVER_GENERATION_0:.*]] = arith.constant 0 : i32
 // CHECK-DAG: %[[RECEIVER_GENERATION_1:.*]] = arith.constant 1 : i32
 // CHECK-DAG: %[[RECEIVER_INDEX_0:.*]] = arith.constant 0 : index

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_repeated_ownership.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_repeated_ownership.mlir
@@ -13,7 +13,7 @@
 // CHECK-SAME: ttl.pipe_sync_semaphore_count = 1 : i64
 // CHECK-LABEL: func.func @sender_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<
-// CHECK-SAME: interferingIntervals = >
+// CHECK-SAME: interferingIntervals = []>
 // CHECK: %[[SENDER_COUNTER:.*]] = memref.alloca() : memref<1xi32>
 // CHECK: memref.store {{.*}}, %[[SENDER_COUNTER]]
 // CHECK: scf.for
@@ -28,7 +28,7 @@
 // CHECK: memref.store %[[SENDER_NEXT]], %[[SENDER_COUNTER]]
 // CHECK-LABEL: func.func @receiver_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<
-// CHECK-SAME: interferingIntervals = >
+// CHECK-SAME: interferingIntervals = []>
 // CHECK: %[[RECEIVER_COUNTER:.*]] = memref.alloca() : memref<1xi32>
 // CHECK: memref.store {{.*}}, %[[RECEIVER_COUNTER]]
 // CHECK: scf.for

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_unproven_ownership.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_fabric_manager_unproven_ownership.mlir
@@ -14,10 +14,10 @@
 // CHECK-SAME: ttl.pipe_sync_semaphore_count = 0 : i64
 // CHECK-LABEL: func.func @sender_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<
-// CHECK-SAME: interferingIntervals = "generated.
+// CHECK-SAME: interferingIntervals = ["generated.
 // CHECK-LABEL: func.func @receiver_node
 // CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<
-// CHECK-SAME: interferingIntervals = "generated.
+// CHECK-SAME: interferingIntervals = ["generated.
 
 module attributes {ttl.launch_grid = [2, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @idle_compute() attributes {ttl.base_cta_index = 2 : i32, ttl.crta_indices = [], ttl.kernel_thread = #ttkernel.thread<compute>, ttl.logical_kernel = #ttl.logical_kernel<kind = compute>} {


### PR DESCRIPTION
## Overview

- Preserve proven launch-node domains for external fabric manager claims.
- Validate runtime bindings against those domains.

## Testing

- 177 focused host tests
- 334 MLIR tests
- Galaxy device regression: N=2, cached N=2, and N=100
- Focused pre-commit checks