### PR TITLE
Preserve DFB lifetime safety for fused DSpark

### DIFF
--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -594,6 +594,10 @@ struct TTLFinalizeDFBIndicesPass
         }
       };
 
+      // The bind anchors the interval; binds are hoisted to the function
+      // entry, so the start is refined to the first acquire below.
+      extendInterval(dfb, bindOp, func, *order);
+
       // Pipe destinations are slot-addressed (block_count == sender count)
       // and pipe sends read asynchronously, so pipe-attached DFBs keep
       // dedicated indices.

--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -130,8 +130,8 @@ struct LogicalDFB {
 
 enum class ResetControlFlow { Linear, Cyclic };
 
-constexpr llvm::StringLiteral kDFBResetPreservedIndicesAttrName(
-    "ttl.dfb_reset_preserved_indices");
+constexpr llvm::StringLiteral
+    kDFBResetPreservedIndicesAttrName("ttl.dfb_reset_preserved_indices");
 
 enum class HardwareDataFormat : int64_t {
   Float32 = 0,
@@ -450,8 +450,7 @@ struct TTLFinalizeDFBIndicesPass
 
     SmallVector<SmallVector<int64_t>> preservedByResetOrdinal(
         resetCount.value_or(0));
-    SmallVector<bool> initializedPreserveOrdinal(resetCount.value_or(0),
-                                                 false);
+    SmallVector<bool> initializedPreserveOrdinal(resetCount.value_or(0), false);
     llvm::DenseSet<int64_t> preservedLogicalIndices;
     for (func::FuncOp func : moduleOp.getOps<func::FuncOp>()) {
       auto callsIt = resetCallsByFunction.find(func.getOperation());
@@ -463,8 +462,7 @@ struct TTLFinalizeDFBIndicesPass
         SmallVector<int64_t> preserved;
         for (Value operand : call.getArgOperands()) {
           if (!isa<CircularBufferType>(operand.getType())) {
-            call.emitError(
-                "preserve operands must be dataflow buffers");
+            call.emitError("preserve operands must be dataflow buffers");
             invalidResetContract = true;
             continue;
           }
@@ -878,8 +876,8 @@ struct TTLFinalizeDFBIndicesPass
     llvm::DenseSet<int64_t> unpackToDestFp32DFBs;
     bool fp32DestAcc = false;
     moduleOp->walk([&](func::FuncOp func) {
-      auto thread = func->getAttrOfType<ttkernel::ThreadTypeAttr>(
-          kKernelThreadAttrName);
+      auto thread =
+          func->getAttrOfType<ttkernel::ThreadTypeAttr>(kKernelThreadAttrName);
       if (!thread || thread.getValue() != ttkernel::ThreadType::Compute) {
         return;
       }
@@ -1009,8 +1007,8 @@ struct TTLFinalizeDFBIndicesPass
           return lhs < rhs;
         });
         usedIndices.erase(llvm::unique(usedIndices), usedIndices.end());
-        maxEpochLocalSlots = std::max(
-            maxEpochLocalSlots, static_cast<int64_t>(usedIndices.size()));
+        maxEpochLocalSlots = std::max(maxEpochLocalSlots,
+                                      static_cast<int64_t>(usedIndices.size()));
         DenseMap<int64_t, int64_t> rank;
         for (auto [i, index] : llvm::enumerate(usedIndices)) {
           rank[index] = static_cast<int64_t>(i);
@@ -1029,8 +1027,7 @@ struct TTLFinalizeDFBIndicesPass
         return lhs->origIndex < rhs->origIndex;
       });
       for (auto [ordinal, dfb] : llvm::enumerate(pinnedDFBs)) {
-        dfb->finalIndex =
-            maxEpochLocalSlots + static_cast<int64_t>(ordinal);
+        dfb->finalIndex = maxEpochLocalSlots + static_cast<int64_t>(ordinal);
       }
     } else {
       // Compact to a dense index space (the runtime builds one CB descriptor
@@ -1077,12 +1074,12 @@ struct TTLFinalizeDFBIndicesPass
           builder.getNamedAttr(
               "physical_index",
               builder.getI32IntegerAttr(static_cast<int32_t>(dfb.finalIndex))),
-          builder.getNamedAttr(
-              "epoch", builder.getI32IntegerAttr(
-                           static_cast<int32_t>(dfb.firstUseEpoch))),
-          builder.getNamedAttr(
-              "num_pages", builder.getI32IntegerAttr(
-                               static_cast<int32_t>(dfb.totalPages()))),
+          builder.getNamedAttr("epoch",
+                               builder.getI32IntegerAttr(
+                                   static_cast<int32_t>(dfb.firstUseEpoch))),
+          builder.getNamedAttr("num_pages",
+                               builder.getI32IntegerAttr(
+                                   static_cast<int32_t>(dfb.totalPages()))),
           builder.getNamedAttr("element_type", TypeAttr::get(dfb.elemType)),
           builder.getNamedAttr(
               "unpack_to_dest_fp32",
@@ -1093,10 +1090,9 @@ struct TTLFinalizeDFBIndicesPass
           builder.getNamedAttr(
               "block_count",
               builder.getI32IntegerAttr(static_cast<int32_t>(dfb.blockCount))),
-          builder.getNamedAttr(
-              "elems_per_block",
-              builder.getI32IntegerAttr(
-                  static_cast<int32_t>(dfb.elemsPerBlock)))};
+          builder.getNamedAttr("elems_per_block",
+                               builder.getI32IntegerAttr(
+                                   static_cast<int32_t>(dfb.elemsPerBlock)))};
       if (dfb.addressScope) {
         attrs.push_back(
             builder.getNamedAttr("address_scope", dfb.addressScope));
@@ -1167,8 +1163,7 @@ struct TTLFinalizeDFBIndicesPass
           auto [it, inserted] =
               configs.try_emplace(logicalDFB->finalIndex, logicalDFB);
           if (!inserted) {
-            auto currentTileType =
-                cast<ttcore::TileType>(it->second->elemType);
+            auto currentTileType = cast<ttcore::TileType>(it->second->elemType);
             int64_t currentBytes =
                 it->second->totalPages() * currentTileType.getSizeBytes();
             int64_t candidateBytes =
@@ -1196,8 +1191,7 @@ struct TTLFinalizeDFBIndicesPass
       int64_t physicalSlotCount = 0;
       for (const auto &[idx, dfb] : dfbs) {
         (void)idx;
-        physicalSlotCount =
-            std::max(physicalSlotCount, dfb.finalIndex + 1);
+        physicalSlotCount = std::max(physicalSlotCount, dfb.finalIndex + 1);
       }
       SmallVector<Attribute> physicalConfigs;
       for (int64_t physicalIndex = 0; physicalIndex < physicalSlotCount;
@@ -1323,9 +1317,9 @@ struct TTLFinalizeDFBIndicesPass
       for (auto &[funcOperation, calls] : resetCallsByFunction) {
         if (hasCyclicResetDataflowBuffers) {
           for (auto [ordinal, call] : llvm::enumerate(calls)) {
-            appendConfiguration(call, (static_cast<int64_t>(ordinal) + 1) %
-                                          epochCount,
-                                preservedPhysicalByResetOrdinal[ordinal]);
+            appendConfiguration(
+                call, (static_cast<int64_t>(ordinal) + 1) % epochCount,
+                preservedPhysicalByResetOrdinal[ordinal]);
           }
         } else {
           for (auto [ordinal, call] : llvm::enumerate(calls)) {

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -365,7 +365,7 @@ LogicalResult translateKernelFuncToCpp(func::FuncOp entry,
   if (failed(kernelModule)) {
     return failure();
   }
-  auto moduleCleanup = llvm::make_scope_exit([&]() { kernelModule->erase(); });
+  auto moduleCleanup = llvm::scope_exit([&]() { kernelModule->erase(); });
   return emitc::translateToCpp(*kernelModule, os);
 }
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
@@ -11,6 +11,7 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=USER
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=XTHREAD
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=EPOCH
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=CYCLIC1
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=CYCLIC2
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=CYCLIC3
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)' | FileCheck %s --check-prefix=UNPACK
@@ -300,7 +301,9 @@ func.func @single_dfb_no_reuse()
 // DEBUG: Total DFB count: 1
 
 // USER: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]
-// USER: ttl.logical_dfb_configs = [{{.*}}logical_index = 0 : i32{{.*}}physical_index = 0 : i32{{.*}}logical_index = 1 : i32{{.*}}physical_index = 0 : i32{{.*}}]
+// USER: ttl.logical_dfb_configs = [
+// USER-SAME: {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, bf16>, elems_per_block = 1 : i32, epoch = 0 : i32, logical_index = 0 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}
+// USER-SAME: , {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, bf16>, elems_per_block = 1 : i32, epoch = 0 : i32, logical_index = 1 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}]
 
 // USER-LABEL: func.func @thread_local_user
 // USER-SAME: ttl.base_cta_index = 1 : i32
@@ -374,13 +377,15 @@ func.func @xt_compute()
 
 // EPOCH: ttl.dfb_epoch_physical_configs = [{dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, tile_height = 32 : i32, tile_width = 32 : i32, total_size = 8192 : i64}]
 // EPOCH: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]
-// EPOCH: ttl.logical_dfb_configs = [{{.*}}element_type = !ttcore.tile<32x32, bf16>{{.*}}epoch = 0 : i32{{.*}}logical_index = 0 : i32{{.*}}physical_index = 0 : i32{{.*}}element_type = !ttcore.tile<32x32, f32>{{.*}}epoch = 1 : i32{{.*}}logical_index = 1 : i32{{.*}}physical_index = 0 : i32{{.*}}]
+// EPOCH: ttl.logical_dfb_configs = [
+// EPOCH-SAME: {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, bf16>, elems_per_block = 1 : i32, epoch = 0 : i32, logical_index = 0 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}
+// EPOCH-SAME: , {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, f32>, elems_per_block = 1 : i32, epoch = 1 : i32, logical_index = 1 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}]
 // EPOCH-LABEL: func.func @epoch_restart
 // EPOCH: ttl.bind_cb{cb_index = 0, block_count = 2} {ttl.dfb_logical_index = 0 : i64}
 // EPOCH: ttl.bind_cb{cb_index = 0, block_count = 2} {ttl.dfb_logical_index = 1 : i64}
-// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
+// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
 // EPOCH: ttl.cb_reserve
-// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32{{.*}}}
+// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32, ttl.dfb_reset_preserved_indices = []}
 // EPOCH: ttl.cb_reserve
 // EPOCH-NOT: cb_index = 1
 // EPOCH: return
@@ -403,6 +408,28 @@ func.func @epoch_restart()
 
 // -----
 
+// A single cyclic cut restores phase zero on every loop backedge.
+
+// CYCLIC1: ttl.dfb_epoch_physical_configs = []
+// CYCLIC1: ttl.logical_dfb_configs = []
+// CYCLIC1-LABEL: func.func @one_cyclic_cut
+// CYCLIC1: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 0], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
+// CYCLIC1: scf.for
+// CYCLIC1: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 0], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
+// CYCLIC1: return
+func.func @one_cyclic_cut()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  scf.for %i = %c0 to %c4 step %c1 {
+    ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h"} : () -> ()
+  }
+  return
+}
+
+// -----
+
 // Two resets directly in a resident loop alternate between phase A and phase
 // B. The prologue configures A, the first reset configures B, and the second
 // reset restores A before the loop backedge.
@@ -411,12 +438,12 @@ func.func @epoch_restart()
 // CYCLIC2: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]
 // CYCLIC2-LABEL: func.func @two_phase_resident_loop
 // CYCLIC2-COUNT-2: ttl.bind_cb{cb_index = 0,
-// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
+// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
 // CYCLIC2: scf.for
 // CYCLIC2: ttl.cb_reserve
-// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32{{.*}}}
+// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32, ttl.dfb_reset_preserved_indices = []}
 // CYCLIC2: ttl.cb_reserve
-// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
+// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
 // CYCLIC2: return
 func.func @two_phase_resident_loop()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
@@ -450,11 +477,11 @@ func.func @two_phase_resident_loop()
 // CYCLIC3: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}, {new_index = 0 : i32, old_index = 2 : i32}]
 // CYCLIC3-LABEL: func.func @three_phase_resident_loop
 // CYCLIC3-COUNT-3: ttl.bind_cb{cb_index = 0,
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
 // CYCLIC3: scf.for
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32{{.*}}}
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 2048, 2, 1024, 5, 16, 32, 16, 2, 5, 5], ttl.dfb_reset_epoch = 2 : i32{{.*}}}
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32, ttl.dfb_reset_preserved_indices = []}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 2048, 2, 1024, 5, 16, 32, 16, 2, 5, 5], ttl.dfb_reset_epoch = 2 : i32, ttl.dfb_reset_preserved_indices = []}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
 // CYCLIC3: return
 func.func @three_phase_resident_loop()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
