### PR TITLE
[ci] Enable loudbox tests for PRs and pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
     secrets: inherit
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
-      run_galaxy_tests: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}
+      run_galaxy_tests: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}
       run_loudbox_tests: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.run_loudbox_tests) }}
 
   build-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
       run_galaxy_tests: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}
-      run_loudbox_tests: ${{ github.event_name == 'workflow_dispatch' && inputs.run_loudbox_tests }}
+      run_loudbox_tests: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.run_loudbox_tests) }}
 
   build-docs:
     name: Build documentation

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -45,8 +45,10 @@ def test_hardware_event_policy_and_manual_controls() -> None:
         in ci_workflow
     )
     assert (
-        "run_loudbox_tests: ${{ github.event_name == 'workflow_dispatch' "
-        "&& inputs.run_loudbox_tests }}" in ci_workflow
+        "run_loudbox_tests: ${{ github.event_name == 'pull_request' || "
+        "(github.event_name == 'push' && github.ref == 'refs/heads/main') || "
+        "(github.event_name == 'workflow_dispatch' && inputs.run_loudbox_tests) }}"
+        in ci_workflow
     )
     assert call_build.count("run_galaxy_tests:") == 2
     assert call_build.count("run_loudbox_tests:") == 2

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -38,9 +38,7 @@ def test_hardware_event_policy_and_manual_controls() -> None:
     assert ci_workflow.count("run_galaxy_tests:") == 2
     assert ci_workflow.count("run_loudbox_tests:") == 2
     assert (
-        "run_galaxy_tests: ${{ (github.event_name == 'push' "
-        "&& github.ref == 'refs/heads/main') || "
-        "github.event_name == 'schedule' || "
+        "run_galaxy_tests: ${{ github.event_name == 'schedule' || "
         "(github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}"
         in ci_workflow
     )


### PR DESCRIPTION
### Problem description

Blackhole loudbox tests run only when manually selected, while Galaxy tests run after every push to `main`.

### What's changed

- run loudbox tests for pull requests targeting `main`
- run loudbox tests for pushes to `main`
- run Galaxy tests only in nightly CI or when manually selected

### Checklist

- [x] New/Existing tests provide coverage for changes
