### PR TITLE
[ci] Restrict PR CI and add hardware controls

### DIFF
--- a/.github/scripts/check-hardware-job-results.py
+++ b/.github/scripts/check-hardware-job-results.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Collection
 from enum import Enum
 from typing import Any
 
@@ -104,23 +103,7 @@ def _hardware_jobs(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [job for job in jobs if HARDWARE_JOB_NAME_MARKER in str(job.get("name", ""))]
 
 
-def _runner_name(job: dict[str, Any]) -> str | None:
-    job_name = str(job.get("name", ""))
-    runner_start = job_name.find(HARDWARE_JOB_NAME_MARKER)
-    if runner_start == -1:
-        return None
-    runner_start += len(HARDWARE_JOB_NAME_MARKER)
-    runner_end = job_name.find(")", runner_start)
-    if runner_end == -1:
-        return None
-    return job_name[runner_start:runner_end]
-
-
-def check_hardware_jobs(
-    jobs: list[dict[str, Any]],
-    expected_job_count: int,
-    optional_runners: Collection[str] = (),
-) -> bool:
+def check_hardware_jobs(jobs: list[dict[str, Any]], expected_job_count: int) -> bool:
     hardware_jobs = _hardware_jobs(jobs)
     if len(hardware_jobs) != expected_job_count:
         print(
@@ -129,19 +112,13 @@ def check_hardware_jobs(
         )
         return False
 
-    successful_required_jobs = 0
+    successful_jobs = 0
     post_setup_failures = 0
     for job in sorted(hardware_jobs, key=lambda hardware_job: hardware_job["name"]):
         job_name = job["name"]
         result, description = _classify_job(job)
-        if _runner_name(job) in optional_runners:
-            if result is HardwareJobResult.SUCCESS:
-                print(f"{job_name}: {description} (optional).")
-            else:
-                print(f"::warning::{job_name}: {description}; optional hardware job.")
-            continue
         if result is HardwareJobResult.SUCCESS:
-            successful_required_jobs += 1
+            successful_jobs += 1
             print(f"{job_name}: {description}.")
         elif result is HardwareJobResult.RUNNER_SETUP_FAILURE:
             print(f"::warning::{job_name}: {description}; hardware tests did not run.")
@@ -151,8 +128,8 @@ def check_hardware_jobs(
 
     if post_setup_failures:
         return False
-    if successful_required_jobs == 0:
-        print("::error::No required hardware runner completed the test suite.")
+    if successful_jobs == 0:
+        print("::error::No hardware runner completed the test suite.")
         return False
 
     return True
@@ -168,12 +145,6 @@ def main() -> int:
         required=True,
         help="Number of hardware matrix jobs expected in the workflow run.",
     )
-    parser.add_argument(
-        "--optional-runner",
-        action="append",
-        default=[],
-        help="Hardware configuration whose failure does not fail the aggregate check.",
-    )
     arguments = parser.parse_args()
 
     try:
@@ -181,13 +152,7 @@ def main() -> int:
     except (OSError, ValueError, json.JSONDecodeError) as error:
         parser.error(str(error))
 
-    return (
-        0
-        if check_hardware_jobs(
-            jobs, arguments.expected_job_count, arguments.optional_runner
-        )
-        else 1
-    )
+    return 0 if check_hardware_jobs(jobs, arguments.expected_job_count) else 1
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check-hardware-job-results.py
+++ b/.github/scripts/check-hardware-job-results.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Collection
 from enum import Enum
 from typing import Any
 
@@ -103,7 +104,23 @@ def _hardware_jobs(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [job for job in jobs if HARDWARE_JOB_NAME_MARKER in str(job.get("name", ""))]
 
 
-def check_hardware_jobs(jobs: list[dict[str, Any]], expected_job_count: int) -> bool:
+def _runner_name(job: dict[str, Any]) -> str | None:
+    job_name = str(job.get("name", ""))
+    runner_start = job_name.find(HARDWARE_JOB_NAME_MARKER)
+    if runner_start == -1:
+        return None
+    runner_start += len(HARDWARE_JOB_NAME_MARKER)
+    runner_end = job_name.find(")", runner_start)
+    if runner_end == -1:
+        return None
+    return job_name[runner_start:runner_end]
+
+
+def check_hardware_jobs(
+    jobs: list[dict[str, Any]],
+    expected_job_count: int,
+    optional_runners: Collection[str] = (),
+) -> bool:
     hardware_jobs = _hardware_jobs(jobs)
     if len(hardware_jobs) != expected_job_count:
         print(
@@ -112,13 +129,19 @@ def check_hardware_jobs(jobs: list[dict[str, Any]], expected_job_count: int) -> 
         )
         return False
 
-    successful_jobs = 0
+    successful_required_jobs = 0
     post_setup_failures = 0
     for job in sorted(hardware_jobs, key=lambda hardware_job: hardware_job["name"]):
         job_name = job["name"]
         result, description = _classify_job(job)
+        if _runner_name(job) in optional_runners:
+            if result is HardwareJobResult.SUCCESS:
+                print(f"{job_name}: {description} (optional).")
+            else:
+                print(f"::warning::{job_name}: {description}; optional hardware job.")
+            continue
         if result is HardwareJobResult.SUCCESS:
-            successful_jobs += 1
+            successful_required_jobs += 1
             print(f"{job_name}: {description}.")
         elif result is HardwareJobResult.RUNNER_SETUP_FAILURE:
             print(f"::warning::{job_name}: {description}; hardware tests did not run.")
@@ -128,8 +151,8 @@ def check_hardware_jobs(jobs: list[dict[str, Any]], expected_job_count: int) -> 
 
     if post_setup_failures:
         return False
-    if successful_jobs == 0:
-        print("::error::No hardware runner completed the test suite.")
+    if successful_required_jobs == 0:
+        print("::error::No required hardware runner completed the test suite.")
         return False
 
     return True
@@ -145,6 +168,12 @@ def main() -> int:
         required=True,
         help="Number of hardware matrix jobs expected in the workflow run.",
     )
+    parser.add_argument(
+        "--optional-runner",
+        action="append",
+        default=[],
+        help="Hardware configuration whose failure does not fail the aggregate check.",
+    )
     arguments = parser.parse_args()
 
     try:
@@ -152,7 +181,13 @@ def main() -> int:
     except (OSError, ValueError, json.JSONDecodeError) as error:
         parser.error(str(error))
 
-    return 0 if check_hardware_jobs(jobs, arguments.expected_job_count) else 1
+    return (
+        0
+        if check_hardware_jobs(
+            jobs, arguments.expected_job_count, arguments.optional_runner
+        )
+        else 1
+    )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -11,6 +11,10 @@ on:
                 description: "Run hardware tests on a shared Exabox Galaxy."
                 type: boolean
                 default: false
+            run_loudbox_tests:
+                description: "Run hardware tests on the Blackhole loudbox."
+                type: boolean
+                default: false
             docker_tag:
                 description: "Docker image tag for the ird container."
                 type: string
@@ -24,6 +28,11 @@ on:
                 default: false
             run_galaxy_tests:
                 description: "Run hardware tests on a shared Exabox Galaxy."
+                type: boolean
+                required: false
+                default: false
+            run_loudbox_tests:
+                description: "Run hardware tests on the Blackhole loudbox."
                 type: boolean
                 required: false
                 default: false
@@ -131,17 +140,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                include:
-                    - hardware: n150
-                      runner_label: tt-ubuntu-2204-n150-stable
-                    - hardware: bh-loudbox-viommu
-                      runner_label: tt-ubuntu-2204-bh-loudbox-viommu-stable
+                hardware: ${{ inputs.run_loudbox_tests && fromJSON('["n150","bh-loudbox-viommu"]') || fromJSON('["n150"]') }}
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:
             defer_result_check: true
             hardware: ${{ matrix.hardware }}
-            runner_label: ${{ matrix.runner_label }}
+            runner_label: ${{ matrix.hardware == 'bh-loudbox-viommu' && 'tt-ubuntu-2204-bh-loudbox-viommu-stable' || 'tt-ubuntu-2204-n150-stable' }}
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}
 
@@ -186,5 +191,5 @@ jobs:
                   gh api --paginate \
                       "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" |
                       python3 .github/scripts/check-hardware-job-results.py \
-                          --expected-job-count "${{ inputs.run_galaxy_tests && 3 || 2 }}" \
+                          --expected-job-count "${{ inputs.run_loudbox_tests && (inputs.run_galaxy_tests && 3 || 2) || (inputs.run_galaxy_tests && 2 || 1) }}" \
                           --optional-runner bh-loudbox-viommu

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -128,10 +128,20 @@ jobs:
                   path: ./build/docs/sphinx/_build/html
 
     test-hardware:
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - hardware: n150
+                      runner_label: tt-ubuntu-2204-n150-stable
+                    - hardware: bh-loudbox-viommu
+                      runner_label: tt-ubuntu-2204-bh-loudbox-viommu-stable
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:
             defer_result_check: true
+            hardware: ${{ matrix.hardware }}
+            runner_label: ${{ matrix.runner_label }}
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}
 