@@ -490,7 +517,7 @@ func.func @three_phase_resident_loop()
 // The logical configuration records FP32 unpack routing even without a reset
 // epoch, so later per-core analysis does not lose the compute-kernel contract.
 
-// UNPACK: ttl.logical_dfb_configs = [{{.*}}element_type = !ttcore.tile<32x32, f32>{{.*}}epoch = 0 : i32{{.*}}logical_index = 0 : i32{{.*}}physical_index = 0 : i32{{.*}}unpack_to_dest_fp32 = true}]
+// UNPACK: ttl.logical_dfb_configs = [{block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, f32>, elems_per_block = 1 : i32, epoch = 0 : i32, logical_index = 0 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = true}]
 // UNPACK-LABEL: func.func @no_reset_unpack_to_dest_fp32
 func.func @no_reset_unpack_to_dest_fp32()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
@@ -511,7 +538,11 @@ func.func @no_reset_unpack_to_dest_fp32()
 // configure it normally.
 
 // PRESERVE: ttl.dfb_epoch_physical_configs = [{dfb_index = 0 : i32, {{[^}]*}}}, {dfb_index = 1 : i32, {{[^}]*}}}]
-// PRESERVE: ttl.logical_dfb_configs = [{{.*}}logical_index = 2 : i32{{.*}}physical_index = 1 : i32{{.*}}]
+// PRESERVE: ttl.logical_dfb_configs = [
+// PRESERVE-SAME: {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, bf16>, elems_per_block = 1 : i32, epoch = 0 : i32, logical_index = 0 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}
+// PRESERVE-SAME: , {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, f32>, elems_per_block = 1 : i32, epoch = 1 : i32, logical_index = 1 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}
+// PRESERVE-SAME: , {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<32x32, bf16>, elems_per_block = 1 : i32, epoch = 0 : i32, logical_index = 2 : i32, num_pages = 2 : i32, physical_index = 1 : i32, unpack_to_dest_fp32 = false}
+// PRESERVE-SAME: , {block_count = 2 : i32, compiler_allocated = false, element_type = !ttcore.tile<16x32, bf16>, elems_per_block = 1 : i32, epoch = 2 : i32, logical_index = 3 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}]
 // PRESERVE-LABEL: func.func @preserve_across_one_boundary
 // PRESERVE: ttl.bind_cb{cb_index = 0, block_count = 2} {ttl.dfb_logical_index = 0 : i64}
 // PRESERVE: ttl.bind_cb{cb_index = 0, block_count = 2} {ttl.dfb_logical_index = 1 : i64}

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices.mlir
@@ -300,7 +300,7 @@ func.func @single_dfb_no_reuse()
 // DEBUG: Total DFB count: 1
 
 // USER: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]
