### PR TITLE
[ttl] Support BF16 by block-float matmul [bfp-matmul-2]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -43,8 +43,8 @@ def publish_input():
 ```
 
 The tensor must use TILE layout, height-, width-, or block-sharded L1 storage,
-and BF16 or FP32. Interleaved and ND-sharded tensors are rejected. The optional
-`byte_offset` must be page-aligned. The bound byte size is
+and BF16, FP32, BFP4, or BFP8. Interleaved and ND-sharded tensors are rejected.
+The optional `byte_offset` must be page-aligned. The bound byte size is
 `product(shape) * block_count * page_size`; allocation padding does not change
 the DFB capacity. The current contract supports one device and one or more
 launch nodes whose tensor shards use the same local DFB specification.

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -43,7 +43,8 @@ def publish_input():
 ```
 
 The tensor must use TILE layout, height-, width-, or block-sharded L1 storage,
-and BF16, FP32, BFP4, or BFP8. Interleaved and ND-sharded tensors are rejected.
+and BF16, FP32, BFP4_B, or BFP8_B. Interleaved and ND-sharded tensors are
+rejected.
 The optional `byte_offset` must be page-aligned. The bound byte size is
 `product(shape) * block_count * page_size`; allocation padding does not change
 the DFB capacity. The current contract supports one device and one or more

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -42,7 +42,8 @@ def TTL_BindCBOp : TTL_Op<"bind_cb", [Pure]> {
       allocation for all logical DFBs carrying the same group identity.
     - `tensor_backing`, when present, binds the complete dataflow buffer
       capacity to the specified byte range of an operation tensor argument.
-      The range is relative to the local shard on each launch node.
+      The range is relative to the local shard on each launch node. Tensor
+      backing supports BF16, FP32, BFP4_B, and BFP8_B tile element types.
     Example:
 
     ```mlir
@@ -1682,9 +1683,9 @@ def TTL_MatmulOp : TTL_ComputePrimitiveOp<"matmul", "Matmul", [Pure,
     `transpose_rhs`, `lhs.tile.width == rhs.tile.height` and the result tile is
     `[lhs.tile.height, rhs.tile.width]`. With `transpose_rhs`, the rhs tile
     width is contracted and the result tile width is the rhs tile height.
-    Operand and result tile element data types normally match. The
-    non-transposed mixed-format form accepts BF16 lhs tiles, BFP4_B or BFP8_B
-    rhs tiles, and produces BF16 result tiles.
+    The supported element data type combinations are equal lhs, rhs, and result
+    types, or BF16 lhs and result types with a BFP4_B or BFP8_B rhs. The
+    mixed-format form does not support rhs transposition.
   }];
   let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs,
                        UnitAttr:$transpose_rhs);

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1682,7 +1682,9 @@ def TTL_MatmulOp : TTL_ComputePrimitiveOp<"matmul", "Matmul", [Pure,
     `transpose_rhs`, `lhs.tile.width == rhs.tile.height` and the result tile is
     `[lhs.tile.height, rhs.tile.width]`. With `transpose_rhs`, the rhs tile
     width is contracted and the result tile width is the rhs tile height.
-    Operand and result tile element data types must match.
+    Operand and result tile element data types normally match. The
+    non-transposed BF16-by-BFP4_B form accepts BF16 lhs tiles, BFP4_B rhs
+    tiles, and produces BF16 result tiles.
   }];
   let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs,
                        UnitAttr:$transpose_rhs);
@@ -1715,6 +1717,9 @@ def TTL_TileMatmulBlockOp : TTL_TileOp<"tile_matmul_block", "Matmul",
 
     The lhs, rhs, and result tile types may have different dimensions. Their
     physical dimensions follow the same contraction relation as `ttl.matmul`.
+    The supported mixed-format form is BF16 lhs by BFP4_B rhs with BF16
+    output and no rhs transpose. Destination accumulation precision remains a
+    compute-kernel configuration property.
   }];
   let arguments = (ins TTL_TileOrTensor:$lhs, TTL_TileOrTensor:$rhs,
                        Optional<TTL_TileOrTensor>:$accumulator,

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1683,8 +1683,8 @@ def TTL_MatmulOp : TTL_ComputePrimitiveOp<"matmul", "Matmul", [Pure,
     `[lhs.tile.height, rhs.tile.width]`. With `transpose_rhs`, the rhs tile
     width is contracted and the result tile width is the rhs tile height.
     Operand and result tile element data types normally match. The
-    non-transposed BF16-by-BFP4_B form accepts BF16 lhs tiles, BFP4_B rhs
-    tiles, and produces BF16 result tiles.
+    non-transposed mixed-format form accepts BF16 lhs tiles, BFP4_B or BFP8_B
+    rhs tiles, and produces BF16 result tiles.
   }];
   let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs,
                        UnitAttr:$transpose_rhs);
@@ -1717,9 +1717,9 @@ def TTL_TileMatmulBlockOp : TTL_TileOp<"tile_matmul_block", "Matmul",
 
     The lhs, rhs, and result tile types may have different dimensions. Their
     physical dimensions follow the same contraction relation as `ttl.matmul`.
-    The supported mixed-format form is BF16 lhs by BFP4_B rhs with BF16
-    output and no rhs transpose. Destination accumulation precision remains a
-    compute-kernel configuration property.
+    The supported mixed-format form is BF16 lhs by BFP4_B or BFP8_B rhs with
+    BF16 output and no rhs transpose. Destination accumulation precision
+    remains a compute-kernel configuration property.
   }];
   let arguments = (ins TTL_TileOrTensor:$lhs, TTL_TileOrTensor:$rhs,
                        Optional<TTL_TileOrTensor>:$accumulator,

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -438,12 +438,13 @@ mlir::LogicalResult mlir::tt::ttl::BindCBOp::verify() {
              << "tensor backing requires a TTCore tile element type, got "
              << cbTy.getElementType();
     }
-    // TODO(#812): Extend tensor backing after additional formats are specified.
     if (tileType.getDataType() != ttcore::DataType::BFloat16 &&
-        tileType.getDataType() != ttcore::DataType::Float32) {
+        tileType.getDataType() != ttcore::DataType::Float32 &&
+        tileType.getDataType() != ttcore::DataType::BFP_BFloat4 &&
+        tileType.getDataType() != ttcore::DataType::BFP_BFloat8) {
       return emitOpError()
-             << "tensor backing supports only BF16 and FP32 tile element "
-                "types, got "
+             << "tensor backing supports only BF16, FP32, BFP4, and BFP8 "
+                "tile element types, got "
              << tileType;
     }
     int64_t pageSize = static_cast<int64_t>(tileType.getSizeBytes());

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -443,7 +443,7 @@ mlir::LogicalResult mlir::tt::ttl::BindCBOp::verify() {
         tileType.getDataType() != ttcore::DataType::BFP_BFloat4 &&
         tileType.getDataType() != ttcore::DataType::BFP_BFloat8) {
       return emitOpError()
-             << "tensor backing supports only BF16, FP32, BFP4, and BFP8 "
+             << "tensor backing supports only BF16, FP32, BFP4_B, and BFP8_B "
                 "tile element types, got "
              << tileType;
     }

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -255,14 +255,19 @@ LogicalResult verifyMatmulTileTypes(ttcore::TileType lhsType,
                                     std::string &failureReason) {
   failureReason.clear();
   llvm::raw_string_ostream diagnostic(failureReason);
-  if (lhsType.getDataType() != rhsType.getDataType()) {
-    diagnostic << "element data type mismatch: lhs has " << lhsType
-               << " but rhs has " << rhsType;
-    return failure();
-  }
-  if (resultType.getDataType() != lhsType.getDataType()) {
-    diagnostic << "result element data type " << resultType
-               << " must match input element data type " << lhsType;
+  ttcore::DataType lhsDataType = lhsType.getDataType();
+  ttcore::DataType rhsDataType = rhsType.getDataType();
+  ttcore::DataType resultDataType = resultType.getDataType();
+  bool hasMatchingDataTypes =
+      lhsDataType == rhsDataType && lhsDataType == resultDataType;
+  bool isBFloat16ByBFPBFloat4 = !transposeRhs &&
+                                lhsDataType == ttcore::DataType::BFloat16 &&
+                                rhsDataType == ttcore::DataType::BFP_BFloat4 &&
+                                resultDataType == ttcore::DataType::BFloat16;
+  if (!hasMatchingDataTypes && !isBFloat16ByBFPBFloat4) {
+    diagnostic << "unsupported matmul element data type combination: lhs has "
+               << lhsType << ", rhs has " << rhsType << ", and result has "
+               << resultType;
     return failure();
   }
 

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -260,11 +260,12 @@ LogicalResult verifyMatmulTileTypes(ttcore::TileType lhsType,
   ttcore::DataType resultDataType = resultType.getDataType();
   bool hasMatchingDataTypes =
       lhsDataType == rhsDataType && lhsDataType == resultDataType;
-  bool isBFloat16ByBFPBFloat4 = !transposeRhs &&
-                                lhsDataType == ttcore::DataType::BFloat16 &&
-                                rhsDataType == ttcore::DataType::BFP_BFloat4 &&
-                                resultDataType == ttcore::DataType::BFloat16;
-  if (!hasMatchingDataTypes && !isBFloat16ByBFPBFloat4) {
+  bool isBFloat16ByBFP = !transposeRhs &&
+                         lhsDataType == ttcore::DataType::BFloat16 &&
+                         (rhsDataType == ttcore::DataType::BFP_BFloat4 ||
+                          rhsDataType == ttcore::DataType::BFP_BFloat8) &&
+                         resultDataType == ttcore::DataType::BFloat16;
+  if (!hasMatchingDataTypes && !isBFloat16ByBFP) {
     diagnostic << "unsupported matmul element data type combination: lhs has "
                << lhsType << ", rhs has " << rhsType << ", and result has "
                << resultType;

--- a/python/ttl/constants.py
+++ b/python/ttl/constants.py
@@ -10,6 +10,18 @@ SUPPORTED_MATH_FIDELITIES = ("LoFi", "HiFi2", "HiFi3", "HiFi4")
 SUPPORTED_TENSOR_BACKED_DFB_MEMORY_LAYOUTS = frozenset(
     ["HEIGHT_SHARDED", "WIDTH_SHARDED", "BLOCK_SHARDED"]
 )
+SUPPORTED_TENSOR_BACKED_DFB_DATA_FORMATS = frozenset(
+    [
+        "bfloat16",
+        "bf16",
+        "float32",
+        "f32",
+        "bfloat4_b",
+        "bfp_bf4",
+        "bfloat8_b",
+        "bfp_bf8",
+    ]
+)
 
 
 def validate_math_fidelity(math_fidelity: str | None) -> None:

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -11,7 +11,11 @@ from typing import Any, Optional, Tuple
 from ttl.ir import *
 
 from ._src.ttl_ast import syntax
-from .constants import DEFAULT_TILE_SIZE, SUPPORTED_TENSOR_BACKED_DFB_MEMORY_LAYOUTS
+from .constants import (
+    DEFAULT_TILE_SIZE,
+    SUPPORTED_TENSOR_BACKED_DFB_DATA_FORMATS,
+    SUPPORTED_TENSOR_BACKED_DFB_MEMORY_LAYOUTS,
+)
 from .dfb_allocation_group import (
     DFBAllocationGroup,
     _BoundDFBAllocationGroup,
@@ -53,9 +57,10 @@ def _validate_tensor_backed_dfb_tensor(
         raise ValueError(f"{context} must use TILE layout")
 
     dtype_name = str(tensor.dtype).rsplit(".", maxsplit=1)[-1].lower()
-    if dtype_name not in {"bfloat16", "float32"}:
+    if dtype_name not in SUPPORTED_TENSOR_BACKED_DFB_DATA_FORMATS:
         raise ValueError(
-            f"{context} supports BF16 and FP32 tensors, got {tensor.dtype}"
+            f"{context} supports BF16, FP32, BFP4, and BFP8 tensors, "
+            f"got {tensor.dtype}"
         )
 
     try:

--- a/python/ttl/dataflow_buffer.py
+++ b/python/ttl/dataflow_buffer.py
@@ -59,7 +59,7 @@ def _validate_tensor_backed_dfb_tensor(
     dtype_name = str(tensor.dtype).rsplit(".", maxsplit=1)[-1].lower()
     if dtype_name not in SUPPORTED_TENSOR_BACKED_DFB_DATA_FORMATS:
         raise ValueError(
-            f"{context} supports BF16, FP32, BFP4, and BFP8 tensors, "
+            f"{context} supports BF16, FP32, BFP4_B, and BFP8_B tensors, "
             f"got {tensor.dtype}"
         )
 

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -51,7 +51,10 @@ from .dataflow_buffer import (
     _validate_tensor_backed_dfb_range,
     _validate_tensor_backed_dfb_tensor,
 )
-from .constants import DEFAULT_L1_CB_BUDGET_BYTES
+from .constants import (
+    DEFAULT_L1_CB_BUDGET_BYTES,
+    SUPPORTED_TENSOR_BACKED_DFB_DATA_FORMATS,
+)
 from . import dtype_utils
 from .kernel import Kernel, KernelKind, KernelSelector
 from .runtime_resources import (
@@ -2342,10 +2345,11 @@ def _validate_tensor_backed_dfb_binding(
         raise ValueError(
             f"DFB[{config.dfb_index}] tensor backing {tensor_index} is absent"
         )
-    if config.data_format not in {"bfloat16", "bf16", "float32", "f32"}:
+    if config.data_format not in SUPPORTED_TENSOR_BACKED_DFB_DATA_FORMATS:
         raise ValueError(
             f"DFB[{config.dfb_index}] tensor backing format "
-            f"{config.data_format} is not supported; expected BF16 or FP32"
+            f"{config.data_format} is not supported; expected BF16, FP32, "
+            "BFP4, or BFP8"
         )
     context = f"DFB[{config.dfb_index}] tensor backing"
     properties = _validate_tensor_backed_dfb_tensor(tensor, context=context)

--- a/python/ttl/kernel_runner.py
+++ b/python/ttl/kernel_runner.py
@@ -2349,7 +2349,7 @@ def _validate_tensor_backed_dfb_binding(
         raise ValueError(
             f"DFB[{config.dfb_index}] tensor backing format "
             f"{config.data_format} is not supported; expected BF16, FP32, "
-            "BFP4, or BFP8"
+            "BFP4_B, or BFP8_B"
         )
     context = f"DFB[{config.dfb_index}] tensor backing"
     properties = _validate_tensor_backed_dfb_tensor(tensor, context=context)

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -1203,9 +1203,14 @@ def _build_matmul(lhs: TensorBlock, rhs: TensorBlock, *, transpose_rhs: bool):
         )
     lhs_dtype = ttcore.DataType(lhs_tile.data_type_as_int)
     rhs_dtype = ttcore.DataType(rhs_tile.data_type_as_int)
-    if lhs_dtype != rhs_dtype:
+    is_bfloat16_by_bfp_bfloat4 = (
+        not transpose
+        and lhs_dtype == ttcore.DataType.BFloat16
+        and rhs_dtype == ttcore.DataType.BFP_BFloat4
+    )
+    if lhs_dtype != rhs_dtype and not is_bfloat16_by_bfp_bfloat4:
         raise ValueError(
-            "matmul operand tile data types must match, got "
+            "unsupported matmul operand tile data type combination: "
             f"lhs={lhs_type.element_type}, rhs={rhs_type.element_type}"
         )
 
@@ -1222,6 +1227,8 @@ def _build_matmul(lhs: TensorBlock, rhs: TensorBlock, *, transpose_rhs: bool):
     n = rhs_shape[0] if transpose else rhs_shape[1]
     result_shape = [lhs_shape[0], n]
     result_tile_width = rhs_tile_height if transpose else rhs_tile_width
+    # The supported mixed-format operation packs BF16 output, matching its
+    # BF16 activation operand; destination accumulation remains configurable.
     result_tile = ttcore.ir.TileType.get(
         lhs_type.context, lhs_tile_height, result_tile_width, lhs_dtype
     )

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -1227,8 +1227,6 @@ def _build_matmul(lhs: TensorBlock, rhs: TensorBlock, *, transpose_rhs: bool):
     n = rhs_shape[0] if transpose else rhs_shape[1]
     result_shape = [lhs_shape[0], n]
     result_tile_width = rhs_tile_height if transpose else rhs_tile_width
-    # The supported mixed-format operation packs BF16 output, matching its
-    # BF16 activation operand; destination accumulation remains configurable.
     result_tile = ttcore.ir.TileType.get(
         lhs_type.context, lhs_tile_height, result_tile_width, lhs_dtype
     )

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -1203,12 +1203,12 @@ def _build_matmul(lhs: TensorBlock, rhs: TensorBlock, *, transpose_rhs: bool):
         )
     lhs_dtype = ttcore.DataType(lhs_tile.data_type_as_int)
     rhs_dtype = ttcore.DataType(rhs_tile.data_type_as_int)
-    is_bfloat16_by_bfp_bfloat4 = (
+    is_bfloat16_by_bfp = (
         not transpose
         and lhs_dtype == ttcore.DataType.BFloat16
-        and rhs_dtype == ttcore.DataType.BFP_BFloat4
+        and rhs_dtype in (ttcore.DataType.BFP_BFloat4, ttcore.DataType.BFP_BFloat8)
     )
-    if lhs_dtype != rhs_dtype and not is_bfloat16_by_bfp_bfloat4:
+    if lhs_dtype != rhs_dtype and not is_bfloat16_by_bfp:
         raise ValueError(
             "unsupported matmul operand tile data type combination: "
             f"lhs={lhs_type.element_type}, rhs={rhs_type.element_type}"

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -305,9 +305,16 @@ class _FakeTTNN:
         def __init__(self, tile_shape):
             self.tile_shape = tuple(tile_shape)
 
-        def get_tile_size(self, _data_format):
+        def get_tile_size(self, data_format):
             tile_height, tile_width = self.tile_shape
-            return tile_height * tile_width * 2
+            scalar_count = tile_height * tile_width
+            dtype_name = str(data_format).rsplit(".", maxsplit=1)[-1].lower()
+            exponent_bytes = ((scalar_count // 16 + 15) // 16) * 16
+            if dtype_name == "bfloat4_b":
+                return scalar_count // 2 + exponent_bytes
+            if dtype_name == "bfloat8_b":
+                return scalar_count + exponent_bytes
+            return scalar_count * 2
 
     class TileDescriptor:
         def __init__(self, tile):
@@ -4437,6 +4444,38 @@ def test_build_cb_descriptors_rejects_equal_size_different_tile_shape(monkeypatc
         )
 
 
+@pytest.mark.parametrize(
+    ("data_format", "page_size"),
+    [("bfloat4_b", 576), ("bfloat8_b", 1088)],
+    ids=["bfp4", "bfp8"],
+)
+def test_build_cb_descriptors_accepts_block_float_tensor_backing_format(
+    monkeypatch, data_format, page_size
+):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    monkeypatch.setattr(
+        kernel_runner, "get_min_remaining_l1_for_device", lambda _device: 4096
+    )
+    expected_dtype = kernel_runner.format_name_to_ttnn_dtype(data_format)
+    tensor = _FakeTensor(object(), dtype=expected_dtype, shard_shape=(32, 32))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[tensor],
+        cb_configs=[
+            _tensor_backing_config(
+                0,
+                nodes=((0, 0),),
+                data_format=data_format,
+                page_size=page_size,
+                byte_size=page_size,
+            )
+        ],
+        core_ranges=_FakeCoreRanges(),
+    )
+
+    assert descriptors[0]["total_size"] == page_size
+
+
 def test_build_cb_descriptors_reports_unsupported_tensor_backing_format(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
     monkeypatch.setattr(
@@ -4460,7 +4499,10 @@ def test_build_cb_descriptors_reports_unsupported_tensor_backing_format(monkeypa
         ),
     )
 
-    with pytest.raises(ValueError, match="tensor backing format bfp8 is not supported"):
+    with pytest.raises(
+        ValueError,
+        match="tensor backing format bfp8 is not supported; expected BF16, FP32, BFP4, or BFP8",
+    ):
         kernel_runner.build_cb_descriptors(
             tensors=[tensor],
             cb_configs=[config],
@@ -4520,14 +4562,21 @@ def test_build_cb_descriptors_preserves_descriptor_helper_failure(monkeypatch):
 
 
 def _tensor_backing_config(
-    dfb_index, *, nodes, block_count=1, byte_offset=0, byte_size=2048
+    dfb_index,
+    *,
+    nodes,
+    block_count=1,
+    byte_offset=0,
+    byte_size=2048,
+    data_format="bfloat16",
+    page_size=2048,
 ):
     return PhysicalDFBConfig(
         dfb_index,
         1,
-        "bfloat16",
+        data_format,
         block_count,
-        2048,
+        page_size,
         (32, 32),
         (
             DFBStorageSegment(

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -4501,7 +4501,7 @@ def test_build_cb_descriptors_reports_unsupported_tensor_backing_format(monkeypa
 
     with pytest.raises(
         ValueError,
-        match="tensor backing format bfp8 is not supported; expected BF16, FP32, BFP4, or BFP8",
+        match="tensor backing format bfp8 is not supported; expected BF16, FP32, BFP4_B, or BFP8_B",
     ):
         kernel_runner.build_cb_descriptors(
             tensors=[tensor],

--- a/test/python/test_matmul_mixed_dtype.py
+++ b/test/python/test_matmul_mixed_dtype.py
@@ -15,6 +15,8 @@ from utils.correctness import assert_pcc
 
 TILE_SIZE = 32
 KIMI_MATMUL_TILE_SHAPE = (1, 48, 2)
+KIMI_ACTIVATION_TILE = (1, TILE_SIZE)
+KIMI_WEIGHT_TILE = (TILE_SIZE, TILE_SIZE)
 
 
 def _make_staged_weight_matmul(math_fidelity):
@@ -131,12 +133,13 @@ def _host_tensors(weight_dtype):
     row_tiles, contraction_tiles, column_tiles = KIMI_MATMUL_TILE_SHAPE
     activation = ttnn.from_torch(
         torch.randn(
-            row_tiles * TILE_SIZE,
+            row_tiles * KIMI_ACTIVATION_TILE[0],
             contraction_tiles * TILE_SIZE,
             dtype=torch.bfloat16,
         ),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile(KIMI_ACTIVATION_TILE),
     )
     weights = ttnn.from_torch(
         torch.randn(
@@ -146,15 +149,17 @@ def _host_tensors(weight_dtype):
         ),
         dtype=weight_dtype,
         layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile(KIMI_WEIGHT_TILE),
     )
     output = ttnn.from_torch(
         torch.zeros(
-            row_tiles * TILE_SIZE,
+            row_tiles * KIMI_ACTIVATION_TILE[0],
             column_tiles * TILE_SIZE,
             dtype=torch.bfloat16,
         ),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile(KIMI_ACTIVATION_TILE),
     )
     return activation, weights, output
 
@@ -172,10 +177,11 @@ def test_mixed_dtype_matmul_compile_only(tmp_path, monkeypatch, weight_format):
     initial_text = initial_mlir.read_text()
     final_text = final_mlir.read_text()
     assert "ttl.matmul" in initial_text
-    assert "!ttcore.tile<32x32, bf16>" in initial_text
-    assert f"!ttcore.tile<32x32, {mlir_dtype}>" in initial_text
+    assert "!ttcore.tile<1x32, bf16>" in initial_text
+    assert f"!ttcore.tile<{TILE_SIZE}x{TILE_SIZE}, {mlir_dtype}>" in initial_text
     assert "ttl.matmul" not in final_text
-    assert f"!ttcore.tile<32x32, {mlir_dtype}>" in final_text
+    assert "!ttcore.tile<1x32, bf16>" in final_text
+    assert f"!ttcore.tile<{TILE_SIZE}x{TILE_SIZE}, {mlir_dtype}>" in final_text
     assert f"page_size = {page_size}" in final_text
 
 
@@ -185,12 +191,13 @@ def _make_weight_tensor(weights_torch, weight_dtype, device, memory_config):
         weights_torch,
         dtype=weight_dtype,
         layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile(KIMI_WEIGHT_TILE),
         device=device,
         memory_config=memory_config,
     )
 
 
-def _make_width_sharded_l1_memory_config(tensor_shape):
+def _make_sharded_l1_memory_config(tensor_shape, memory_layout):
     shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(
             {
@@ -204,7 +211,7 @@ def _make_width_sharded_l1_memory_config(tensor_shape):
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     return ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        memory_layout,
         ttnn.BufferType.L1,
         shard_spec,
     )
@@ -212,19 +219,31 @@ def _make_width_sharded_l1_memory_config(tensor_shape):
 
 @pytest.mark.requires_device
 @pytest.mark.parametrize(
-    "weight_storage",
-    ("dram", "interleaved_l1", "tensor_backed_width_sharded_l1"),
-    ids=("dram", "l1", "tensor-backed-width-sharded-l1"),
+    ("weight_storage", "tensor_backing_layout"),
+    (
+        ("dram", None),
+        ("interleaved_l1", None),
+        ("tensor_backed_l1", ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
+        ("tensor_backed_l1", ttnn.TensorMemoryLayout.WIDTH_SHARDED),
+        ("tensor_backed_l1", ttnn.TensorMemoryLayout.BLOCK_SHARDED),
+    ),
+    ids=(
+        "dram",
+        "l1",
+        "tensor-backed-height-sharded-l1",
+        "tensor-backed-width-sharded-l1",
+        "tensor-backed-block-sharded-l1",
+    ),
 )
 @pytest.mark.parametrize("math_fidelity", ("LoFi", "HiFi4"), ids=("lofi", "hifi4"))
 def test_mixed_dtype_matmul_device(
-    device, weight_storage, math_fidelity, weight_format
+    device, weight_storage, tensor_backing_layout, math_fidelity, weight_format
 ):
     weight_dtype, _mlir_dtype, _page_size = weight_format
     row_tiles, contraction_tiles, column_tiles = KIMI_MATMUL_TILE_SHAPE
     torch.manual_seed(0)
     activation_torch = torch.randn(
-        row_tiles * TILE_SIZE,
+        row_tiles * KIMI_ACTIVATION_TILE[0],
         contraction_tiles * TILE_SIZE,
         dtype=torch.bfloat16,
     )
@@ -234,7 +253,7 @@ def test_mixed_dtype_matmul_device(
         dtype=torch.bfloat16,
     )
     output_torch = torch.zeros(
-        row_tiles * TILE_SIZE,
+        row_tiles * KIMI_ACTIVATION_TILE[0],
         column_tiles * TILE_SIZE,
         dtype=torch.bfloat16,
     )
@@ -245,17 +264,19 @@ def test_mixed_dtype_matmul_device(
     elif weight_storage == "interleaved_l1":
         weight_memory_config = ttnn.L1_MEMORY_CONFIG
         matmul = STAGED_WEIGHT_MATMULS[math_fidelity]
-    else:
-        weight_memory_config = _make_width_sharded_l1_memory_config(
-            tuple(weights_torch.shape)
+    elif weight_storage == "tensor_backed_l1":
+        weight_memory_config = _make_sharded_l1_memory_config(
+            tuple(weights_torch.shape), tensor_backing_layout
         )
         matmul = TENSOR_BACKED_WEIGHT_MATMULS[math_fidelity]
+    else:
+        raise ValueError(f"unsupported weight storage {weight_storage}")
 
-    activation = to_dram(activation_torch, device)
+    activation = to_dram(activation_torch, device, tile=KIMI_ACTIVATION_TILE)
     weights = _make_weight_tensor(
         weights_torch, weight_dtype, device, weight_memory_config
     )
-    output = to_dram(output_torch, device)
+    output = to_dram(output_torch, device, tile=KIMI_ACTIVATION_TILE)
     activation_before = ttnn.to_torch(activation).clone()
     weights_before = ttnn.to_torch(weights).clone()
 
@@ -277,6 +298,11 @@ def test_mixed_dtype_matmul_device(
     assert torch.equal(weights_before, ttnn.to_torch(weights))
     assert output.dtype == ttnn.bfloat16
     assert output.layout == ttnn.TILE_LAYOUT
+    assert tuple(activation.get_tile().tile_shape) == KIMI_ACTIVATION_TILE
+    assert tuple(weights.get_tile().tile_shape) == KIMI_WEIGHT_TILE
+    assert tuple(output.get_tile().tile_shape) == KIMI_ACTIVATION_TILE
+    if tensor_backing_layout is not None:
+        assert weights.memory_config().memory_layout == tensor_backing_layout
 
     expected = activation_before.float() @ weights_before.float()
     assert_pcc(expected.float(), first_output.float(), threshold=0.999)

--- a/test/python/test_matmul_mixed_dtype.py
+++ b/test/python/test_matmul_mixed_dtype.py
@@ -10,55 +10,110 @@ import ttl
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
-from ttlang_test_utils import to_dram, to_l1
+from ttlang_test_utils import to_dram
 from utils.correctness import assert_pcc
 
 TILE_SIZE = 32
-MATMUL_TILE_SHAPE = (1, 2, 2)
+KIMI_MATMUL_TILE_SHAPE = (1, 48, 2)
 
 
-@ttl.operation(grid=(1, 1))
-def mixed_dtype_matmul(activation, weights, output):
-    activation_tiles = activation.shape[1] // TILE_SIZE
-    output_tiles = output.shape[1] // TILE_SIZE
-    activation_dfb = ttl.make_dataflow_buffer_like(
-        activation, shape=(1, activation_tiles), block_count=2
-    )
-    weights_dfb = ttl.make_dataflow_buffer_like(
-        weights, shape=(activation_tiles, output_tiles), block_count=2
-    )
-    output_dfb = ttl.make_dataflow_buffer_like(
-        output, shape=(1, output_tiles), block_count=2
-    )
+def _make_staged_weight_matmul(math_fidelity):
+    @ttl.operation(grid=(1, 1), math_fidelity=math_fidelity)
+    def mixed_dtype_matmul(activation, weights, output):
+        activation_tiles = activation.shape[1] // TILE_SIZE
+        output_tiles = output.shape[1] // TILE_SIZE
+        activation_dfb = ttl.make_dataflow_buffer_like(
+            activation, shape=(1, activation_tiles), block_count=2
+        )
+        weights_dfb = ttl.make_dataflow_buffer_like(
+            weights, shape=(activation_tiles, output_tiles), block_count=2
+        )
+        output_dfb = ttl.make_dataflow_buffer_like(
+            output, shape=(1, output_tiles), block_count=2
+        )
 
-    @ttl.compute()
-    def compute_matmul():
-        activation_block = activation_dfb.wait()
-        weights_block = weights_dfb.wait()
-        output_block = output_dfb.reserve()
-        output_block.store(activation_block @ weights_block)
-        activation_block.pop()
-        weights_block.pop()
-        output_block.push()
+        @ttl.compute()
+        def compute_matmul():
+            activation_block = activation_dfb.wait()
+            weights_block = weights_dfb.wait()
+            output_block = output_dfb.reserve()
+            output_block.store(activation_block @ weights_block)
+            activation_block.pop()
+            weights_block.pop()
+            output_block.push()
 
-    @ttl.datamovement()
-    def read_inputs():
-        with activation_dfb.reserve() as activation_block:
-            activation_copy = ttl.copy(
-                activation[0:1, 0:activation_tiles], activation_block
-            )
-            activation_copy.wait()
-        with weights_dfb.reserve() as weights_block:
-            weights_copy = ttl.copy(
-                weights[0:activation_tiles, 0:output_tiles], weights_block
-            )
-            weights_copy.wait()
+        @ttl.datamovement()
+        def read_inputs():
+            with activation_dfb.reserve() as activation_block:
+                activation_copy = ttl.copy(
+                    activation[0:1, 0:activation_tiles], activation_block
+                )
+                activation_copy.wait()
+            with weights_dfb.reserve() as weights_block:
+                weights_copy = ttl.copy(
+                    weights[0:activation_tiles, 0:output_tiles], weights_block
+                )
+                weights_copy.wait()
 
-    @ttl.datamovement()
-    def write_output():
-        with output_dfb.wait() as output_block:
-            output_copy = ttl.copy(output_block, output[0:1, 0:output_tiles])
-            output_copy.wait()
+        @ttl.datamovement()
+        def write_output():
+            with output_dfb.wait() as output_block:
+                output_copy = ttl.copy(output_block, output[0:1, 0:output_tiles])
+                output_copy.wait()
+
+    return mixed_dtype_matmul
+
+
+def _make_tensor_backed_weight_matmul(math_fidelity):
+    @ttl.operation(grid=(1, 1), math_fidelity=math_fidelity)
+    def mixed_dtype_matmul(activation, weights, output):
+        activation_tiles = activation.shape[1] // TILE_SIZE
+        output_tiles = output.shape[1] // TILE_SIZE
+        activation_dfb = ttl.make_dataflow_buffer_like(
+            activation, shape=(1, activation_tiles), block_count=2
+        )
+        weights_dfb = ttl.make_tensor_backed_dfb(
+            weights, shape=(activation_tiles, output_tiles), block_count=1
+        )
+        output_dfb = ttl.make_dataflow_buffer_like(
+            output, shape=(1, output_tiles), block_count=2
+        )
+
+        @ttl.compute()
+        def compute_matmul():
+            activation_block = activation_dfb.wait()
+            weights_block = weights_dfb.wait()
+            output_block = output_dfb.reserve()
+            output_block.store(activation_block @ weights_block)
+            activation_block.pop()
+            weights_block.pop()
+            output_block.push()
+
+        @ttl.datamovement()
+        def publish_inputs():
+            with activation_dfb.reserve() as activation_block:
+                activation_copy = ttl.copy(
+                    activation[0:1, 0:activation_tiles], activation_block
+                )
+                activation_copy.wait()
+            weights_dfb.publish()
+
+        @ttl.datamovement()
+        def write_output():
+            with output_dfb.wait() as output_block:
+                output_copy = ttl.copy(output_block, output[0:1, 0:output_tiles])
+                output_copy.wait()
+
+    return mixed_dtype_matmul
+
+
+STAGED_WEIGHT_MATMULS = {
+    fidelity: _make_staged_weight_matmul(fidelity) for fidelity in ("LoFi", "HiFi4")
+}
+TENSOR_BACKED_WEIGHT_MATMULS = {
+    fidelity: _make_tensor_backed_weight_matmul(fidelity)
+    for fidelity in ("LoFi", "HiFi4")
+}
 
 
 @pytest.fixture(
@@ -73,7 +128,7 @@ def weight_format(request):
 
 
 def _host_tensors(weight_dtype):
-    row_tiles, contraction_tiles, column_tiles = MATMUL_TILE_SHAPE
+    row_tiles, contraction_tiles, column_tiles = KIMI_MATMUL_TILE_SHAPE
     activation = ttnn.from_torch(
         torch.randn(
             row_tiles * TILE_SIZE,
@@ -104,7 +159,7 @@ def _host_tensors(weight_dtype):
     return activation, weights, output
 
 
-def test_mixed_dtype_matmul_compile_only(tmp_path, monkeypatch, capsys, weight_format):
+def test_mixed_dtype_matmul_compile_only(tmp_path, monkeypatch, weight_format):
     weight_dtype, mlir_dtype, page_size = weight_format
     initial_mlir = tmp_path / "initial.mlir"
     final_mlir = tmp_path / "final.mlir"
@@ -112,11 +167,10 @@ def test_mixed_dtype_matmul_compile_only(tmp_path, monkeypatch, capsys, weight_f
     monkeypatch.setenv("TTLANG_INITIAL_MLIR", str(initial_mlir))
     monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir))
 
-    mixed_dtype_matmul(*_host_tensors(weight_dtype))
+    STAGED_WEIGHT_MATMULS["LoFi"](*_host_tensors(weight_dtype))
 
     initial_text = initial_mlir.read_text()
     final_text = final_mlir.read_text()
-    capsys.readouterr()
     assert "ttl.matmul" in initial_text
     assert "!ttcore.tile<32x32, bf16>" in initial_text
     assert f"!ttcore.tile<32x32, {mlir_dtype}>" in initial_text
@@ -136,11 +190,39 @@ def _make_weight_tensor(weights_torch, weight_dtype, device, memory_config):
     )
 
 
+def _make_width_sharded_l1_memory_config(tensor_shape):
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(0, 0),
+                )
+            }
+        ),
+        tensor_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+
+
 @pytest.mark.requires_device
-@pytest.mark.parametrize("memory", ["dram", "l1"])
-def test_mixed_dtype_matmul_device(device, memory, weight_format):
+@pytest.mark.parametrize(
+    "weight_storage",
+    ("dram", "interleaved_l1", "tensor_backed_width_sharded_l1"),
+    ids=("dram", "l1", "tensor-backed-width-sharded-l1"),
+)
+@pytest.mark.parametrize("math_fidelity", ("LoFi", "HiFi4"), ids=("lofi", "hifi4"))
+def test_mixed_dtype_matmul_device(
+    device, weight_storage, math_fidelity, weight_format
+):
     weight_dtype, _mlir_dtype, _page_size = weight_format
-    row_tiles, contraction_tiles, column_tiles = MATMUL_TILE_SHAPE
+    row_tiles, contraction_tiles, column_tiles = KIMI_MATMUL_TILE_SHAPE
+    torch.manual_seed(0)
     activation_torch = torch.randn(
         row_tiles * TILE_SIZE,
         contraction_tiles * TILE_SIZE,
@@ -157,15 +239,44 @@ def test_mixed_dtype_matmul_device(device, memory, weight_format):
         dtype=torch.bfloat16,
     )
 
-    tensor_factory = to_l1 if memory == "l1" else to_dram
-    memory_config = ttnn.L1_MEMORY_CONFIG if memory == "l1" else ttnn.DRAM_MEMORY_CONFIG
-    activation = tensor_factory(activation_torch, device)
-    weights = _make_weight_tensor(weights_torch, weight_dtype, device, memory_config)
-    output = tensor_factory(output_torch, device)
-    quantized_weights = ttnn.to_torch(weights).float()
+    if weight_storage == "dram":
+        weight_memory_config = ttnn.DRAM_MEMORY_CONFIG
+        matmul = STAGED_WEIGHT_MATMULS[math_fidelity]
+    elif weight_storage == "interleaved_l1":
+        weight_memory_config = ttnn.L1_MEMORY_CONFIG
+        matmul = STAGED_WEIGHT_MATMULS[math_fidelity]
+    else:
+        weight_memory_config = _make_width_sharded_l1_memory_config(
+            tuple(weights_torch.shape)
+        )
+        matmul = TENSOR_BACKED_WEIGHT_MATMULS[math_fidelity]
 
-    mixed_dtype_matmul(activation, weights, output)
+    activation = to_dram(activation_torch, device)
+    weights = _make_weight_tensor(
+        weights_torch, weight_dtype, device, weight_memory_config
+    )
+    output = to_dram(output_torch, device)
+    activation_before = ttnn.to_torch(activation).clone()
+    weights_before = ttnn.to_torch(weights).clone()
 
-    actual = ttnn.to_torch(output).float()
-    expected = activation_torch.float() @ quantized_weights
-    assert_pcc(expected.float(), actual.float(), threshold=0.999)
+    device.enable_program_cache()
+    matmul(activation, weights, output)
+    ttnn.synchronize_device(device)
+    first_output = ttnn.to_torch(output).float()
+    first_cache_entries = device.num_program_cache_entries()
+
+    matmul(activation, weights, output)
+    ttnn.synchronize_device(device)
+    second_output = ttnn.to_torch(output).float()
+    second_cache_entries = device.num_program_cache_entries()
+
+    assert first_cache_entries > 0
+    assert first_cache_entries == second_cache_entries
+    assert torch.equal(first_output, second_output)
+    assert torch.equal(activation_before, ttnn.to_torch(activation))
+    assert torch.equal(weights_before, ttnn.to_torch(weights))
+    assert output.dtype == ttnn.bfloat16
+    assert output.layout == ttnn.TILE_LAYOUT
+
+    expected = activation_before.float() @ weights_before.float()
+    assert_pcc(expected.float(), first_output.float(), threshold=0.999)

--- a/test/python/test_matmul_mixed_dtype.py
+++ b/test/python/test_matmul_mixed_dtype.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""BF16 activation by BFP4_B weight matmul coverage."""
+"""BF16 activation by block-float weight matmul coverage."""
 
 import pytest
 import torch
@@ -61,7 +61,18 @@ def mixed_dtype_matmul(activation, weights, output):
             output_copy.wait()
 
 
-def _host_tensors():
+@pytest.fixture(
+    params=(
+        (ttnn.bfloat4_b, "bfp_bf4", 576),
+        (ttnn.bfloat8_b, "bfp_bf8", 1088),
+    ),
+    ids=("bfp4", "bfp8"),
+)
+def weight_format(request):
+    return request.param
+
+
+def _host_tensors(weight_dtype):
     row_tiles, contraction_tiles, column_tiles = MATMUL_TILE_SHAPE
     activation = ttnn.from_torch(
         torch.randn(
@@ -78,7 +89,7 @@ def _host_tensors():
             column_tiles * TILE_SIZE,
             dtype=torch.bfloat16,
         ),
-        dtype=ttnn.bfloat4_b,
+        dtype=weight_dtype,
         layout=ttnn.TILE_LAYOUT,
     )
     output = ttnn.from_torch(
@@ -93,31 +104,32 @@ def _host_tensors():
     return activation, weights, output
 
 
-def test_mixed_dtype_matmul_compile_only(tmp_path, monkeypatch, capsys):
+def test_mixed_dtype_matmul_compile_only(tmp_path, monkeypatch, capsys, weight_format):
+    weight_dtype, mlir_dtype, page_size = weight_format
     initial_mlir = tmp_path / "initial.mlir"
     final_mlir = tmp_path / "final.mlir"
     monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")
     monkeypatch.setenv("TTLANG_INITIAL_MLIR", str(initial_mlir))
     monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir))
 
-    mixed_dtype_matmul(*_host_tensors())
+    mixed_dtype_matmul(*_host_tensors(weight_dtype))
 
     initial_text = initial_mlir.read_text()
     final_text = final_mlir.read_text()
     capsys.readouterr()
     assert "ttl.matmul" in initial_text
     assert "!ttcore.tile<32x32, bf16>" in initial_text
-    assert "!ttcore.tile<32x32, bfp_bf4>" in initial_text
+    assert f"!ttcore.tile<32x32, {mlir_dtype}>" in initial_text
     assert "ttl.matmul" not in final_text
-    assert "!ttcore.tile<32x32, bfp_bf4>" in final_text
-    assert "page_size = 576" in final_text
+    assert f"!ttcore.tile<32x32, {mlir_dtype}>" in final_text
+    assert f"page_size = {page_size}" in final_text
 
 
-def _make_weight_tensor(weights_torch, device, memory_config):
-    # BFP4_B must be requested explicitly because its Torch source is BF16.
+def _make_weight_tensor(weights_torch, weight_dtype, device, memory_config):
+    # Block-float dtype must be explicit because its Torch source is BF16.
     return ttnn.from_torch(
         weights_torch,
-        dtype=ttnn.bfloat4_b,
+        dtype=weight_dtype,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=memory_config,
@@ -126,7 +138,8 @@ def _make_weight_tensor(weights_torch, device, memory_config):
 
 @pytest.mark.requires_device
 @pytest.mark.parametrize("memory", ["dram", "l1"])
-def test_mixed_dtype_matmul_device(device, memory):
+def test_mixed_dtype_matmul_device(device, memory, weight_format):
+    weight_dtype, _mlir_dtype, _page_size = weight_format
     row_tiles, contraction_tiles, column_tiles = MATMUL_TILE_SHAPE
     activation_torch = torch.randn(
         row_tiles * TILE_SIZE,
@@ -147,7 +160,7 @@ def test_mixed_dtype_matmul_device(device, memory):
     tensor_factory = to_l1 if memory == "l1" else to_dram
     memory_config = ttnn.L1_MEMORY_CONFIG if memory == "l1" else ttnn.DRAM_MEMORY_CONFIG
     activation = tensor_factory(activation_torch, device)
-    weights = _make_weight_tensor(weights_torch, device, memory_config)
+    weights = _make_weight_tensor(weights_torch, weight_dtype, device, memory_config)
     output = tensor_factory(output_torch, device)
     quantized_weights = ttnn.to_torch(weights).float()
 

--- a/test/python/test_matmul_mixed_dtype.py
+++ b/test/python/test_matmul_mixed_dtype.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""BF16 activation by BFP4_B weight matmul coverage."""
+
+import pytest
+import torch
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import to_dram, to_l1
+from utils.correctness import assert_pcc
+
+TILE_SIZE = 32
+MATMUL_TILE_SHAPE = (1, 2, 2)
+
+
+@ttl.operation(grid=(1, 1))
+def mixed_dtype_matmul(activation, weights, output):
+    activation_tiles = activation.shape[1] // TILE_SIZE
+    output_tiles = output.shape[1] // TILE_SIZE
+    activation_dfb = ttl.make_dataflow_buffer_like(
+        activation, shape=(1, activation_tiles), block_count=2
+    )
+    weights_dfb = ttl.make_dataflow_buffer_like(
+        weights, shape=(activation_tiles, output_tiles), block_count=2
+    )
+    output_dfb = ttl.make_dataflow_buffer_like(
+        output, shape=(1, output_tiles), block_count=2
+    )
+
+    @ttl.compute()
+    def compute_matmul():
+        activation_block = activation_dfb.wait()
+        weights_block = weights_dfb.wait()
+        output_block = output_dfb.reserve()
+        output_block.store(activation_block @ weights_block)
+        activation_block.pop()
+        weights_block.pop()
+        output_block.push()
+
+    @ttl.datamovement()
+    def read_inputs():
+        with activation_dfb.reserve() as activation_block:
+            activation_copy = ttl.copy(
+                activation[0:1, 0:activation_tiles], activation_block
+            )
+            activation_copy.wait()
+        with weights_dfb.reserve() as weights_block:
+            weights_copy = ttl.copy(
+                weights[0:activation_tiles, 0:output_tiles], weights_block
+            )
+            weights_copy.wait()
+
+    @ttl.datamovement()
+    def write_output():
+        with output_dfb.wait() as output_block:
+            output_copy = ttl.copy(output_block, output[0:1, 0:output_tiles])
+            output_copy.wait()
+
+
+def _host_tensors():
+    row_tiles, contraction_tiles, column_tiles = MATMUL_TILE_SHAPE
+    activation = ttnn.from_torch(
+        torch.randn(
+            row_tiles * TILE_SIZE,
+            contraction_tiles * TILE_SIZE,
+            dtype=torch.bfloat16,
+        ),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    weights = ttnn.from_torch(
+        torch.randn(
+            contraction_tiles * TILE_SIZE,
+            column_tiles * TILE_SIZE,
+            dtype=torch.bfloat16,
+        ),
+        dtype=ttnn.bfloat4_b,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    output = ttnn.from_torch(
+        torch.zeros(
+            row_tiles * TILE_SIZE,
+            column_tiles * TILE_SIZE,
+            dtype=torch.bfloat16,
+        ),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    return activation, weights, output
+
+
+def test_mixed_dtype_matmul_compile_only(tmp_path, monkeypatch, capsys):
+    initial_mlir = tmp_path / "initial.mlir"
+    final_mlir = tmp_path / "final.mlir"
+    monkeypatch.setenv("TTLANG_COMPILE_ONLY", "1")
+    monkeypatch.setenv("TTLANG_INITIAL_MLIR", str(initial_mlir))
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir))
+
+    mixed_dtype_matmul(*_host_tensors())
+
+    initial_text = initial_mlir.read_text()
+    final_text = final_mlir.read_text()
+    capsys.readouterr()
+    assert "ttl.matmul" in initial_text
+    assert "!ttcore.tile<32x32, bf16>" in initial_text
+    assert "!ttcore.tile<32x32, bfp_bf4>" in initial_text
+    assert "ttl.matmul" not in final_text
+    assert "!ttcore.tile<32x32, bfp_bf4>" in final_text
+    assert "page_size = 576" in final_text
+
+
+def _make_weight_tensor(weights_torch, device, memory_config):
+    # BFP4_B must be requested explicitly because its Torch source is BF16.
+    return ttnn.from_torch(
+        weights_torch,
+        dtype=ttnn.bfloat4_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=memory_config,
+    )
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("memory", ["dram", "l1"])
+def test_mixed_dtype_matmul_device(device, memory):
+    row_tiles, contraction_tiles, column_tiles = MATMUL_TILE_SHAPE
+    activation_torch = torch.randn(
+        row_tiles * TILE_SIZE,
+        contraction_tiles * TILE_SIZE,
+        dtype=torch.bfloat16,
+    )
+    weights_torch = torch.randn(
+        contraction_tiles * TILE_SIZE,
+        column_tiles * TILE_SIZE,
+        dtype=torch.bfloat16,
+    )
+    output_torch = torch.zeros(
+        row_tiles * TILE_SIZE,
+        column_tiles * TILE_SIZE,
+        dtype=torch.bfloat16,
+    )
+
+    tensor_factory = to_l1 if memory == "l1" else to_dram
+    memory_config = ttnn.L1_MEMORY_CONFIG if memory == "l1" else ttnn.DRAM_MEMORY_CONFIG
+    activation = tensor_factory(activation_torch, device)
+    weights = _make_weight_tensor(weights_torch, device, memory_config)
+    output = tensor_factory(output_torch, device)
+    quantized_weights = ttnn.to_torch(weights).float()
+
+    mixed_dtype_matmul(activation, weights, output)
+
+    actual = ttnn.to_torch(output).float()
+    expected = activation_torch.float() @ quantized_weights
+    assert_pcc(expected.float(), actual.float(), threshold=0.999)

--- a/test/python/test_tensor_backed_dfb_api.py
+++ b/test/python/test_tensor_backed_dfb_api.py
@@ -285,7 +285,7 @@ def test_make_tensor_backed_dfb_requires_ttnn_tensor(monkeypatch):
     [
         (_FakeTensor(buffer_type="DRAM"), "must use L1 storage"),
         (_FakeTensor(layout="ROW_MAJOR"), "must use TILE layout"),
-        (_FakeTensor(dtype="int32"), "supports BF16, FP32, BFP4, and BFP8"),
+        (_FakeTensor(dtype="int32"), "supports BF16, FP32, BFP4_B, and BFP8_B"),
     ],
     ids=["dram", "row_major", "int32"],
 )

--- a/test/python/test_tensor_backed_dfb_api.py
+++ b/test/python/test_tensor_backed_dfb_api.py
@@ -30,8 +30,13 @@ class _FakeTile:
     tile_shape = (32, 32)
 
     @staticmethod
-    def get_tile_size(_dtype):
-        return 2048
+    def get_tile_size(dtype):
+        return {
+            "bfloat16": 2048,
+            "float32": 4096,
+            "bfloat4_b": 576,
+            "bfloat8_b": 1088,
+        }[dtype]
 
 
 class _FakeTensor:
@@ -72,6 +77,28 @@ def test_make_tensor_backed_dfb_records_complete_capacity(monkeypatch):
     assert dfb.block_count == 2
     assert dfb.byte_offset == 2048
     assert dfb.byte_size == 16384
+
+
+@pytest.mark.parametrize(
+    ("dtype", "page_size"),
+    [
+        ("bfloat16", 2048),
+        ("float32", 4096),
+        ("bfloat4_b", 576),
+        ("bfloat8_b", 1088),
+    ],
+    ids=["bf16", "fp32", "bfp4", "bfp8"],
+)
+def test_make_tensor_backed_dfb_accepts_supported_dtypes(monkeypatch, dtype, page_size):
+    monkeypatch.setattr(
+        "ttl.dtype_utils.is_ttnn_tensor", lambda tensor: isinstance(tensor, _FakeTensor)
+    )
+
+    dfb = dataflow_buffer.make_tensor_backed_dfb(
+        _FakeTensor(dtype=dtype), shape=(1, 1), block_count=1
+    )
+
+    assert dfb.byte_size == page_size
 
 
 @pytest.mark.parametrize(
@@ -258,7 +285,7 @@ def test_make_tensor_backed_dfb_requires_ttnn_tensor(monkeypatch):
     [
         (_FakeTensor(buffer_type="DRAM"), "must use L1 storage"),
         (_FakeTensor(layout="ROW_MAJOR"), "must use TILE layout"),
-        (_FakeTensor(dtype="int32"), "supports BF16 and FP32"),
+        (_FakeTensor(dtype="int32"), "supports BF16, FP32, BFP4, and BFP8"),
     ],
     ids=["dram", "row_major", "int32"],
 )

--- a/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
@@ -90,6 +90,48 @@ func.func @matmul_bf16_bfp4(
 
 // -----
 
+// BF16 activations and BFP8_B weights retain their distinct input formats
+// while the generated matmul result remains BF16.
+// CHECK-LABEL: func.func @matmul_bf16_bfp8
+func.func @matmul_bf16_bfp8(
+    %arg0: tensor<1x2x!ttcore.tile<32x32, bf16>>,
+    %arg1: tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>)
+    -> tensor<1x2x!ttcore.tile<32x32, bf16>> {
+  // CHECK: ttl.compute
+  // CHECK-SAME: ins({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>)
+  // CHECK-SAME: outs({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>)
+  // CHECK: ^bb0(%[[LHS:.*]]: !ttcore.tile<32x32, bf16>, %[[RHS:.*]]: !ttcore.tile<32x32, bfp_bf8>
+  // CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[LHS]], %[[RHS]]
+  // CHECK-SAME: !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bfp_bf8> -> !ttcore.tile<32x32, bf16>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf8>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %a = ttl.attach_cb %arg0, %cb0
+      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %b = ttl.attach_cb %arg1, %cb1
+      : (tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>,
+         !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf8>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>
+  %reserve = ttl.cb_reserve %cb2
+      : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %mm = ttl.matmul %a, %b
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.store %mm, %reserve
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+  func.return %mm : tensor<1x2x!ttcore.tile<32x32, bf16>>
+}
+
+// -----
+
 // Non-square [2,4] @ [4,3] -> [2,3].
 // CHECK-LABEL: func.func @matmul_2x4_4x3
 func.func @matmul_2x4_4x3(

--- a/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
@@ -48,6 +48,48 @@ func.func @matmul_1x1_f32(
 
 // -----
 
+// BF16 activations and BFP4_B weights retain their distinct input formats
+// while the generated matmul result remains BF16.
+// CHECK-LABEL: func.func @matmul_bf16_bfp4
+func.func @matmul_bf16_bfp4(
+    %arg0: tensor<1x2x!ttcore.tile<32x32, bf16>>,
+    %arg1: tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>)
+    -> tensor<1x2x!ttcore.tile<32x32, bf16>> {
+  // CHECK: ttl.compute
+  // CHECK-SAME: ins({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>)
+  // CHECK-SAME: outs({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>)
+  // CHECK: ^bb0(%[[LHS:.*]]: !ttcore.tile<32x32, bf16>, %[[RHS:.*]]: !ttcore.tile<32x32, bfp_bf4>
+  // CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[LHS]], %[[RHS]]
+  // CHECK-SAME: !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bfp_bf4> -> !ttcore.tile<32x32, bf16>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2}
+      : !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf4>, 2>
+  %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2}
+      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+  %a = ttl.attach_cb %arg0, %cb0
+      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>)
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %b = ttl.attach_cb %arg1, %cb1
+      : (tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>,
+         !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf4>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>
+  %reserve = ttl.cb_reserve %cb2
+      : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  %mm = ttl.matmul %a, %b
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>
+        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+  ttl.store %mm, %reserve
+      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+        tensor<1x2x!ttcore.tile<32x32, bf16>>
+  func.return %mm : tensor<1x2x!ttcore.tile<32x32, bf16>>
+}
+
+// -----
+
 // Non-square [2,4] @ [4,3] -> [2,3].
 // CHECK-LABEL: func.func @matmul_2x4_4x3
 func.func @matmul_2x4_4x3(

--- a/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/matmul_to_compute.mlir
@@ -48,86 +48,86 @@ func.func @matmul_1x1_f32(
 
 // -----
 
-// BF16 activations and BFP4_B weights retain their distinct input formats
-// while the generated matmul result remains BF16.
+// The Kimi 1x32 BF16 activation/output tiles and 32x32 BFP4_B weight tiles
+// retain their distinct formats through lowering.
 // CHECK-LABEL: func.func @matmul_bf16_bfp4
 func.func @matmul_bf16_bfp4(
-    %arg0: tensor<1x2x!ttcore.tile<32x32, bf16>>,
+    %arg0: tensor<1x2x!ttcore.tile<1x32, bf16>>,
     %arg1: tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>)
-    -> tensor<1x2x!ttcore.tile<32x32, bf16>> {
+    -> tensor<1x2x!ttcore.tile<1x32, bf16>> {
   // CHECK: ttl.compute
-  // CHECK-SAME: ins({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>)
-  // CHECK-SAME: outs({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>)
-  // CHECK: ^bb0(%[[LHS:.*]]: !ttcore.tile<32x32, bf16>, %[[RHS:.*]]: !ttcore.tile<32x32, bfp_bf4>
+  // CHECK-SAME: ins({{.*}} : tensor<1x2x!ttcore.tile<1x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>)
+  // CHECK-SAME: outs({{.*}} : tensor<1x2x!ttcore.tile<1x32, bf16>>)
+  // CHECK: ^bb0(%[[LHS:.*]]: !ttcore.tile<1x32, bf16>, %[[RHS:.*]]: !ttcore.tile<32x32, bfp_bf4>
   // CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[LHS]], %[[RHS]]
-  // CHECK-SAME: !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bfp_bf4> -> !ttcore.tile<32x32, bf16>
+  // CHECK-SAME: !ttcore.tile<1x32, bf16>, !ttcore.tile<32x32, bfp_bf4> -> !ttcore.tile<1x32, bf16>
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2}
-      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+      : !ttl.cb<[1, 2], !ttcore.tile<1x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2}
       : !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf4>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2}
-      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+      : !ttl.cb<[1, 2], !ttcore.tile<1x32, bf16>, 2>
   %a = ttl.attach_cb %arg0, %cb0
-      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
-         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+      : (tensor<1x2x!ttcore.tile<1x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<1x32, bf16>, 2>)
+        -> tensor<1x2x!ttcore.tile<1x32, bf16>>
   %b = ttl.attach_cb %arg1, %cb1
       : (tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>,
          !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf4>, 2>)
         -> tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>
   %reserve = ttl.cb_reserve %cb2
-      : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
-        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+      : <[1, 2], !ttcore.tile<1x32, bf16>, 2>
+        -> tensor<1x2x!ttcore.tile<1x32, bf16>>
   %mm = ttl.matmul %a, %b
-      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+      : tensor<1x2x!ttcore.tile<1x32, bf16>>,
         tensor<2x2x!ttcore.tile<32x32, bfp_bf4>>
-        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x2x!ttcore.tile<1x32, bf16>>
   ttl.store %mm, %reserve
-      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
-        tensor<1x2x!ttcore.tile<32x32, bf16>>
-  func.return %mm : tensor<1x2x!ttcore.tile<32x32, bf16>>
+      : tensor<1x2x!ttcore.tile<1x32, bf16>>,
+        tensor<1x2x!ttcore.tile<1x32, bf16>>
+  func.return %mm : tensor<1x2x!ttcore.tile<1x32, bf16>>
 }
 
 // -----
 
-// BF16 activations and BFP8_B weights retain their distinct input formats
-// while the generated matmul result remains BF16.
+// The Kimi 1x32 BF16 activation/output tiles and 32x32 BFP8_B weight tiles
+// retain their distinct formats through lowering.
 // CHECK-LABEL: func.func @matmul_bf16_bfp8
 func.func @matmul_bf16_bfp8(
-    %arg0: tensor<1x2x!ttcore.tile<32x32, bf16>>,
+    %arg0: tensor<1x2x!ttcore.tile<1x32, bf16>>,
     %arg1: tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>)
-    -> tensor<1x2x!ttcore.tile<32x32, bf16>> {
+    -> tensor<1x2x!ttcore.tile<1x32, bf16>> {
   // CHECK: ttl.compute
-  // CHECK-SAME: ins({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>)
-  // CHECK-SAME: outs({{.*}} : tensor<1x2x!ttcore.tile<32x32, bf16>>)
-  // CHECK: ^bb0(%[[LHS:.*]]: !ttcore.tile<32x32, bf16>, %[[RHS:.*]]: !ttcore.tile<32x32, bfp_bf8>
+  // CHECK-SAME: ins({{.*}} : tensor<1x2x!ttcore.tile<1x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>)
+  // CHECK-SAME: outs({{.*}} : tensor<1x2x!ttcore.tile<1x32, bf16>>)
+  // CHECK: ^bb0(%[[LHS:.*]]: !ttcore.tile<1x32, bf16>, %[[RHS:.*]]: !ttcore.tile<32x32, bfp_bf8>
   // CHECK: %[[MM:.*]] = ttl.tile_matmul_block %[[LHS]], %[[RHS]]
-  // CHECK-SAME: !ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bfp_bf8> -> !ttcore.tile<32x32, bf16>
+  // CHECK-SAME: !ttcore.tile<1x32, bf16>, !ttcore.tile<32x32, bfp_bf8> -> !ttcore.tile<1x32, bf16>
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2}
-      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+      : !ttl.cb<[1, 2], !ttcore.tile<1x32, bf16>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2}
       : !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf8>, 2>
   %cb2 = ttl.bind_cb {cb_index = 2, block_count = 2}
-      : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>
+      : !ttl.cb<[1, 2], !ttcore.tile<1x32, bf16>, 2>
   %a = ttl.attach_cb %arg0, %cb0
-      : (tensor<1x2x!ttcore.tile<32x32, bf16>>,
-         !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 2>)
-        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+      : (tensor<1x2x!ttcore.tile<1x32, bf16>>,
+         !ttl.cb<[1, 2], !ttcore.tile<1x32, bf16>, 2>)
+        -> tensor<1x2x!ttcore.tile<1x32, bf16>>
   %b = ttl.attach_cb %arg1, %cb1
       : (tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>,
          !ttl.cb<[2, 2], !ttcore.tile<32x32, bfp_bf8>, 2>)
         -> tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>
   %reserve = ttl.cb_reserve %cb2
-      : <[1, 2], !ttcore.tile<32x32, bf16>, 2>
-        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+      : <[1, 2], !ttcore.tile<1x32, bf16>, 2>
+        -> tensor<1x2x!ttcore.tile<1x32, bf16>>
   %mm = ttl.matmul %a, %b
-      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
+      : tensor<1x2x!ttcore.tile<1x32, bf16>>,
         tensor<2x2x!ttcore.tile<32x32, bfp_bf8>>
-        -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x2x!ttcore.tile<1x32, bf16>>
   ttl.store %mm, %reserve
-      : tensor<1x2x!ttcore.tile<32x32, bf16>>,
-        tensor<1x2x!ttcore.tile<32x32, bf16>>
-  func.return %mm : tensor<1x2x!ttcore.tile<32x32, bf16>>
+      : tensor<1x2x!ttcore.tile<1x32, bf16>>,
+        tensor<1x2x!ttcore.tile<1x32, bf16>>
+  func.return %mm : tensor<1x2x!ttcore.tile<1x32, bf16>>
 }
 
 // -----

--- a/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
@@ -34,11 +34,11 @@ func.func @matmul_lhs_rank3(
 
 // -----
 
-// Test: Element type mismatch between inputs
+// Test: unsupported mixed input data types.
 func.func @matmul_element_mismatch(
     %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
     %b: tensor<3x4x!ttcore.tile<32x32, f32>>) -> tensor<2x4x!ttcore.tile<32x32, bf16>> {
-  // expected-error @below {{element data type mismatch}}
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, bf16>, rhs has !ttcore.tile<32x32, f32>, and result has !ttcore.tile<32x32, bf16>}}
   %r = ttl.matmul %a, %b : tensor<2x3x!ttcore.tile<32x32, bf16>>, tensor<3x4x!ttcore.tile<32x32, f32>> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
   return %r : tensor<2x4x!ttcore.tile<32x32, bf16>>
 }
@@ -67,13 +67,29 @@ func.func @matmul_dynamic_lhs(
 
 // -----
 
-// Test: Result element type mismatch (inputs bf16 but result f32)
+// Test: result data type must match the supported input combination.
 func.func @matmul_result_element_mismatch(
     %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
     %b: tensor<3x4x!ttcore.tile<32x32, bf16>>) -> tensor<2x4x!ttcore.tile<32x32, f32>> {
-  // expected-error @below {{result element data type !ttcore.tile<32x32, f32> must match input element data type !ttcore.tile<32x32, bf16>}}
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, bf16>, rhs has !ttcore.tile<32x32, bf16>, and result has !ttcore.tile<32x32, f32>}}
   %r = ttl.matmul %a, %b : tensor<2x3x!ttcore.tile<32x32, bf16>>, tensor<3x4x!ttcore.tile<32x32, bf16>> -> tensor<2x4x!ttcore.tile<32x32, f32>>
   return %r : tensor<2x4x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Mixed-format matmul does not support a transposed packed rhs because the
+// Blackhole unpacker contract used by the generated primitive is non-transposed.
+func.func @matmul_transposed_bfp4_rhs(
+    %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
+    %b: tensor<4x3x!ttcore.tile<32x32, bfp_bf4>>)
+    -> tensor<2x4x!ttcore.tile<32x32, bf16>> {
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, bf16>, rhs has !ttcore.tile<32x32, bfp_bf4>, and result has !ttcore.tile<32x32, bf16>}}
+  %r = ttl.matmul %a, %b {transpose_rhs}
+      : tensor<2x3x!ttcore.tile<32x32, bf16>>,
+        tensor<4x3x!ttcore.tile<32x32, bfp_bf4>>
+        -> tensor<2x4x!ttcore.tile<32x32, bf16>>
+  return %r : tensor<2x4x!ttcore.tile<32x32, bf16>>
 }
 
 // -----

--- a/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
@@ -94,6 +94,22 @@ func.func @matmul_transposed_bfp4_rhs(
 
 // -----
 
+// Mixed-format matmul does not support a transposed packed rhs because the
+// Blackhole unpacker contract used by the generated primitive is non-transposed.
+func.func @matmul_transposed_bfp8_rhs(
+    %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
+    %b: tensor<4x3x!ttcore.tile<32x32, bfp_bf8>>)
+    -> tensor<2x4x!ttcore.tile<32x32, bf16>> {
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, bf16>, rhs has !ttcore.tile<32x32, bfp_bf8>, and result has !ttcore.tile<32x32, bf16>}}
+  %r = ttl.matmul %a, %b {transpose_rhs}
+      : tensor<2x3x!ttcore.tile<32x32, bf16>>,
+        tensor<4x3x!ttcore.tile<32x32, bfp_bf8>>
+        -> tensor<2x4x!ttcore.tile<32x32, bf16>>
+  return %r : tensor<2x4x!ttcore.tile<32x32, bf16>>
+}
+
+// -----
+
 // Test: transpose_rhs K mismatch. RHS is [N, K]=[4, 5] so its K (5) does not
 // match lhs K (3).
 func.func @matmul_transpose_k_mismatch(

--- a/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
@@ -78,7 +78,7 @@ func.func @matmul_result_element_mismatch(
 
 // -----
 
-// Mixed-format matmul rejects a transposed BFP4 rhs.
+// Mixed-format matmul rejects a transposed BFP4_B rhs.
 func.func @matmul_transposed_bfp4_rhs(
     %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
     %b: tensor<4x3x!ttcore.tile<32x32, bfp_bf4>>)
@@ -93,7 +93,7 @@ func.func @matmul_transposed_bfp4_rhs(
 
 // -----
 
-// Mixed-format matmul rejects a transposed BFP8 rhs.
+// Mixed-format matmul rejects a transposed BFP8_B rhs.
 func.func @matmul_transposed_bfp8_rhs(
     %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
     %b: tensor<4x3x!ttcore.tile<32x32, bfp_bf8>>)

--- a/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/matmul_invalid.mlir
@@ -78,8 +78,7 @@ func.func @matmul_result_element_mismatch(
 
 // -----
 
-// Mixed-format matmul does not support a transposed packed rhs because the
-// Blackhole unpacker contract used by the generated primitive is non-transposed.
+// Mixed-format matmul rejects a transposed BFP4 rhs.
 func.func @matmul_transposed_bfp4_rhs(
     %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
     %b: tensor<4x3x!ttcore.tile<32x32, bfp_bf4>>)
@@ -94,8 +93,7 @@ func.func @matmul_transposed_bfp4_rhs(
 
 // -----
 
-// Mixed-format matmul does not support a transposed packed rhs because the
-// Blackhole unpacker contract used by the generated primitive is non-transposed.
+// Mixed-format matmul rejects a transposed BFP8 rhs.
 func.func @matmul_transposed_bfp8_rhs(
     %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
     %b: tensor<4x3x!ttcore.tile<32x32, bfp_bf8>>)
@@ -106,6 +104,36 @@ func.func @matmul_transposed_bfp8_rhs(
         tensor<4x3x!ttcore.tile<32x32, bfp_bf8>>
         -> tensor<2x4x!ttcore.tile<32x32, bf16>>
   return %r : tensor<2x4x!ttcore.tile<32x32, bf16>>
+}
+
+// -----
+
+// Mixed BFP4_B matmul requires a BF16 result.
+func.func @matmul_bfp4_result_type(
+    %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
+    %b: tensor<3x4x!ttcore.tile<32x32, bfp_bf4>>)
+    -> tensor<2x4x!ttcore.tile<32x32, bfp_bf4>> {
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, bf16>, rhs has !ttcore.tile<32x32, bfp_bf4>, and result has !ttcore.tile<32x32, bfp_bf4>}}
+  %r = ttl.matmul %a, %b
+      : tensor<2x3x!ttcore.tile<32x32, bf16>>,
+        tensor<3x4x!ttcore.tile<32x32, bfp_bf4>>
+        -> tensor<2x4x!ttcore.tile<32x32, bfp_bf4>>
+  return %r : tensor<2x4x!ttcore.tile<32x32, bfp_bf4>>
+}
+
+// -----
+
+// Mixed BFP8_B matmul requires a BF16 result.
+func.func @matmul_bfp8_result_type(
+    %a: tensor<2x3x!ttcore.tile<32x32, bf16>>,
+    %b: tensor<3x4x!ttcore.tile<32x32, bfp_bf8>>)
+    -> tensor<2x4x!ttcore.tile<32x32, bfp_bf8>> {
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, bf16>, rhs has !ttcore.tile<32x32, bfp_bf8>, and result has !ttcore.tile<32x32, bfp_bf8>}}
+  %r = ttl.matmul %a, %b
+      : tensor<2x3x!ttcore.tile<32x32, bf16>>,
+        tensor<3x4x!ttcore.tile<32x32, bfp_bf8>>
+        -> tensor<2x4x!ttcore.tile<32x32, bfp_bf8>>
+  return %r : tensor<2x4x!ttcore.tile<32x32, bfp_bf8>>
 }
 
 // -----

--- a/test/ttlang/Dialect/TTL/IR/tensor_backing.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tensor_backing.mlir
@@ -1,0 +1,26 @@
+// Tests supported block-float tensor-backed DFB element types.
+// RUN: ttlang-opt --split-input-file %s | FileCheck %s
+
+// BFP4 tensor backing uses its physical 576-byte tile page size.
+module {
+  // CHECK-LABEL: func.func @bfp4_tensor_backing
+  func.func @bfp4_tensor_backing() {
+    // CHECK: ttl.bind_cb{{.*}}byte_size = 576{{.*}}!ttcore.tile<32x32, bfp_bf4>
+    // CHECK-NEXT: return
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 576>} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bfp_bf4>, 1>
+    return
+  }
+}
+
+// -----
+
+// BFP8 tensor backing uses its physical 1088-byte tile page size.
+module {
+  // CHECK-LABEL: func.func @bfp8_tensor_backing
+  func.func @bfp8_tensor_backing() {
+    // CHECK: ttl.bind_cb{{.*}}byte_size = 1088{{.*}}!ttcore.tile<32x32, bfp_bf8>
+    // CHECK-NEXT: return
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 1088>} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bfp_bf8>, 1>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/IR/tensor_backing.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tensor_backing.mlir
@@ -1,7 +1,7 @@
 // Tests supported block-float tensor-backed DFB element types.
 // RUN: ttlang-opt --split-input-file %s | FileCheck %s
 
-// BFP4 tensor backing uses its physical 576-byte tile page size.
+// BFP4_B tensor backing uses its physical 576-byte tile page size.
 module {
   // CHECK-LABEL: func.func @bfp4_tensor_backing
   func.func @bfp4_tensor_backing() {
@@ -14,7 +14,7 @@ module {
 
 // -----
 
-// BFP8 tensor backing uses its physical 1088-byte tile page size.
+// BFP8_B tensor backing uses its physical 1088-byte tile page size.
 module {
   // CHECK-LABEL: func.func @bfp8_tensor_backing
   func.func @bfp8_tensor_backing() {

--- a/test/ttlang/Dialect/TTL/IR/tensor_backing_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tensor_backing_invalid.mlir
@@ -114,7 +114,7 @@ module {
 // Tensor-backed formats reject tile data types outside the supported set.
 module {
   func.func @unsupported_tile_data_type() {
-    // expected-error @below {{tensor backing supports only BF16, FP32, BFP4, and BFP8 tile element types}}
+    // expected-error @below {{tensor backing supports only BF16, FP32, BFP4_B, and BFP8_B tile element types}}
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 2048>} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 1>
     return
   }

--- a/test/ttlang/Dialect/TTL/IR/tensor_backing_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tensor_backing_invalid.mlir
@@ -111,10 +111,10 @@ module {
 
 // -----
 
-// Tensor-backed formats are limited to the data types defined by the specification.
+// Tensor-backed formats reject tile data types outside the supported set.
 module {
   func.func @unsupported_tile_data_type() {
-    // expected-error @below {{tensor backing supports only BF16 and FP32 tile element types}}
+    // expected-error @below {{tensor backing supports only BF16, FP32, BFP4, and BFP8 tile element types}}
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 1} {dfb_id = 0 : index, tensor_backing = #ttl.tensor_backing<tensor_index = 0, byte_offset = 0, byte_size = 2048>} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f16>, 1>
     return
   }

--- a/test/ttlang/Dialect/TTL/IR/tile_matmul_block_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tile_matmul_block_invalid.mlir
@@ -55,3 +55,17 @@ func.func @tile_matmul_scalar_tensor(
         -> !ttcore.tile<32x32, bf16>
   return
 }
+
+// -----
+
+// Only BF16 lhs by BFP4_B rhs can use different operand data types.
+func.func @tile_matmul_unsupported_mixed_types(
+    %lhs: !ttcore.tile<32x32, f32>,
+    %rhs: !ttcore.tile<32x32, bfp_bf4>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, f32>, rhs has !ttcore.tile<32x32, bfp_bf4>, and result has !ttcore.tile<32x32, f32>}}
+  %result = ttl.tile_matmul_block %lhs, %rhs into dst[%c0]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, bfp_bf4>
+        -> !ttcore.tile<32x32, f32>
+  return
+}

--- a/test/ttlang/Dialect/TTL/IR/tile_matmul_block_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/tile_matmul_block_invalid.mlir
@@ -58,7 +58,7 @@ func.func @tile_matmul_scalar_tensor(
 
 // -----
 
-// Only BF16 lhs by BFP4_B rhs can use different operand data types.
+// BF16 lhs is required for mixed block-float matmul.
 func.func @tile_matmul_unsupported_mixed_types(
     %lhs: !ttcore.tile<32x32, f32>,
     %rhs: !ttcore.tile<32x32, bfp_bf4>) {
@@ -66,6 +66,20 @@ func.func @tile_matmul_unsupported_mixed_types(
   // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, f32>, rhs has !ttcore.tile<32x32, bfp_bf4>, and result has !ttcore.tile<32x32, f32>}}
   %result = ttl.tile_matmul_block %lhs, %rhs into dst[%c0]
       : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, bfp_bf4>
+        -> !ttcore.tile<32x32, f32>
+  return
+}
+
+// -----
+
+// BF16 lhs is required for mixed BFP8_B matmul.
+func.func @tile_matmul_unsupported_bfp8_types(
+    %lhs: !ttcore.tile<32x32, f32>,
+    %rhs: !ttcore.tile<32x32, bfp_bf8>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @below {{unsupported matmul element data type combination: lhs has !ttcore.tile<32x32, f32>, rhs has !ttcore.tile<32x32, bfp_bf8>, and result has !ttcore.tile<32x32, f32>}}
+  %result = ttl.tile_matmul_block %lhs, %rhs into dst[%c0]
+      : !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, bfp_bf8>
         -> !ttcore.tile<32x32, f32>
   return
 }


### PR DESCRIPTION
### Problem description

TT-Lang rejects hardware-supported matmul operations with a BF16 lhs and a BFP4_B or BFP8_B rhs because the verifier requires matching operand formats. Kimi routed-expert matmuls use BF16 activations with block-float weights.

Fixes #843.

### What's changed

~80 LOC implementation (tests and documentation excluded).

Accept non-transposed `BF16 x BFP4_B/BFP8_B -> BF16` matmul on Wormhole and Blackhole. Preserve independent lhs and rhs formats through frontend construction, compute planning, TTKernel lowering, initialization, and reconfiguration. Existing same-format matmul behavior is unchanged.

```python
with activation_dfb.wait() as activation:
    with weights_dfb.wait() as weights:
        with output_dfb.reserve() as output:
            output.store(ttl.matmul(activation, weights))
```

The operation supports `1x32` BF16 activation/output tiles with `32x32` BFP4_B or BFP8_B weight tiles. Unsupported mixed tuples, non-BF16 results, and transposed block-float rhs operands are rejected. Native block-float support is not checkpoint MXFP4 support.

### Validation

- New Wormhole and Blackhole device cases cover BFP4_B/BFP8_B, LoFi/HiFi4, DRAM, interleaved L1, and height-, width-, and block-sharded tensor-backed L1 weights.
- New focused compiler cases cover successful lowering and precise rejection of unsupported operand, result, transpose, and tile-matmul combinations.

### Checklist

- [x] New/Existing tests provide coverage for changes