@@ -176,4 +186,5 @@ jobs:
                   gh api --paginate \
                       "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" |
                       python3 .github/scripts/check-hardware-job-results.py \
-                          --expected-job-count "${{ inputs.run_galaxy_tests && 2 || 1 }}"
+                          --expected-job-count "${{ inputs.run_galaxy_tests && 3 || 2 }}" \
+                          --optional-runner bh-loudbox-viommu

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -144,7 +144,7 @@ jobs:
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:
-            defer_result_check: true
+            defer_result_check: ${{ matrix.hardware != 'bh-loudbox-viommu' }}
             hardware: ${{ matrix.hardware }}
             runner_label: ${{ matrix.hardware == 'bh-loudbox-viommu' && 'tt-ubuntu-2204-bh-loudbox-viommu-stable' || 'tt-ubuntu-2204-n150-stable' }}
             timeout: 90

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -191,5 +191,4 @@ jobs:
                   gh api --paginate \
                       "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" |
                       python3 .github/scripts/check-hardware-job-results.py \
-                          --expected-job-count "${{ inputs.run_loudbox_tests && (inputs.run_galaxy_tests && 3 || 2) || (inputs.run_galaxy_tests && 2 || 1) }}" \
-                          --optional-runner bh-loudbox-viommu
+                          --expected-job-count "${{ inputs.run_loudbox_tests && (inputs.run_galaxy_tests && 3 || 2) || (inputs.run_galaxy_tests && 2 || 1) }}"

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -1,8 +1,18 @@
-name: N150 Hardware Tests
+name: Hardware Tests
 
 on:
   workflow_dispatch:
     inputs:
+      hardware:
+        description: 'Hardware configuration name.'
+        required: false
+        type: string
+        default: 'n150'
+      runner_label:
+        description: 'GitHub Actions runner label.'
+        required: false
+        type: string
+        default: 'tt-ubuntu-2204-n150-stable'
       timeout:
         description: 'Job timeout in minutes'
         required: false
@@ -14,6 +24,16 @@ on:
         type: string
   workflow_call:
     inputs:
+      hardware:
+        description: 'Hardware configuration name.'
+        required: false
+        type: string
+        default: 'n150'
+      runner_label:
+        description: 'GitHub Actions runner label.'
+        required: false
+        type: string
+        default: 'tt-ubuntu-2204-n150-stable'
       defer_result_check:
         description: 'Allow the calling workflow to check the aggregate hardware result.'
         required: false
@@ -34,9 +54,9 @@ permissions:
   contents: read
 
 jobs:
-  test-n150:
-    name: "Hardware Tests (n150)"
-    runs-on: tt-ubuntu-2204-n150-stable
+  test-hardware:
+    name: "Hardware Tests (${{ inputs.hardware }})"
+    runs-on: ${{ inputs.runner_label }}
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     continue-on-error: ${{ inputs.defer_result_check }}
 
@@ -54,7 +74,7 @@ jobs:
         shell: bash
 
     env:
-      RUNS_ON: n150
+      RUNS_ON: ${{ inputs.hardware }}
       PYTHONDONTWRITEBYTECODE: 1
       TTLANG_TEST_SEED: 42
 
@@ -73,7 +93,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: Linux-ttlang-hw-n150
+          key: Linux-ttlang-hw-${{ inputs.hardware }}
           max-size: 200M
 
       - name: Build tt-lang
@@ -110,7 +130,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: hardware-test-reports-n150
+          name: hardware-test-reports-${{ inputs.hardware }}
           path: |
             build/test/me2e-report*.xml
             build/test/python-lit-report*.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   push:
     branches: ["main"]
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,17 @@ on:
   schedule:
     - cron: "0 22 * * *"
   workflow_dispatch:
+    inputs:
+      run_galaxy_tests:
+        description: "Run hardware tests on a shared Exabox Galaxy."
+        required: false
+        type: boolean
+        default: false
+      run_loudbox_tests:
+        description: "Run hardware tests on the Blackhole loudbox."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -160,7 +171,8 @@ jobs:
     secrets: inherit
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
-      run_galaxy_tests: false
+      run_galaxy_tests: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}
+      run_loudbox_tests: ${{ github.event_name == 'workflow_dispatch' && inputs.run_loudbox_tests }}
 
   build-docs:
     name: Build documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
     secrets: inherit
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
-      run_galaxy_tests: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
+      run_galaxy_tests: false
 
   build-docs:
     name: Build documentation

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -73,6 +73,10 @@ def test_hardware_matrix_adds_manual_blackhole_loudbox() -> None:
     assert "matrix.hardware == 'bh-loudbox-viommu'" in call_build
     assert "tt-ubuntu-2204-bh-loudbox-viommu-stable" in call_build
     assert "tt-ubuntu-2204-n150-stable" in call_build
+    assert (
+        "defer_result_check: ${{ matrix.hardware != 'bh-loudbox-viommu' }}"
+        in call_build
+    )
     assert "--optional-runner" not in call_build
     assert "inputs.run_galaxy_tests && 3 || 2" in call_build
     assert "inputs.run_galaxy_tests && 2 || 1" in call_build

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -31,15 +31,11 @@ def test_pull_request_ci_targets_main_only() -> None:
     )
 
 
-def test_galaxy_tests_run_only_for_pull_requests_targeting_main() -> None:
+def test_disabled_galaxy_tests_retain_exabox_configuration() -> None:
     ci_workflow = CI_WORKFLOW.read_text()
     call_build = CALL_BUILD.read_text()
-    n150_workflow = CALL_TEST_HARDWARE.read_text()
 
-    assert (
-        "run_galaxy_tests: ${{ github.event_name == 'pull_request' "
-        "&& github.base_ref == 'main' }}" in ci_workflow
-    )
+    assert "run_galaxy_tests: false" in ci_workflow
     assert "uses: ./.github/workflows/call-test-exabox.yml" in call_build
     assert "if: ${{ inputs.run_galaxy_tests }}" in call_build
     assert "needs: [test-hardware, test-exabox]" in call_build
@@ -47,8 +43,21 @@ def test_galaxy_tests_run_only_for_pull_requests_targeting_main() -> None:
         "\n    report-skipped-galaxy:", 1
     )[0]
     assert "timeout: 90" in test_exabox