-// USER: ttl.logical_dfb_configs = [{element_type = !ttcore.tile<32x32, bf16>, epoch = 0 : i32, logical_index = 0 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}, {element_type = !ttcore.tile<32x32, bf16>, epoch = 0 : i32, logical_index = 1 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}]
+// USER: ttl.logical_dfb_configs = [{{.*}}logical_index = 0 : i32{{.*}}physical_index = 0 : i32{{.*}}logical_index = 1 : i32{{.*}}physical_index = 0 : i32{{.*}}]
 
 // USER-LABEL: func.func @thread_local_user
 // USER-SAME: ttl.base_cta_index = 1 : i32
@@ -374,13 +374,13 @@ func.func @xt_compute()
 
 // EPOCH: ttl.dfb_epoch_physical_configs = [{dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, tile_height = 32 : i32, tile_width = 32 : i32, total_size = 8192 : i64}]
 // EPOCH: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]
-// EPOCH: ttl.logical_dfb_configs = [{element_type = !ttcore.tile<32x32, bf16>, epoch = 0 : i32, logical_index = 0 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}, {element_type = !ttcore.tile<32x32, f32>, epoch = 1 : i32, logical_index = 1 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = false}]
+// EPOCH: ttl.logical_dfb_configs = [{{.*}}element_type = !ttcore.tile<32x32, bf16>{{.*}}epoch = 0 : i32{{.*}}logical_index = 0 : i32{{.*}}physical_index = 0 : i32{{.*}}element_type = !ttcore.tile<32x32, f32>{{.*}}epoch = 1 : i32{{.*}}logical_index = 1 : i32{{.*}}physical_index = 0 : i32{{.*}}]
 // EPOCH-LABEL: func.func @epoch_restart
 // EPOCH: ttl.bind_cb{cb_index = 0, block_count = 2} {ttl.dfb_logical_index = 0 : i64}
 // EPOCH: ttl.bind_cb{cb_index = 0, block_count = 2} {ttl.dfb_logical_index = 1 : i64}
-// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32}
+// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
 // EPOCH: ttl.cb_reserve
-// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32}
+// EPOCH: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32{{.*}}}
 // EPOCH: ttl.cb_reserve
 // EPOCH-NOT: cb_index = 1
 // EPOCH: return
@@ -411,12 +411,12 @@ func.func @epoch_restart()
 // CYCLIC2: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}]
 // CYCLIC2-LABEL: func.func @two_phase_resident_loop
 // CYCLIC2-COUNT-2: ttl.bind_cb{cb_index = 0,
-// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32}
+// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
 // CYCLIC2: scf.for
 // CYCLIC2: ttl.cb_reserve
-// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32}
+// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32{{.*}}}
 // CYCLIC2: ttl.cb_reserve
-// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32}
+// CYCLIC2: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
 // CYCLIC2: return
 func.func @two_phase_resident_loop()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 2 : i32,
@@ -450,11 +450,11 @@ func.func @two_phase_resident_loop()
 // CYCLIC3: ttl.dfb_index_map = [{new_index = 0 : i32, old_index = 1 : i32}, {new_index = 0 : i32, old_index = 2 : i32}]
 // CYCLIC3-LABEL: func.func @three_phase_resident_loop
 // CYCLIC3-COUNT-3: ttl.bind_cb{cb_index = 0,
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
 // CYCLIC3: scf.for
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32}
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 2048, 2, 1024, 5, 16, 32, 16, 2, 5, 5], ttl.dfb_reset_epoch = 2 : i32}
-// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 8192, 2, 4096, 0, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 1 : i32{{.*}}}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 2048, 2, 1024, 5, 16, 32, 16, 2, 5, 5], ttl.dfb_reset_epoch = 2 : i32{{.*}}}
+// CYCLIC3: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, 4096, 2, 2048, 5, 32, 32, 16, 4, 5, 5], ttl.dfb_reset_epoch = 0 : i32{{.*}}}
 // CYCLIC3: return
 func.func @three_phase_resident_loop()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>, ttl.base_cta_index = 3 : i32,
