### PR TITLE
[ci] Enforce main-target PR job scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,12 @@ concurrency:
 
 jobs:
   pre-commit:
+    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     uses: ./.github/workflows/call-pre-commit.yml
     secrets: inherit
 
   check-tt-metal-version:
+    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     name: Verify tt-metal version (third-party/tt-metal-version)
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -47,6 +49,7 @@ jobs:
       - run: .github/scripts/check-tt-metal-version.sh
 
   resolve-docker-tag:
+    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     name: Resolve docker tag for this branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -126,6 +129,7 @@ jobs:
     secrets: inherit
 
   changes:
+    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     name: Detect wheel/container-affecting changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -226,10 +230,12 @@ jobs:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
 
   test-sim:
+    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     uses: ./.github/workflows/call-test-sim.yml
     secrets: inherit
 
   test-scripts:
+    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     uses: ./.github/workflows/call-test-scripts.yml
 
   test-dist-tutorials:
@@ -270,7 +276,7 @@ jobs:
         uses: actions/deploy-pages@v5
 
   check-all-green:
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.base_ref == 'main') }}
     needs:
       - pre-commit
       - check-tt-metal-version

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import yaml
+
 from conftest import REPO_ROOT
 
 CALL_BUILD = REPO_ROOT / ".github" / "workflows" / "call-build.yml"
@@ -24,11 +26,28 @@ UPLIFT_PATHS = REPO_ROOT / ".github" / "scripts" / "uplift-paths.sh"
 
 def test_pull_request_ci_targets_main_only() -> None:
     ci_workflow = CI_WORKFLOW.read_text()
+    ci_jobs = yaml.safe_load(ci_workflow)["jobs"]
+    pull_request_guard = (
+        "${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}"
+    )
 
     assert (
         '  pull_request:\n    branches: ["main"]\n'
         "    types: [opened, synchronize, reopened, ready_for_review, edited]"
         in ci_workflow
+    )
+    root_jobs = {
+        job_name: job for job_name, job in ci_jobs.items() if "needs" not in job
+    }
+    assert root_jobs["build-docs"]["if"].endswith(
+        "github.event_name != 'pull_request' }}"
+    )
+    for job_name, job in root_jobs.items():
+        if job_name != "build-docs":
+            assert job["if"] == pull_request_guard
+    assert ci_jobs["check-all-green"]["if"] == (
+        "${{ always() && (github.event_name != 'pull_request' || "
+        "github.base_ref == 'main') }}"
     )
 
 


### PR DESCRIPTION
### Problem description

Stacked PR #911 started workflow `32151005419` despite the pull-request branch filter.

### What's changed

~8 LOC implementation (tests excluded).

Guard every root CI job and the aggregate result by pull-request base ref so stacked PR runs schedule no work.

A focused workflow-contract test derives root jobs from the workflow and requires the main-target guard on each one.

### Checklist

- [x] New/Existing tests provide coverage for changes