-    assert '"in-service", "galaxy-bh"' not in call_build
-    assert "galaxy-bh" not in n150_workflow
+
+
+def test_hardware_matrix_adds_optional_blackhole_loudbox() -> None:
+    call_build = CALL_BUILD.read_text()
+    hardware_workflow = CALL_TEST_HARDWARE.read_text()
+
+    assert "hardware: n150" in call_build
+    assert "runner_label: tt-ubuntu-2204-n150-stable" in call_build
+    assert "hardware: bh-loudbox-viommu" in call_build
+    assert "runner_label: tt-ubuntu-2204-bh-loudbox-viommu-stable" in call_build
+    assert "--optional-runner bh-loudbox-viommu" in call_build
+    assert "inputs.run_galaxy_tests && 3 || 2" in call_build
+    assert 'name: "Hardware Tests (${{ inputs.hardware }})"' in hardware_workflow
+    assert "runs-on: ${{ inputs.runner_label }}" in hardware_workflow
+    assert "RUNS_ON: ${{ inputs.hardware }}" in hardware_workflow
 
 
 def test_exabox_workflow_dispatches_all_worker_operations_through_scripts() -> None:

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -21,6 +21,16 @@ INSTALL_EXABOX_WORKER = (
 UPLIFT_PATHS = REPO_ROOT / ".github" / "scripts" / "uplift-paths.sh"
 
 
+def test_pull_request_ci_targets_main_only() -> None:
+    ci_workflow = CI_WORKFLOW.read_text()
+
+    assert (
+        '  pull_request:\n    branches: ["main"]\n'
+        "    types: [opened, synchronize, reopened, ready_for_review, edited]"
+        in ci_workflow
+    )
+
+
 def test_galaxy_tests_run_only_for_pull_requests_targeting_main() -> None:
     ci_workflow = CI_WORKFLOW.read_text()
     call_build = CALL_BUILD.read_text()

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -31,11 +31,30 @@ def test_pull_request_ci_targets_main_only() -> None:
     )
 
 
-def test_disabled_galaxy_tests_retain_exabox_configuration() -> None:
+def test_hardware_event_policy_and_manual_controls() -> None:
     ci_workflow = CI_WORKFLOW.read_text()
     call_build = CALL_BUILD.read_text()
 
-    assert "run_galaxy_tests: false" in ci_workflow
+    assert ci_workflow.count("run_galaxy_tests:") == 2
+    assert ci_workflow.count("run_loudbox_tests:") == 2
+    assert (
+        "run_galaxy_tests: ${{ (github.event_name == 'push' "
+        "&& github.ref == 'refs/heads/main') || "
+        "github.event_name == 'schedule' || "
+        "(github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}"
+        in ci_workflow
+    )
+    assert (
+        "run_loudbox_tests: ${{ github.event_name == 'workflow_dispatch' "
+        "&& inputs.run_loudbox_tests }}" in ci_workflow
+    )
+    assert call_build.count("run_galaxy_tests:") == 2
+    assert call_build.count("run_loudbox_tests:") == 2
+
+
+def test_exabox_configuration_remains_available() -> None:
+    call_build = CALL_BUILD.read_text()
+
     assert "uses: ./.github/workflows/call-test-exabox.yml" in call_build
     assert "if: ${{ inputs.run_galaxy_tests }}" in call_build
     assert "needs: [test-hardware, test-exabox]" in call_build
@@ -49,12 +68,14 @@ def test_hardware_matrix_adds_optional_blackhole_loudbox() -> None:
     call_build = CALL_BUILD.read_text()
     hardware_workflow = CALL_TEST_HARDWARE.read_text()
 
-    assert "hardware: n150" in call_build
-    assert "runner_label: tt-ubuntu-2204-n150-stable" in call_build
-    assert "hardware: bh-loudbox-viommu" in call_build
-    assert "runner_label: tt-ubuntu-2204-bh-loudbox-viommu-stable" in call_build
+    assert "inputs.run_loudbox_tests && fromJSON" in call_build
+    assert '["n150","bh-loudbox-viommu"]' in call_build
+    assert "matrix.hardware == 'bh-loudbox-viommu'" in call_build
+    assert "tt-ubuntu-2204-bh-loudbox-viommu-stable" in call_build
+    assert "tt-ubuntu-2204-n150-stable" in call_build
     assert "--optional-runner bh-loudbox-viommu" in call_build
     assert "inputs.run_galaxy_tests && 3 || 2" in call_build