@@ -490,7 +490,7 @@ func.func @three_phase_resident_loop()
 // The logical configuration records FP32 unpack routing even without a reset
 // epoch, so later per-core analysis does not lose the compute-kernel contract.
 
-// UNPACK: ttl.logical_dfb_configs = [{element_type = !ttcore.tile<32x32, f32>, epoch = 0 : i32, logical_index = 0 : i32, num_pages = 2 : i32, physical_index = 0 : i32, unpack_to_dest_fp32 = true}]
+// UNPACK: ttl.logical_dfb_configs = [{{.*}}element_type = !ttcore.tile<32x32, f32>{{.*}}epoch = 0 : i32{{.*}}logical_index = 0 : i32{{.*}}physical_index = 0 : i32{{.*}}unpack_to_dest_fp32 = true}]
 // UNPACK-LABEL: func.func @no_reset_unpack_to_dest_fp32
 func.func @no_reset_unpack_to_dest_fp32()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
@@ -518,7 +518,7 @@ func.func @no_reset_unpack_to_dest_fp32()
 // PRESERVE: ttl.bind_cb{cb_index = 1, block_count = 2} {ttl.dfb_logical_index = 2 : i64}
 // PRESERVE: ttl.bind_cb{cb_index = 0, block_count = 2} {ttl.dfb_logical_index = 3 : i64}
 // Prologue: configure the local DFB and pinned DFB.
