### PR TITLE
[ttl] Cost Estimator based on tracing execution on RISC cores with synchronization awareness

### DIFF
--- a/include/ttlang/Analysis/CostEstimator.h
+++ b/include/ttlang/Analysis/CostEstimator.h
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTLANG_ANALYSIS_COSTESTIMATOR_H
+#define TTLANG_ANALYSIS_COSTESTIMATOR_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Location.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace mlir::tt {
+
+/// Estimates the cost of one TT-Lang device launch from TTKernel IR.
+///
+/// Expects a module lowered to TTKernel but not yet to EmitC. TTKernel ops map
+/// one-to-one onto the emitted compute-API calls at that point, and the
+/// constant operands carrying tile counts are already folded. Running earlier
+/// misses operations that later passes insert (`ttkernel-insert-inits`,
+/// `ttkernel-combine-pack-tiles`); running later leaves circular-buffer calls
+/// as opaque `emitc.verbatim` strings.
+class CostEstimator {
+public:
+  /// A hardware timeline that serializes the work placed on it. One Tensix
+  /// core has five: two data-movement RISCs and the three compute TRISCs.
+  ///
+  /// Declaration order is dataflow order, so a forward dependence runs from a
+  /// lower lane to a higher one and back-pressure runs the other way.
+  ///
+  /// The engines a TRISC drives (unpacker, FPU, SFPU, packer) are folded into
+  /// their processor lane. That is sound only while the processor is not on the
+  /// limiting dependence chain. The unpack processor is known to decouple from
+  /// its engine through a two-credit config-context counter
+  /// (`wait_for_next_context(2)`), so this assumption must be revisited before
+  /// the estimator is trusted for unpack-bound kernels.
+  enum class Lane : unsigned {
+    Ncrisc = 0,   ///< RISCV_1, `ttl.noc_index` = 0, the DRAM reader preset.
+    Trisc0Unpack, ///< L1 -> SrcA/SrcB.
+    Trisc1Math,   ///< SrcA/SrcB -> DST.
+    Trisc2Pack,   ///< DST -> L1.
+    Brisc,        ///< RISCV_0, `ttl.noc_index` = 1, the DRAM writer preset.
+  };
+
+  static constexpr unsigned kNumLanes = 5;
+
+  /// Every lane, in dataflow order.
+  static llvm::ArrayRef<Lane> getAllLanes();
+
+  /// Short display name, e.g. "TRISC0 unpack".
+  static llvm::StringRef getLaneName(Lane lane);
+
+  static constexpr unsigned getLaneIndex(Lane lane) {
+    return static_cast<unsigned>(lane);
+  }
+
+  /// What an operation does to a shared resource.
+  ///
+  /// Every mechanism modelled here is a credit counter, so double buffering is
+  /// never represented directly: a circular buffer holds `capacity` tiles and
+  /// DST holds one or two halves, and whether a given acquire blocks is an
+  /// outcome of the counter at that point. Raising `block_count` from 2 to 3
+  /// changes no code.
+  struct ResourceEffect {
+    enum class Kind {
+      None,
+      CbReserve,  ///< producer claims tiles; blocks until that many are free
+      CbPush,     ///< producer publishes its claimed tiles to the consumer
+      CbWait,     ///< consumer blocks until that many tiles are published
+      CbPop,      ///< consumer frees tiles back to the producer
+      DstAcquire, ///< MATH blocks until a DST half is free
+      DstCommit,  ///< MATH hands its half to PACK
+      DstWait,    ///< PACK blocks until MATH has committed a half
+      DstRelease, ///< PACK returns the half to MATH
+      /// MATH re-initializes the DST pipeline: it blocks until the packer has
+      /// drained every committed half, then re-seeds the handshake and resets
+      /// the section base. Stricter than DstAcquire, which needs only one free
+      /// half. This is a boundary rather than a stall better scheduling could
+      /// hide -- sections cannot pipeline across a reset that redefines where
+      /// they are.
+      DstSyncInit,
+      /// UNPACK fills a SrcA/SrcB bank and sets dvalid. Blocks when no bank is
+      /// free, which is what stops the unpacker running further ahead of MATH
+      /// than the bank count allows.
+      SrcProduce,
+      /// MATH consumes a bank; the math MOP's end op clears dvalid and returns
+      /// it. Blocks until UNPACK has produced one.
+      SrcConsume,
+    };
+
+    Kind kind = Kind::None;
+    /// Compile-time arg index of the circular buffer, for the `Cb*` kinds. The
+    /// same index in two different kernels is the same buffer, which is what
+    /// links a reader's push to a compute kernel's wait.
+    unsigned cb = 0;
+    uint64_t tiles = 0;
+  };
+
+  /// One operation placed on a lane.
+  struct PlacedOp {
+    /// Fully qualified name, e.g. "ttkernel.cb_wait_front".
+    std::string name;
+    Location loc;
+
+    /// Cost of this operation on this lane. One operation can land on several
+    /// lanes with a different cost on each: `binary_op_init_common` configures
+    /// the unpacker, the math sync and the packer, and the three are not equal.
+    ///
+    /// Zero when nothing measured stands behind this placement, which is how
+    /// the circular-buffer and DST handshake operations land: the table carries
+    /// measurements alone and no perf source isolates a handshake, so they are
+    /// modelled as pure synchronization. An operation the table does not know
+    /// at all fails the estimate instead of landing here at zero.
+    uint64_t cost = 0;
+
+    /// True when `cost` came from a measurement keyed to this kernel's exact
+    /// configuration. False means nothing was charged, for one of two reasons
+    /// the report keeps apart: no sweep timed this operation on this lane, or
+    /// one did in a configuration this kernel cannot match. Reported per
+    /// operation because a kernel is usually a mixture, and a mixed total
+    /// should not be read as if it were measured throughout.
+    bool measured = false;
+
+    ResourceEffect effect;
+
+    /// Filled in by scheduling. `stall` is the gap between the lane becoming
+    /// free and this operation actually starting, so it attributes waiting to
+    /// the operation that waited.
+    uint64_t start = 0;
+    uint64_t finish = 0;
+    uint64_t stall = 0;
+  };
+
+  /// What lands on one lane, in program order.
+  ///
+  /// These are static occurrences, so the list is bounded by the size of the IR
+  /// rather than by loop trip counts. Weighting by execution count is a
+  /// separate step.
+  struct LaneReport {
+    llvm::SmallVector<PlacedOp> ops;
+  };
+
+  /// Result of estimating one module.
+  struct Report {
+    /// Kernel-thread functions the estimator recognized, by symbol name.
+    llvm::SmallVector<std::string> kernels;
+    std::array<LaneReport, kNumLanes> lanes = {};
+
+    /// Accumulated cost at which the last lane retires. Zero when scheduling
+    /// did not run.
+    uint64_t totalCost = 0;
+
+    /// How the placements split by provenance, counted per (operation, lane)
+    /// placement rather than per distinct key, so the figures say how much of
+    /// *this* module's work is measured rather than how much of the table was
+    /// used.
+    ///
+    /// The three are different answers rather than degrees of one: a measured
+    /// placement carries a number, an unmatched one means a measurement exists
+    /// that this configuration cannot match -- a key mismatch, closed by
+    /// supplying the field it is missing -- and an untimed one means no sweep
+    /// timed that engine at all. Only the first contributes cost; the other two
+    /// are charged nothing and occupy their lane for the one-cost floor
+    /// scheduling gives every placement, so their ordering and their resource
+    /// effects still hold.
+    uint64_t measuredPlacements = 0;
+    uint64_t unmatchedPlacements = 0;
+    uint64_t untimedPlacements = 0;
+
+    /// Summary: per-lane totals and overall latency, all in cost. This is the
+    /// default output, because the per-operation views below are debugging aids
+    /// that run to hundreds of thousands of rows on a real kernel.
+    std::string render() const;
+
+    /// Per-lane operation tables with start, end, cost, wait and source line.
+    /// Capped per lane, and says how many it omitted.
+    std::string renderDetail() const;
+
+    /// Five-column timeline: one row per event boundary, one column per lane.
+    ///
+    /// Rows are the distinct starts, finishes and wait-interval boundaries, not
+    /// a fixed sample rate, so no interval is invented and nothing is aliased
+    /// away. The trade is that row height carries no meaning: the `gap` column
+    /// is the distance to the next event on *any* lane. Empty if scheduling did
+    /// not run.
+    std::string renderTimeline() const;
+  };
+
+  struct Options {
+    /// Fold TRISC engine time into the processor lane; see Lane.
+    bool foldEngineIntoProcessor = true;
+
+    /// SrcA/SrcB banks the unpacker can fill before it has to wait for MATH.
+    /// Two on Wormhole and Blackhole, which is what lets the unpacker work one
+    /// tile ahead. Exposed so a caller can check whether the credit binds at
+    /// all: if 1 and 2 give the same answer, it is slack rather than a
+    /// bottleneck.
+    unsigned srcBanks = 2;
+
+    /// Math fidelity as the cost table spells it: "LoFi", "HiFi2", "HiFi3" or
+    /// "HiFi4". Empty when the caller does not know.
+    ///
+    /// The one key field the IR cannot answer, because fidelity is a runtime
+    /// compute-config field that never reaches TTKernel. The rows keyed on it
+    /// -- `mul_tiles` and `reduce_tile` on math, whose cost spans a factor of
+    /// four across the four settings -- stay unmatched until it is supplied,
+    /// which the report counts rather than papering over.
+    std::string mathFidelity;
+  };
+
+  explicit CostEstimator(ModuleOp module);
+  CostEstimator(ModuleOp module, Options options);
+  ~CostEstimator();
+
+  CostEstimator(CostEstimator &&) noexcept;
+  CostEstimator &operator=(CostEstimator &&) noexcept;
+
+  CostEstimator(const CostEstimator &) = delete;
+  CostEstimator &operator=(const CostEstimator &) = delete;
+
+  /// Estimate the whole module, or fail if anything in it cannot be accounted
+  /// for: a module at the wrong pipeline stage, an operation the cost table
+  /// does not cover, control flow whose outcome is not resolved, or a loop that
+  /// cannot be unrolled. A returned report describes
+  /// every operation in the module; there is no partial result, because a
+  /// latency computed from an incomplete program is neither an upper nor a
+  /// lower bound on the real one. Diagnostics name each gap at its own
+  /// operation.
+  FailureOr<Report> estimate();
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl;
+};
+
+} // namespace mlir::tt
+
+#endif // TTLANG_ANALYSIS_COSTESTIMATOR_H

--- a/include/ttlang/Analysis/CostEstimator.h
+++ b/include/ttlang/Analysis/CostEstimator.h
@@ -121,13 +121,25 @@ public:
     /// at all fails the estimate instead of landing here at zero.
     uint64_t cost = 0;
 
-    /// True when `cost` came from a measurement keyed to this kernel's exact
-    /// configuration. False means nothing was charged, for one of two reasons
-    /// the report keeps apart: no sweep timed this operation on this lane, or
-    /// one did in a configuration this kernel cannot match. Reported per
-    /// operation because a kernel is usually a mixture, and a mixed total
-    /// should not be read as if it were measured throughout.
-    bool measured = false;
+    /// Where this placement's cost came from.
+    ///
+    /// Recorded per placement because a kernel is usually a mixture, and a
+    /// mixed total should not be read as if it were measured throughout. Kept
+    /// on the placement rather than recomputed when rendering, so a report
+    /// answers for itself without asking the cost library again.
+    enum class Provenance {
+      /// A measurement keyed to this kernel's exact configuration.
+      Measured,
+      /// Measurements exist for this operation and engine, in no configuration
+      /// this kernel can supply. Charged nothing.
+      NoMatchingKey,
+      /// Nothing has timed this operation on this engine. Charged nothing.
+      Untimed,
+    };
+
+    Provenance provenance = Provenance::Untimed;
+
+    bool isMeasured() const { return provenance == Provenance::Measured; }
 
     ResourceEffect effect;
 
@@ -152,6 +164,11 @@ public:
   struct Report {
     /// Kernel-thread functions the estimator recognized, by symbol name.
     llvm::SmallVector<std::string> kernels;
+
+    /// The architecture the costs were measured on, recovered from the module.
+    std::string arch;
+    uint64_t tableRows = 0;
+    uint64_t tableOperations = 0;
     std::array<LaneReport, kNumLanes> lanes = {};
 
     /// Accumulated cost at which the last lane retires. Zero when scheduling

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1252,8 +1252,14 @@ def TTKernelCostEstimate
     estimator cannot account for -- an operation the cost table does not know,
     control flow it cannot resolve, a loop it cannot unroll -- is warned about at
     the operation responsible, and the report says only that no estimate is
-    available. The pass never signals failure: the estimate is opt-in and mutates
-    nothing, so a gap in it does not fail a compile.
+    available. Nothing found in the IR fails the pass: the estimate is opt-in and
+    mutates nothing, so a gap in it does not fail a compile.
+
+    Off unless `enable` says otherwise, so that a pipeline can carry it
+    unconditionally. The one thing that does fail the pass is being asked for the
+    detail view with the estimate itself disabled: the detail view is part of the
+    report, and there is no report to add it to, so the request is refused rather
+    than silently ignored.
 
     Costs come from TTLangOpCost, which holds measurements alone. A placement no
     measurement covers is charged nothing and counted, so a report says how much
@@ -1276,11 +1282,15 @@ def TTKernelCostEstimate
   }];
 
   let options = [
+    Option<"enable", "enable", "bool", "false",
+           "Produce the estimate. Off by default, so a pipeline can carry the "
+           "pass unconditionally and a caller opts in.">,
     Option<"outputPath", "output", "std::string", "\"\"",
            "Path to write the report (empty for stdout)">,
     Option<"detail", "detail", "bool", "false",
            "Also print per-lane operation tables and an event-boundary "
-           "timeline. Off by default: both are capped but still long.">,
+           "timeline. Off by default: both are capped but still long. An error "
+           "without `enable`, since it adds to a report that would not exist.">,
     Option<"mathFidelity", "math-fidelity", "std::string", "\"\"",
            "Math fidelity the kernel runs at, as the cost table spells it: "
            "LoFi, HiFi2, HiFi3 or HiFi4. The IR does not carry it -- it is a "

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1234,4 +1234,63 @@ def TTKernelCombinePackTiles
   ];
 }
 
+def TTKernelCostEstimate
+    : Pass<"ttkernel-cost-estimate", "::mlir::ModuleOp"> {
+  let summary = "Estimate per-core cost from TTKernel IR";
+  let description = [{
+    Non-mutating analysis pass that runs `mlir::tt::CostEstimator` and reports
+    how the program's work splits across the five RISCs of a Tensix core.
+
+    Must run after `ttkernel-insert-inits` and `ttkernel-combine-pack-tiles`,
+    which create operations the estimate depends on, and before
+    `convert-ttkernel-to-emitc`, which turns circular-buffer calls into opaque
+    verbatim strings. Placing it last in the TTKernel stage also means the
+    constant operands carrying tile counts are already folded.
+
+    An estimate covers every operation in the module or is not produced at all,
+    so an unmodelled kernel is never mistaken for a cheap one. Anything the
+    estimator cannot account for -- an operation the cost table does not know,
+    control flow it cannot resolve, a loop it cannot unroll -- is warned about at
+    the operation responsible, and the report says only that no estimate is
+    available. The pass never signals failure: the estimate is opt-in and mutates
+    nothing, so a gap in it does not fail a compile.
+
+    Costs come from TTLangOpCost, which holds measurements alone. A placement no
+    measurement covers is charged nothing and counted, so a report says how much
+    of itself is measured instead of blending guesses into one number.
+
+    Example output:
+    ```
+    cost estimate: 108 of 134 placements measured (81%)
+      26 unmatched (measured in no configuration this kernel can supply), 0 untimed (nothing measured them); both charged 0
+      measured on blackhole from 3045 rows over 197 operations; per-operation provenance in the detail view
+      kernels: compute read write
+      NCRISC reader: 43 ops, 2140 busy, 0 stalled, 7185 drained, 23% utilized
+      TRISC0 unpack: 23 ops, 3460 busy, 3580 stalled, 2285 drained, 37% utilized
+      TRISC1 math: 23 ops, 5060 busy, 2360 stalled, 1905 drained, 54% utilized
+      TRISC2 pack: 23 ops, 3460 busy, 4780 stalled, 1085 drained, 37% utilized
+      BRISC writer: 22 ops, 1085 busy, 8240 stalled, 0 drained, 12% utilized
+      latency: 8999
+      busiest lane: TRISC1 math (4984 busy)
+    ```
+  }];
+
+  let options = [
+    Option<"outputPath", "output", "std::string", "\"\"",
+           "Path to write the report (empty for stdout)">,
+    Option<"detail", "detail", "bool", "false",
+           "Also print per-lane operation tables and an event-boundary "
+           "timeline. Off by default: both are capped but still long.">,
+    Option<"mathFidelity", "math-fidelity", "std::string", "\"\"",
+           "Math fidelity the kernel runs at, as the cost table spells it: "
+           "LoFi, HiFi2, HiFi3 or HiFi4. The IR does not carry it -- it is a "
+           "runtime compute-config field -- so the measurements keyed on it "
+           "stay unmatched unless it is given here.">
+  ];
+
+  let dependentDialects = [
+    "::mlir::tt::ttkernel::TTKernelDialect"
+  ];
+}
+
 #endif // TTLANG_DIALECT_TTL_PASSES_TD

--- a/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
+++ b/include/ttlang/Dialect/TTL/Pipelines/TTLPipelines.h
@@ -104,6 +104,25 @@ struct TTLToTTKernelPipelineOptions
           "Clone TTKernel functions that branch on a core coordinate once "
           "per launch coordinate (ttkernel-specialize-cores)."),
       llvm::cl::init(false)};