+    assert "inputs.run_galaxy_tests && 2 || 1" in call_build
     assert 'name: "Hardware Tests (${{ inputs.hardware }})"' in hardware_workflow
     assert "runs-on: ${{ inputs.runner_label }}" in hardware_workflow
     assert "RUNS_ON: ${{ inputs.hardware }}" in hardware_workflow

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -64,7 +64,7 @@ def test_exabox_configuration_remains_available() -> None:
     assert "timeout: 90" in test_exabox
 
 
-def test_hardware_matrix_adds_optional_blackhole_loudbox() -> None:
+def test_hardware_matrix_adds_manual_blackhole_loudbox() -> None:
     call_build = CALL_BUILD.read_text()
     hardware_workflow = CALL_TEST_HARDWARE.read_text()
 
@@ -73,7 +73,7 @@ def test_hardware_matrix_adds_optional_blackhole_loudbox() -> None:
     assert "matrix.hardware == 'bh-loudbox-viommu'" in call_build
     assert "tt-ubuntu-2204-bh-loudbox-viommu-stable" in call_build
     assert "tt-ubuntu-2204-n150-stable" in call_build
-    assert "--optional-runner bh-loudbox-viommu" in call_build
+    assert "--optional-runner" not in call_build
     assert "inputs.run_galaxy_tests && 3 || 2" in call_build
     assert "inputs.run_galaxy_tests && 2 || 1" in call_build
     assert 'name: "Hardware Tests (${{ inputs.hardware }})"' in hardware_workflow