-// PRESERVE: ttl.opaque_call "ttlang::reset_dataflow_buffers"(%{{.*}}) {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 2, 0, {{.*}}, 1, {{.*}}], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
+// PRESERVE: ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 2, 0, {{.*}}, 1, {{.*}}], ttl.dfb_reset_epoch = 0 : i32, ttl.dfb_reset_preserved_indices = []}
 // First boundary: preserve physical DFB 1 and configure only local DFB 0.
 // PRESERVE: ttl.opaque_call "ttlang::reset_dataflow_buffers"(%{{.*}}) {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h", template_args = [0, 1, 0, {{.*}}], ttl.dfb_reset_epoch = 1 : i32, ttl.dfb_reset_preserved_indices = [1]}
 // Second boundary: reset and configure both physical DFBs.

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
@@ -1,20 +1,6 @@
 // Invalid control-flow and lifetime contracts for ttl-finalize-dfb-indices.
 // RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)'
 
-// A single cyclic cut restores phase zero on every loop backedge.
-func.func @one_cyclic_cut()
-    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %c4 = arith.constant 4 : index
-  scf.for %i = %c0 to %c4 step %c1 {
-    ttl.opaque_call "ttlang::reset_dataflow_buffers"() {header = "ttlang/Target/TTKernel/LLKs/reset_dataflow_buffers.h"} : () -> ()
-  }
-  return
-}
-
-// -----
-
 // A reset under conditional control flow cannot define one static phase order.
 
 func.func @conditional_reset(%condition: i1)

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_invalid.mlir
@@ -1,9 +1,7 @@
 // Invalid control-flow and lifetime contracts for ttl-finalize-dfb-indices.
 // RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices)'
 
-// A resident loop needs a forward phase cut and a cyclic return cut.
-
-// expected-error @below {{a cyclic resident loop requires at least two reset_dataflow_buffers calls}}
+// A single cyclic cut restores phase zero on every loop backedge.
 func.func @one_cyclic_cut()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %c0 = arith.constant 0 : index

--- a/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_intermediate_dfbs_nested.mlir
@@ -12,7 +12,7 @@
 // entry, the rest of the materialization bundle stays inside the loop.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_for
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated, ttl.dfb_logical_index = 3 : i64}
 // CHECK: scf.for
 // CHECK:   ttl.add
 // CHECK:   ttl.cb_reserve
@@ -58,7 +58,7 @@ func.func @intermediate_in_scf_for()
 // function body entry, not inside the if region.
 
 // CHECK-LABEL: func.func @intermediate_in_scf_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated, ttl.dfb_logical_index = 3 : i64}
 // CHECK: scf.if
 // CHECK-NOT: ttl.compiler_allocated
 // CHECK:   ttl.add
@@ -101,7 +101,7 @@ func.func @intermediate_in_scf_if(%cond: i1)
 // Before the fix, this crashed in TTLFinalizeDFBIndices.
 
 // CHECK-LABEL: func.func @intermediate_in_nested_for_if
-// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated}
+// CHECK: ttl.bind_cb{cb_index = 3, block_count = 2} {ttl.compiler_allocated, ttl.dfb_logical_index = 3 : i64}
 // CHECK: scf.for
 // CHECK:   scf.if
 // CHECK-NOT: ttl.compiler_allocated


### PR DESCRIPTION
## Summary

- base the DSpark compiler dependency on ops-and-models/sep1
- retain the scope-exit API compatibility fix
- preserve bind-anchored DFB lifetimes so overlapping logical buffers cannot receive the same physical CB
- refresh DFB checks for the metadata and reset attributes emitted by the Sep 1 integration

## Why

The Aug 29 reset-barrier change accidentally removed the bind lifetime anchor from DFB resource planning. That allowed buffers with overlapping effective lifetimes to alias one physical circular buffer, corrupting the fused DSpark output. Restoring the original anchor fixes the regression while keeping reuse for genuinely disjoint lifetimes.

## Validation

- clean TT-Lang build
- ninja -C build check-ttlang: 178 MLIR passed, 1 expected failure; 3 Python binding tests passed; 116 packaging tests passed
- fused DSpark device-top golden tests: 7 passed
- exact Galaxy branch DSpark suite: 533 passed, 3 skipped
- downstream K3-spatial superset: 602 passed, 4 skipped
- git diff --check

## Target-branch CI note

The current checks also expose pre-existing drift in ops-and-models/sep1: its tt-metal gitlink is a749fcc6e69c while the version manifest expects e908c31332b6 and the former is not fetchable from the public tt-metal remote; simulator tests still assert a 32-DFB default while the branch config uses 64; and the repository-wide pre-commit hook reports formatting changes across unrelated base files. Those failures are outside this five-file compiler fix and are documented here so they are not mistaken for DSpark regressions.