### PR TITLE
[TTL] Prove scoped fabric manager ordering

### DIFF
--- a/docs/development/PipesOnFabric.md
+++ b/docs/development/PipesOnFabric.md
@@ -621,6 +621,13 @@ domain means the complete descriptor executes the interval; a present empty
 domain means no node executes it. The external binding must cover the resulting
 node set exactly.
 
+Each scoped external call releases its manager before returning. Scoped calls
+in one RISC function are therefore sequential even when sibling structured
+control-flow regions contain them, provided both execute on the same single
+launch node. Multiple launch nodes may progress independently, and calls in
+different functions may execute concurrently, so those intervals remain
+interfering.
+
 The compiler serializes an ordered sequence of generated receiver and sender
 manager intervals only when corresponding intervals each contain one protocol
 operation, implement the same transfers at the same device and TENSIX node,

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsAttrs.td
@@ -231,7 +231,10 @@ def TTL_FabricManagerIntervalAttr
     optional launch-node list records the exact nodes that execute an external
     interval. An absent list uses the enclosing kernel descriptor; a present
     empty list means no node executes the interval. The interference list
-    contains interval identities whose lifetimes may overlap.
+    contains interval identities whose lifetimes may overlap. Scoped external
+    intervals in distinct structured-control regions are sequential when they
+    execute on the same single launch node because each call releases its
+    manager before returning.
   }];
   let parameters = (ins
     "StringAttr":$identity,

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -416,8 +416,22 @@ externalManagerIntervalsAreSequential(const FabricManagerIntervalPlan &lhs,
                                       const FabricManagerIntervalPlan &rhs) {
   if (lhs.kind != FabricManagerIntervalKind::External ||
       rhs.kind != FabricManagerIntervalKind::External ||
-      lhs.function != rhs.function ||
-      lhs.releaseBoundary->getBlock() != rhs.acquireBoundary->getBlock()) {
+      lhs.function != rhs.function) {
+    return false;
+  }
+
+  bool lhsIsScoped = lhs.acquireBoundary == lhs.releaseBoundary;
+  bool rhsIsScoped = rhs.acquireBoundary == rhs.releaseBoundary;
+  bool sameSingleLaunchNode = lhs.launchNodes && rhs.launchNodes &&
+                              lhs.launchNodes->size() == 1 &&
+                              lhs.launchNodes == rhs.launchNodes;
+  // One RISC cannot overlap synchronous scoped calls. Multiple launch nodes
+  // may progress independently, so cross-region ordering requires one node.
+  if (lhsIsScoped && rhsIsScoped && sameSingleLaunchNode) {
+    return true;
+  }
+
+  if (lhs.releaseBoundary->getBlock() != rhs.acquireBoundary->getBlock()) {
     return false;
   }
   return lhs.releaseBoundary->isBeforeInBlock(rhs.acquireBoundary);

--- a/test/python/atom/test_kernel_spec_identity.py
+++ b/test/python/atom/test_kernel_spec_identity.py
@@ -158,20 +158,21 @@ def test_scoped_external_managers_retain_conditional_launch_domain(monkeypatch):
     @ttl.operation(grid=(3, 2))
     def conditional_managers(inp):
         core_x, core_y = ttl.node(dims=2)
-        if core_x == 1:
-            if core_y == 0:
-                ttl.call_extern_func(
-                    HEADER,
-                    "pre",
-                    kernel=ttl.PIPE_SOURCE_KERNEL,
-                    fabric_manager_effects=(pre_manager.scoped(),),
-                )
-                ttl.call_extern_func(
-                    HEADER,
-                    "post",
-                    kernel=ttl.PIPE_SOURCE_KERNEL,
-                    fabric_manager_effects=(post_manager.scoped(),),
-                )
+        active = core_x == 1 and core_y == 0
+        if active:
+            ttl.call_extern_func(
+                HEADER,
+                "pre",
+                kernel=ttl.PIPE_SOURCE_KERNEL,
+                fabric_manager_effects=(pre_manager.scoped(),),
+            )
+        if active:
+            ttl.call_extern_func(
+                HEADER,
+                "post",
+                kernel=ttl.PIPE_SOURCE_KERNEL,
+                fabric_manager_effects=(post_manager.scoped(),),
+            )
 
     conditional_managers(
         ttnn.from_torch(

--- a/test/ttlang/Dialect/TTL/Transforms/fabric_manager_scoped_ordering.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/fabric_manager_scoped_ordering.mlir
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttlang-opt %s --split-input-file -convert-ttl-to-ttkernel | FileCheck %s
+
+// Summary: Verify scoped external manager calls are sequential within one
+// function and remain concurrent across functions.
+
+// CHECK-LABEL: func.func @sibling_conditionals
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.first", kind = external, claim = "first", routeIndices = [], interferingIntervals = [], launchNodes = [0, 0]>, #ttl.fabric_manager_interval<identity = "external.second", kind = external, claim = "second", routeIndices = [], interferingIntervals = [], launchNodes = [0, 0]>]
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
+  func.func @sibling_conditionals() attributes {
+      ttl.kernel_thread = #ttkernel.thread<noc>,
+      ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
+    %node_x = ttl.core_x : index
+    %selected_x = arith.constant 0 : index
+    %selected = arith.cmpi eq, %node_x, %selected_x : index
+    scf.if %selected {
+      ttl.opaque_call "run_first" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "first", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
+    scf.if %selected {
+      ttl.opaque_call "run_second" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "second", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @looped_sequence
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.loop.first", kind = external, claim = "loop.first", routeIndices = [], interferingIntervals = [], launchNodes = [0, 0]>, #ttl.fabric_manager_interval<identity = "external.loop.second", kind = external, claim = "loop.second", routeIndices = [], interferingIntervals = [], launchNodes = [0, 0]>]
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
+  func.func @looped_sequence() attributes {
+      ttl.kernel_thread = #ttkernel.thread<noc>,
+      ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      ttl.opaque_call "run_loop_first" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "loop.first", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+      ttl.opaque_call "run_loop_second" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "loop.second", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @distinct_launch_nodes
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.left", kind = external, claim = "left", routeIndices = [], interferingIntervals = ["external.right"], launchNodes = [0, 0]>, #ttl.fabric_manager_interval<identity = "external.right", kind = external, claim = "right", routeIndices = [], interferingIntervals = ["external.left"], launchNodes = [1, 0]>]
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @distinct_launch_nodes() attributes {
+      ttl.kernel_thread = #ttkernel.thread<noc>,
+      ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
+    %node_x = ttl.core_x : index
+    %left_x = arith.constant 0 : index
+    %right_x = arith.constant 1 : index
+    %is_left = arith.cmpi eq, %node_x, %left_x : index
+    %is_right = arith.cmpi eq, %node_x, %right_x : index
+    scf.if %is_left {
+      ttl.opaque_call "run_left" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "left", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
+    scf.if %is_right {
+      ttl.opaque_call "run_right" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "right", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @multiple_launch_nodes
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.multi.first", kind = external, claim = "multi.first", routeIndices = [], interferingIntervals = ["external.multi.second"], launchNodes = [0, 0, 1, 0]>, #ttl.fabric_manager_interval<identity = "external.multi.second", kind = external, claim = "multi.second", routeIndices = [], interferingIntervals = ["external.multi.first"], launchNodes = [0, 0, 1, 0]>]
+module attributes {ttl.launch_grid = array<i64: 3, 1>} {
+  func.func @multiple_launch_nodes() attributes {
+      ttl.kernel_thread = #ttkernel.thread<noc>,
+      ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
+    %node_x = ttl.core_x : index
+    %upper_x = arith.constant 2 : index
+    %selected = arith.cmpi ult, %node_x, %upper_x : index
+    scf.if %selected {
+      ttl.opaque_call "run_multi_first" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "multi.first", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
+    scf.if %selected {
+      ttl.opaque_call "run_multi_second" () {
+          fabric_manager_effects = [#ttl.fabric_manager_effect<
+              claim = "multi.second", kind = scoped>],
+          header = "fabric.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func.func @first_function
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.concurrent.first", kind = external, claim = "concurrent.first", routeIndices = [], interferingIntervals = ["external.concurrent.second"]>]
+// CHECK-LABEL: func.func @second_function
+// CHECK-SAME: ttl.fabric_manager_intervals = [#ttl.fabric_manager_interval<identity = "external.concurrent.second", kind = external, claim = "concurrent.second", routeIndices = [], interferingIntervals = ["external.concurrent.first"]>]
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
+  func.func @first_function() attributes {
+      ttl.kernel_thread = #ttkernel.thread<noc>,
+      ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
+    ttl.opaque_call "run_concurrent_first" () {
+        fabric_manager_effects = [#ttl.fabric_manager_effect<
+            claim = "concurrent.first", kind = scoped>],
+        header = "fabric.hpp"} : () -> ()
+    return
+  }
+
+  func.func @second_function() attributes {
+      ttl.kernel_thread = #ttkernel.thread<noc>,
+      ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>} {
+    ttl.opaque_call "run_concurrent_second" () {
+        fabric_manager_effects = [#ttl.fabric_manager_effect<
+            claim = "concurrent.second", kind = scoped>],
+        header = "fabric.hpp"} : () -> ()
+    return
+  }
+}


### PR DESCRIPTION
## Summary

- Allow proven sequential scoped manager calls to reuse connection resources.
- Preserve interference for concurrently executable calls.
- Add focused compiler and device coverage.

## Testing

- 32-device Blackhole: N=2, cached N=2, and N=100
- Focused host pytest: 6 passed
- MLIR: 335 passed
- Pre-commit: passed