--- a/test/packaging/test_hardware_job_results.py
+++ b/test/packaging/test_hardware_job_results.py
@@ -59,7 +59,6 @@ def _run_check(
     jobs: list[dict[str, object]],
     *,
     expected_job_count: int = 2,
-    optional_runners: list[str] | None = None,
     separate_pages: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     if separate_pages:
@@ -68,16 +67,13 @@ def _run_check(
         )
     else:
         jobs_json = json.dumps([{"total_count": len(jobs), "jobs": jobs}])
-    command = [
-        sys.executable,
-        str(CHECK_HARDWARE_JOB_RESULTS),
-        "--expected-job-count",
-        str(expected_job_count),
-    ]
-    for optional_runner in optional_runners or []:
-        command.extend(["--optional-runner", optional_runner])
     return subprocess.run(
-        command,
+        [
+            sys.executable,
+            str(CHECK_HARDWARE_JOB_RESULTS),
+            "--expected-job-count",
+            str(expected_job_count),
+        ],
         input=jobs_json,
         text=True,
         capture_output=True,
@@ -137,51 +133,10 @@ def test_both_setup_failures_fail() -> None:
     )
 
     assert result.returncode == 1
-    assert "No required hardware runner completed the test suite" in result.stdout
+    assert "No hardware runner completed the test suite" in result.stdout
 
 
-@pytest.mark.parametrize(
-    "optional_job",
-    [
-        _hardware_job(
-            "bh-loudbox-viommu",
-            setup_conclusion="failure",
-            tests_complete=False,
-        ),
-        _hardware_job(
-            "bh-loudbox-viommu",
-            tests_complete=False,
-            failed_step_name="Build tt-lang",
-        ),
-        _hardware_job("bh-loudbox-viommu", tests_complete=False),
-        _hardware_job("bh-loudbox-viommu", complete_runner_conclusion="failure"),
-    ],
-    ids=["setup", "test-step", "incomplete", "runner-completion"],
-)
-def test_optional_runner_failure_succeeds(optional_job: dict[str, object]) -> None:
-    result = _run_check(
-        [_hardware_job("n150"), optional_job],
-        optional_runners=["bh-loudbox-viommu"],
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "optional hardware job" in result.stdout
-
-
-def test_optional_runner_does_not_replace_required_success() -> None:
-    result = _run_check(
-        [
-            _hardware_job("n150", setup_conclusion="failure", tests_complete=False),
-            _hardware_job("bh-loudbox-viommu"),
-        ],
-        optional_runners=["bh-loudbox-viommu"],
-    )
-
-    assert result.returncode == 1
-    assert "No required hardware runner completed the test suite" in result.stdout
-
-
-@pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh"])
+@pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh", "bh-loudbox-viommu"])
 def test_post_setup_failure_fails(failed_runner: str) -> None:
     other_runner = "galaxy-bh" if failed_runner == "n150" else "n150"
     result = _run_check(

--- a/test/packaging/test_hardware_job_results.py
+++ b/test/packaging/test_hardware_job_results.py
@@ -59,6 +59,7 @@ def _run_check(
     jobs: list[dict[str, object]],
     *,
     expected_job_count: int = 2,
+    optional_runners: list[str] | None = None,
     separate_pages: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     if separate_pages:
@@ -67,13 +68,16 @@ def _run_check(
         )
     else:
         jobs_json = json.dumps([{"total_count": len(jobs), "jobs": jobs}])
+    command = [
+        sys.executable,
+        str(CHECK_HARDWARE_JOB_RESULTS),
+        "--expected-job-count",
+        str(expected_job_count),
+    ]
+    for optional_runner in optional_runners or []:
+        command.extend(["--optional-runner", optional_runner])
     return subprocess.run(
-        [
-            sys.executable,
-            str(CHECK_HARDWARE_JOB_RESULTS),
-            "--expected-job-count",
-            str(expected_job_count),
-        ],
+        command,
         input=jobs_json,
         text=True,
         capture_output=True,
@@ -133,7 +137,48 @@ def test_both_setup_failures_fail() -> None:
     )
 
     assert result.returncode == 1
-    assert "No hardware runner completed the test suite" in result.stdout
+    assert "No required hardware runner completed the test suite" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "optional_job",
+    [
+        _hardware_job(
+            "bh-loudbox-viommu",
+            setup_conclusion="failure",
+            tests_complete=False,
+        ),
+        _hardware_job(
+            "bh-loudbox-viommu",
+            tests_complete=False,
+            failed_step_name="Build tt-lang",
+        ),
+        _hardware_job("bh-loudbox-viommu", tests_complete=False),
+        _hardware_job("bh-loudbox-viommu", complete_runner_conclusion="failure"),
+    ],
+    ids=["setup", "test-step", "incomplete", "runner-completion"],
+)
+def test_optional_runner_failure_succeeds(optional_job: dict[str, object]) -> None:
+    result = _run_check(
+        [_hardware_job("n150"), optional_job],
+        optional_runners=["bh-loudbox-viommu"],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "optional hardware job" in result.stdout
+
+
+def test_optional_runner_does_not_replace_required_success() -> None:
+    result = _run_check(
+        [
+            _hardware_job("n150", setup_conclusion="failure", tests_complete=False),
+            _hardware_job("bh-loudbox-viommu"),
+        ],
+        optional_runners=["bh-loudbox-viommu"],
+    )
+
+    assert result.returncode == 1
+    assert "No required hardware runner completed the test suite" in result.stdout
 
 
 @pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh"])


### PR DESCRIPTION
### Problem description

Run pull-request CI only for changes targeting `main` and select hardware tests by event.

### What's changed

- restrict pull-request CI to PRs targeting `main`
- run Galaxy tests after pushes to `main` and in nightly CI
- add independent manual Galaxy and Blackhole loudbox options; selected loudbox tests are required

### Checklist

- [x] New/Existing tests provide coverage for changes