+  Option<bool> costEstimate{
+      *this, "cost-estimate",
+      llvm::cl::desc("Report how the program's work splits across the five "
+                     "RISCs of a Tensix core (ttkernel-cost-estimate). Reads "
+                     "the IR and mutates nothing."),
+      llvm::cl::init(false)};
+  Option<bool> costEstimateDetail{
+      *this, "cost-estimate-detail",
+      llvm::cl::desc("Add per-lane operation tables and an event-boundary "
+                     "timeline to the cost estimate. An error without "
+                     "cost-estimate."),
+      llvm::cl::init(false)};
+  Option<std::string> costEstimateMathFidelity{
+      *this, "cost-estimate-math-fidelity",
+      llvm::cl::desc("Math fidelity the kernel runs at, as the cost table "
+                     "spells it: LoFi, HiFi2, HiFi3 or HiFi4. TTKernel IR does "
+                     "not carry it, so the measurements keyed on it stay "
+                     "unmatched unless it is given."),
+      llvm::cl::init("")};
 };
 
 void createTTLToTTKernelPipeline(mlir::OpPassManager &pm,

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(TTLangOpCost PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_mlir_library(TTLangAnalysis
   PARTIAL_SOURCES_INTENDED
+  CostEstimator.cpp
   ExecutionCountAnalysis.cpp
   IntegerExpressionEvaluator.cpp
   LoopIterationUtils.cpp
@@ -29,8 +30,12 @@ add_mlir_library(TTLangAnalysis
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRControlFlowInterfaces
+  MLIRFuncDialect
   MLIRIR
   MLIRLoopLikeInterface
   MLIRSCFDialect
   MLIRTensorDialect
+  MLIRTTKernelDialect
+  MLIRTTLDialect
+  TTLangOpCost
 )

--- a/lib/Analysis/CostEstimator.cpp
+++ b/lib/Analysis/CostEstimator.cpp
@@ -1,0 +1,1552 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Analysis/CostEstimator.h"
+#include "ttlang/Analysis/OpCost.h"
+
+#include "ttlang/Analysis/LoopIterationUtils.h"
+
+#include "ttlang/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
+#include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
+#include "ttlang/Dialect/TTKernel/IR/TTKernelTraits.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cinttypes>
+#include <cmath>
+#include <limits>
+#include <optional>
+
+namespace mlir::tt {
+
+namespace {
+
+constexpr llvm::StringLiteral kThreadAttrName("ttkernel.thread");
+constexpr llvm::StringLiteral kTTKernelDialect("ttkernel");
+
+/// Loop iterations a single kernel may unroll, shared across the whole nest.
+/// Exceeding it fails the estimate rather than truncating the program; see
+/// placeLoop.
+///
+/// Counted in iterations, which is not the quantity that matters: a body of N
+/// operations costs trip * N placements, and placements are what the report
+/// holds and what the scheduler walks, so this bounds time and memory only
+/// loosely. A 16x16 block nest over 4x4-tile blocks needs a few tens of
+/// thousands of iterations and places 59k operations, which the estimator
+/// handles in a few hundred milliseconds and no measurable memory over the rest
+/// of a compile. This value is set well above such a kernel while still
+/// bounding a pathological one, but a loop whose body is far larger can still
+/// cost more than the count suggests.
+constexpr std::uint64_t kUnrollBudget = 1ull << 20;
+
+/// Output caps. A kernel whose loops unroll to tens of thousands of operations
+/// would otherwise emit a report longer than anyone will read. Truncation is
+/// always announced, never silent.
+constexpr size_t kMaxTimelineRows = 200;
+constexpr size_t kMaxListedOpsPerLane = 30;
+
+using Lane = CostEstimator::Lane;
+using opcost::Engine;
+using opcost::KernelConfig;
+
+/// The engine a lane's work is charged to.
+///
+/// Five in-order instruction streams over four engines: NCRISC and BRISC both
+/// read `Dm`, because an operation does not choose which data-movement core
+/// runs it -- `ttl.noc_index` on the enclosing function does.
+Engine engineFor(Lane lane) {
+  switch (lane) {
+  case Lane::Ncrisc:
+  case Lane::Brisc:
+    return Engine::Dm;
+  case Lane::Trisc0Unpack:
+    return Engine::Unpack;
+  case Lane::Trisc1Math:
+    return Engine::Math;
+  case Lane::Trisc2Pack:
+    return Engine::Pack;
+  }
+  llvm_unreachable("unhandled lane");
+}
+
+using ResourceEffect = CostEstimator::ResourceEffect;
+
+/// Resource effect of one TTKernel operation, read from its operands.
+///
+/// Nothing here is hand-maintained data: the buffer identity, the tile count
+/// and the capacity all come from the module. Only the op-name-to-kind mapping
+/// is fixed, and that follows from the operation's own semantics. Operations
+/// that unpack into SrcA/SrcB without carrying `TTKernelFPUOpTrait`. The trait
+/// covers the six FPU ops; these are the datacopy and (un)tilize paths, which
+/// feed Src exactly the same way but are not FPU operations. Missing one means
+/// MATH is free to run before the data exists, so the assert below cross-checks
+/// this list against the lanes each operation runs on.
+const llvm::StringSet<> &getNonFpuSrcCouplingOps() {
+  static const llvm::StringSet<> ops = {"copy_tile",
+                                        "copy_block_matmul_partials",
+                                        "tilize_block", "untilize_block"};
+  return ops;
+}
+
+/// Whether an operation's lanes are consistent with a Src handshake: it has to
+/// fill a bank on UNPACK and drain one on MATH. Used only to validate the set
+/// above.
+///
+/// This is the half of the old per-call cross-check that survives at lane
+/// granularity, and it is the half that catches the mistake that matters: an
+/// operation named as Src coupled but not running on both lanes would leave
+/// MATH waiting on a bank nothing fills. The converse -- an operation on both
+/// lanes that only configures the unpacker -- can no longer be checked, because
+/// `add_tiles` and `add_tiles_init` are indistinguishable once the call names
+/// are gone.
+bool lanesAllowSrcCoupling(llvm::StringRef name) {
+  return opcost::runsOnEngine(name, Engine::Unpack) &&
+         opcost::runsOnEngine(name, Engine::Math);
+}
+
+/// Operations whose MATH half re-initializes the DST pipeline.
+///
+/// Their MATH half calls `llk_math_pack_sync_init`, which spins until the
+/// MATH/PACK semaphore reads zero -- every committed half drained -- before
+/// re-seeding that semaphore and resetting the DST section base
+/// (tt_llk_blackhole/llk_lib/llk_math_common.h:130). The wait is the price of
+/// the reset: the section base cannot move under a packer still reading a half.
+///
+/// Keyed on what convert-ttkernel-to-emitc emits rather than on the compute-API
+/// wrapper of the same name, because the two disagree here. `mm_init` and
+/// `mm_block_init` lower to `compute_kernel_hw_startup` plus
+/// `matmul_init`/`matmul_block_init` (TTKernelToEmitC.cpp:1188-1203), and it is
+/// the startup call that carries the sync; `mm_block_init_short` emits
+/// `matmul_block_init` alone and so does not.
+///
+/// The per-operation inits that stay inside compiler-generated tile and
+/// subblock loops -- add_tiles_init, copy_tile_init, matmul_block_init -- carry
+/// no sync, which is what leaves the DST halves free to pipeline there. Only a
+/// common init re-executed inside a user loop pays this.
+///
+/// tilize_init, transpose_wh_init and the bcast inits carry it too, and belong
+/// here once the cost table covers them.
+const llvm::StringSet<> &getDstSyncInitOps() {
+  static const llvm::StringSet<> ops = {"binary_op_init_common",
+                                        "unary_op_init_common",
+                                        "init_sfpu",
+                                        "compute_kernel_hw_startup",
+                                        "mm_init",
+                                        "mm_block_init"};
+  return ops;
+}
+
+ResourceEffect getResourceEffect(Operation *op, Lane lane) {
+  llvm::StringRef name = op->getName().stripDialect();
+
+  // The Src handshake is the one effect that depends on which lane the
+  // placement is for: the UNPACK half fills a bank and the MATH half drains
+  // one. Every other effect below lands on exactly one lane, so they ignore
+  // `lane`.
+  bool coupled = op->hasTrait<ttkernel::TTKernelFPUOpTrait>() ||
+                 getNonFpuSrcCouplingOps().contains(name);
+  assert(
+      (!coupled || !opcost::isKnownOp(name) || lanesAllowSrcCoupling(name)) &&
+      "Src coupling disagrees with the operation's lanes: an op that feeds "
+      "SrcA/SrcB has to run on both UNPACK and MATH");
+  if (coupled) {
+    if (lane == Lane::Trisc0Unpack) {
+      return {ResourceEffect::Kind::SrcProduce, 0, 0};
+    }
+    if (lane == Lane::Trisc1Math) {
+      return {ResourceEffect::Kind::SrcConsume, 0, 0};
+    }
+    return {};
+  }
+
+  // Only the MATH half re-initializes DST. The same operation's unpack and pack
+  // halves configure their own engines and leave the handshake alone.
+  if (lane == Lane::Trisc1Math && getDstSyncInitOps().contains(name)) {
+    return {ResourceEffect::Kind::DstSyncInit, 0, 0};
+  }
+
+  ResourceEffect::Kind kind = ResourceEffect::Kind::None;
+  if (name == "cb_reserve_back") {
+    kind = ResourceEffect::Kind::CbReserve;
+  } else if (name == "cb_push_back") {
+    kind = ResourceEffect::Kind::CbPush;
+  } else if (name == "cb_wait_front") {
+    kind = ResourceEffect::Kind::CbWait;
+  } else if (name == "cb_pop_front") {
+    kind = ResourceEffect::Kind::CbPop;
+  } else if (name == "tile_regs_acquire") {
+    return {ResourceEffect::Kind::DstAcquire, 0, 0};
+  } else if (name == "tile_regs_commit") {
+    return {ResourceEffect::Kind::DstCommit, 0, 0};
+  } else if (name == "tile_regs_wait") {
+    return {ResourceEffect::Kind::DstWait, 0, 0};
+  } else if (name == "tile_regs_release") {
+    return {ResourceEffect::Kind::DstRelease, 0, 0};
+  } else {
+    return {};
+  }
+
+  // Circular-buffer ops carry the buffer as operand 0 and the tile count as
+  // operand 1. By this point in the pipeline canonicalization has folded the
+  // count, so it is a plain constant.
+  if (op->getNumOperands() < 2) {
+    return {};
+  }
+  auto argVal = op->getOperand(0).getDefiningOp<ttkernel::GetCompileArgValOp>();
+  std::optional<int64_t> tiles = getConstantIntValue(op->getOperand(1));
+  if (!argVal || !tiles || *tiles <= 0) {
+    return {};
+  }
+  return {kind, static_cast<unsigned>(argVal.getArgIndex()),
+          static_cast<uint64_t>(*tiles)};
+}
+
+/// Capacity in tiles of the circular buffer an operation touches.
+std::optional<uint64_t> getCbCapacity(Operation *op) {
+  if (op->getNumOperands() < 1) {
+    return std::nullopt;
+  }
+  auto cbType = mlir::dyn_cast<ttkernel::CBType>(op->getOperand(0).getType());
+  if (!cbType) {
+    return std::nullopt;
+  }
+  return static_cast<uint64_t>(cbType.getNumTiles());
+}
+
+/// Short display name for the timeline columns.
+///
+/// Presentation only: a name missing from the map falls back to the operation
+/// name without its dialect prefix, so an unlisted operation renders wide
+/// rather than wrong. Mechanical truncation is not an option because
+/// `tile_regs_*` would collide.
+llvm::StringRef getShortName(llvm::StringRef opName) {
+  static const llvm::StringMap<llvm::StringRef> names = [] {
+    llvm::StringMap<llvm::StringRef> n;
+    n["cb_wait_front"] = "cbwait";
+    n["cb_pop_front"] = "cbpop";
+    n["cb_reserve_back"] = "cbresv";
+    n["cb_push_back"] = "cbpush";
+    n["tile_regs_acquire"] = "dstacq";
+    n["tile_regs_commit"] = "dstcmt";
+    n["tile_regs_wait"] = "dstwait";
+    n["tile_regs_release"] = "dstrel";
+    n["binary_op_init_common"] = "binit";
+    n["add_tiles_init"] = "addinit";
+    n["add_tiles"] = "add";
+    n["pack_tile"] = "pack1";
+    n["pack_tile_block"] = "pack";
+    n["noc_async_read_tile"] = "read";
+    n["noc_async_write_tile"] = "write";
+    n["noc_async_read_barrier"] = "rbar";
+    n["noc_async_write_barrier"] = "wbar";
+    n["get_common_arg_val"] = "arg";
+    n["get_write_ptr"] = "wptr";
+    n["get_read_ptr"] = "rptr";
+    n["TensorAccessor"] = "tacc";
+    return n;
+  }();
+
+  llvm::StringRef bare = opName;
+  bare.consume_front("ttkernel.");
+  auto entry = names.find(bare);
+  return entry == names.end() ? bare : entry->second;
+}
+
+/// Compact source position for the report, e.g. "eltwise_add.py:34". Empty when
+/// the location is not a file/line, which keeps the report readable for IR that
+/// carries no debug info (hand-written test cases, for instance).
+std::string formatLoc(Location loc) {
+  auto fileLine = dyn_cast<FileLineColLoc>(loc);
+  if (!fileLine) {
+    return "";
+  }
+  llvm::StringRef path = fileLine.getFilename().getValue();
+  llvm::StringRef base = path.rsplit('/').second;
+  if (base.empty()) {
+    base = path;
+  }
+  return (base + ":" + std::to_string(fileLine.getLine())).str();
+}
+
+/// Lane a data-movement kernel runs on. `ttl.noc_index` 0 is the reader on
+/// RISCV_1 (NCRISC) and 1 is the writer on RISCV_0 (BRISC), matching
+/// `getNocIndex` in TTLOpsUtils.h and the Metalium reader/writer presets.
+/// A function without the attribute takes the reader default, as lowering does.
+Lane getDataMovementLane(func::FuncOp funcOp) {
+  auto nocIndex = funcOp->getAttrOfType<IntegerAttr>(ttl::kNocIndexAttrName);
+  if (nocIndex && nocIndex.getInt() == 1) {
+    return Lane::Brisc;
+  }
+  return Lane::Ncrisc;
+}
+
+/// Architecture the compiled-in measurements were taken on. Costs do not
+/// transfer across architectures, so a caller that does not know its target
+/// must not use them.
+constexpr llvm::StringLiteral kPerfTableArch("blackhole");
+
+/// Data format as the perf CSVs spell it.
+///
+/// The benchmarks name formats the way the LLK does, so the table's keys are
+/// those spellings and a lookup has to translate. An unmapped type returns
+/// empty, which makes the lookup miss rather than match some other format's
+/// cost.
+llvm::StringRef getPerfFormatName(ttcore::DataType dataType) {
+  switch (dataType) {
+  case ttcore::DataType::BFloat16:
+    return "Float16_b";
+  case ttcore::DataType::Float16:
+    return "Float16";
+  case ttcore::DataType::Float32:
+    return "Float32";
+  case ttcore::DataType::BFP_BFloat8:
+    return "Bfp8_b";
+  case ttcore::DataType::BFP_Float8:
+    return "Bfp8";
+  case ttcore::DataType::Int32:
+    return "Int32";
+  default:
+    return {};
+  }
+}
+
+/// Format of the tiles a circular buffer holds, or empty when the operand is
+/// not a circular buffer of tiles.
+llvm::StringRef getCbFormatName(Value value) {
+  auto cbType = mlir::dyn_cast<ttkernel::CBType>(value.getType());
+  if (!cbType) {
+    return {};
+  }
+  auto tileType = mlir::dyn_cast<ttcore::TileType>(cbType.getElementType());
+  if (!tileType) {
+    return {};
+  }
+  return getPerfFormatName(tileType.getDataType());
+}
+
+/// Whether an operation is one of the packer's writes.
+bool isPackOp(llvm::StringRef name) {
+  return name == "pack_tile" || name == "pack_tile_block";
+}
+
+/// The formats one kernel reads and writes.
+///
+/// Both are the kernel's rather than any one operation's, because a measurement
+/// is keyed on the pair while an operation rarely names either: a compute
+/// operation like `add_tiles` has no output buffer among its operands, and an
+/// SFPU operation like `exp_tile` has neither -- it takes a DST index, and the
+/// tile it works on reached DST from a buffer several operations earlier.
+///
+/// A buffer the packer writes is an output and every other one is an input,
+/// which is what lets a kernel reading bf16 and packing f32 -- a pair the table
+/// measures -- answer for both sides instead of calling its two formats a
+/// conflict. Either side is empty when the kernel gives more than one answer
+/// for it, so the lookup misses rather than picking one of them.
+struct KernelFormats {
+  llvm::StringRef in;
+  llvm::StringRef out;
+};
+
+KernelFormats getKernelFormats(func::FuncOp funcOp) {
+  /// Every circular buffer the kernel names, with the compile-time argument
+  /// index that identifies it. A buffer that does not come from an argument
+  /// cannot be matched against the packed set, so it counts as an input; every
+  /// buffer in lowered IR does come from one.
+  llvm::SmallVector<std::pair<std::optional<int32_t>, llvm::StringRef>> buffers;
+  llvm::SmallDenseSet<int32_t, 4> packed;
+
+  funcOp.walk([&](Operation *op) {
+    bool packs = isPackOp(op->getName().stripDialect());
+    for (Value operand : op->getOperands()) {
+      llvm::StringRef format = getCbFormatName(operand);
+      if (format.empty()) {
+        continue;
+      }
+      std::optional<int32_t> index;
+      if (auto argVal = operand.getDefiningOp<ttkernel::GetCompileArgValOp>()) {
+        index = argVal.getArgIndex();
+      }
+      if (packs && index) {
+        packed.insert(*index);
+      }
+      buffers.emplace_back(index, format);
+    }
+  });
+
+  // Classified after the walk rather than during it: a buffer read early in the
+  // function is not known to be an output until the pack that writes it is
+  // seen.
+  KernelFormats formats;
+  bool inConflict = false;
+  bool outConflict = false;
+  for (auto [index, format] : buffers) {
+    bool isOutput = index && packed.contains(*index);
+    llvm::StringRef &side = isOutput ? formats.out : formats.in;
+    bool &conflict = isOutput ? outConflict : inConflict;
+    if (side.empty()) {
+      side = format;
+    } else if (side != format) {
+      conflict = true;
+    }
+  }
+  if (inConflict) {
+    formats.in = {};
+  }
+  if (outConflict) {
+    formats.out = {};
+  }
+  return formats;
+}
+
+/// Recover the kernel-wide half of a lookup key from one kernel function.
+///
+/// The other half is per placement: the format the operation reads and the
+/// knobs it can answer for, assembled into an OpKey by resolve().
+KernelConfig getKernelConfig(func::FuncOp funcOp,
+                             const KernelFormats &formats) {
+  KernelConfig config;
+  if (auto destAcc =
+          funcOp->getAttrOfType<BoolAttr>(ttl::kFp32DestAccEnAttrName)) {
+    config.destAcc = destAcc.getValue();
+  }
+  if (auto fullSync =
+          funcOp->getAttrOfType<BoolAttr>(ttl::kDstFullSyncEnAttrName)) {
+    config.dstSync = fullSync.getValue() ? "Full" : "Half";
+  }
+  config.outFormat = formats.out;
+  return config;
+}
+
+/// Circular buffers the unpacker writes straight to DST for, as CB indices.
+///
+/// A per-buffer decision rather than a kernel-wide one, and not a small effect:
+/// the same `copy_tile` reads 120.78 cycles/tile on unpack for a listed buffer
+/// against 42.20 for an unlisted one. The index is the compile-time argument
+/// index a `get_compile_time_arg_val` carries, because that is what the ttl
+/// `cb_index` lowers to, so the attribute's numbers and the operation's operand
+/// are the same namespace.
+llvm::SmallVector<int32_t, 4> getUnpackToDestCbs(func::FuncOp funcOp) {
+  llvm::SmallVector<int32_t, 4> cbs;
+  if (auto listed = funcOp->getAttrOfType<DenseI32ArrayAttr>(
+          ttl::kUnpackToDestFp32AttrName)) {
+    llvm::append_range(cbs, listed.asArrayRef());
+  }
+  return cbs;
+}
+
+/// CB index of an operation's first circular-buffer operand, or nothing when it
+/// has none.
+///
+/// The first rather than operand zero, for the same reason the input format is
+/// found that way: `pack_tile` leads with a DST index, so position is not a
+/// reliable way to find the buffer.
+std::optional<int32_t> getFirstCbIndex(Operation *op) {
+  for (Value operand : op->getOperands()) {
+    if (!mlir::isa<ttkernel::CBType>(operand.getType())) {
+      continue;
+    }
+    if (auto argVal = operand.getDefiningOp<ttkernel::GetCompileArgValOp>()) {
+      return argVal.getArgIndex();
+    }
+  }
+  return std::nullopt;
+}
+
+/// The reduced dimension as the table spells it.
+///
+/// The table calls it `mathop`, which is the sweep's name for whatever the
+/// benchmark varied, and for the reduce benchmarks that is the dimension. The
+/// spellings are the LLK enum names, matching what
+/// convert-ttkernel-to-emitc emits for the same attribute
+/// (`ReduceDim::REDUCE_ROW` and friends). An unmapped case returns empty, which
+/// leaves the knob unanswered and makes the row miss rather than match another
+/// dimension's cost.
+llvm::StringRef getReduceDimName(ttkernel::ReduceDim dim) {
+  switch (dim) {
+  case ttkernel::ReduceDim::Row:
+    return "ReduceRow";
+  case ttkernel::ReduceDim::Col:
+    return "ReduceColumn";
+  case ttkernel::ReduceDim::Scalar:
+    return "ReduceScalar";
+  }
+  return {};
+}
+
+/// The pooling function as the table spells it. Avg returns empty: no sweep
+/// measured it, so there is nothing for it to match.
+llvm::StringRef getReducePoolTypeName(ttkernel::ReduceType type) {
+  switch (type) {
+  case ttkernel::ReduceType::Sum:
+    return "Sum";
+  case ttkernel::ReduceType::Max:
+    return "Max";
+  case ttkernel::ReduceType::Avg:
+    return {};
+  }
+  return {};
+}
+
+/// Metal's default SFPU inner-loop trip count, and what tt-lang compiles at
+/// every call site that does not carry the attribute. The table's SFPU rows are
+/// all keyed on 8, so a kernel that asked for another count misses rather than
+/// borrowing this one.
+constexpr int64_t kSfpuIterationsDefault = 8;
+
+/// The knobs one placement can answer for.
+///
+/// `OpKey::knobs` is deliberately untyped, so the three origins that
+/// meet here are the caller's to keep straight: a kernel-wide value the IR does
+/// not carry (`math_fidelity`), a per-buffer decision (`unpack_to_dest`), and
+/// the attributes of the operation being asked about (`approx_mode`,
+/// `iterations`, `input_clamping`, `mathop`, `reduce_pool_type`).
+///
+/// Supplying a knob no row names is harmless -- matching walks the row's knobs
+/// and looks each up here, never the other way round -- so this answers
+/// everything it can rather than trying to predict which rows the lookup will
+/// reach.
+///
+/// Every value is a string literal but for `iterations`, whose text this owns
+/// -- hence the one purpose-built setter rather than a general numeric one,
+/// since a second number would move the first one's storage out from under it.
+/// The knob list points into that buffer, so a set has to outlive the lookup it
+/// was built for and must not be copied in between.
+struct KnobSet {
+  llvm::SmallVector<opcost::Knob, 4> knobs;
+  llvm::SmallString<16> iterationsText;
+
+  void add(llvm::StringRef name, llvm::StringRef value) {
+    knobs.push_back({name, value});
+  }
+
+  void setIterations(int64_t value) {
+    assert(iterationsText.empty() && "iterations can only be set once");
+    llvm::raw_svector_ostream(iterationsText) << value;
+    add("iterations", iterationsText);
+  }
+};
+
+void gatherKnobs(Operation *op, llvm::StringRef mathFidelity,
+                 llvm::ArrayRef<int32_t> unpackToDestCbs, KnobSet &set) {
+  if (!mathFidelity.empty()) {
+    set.add("math_fidelity", mathFidelity);
+  }
+
+  // The buffer the unpacker reads, which is the operation's first: the knob
+  // describes an input route, and no operation keyed on it leads with an output
+  // buffer.
+  if (std::optional<int32_t> cb = getFirstCbIndex(op)) {
+    set.add("unpack_to_dest",
+            llvm::is_contained(unpackToDestCbs, *cb) ? "true" : "false");
+  }
+
+  // Read from the attributes rather than from the operation type, so the two
+  // reduce operations and anything later given the same attributes are covered
+  // by one rule. The attribute names are the ones TTKernelOps.td declares.
+  if (auto dim = op->getAttrOfType<ttkernel::ReduceDimAttr>("reduce_dim")) {
+    if (llvm::StringRef name = getReduceDimName(dim.getValue());
+        !name.empty()) {
+      set.add("mathop", name);
+    }
+  }
+  if (auto type = op->getAttrOfType<ttkernel::ReduceTypeAttr>("reduce_type")) {
+    if (llvm::StringRef name = getReducePoolTypeName(type.getValue());
+        !name.empty()) {
+      set.add("reduce_pool_type", name);
+    }
+  }
+
+  // The SFPU exponential is the one operation whose own attributes reach the
+  // table. Absent attributes are metal's defaults rather than unknowns: the
+  // operation lowers to a bare `exp_tile(idst)` call, which is compiled with
+  // them, and the Python wrapper drops every flag left at its default -- so the
+  // defaults are the ordinary case rather than an edge one.
+  BoolAttr approx;
+  IntegerAttr iterations;
+  ttkernel::InputClampingAttr clamping;
+  if (auto exp = dyn_cast<ttkernel::ExpTileOp>(op)) {
+    approx = exp.getApproxAttr();
+    iterations = exp.getIterationsAttr();
+    clamping = exp.getInputClampingAttr();
+  } else if (auto expInit = dyn_cast<ttkernel::ExpTileInitOp>(op)) {
+    // exp_tile_init carries no trip count of its own; it configures the SFPU
+    // for the loop the following exp_tile runs.
+    approx = expInit.getApproxAttr();
+    clamping = expInit.getInputClampingAttr();
+  } else {
+    return;
+  }
+  set.add("approx_mode", approx && approx.getValue() ? "true" : "false");
+  set.setIterations(iterations ? iterations.getInt() : kSfpuIterationsDefault);
+
+  // The table spells the clamp as a boolean: on for ClampToNegative and off for
+  // None, which skips the check. Absent means on, the template default -- and
+  // that is not a detail worth glossing, because it is the difference between
+  // 112 cycles/tile and 29 for the approximate exponential.
+  bool clamped = !clamping || clamping.getValue() ==
+                                  ttkernel::InputClamping::ClampToNegative;
+  set.add("input_clamping", clamped ? "true" : "false");
+}
+
+/// What one placement is charged for a resolved cost.
+///
+/// The estimator charges a flat integer per placement, and one placement is one
+/// call over one tile: a `PerTile` value is charged as it stands and a
+/// `PerCall` value carries its intercept. A `PerTile` intercept is dropped,
+/// because it is the intercept of a fit against a block dimension -- it belongs
+/// to the loop rather than to any one tile of it, and once the loop is unrolled
+/// there is no placement to attach it to. Every row in today's table has a zero
+/// intercept, so nothing is dropped yet.
+///
+/// No cost means nothing measured, so nothing charged. Scheduling still gives
+/// the placement a one-cost floor, so it holds its position on the lane and its
+/// resource effect happens in order.
+uint64_t getChargedCost(const std::optional<opcost::Cost> &cost) {
+  if (!cost) {
+    return 0;
+  }
+  double total = cost->unit == opcost::Unit::PerCall ? cost->value + cost->fixed
+                                                     : cost->value;
+  return static_cast<uint64_t>(std::llround(std::max(0.0, total)));
+}
+
+/// Why a placement carries no measured cost, for the detail view's `src`
+/// column.
+///
+/// Recomputed from the table rather than stored per placement: it is a property
+/// of the (operation, engine) slot, and a report holds hundreds of thousands of
+/// placements.
+llvm::StringRef getCostSource(llvm::StringRef opName, Engine engine,
+                              bool measured) {
+  if (measured) {
+    return "meas";
+  }
+  llvm::StringRef bare = opName;
+  bare.consume_front("ttkernel.");
+  // A slot with rows that none of them match is a key mismatch, which supplying
+  // the missing field closes; a slot with no rows at all is missing data.
+  return opcost::getMeasurementCount(bare, engine) > 0 ? "nokey" : "untimed";
+}
+
+} // namespace
+
+llvm::ArrayRef<CostEstimator::Lane> CostEstimator::getAllLanes() {
+  static constexpr Lane lanes[kNumLanes] = {Lane::Ncrisc, Lane::Trisc0Unpack,
+                                            Lane::Trisc1Math, Lane::Trisc2Pack,
+                                            Lane::Brisc};
+  return lanes;
+}
+
+llvm::StringRef CostEstimator::getLaneName(Lane lane) {
+  switch (lane) {
+  case Lane::Ncrisc:
+    return "NCRISC reader";
+  case Lane::Trisc0Unpack:
+    return "TRISC0 unpack";
+  case Lane::Trisc1Math:
+    return "TRISC1 math";
+  case Lane::Trisc2Pack:
+    return "TRISC2 pack";
+  case Lane::Brisc:
+    return "BRISC writer";
+  }
+  return "unknown lane";
+}
+
+std::string CostEstimator::Report::render() const {
+  std::string text;
+  llvm::raw_string_ostream out(text);
+
+  uint64_t placements =
+      measuredPlacements + unmatchedPlacements + untimedPlacements;
+  out << "cost estimate: " << measuredPlacements << " of " << placements
+      << " placements measured";
+  if (placements > 0) {
+    out << llvm::format(" (%.0f%%)", 100.0 * measuredPlacements / placements);
+  }
+  out << "\n";
+  // The rest is charged nothing, and the two reasons call for opposite
+  // responses: an unmatched placement is a key this kernel cannot supply, which
+  // a caller can close, while an untimed one waits on a sweep.
+  out << "  " << unmatchedPlacements
+      << " unmatched (measured in no configuration this kernel can supply), "
+      << untimedPlacements << " untimed (nothing measured them); both charged 0"
+      << "\n";
+  opcost::TableStats stats = opcost::getTableStats();
+  out << "  measured on " << kPerfTableArch << " from " << stats.measuredRows
+      << " rows over " << stats.operations
+      << " operations; per-operation provenance in the detail view\n";
+
+  out << "  kernels:";
+  for (llvm::StringRef kernel : kernels) {
+    out << " " << kernel;
+  }
+  if (kernels.empty()) {
+    out << " (none)";
+  }
+  out << "\n";
+
+  Lane busiestLane = Lane::Ncrisc;
+  uint64_t busiestWork = 0;
+  for (Lane lane : getAllLanes()) {
+    const LaneReport &laneReport = lanes[getLaneIndex(lane)];
+    // Occupancy, not the sum of the table's costs. The two differ for an
+    // operation the table costs at zero, which still occupies its lane for the
+    // one the scheduler charges as a floor, so that no interval is empty.
+    uint64_t work = 0;
+    for (const PlacedOp &op : laneReport.ops) {
+      work += op.finish - op.start;
+    }
+    if (work > busiestWork) {
+      busiestWork = work;
+      busiestLane = lane;
+    }
+    // Split the non-busy time. "idle" alone conflates two situations that call
+    // for opposite responses: a lane blocked on another lane is a dependency
+    // signal, while a lane that has run out of work is a balance observation.
+    //
+    // The three partition totalCost exactly, because a lane's own span is
+    // busy + stalled: each operation contributes its stall gap then its
+    // occupancy, telescoping to the last finish.
+    uint64_t stalled = 0;
+    for (const PlacedOp &op : laneReport.ops) {
+      stalled += op.stall;
+    }
+    uint64_t lastFinish =
+        laneReport.ops.empty() ? 0 : laneReport.ops.back().finish;
+    uint64_t drained = totalCost > lastFinish ? totalCost - lastFinish : 0;
+    assert((laneReport.ops.empty() || work + stalled + drained == totalCost) &&
+           "lane time must account for the whole run");
+
+    out << "  " << getLaneName(lane) << ": " << laneReport.ops.size()
+        << " ops, " << work << " busy, " << stalled << " stalled, " << drained
+        << " drained";
+    if (totalCost > 0) {
+      out << llvm::format(", %.0f%% utilized", 100.0 * work / totalCost);
+    }
+    out << "\n";
+  }
+
+  out << "  latency: " << totalCost << "\n";
+  out << "  busiest lane: " << getLaneName(busiestLane) << " (" << busiestWork
+      << " busy)\n";
+  return text;
+}
+
+std::string CostEstimator::Report::renderDetail() const {
+  std::string text;
+  llvm::raw_string_ostream out(text);
+
+  // Widest op name across all lanes, so the source column lines up.
+  size_t nameWidth = 0;
+  for (const LaneReport &lane : lanes) {
+    for (const PlacedOp &op : lane.ops) {
+      nameWidth = std::max(nameWidth, op.name.size());
+    }
+  }
+
+  for (Lane lane : getAllLanes()) {
+    const LaneReport &laneReport = lanes[getLaneIndex(lane)];
+    out << "\n  " << getLaneName(lane) << "\n";
+    if (laneReport.ops.empty()) {
+      out << "    (idle)\n";
+      continue;
+    }
+    // The `src` column says where each cost came from, so a mixed report cannot
+    // be misread as measured throughout.
+    out << "    " << llvm::left_justify("op", nameWidth)
+        << "  start    end   cost   wait  src\n";
+    Engine engine = engineFor(lane);
+    size_t listed =
+        std::min<size_t>(laneReport.ops.size(), kMaxListedOpsPerLane);
+    for (const PlacedOp &op :
+         llvm::ArrayRef<PlacedOp>(laneReport.ops).take_front(listed)) {
+      out << "    " << llvm::left_justify(op.name, nameWidth)
+          << llvm::format("%7" PRIu64 "%7" PRIu64 "%7" PRIu64 "%7" PRIu64,
+                          op.start, op.finish, op.cost, op.stall);
+      // Fixed width, so the source position that follows lines up.
+      out << "  "
+          << llvm::left_justify(
+                 getCostSource(op.name, engine, op.measured).str(), 7);
+      std::string where = formatLoc(op.loc);
+      if (!where.empty()) {
+        out << "  [" << where << "]";
+      }
+      out << "\n";
+    }
+    if (listed < laneReport.ops.size()) {
+      out << "    ... " << (laneReport.ops.size() - listed)
+          << " more ops on this lane omitted\n";
+    }
+  }
+  return text;
+}
+
+std::string CostEstimator::Report::renderTimeline() const {
+  if (totalCost == 0) {
+    return "";
+  }
+
+  // Row boundaries: every start, every finish, and the point a lane began
+  // waiting, so a wait gets its own row instead of being folded into the
+  // preceding op.
+  llvm::SmallVector<uint64_t> times{0};
+  for (const LaneReport &lane : lanes) {
+    for (const PlacedOp &op : lane.ops) {
+      times.push_back(op.start);
+      times.push_back(op.finish);
+      if (op.stall > 0) {
+        times.push_back(op.start - op.stall);
+      }
+    }
+  }
+  llvm::sort(times);
+  times.erase(std::unique(times.begin(), times.end()), times.end());
+
+  size_t width = 8;
+  for (const LaneReport &lane : lanes) {
+    for (const PlacedOp &op : lane.ops) {
+      width = std::max(width, getShortName(op.name).size() + 1);
+    }
+  }
+
+  std::string text;
+  llvm::raw_string_ostream out(text);
+  out << "timeline: one row per event, '|' running, 'w' waiting, '^' ended, "
+         "'.' idle\n\n";
+  out << llvm::right_justify("cost", 8) << llvm::right_justify("gap", 7)
+      << "  ";
+  for (Lane lane : getAllLanes()) {
+    out << llvm::left_justify(getLaneName(lane).split(' ').first.str(), width)
+        << "|";
+  }
+  out << "\n" << std::string(17, ' ');
+  for (unsigned i = 0; i < kNumLanes; ++i) {
+    out << std::string(width, '-') << "|";
+  }
+  out << "\n";
+
+  // A lane's operations are non-overlapping and sorted by start, so a cursor
+  // that only moves forward keeps this linear in the number of rows. Scanning
+  // each lane's whole list per row is quadratic, which is minutes of hang on a
+  // kernel whose loops unroll to tens of thousands of operations.
+  std::array<size_t, kNumLanes> cursor = {};
+
+  size_t rows = std::min<size_t>(times.size(), kMaxTimelineRows);
+  for (size_t row = 0; row < rows; ++row) {
+    uint64_t now = times[row];
+    bool last = row + 1 == times.size();
+    out << llvm::format("%8" PRIu64, now);
+    if (last) {
+      out << llvm::right_justify("end", 7);
+    } else {
+      out << llvm::format("%7" PRIu64, times[row + 1] - now);
+    }
+    out << "  ";
+
+    for (Lane lane : getAllLanes()) {
+      llvm::ArrayRef<PlacedOp> ops = lanes[getLaneIndex(lane)].ops;
+      size_t &at = cursor[getLaneIndex(lane)];
+      while (at < ops.size() && ops[at].finish < now) {
+        ++at;
+      }
+      // At most two operations can matter at one instant: the one ending here
+      // and the one starting here, and they are adjacent.
+      llvm::StringRef cell = ".";
+      for (size_t k = at; k < ops.size() && k <= at + 1; ++k) {
+        const PlacedOp &op = ops[k];
+        if (op.start == now) {
+          cell = getShortName(op.name);
+          break;
+        }
+        if (now > op.start && now < op.finish) {
+          cell = "|";
+          break;
+        }
+        // A wait shown in preference to the previous op's end: the two share a
+        // boundary and the wait is what explains the gap.
+        if (op.stall > 0 && now >= op.start - op.stall && now < op.start) {
+          cell = "w";
+          break;
+        }
+        if (op.finish == now) {
+          cell = "^"; // keep looking, in case the next op starts here too
+        }
+      }
+      out << llvm::left_justify(cell.str(), width) << "|";
+    }
+    out << "\n";
+  }
+  if (rows < times.size()) {
+    out << "  ... " << (times.size() - rows) << " later event rows omitted\n";
+  }
+  return text;
+}
+
+namespace {
+
+/// Tiles of one circular buffer. `capacity` comes from the CB type, so the
+/// number of blocks it holds is `capacity / tiles-per-op` and is never stored.
+///
+/// One counter, because the hardware has one quantity. A CB is a lock-free SPSC
+/// ring holding two monotonic counters -- `tiles_received`, written only by the
+/// producer, and `tiles_acked`, written only by the consumer -- so that neither
+/// RISC read-modify-writes the other's word, and occupancy is their difference
+/// (llk_io_pack.h:38-41). Tracking a separate reservation would add a state the
+/// hardware cannot be in: `cb_reserve_back` only waits, and the write pointer
+/// advances in `cb_push_back`, so reserving twice returns the same address
+/// rather than two slots. Keeping the producer to one reservation at a time is
+/// the SPSC discipline that ttl-insert-cb-sync and ttl-verify-dfb-spsc own.
+struct CbState {
+  uint64_t capacity = 0;
+  uint64_t occupancy = 0; ///< pushed, not yet popped: received - acked
+
+  uint64_t freeTiles() const { return capacity - occupancy; }
+};
+
+/// DST halves handed to PACK. `SyncHalf` gives two, so MATH can fill one while
+/// PACK drains the other; `dst_full_sync_en` gives one and the two serialize.
+///
+/// One counter for the same reason, and here the hardware really is one: the
+/// MATH_PACK semaphore. MATH posts on commit and the packer's
+/// dest_section_done takes it back, while both waits only gate -- MATH stalls
+/// on max, PACK stalls on zero. The half MATH writes advances at commit
+/// (`dest_section_flip`), not at acquire, so acquiring twice keeps MATH on the
+/// same half instead of claiming two.
+struct DstState {
+  unsigned halves = 2; ///< the semaphore's max count
+  unsigned handed = 0; ///< committed to PACK, not yet returned == MATH_PACK
+};
+
+/// SrcA/SrcB banks between the unpacker and the Matrix Unit.
+///
+/// The unpacker sets dvalid on the bank it filled and the math MOP's end op
+/// clears it, so this is a credit counter like the others and the ping-pong
+/// between banks is emergent.
+///
+/// Simplification: SrcA and SrcB are counted as one credit rather than two
+/// independent register files. That is exact for the AB-style ops that read
+/// both and conservative for single-operand ops, which leave the other file
+/// idle.
+struct SrcState {
+  unsigned freeBanks = 2; ///< banks the unpacker may fill
+  unsigned valid = 0;     ///< filled and dvalid, not yet consumed by MATH
+};
+
+/// One lane's position in its own program.
+struct LaneSim {
+  size_t pc = 0;
+  bool inFlight = false;
+  uint64_t busyUntil = 0;
+  uint64_t idleSince = 0;    ///< when the lane last became free, for stalls
+  llvm::StringRef blockedOn; ///< set while a lane cannot start its next op
+};
+
+} // namespace
+
+class CostEstimator::Impl {
+public:
+  Impl(ModuleOp module, Options options) : module(module), options(options) {}
+
+  FailureOr<Report> estimate() {
+    Report report;
+    uint64_t ttkernelOps = 0;
+
+    for (auto funcOp : module.getOps<func::FuncOp>()) {
+      auto thread =
+          funcOp->getAttrOfType<ttkernel::ThreadTypeAttr>(kThreadAttrName);
+      if (!thread) {
+        continue;
+      }
+      report.kernels.push_back(funcOp.getSymName().str());
+
+      switch (thread.getValue()) {
+      case ttkernel::ThreadType::Noc:
+        ttkernelOps += placeFunc(funcOp, getDataMovementLane(funcOp), report);
+        break;
+      case ttkernel::ThreadType::Compute:
+        // DstSync::SyncHalf is the default, so an absent attribute means two
+        // halves, not "unknown".
+        if (auto fullSync =
+                funcOp->getAttrOfType<BoolAttr>(ttl::kDstFullSyncEnAttrName)) {
+          dstHalves = fullSync.getValue() ? 1 : 2;
+        }
+        ttkernelOps += placeFunc(funcOp, std::nullopt, report);
+        break;
+      default:
+        // Structural: an unhandled thread type means the whole function's work
+        // lands nowhere.
+        failToModel(
+            "thread-type", funcOp,
+            "cost estimator does not model the kernel thread type on '" +
+                funcOp.getSymName() + "'");
+        break;
+      }
+    }
+
+    // Reject IR from after convert-ttkernel-to-emitc: circular-buffer calls
+    // have become opaque verbatim strings by then, so an empty walk here means
+    // the module is past the stage this estimator reads, not that it is
+    // trivial.
+    if (ttkernelOps == 0 && !report.kernels.empty()) {
+      module.emitWarning() << "cost estimator found no ttkernel operations in "
+                           << report.kernels.size()
+                           << " kernel function(s); the module is probably "
+                              "already lowered to EmitC";
+      return failure();
+    }
+
+    if (cannotModel) {
+      // The diagnostic was already emitted at the operation responsible.
+      return failure();
+    }
+
+    if (failed(schedule(report))) {
+      return failure();
+    }
+    return report;
+  }
+
+private:
+  /// Walk the five lane programs forward in time, blocking on resources.
+  ///
+  /// Each lane is strictly in order and blocking: these are bare RISCs spinning
+  /// on a semaphore, with no reordering and nothing else to run. That makes the
+  /// loop much simpler than a general resource scheduler, and it makes a stuck
+  /// lane genuinely stuck.
+  ///
+  /// Acquires are checked and taken when an operation starts; releases apply
+  /// when it retires. A push therefore becomes visible to the consumer at the
+  /// end of the push, not the start.
+  LogicalResult schedule(Report &report) {
+    llvm::DenseMap<unsigned, CbState> cbs;
+    for (auto &[index, capacity] : cbCapacity) {
+      cbs[index].capacity = capacity;
+    }
+
+    DstState dst;
+    dst.halves = dstHalves;
+
+    SrcState src;
+    src.freeBanks = options.srcBanks;
+
+    std::array<LaneSim, kNumLanes> sim = {};
+
+    auto canStart = [&](const PlacedOp &op) -> llvm::StringRef {
+      const ResourceEffect &effect = op.effect;
+      switch (effect.kind) {
+      case ResourceEffect::Kind::CbReserve:
+        return cbs[effect.cb].freeTiles() >= effect.tiles ? llvm::StringRef()
+                                                          : "cb free tiles";
+      case ResourceEffect::Kind::CbWait:
+        return cbs[effect.cb].occupancy >= effect.tiles ? llvm::StringRef()
+                                                        : "cb published tiles";
+      case ResourceEffect::Kind::DstAcquire:
+        // Stalls on max, like the SEMWAIT it stands for. It claims nothing, so
+        // a second acquire with no commit between them passes, as on hardware.
+        return dst.handed < dst.halves ? llvm::StringRef() : "dst half";
+      case ResourceEffect::Kind::DstWait:
+        return dst.handed > 0 ? llvm::StringRef() : "dst commit";
+      case ResourceEffect::Kind::DstSyncInit:
+        // Nothing handed out is the semaphore reading zero. A half MATH holds
+        // but has not committed does not hold the reset up, matching the
+        // hardware, which waits only on what the packer still owes.
+        return dst.handed == 0 ? llvm::StringRef() : "dst drain";
+      case ResourceEffect::Kind::SrcProduce:
+        return src.freeBanks > 0 ? llvm::StringRef() : "srcA/B bank";
+      case ResourceEffect::Kind::SrcConsume:
+        return src.valid > 0 ? llvm::StringRef() : "srcA/B dvalid";
+      default:
+        return llvm::StringRef();
+      }
+    };
+
+    // Only the Src handshake takes anything when an operation starts. The CB
+    // and DST waits are gates: they read their counter and never move it, so
+    // nothing here corresponds to `cb_reserve_back` or `tile_regs_acquire`.
+    auto takeAtStart = [&](const PlacedOp &op) {
+      const ResourceEffect &effect = op.effect;
+      if (effect.kind == ResourceEffect::Kind::SrcProduce) {
+        --src.freeBanks;
+      } else if (effect.kind == ResourceEffect::Kind::SrcConsume) {
+        --src.valid;
+      }
+    };
+
+    auto releaseAtFinish = [&](const PlacedOp &op) {
+      const ResourceEffect &effect = op.effect;
+      CbState &cb = cbs[effect.cb];
+      switch (effect.kind) {
+      case ResourceEffect::Kind::CbPush:
+        // The producer's `tiles_received += n`, which is also what advances the
+        // write pointer, so the tiles become visible to the consumer here.
+        cb.occupancy += effect.tiles;
+        break;
+      case ResourceEffect::Kind::CbPop:
+        // The consumer's `tiles_acked += n`.
+        cb.occupancy -= std::min(cb.occupancy, effect.tiles);
+        break;
+      case ResourceEffect::Kind::DstCommit:
+        ++dst.handed; ///< t6_semaphore_post(MATH_PACK)
+        break;
+      case ResourceEffect::Kind::DstRelease:
+        // The packer's dest_section_done is the semaphore_get matching MATH's
+        // post at commit, and it runs after the pack itself has finished, so
+        // the half comes back here rather than when PACK started draining it.
+        dst.handed -= std::min<unsigned>(dst.handed, 1);
+        break;
+      case ResourceEffect::Kind::SrcProduce:
+        // dvalid is set when the unpack retires, so MATH cannot start on this
+        // tile before then.
+        ++src.valid;
+        break;
+      case ResourceEffect::Kind::SrcConsume:
+        ++src.freeBanks;
+        break;
+      default:
+        break;
+      }
+    };
+
+    uint64_t now = 0;
+    while (true) {
+      // Retire whatever finishes at `now` before anything starts, so a push and
+      // the wait it satisfies cannot both resolve in the same instant.
+      for (Lane lane : getAllLanes()) {
+        LaneSim &laneSim = sim[getLaneIndex(lane)];
+        if (!laneSim.inFlight || laneSim.busyUntil != now) {
+          continue;
+        }
+        releaseAtFinish(report.lanes[getLaneIndex(lane)].ops[laneSim.pc]);
+        laneSim.inFlight = false;
+        laneSim.idleSince = now;
+        ++laneSim.pc;
+      }
+
+      bool anyRemaining = false;
+      bool anyInFlight = false;
+      for (Lane lane : getAllLanes()) {
+        LaneSim &laneSim = sim[getLaneIndex(lane)];
+        LaneReport &laneReport = report.lanes[getLaneIndex(lane)];
+        if (laneSim.inFlight) {
+          anyInFlight = anyRemaining = true;
+          continue;
+        }
+        if (laneSim.pc >= laneReport.ops.size()) {
+          continue;
+        }
+        anyRemaining = true;
+
+        PlacedOp &op = laneReport.ops[laneSim.pc];
+        laneSim.blockedOn = canStart(op);
+        if (!laneSim.blockedOn.empty()) {
+          continue;
+        }
+        takeAtStart(op);
+        op.start = now;
+        op.stall = now - laneSim.idleSince;
+        op.finish = now + std::max<uint64_t>(op.cost, 1);
+        laneSim.busyUntil = op.finish;
+        laneSim.inFlight = true;
+        anyInFlight = true;
+      }
+
+      if (!anyRemaining) {
+        break;
+      }
+
+      if (!anyInFlight) {
+        // Every lane with work left is blocked and nothing is running, so no
+        // resource can ever be released. Report it rather than returning a
+        // plausible number for a program that cannot run.
+        std::string detail;
+        llvm::raw_string_ostream os(detail);
+        for (Lane lane : getAllLanes()) {
+          const LaneSim &laneSim = sim[getLaneIndex(lane)];
+          if (laneSim.pc < report.lanes[getLaneIndex(lane)].ops.size()) {
+            os << "\n    " << getLaneName(lane) << " blocked on "
+               << laneSim.blockedOn;
+          }
+        }
+        module.emitWarning()
+            << "cost estimator deadlocked at cost " << now << detail;
+        return failure();
+      }
+
+      uint64_t next = std::numeric_limits<uint64_t>::max();
+      for (Lane lane : getAllLanes()) {
+        const LaneSim &laneSim = sim[getLaneIndex(lane)];
+        if (laneSim.inFlight) {
+          next = std::min(next, laneSim.busyUntil);
+        }
+      }
+      now = next;
+      report.totalCost = std::max(report.totalCost, now);
+    }
+
+    return success();
+  }
+
+  /// Place every TTKernel operation in one kernel function.
+  ///
+  /// `dmLane` is set for a data-movement kernel, which compiles for a single
+  /// RISC so all of its work lands on that one lane. For a compute kernel it is
+  /// nullopt and each operation fans out onto the TRISCs whose macro keeps it.
+  /// Returns the number of TTKernel operations seen, placed or not.
+  /// Shared state for one function's traversal.
+  struct PlaceContext {
+    std::optional<Lane> dmLane;
+    Report *report;
+    uint64_t seen = 0;
+
+    /// The measured table's key fields that come from the enclosing function
+    /// rather than from each operation.
+    KernelConfig config;
+
+    /// Kernel-wide, and not in the IR; see Options::mathFidelity.
+    llvm::StringRef mathFidelity;
+
+    /// Input format for the operations that name no buffer; see KernelFormats.
+    llvm::StringRef kernelFormat;
+
+    /// See getUnpackToDestCbs.
+    llvm::SmallVector<int32_t, 4> unpackToDestCbs;
+
+    /// Resolved costs, keyed by everything a lookup depends on.
+    ///
+    /// `config` is fixed for the function while `inFormat` and the knobs come
+    /// from the operation, so the answer repeats on every placement of the same
+    /// operation in the same configuration. Without this the scan runs once per
+    /// placement, and a kernel whose loops unroll places hundreds of thousands
+    /// against slices as long as 460 rows, each row costing a `variantMatches`
+    /// parse. With it the scan runs once per distinct key -- a few dozen times
+    /// per function.
+    ///
+    /// Keyed on text rather than on pointers because the knobs are part of the
+    /// key and a tuple of pointers cannot spell them. Hashing a few dozen
+    /// characters is nothing against the scan it saves.
+    llvm::StringMap<std::optional<opcost::Cost>> resolved;
+
+    std::optional<opcost::Cost> resolve(Operation *op, llvm::StringRef name,
+                                        Lane lane, llvm::StringRef inFormat) {
+      // Outlives the lookup below and is not copied, which is what KnobSet
+      // requires of whoever holds one.
+      KnobSet knobs;
+      gatherKnobs(op, mathFidelity, unpackToDestCbs, knobs);
+
+      llvm::SmallString<128> key;
+      {
+        // Separated by a byte that cannot appear in a name or a value, so no
+        // two distinct keys can spell the same string.
+        llvm::raw_svector_ostream keyOut(key);
+        keyOut << name << '\0' << static_cast<unsigned>(lane) << '\0'
+               << inFormat;
+        for (const opcost::Knob &knob : knobs.knobs) {
+          keyOut << '\0' << knob.name << '=' << knob.value;
+        }
+      }
+
+      auto [it, inserted] = resolved.try_emplace(key);
+      if (inserted) {
+        opcost::OpKey opKey{inFormat, knobs.knobs};
+        it->second = opcost::lookup(name, engineFor(lane), opKey, config);
+      }
+      return it->second;
+    }
+  };
+
+  /// Record a gap the estimate cannot survive: diagnose it once per distinct
+  /// `key` and mark the estimate unusable.
+  ///
+  /// Every gap found while walking the module reports through here, so one run
+  /// names all of them. `key` decides how much counts as one gap, and the right
+  /// granularity differs by kind: an operation the cost table does not know is
+  /// keyed by name, because an unrolled loop body would otherwise repeat the
+  /// same complaint once per iteration, while a loop the estimator cannot
+  /// enumerate is keyed by what went wrong with it. Dedup spans the module
+  /// rather than one kernel, because a three-thread module hits the same gap
+  /// three times and the reader learns nothing from the repeats.
+  ///
+  /// A warning rather than an error. The gap is in the estimator, and the
+  /// estimate is a read-only side output, so a module the estimator cannot
+  /// account for still compiles; `estimate()` returning failure is what tells a
+  /// caller not to trust a number.
+  void failToModel(llvm::StringRef key, Operation *op,
+                   const llvm::Twine &message) {
+    if (reportedGaps.insert(key).second) {
+      op->emitWarning() << message;
+    }
+    cannotModel = true;
+  }
+
+  uint64_t placeFunc(func::FuncOp funcOp, std::optional<Lane> dmLane,
+                     Report &report) {
+    PlaceContext ctx;
+    ctx.dmLane = dmLane;
+    ctx.report = &report;
+    KernelFormats formats = getKernelFormats(funcOp);
+    ctx.config = getKernelConfig(funcOp, formats);
+    ctx.mathFidelity = options.mathFidelity;
+    ctx.kernelFormat = formats.in;
+    ctx.unpackToDestCbs = getUnpackToDestCbs(funcOp);
+
+    // Walk regions structurally rather than with Operation::walk, because a
+    // loop body has to be repeated in place: the correct lane order for a body
+    // of A,B,C over two iterations is A,B,C,A,B,C, not A,A,B,B,C,C.
+    LoopInductionBindings bindings;
+    EnumerationBudget budget(kUnrollBudget);
+    placeBlock(funcOp.getBody().front(), ctx, bindings, budget);
+    return ctx.seen;
+  }
+
+  void placeBlock(Block &block, PlaceContext &ctx,
+                  LoopInductionBindings &bindings, EnumerationBudget &budget) {
+    for (Operation &op : block) {
+      placeOperation(&op, ctx, bindings, budget);
+    }
+  }
+
+  void placeOperation(Operation *op, PlaceContext &ctx,
+                      LoopInductionBindings &bindings,
+                      EnumerationBudget &budget) {
+    if (op->getName().getDialectNamespace() == kTTKernelDialect) {
+      placeTTKernelOp(op, ctx);
+      return;
+    }
+    if (auto loop = dyn_cast<LoopLikeOpInterface>(op)) {
+      placeLoop(loop, ctx, bindings, budget);
+      return;
+    }
+    // Any other region-carrying operation is control flow this does not model.
+    // Walking into it would count a guarded body as taken and both arms of an
+    // if/else as executed.
+    //
+    // TODO(ttl): resolve the condition rather than failing. Induction variables
+    // are already bound during unrolling, so
+    // evaluateIndexExpression(ifOp.getCondition(), bindings) folds the bounds
+    // guards that dominate real kernels, and the live branch can be placed on
+    // its own. Launch-coordinate predicates (ttl.is_src, ttl.is_dst) need the
+    // same facts as LaunchNodeDomainAnalysis, or `specialize_cores` to have
+    // folded them first. Only a genuinely dynamic condition need fail, because
+    // two branches that mutate resource counters differently leave no sound
+    // single state to continue from.
+    if (op->getNumRegions() > 0) {
+      failToModel(op->getName().getStringRef(), op,
+                  "cost estimator currently does not model '" +
+                      op->getName().getStringRef() +
+                      "': a guarded body would be counted as taken and both "
+                      "arms of a branch as executed");
+    }
+  }
+
+  /// Repeat a loop body once per iteration, with the induction variables bound
+  /// so that expressions inside the body see the current iteration.
+  void placeLoop(LoopLikeOpInterface loop, PlaceContext &ctx,
+                 LoopInductionBindings &bindings, EnumerationBudget &budget) {
+    std::optional<uint64_t> trip = getLoopTripCount(loop, bindings);
+    if (!trip) {
+      // TODO(ttl): a dynamic trip count cannot be unrolled at all, so this
+      // needs steady-state extrapolation rather than a larger budget: unroll a
+      // bounded prefix, detect when the resource state and per-lane program
+      // counters repeat, take that cost delta as the initiation interval, and
+      // report prologue + II * (trip - warmup) + epilogue with the trip count
+      // left symbolic. Until then, failing is the honest answer -- placing
+      // nothing for the loop would schedule a different program.
+      failToModel("loop-trip-count", loop,
+                  "cost estimator cannot determine this loop's trip count "
+                  "statically, and steady-state extrapolation is not "
+                  "implemented yet, so no estimate is produced");
+      return;
+    }
+    // Skipping the body would leave the lanes holding a different program than
+    // the one being estimated, and scheduling that still yields a
+    // confident-looking latency which is neither an upper nor a lower bound on
+    // the real one.
+    if (!budget.canConsume(*trip)) {
+      // The budget is shared across the enclosing nest, so this loop is usually
+      // an inner one that would have fit on its own and the iterations were
+      // spent by the loops around it. Saying so matters: the trip count named
+      // here is not what the limit was compared against.
+      failToModel(
+          "loop-unroll-budget", loop,
+          "cost estimator cannot unroll this loop's " + std::to_string(*trip) +
+              " iterations: the per-kernel budget of " +
+              std::to_string(kUnrollBudget) +
+              " iterations is exhausted, spent on this loop and the ones "
+              "enclosing it. Steady-state extrapolation is not "
+              "implemented yet, so no estimate is produced.");
+      return;
+    }
+
+    LogicalResult enumerated =
+        enumerateLoopNest({loop}, bindings, budget,
+                          [&](const LoopInductionBindings &) -> LogicalResult {
+                            for (Region &region : loop->getRegions()) {
+                              for (Block &block : region) {
+                                placeBlock(block, ctx, bindings, budget);
+                              }
+                            }
+                            return success();
+                          });
+    // Worse than the case above: enumeration stopped partway, so some
+    // iterations are already placed and the lanes hold a truncated program.
+    if (failed(enumerated)) {
+      failToModel("loop-enumeration", loop,
+                  "cost estimator exhausted its unroll budget of " +
+                      std::to_string(kUnrollBudget) +
+                      " iterations partway through this loop, or hit an "
+                      "iteration range it cannot enumerate");
+    }
+  }
+
+  void placeTTKernelOp(Operation *op, PlaceContext &ctx) {
+    Report &report = *ctx.report;
+    const std::optional<Lane> dmLane = ctx.dmLane;
+    {
+      llvm::StringRef name = op->getName().getStringRef();
+      ++ctx.seen;
+
+      // Messages keep the qualified name so they can be grepped against the IR.
+      llvm::StringRef bare = op->getName().stripDialect();
+      if (!opcost::isKnownOp(bare)) {
+        // Unreachable while the table covers the dialect, which generation
+        // enforces by reading the op list out of TTKernelOps.td. Kept because a
+        // hand-edited table would otherwise place the operation on no lane at
+        // all, losing both its time and its resource effects.
+        failToModel(name, op,
+                    "no cost table entry for '" + name +
+                        "': the operation would be left out of every lane");
+        return;
+      }
+      // Input format comes from the operation's own circular buffer, output
+      // format and the rest from the enclosing kernel; see OpKey and
+      // KernelConfig.
+      //
+      // The first CB operand rather than operand zero: `pack_tile` leads with a
+      // DST index, so position is not a reliable way to find the buffer.
+      llvm::StringRef inFormat;
+      for (Value operand : op->getOperands()) {
+        inFormat = getCbFormatName(operand);
+        if (!inFormat.empty()) {
+          break;
+        }
+      }
+      // An operation with no buffer of its own -- every SFPU operation, which
+      // reads DST -- takes the kernel's.
+      if (inFormat.empty()) {
+        inFormat = ctx.kernelFormat;
+      }
+
+      auto place = [&](Lane lane) {
+        // The table decides where an operation runs, and a missing measurement
+        // does not move it: placing on a lane it does not occupy would invent
+        // work, and skipping one it does occupy because nothing timed it would
+        // drop its ordering and its resource effect along with its time.
+        Engine engine = engineFor(lane);
+        if (!opcost::runsOnEngine(bare, engine)) {
+          return false;
+        }
+
+        std::optional<opcost::Cost> cost =
+            ctx.resolve(op, bare, lane, inFormat);
+        if (cost) {
+          ++report.measuredPlacements;
+        } else if (opcost::getMeasurementCount(bare, engine) > 0) {
+          ++report.unmatchedPlacements;
+        } else {
+          ++report.untimedPlacements;
+        }
+
+        ResourceEffect effect = getResourceEffect(op, lane);
+
+        PlacedOp placed{name.str(), op->getLoc(), getChargedCost(cost),
+                        cost.has_value(), effect};
+        if (placed.effect.kind != ResourceEffect::Kind::None &&
+            placed.effect.tiles > 0) {
+          if (std::optional<uint64_t> capacity = getCbCapacity(op)) {
+            uint64_t &known = cbCapacity[placed.effect.cb];
+            known = std::max(known, *capacity);
+          }
+        }
+        report.lanes[getLaneIndex(lane)].ops.push_back(std::move(placed));
+        return true;
+      };
+
+      bool placed = false;
+      if (dmLane) {
+        // A data-movement kernel compiles for one RISC, so all of its work
+        // lands on that lane; both read the entry's single `dm` slot.
+        placed = place(*dmLane);
+      } else {
+        placed |= place(Lane::Trisc0Unpack);
+        placed |= place(Lane::Trisc1Math);
+        placed |= place(Lane::Trisc2Pack);
+      }
+
+      // The table knows this operation, but not for the kind of kernel it
+      // appeared in. Placing nothing would silently report it as free.
+      if (!placed && !opcost::runsNowhere(bare)) {
+        failToModel(name, op,
+                    "'" + name + "' runs on no lane of a " +
+                        (dmLane ? "data-movement" : "compute") +
+                        " kernel, so it would be left out of every lane");
+      }
+    }
+  }
+
+  /// Capacity in tiles per circular buffer, keyed by compile-time arg index and
+  /// gathered while placing operations.
+  llvm::DenseMap<unsigned, uint64_t> cbCapacity;
+
+  /// DST halves available to MATH. `dst_full_sync_en` collapses them to one.
+  unsigned dstHalves = 2;
+
+  /// Gap keys already diagnosed, so each is reported once per module. See
+  /// failToModel.
+  llvm::StringSet<> reportedGaps;
+
+  /// Set when the module contains anything the estimate cannot account for: an
+  /// operation the cost table does not know, control flow whose outcome is not
+  /// resolved, or a loop that cannot be unrolled. The lanes then describe
+  /// either a different program than the real one or the same program with work
+  /// missing from it, and a latency computed from either is neither an upper
+  /// nor a lower bound on the real one, so estimate() fails rather than
+  /// reporting it.
+  bool cannotModel = false;
+
+  ModuleOp module;
+  Options options;
+};
+
+CostEstimator::CostEstimator(ModuleOp module)
+    : CostEstimator(module, Options{}) {}
+
+CostEstimator::CostEstimator(ModuleOp module, Options options)
+    : impl(std::make_unique<Impl>(module, options)) {}
+
+CostEstimator::~CostEstimator() = default;
+CostEstimator::CostEstimator(CostEstimator &&) noexcept = default;
+CostEstimator &CostEstimator::operator=(CostEstimator &&) noexcept = default;
+
+FailureOr<CostEstimator::Report> CostEstimator::estimate() {
+  return impl->estimate();
+}
+
+} // namespace mlir::tt

--- a/lib/Analysis/CostEstimator.cpp
+++ b/lib/Analysis/CostEstimator.cpp
@@ -12,6 +12,7 @@
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelTraits.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Target/TargetInfo.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -116,9 +117,9 @@ const llvm::StringSet<> &getNonFpuSrcCouplingOps() {
 /// lanes that only configures the unpacker -- can no longer be checked, because
 /// `add_tiles` and `add_tiles_init` are indistinguishable once the call names
 /// are gone.
-bool lanesAllowSrcCoupling(llvm::StringRef name) {
-  return opcost::runsOnEngine(name, Engine::Unpack) &&
-         opcost::runsOnEngine(name, Engine::Math);
+bool lanesAllowSrcCoupling(llvm::StringRef name, opcost::Arch arch) {
+  return opcost::runsOnEngine(name, Engine::Unpack, arch) &&
+         opcost::runsOnEngine(name, Engine::Math, arch);
 }
 
 /// Operations whose MATH half re-initializes the DST pipeline.
@@ -153,7 +154,7 @@ const llvm::StringSet<> &getDstSyncInitOps() {
   return ops;
 }
 
-ResourceEffect getResourceEffect(Operation *op, Lane lane) {
+ResourceEffect getResourceEffect(Operation *op, Lane lane, opcost::Arch arch) {
   llvm::StringRef name = op->getName().stripDialect();
 
   // The Src handshake is the one effect that depends on which lane the
@@ -162,10 +163,10 @@ ResourceEffect getResourceEffect(Operation *op, Lane lane) {
   // `lane`.
   bool coupled = op->hasTrait<ttkernel::TTKernelFPUOpTrait>() ||
                  getNonFpuSrcCouplingOps().contains(name);
-  assert(
-      (!coupled || !opcost::isKnownOp(name) || lanesAllowSrcCoupling(name)) &&
-      "Src coupling disagrees with the operation's lanes: an op that feeds "
-      "SrcA/SrcB has to run on both UNPACK and MATH");
+  assert((!coupled || !opcost::isKnownOp(name, arch) ||
+          lanesAllowSrcCoupling(name, arch)) &&
+         "Src coupling disagrees with the operation's lanes: an op that feeds "
+         "SrcA/SrcB has to run on both UNPACK and MATH");
   if (coupled) {
     if (lane == Lane::Trisc0Unpack) {
       return {ResourceEffect::Kind::SrcProduce, 0, 0};
@@ -297,10 +298,34 @@ Lane getDataMovementLane(func::FuncOp funcOp) {
   return Lane::Ncrisc;
 }
 
-/// Architecture the compiled-in measurements were taken on. Costs do not
-/// transfer across architectures, so a caller that does not know its target
-/// must not use them.
-constexpr llvm::StringLiteral kPerfTableArch("blackhole");
+/// The cost library's name for one ttcore architecture, or nothing when it has
+/// no notion of it.
+///
+/// Costs do not transfer across architectures, so an architecture the library
+/// cannot name is one it cannot answer for -- which is a refusal, not a reason
+/// to fall back on the architecture that happens to have a table.
+std::optional<opcost::Arch> getOpCostArch(ttcore::Arch arch) {
+  switch (arch) {
+  case ttcore::Arch::Blackhole:
+    return opcost::Arch::Blackhole;
+  case ttcore::Arch::WormholeB0:
+    return opcost::Arch::Wormhole;
+  case ttcore::Arch::Quasar:
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+/// Name of an architecture for the report.
+llvm::StringRef getArchName(opcost::Arch arch) {
+  switch (arch) {
+  case opcost::Arch::Blackhole:
+    return "blackhole";
+  case opcost::Arch::Wormhole:
+    return "wormhole";
+  }
+  return "unknown";
+}
 
 /// Data format as the perf CSVs spell it.
 ///
@@ -633,16 +658,18 @@ uint64_t getChargedCost(const std::optional<opcost::Cost> &cost) {
 /// Recomputed from the table rather than stored per placement: it is a property
 /// of the (operation, engine) slot, and a report holds hundreds of thousands of
 /// placements.
-llvm::StringRef getCostSource(llvm::StringRef opName, Engine engine,
-                              bool measured) {
-  if (measured) {
+llvm::StringRef getCostSource(CostEstimator::PlacedOp::Provenance provenance) {
+  switch (provenance) {
+  case CostEstimator::PlacedOp::Provenance::Measured:
     return "meas";
+  // Rows exist that this kernel cannot key, which supplying the missing field
+  // closes; untimed means no rows at all, which waits on a sweep.
+  case CostEstimator::PlacedOp::Provenance::NoMatchingKey:
+    return "nokey";
+  case CostEstimator::PlacedOp::Provenance::Untimed:
+    return "untimed";
   }
-  llvm::StringRef bare = opName;
-  bare.consume_front("ttkernel.");
-  // A slot with rows that none of them match is a key mismatch, which supplying
-  // the missing field closes; a slot with no rows at all is missing data.
-  return opcost::getMeasurementCount(bare, engine) > 0 ? "nokey" : "untimed";
+  return "?";
 }
 
 } // namespace
@@ -689,9 +716,8 @@ std::string CostEstimator::Report::render() const {
       << " unmatched (measured in no configuration this kernel can supply), "
       << untimedPlacements << " untimed (nothing measured them); both charged 0"
       << "\n";
-  opcost::TableStats stats = opcost::getTableStats();
-  out << "  measured on " << kPerfTableArch << " from " << stats.measuredRows
-      << " rows over " << stats.operations
+  out << "  measured on " << arch << " from " << tableRows << " rows over "
+      << tableOperations
       << " operations; per-operation provenance in the detail view\n";
 
   out << "  kernels:";
@@ -773,7 +799,6 @@ std::string CostEstimator::Report::renderDetail() const {
     // be misread as measured throughout.
     out << "    " << llvm::left_justify("op", nameWidth)
         << "  start    end   cost   wait  src\n";
-    Engine engine = engineFor(lane);
     size_t listed =
         std::min<size_t>(laneReport.ops.size(), kMaxListedOpsPerLane);
     for (const PlacedOp &op :
@@ -782,9 +807,7 @@ std::string CostEstimator::Report::renderDetail() const {
           << llvm::format("%7" PRIu64 "%7" PRIu64 "%7" PRIu64 "%7" PRIu64,
                           op.start, op.finish, op.cost, op.stall);
       // Fixed width, so the source position that follows lines up.
-      out << "  "
-          << llvm::left_justify(
-                 getCostSource(op.name, engine, op.measured).str(), 7);
+      out << "  " << llvm::left_justify(getCostSource(op.provenance).str(), 7);
       std::string where = formatLoc(op.loc);
       if (!where.empty()) {
         out << "  [" << where << "]";
@@ -968,6 +991,43 @@ public:
   FailureOr<Report> estimate() {
     Report report;
     uint64_t ttkernelOps = 0;
+
+    // Which architecture the module targets, before any cost is asked for. A
+    // cost is only valid for the architecture it was measured on, and this is
+    // the only place that knows which one the module means -- so an answer that
+    // cannot be had is refused here rather than silently taken from whichever
+    // architecture has a table.
+    std::string reason;
+    FailureOr<std::optional<ttcore::Arch>> targetArch =
+        resolveTargetArch(module, reason);
+    if (failed(targetArch)) {
+      module.emitWarning() << "cost estimator cannot resolve the target "
+                              "architecture: "
+                           << reason;
+      return failure();
+    }
+    if (!*targetArch) {
+      module.emitWarning()
+          << "cost estimator does not know which architecture this module "
+             "targets: no '"
+          << kTargetArchAttrName
+          << "' and no device to read it from. Costs do not transfer between "
+             "architectures, so none is assumed";
+      return failure();
+    }
+    std::optional<opcost::Arch> resolved = getOpCostArch(**targetArch);
+    if (!resolved || !opcost::hasTable(*resolved)) {
+      module.emitWarning()
+          << "cost estimator has no cost table for "
+          << ttcore::stringifyArch(**targetArch)
+          << "; costs are not transferable from another architecture";
+      return failure();
+    }
+    arch = *resolved;
+    report.arch = getArchName(arch);
+    opcost::TableStats stats = opcost::getTableStats(arch);
+    report.tableRows = stats.measuredRows;
+    report.tableOperations = stats.operations;
 
     for (auto funcOp : module.getOps<func::FuncOp>()) {
       auto thread =
@@ -1223,6 +1283,9 @@ private:
     /// Kernel-wide, and not in the IR; see Options::mathFidelity.
     llvm::StringRef mathFidelity;
 
+    /// The module's architecture, resolved once by estimate().
+    const opcost::Arch *arch = nullptr;
+
     /// Input format for the operations that name no buffer; see KernelFormats.
     llvm::StringRef kernelFormat;
 
@@ -1266,7 +1329,8 @@ private:
       auto [it, inserted] = resolved.try_emplace(key);
       if (inserted) {
         opcost::OpKey opKey{inFormat, knobs.knobs};
-        it->second = opcost::lookup(name, engineFor(lane), opKey, config);
+        it->second =
+            opcost::lookup(name, engineFor(lane), opKey, config, *arch);
       }
       return it->second;
     }
@@ -1304,6 +1368,7 @@ private:
     KernelFormats formats = getKernelFormats(funcOp);
     ctx.config = getKernelConfig(funcOp, formats);
     ctx.mathFidelity = options.mathFidelity;
+    ctx.arch = &arch;
     ctx.kernelFormat = formats.in;
     ctx.unpackToDestCbs = getUnpackToDestCbs(funcOp);
 
@@ -1425,7 +1490,7 @@ private:
 
       // Messages keep the qualified name so they can be grepped against the IR.
       llvm::StringRef bare = op->getName().stripDialect();
-      if (!opcost::isKnownOp(bare)) {
+      if (!opcost::isKnownOp(bare, arch)) {
         // Unreachable while the table covers the dialect, which generation
         // enforces by reading the op list out of TTKernelOps.td. Kept because a
         // hand-edited table would otherwise place the operation on no lane at
@@ -1460,24 +1525,28 @@ private:
         // work, and skipping one it does occupy because nothing timed it would
         // drop its ordering and its resource effect along with its time.
         Engine engine = engineFor(lane);
-        if (!opcost::runsOnEngine(bare, engine)) {
+        if (!opcost::runsOnEngine(bare, engine, arch)) {
           return false;
         }
 
         std::optional<opcost::Cost> cost =
             ctx.resolve(op, bare, lane, inFormat);
+        PlacedOp::Provenance provenance;
         if (cost) {
+          provenance = PlacedOp::Provenance::Measured;
           ++report.measuredPlacements;
-        } else if (opcost::getMeasurementCount(bare, engine) > 0) {
+        } else if (opcost::getMeasurementCount(bare, engine, arch) > 0) {
+          provenance = PlacedOp::Provenance::NoMatchingKey;
           ++report.unmatchedPlacements;
         } else {
+          provenance = PlacedOp::Provenance::Untimed;
           ++report.untimedPlacements;
         }
 
-        ResourceEffect effect = getResourceEffect(op, lane);
+        ResourceEffect effect = getResourceEffect(op, lane, arch);
 
         PlacedOp placed{name.str(), op->getLoc(), getChargedCost(cost),
-                        cost.has_value(), effect};
+                        provenance, effect};
         if (placed.effect.kind != ResourceEffect::Kind::None &&
             placed.effect.tiles > 0) {
           if (std::optional<uint64_t> capacity = getCbCapacity(op)) {
@@ -1502,7 +1571,7 @@ private:
 
       // The table knows this operation, but not for the kind of kernel it
       // appeared in. Placing nothing would silently report it as free.
-      if (!placed && !opcost::runsNowhere(bare)) {
+      if (!placed && !opcost::runsNowhere(bare, arch)) {
         failToModel(name, op,
                     "'" + name + "' runs on no lane of a " +
                         (dmLane ? "data-movement" : "compute") +
@@ -1514,6 +1583,9 @@ private:
   /// Capacity in tiles per circular buffer, keyed by compile-time arg index and
   /// gathered while placing operations.
   llvm::DenseMap<unsigned, uint64_t> cbCapacity;
+
+  /// The module's architecture, resolved by estimate() before any placement.
+  opcost::Arch arch = opcost::Arch::Blackhole;
 
   /// DST halves available to MATH. `dst_full_sync_en` collapses them to one.
   unsigned dstHalves = 2;

--- a/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(TTLangTTKernelTransforms
   TTKernelCleanupPatterns.cpp
   TTKernelCombinePackTiles.cpp
+  TTKernelCostEstimate.cpp
   TTKernelInsertInits.cpp
   TTKernelInsertL1Accumulation.cpp
   TTKernelLowerScalarFpTypes.cpp
@@ -10,6 +11,7 @@ add_mlir_dialect_library(TTLangTTKernelTransforms
   TTLangTTLTransformsIncGen
 
   LINK_LIBS PUBLIC
+  TTLangAnalysis
   MLIRArithDialect
   MLIRFuncDialect
   MLIRFuncTransforms

--- a/lib/Dialect/TTKernel/Transforms/TTKernelCostEstimate.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelCostEstimate.cpp
@@ -35,11 +35,26 @@ struct TTKernelCostEstimatePass
       TTKernelCostEstimatePass>::TTKernelCostEstimateBase;
 
   void runOnOperation() override {
-    // Nothing below signals pass failure. The estimate is opt-in and mutates
-    // nothing, so a program the estimator cannot account for is a gap in the
-    // estimator, not a reason to fail a compile that would otherwise succeed.
-    // The analysis warns at each operation responsible; this pass reports that
-    // no estimate is coming and lets the pipeline continue.
+    // The detail view is part of the report, so asking for it with the estimate
+    // disabled asks for something that cannot exist. Refused rather than
+    // ignored: a caller who typed it wants the tables, and silence would look
+    // like the kernel had nothing to say.
+    if (detail && !enable) {
+      getOperation().emitError()
+          << "cost estimate detail was requested with the estimate disabled: "
+             "pass 'enable' to produce a report for it to add to";
+      signalPassFailure();
+      return;
+    }
+    if (!enable) {
+      return;
+    }
+
+    // Nothing past here signals pass failure. The estimate is opt-in and
+    // mutates nothing, so a program the estimator cannot account for is a gap
+    // in the estimator, not a reason to fail a compile that would otherwise
+    // succeed. The analysis warns at each operation responsible; this pass
+    // reports that no estimate is coming and lets the pipeline continue.
     std::string text;
 
     CostEstimator::Options options;

--- a/lib/Dialect/TTKernel/Transforms/TTKernelCostEstimate.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelCostEstimate.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//===----------------------------------------------------------------------===//
+// TTKernelCostEstimate Pass
+//===----------------------------------------------------------------------===//
+//
+// Runs the CostEstimator analysis and reports the per-core work split. The
+// pass is a placement wrapper only: it owns where in the pipeline the estimate
+// happens and where the report goes, while the analysis itself stays reusable
+// by any other consumer.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ttlang/Analysis/CostEstimator.h"
+#include "ttlang/Dialect/TTL/Passes.h"
+
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "ttkernel-cost-estimate"
+
+namespace mlir::tt::ttl {
+
+#define GEN_PASS_DEF_TTKERNELCOSTESTIMATE
+#include "ttlang/Dialect/TTL/Passes.h.inc"
+
+namespace {
+
+struct TTKernelCostEstimatePass
+    : public impl::TTKernelCostEstimateBase<TTKernelCostEstimatePass> {
+  using impl::TTKernelCostEstimateBase<
+      TTKernelCostEstimatePass>::TTKernelCostEstimateBase;
+
+  void runOnOperation() override {
+    // Nothing below signals pass failure. The estimate is opt-in and mutates
+    // nothing, so a program the estimator cannot account for is a gap in the
+    // estimator, not a reason to fail a compile that would otherwise succeed.
+    // The analysis warns at each operation responsible; this pass reports that
+    // no estimate is coming and lets the pipeline continue.
+    std::string text;
+
+    CostEstimator::Options options;
+    // The IR does not carry math fidelity, so the rows keyed on it can only be
+    // reached by a caller that knows the value. Left empty they stay unmatched,
+    // which the report counts.
+    options.mathFidelity = mathFidelity;
+
+    CostEstimator estimator(getOperation(), options);
+    FailureOr<CostEstimator::Report> report = estimator.estimate();
+    if (failed(report)) {
+      text = "cost estimate: unavailable, see the warnings above\n";
+    } else {
+      // Summary only by default. The per-operation views are opt-in because a
+      // kernel whose loops unroll to tens of thousands of operations produces a
+      // report far longer than anyone reads.
+      text = report->render();
+      if (detail) {
+        text += report->renderDetail() + "\n" + report->renderTimeline();
+      }
+    }
+
+    if (outputPath.empty()) {
+      llvm::outs() << text;
+      return;
+    }
+
+    std::error_code error;
+    llvm::raw_fd_ostream out(outputPath, error, llvm::sys::fs::OF_Text);
+    if (error) {
+      // The report is a side output, so losing it does not invalidate the
+      // compile either. Say where it went instead of dropping it silently.
+      getOperation().emitWarning()
+          << "cannot write cost estimate to '" << outputPath
+          << "': " << error.message() << "; writing it to stdout instead";
+      llvm::outs() << text;
+      return;
+    }
+    out << text;
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/IR/CMakeLists.txt
+++ b/lib/Dialect/TTL/IR/CMakeLists.txt
@@ -16,5 +16,4 @@ add_mlir_dialect_library(MLIRTTLDialect
     MLIRIndexingMapOpInterface
     MLIRTTCoreDialect
     MLIRTilingInterface
-    TTLangAnalysis
 )

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -98,6 +98,13 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
     pm.addPass(createCanonicalizerPass());
     pm.addPass(createCSEPass());
   }
+  {
+    TTKernelCostEstimateOptions estimateOpts;
+    estimateOpts.enable = options.costEstimate;
+    estimateOpts.detail = options.costEstimateDetail;
+    estimateOpts.mathFidelity = options.costEstimateMathFidelity;
+    pm.addPass(createTTKernelCostEstimate(estimateOpts));
+  }
   if (options.lowerToEmitC) {
     pm.addPass(createLowerAffinePass());
     pm.addPass(::mlir::tt::createConvertTTKernelToEmitC());

--- a/python/ttl/compiler_options.py
+++ b/python/ttl/compiler_options.py
@@ -163,6 +163,24 @@ def _make_parser() -> argparse.ArgumentParser:
         "removed (ttkernel-specialize-cores). Opt-in (default: disabled).",
     )
     p.add_argument(
+        "--ttl-cost-estimate",
+        default=None,
+        dest="cost_estimate",
+        action=argparse.BooleanOptionalAction,
+        help="Report how the program's work splits across the five RISCs of a "
+        "Tensix core, read from TTKernel IR just before EmitC conversion "
+        "(ttkernel-cost-estimate). Non-mutating. Opt-in (default: disabled).",
+    )
+    p.add_argument(
+        "--ttl-cost-estimate-detail",
+        default=None,
+        dest="cost_estimate_detail",
+        action=argparse.BooleanOptionalAction,
+        help="Add per-lane operation tables and an event-boundary timeline to "
+        "the cost estimate. Capped, but still long. Requires "
+        "--ttl-cost-estimate.",
+    )
+    p.add_argument(
         "--ttl-l1-budget",
         default=None,
         dest="l1_budget",
@@ -226,6 +244,8 @@ class CompilerOptions:
     reuse_user_dfbs: bool = True
     dfb_exact_coloring_search_limit: int = 1_000_000
     specialize_cores: bool = False
+    cost_estimate: bool = False
+    cost_estimate_detail: bool = False
     l1_budget: int = dataclasses.field(default=0, compare=False, hash=False)
 
     # Fields that were explicitly provided (not defaulted). Excluded from

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -2438,23 +2438,26 @@ def _lower_program_to_kernel(
             ]
         # Runs last in the TTKernel stage: after the passes that create the ops
         # it reads, and before EmitC conversion turns circular-buffer calls into
-        # opaque verbatim strings. The measurements the estimate draws on are
-        # keyed on math fidelity, which the IR does not carry, so it is passed
-        # through here rather than recovered there.
-        if compiler_options.cost_estimate or compiler_options.cost_estimate_detail:
-            # Both flags go through as they were given, including the case where
-            # the detail view was asked for without the estimate: the pass
-            # rejects that pair, so the rule lives with the options it governs
-            # rather than being restated here.
-            estimate_options = [
-                f"enable={int(compiler_options.cost_estimate)}",
-                f"detail={int(compiler_options.cost_estimate_detail)}",
-            ]
-            if math_fidelity:
-                estimate_options.append(f"math-fidelity={math_fidelity}")
-            pipeline_passes.append(
-                "ttkernel-cost-estimate{" + " ".join(estimate_options) + "}"
-            )
+        # opaque verbatim strings. Always in the list and gated on its own
+        # `enable`, which is how ttl-to-ttkernel-pipeline carries it too, so both
+        # pipelines have one shape and a disabled estimate costs a pass that
+        # returns immediately.
+        #
+        # Both flags go through as they were given, including the case where the
+        # detail view was asked for without the estimate: the pass rejects that
+        # pair, so the rule lives with the options it governs rather than being
+        # restated here. Math fidelity is passed only when set, since the
+        # measurements keyed on it are unreachable without it and the IR does not
+        # carry it.
+        estimate_options = [
+            f"enable={int(compiler_options.cost_estimate)}",
+            f"detail={int(compiler_options.cost_estimate_detail)}",
+        ]
+        if math_fidelity:
+            estimate_options.append(f"math-fidelity={math_fidelity}")
+        pipeline_passes.append(
+            "ttkernel-cost-estimate{" + " ".join(estimate_options) + "}"
+        )
         pipeline_passes += [
             "convert-ttkernel-to-emitc",
             "symbol-dce",

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -2441,9 +2441,15 @@ def _lower_program_to_kernel(
         # opaque verbatim strings. The measurements the estimate draws on are
         # keyed on math fidelity, which the IR does not carry, so it is passed
         # through here rather than recovered there.
-        if compiler_options.cost_estimate:
-            detail = int(compiler_options.cost_estimate_detail)
-            estimate_options = [f"detail={detail}"]
+        if compiler_options.cost_estimate or compiler_options.cost_estimate_detail:
+            # Both flags go through as they were given, including the case where
+            # the detail view was asked for without the estimate: the pass
+            # rejects that pair, so the rule lives with the options it governs
+            # rather than being restated here.
+            estimate_options = [
+                f"enable={int(compiler_options.cost_estimate)}",
+                f"detail={int(compiler_options.cost_estimate_detail)}",
+            ]
             if math_fidelity:
                 estimate_options.append(f"math-fidelity={math_fidelity}")
             pipeline_passes.append(

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -2436,6 +2436,19 @@ def _lower_program_to_kernel(
                 "canonicalize",
                 "cse",
             ]
+        # Runs last in the TTKernel stage: after the passes that create the ops
+        # it reads, and before EmitC conversion turns circular-buffer calls into
+        # opaque verbatim strings. The measurements the estimate draws on are
+        # keyed on math fidelity, which the IR does not carry, so it is passed
+        # through here rather than recovered there.
+        if compiler_options.cost_estimate:
+            detail = int(compiler_options.cost_estimate_detail)
+            estimate_options = [f"detail={detail}"]
+            if math_fidelity:
+                estimate_options.append(f"math-fidelity={math_fidelity}")
+            pipeline_passes.append(
+                "ttkernel-cost-estimate{" + " ".join(estimate_options) + "}"
+            )
         pipeline_passes += [
             "convert-ttkernel-to-emitc",
             "symbol-dce",

--- a/test/ttlang/Analysis/cost_estimator.mlir
+++ b/test/ttlang/Analysis/cost_estimator.mlir
@@ -12,7 +12,7 @@
 // test for the table wiring: a lookup that stops matching shows up as a column
 // flipping away from meas.
 
-module {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @read() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32} {
     %c4_i32 = arith.constant 4 : i32
     %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Analysis/cost_estimator.mlir
+++ b/test/ttlang/Analysis/cost_estimator.mlir
@@ -1,0 +1,97 @@
+// RUN: ttlang-opt --ttkernel-cost-estimate=detail=1 %s -o /dev/null 2>&1 | FileCheck %s
+
+// Three kernel threads over two input CBs and one output, four tiles per block.
+// The reader and writer only move credits, which is all the compute kernel needs
+// to get past cb_wait_front; the point is the cost table and the credit model,
+// not the data movement.
+//
+// Every op here is in the cost table, so the estimate is produced rather than
+// failed, and the per-op `src` column shows what backs each cost: `meas` a
+// measurement keyed to this kernel, `nokey` one taken in a configuration this
+// kernel cannot key, `untimed` an engine no sweep timed. This is the regression
+// test for the table wiring: a lookup that stops matching shows up as a column
+// flipping away from meas.
+
+module {
+  func.func @read() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32} {
+    %c4_i32 = arith.constant 4 : i32
+    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    ttkernel.cb_reserve_back(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_reserve_back(%2, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.noc_async_read_barrier() : () -> ()
+    ttkernel.cb_push_back(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_push_back(%2, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    return
+  }
+
+  func.func @compute() attributes {dst_full_sync_en = false, fp32_dest_acc_en = false, ttkernel.thread = #ttkernel.thread<compute>} {
+    %c3 = arith.constant 3 : index
+    %c2 = arith.constant 2 : index
+    %c4_i32 = arith.constant 4 : i32
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    ttkernel.cb_wait_front(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_wait_front(%2, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_reserve_back(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.binary_op_init_common(%0, %2, %1) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>) -> ()
+    ttkernel.tile_regs_acquire() : () -> ()
+    ttkernel.add_tiles_init(%0, %2) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>) -> ()
+    ttkernel.add_tiles(%0, %2, %c0, %c0, %c0) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index, index) -> ()
+    ttkernel.add_tiles(%0, %2, %c1, %c1, %c1) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index, index) -> ()
+    ttkernel.add_tiles(%0, %2, %c2, %c2, %c2) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index, index) -> ()
+    ttkernel.add_tiles(%0, %2, %c3, %c3, %c3) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index, index) -> ()
+    ttkernel.tile_regs_commit() : () -> ()
+    ttkernel.tile_regs_wait() : () -> ()
+    ttkernel.pack_tile(%c0, %1, %c0, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.pack_tile(%c1, %1, %c1, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.pack_tile(%c2, %1, %c2, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.pack_tile(%c3, %1, %c3, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.tile_regs_release() : () -> ()
+    ttkernel.cb_push_back(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_pop_front(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_pop_front(%2, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    return
+  }
+
+  func.func @write() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32} {
+    %c4_i32 = arith.constant 4 : i32
+    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    ttkernel.cb_wait_front(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.noc_async_write_barrier() : () -> ()
+    ttkernel.cb_pop_front(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    return
+  }
+}
+
+// The three threads are recognized and none of them deadlocks. Nothing here is
+// keyed on a field this kernel cannot supply, so the placements that carry no
+// cost are all untimed ones -- the circular-buffer and DST handshakes.
+// CHECK: cost estimate: {{[0-9]+}} of {{[0-9]+}} placements measured
+// CHECK-NEXT: 0 unmatched {{.*}} untimed
+// CHECK: kernels: read compute write
+
+// Both halves of the eltwise add are measured on both engines. That is what
+// splitting the benchmark's init zones bought: an init whose halves are
+// separately attributed, where a lumped zone leaves one of these columns
+// unattributed.
+// CHECK: TRISC0 unpack
+// CHECK: ttkernel.binary_op_init_common {{.*}} meas
+// CHECK: ttkernel.add_tiles_init {{.*}} meas
+// CHECK: ttkernel.add_tiles {{.*}} meas
+
+// MATH trails UNPACK by the Src bank credit rather than running with it.
+// CHECK: TRISC1 math
+// CHECK: ttkernel.binary_op_init_common {{.*}} meas
+// CHECK: ttkernel.add_tiles {{.*}} meas
+
+// The credit operations are the untimed ones: no perf source isolates a
+// handshake, so they cost nothing and are counted apart from the measured work.
+// CHECK: ttkernel.tile_regs_commit {{.*}} untimed
+
+// CHECK: TRISC2 pack
+// CHECK: ttkernel.binary_op_init_common {{.*}} meas
+// CHECK: ttkernel.pack_tile {{.*}} meas

--- a/test/ttlang/Analysis/cost_estimator.mlir
+++ b/test/ttlang/Analysis/cost_estimator.mlir
@@ -1,4 +1,10 @@
-// RUN: ttlang-opt --ttkernel-cost-estimate=detail=1 %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: ttlang-opt --ttkernel-cost-estimate='enable=1 detail=1' %s -o /dev/null 2>&1 | FileCheck %s
+// The detail view is part of the report, so asking for it without the
+// estimate is refused rather than ignored.
+// RUN: not ttlang-opt --ttkernel-cost-estimate='detail=1' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=NOENABLE
+// NOENABLE: error: cost estimate detail was requested with the estimate disabled
+// NOENABLE-SAME: pass 'enable'
+// NOENABLE-NOT: cost estimate:
 
 // Three kernel threads over two input CBs and one output, four tiles per block.
 // The reader and writer only move credits, which is all the compute kernel needs

--- a/test/ttlang/Analysis/cost_estimator_copy_tile.mlir
+++ b/test/ttlang/Analysis/cost_estimator_copy_tile.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt --ttkernel-cost-estimate=detail=1 %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: ttlang-opt --ttkernel-cost-estimate='enable=1 detail=1' %s -o /dev/null 2>&1 | FileCheck %s
 
 // The unary datacopy path, which the eltwise test in this directory does not
 // reach. Its three compute ops are the ones perf_copy_tile measures, and every

--- a/test/ttlang/Analysis/cost_estimator_copy_tile.mlir
+++ b/test/ttlang/Analysis/cost_estimator_copy_tile.mlir
@@ -1,0 +1,81 @@
+// RUN: ttlang-opt --ttkernel-cost-estimate=detail=1 %s -o /dev/null 2>&1 | FileCheck %s
+
+// The unary datacopy path, which the eltwise test in this directory does not
+// reach. Its three compute ops are the ones perf_copy_tile measures, and every
+// row it left behind is keyed on `unpack_to_dest` -- a per-buffer decision, not
+// a kernel-wide one, and worth a factor of three on unpack. This kernel lists no
+// buffer in `ttl.unpack_to_dest_fp32`, so the answer is false for each of them
+// and copy_tile costs 42 on unpack rather than the 121 a listed buffer would.
+
+module {
+  func.func @read() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32} {
+    %c4_i32 = arith.constant 4 : i32
+    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    ttkernel.cb_reserve_back(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.noc_async_read_barrier() : () -> ()
+    ttkernel.cb_push_back(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    return
+  }
+
+  func.func @compute() attributes {dst_full_sync_en = false, fp32_dest_acc_en = false, ttkernel.thread = #ttkernel.thread<compute>} {
+    %c3 = arith.constant 3 : index
+    %c2 = arith.constant 2 : index
+    %c4_i32 = arith.constant 4 : i32
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    ttkernel.cb_wait_front(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_reserve_back(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.compute_kernel_hw_startup(%0, %1) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>) -> ()
+    ttkernel.tile_regs_acquire() : () -> ()
+    ttkernel.copy_tile_init(%0) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>) -> ()
+    ttkernel.copy_tile(%0, %c0, %c0) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index) -> ()
+    ttkernel.copy_tile(%0, %c1, %c1) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index) -> ()
+    ttkernel.copy_tile(%0, %c2, %c2) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index) -> ()
+    ttkernel.copy_tile(%0, %c3, %c3) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index, index) -> ()
+    ttkernel.tile_regs_commit() : () -> ()
+    ttkernel.tile_regs_wait() : () -> ()
+    ttkernel.pack_tile(%c0, %1, %c0, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.pack_tile(%c1, %1, %c1, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.pack_tile(%c2, %1, %c2, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.pack_tile(%c3, %1, %c3, true) : (index, !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.tile_regs_release() : () -> ()
+    ttkernel.cb_push_back(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.cb_pop_front(%0, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    return
+  }
+
+  func.func @write() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32} {
+    %c4_i32 = arith.constant 4 : i32
+    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>
+    ttkernel.cb_wait_front(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.noc_async_write_barrier() : () -> ()
+    ttkernel.cb_pop_front(%1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    return
+  }
+}
+
+// CHECK: cost estimate: {{[0-9]+}} of {{[0-9]+}} placements measured
+// CHECK-NEXT: 0 unmatched {{.*}} untimed
+// CHECK: kernels: read compute write
+
+// Every compute op on every lane is measured. That is what splitting the
+// benchmark's init zone bought: an init whose halves are separately attributed,
+// where a lumped zone leaves one of these two columns unattributed.
+// CHECK: TRISC0 unpack
+// CHECK: ttkernel.compute_kernel_hw_startup {{.*}} meas
+// CHECK: ttkernel.copy_tile_init {{.*}} meas
+// CHECK: ttkernel.copy_tile {{.*}} 42 {{.*}} meas
+
+// CHECK: TRISC1 math
+// CHECK: ttkernel.compute_kernel_hw_startup {{.*}} meas
+// CHECK: ttkernel.copy_tile_init {{.*}} meas
+// CHECK: ttkernel.copy_tile {{.*}} meas
+
+// The pack lane's init zone was left unsplit because copy_tile_init has no pack
+// half; the zone is compute_kernel_hw_startup's three pack calls exactly, which
+// is why it is attributable without a split.
+// CHECK: TRISC2 pack
+// CHECK: ttkernel.compute_kernel_hw_startup {{.*}} meas
+// CHECK: ttkernel.pack_tile {{.*}} meas

--- a/test/ttlang/Analysis/cost_estimator_copy_tile.mlir
+++ b/test/ttlang/Analysis/cost_estimator_copy_tile.mlir
@@ -7,7 +7,7 @@
 // buffer in `ttl.unpack_to_dest_fp32`, so the answer is false for each of them
 // and copy_tile costs 42 on unpack rather than the 121 a listed buffer would.
 
-module {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @read() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32} {
     %c4_i32 = arith.constant 4 : i32
     %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Analysis/cost_estimator_knobs.mlir
+++ b/test/ttlang/Analysis/cost_estimator_knobs.mlir
@@ -120,26 +120,27 @@ module {
 // comes from the kernel's buffers, which here all hold bf16.
 //
 // Three shapes, and the middle one is why the clamp has to be answered: the same
-// approximate exponential costs 112 clamped and 29 with the check skipped. The
+// approximate exponential costs 112 clamped and 29 with the check skipped, and
+// its init moves the other way, 85 against 132. The
 // last pair carries no attributes at all, which is what tt-lang emits for a plain
 // `ttl.exp` -- the Python wrapper drops every flag left at its default -- so the
 // knobs answer metal's defaults on its behalf and it lands on the exact,
 // clamped path at 73 and 152.
 // UNKEYED: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
 // UNKEYED-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
-// UNKEYED-NEXT: ttkernel.exp_tile_init {{.*}} 129 {{.*}} meas
+// UNKEYED-NEXT: ttkernel.exp_tile_init {{.*}} 132 {{.*}} meas
 // UNKEYED-NEXT: ttkernel.exp_tile {{.*}} 29 {{.*}} meas
 // UNKEYED-NEXT: ttkernel.exp_tile_init {{.*}} 73 {{.*}} meas
 // UNKEYED-NEXT: ttkernel.exp_tile {{.*}} 152 {{.*}} meas
 // HIFI4: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
 // HIFI4-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
-// HIFI4-NEXT: ttkernel.exp_tile_init {{.*}} 129 {{.*}} meas
+// HIFI4-NEXT: ttkernel.exp_tile_init {{.*}} 132 {{.*}} meas
 // HIFI4-NEXT: ttkernel.exp_tile {{.*}} 29 {{.*}} meas
 // HIFI4-NEXT: ttkernel.exp_tile_init {{.*}} 73 {{.*}} meas
 // HIFI4-NEXT: ttkernel.exp_tile {{.*}} 152 {{.*}} meas
 // LOFI: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
 // LOFI-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
-// LOFI-NEXT: ttkernel.exp_tile_init {{.*}} 129 {{.*}} meas
+// LOFI-NEXT: ttkernel.exp_tile_init {{.*}} 132 {{.*}} meas
 // LOFI-NEXT: ttkernel.exp_tile {{.*}} 29 {{.*}} meas
 // LOFI-NEXT: ttkernel.exp_tile_init {{.*}} 73 {{.*}} meas
 // LOFI-NEXT: ttkernel.exp_tile {{.*}} 152 {{.*}} meas

--- a/test/ttlang/Analysis/cost_estimator_knobs.mlir
+++ b/test/ttlang/Analysis/cost_estimator_knobs.mlir
@@ -1,6 +1,6 @@
-// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=UNKEYED
-// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1 math-fidelity=HiFi4})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=HIFI4
-// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1 math-fidelity=LoFi})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=LOFI
+// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{enable=1 detail=1})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=UNKEYED
+// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{enable=1 detail=1 math-fidelity=HiFi4})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=HIFI4
+// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{enable=1 detail=1 math-fidelity=LoFi})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=LOFI
 
 // The knobs a measurement can be keyed on, and where each one comes from.
 //

--- a/test/ttlang/Analysis/cost_estimator_knobs.mlir
+++ b/test/ttlang/Analysis/cost_estimator_knobs.mlir
@@ -17,7 +17,7 @@
 // lib/Analysis/CostTableBlackhole.inc rather than off this test's failure, since
 // the point of each is which row it came from.
 
-module {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
       dst_full_sync_en = false,
       fp32_dest_acc_en = false,

--- a/test/ttlang/Analysis/cost_estimator_knobs.mlir
+++ b/test/ttlang/Analysis/cost_estimator_knobs.mlir
@@ -1,0 +1,149 @@
+// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=UNKEYED
+// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1 math-fidelity=HiFi4})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=HIFI4
+// RUN: ttlang-opt --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1 math-fidelity=LoFi})' %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=LOFI
+
+// The knobs a measurement can be keyed on, and where each one comes from.
+//
+// TTLangOpCost keys its rows on more than the operation and the data format,
+// and it cannot guess: a row naming a knob the caller did not answer is
+// unmatchable. This kernel exercises all three origins in one function -- the
+// reduce attributes (`mathop`, `reduce_pool_type`), the SFPU exponential's own
+// attributes (`approx_mode`, `iterations`, `input_clamping`), and math fidelity,
+// which the IR does not carry and the pass option supplies.
+//
+// The costs below are the table's own numbers, so a lookup that stops matching
+// shows up as a cost changing rather than as a column no one reads. They move
+// when the table is regenerated -- read the new ones out of
+// lib/Analysis/CostTableBlackhole.inc rather than off this test's failure, since
+// the point of each is which row it came from.
+
+module {
+  func.func @compute() attributes {
+      dst_full_sync_en = false,
+      fp32_dest_acc_en = false,
+      ttkernel.thread = #ttkernel.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %cb0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>
+    %cb1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>
+    %cb2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>
+
+    ttkernel.tile_regs_acquire() : () -> ()
+
+    // Reduce over rows, summing: the pair of attributes the table calls
+    // `mathop` and `reduce_pool_type`. Both halves of the reduce read them, and
+    // the math half is keyed on fidelity as well.
+    ttkernel.reduce_init(%cb0, %cb1, %cb2, <reduce_sum>, <reduce_dim_row>) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>) -> ()
+    ttkernel.reduce_tile(%cb0, %cb1, %c0, %c0, %c0, <reduce_sum>, <reduce_dim_row>) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, index, index, index) -> ()
+
+    // An FPU multiply, whose math cost spans a factor of four across the four
+    // fidelities and whose unpack cost does not depend on them at all.
+    ttkernel.mul_tiles_init(%cb0, %cb1) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>) -> ()
+    ttkernel.mul_tiles(%cb0, %cb1, %c0, %c0, %c0) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, index, index, index) -> ()
+
+    // The approximate exponential, at metal's default trip count and default
+    // clamping. Fidelity does not reach the SFPU, so these match whether or not
+    // it was supplied.
+    ttkernel.exp_tile_init() {approx = true} : () -> ()
+    ttkernel.exp_tile(%c0) {approx = true, iterations = 8 : i32} : (index) -> ()
+
+    // The same approximate exponential with the clamp turned off, which is the
+    // one flag on this operation worth a factor of four: skipping the check on
+    // very negative inputs takes the tile from 112 cycles to 29.
+    ttkernel.exp_tile_init() {approx = true, input_clamping = #ttkernel.input_clamping<none>} : () -> ()
+    ttkernel.exp_tile(%c0) {approx = true, iterations = 8 : i32, input_clamping = #ttkernel.input_clamping<none>} : (index) -> ()
+
+    // The same operation with no attributes at all, which is what tt-lang emits
+    // for a plain `ttl.exp`: the Python wrapper drops every flag left at its
+    // default, so the op lowers to a bare `exp_tile(idst)` compiled with metal's
+    // approx=false and iterations=8. The knobs have to answer those defaults or
+    // the ordinary case is the one that misses.
+    ttkernel.exp_tile_init() : () -> ()
+    ttkernel.exp_tile(%c0) : (index) -> ()
+
+    ttkernel.tile_regs_commit() : () -> ()
+    ttkernel.tile_regs_wait() : () -> ()
+    ttkernel.pack_tile(%c0, %cb2, %c0, true) : (index, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, index) -> ()
+    ttkernel.tile_regs_release() : () -> ()
+    return
+  }
+}
+
+// Without fidelity the three rows keyed on it are unmatched rather than
+// answered at some other fidelity's cost, and they are counted apart from the
+// four DST handshakes, which no sweep timed at all.
+// UNKEYED: cost estimate: 12 of 20 placements measured
+// UNKEYED-NEXT: 4 unmatched {{.*}}, 4 untimed
+// HIFI4: cost estimate: 16 of 20 placements measured
+// HIFI4-NEXT: 0 unmatched {{.*}}, 4 untimed
+// LOFI: cost estimate: 16 of 20 placements measured
+// LOFI-NEXT: 0 unmatched {{.*}}, 4 untimed
+
+// The unpack halves do not depend on fidelity, so all three runs agree on them.
+// Both reduce halves need `mathop` and `reduce_pool_type`: recovered here from
+// reduce_dim and reduce_type, and unanswerable from the operation's name alone.
+// UNKEYED: TRISC0 unpack
+// UNKEYED: ttkernel.reduce_init {{.*}} 72 {{.*}} meas
+// UNKEYED: ttkernel.reduce_tile {{.*}} 37 {{.*}} meas
+// UNKEYED: ttkernel.mul_tiles {{.*}} 37 {{.*}} meas
+// HIFI4: TRISC0 unpack
+// HIFI4: ttkernel.reduce_init {{.*}} 72 {{.*}} meas
+// HIFI4: ttkernel.reduce_tile {{.*}} 37 {{.*}} meas
+// HIFI4: ttkernel.mul_tiles {{.*}} 37 {{.*}} meas
+// LOFI: TRISC0 unpack
+// LOFI: ttkernel.reduce_init {{.*}} 72 {{.*}} meas
+// LOFI: ttkernel.reduce_tile {{.*}} 37 {{.*}} meas
+// LOFI: ttkernel.mul_tiles {{.*}} 37 {{.*}} meas
+
+// Math is where fidelity lands, for all four of this kernel's math rows.
+// `nokey` says a measurement exists that this kernel cannot key, which supplying
+// the fidelity closes; the rows then carry LoFi's numbers, a third of HiFi4's for
+// the multiply.
+// UNKEYED: TRISC1 math
+// UNKEYED: ttkernel.reduce_init {{.*}} nokey
+// UNKEYED: ttkernel.reduce_tile {{.*}} nokey
+// UNKEYED: ttkernel.mul_tiles_init {{.*}} nokey
+// UNKEYED: ttkernel.mul_tiles {{.*}} nokey
+// HIFI4: TRISC1 math
+// HIFI4: ttkernel.reduce_init {{.*}} 134 {{.*}} meas
+// HIFI4: ttkernel.reduce_tile {{.*}} 52 {{.*}} meas
+// HIFI4: ttkernel.mul_tiles_init {{.*}} 86 {{.*}} meas
+// HIFI4: ttkernel.mul_tiles {{.*}} 84 {{.*}} meas
+// LOFI: TRISC1 math
+// LOFI: ttkernel.reduce_init {{.*}} 133 {{.*}} meas
+// LOFI: ttkernel.reduce_tile {{.*}} 15 {{.*}} meas
+// LOFI: ttkernel.mul_tiles_init {{.*}} 87 {{.*}} meas
+// LOFI: ttkernel.mul_tiles {{.*}} 19 {{.*}} meas
+
+// The exponential's own attributes reach the table, and its cost does not depend
+// on fidelity: approximate at metal's default trip count is 29 against the exact
+// path's 152. It names no circular buffer at all, so the format it was keyed on
+// comes from the kernel's buffers, which here all hold bf16.
+//
+// Three shapes, and the middle one is why the clamp has to be answered: the same
+// approximate exponential costs 112 clamped and 29 with the check skipped. The
+// last pair carries no attributes at all, which is what tt-lang emits for a plain
+// `ttl.exp` -- the Python wrapper drops every flag left at its default -- so the
+// knobs answer metal's defaults on its behalf and it lands on the exact,
+// clamped path at 73 and 152.
+// UNKEYED: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
+// UNKEYED-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
+// UNKEYED-NEXT: ttkernel.exp_tile_init {{.*}} 129 {{.*}} meas
+// UNKEYED-NEXT: ttkernel.exp_tile {{.*}} 29 {{.*}} meas
+// UNKEYED-NEXT: ttkernel.exp_tile_init {{.*}} 73 {{.*}} meas
+// UNKEYED-NEXT: ttkernel.exp_tile {{.*}} 152 {{.*}} meas
+// HIFI4: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
+// HIFI4-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
+// HIFI4-NEXT: ttkernel.exp_tile_init {{.*}} 129 {{.*}} meas
+// HIFI4-NEXT: ttkernel.exp_tile {{.*}} 29 {{.*}} meas
+// HIFI4-NEXT: ttkernel.exp_tile_init {{.*}} 73 {{.*}} meas
+// HIFI4-NEXT: ttkernel.exp_tile {{.*}} 152 {{.*}} meas
+// LOFI: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
+// LOFI-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
+// LOFI-NEXT: ttkernel.exp_tile_init {{.*}} 129 {{.*}} meas
+// LOFI-NEXT: ttkernel.exp_tile {{.*}} 29 {{.*}} meas
+// LOFI-NEXT: ttkernel.exp_tile_init {{.*}} 73 {{.*}} meas
+// LOFI-NEXT: ttkernel.exp_tile {{.*}} 152 {{.*}} meas
+
+// The DST handshakes are the untimed four: no perf source isolates a handshake,
+// so they are modelled as pure synchronization and charged nothing.
+// HIFI4: ttkernel.tile_regs_commit {{.*}} untimed

--- a/test/ttlang/Analysis/cost_estimator_loop.mlir
+++ b/test/ttlang/Analysis/cost_estimator_loop.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt --split-input-file --ttkernel-cost-estimate=detail=1 %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: ttlang-opt --split-input-file --ttkernel-cost-estimate='enable=1 detail=1' %s -o /dev/null 2>&1 | FileCheck %s
 
 // Loops, which the estimator unrolls in place rather than costing once.
 //

--- a/test/ttlang/Analysis/cost_estimator_loop.mlir
+++ b/test/ttlang/Analysis/cost_estimator_loop.mlir
@@ -10,7 +10,7 @@
 // threads are added to supply the credits, since a compute kernel waiting on
 // buffers nothing fills would deadlock rather than be estimated.
 
-module {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @read() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32} {
     %c6_i32 = arith.constant 6 : i32
     %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, f32>>
@@ -111,7 +111,7 @@ module {
 // some arbitrary number of times. The trip count arrives as a function argument
 // here to keep the refusal to one cause; a compute kernel reading it through
 // `ttkernel.get_common_arg_val` would fail for a second, unrelated reason.
-module {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute(%trip: index) attributes {dst_full_sync_en = false, fp32_dest_acc_en = false, ttkernel.thread = #ttkernel.thread<compute>} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index

--- a/test/ttlang/Analysis/cost_estimator_loop.mlir
+++ b/test/ttlang/Analysis/cost_estimator_loop.mlir
@@ -1,0 +1,138 @@
+// RUN: ttlang-opt --split-input-file --ttkernel-cost-estimate=detail=1 %s -o /dev/null 2>&1 | FileCheck %s
+
+// Loops, which the estimator unrolls in place rather than costing once.
+//
+// The compute function here is real lowered IR, not hand-written: it is
+// test/ttlang/Conversion/TTLToTTKernel/fpu_binary_lowering.mlir's f32 add+tanh
+// kernel run through ttl-subblock-compute-for-dst and convert-ttl-to-ttkernel,
+// so the loop is a genuine subblock loop over a 2x3 block with the
+// affine.linearize_index tile addressing that pass emits. Reader and writer
+// threads are added to supply the credits, since a compute kernel waiting on
+// buffers nothing fills would deadlock rather than be estimated.
+
+module {
+  func.func @read() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 0 : i32} {
+    %c6_i32 = arith.constant 6 : i32
+    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, f32>>
+    %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, f32>>
+    ttkernel.cb_reserve_back(%0, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    ttkernel.cb_reserve_back(%2, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    ttkernel.noc_async_read_barrier() : () -> ()
+    ttkernel.cb_push_back(%0, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    ttkernel.cb_push_back(%2, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    return
+  }
+
+  func.func @compute() attributes {dst_full_sync_en = false, fp32_dest_acc_en = true, ttkernel.thread = #ttkernel.thread<compute>, ttl.unpack_to_dest_fp32 = array<i32>} {
+    %c3_i32 = arith.constant 3 : i32
+    %c6_i32 = arith.constant 6 : i32
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c0 = arith.constant 0 : index
+    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, f32>>
+    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, f32>>
+    %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, f32>>
+    ttkernel.cb_wait_front(%0, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    ttkernel.cb_wait_front(%2, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    ttkernel.binary_op_init_common(%0, %2, %1) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>) -> ()
+    scf.for %arg0 = %c0 to %c2 step %c1 {
+      ttkernel.cb_reserve_back(%1, %c3_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+      ttkernel.tile_regs_acquire() : () -> ()
+      %3 = affine.linearize_index [%arg0, %c0] by (2, 3) : index
+      ttkernel.add_tiles_init(%0, %2) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>) -> ()
+      ttkernel.add_tiles(%0, %2, %3, %3, %c0) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>, index, index, index) -> ()
+      %4 = affine.linearize_index [%arg0, %c1] by (2, 3) : index
+      ttkernel.add_tiles(%0, %2, %4, %4, %c1) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>, index, index, index) -> ()
+      %5 = affine.linearize_index [%arg0, %c2] by (2, 3) : index
+      ttkernel.add_tiles(%0, %2, %5, %5, %c2) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>, index, index, index) -> ()
+      ttkernel.tanh_tile_init() : () -> ()
+      ttkernel.tanh_tile(%c0) : (index) -> ()
+      ttkernel.tanh_tile(%c1) : (index) -> ()
+      ttkernel.tanh_tile(%c2) : (index) -> ()
+      ttkernel.tile_regs_commit() : () -> ()
+      ttkernel.tile_regs_wait() : () -> ()
+      ttkernel.pack_tile(%c0, %1, %c0, true) : (index, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>, index) -> ()
+      ttkernel.pack_tile(%c1, %1, %c1, true) : (index, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>, index) -> ()
+      ttkernel.pack_tile(%c2, %1, %c2, true) : (index, !ttkernel.cb<12, !ttcore.tile<32x32, f32>>, index) -> ()
+      ttkernel.tile_regs_release() : () -> ()
+      ttkernel.cb_push_back(%1, %c3_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    } {ttl.subblock_dim = 0 : index, ttl.subblock_loop_stride = 3 : index}
+    ttkernel.cb_pop_front(%0, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    ttkernel.cb_pop_front(%2, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    return
+  }
+
+  func.func @write() attributes {ttkernel.thread = #ttkernel.thread<noc>, ttl.noc_index = 1 : i32} {
+    %c6_i32 = arith.constant 6 : i32
+    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<12, !ttcore.tile<32x32, f32>>
+    ttkernel.cb_wait_front(%1, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    ttkernel.noc_async_write_barrier() : () -> ()
+    ttkernel.cb_pop_front(%1, %c6_i32) : (!ttkernel.cb<12, !ttcore.tile<32x32, f32>>, i32) -> ()
+    return
+  }
+}
+
+// Two iterations, unrolled in place: every body operation is placed once per
+// iteration, in program order, so a lane holds A,B,C,A,B,C rather than A,A,B,B.
+// The op counts are trip x body -- 21 on math for a body of nine, ten with the
+// pre-loop init -- and the costs are the table's own numbers, which a
+// regeneration can move.
+// CHECK: cost estimate: 33 of 57 placements measured
+// CHECK-NEXT: 0 unmatched {{.*}} untimed
+// CHECK: kernels: read compute write
+// CHECK: TRISC0 unpack: 13 ops
+// CHECK: TRISC1 math: 21 ops
+// CHECK: TRISC2 pack: 15 ops
+
+// First iteration on math, then the second with no operation between the
+// commit and the next acquire: the loop body repeated, not a body costed once
+// and multiplied.
+// CHECK: TRISC1 math{{$}}
+// CHECK: ttkernel.binary_op_init_common {{.*}} meas
+// CHECK-NEXT: ttkernel.tile_regs_acquire {{.*}} untimed
+// CHECK-NEXT: ttkernel.add_tiles_init {{.*}} 90 {{.*}} meas
+// CHECK-NEXT: ttkernel.add_tiles {{.*}} 18 {{.*}} meas
+// CHECK-NEXT: ttkernel.add_tiles {{.*}} 18 {{.*}} meas
+// CHECK-NEXT: ttkernel.add_tiles {{.*}} 18 {{.*}} meas
+// CHECK-NEXT: ttkernel.tanh_tile_init {{.*}} meas
+// CHECK-NEXT: ttkernel.tanh_tile {{.*}} 362 {{.*}} meas
+// CHECK-NEXT: ttkernel.tanh_tile {{.*}} 362 {{.*}} meas
+// CHECK-NEXT: ttkernel.tanh_tile {{.*}} 362 {{.*}} meas
+// CHECK-NEXT: ttkernel.tile_regs_commit {{.*}} untimed
+// CHECK-NEXT: ttkernel.tile_regs_acquire {{.*}} untimed
+// CHECK-NEXT: ttkernel.add_tiles_init {{.*}} 90 {{.*}} meas
+// CHECK-NEXT: ttkernel.add_tiles {{.*}} 18 {{.*}} meas
+
+// -----
+
+// The trip count has to be static. A loop bounded by a value only known at
+// runtime cannot be unrolled, and steady-state extrapolation is not implemented,
+// so the estimate is refused at the loop rather than produced from a body placed
+// some arbitrary number of times. The trip count arrives as a function argument
+// here to keep the refusal to one cause; a compute kernel reading it through
+// `ttkernel.get_common_arg_val` would fail for a second, unrelated reason.
+module {
+  func.func @compute(%trip: index) attributes {dst_full_sync_en = false, fp32_dest_acc_en = false, ttkernel.thread = #ttkernel.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cb0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>
+    %cb1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>
+    ttkernel.binary_op_init_common(%cb0, %cb0, %cb1) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>) -> ()
+    scf.for %i = %c0 to %trip step %c1 {
+      ttkernel.tile_regs_acquire() : () -> ()
+      ttkernel.add_tiles_init(%cb0, %cb0) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>) -> ()
+      ttkernel.add_tiles(%cb0, %cb0, %c0, %c0, %c0) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, index, index, index) -> ()
+      ttkernel.tile_regs_commit() : () -> ()
+      ttkernel.tile_regs_wait() : () -> ()
+      ttkernel.pack_tile(%c0, %cb1, %c0, true) : (index, !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, index) -> ()
+      ttkernel.tile_regs_release() : () -> ()
+    }
+    return
+  }
+}
+
+// The loop is named as the reason, at the loop, and no estimate is offered --
+// rather than a latency computed from a program the hardware will not run.
+// CHECK: warning: cost estimator cannot determine this loop's trip count
+// CHECK-SAME: statically
+// CHECK: cost estimate: unavailable, see the warnings above

--- a/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
+++ b/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
@@ -9,7 +9,7 @@
 
 // A kernel that reads bf16 and packs f32. The two formats are not a conflict,
 // they are the pair the row was measured at, so the SFPU operations resolve.
-module {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @unary_bf16_to_f32() attributes {
       dst_full_sync_en = false,
       fp32_dest_acc_en = false,
@@ -42,7 +42,7 @@ module {
 // The same kernel reading two formats. Which one the exponential saw is no
 // longer decidable from the buffers, so it answers nothing rather than guessing
 // -- while `add_tiles`, which names its own buffer, still resolves.
-module {
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @binary_mixed_inputs() attributes {
       dst_full_sync_en = false,
       fp32_dest_acc_en = false,

--- a/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
+++ b/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
@@ -1,0 +1,72 @@
+// RUN: ttlang-opt --split-input-file --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1})' %s -o /dev/null 2>&1 | FileCheck %s
+
+// The format an SFPU operation was measured on, which it does not name itself.
+//
+// `exp_tile` takes a DST index and no circular buffer: the tile it works on
+// reached DST several operations earlier. The measurement is still keyed on the
+// formats the engines saw, so the format comes from the kernel's own buffers --
+// the ones the packer writes are the output side, the rest the input side.
+
+// A kernel that reads bf16 and packs f32. The two formats are not a conflict,
+// they are the pair the row was measured at, so the SFPU operations resolve.
+module {
+  func.func @unary_bf16_to_f32() attributes {
+      dst_full_sync_en = false,
+      fp32_dest_acc_en = false,
+      ttkernel.thread = #ttkernel.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %in = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>
+    %out = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, f32>>
+    ttkernel.tile_regs_acquire() : () -> ()
+    ttkernel.copy_tile_init(%in) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>) -> ()
+    ttkernel.copy_tile(%in, %c0, %c0) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, index, index) -> ()
+    ttkernel.exp_tile_init() {approx = true} : () -> ()
+    ttkernel.exp_tile(%c0) {approx = true, iterations = 8 : i32} : (index) -> ()
+    ttkernel.tile_regs_commit() : () -> ()
+    ttkernel.tile_regs_wait() : () -> ()
+    ttkernel.pack_tile(%c0, %out, %c0, true) : (index, !ttkernel.cb<4, !ttcore.tile<32x32, f32>>, index) -> ()
+    ttkernel.tile_regs_release() : () -> ()
+    return
+  }
+}
+
+// CHECK: cost estimate: 7 of 11 placements measured
+// CHECK-NEXT: 0 unmatched {{.*}}, 4 untimed
+// CHECK: TRISC1 math
+// CHECK: ttkernel.copy_tile {{.*}} 19 {{.*}} meas
+// CHECK: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
+// CHECK-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
+
+// -----
+
+// The same kernel reading two formats. Which one the exponential saw is no
+// longer decidable from the buffers, so it answers nothing rather than guessing
+// -- while `add_tiles`, which names its own buffer, still resolves.
+module {
+  func.func @binary_mixed_inputs() attributes {
+      dst_full_sync_en = false,
+      fp32_dest_acc_en = false,
+      ttkernel.thread = #ttkernel.thread<compute>} {
+    %c0 = arith.constant 0 : index
+    %lhs = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, bf16>>
+    %rhs = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, f32>>
+    %out = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, f32>>
+    ttkernel.tile_regs_acquire() : () -> ()
+    ttkernel.binary_op_init_common(%lhs, %rhs, %out) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, f32>>, !ttkernel.cb<4, !ttcore.tile<32x32, f32>>) -> ()
+    ttkernel.add_tiles_init(%lhs, %rhs) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, f32>>) -> ()
+    ttkernel.add_tiles(%lhs, %rhs, %c0, %c0, %c0) : (!ttkernel.cb<4, !ttcore.tile<32x32, bf16>>, !ttkernel.cb<4, !ttcore.tile<32x32, f32>>, index, index, index) -> ()
+    ttkernel.exp_tile_init() {approx = true} : () -> ()
+    ttkernel.exp_tile(%c0) {approx = true, iterations = 8 : i32} : (index) -> ()
+    ttkernel.tile_regs_commit() : () -> ()
+    ttkernel.tile_regs_wait() : () -> ()
+    ttkernel.pack_tile(%c0, %out, %c0, true) : (index, !ttkernel.cb<4, !ttcore.tile<32x32, f32>>, index) -> ()
+    ttkernel.tile_regs_release() : () -> ()
+    return
+  }
+}
+
+// CHECK: cost estimate:
+// CHECK: TRISC1 math
+// CHECK: ttkernel.add_tiles {{.*}} meas
+// CHECK: ttkernel.exp_tile_init {{.*}} nokey
+// CHECK-NEXT: ttkernel.exp_tile {{.*}} nokey

--- a/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
+++ b/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt --split-input-file --pass-pipeline='builtin.module(ttkernel-cost-estimate{detail=1})' %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: ttlang-opt --split-input-file --pass-pipeline='builtin.module(ttkernel-cost-estimate{enable=1 detail=1})' %s -o /dev/null 2>&1 | FileCheck %s
 
 // The format an SFPU operation was measured on, which it does not name itself.
 //

--- a/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
+++ b/test/ttlang/Analysis/cost_estimator_sfpu_format.mlir
@@ -34,7 +34,7 @@ module {
 // CHECK-NEXT: 0 unmatched {{.*}}, 4 untimed
 // CHECK: TRISC1 math
 // CHECK: ttkernel.copy_tile {{.*}} 19 {{.*}} meas
-// CHECK: ttkernel.exp_tile_init {{.*}} 85 {{.*}} meas
+// CHECK: ttkernel.exp_tile_init {{.*}} 88 {{.*}} meas
 // CHECK-NEXT: ttkernel.exp_tile {{.*}} 112 {{.*}} meas
 
 // -----

--- a/test/ttlang/Dialect/TTL/Pipelines/cost_estimate.mlir
+++ b/test/ttlang/Dialect/TTL/Pipelines/cost_estimate.mlir
@@ -1,0 +1,32 @@
+// Summary: Verify the TTL pipeline carries the cost estimate and its options.
+// RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=OFF
+// RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline=cost-estimate=1 --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=ON
+// RUN: ttlang-opt %s '--ttl-to-ttkernel-pipeline=cost-estimate=1 cost-estimate-detail=1 cost-estimate-math-fidelity=HiFi4' --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=DETAIL
+// RUN: not ttlang-opt %s --ttl-to-ttkernel-pipeline=cost-estimate-detail=1 -o /dev/null 2>&1 | FileCheck %s --check-prefix=NOENABLE
+
+// The pass is in the pipeline either way, gated on its own `enable`, so the
+// pipeline has one shape rather than two. Disabled it returns immediately.
+// OFF: ttkernel-cost-estimate{detail=false enable=false
+// OFF-SAME: math-fidelity=
+
+// Enabling it through the pipeline is what _lower_program_to_kernel does for
+// --ttl-cost-estimate, which is the equivalence this pipeline claims.
+// ON: ttkernel-cost-estimate{detail=false enable=true
+
+// Both extra options reach the pass: the detail view, and the math fidelity the
+// IR cannot carry.
+// DETAIL: ttkernel-cost-estimate{detail=true enable=true math-fidelity=HiFi4
+
+// Asking for detail alone is refused by the pass, through the pipeline as
+// directly.
+// NOENABLE: error: cost estimate detail was requested with the estimate disabled
+
+// It runs last in the TTKernel stage: after the passes that create the
+// operations it reads, and before EmitC conversion turns circular-buffer calls
+// into opaque verbatim strings.
+// RUN: ttlang-opt %s '--ttl-to-ttkernel-pipeline=cost-estimate=1 lower-to-emitc=1' --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=ORDER
+// ORDER: ttkernel-insert-inits
+// ORDER: ttkernel-cost-estimate
+// ORDER: convert-ttkernel-to-emitc
+
+module {}


### PR DESCRIPTION
# Purpose

Estimate the cycle cost of a device launch by reading TTKernel IR, so that
**optimization candidates can be compared without a device, a profiler run, or a
build**. The target is ranking lowerings against each other -- does subblocking
pay for the extra init zones, does an FPU path beat an SFPU one, which lane is
this kernel actually bound on -- not predicting absolute runtime. Read-only: it
never mutates the IR, and it never fails a compile.

Design and open gaps: https://github.com/tenstorrent/tt-lang/issues/800

TTKernel just before EmitC is the stage that makes this possible. Operations map
one-to-one onto the emitted compute-API calls, the constants carrying tile counts
are folded, and the circular-buffer calls are still operations rather than the
opaque `emitc.verbatim` strings they become afterwards.

```
$ ttlang-opt --ttkernel-cost-estimate test/ttlang/Analysis/cost_estimator.mlir -o /dev/null
cost estimate: 17 of 35 placements measured (49%)
  0 unmatched (measured in no configuration this kernel can supply), 18 untimed (nothing measured them); both charged 0
  measured on blackhole from 3127 rows over 296 operations; per-operation provenance in the detail view
  kernels: read compute write
  NCRISC reader: 5 ops, 5 busy, 0 stalled, 532 drained, 1% utilized
  TRISC0 unpack: 10 ops, 389 busy, 4 stalled, 144 drained, 72% utilized
  TRISC1 math: 8 ops, 257 busy, 154 stalled, 126 drained, 48% utilized
  TRISC2 pack: 9 ops, 329 busy, 205 stalled, 3 drained, 61% utilized
  BRISC writer: 3 ops, 3 busy, 534 stalled, 0 drained, 1% utilized
  latency: 537
  busiest lane: TRISC0 unpack (389 busy)
```

`--ttl-cost-estimate-detail` adds per-lane operation tables with start, end, cost
and stall per placement, and a timeline with one row per event boundary -- every
start, every finish, and the instant a lane began waiting, so nothing is aliased
away and no interval is invented. The `gap` column is the distance to the next
event on *any* lane, which is what row height does and does not mean here:

```
timeline: one row per event, '|' running, 'w' waiting, '^' ended, '.' idle

    cost    gap  NCRISC  |TRISC0  |TRISC1  |TRISC2  |BRISC   |
                 --------|--------|--------|--------|--------|
       0      1  cbresv  |w       |binit   |cbresv  |w       |
       4      1  cbpush  |cbwait  ||       ||       |w       |
       6     86  .       |binit   ||       ||       |w       |
      92      1  .       ||       |dstacq  ||       |w       |
      93     84  .       ||       |addinit ||       |w       |
     177      3  .       |addinit ||       ||       |w       |
     243     37  .       |add     |w       |w       |w       |
     280     19  .       |add     |add     |w       |w       |
     299     18  .       ||       |w       |w       |w       |
     391      1  .       |cbpop   |add     |w       |w       |
     410      1  .       |.       |dstcmt  |w       |w       |
     411      1  .       |.       |^       |dstwait |w       |
     412     30  .       |.       |.       |pack1   |w       |
     532      1  .       |.       |.       |dstrel  |w       |
     534      1  .       |.       |.       |^       |cbwait  |
     537    end  .       |.       |.       |.       |^       |
```

That is the eltwise-add module above, abridged. It is also the argument for the
credit model over a `max(lane busy)` heuristic: MATH trails UNPACK by one tile
throughout, because it waits on a Src bank the unpacker has yet to fill, and PACK
cannot start at all until `tile_regs_commit` hands over the whole four-tile block
at 410 -- so 537 of latency comes out of 389 of busiest-lane work, and a heuristic
would rank a kernel that pipelines properly identically to one that does not.

# Approach

**Five lanes.** `NCRISC`, `TRISC0 unpack`, `TRISC1 math`, `TRISC2 pack`, `BRISC`,
each an in-order blocking timeline. A compute function is split three ways
because the TRISCs overlap, and how much overlap a kernel achieves is exactly
what a single summed compute timeline cannot say.

**Placement.** Every operation lands on the lanes the cost table says it occupies
-- one source of truth for both where an operation runs and what it costs.
Traversal is structural rather than a walk, so a loop body repeats in place and a
lane holds the program in execution order. Loops are unrolled within a budget.

**Resources as credit counters.** Circular-buffer occupancy, the MATH/PACK
semaphore behind the DST halves, and the SrcA/SrcB dvalid banks. Nothing models
double buffering directly: whether an acquire blocks is an outcome of a counter,
so raising a block count changes no code. Acquires take effect when an operation
starts and releases when it retires, so a push becomes visible to its consumer at
the end of the push. A program that cannot progress is reported as a deadlock
with each lane's blocking reason, rather than as a plausible number.

**Costs are measured or absent.** From `TTLangOpCost`, which holds measurements
alone, so a placement is either measured or charged nothing -- and the report
keeps the two reasons for nothing apart: `nokey`, a measurement exists in no
configuration this kernel can supply, and `untimed`, nothing measured that engine
at all. Recovering the lookup key is this pass's job: the packed format and the
dest-accumulation and sync flags from the enclosing function, `unpack_to_dest`
from `ttl.unpack_to_dest_fp32` against the buffer an operation reads, and
`mathop`, `reduce_pool_type`, `approx_mode`, `iterations` and `input_clamping`
from the operation's own attributes. Math fidelity is the one key field TTKernel
IR does not carry -- it is a runtime compute-config value -- so it arrives as a
pass option, forwarded from the operation's `math_fidelity` on the Python path.

**Where it runs is not settled.** The pass sits last in the TTKernel stage today
because that is the earliest point where every operation exists and none has
become an `emitc.verbatim` string -- which makes it a convenient place to test,
not the right place to consume. Ranking candidates means asking about several
lowerings, which is a query from whatever code is choosing between them, not a
report printed once at the end of a compile. The pass wrapper is deliberately
thin for that reason: it owns only where the estimate happens and where the
report goes, while `mlir::tt::CostEstimator` is reusable by any caller. Expect
the placement to move once the first consumer decides what it needs.

**All or nothing.** An estimate covers every operation in a module or is not
produced, so a kernel the estimator cannot model is never mistaken for a cheap
one. Each gap is warned about at the operation responsible -- an operation the
table does not know, control flow whose outcome is unresolved, a loop whose trip
count is not static -- and the report then says only that no estimate is
available.

Against the plan in #800, this closes: pointing the estimator at the generated
table, reporting a miss instead of falling back to an invented number, per-lane
provenance in the report, computing `unpack_to_dest` per operation, answering the
SFPU knobs, and per-lane rather than per-benchmark keying. Still open there:
steady state for loops instead of unrolling, folding conditionals (`scf.if` fails
the estimate today), recovering the face count from IR, splitting the MATH lane
into FPU and SFPU, data-movement measurements, and hardware validation of the
ranking.

# Tests

Four lit tests, all driving the pass over hand-written TTKernel IR. Unlike the
library's own test, these **do** pin exact costs: the point of each is which row
the lookup matched, and a cost that moves without the table moving is the
regression they exist to catch. Regenerating the table can move them -- read the
new values out of `lib/Analysis/CostTableBlackhole.inc`, not out of the failure.

**`cost_estimator.mlir`** -- an eltwise add over two input buffers and one output,
four tiles per block, across all three kernel threads. Checks that the threads
are recognized and none deadlocks, that nothing is unmatched, that both halves of
the add are measured on both engines they occupy, and that the credit operations
report as untimed. This is the regression test for the table wiring: a lookup that
stops matching shows up as a column flipping away from `meas`.

**`cost_estimator_copy_tile.mlir`** -- the unary datacopy path, whose every row is
keyed on `unpack_to_dest`: the flag changes the unpacker's route rather than its
speed, and the rows differ by roughly 3x (42 cycles/tile unlisted against 120 for
a listed f32 buffer). This kernel lists nothing in `ttl.unpack_to_dest_fp32`, so
the knob answers false for each buffer and the test pins the unlisted figure. It
is the only test that reaches the per-buffer recovery.

**`cost_estimator_knobs.mlir`** -- one kernel run three times, without fidelity
and at HiFi4 and LoFi, exercising all three origins of a knob in one function:
the reduce attributes (`mathop`, `reduce_pool_type`), the exponential's own
attributes across three shapes (default clamping, clamp skipped, and no
attributes at all -- the last being what a plain `ttl.exp` emits), and fidelity
from the pass option. Without fidelity the four math rows keyed on it report
`nokey` rather than borrowing another fidelity's number; supplying it turns them
measured, and LoFi's multiply costs a quarter of HiFi4's. The clamp is worth a
factor of four on the approximate exponential, which is why it has to be
answered.

**`cost_estimator_sfpu_format.mlir`** -- an SFPU operation names no buffer at all
(`exp_tile` takes a DST index), so its format comes from the kernel's buffers,
split into an input and an output side by which ones the packer writes. First
chunk: a kernel reading bf16 and packing f32 resolves both exponential
placements, a pair the table measures. Second chunk: a kernel reading two formats
leaves the exponential `nokey`, because which format reached DST is no longer
decidable -- while `add_tiles`, which names its own buffer, still resolves. The
honest limit is pinned alongside the capability.

## Running them

```bash
cmake --build build --target check-ttlang-mlir      # the CI suite; 321/321 here

llvm-lit -v build/test/ttlang/Analysis              # just the analysis tests
ttlang-opt --ttkernel-cost-estimate=detail=1 test/ttlang/Analysis/cost_estimator.mlir -o /dev/null
```

End to end from Python, on any kernel:

```bash
python examples/eltwise_add.py --ttl-cost-estimate --ttl-cost-estimate-detail
```

Note what that particular example reports: the estimate is unavailable, because
the kernel contains an `scf.if` the estimator declines to model rather than
counting a guarded body as taken. That is the intended behaviour for an
unmodelled construct, and the loop-free kernels the tests use are what exercise a
complete estimate today.
