### PR TITLE
[ttl] Reuse opaque DFB storage after synchronized reset [dfb-reuse-17]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1429,9 +1429,9 @@ and the order of statically expanded transactions. Effects are synchronous
 facts about actions completed inside the external call; they do not emit
 lifecycle operations.
 
-An occurrence with no effect remains a possible read or write from call entry
-through completion. If operand adaptation aliases several occurrences to one
-DFB, every occurrence requires effects to eliminate that opaque interval.
+An occurrence with no effect remains a possible read or write from call entry.
+If operand adaptation aliases several occurrences to one DFB, every occurrence
+requires effects to eliminate that opaque interval.
 Ordinary storage accesses between summarized acquisitions and releases remain
 inside the corresponding lifetime. A partial summary supplies its listed
 events but cannot establish the complete reserve/push/wait/pop lifecycle for
@@ -1446,9 +1446,15 @@ listed DFBs, over the call's launch-node domain. Listed effects remain available
 to other verification. Unknown access applies only to user-managed DFBs;
 compiler-created DFB accesses require listed operands.
 
-The callee must complete every synchronous and asynchronous DFB access before
-returning. Work that remains active after return requires a separate explicit
-completion contract. The frontend and IR representation are described in
+Every declared effect action must complete before the callee returns. Associated
+interface work may remain active while the declared protocol retains ownership;
+it must complete before the terminal consumer release or a synchronized reset.
+For a named dependency with no effect summary, a synchronized reset ordered
+after the call may terminate the opaque access and canonicalize protocol state.
+The reset must complete earlier interface work before publishing arrival. This
+does not validate the callee's internal protocol. Unlisted access declared by
+`unknown_dfb_access` remains unbounded. The frontend and IR representation are
+described in
 [External Function Interop Lowering](ExternalFuncInteropLowering.md).
 
 An exact static `dfb_effects` sequence may describe cumulative queue state

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -7,12 +7,14 @@ compiler preserves argument order, emits the header before the call, and lowers
 each argument according to its source category. It does not inspect the C++
 body or validate the foreign function signature.
 
-External code must complete all synchronous and asynchronous resource accesses
-before returning. DFB behavior is declared rather than inferred:
-`ttl.opaque_call` exposes dependencies, ordered protocol effects, and unknown
-access through `DFBAccessOpInterface`. A dependency occurrence with no listed
-effect remains an opaque access for the call duration. A complete effect summary
-can establish the lifecycle facts required for physical-index reuse.
+DFB behavior is declared rather than inferred: `ttl.opaque_call` exposes
+dependencies, ordered protocol effects, and unknown access through
+`DFBAccessOpInterface`. Every declared effect action completes before return,
+but associated asynchronous interface work may remain live until the terminal
+consumer release or a synchronized reset. A dependency occurrence with no
+listed effect remains opaque until a synchronized reset proves completion. A
+complete effect summary can establish the lifecycle facts required for
+physical-index reuse.
 
 The Python interface currently supports void calls.
 
@@ -230,9 +232,9 @@ selects allocation metadata or an integer index.
 The [external-functions reference](../sphinx/reference/external-functions.md)
 defines the Python API and static-expression rules. Every statically known DFB
 accessed by external code must be declared as a dependency. The `dfb_effects`
-summary is optional: without it, each dependency remains an opaque access for
-the call duration. A complete, accurate summary can prove a bounded lifecycle
-and permit physical-index reuse.
+summary is optional: without it, each dependency remains an opaque access until
+a synchronized reset proves completion. A complete, accurate summary can prove
+a bounded lifecycle and permit physical-index reuse.
 
 `OpaqueCallOp::getDFBDependencyOperands()` returns dependency occurrences in
 this order:
@@ -341,15 +343,19 @@ An effect summary describes actions performed by external C++; it does not
 create executable TTL operations. Every listed action must execute on every
 execution of the call and complete before return. Conditional external actions
 require corresponding TTL control flow around a call with an unconditional
-summary. Work that remains active after return requires a separate completion
-contract and cannot be represented by these effects.
+summary. The effect list does not state when associated hardware interface work
+completes; the declared protocol terminal or a synchronized reset must complete
+that work before storage reuse.
 
-An occurrence with no effect is a possible read and write for the complete
-call. Ordinary storage accesses between summarized acquisitions and releases
-remain inside the corresponding lifetime. A partial effect sequence is valid
-metadata but cannot prove a bounded lifecycle for that DFB. When the same DFB
-has multiple dependency occurrences, every occurrence requires effects to
-eliminate the opaque call-duration access. For allocation,
+An occurrence with no effect is a possible read and write beginning at call
+entry. A synchronized reset ordered after the call through the same
+participating logical kernel terminates a named opaque access and canonicalizes
+its protocol state. The reset implementation must complete earlier interface
+work before publishing arrival. Ordinary storage accesses between summarized
+acquisitions and releases remain inside the corresponding lifetime. A partial
+effect sequence is valid metadata but cannot prove a bounded lifecycle for that
+DFB. When the same DFB has multiple dependency occurrences, every occurrence
+requires effects to eliminate the opaque access without a reset. For allocation,
 `unknown_dfb_access` conservatively adds the call as an opaque occurrence on
 every user-managed DFB, including listed DFBs, in each affected allocation
 scope. The compiler does not infer facts from the callee name, header, emitted

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -468,9 +468,9 @@ alter the C++ call. TTKernel to EmitC resolves constants and descriptor types,
 and C++ emission inserts the required prelude and header during its existing
 operation scan.
 
-See `examples/external_dfb_reuse.py` for two external calls surrounded by
-visible TTL protocol operations. An acknowledgment proves that the result
-lifetimes do not overlap, while typed descriptor operands keep each opaque call
-inside the corresponding lifetime. See
+See `examples/external_dfb_descriptors.py` for two external calls surrounded by
+visible TTL protocol operations. Descriptor operands preserve each DFB's
+compile-time metadata but do not summarize storage behavior, so the two opaque
+result DFBs remain distinct. See
 `test/python/call_extern_func_dfb_effects.py` for dependency-only operands,
 ordered effect expansion, unknown access, and generated-C++ invariance.

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -324,9 +324,16 @@ opaque. Repeated transactions retain every action and its position. A bounded
 lifecycle requires ordered reserve/push and wait/pop transactions with matching
 tile counts. A partial summary is valid but does not prove a bounded lifecycle
 for that dependency. A dependency occurrence with no listed effect is an opaque
-storage access for the complete call duration, including when operand adaptation
-aliases multiple occurrences to the same SSA DFB. Every aliased occurrence
-requires its own effects to avoid an opaque call-duration access.
+storage access beginning at call entry, including when operand adaptation aliases
+multiple occurrences to the same SSA DFB. Every aliased occurrence requires its
+own effects to avoid an opaque access without a reset.
+
+A named opaque dependency may retain protocol and asynchronous interface work
+after the call. A synchronized reset ordered after the call through the same
+participating logical kernel terminates that access and canonicalizes protocol
+state. The reset implementation must complete earlier interface work before
+publishing arrival. Storage reuse is permitted only after reset completion. This
+does not validate the external function's internal queue protocol.
 
 `unknown_dfb_access=True` declares that external C++ may access user-managed
 DFBs not present in the declared dependencies. This is distinct from malformed
@@ -334,10 +341,11 @@ metadata. For allocation, the call becomes an opaque occurrence on every
 user-managed DFB in each scope where it may execute, including listed DFBs.
 Listed dependencies and effects remain available to other verification.
 
-Every listed effect is complete when the external function returns. External
-work that continues after return requires separate explicit completion
-semantics and cannot be represented by this synchronous effect list. Effects
-describe external behavior; they do not emit reserve, push, wait, or pop calls.
+Every listed effect action is complete when the external function returns.
+Associated interface work may remain active while the declared protocol retains
+ownership; it must complete before the terminal consumer release or a
+synchronized reset. Effects describe external behavior; they do not emit
+reserve, push, wait, or pop calls.
 Dependency-only operands and all effect metadata leave the generated C++ call
 signature unchanged.
 
@@ -366,9 +374,12 @@ ttl.call_extern_func(
 
 ## DFB synchronization ownership
 
-External C++ must complete its resource accesses before returning. The compiler
-does not infer reserve, wait, push, or pop operations from the C++ body; the
-`dfb_effects` contract supplies those facts when required.
+Every `dfb_effects` action must complete before the external call returns. Its
+associated interface work must complete before the terminal consumer release or
+a synchronized reset. The compiler does not infer reserve, wait, push, or pop
+operations from the C++ body; the `dfb_effects` contract supplies those facts
+when required. A named dependency without effects remains opaque and requires a
+synchronized reset before storage reuse.
 
 `TensorBlock.push` and `TensorBlock.pop` accept one `kernel=` selector when a
 DFB transaction has no other use from which ownership can be inferred.

--- a/examples/external_dfb_descriptors.py
+++ b/examples/external_dfb_descriptors.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Use typed DFB descriptors in external functions while reusing an index.
+"""Use typed DFB descriptors in external functions.
 
 TTL operations declare each DFB transaction around the opaque C++ calls. An
-acknowledgment orders the first result's pop before the second result's reserve,
-which permits those two logical DFBs to use one physical index.
+acknowledgment orders the first result's pop before the second result's reserve.
+The calls do not summarize their storage behavior, so their result DFBs remain
+distinct despite that ordering.
 """
 
 import os
@@ -25,7 +26,7 @@ EXTERNAL_MULTIPLY_HEADER = os.path.join(
 
 
 @ttl.operation(grid=(1, 1))
-def external_dfb_reuse(lhs, rhs, result):
+def external_dfb_descriptors(lhs, rhs, result):
     lhs_dfb = ttl.make_dataflow_buffer_like(lhs, shape=(1, 1), block_count=2)
     rhs_dfb = ttl.make_dataflow_buffer_like(rhs, shape=(1, 1), block_count=2)
     first_result_dfb = ttl.make_dataflow_buffer_like(
@@ -142,7 +143,9 @@ def main() -> None:
             previous_final_mlir = os.environ.get("TTLANG_FINAL_MLIR")
             os.environ["TTLANG_FINAL_MLIR"] = str(final_mlir_path)
             try:
-                external_dfb_reuse(lhs, rhs, result, options="--ttl-reuse-user-dfbs")
+                external_dfb_descriptors(
+                    lhs, rhs, result, options="--ttl-reuse-user-dfbs"
+                )
             finally:
                 if previous_final_mlir is None:
                     del os.environ["TTLANG_FINAL_MLIR"]
@@ -150,7 +153,7 @@ def main() -> None:
                     os.environ["TTLANG_FINAL_MLIR"] = previous_final_mlir
 
             first_index, second_index = _descriptor_result_indices(final_mlir_path)
-            assert first_index == second_index
+            assert first_index != second_index
         torch.testing.assert_close(ttnn.to_torch(result), lhs_host * rhs_host)
     finally:
         ttnn.close_device(device)

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -2077,16 +2077,21 @@ def TTL_OpaqueCallOp : TTL_Op<"opaque_call",
     unlisted user-managed DFBs and disables physical-index reuse in affected
     allocation scopes.
 
-    A named DFB dependency occurrence without `dfb_effects` contributes a
-    call-duration storage access. A synchronized DFB reset canonicalizes its
-    unknown protocol state only when the access completes before the reset
-    boundary through the same participating logical kernel. Storage reuse is
-    then permitted only after the reset. This does not validate the callee's
-    internal queue protocol.
+    A named DFB dependency occurrence without `dfb_effects` contributes an
+    opaque storage access that begins at call entry. Its protocol and
+    asynchronous interface work may remain live after the call. When the call
+    is ordered before a synchronized DFB reset through the same participating
+    logical kernel, reset completion terminates the access and canonicalizes
+    its unknown protocol state. The reset implementation must complete each
+    participant's earlier interface work before publishing arrival. Storage
+    reuse is permitted only after the reset. This does not validate the
+    callee's internal queue protocol.
 
-    Every asynchronous DFB access must also complete before the call returns.
-    A callee with outstanding asynchronous work requires a separate explicit
-    completion contract and cannot use this operation's synchronous summary.
+    Every action declared by `dfb_effects` must occur before the call returns.
+    Interface work still active after return must remain ordered by the
+    declared protocol and complete before its terminal consumer release or a
+    synchronized reset. Work that can outlive that terminal must leave the
+    affected DFB dependency opaque.
 
     `unsigned_arg_indices` identifies signless i32 operands that represent
     unsigned addresses at the C++ boundary. The lowering inserts explicit

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -2077,6 +2077,12 @@ def TTL_OpaqueCallOp : TTL_Op<"opaque_call",
     unlisted user-managed DFBs and disables physical-index reuse in affected
     allocation scopes.
 
+    A named DFB dependency occurrence without `dfb_effects` contributes a
+    call-duration storage access. A following synchronized DFB reset may
+    canonicalize its unknown protocol state, permitting storage reuse only
+    after the reset. This does not validate the callee's internal queue
+    protocol.
+
     Every asynchronous DFB access must also complete before the call returns.
     A callee with outstanding asynchronous work requires a separate explicit
     completion contract and cannot use this operation's synchronous summary.

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -2070,9 +2070,9 @@ def TTL_OpaqueCallOp : TTL_Op<"opaque_call",
     greater than the selected DFB's capacity. Every listed effect occurs on
     every execution of the call. Repeated effects retain list order. The summary
     does not emit protocol calls. Effects omitted for a dependency occurrence
-    leave its access opaque for the call duration. If one DFB occupies multiple
-    dependency occurrences, every occurrence requires its own effects to avoid
-    an opaque call-duration access. The
+    leave its access opaque. If one DFB occupies multiple dependency
+    occurrences, every occurrence requires its own effects to avoid an opaque
+    access. The
     `unknown_dfb_access` unit attribute declares that the callee may also access
     unlisted user-managed DFBs and disables physical-index reuse in affected
     allocation scopes.

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -2078,10 +2078,11 @@ def TTL_OpaqueCallOp : TTL_Op<"opaque_call",
     allocation scopes.
 
     A named DFB dependency occurrence without `dfb_effects` contributes a
-    call-duration storage access. A following synchronized DFB reset may
-    canonicalize its unknown protocol state, permitting storage reuse only
-    after the reset. This does not validate the callee's internal queue
-    protocol.
+    call-duration storage access. A synchronized DFB reset canonicalizes its
+    unknown protocol state only when the access completes before the reset
+    boundary through the same participating logical kernel. Storage reuse is
+    then permitted only after the reset. This does not validate the callee's
+    internal queue protocol.
 
     Every asynchronous DFB access must also complete before the call returns.
     A callee with outstanding asynchronous work requires a separate explicit

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_dfb_reset.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_dfb_reset.h
@@ -36,7 +36,6 @@ constexpr uint32_t stateWordCount = 4;
 constexpr uint32_t participantCount = 3;
 constexpr uint32_t entryComplete = 1;
 constexpr uint32_t exitComplete = 2;
-constexpr uint32_t completionMarker = 0xDFB0;
 
 static_assert(releaseWord + 1 == stateWordCount);
 
@@ -75,20 +74,17 @@ participantsHaveState(volatile uint32_t tt_l1_ptr *synchronizationState,
   return true;
 }
 
-// The readback is ordered after prior engine work and therefore prevents an
-// interface owner from publishing arrival before its commands retire.
+// The blocking instruction-buffer synchronization makes the PACK or UNPACK
+// stall complete before the interface owner publishes its arrival.
 FORCE_INLINE void drainComputeEngine() {
 #if defined(TTL_DFB_RESET_UNPACK)
   constexpr uint32_t waitResources = p_stall::UNPACK;
-  constexpr uint32_t completionGpr = p_gpr_unpack::TMP0;
 #elif defined(TTL_DFB_RESET_PACK)
   constexpr uint32_t waitResources = p_stall::PACK;
-  constexpr uint32_t completionGpr = p_gpr_pack::TMP0;
 #endif
 #if defined(TTL_DFB_RESET_UNPACK) || defined(TTL_DFB_RESET_PACK)
   TTI_STALLWAIT(p_stall::STALL_TDMA, waitResources);
-  TTI_SETDMAREG(0, completionMarker, 0, LO_16(completionGpr));
-  sync_regfile_write(completionGpr);
+  tensix_sync();
 #endif
 }
 

--- a/include/ttlang/Target/TTKernel/LLKs/experimental_dfb_reset.h
+++ b/include/ttlang/Target/TTKernel/LLKs/experimental_dfb_reset.h
@@ -74,9 +74,12 @@ participantsHaveState(volatile uint32_t tt_l1_ptr *synchronizationState,
   return true;
 }
 
-// The blocking instruction-buffer synchronization makes the PACK or UNPACK
-// stall complete before the interface owner publishes its arrival.
-FORCE_INLINE void drainComputeEngine() {
+// Every interface owner must complete earlier asynchronous work before a
+// reset participant publishes its arrival.
+FORCE_INLINE void completeInterfaceWork() {
+#if defined(TTL_DFB_RESET_DM0) || defined(TTL_DFB_RESET_DM1)
+  noc_async_full_barrier();
+#endif
 #if defined(TTL_DFB_RESET_UNPACK)
   constexpr uint32_t waitResources = p_stall::UNPACK;
 #elif defined(TTL_DFB_RESET_PACK)
@@ -96,18 +99,13 @@ FORCE_INLINE void enter(volatile uint32_t tt_l1_ptr *synchronizationState) {
 #elif defined(TTL_DFB_RESET_PACK)
   constexpr uint32_t arrivalWord = packStateWord;
 #endif
-#if defined(TTL_DFB_RESET_DM0)
-  noc_async_full_barrier();
-#elif defined(TTL_DFB_RESET_UNPACK) || defined(TTL_DFB_RESET_PACK)
-  drainComputeEngine();
-#endif
+  completeInterfaceWork();
 #if defined(TTL_DFB_RESET_DM0) || defined(TTL_DFB_RESET_UNPACK) ||             \
     defined(TTL_DFB_RESET_PACK)
   storeStateWord(&synchronizationState[arrivalWord], entryComplete);
   while (loadStateWord(&synchronizationState[releaseWord]) != entryComplete) {
   }
 #elif defined(TTL_DFB_RESET_DM1)
-  noc_async_full_barrier();
   while (!participantsHaveState(synchronizationState, entryComplete)) {
   }
   storeStateWord(&synchronizationState[releaseWord], entryComplete);
@@ -178,6 +176,11 @@ FORCE_INLINE void applyMask(uint32_t activeMask, uint32_t firstDFBIndex) {
 }
 
 } // namespace dfb_reset_detail
+
+// Custom resets must complete interface work before publishing arrival.
+FORCE_INLINE void complete_dfb_interface_work() {
+  dfb_reset_detail::completeInterfaceWork();
+}
 
 FORCE_INLINE void reset_dfb_interfaces(uint32_t synchronizationAddress,
                                        uint32_t lowMask, uint32_t highMask) {

--- a/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationDebugReport.cpp
@@ -148,7 +148,11 @@ static void printAccesses(llvm::raw_ostream &output,
       output << "none";
     }
     output << " tiles=" << access.numTiles
-           << " sequence=" << access.sequenceIndex << " domain=";
+           << " sequence=" << access.sequenceIndex;
+    if (access.opaqueExternalAccess) {
+      output << " opaque_external=1";
+    }
+    output << " domain=";
     printDomain(output, access.launchDomain);
     output << " operation=";
     printOperation(output, access.operation);
@@ -257,6 +261,9 @@ static void printResetEpochs(llvm::raw_ostream &output,
         } else {
           output << "none";
         }
+        if (epoch.resetCanonicalizedOpaqueProtocol) {
+          output << ",opaque_protocol_reset=1";
+        }
         output << ",terminal_state="
                << (epoch.terminalStateCanonical ? "canonical" : "protocol")
                << '}';
@@ -281,6 +288,8 @@ static bool hasEqualResetEpochs(ArrayRef<DFBLifecycleEpoch> lhs,
                lhsEpoch.terminalReadPointerOwner ==
                    rhsEpoch.terminalReadPointerOwner &&
                lhsEpoch.terminalResetOrdinal == rhsEpoch.terminalResetOrdinal &&
+               lhsEpoch.resetCanonicalizedOpaqueProtocol ==
+                   rhsEpoch.resetCanonicalizedOpaqueProtocol &&
                lhsEpoch.terminalStateCanonical ==
                    rhsEpoch.terminalStateCanonical &&
                lhsEpoch.quiescence.failure == rhsEpoch.quiescence.failure &&
@@ -307,6 +316,8 @@ hasEqualPossibleFacts(const DFBPerNodeLifetime &lhs,
       lhs.terminalReadCursorRuns != rhs.terminalReadCursorRuns ||
       lhs.terminalWritePointerOwner != rhs.terminalWritePointerOwner ||
       lhs.terminalReadPointerOwner != rhs.terminalReadPointerOwner ||
+      lhs.resetCanonicalizedOpaqueProtocol !=
+          rhs.resetCanonicalizedOpaqueProtocol ||
       lhs.terminalStateCanonical != rhs.terminalStateCanonical ||
       !hasEqualResetEpochs(lhs.resetEpochs, rhs.resetEpochs) ||
       !(lhsDiagnostics == rhsDiagnostics)) {
@@ -382,8 +393,11 @@ static void printPossibleLifetimes(
            << getQuiescenceFailureName(lifetime.quiescence.failure)
            << " domain_assumption=unknown-possible may_be_active="
            << lifetime.mayBeActive
-           << " conditional_execution=" << lifetime.conditionalExecutionProven
-           << " node_count=" << group.nodes.size();
+           << " conditional_execution=" << lifetime.conditionalExecutionProven;
+    if (lifetime.resetCanonicalizedOpaqueProtocol) {
+      output << " opaque_protocol_reset=1";
+    }
+    output << " node_count=" << group.nodes.size();
     if (group.nodes.size() <= 8) {
       output << " nodes={";
       llvm::interleaveComma(group.nodes, output, [&](LaunchNodeCoord node) {
@@ -420,6 +434,9 @@ static void printNodeLifetimes(llvm::raw_ostream &output,
            << getQuiescenceFailureName(lifetime.quiescence.failure)
            << " domain_assumption=exact conditional_execution="
            << lifetime.conditionalExecutionProven;
+    if (lifetime.resetCanonicalizedOpaqueProtocol) {
+      output << " opaque_protocol_reset=1";
+    }
     printLifetimeFacts(output, lifetime, diagnostics);
     output << '\n';
   }
@@ -458,8 +475,11 @@ void printDFBAllocationDebugReport(
     output << "DFB logical_id=" << logicalDFB.logicalId
            << " bounded=" << logicalDFB.bounded
            << " compiler_created=" << logicalDFB.compilerCreated
-           << " conditionally_bounded=" << logicalDFB.conditionallyBounded
-           << " allocation_group=";
+           << " conditionally_bounded=" << logicalDFB.conditionallyBounded;
+    if (logicalDFB.hasOpaqueExternalAccess) {
+      output << " opaque_external_access=1";
+    }
+    output << " allocation_group=";
     if (logicalDFB.allocationGroup) {
       Attribute allocationGroup = logicalDFB.allocationGroup;
       allocationGroup.print(output);

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -927,6 +927,30 @@ static SmallVector<unsigned> findMinimalEntryEvents(
   return minimal;
 }
 
+static void recordEntryFrontierEvidence(
+    DFBPerNodeLifetime &lifetime, DFBPerNodeLifetimeDiagnostics *diagnostics,
+    ArrayRef<const DFBAccessOccurrence *> accesses,
+    const DFBLogicalLifecycle &logicalDFB,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
+  for (const DFBAccessOccurrence *access : accesses) {
+    std::optional<AccessEventSpan> events =
+        getAccessEventSpan(*access, operationEvents, accessEvents);
+    if (!events || !llvm::is_contained(lifetime.earliestEntryEvents,
+                                       events->first.entry)) {
+      continue;
+    }
+    if (!lifetime.entryEvidence) {
+      lifetime.entryEvidence = access->operation;
+    }
+    if (diagnostics) {
+      diagnostics->earliestAccessOccurrenceIndices.push_back(
+          static_cast<unsigned>(access - logicalDFB.accesses.data()));
+    }
+  }
+}
+
 // Retains every possible lifetime end so each one constrains storage reuse.
 static SmallVector<const DFBAccessOccurrence *> findMaximalCompletionAccesses(
     ArrayRef<const DFBAccessOccurrence *> accesses,
@@ -2951,30 +2975,17 @@ static DFBQuiescenceProof computeProtocolLifetime(
               (*unscopedOpaqueAccess)->operation};
     }
 
-    SmallVector<const DFBAccessOccurrence *> earliestAccesses =
-        findMinimalEntryAccesses(activeAccesses, graph, operationEvents,
-                                 accessEvents);
+    lifetime.earliestEntryEvents = findMinimalEntryEvents(
+        activeAccesses, graph, operationEvents, accessEvents);
     SmallVector<const DFBAccessOccurrence *> terminalAccesses =
         findMaximalCompletionAccesses(activeAccesses, graph, operationEvents,
                                       accessEvents);
-    if (earliestAccesses.empty() || terminalAccesses.empty()) {
+    if (lifetime.earliestEntryEvents.empty() || terminalAccesses.empty()) {
       return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
               activeAccesses.front()->operation};
     }
-    for (const DFBAccessOccurrence *earliestAccess : earliestAccesses) {
-      std::optional<AccessEventSpan> events =
-          getAccessEventSpan(*earliestAccess, operationEvents, accessEvents);
-      if (!events) {
-        return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
-                earliestAccess->operation};
-      }
-      if (!llvm::is_contained(lifetime.earliestEntryEvents,
-                              events->first.entry)) {
-        lifetime.earliestEntryEvents.push_back(events->first.entry);
-      }
-      lifetime.earliestAccessOccurrenceIndices.push_back(
-          static_cast<unsigned>(earliestAccess - logicalDFB.accesses.data()));
-    }
+    recordEntryFrontierEvidence(lifetime, diagnostics, activeAccesses,
+                                logicalDFB, operationEvents, accessEvents);
     for (const DFBAccessOccurrence *terminalAccess : terminalAccesses) {
       std::optional<AccessEventSpan> events =
           getAccessEventSpan(*terminalAccess, operationEvents, accessEvents);
@@ -2986,8 +2997,10 @@ static DFBQuiescenceProof computeProtocolLifetime(
                               events->last.completion)) {
         lifetime.terminalCompletionEvents.push_back(events->last.completion);
       }
-      lifetime.terminalAccessOccurrenceIndices.push_back(
-          static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data()));
+      if (diagnostics) {
+        diagnostics->terminalAccessOccurrenceIndices.push_back(
+            static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data()));
+      }
     }
     lifetime.resetCanonicalizedOpaqueProtocol = true;
     return {};
@@ -3333,20 +3346,8 @@ static DFBQuiescenceProof computeProtocolLifetime(
   lifetime.earliestEntryEvents = findMinimalEntryEvents(
       activeAccesses, graph, operationEvents, accessEvents);
   lifetime.terminalCompletionEvents = {terminalEvents->last.completion};
-  for (const DFBAccessOccurrence *activeAccess : activeAccesses) {
-    std::optional<AccessEventSpan> activeEvents =
-        getAccessEventSpan(*activeAccess, operationEvents, accessEvents);
-    if (activeEvents && llvm::is_contained(lifetime.earliestEntryEvents,
-                                           activeEvents->first.entry)) {
-      if (!lifetime.entryEvidence) {
-        lifetime.entryEvidence = activeAccess->operation;
-      }
-      if (diagnostics) {
-        diagnostics->earliestAccessOccurrenceIndices.push_back(
-            static_cast<unsigned>(activeAccess - logicalDFB.accesses.data()));
-      }
-    }
-  }
+  recordEntryFrontierEvidence(lifetime, diagnostics, activeAccesses, logicalDFB,
+                              operationEvents, accessEvents);
   if (diagnostics) {
     diagnostics->terminalAccessOccurrenceIndices = {
         static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data())};

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1258,8 +1258,8 @@ static LogicalResult collectLogicalDFBs(
     }
 
     // Preserve dependency occurrences because aliased operands may have
-    // different summaries. An occurrence without an effect remains opaque for
-    // the operation's complete duration.
+    // different summaries. An occurrence without an effect remains opaque
+    // until a synchronized reset proves that its lifetime terminates.
     llvm::BitVector effectedDependencies(dfbOperands.size());
     for (const DFBProtocolEffect &effect : access.getDFBProtocolEffects()) {
       assert(effect.dependencyIndex < dependencyLogicalIndices.size() &&

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -3541,6 +3541,9 @@ static DFBQuiescenceProof computePerNodeLifetime(
     epoch.quiescence = proof;
     if (resetTerminated) {
       const OrderedResetBoundary &boundary = boundaries[epochIndex];
+      if (boundary.reset->conditionalExecution) {
+        epochLifetime.conditionalExecutionProven = true;
+      }
       epoch.terminalResetOrdinal = boundary.reset->reset.getOrdinal();
       epoch.terminalStateCanonical = true;
       epochLifetime.terminalCompletionEvents = {boundary.events.completion};

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -927,7 +927,7 @@ static SmallVector<unsigned> findMinimalEntryEvents(
   return minimal;
 }
 
-// Finds every access without a proved completion successor.
+// Retains every possible lifetime end so each one constrains storage reuse.
 static SmallVector<const DFBAccessOccurrence *> findMaximalCompletionAccesses(
     ArrayRef<const DFBAccessOccurrence *> accesses,
     const HappensBeforeGraph &graph,

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -927,6 +927,34 @@ static SmallVector<unsigned> findMinimalEntryEvents(
   return minimal;
 }
 
+// Finds every access without a proved completion successor.
+static SmallVector<const DFBAccessOccurrence *> findMaximalCompletionAccesses(
+    ArrayRef<const DFBAccessOccurrence *> accesses,
+    const HappensBeforeGraph &graph,
+    const DenseMap<Operation *, EventPair> &operationEvents,
+    const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+        &accessEvents) {
+  SmallVector<const DFBAccessOccurrence *> maximal;
+  for (const DFBAccessOccurrence *candidate : accesses) {
+    std::optional<AccessEventSpan> candidateEvents =
+        getAccessEventSpan(*candidate, operationEvents, accessEvents);
+    if (!candidateEvents) {
+      continue;
+    }
+    bool hasSuccessor = llvm::any_of(accesses, [&](const auto *otherAccess) {
+      std::optional<AccessEventSpan> otherEvents =
+          getAccessEventSpan(*otherAccess, operationEvents, accessEvents);
+      return otherEvents &&
+             graph.strictlyPrecedes(candidateEvents->last.completion,
+                                    otherEvents->last.completion);
+    });
+    if (!hasSuccessor) {
+      maximal.push_back(candidate);
+    }
+  }
+  return maximal;
+}
+
 // Requires a custom function that consumes a physical index to name the same
 // logical DFB as a direct storage dependency.
 static LogicalResult verifyCustomFunctionIndexDependency(
@@ -1255,9 +1283,12 @@ static LogicalResult collectLogicalDFBs(
       std::optional<unsigned> logicalIndex =
           dependencyLogicalIndices[dependencyIndex];
       assert(logicalIndex && "DFB dependencies were validated above");
-      logicalDFBs[*logicalIndex].accesses.push_back(
-          {operation, std::nullopt, 0, 0, LaunchNodeDomain::unknown(),
-           nullptr});
+      DFBLogicalLifecycle &logicalDFB = logicalDFBs[*logicalIndex];
+      bool opaqueExternalAccess = isa<OpaqueCallOp>(operation);
+      logicalDFB.accesses.push_back({operation, std::nullopt, 0, 0,
+                                     LaunchNodeDomain::unknown(), nullptr,
+                                     opaqueExternalAccess});
+      logicalDFB.hasOpaqueExternalAccess |= opaqueExternalAccess;
     }
     return WalkResult::advance();
   });
@@ -2900,6 +2931,68 @@ static DFBQuiescenceProof computeProtocolLifetime(
     return {};
   }
 
+  auto opaqueExternalAccess =
+      llvm::find_if(activeAccesses, [](const DFBAccessOccurrence *access) {
+        return access->opaqueExternalAccess;
+      });
+  if (opaqueExternalAccess != activeAccesses.end()) {
+    if (!hasCanonicalResetTerminator) {
+      return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+              (*opaqueExternalAccess)->operation};
+    }
+    auto unscopedOpaqueAccess =
+        llvm::find_if(activeAccesses, [](const DFBAccessOccurrence *access) {
+          return !access->protocolEffect &&
+                 isa<OpaqueCallOp>(access->operation) &&
+                 !access->opaqueExternalAccess;
+        });
+    if (unscopedOpaqueAccess != activeAccesses.end()) {
+      return {DFBQuiescenceFailureReason::MissingProtocolEffect,
+              (*unscopedOpaqueAccess)->operation};
+    }
+
+    SmallVector<const DFBAccessOccurrence *> earliestAccesses =
+        findMinimalEntryAccesses(activeAccesses, graph, operationEvents,
+                                 accessEvents);
+    SmallVector<const DFBAccessOccurrence *> terminalAccesses =
+        findMaximalCompletionAccesses(activeAccesses, graph, operationEvents,
+                                      accessEvents);
+    if (earliestAccesses.empty() || terminalAccesses.empty()) {
+      return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+              activeAccesses.front()->operation};
+    }
+    for (const DFBAccessOccurrence *earliestAccess : earliestAccesses) {
+      std::optional<AccessEventSpan> events =
+          getAccessEventSpan(*earliestAccess, operationEvents, accessEvents);
+      if (!events) {
+        return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+                earliestAccess->operation};
+      }
+      if (!llvm::is_contained(lifetime.earliestEntryEvents,
+                              events->first.entry)) {
+        lifetime.earliestEntryEvents.push_back(events->first.entry);
+      }
+      lifetime.earliestAccessOccurrenceIndices.push_back(
+          static_cast<unsigned>(earliestAccess - logicalDFB.accesses.data()));
+    }
+    for (const DFBAccessOccurrence *terminalAccess : terminalAccesses) {
+      std::optional<AccessEventSpan> events =
+          getAccessEventSpan(*terminalAccess, operationEvents, accessEvents);
+      if (!events) {
+        return {DFBQuiescenceFailureReason::UnsupportedControlFlow,
+                terminalAccess->operation};
+      }
+      if (!llvm::is_contained(lifetime.terminalCompletionEvents,
+                              events->last.completion)) {
+        lifetime.terminalCompletionEvents.push_back(events->last.completion);
+      }
+      lifetime.terminalAccessOccurrenceIndices.push_back(
+          static_cast<unsigned>(terminalAccess - logicalDFB.accesses.data()));
+    }
+    lifetime.resetCanonicalizedOpaqueProtocol = true;
+    return {};
+  }
+
   bool resetTerminatedProducer = hasCanonicalResetTerminator && hasReserve &&
                                  hasPush && !hasWait && !hasPop;
   if ((!hasReserve || !hasPush || !hasWait || !hasPop) &&
@@ -3443,6 +3536,8 @@ static DFBQuiescenceProof computePerNodeLifetime(
     epoch.readCursorRuns = epochLifetime.readCursorRuns;
     epoch.writePointerOwner = epochLifetime.writePointerOwner;
     epoch.readPointerOwner = epochLifetime.readPointerOwner;
+    epoch.resetCanonicalizedOpaqueProtocol =
+        epochLifetime.resetCanonicalizedOpaqueProtocol;
     epoch.quiescence = proof;
     if (resetTerminated) {
       const OrderedResetBoundary &boundary = boundaries[epochIndex];
@@ -3469,6 +3564,8 @@ static DFBQuiescenceProof computePerNodeLifetime(
       lifetime.readCursorRuns = epochLifetime.readCursorRuns;
       lifetime.writePointerOwner = epochLifetime.writePointerOwner;
       lifetime.readPointerOwner = epochLifetime.readPointerOwner;
+      lifetime.resetCanonicalizedOpaqueProtocol =
+          epochLifetime.resetCanonicalizedOpaqueProtocol;
       hasActiveEpoch = true;
     }
     lifetime.conditionalExecutionProven |=
@@ -3484,6 +3581,8 @@ static DFBQuiescenceProof computePerNodeLifetime(
     lifetime.terminalWritePointerOwner =
         epochLifetime.terminalWritePointerOwner;
     lifetime.terminalReadPointerOwner = epochLifetime.terminalReadPointerOwner;
+    lifetime.resetCanonicalizedOpaqueProtocol |=
+        epochLifetime.resetCanonicalizedOpaqueProtocol;
     lifetime.terminalStateCanonical = epochLifetime.terminalStateCanonical;
   }
 

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -71,12 +71,13 @@ struct DFBQuiescenceProof {
 /// A concrete lifecycle operation contributes one occurrence. An operation
 /// with a protocol summary contributes one occurrence per effect, preserving
 /// actions on different DFBs as distinct events. A dependency occurrence with
-/// no effect contributes an opaque call-duration access.
+/// no effect contributes an opaque access whose completion may require a
+/// synchronized reset.
 struct DFBAccessOccurrence {
   /// Operation that performs the access; several occurrences may share it.
   Operation *operation = nullptr;
 
-  /// Null for an opaque call-duration storage access.
+  /// Null for an access without an explicit protocol effect.
   std::optional<DFBProtocolEffectKind> protocolEffect;
 
   /// Positive for protocol effects and zero for opaque accesses.
@@ -91,7 +92,7 @@ struct DFBAccessOccurrence {
   /// Operation that prevented a precise launch domain, or null when precise.
   Operation *unanalyzableDomainOperation = nullptr;
 
-  /// Whether this call-duration access is a named opaque external dependency.
+  /// Whether this occurrence is a named opaque external DFB dependency.
   bool opaqueExternalAccess = false;
 };
 

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.h
@@ -90,6 +90,9 @@ struct DFBAccessOccurrence {
 
   /// Operation that prevented a precise launch domain, or null when precise.
   Operation *unanalyzableDomainOperation = nullptr;
+
+  /// Whether this call-duration access is a named opaque external dependency.
+  bool opaqueExternalAccess = false;
 };
 
 /// Execution count retained for one access in the allocation report.
@@ -157,6 +160,7 @@ struct DFBLifecycleEpoch {
   std::optional<DFBPointerOwner> terminalWritePointerOwner;
   std::optional<DFBPointerOwner> terminalReadPointerOwner;
   std::optional<int64_t> terminalResetOrdinal;
+  bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
   DFBQuiescenceProof quiescence;
 };
@@ -200,6 +204,7 @@ struct DFBPerNodeLifetime {
   SmallVector<DFBTransactionRun, 0> terminalReadCursorRuns;
   std::optional<DFBPointerOwner> terminalWritePointerOwner;
   std::optional<DFBPointerOwner> terminalReadPointerOwner;
+  bool resetCanonicalizedOpaqueProtocol = false;
   bool terminalStateCanonical = false;
   SmallVector<DFBLifecycleEpoch, 0> resetEpochs;
   DFBQuiescenceProof quiescence;
@@ -220,6 +225,7 @@ struct DFBLogicalLifecycle {
   bool compilerCreated = false;
   SmallVector<BindCBOp> declarations;
   SmallVector<DFBAccessOccurrence> accesses;
+  bool hasOpaqueExternalAccess = false;
   LaunchNodeDomain launchDomain;
   SmallVector<DFBPerNodeLifetime, 0> nodeLifetimes;
   SmallVector<DFBPerNodeLifetime, 0> possibleNodeLifetimes;

--- a/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBPhysicalAllocationPlan.cpp
@@ -262,8 +262,13 @@ public:
         DFBAllocationGroupAttr lhsGroup = logicalDFBs[lhsIndex].allocationGroup;
         DFBAllocationGroupAttr rhsGroup = logicalDFBs[rhsIndex].allocationGroup;
         bool sameAllocationGroup = lhsGroup && lhsGroup == rhsGroup;
+        bool opaqueAccessRequiresExactDescriptor =
+            logicalDFBs[lhsIndex].hasOpaqueExternalAccess ||
+            logicalDFBs[rhsIndex].hasOpaqueExternalAccess;
         addPairConflicts(model, liveness, lhsIndex, rhsIndex,
-                         /*requireExactDescriptor=*/!sameAllocationGroup,
+                         /*requireExactDescriptor=*/
+                         !sameAllocationGroup ||
+                             opaqueAccessRequiresExactDescriptor,
                          /*requireMatchingTransactions=*/!sameAllocationGroup,
                          /*useAllocationGroupEpochs=*/sameAllocationGroup);
       }
@@ -309,7 +314,8 @@ public:
       return model;
     }
     addPairConflicts(model, liveness, lhsIndex, rhsIndex,
-                     /*requireExactDescriptor=*/false,
+                     /*requireExactDescriptor=*/lhs.hasOpaqueExternalAccess ||
+                         rhs.hasOpaqueExternalAccess,
                      /*requireMatchingTransactions=*/false,
                      /*useAllocationGroupEpochs=*/true);
     addResetAllocationConflicts(model, liveness,

--- a/test/python/test_external_dfb_reuse.py
+++ b/test/python/test_external_dfb_reuse.py
@@ -252,8 +252,6 @@ _external_bf16_multiply = _make_external_multiply_kernel("bf16")
 _external_f32_multiply = _make_external_multiply_kernel("float32")
 _external_bf16_reset_same_dfb = _make_external_reset_kernel("bf16", False)
 _external_f32_reset_same_dfb = _make_external_reset_kernel("float32", False)
-_external_bf16_reset_reuse = _make_external_reset_kernel("bf16", True)
-_external_f32_reset_reuse = _make_external_reset_kernel("float32", True)
 _external_bf16_composition = _make_external_composition_kernel("bf16", False)
 _external_f32_composition = _make_external_composition_kernel("float32", False)
 _tensor_backed_bf16_composition = _make_external_composition_kernel("bf16", True)
@@ -364,10 +362,10 @@ def test_external_multiply_with_dfb_allocation(
 
 
 @pytest.mark.parametrize(
-    ("operation", "dtype"),
+    ("data_format", "dtype"),
     [
-        (_external_bf16_reset_reuse, torch.bfloat16),
-        (_external_f32_reset_reuse, torch.float32),
+        ("bf16", torch.bfloat16),
+        ("float32", torch.float32),
     ],
     ids=["bf16", "f32"],
 )
@@ -377,11 +375,12 @@ def test_external_multiply_with_dfb_allocation(
     ids=["dram", "l1"],
 )
 def test_external_protocol_state_reset_allows_group_reuse(
-    device, operation, dtype, to_device, monkeypatch, tmp_path
+    device, data_format, dtype, to_device, monkeypatch, tmp_path
 ):
     if ttl_api._detect_device_arch(device) != "blackhole":
         pytest.skip("requires Blackhole DFB reset support")
 
+    operation = _make_external_reset_kernel(data_format, True)
     element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
     lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
     rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)

--- a/test/python/test_external_dfb_reuse.py
+++ b/test/python/test_external_dfb_reuse.py
@@ -80,7 +80,7 @@ def _make_external_multiply_kernel(data_format):
     return external_multiply_kernel
 
 
-def _make_external_reset_kernel(data_format):
+def _make_external_reset_kernel(data_format, distinct_logical_dfbs):
     compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
     reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
     writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
@@ -92,11 +92,27 @@ def _make_external_reset_kernel(data_format):
     def external_reset_kernel(lhs, rhs, result):
         lhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
         rhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
-        stale_result = ttl.make_dfb(
-            data_format,
-            shape=(1, 1),
-            block_count=2,
-        )
+        if distinct_logical_dfbs:
+            shared_allocation = ttl.make_dfb_allocation_group()
+            stale_result = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=2,
+                allocation_group=shared_allocation,
+            )
+            current_result = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=2,
+                allocation_group=shared_allocation,
+            )
+        else:
+            stale_result = ttl.make_dfb(
+                data_format,
+                shape=(1, 1),
+                block_count=2,
+            )
+            current_result = stale_result
 
         @ttl.compute(kernel=compute_kernel)
         def compute():
@@ -118,13 +134,13 @@ def _make_external_reset_kernel(data_format):
             with rhs_dfb.reserve() as rhs_destination:
                 ttl.copy(rhs[0, 0], rhs_destination).wait()
             ttl.reset_dfbs(reset, dfbs=[stale_result])
-            with stale_result.reserve() as current_destination:
+            with current_result.reserve() as current_destination:
                 ttl.copy(rhs[0, 0], current_destination).wait()
 
         @ttl.datamovement(kernel=writer_kernel)
         def write():
             ttl.reset_dfbs(reset, dfbs=[stale_result])
-            with stale_result.wait() as current_source:
+            with current_result.wait() as current_source:
                 ttl.copy(current_source, result[0, 0]).wait()
 
     return external_reset_kernel
@@ -234,8 +250,10 @@ def _make_external_composition_kernel(data_format, tensor_backed):
 
 _external_bf16_multiply = _make_external_multiply_kernel("bf16")
 _external_f32_multiply = _make_external_multiply_kernel("float32")
-_external_bf16_reset_same_dfb = _make_external_reset_kernel("bf16")
-_external_f32_reset_same_dfb = _make_external_reset_kernel("float32")
+_external_bf16_reset_same_dfb = _make_external_reset_kernel("bf16", False)
+_external_f32_reset_same_dfb = _make_external_reset_kernel("float32", False)
+_external_bf16_reset_reuse = _make_external_reset_kernel("bf16", True)
+_external_f32_reset_reuse = _make_external_reset_kernel("float32", True)
 _external_bf16_composition = _make_external_composition_kernel("bf16", False)
 _external_f32_composition = _make_external_composition_kernel("float32", False)
 _tensor_backed_bf16_composition = _make_external_composition_kernel("bf16", True)
@@ -343,6 +361,50 @@ def test_external_multiply_with_dfb_allocation(
             rtol=F32_EXTERNAL_MULTIPLY_RTOL,
             atol=F32_EXTERNAL_MULTIPLY_ATOL,
         )
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_external_bf16_reset_reuse, torch.bfloat16),
+        (_external_f32_reset_reuse, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    "to_device",
+    [to_dram, to_l1],
+    ids=["dram", "l1"],
+)
+def test_external_protocol_state_reset_allows_group_reuse(
+    device, operation, dtype, to_device, monkeypatch, tmp_path
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
+    rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)
+    lhs = to_device(lhs_host, device)
+    rhs = to_device(rhs_host, device)
+    result = to_device(torch.zeros_like(rhs_host), device)
+    final_mlir_path = tmp_path / "external_reset_reuse.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+
+    for _invocation_index in range(2):
+        operation(
+            lhs,
+            rhs,
+            result,
+            options="--ttl-reuse-user-dfbs --ttl-specialize-cores",
+        )
+
+    assert _count_final_dfb_allocations(final_mlir_path) == 3
+    actual = ttnn.to_torch(result).float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, rhs_host.float(), rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, rhs_host.float(), rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/test/python/test_external_dfb_reuse.py
+++ b/test/python/test_external_dfb_reuse.py
@@ -19,6 +19,7 @@ import torch
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 import ttl  # noqa: E402
+from ttl import ttl_api  # noqa: E402
 from ttlang_test_utils import to_dram, to_l1, to_l1_sharded  # noqa: E402
 from utils.correctness import assert_allclose  # noqa: E402
 
@@ -77,6 +78,56 @@ def _make_external_multiply_kernel(data_format):
         result_source.pop()
 
     return external_multiply_kernel
+
+
+def _make_external_reset_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    reset = ttl.DFBReset(
+        participants=(compute_kernel, reader_kernel, writer_kernel),
+    )
+
+    @ttl.operation(grid=(1, 1))
+    def external_reset_kernel(lhs, rhs, result):
+        lhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        rhs_dfb = ttl.make_dfb(data_format, shape=(1, 1), block_count=2)
+        stale_result = ttl.make_dfb(
+            data_format,
+            shape=(1, 1),
+            block_count=2,
+        )
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            ttl.call_extern_func(
+                EXTERNAL_MULTIPLY_HEADER,
+                "ttl_external_eltwise_mul",
+                template_args=[
+                    ttl.dfb_descriptor(lhs_dfb),
+                    ttl.dfb_descriptor(rhs_dfb),
+                    ttl.dfb_descriptor(stale_result),
+                ],
+            )
+            ttl.reset_dfbs(reset, dfbs=[stale_result])
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            with lhs_dfb.reserve() as lhs_destination:
+                ttl.copy(lhs[0, 0], lhs_destination).wait()
+            with rhs_dfb.reserve() as rhs_destination:
+                ttl.copy(rhs[0, 0], rhs_destination).wait()
+            ttl.reset_dfbs(reset, dfbs=[stale_result])
+            with stale_result.reserve() as current_destination:
+                ttl.copy(rhs[0, 0], current_destination).wait()
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            ttl.reset_dfbs(reset, dfbs=[stale_result])
+            with stale_result.wait() as current_source:
+                ttl.copy(current_source, result[0, 0]).wait()
+
+    return external_reset_kernel
 
 
 def _make_nested_copy_atom(data_format, level_count):
@@ -183,6 +234,8 @@ def _make_external_composition_kernel(data_format, tensor_backed):
 
 _external_bf16_multiply = _make_external_multiply_kernel("bf16")
 _external_f32_multiply = _make_external_multiply_kernel("float32")
+_external_bf16_reset_same_dfb = _make_external_reset_kernel("bf16")
+_external_f32_reset_same_dfb = _make_external_reset_kernel("float32")
 _external_bf16_composition = _make_external_composition_kernel("bf16", False)
 _external_f32_composition = _make_external_composition_kernel("float32", False)
 _tensor_backed_bf16_composition = _make_external_composition_kernel("bf16", True)
@@ -194,6 +247,47 @@ assert EXTERNAL_COMPOSITION_LOGICAL_DFBS > 64
 def _count_final_dfb_allocations(final_mlir_path):
     final_mlir = final_mlir_path.read_text()
     return final_mlir.count("dfb_index =")
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype"),
+    [
+        (_external_bf16_reset_same_dfb, torch.bfloat16),
+        (_external_f32_reset_same_dfb, torch.float32),
+    ],
+    ids=["bf16", "f32"],
+)
+@pytest.mark.parametrize(
+    "to_device",
+    [to_dram, to_l1],
+    ids=["dram", "l1"],
+)
+def test_external_protocol_state_reset_drains_compute_interfaces(
+    device, operation, dtype, to_device
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    element_indices = torch.arange(TILE * TILE, dtype=torch.float32).reshape(TILE, TILE)
+    lhs_host = ((element_indices.remainder(41) - 20) / 16).to(dtype)
+    rhs_host = (((3 * element_indices).remainder(37) - 18) / 16).to(dtype)
+    lhs = to_device(lhs_host, device)
+    rhs = to_device(rhs_host, device)
+    result = to_device(torch.zeros_like(rhs_host), device)
+
+    for _invocation_index in range(2):
+        operation(
+            lhs,
+            rhs,
+            result,
+            options="--ttl-reuse-user-dfbs --ttl-specialize-cores",
+        )
+
+    actual = ttnn.to_torch(result).float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, rhs_host.float(), rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, rhs_host.float(), rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_external_call.mlir
@@ -2,22 +2,21 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s
 
 // A descriptor reference keeps A live through the external call without a
-// runtime DFB argument. The call completes before A's pop, so the
-// acknowledgment still orders B after A and permits A and B to share physical
-// index 0. The index query after the pop does not access physical storage and
-// does not extend A's lifetime.
+// runtime DFB argument. The unsummarized call may change A's protocol state,
+// so A remains unbounded and cannot share with B. The index query after the pop
+// does not access physical storage and does not extend A's lifetime.
 
-// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}]}
+// CHECK: module attributes {ttl.dfb_allocations = [{{.*}}dfb_index = 0 : i32{{.*}}, {{.*}}dfb_index = 1 : i32{{.*}}, {{.*}}dfb_index = 2 : i32{{.*}}]}
 // CHECK-LABEL: func.func @external_use_before_release_dm
-// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK-SAME: ttl.base_cta_index = 3 : i32
 // CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
-// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
 // CHECK-LABEL: func.func @external_use_before_release_compute
-// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK-SAME: ttl.base_cta_index = 3 : i32
 // CHECK-DAG: %[[A:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // CHECK-DAG: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
-// CHECK-DAG: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+// CHECK-DAG: ttl.bind_cb{cb_index = 2, block_count = 2} {dfb_id = 2 : index}
 // CHECK: ttl.opaque_call "inspect_dfb" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%[[A]] : !ttl.cb<{{.*}}>) () {header = "inspect_dfb.hpp"}
 // CHECK: ttl.cb_pop %[[A]]
 // CHECK: ttl.get_dfb_id %[[A]]

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
@@ -11,7 +11,7 @@
 
 // REPORT: DFB logical_id=0 bounded=0 compiler_created=0
 // REPORT-SAME: domain={}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={}
 // REPORT: DFB logical_id=1 bounded=0 compiler_created=0
 // REPORT-SAME: domain=unknown
 // REPORT-NOT: DFB conflict lhs=0 rhs=1
@@ -101,7 +101,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // REPORT: DFB logical_id=12 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(0,0), (1,0)}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0), (1,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={(0,0), (1,0)}
 // REPORT: DFB conflict lhs=12 rhs=13 reason=unknown-launch-node-domain
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
@@ -146,7 +146,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // REPORT: DFB logical_id=14 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(0,0)}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={(0,0)}
 // REPORT: DFB logical_id=15 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(1,0)}
 // REPORT-NOT: DFB conflict lhs=14 rhs=15
@@ -202,7 +202,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 // REPORT: DFB logical_id=16 bounded=0 compiler_created=0
 // REPORT-SAME: domain=unknown
 // REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(0,0), (1,0)}
-// REPORT: access 4 effect=none tiles=0 sequence=0 domain=unknown
+// REPORT: access 4 effect=none tiles=0 sequence=0 opaque_external=1 domain=unknown
 // REPORT: DFB logical_id=17 bounded=1 compiler_created=0
 // REPORT-SAME: domain={(0,0), (1,0)}
 // REPORT: DFB conflict lhs=16 rhs=17 reason=unknown-launch-node-domain
@@ -323,7 +323,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // REPORT: DFB logical_id=24 bounded=0 compiler_created=0
 // REPORT-SAME: domain={(0,0)}
-// REPORT: access 0 effect=none tiles=0 sequence=0 domain={(0,0)}
+// REPORT: access 0 effect=none tiles=0 sequence=0 opaque_external=1 domain={(0,0)}
 // REPORT: access 1 effect=none tiles=0 sequence=0 domain={(0,0)}
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
@@ -1,6 +1,6 @@
 // Tests storage reuse after a synchronized reset canonicalizes protocol state
 // following named opaque external DFB accesses.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s
 
 // Reader and compute execute runtime-dependent external protocols on `old`.
 // Their collective reset establishes canonical protocol state without
@@ -66,6 +66,89 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
     ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "opaque_reset">, <kind = data_movement, identity = "reader", operation = "opaque_reset">, <kind = data_movement, identity = "writer", operation = "opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+}
+
+// -----
+
+// Equal typed predicates prove that the opaque access, matching reset, and
+// following lifecycle execute together on each possible launch node.
+
+// CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// CHECK: DFB logical_id=0 bounded=1 compiler_created=0 conditionally_bounded=0 opaque_external_access=1
+// CHECK: node (0,0) quiescence=none domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
+// CHECK: node (1,0) quiescence=none domain_assumption=exact conditional_execution=1 opaque_protocol_reset=1
+// CHECK: DFB logical_id=1 bounded=1 compiler_created=0 conditionally_bounded=0
+// CHECK: Total DFB count: 1
+
+module attributes {ttl.launch_grid = [2, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @conditional_opaque_reset_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : i64
+    %value = ttl.opaque_call "reader_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+    %active = arith.cmpi ne, %value, %zero : i64
+    scf.if %active {
+      ttl.opaque_call "runtime_chunk_reader" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+      %slot = ttl.cb_reserve %current
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    }
+    return
+  }
+
+  func.func @conditional_opaque_reset_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "conditional_opaque_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : i64
+    %value = ttl.opaque_call "compute_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+    %active = arith.cmpi ne, %value, %zero : i64
+    scf.if %active {
+      ttl.opaque_call "runtime_chunk_compute" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+      %slot = ttl.cb_wait %current
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+            -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    }
+    return
+  }
+
+  func.func @conditional_opaque_reset_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %zero = arith.constant 0 : i64
+    %value = ttl.opaque_call "writer_active" () {condition_result = #ttl.dispatch_condition<0, i64>, header = "condition.hpp"} : () -> i64
+    %active = arith.cmpi ne, %value, %zero : i64
+    scf.if %active {
+      ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "reader", operation = "conditional_opaque_reset">, <kind = data_movement, identity = "writer", operation = "conditional_opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    }
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime.mlir
@@ -1,0 +1,71 @@
+// Tests storage reuse after a synchronized reset canonicalizes protocol state
+// following named opaque external DFB accesses.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s
+
+// Reader and compute execute runtime-dependent external protocols on `old`.
+// Their collective reset establishes canonical protocol state without
+// asserting internal transaction counts, then permits `current` to reuse the
+// physical DFB.
+
+// CHECK: DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] envelope_bytes=6144 handoff=proven
+// CHECK: DFB logical_id=0 bounded=1{{.*}}opaque_external_access=1
+// CHECK: opaque_protocol_reset=1
+// CHECK: reset_epochs=[{accesses=[0, 1],transactions=[],write_owner=unknown,read_owner=unknown,terminal_reset=0,opaque_protocol_reset=1,terminal_state=canonical}]
+// CHECK: DFB logical_id=1 bounded=1{{.*}}allocation_group=#ttl.dfb_allocation_group<0>
+// CHECK: Total DFB count: 1
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @opaque_reset_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "opaque_reset">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "runtime_chunk_reader" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "opaque_reset">, <kind = data_movement, identity = "reader", operation = "opaque_reset">, <kind = data_movement, identity = "writer", operation = "opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @opaque_reset_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "opaque_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "runtime_chunk_compute" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>) () {header = "sdpa.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "opaque_reset">, <kind = data_movement, identity = "reader", operation = "opaque_reset">, <kind = data_movement, identity = "writer", operation = "opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %slot = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @opaque_reset_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "opaque_reset">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "opaque_reset">, <kind = data_movement, identity = "reader", operation = "opaque_reset">, <kind = data_movement, identity = "writer", operation = "opaque_reset">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime_invalid.mlir
@@ -11,7 +11,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
     %old = ttl.bind_cb {cb_index = 0, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] cannot alias logical DFBs 0 and 1: unproven-quiescence}}
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] cannot alias logical DFBs 0 and 1: access-completion-not-proven}}
     %current = ttl.bind_cb {cb_index = 1, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -46,7 +46,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     ttl.opaque_call "reserve_only" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>] () {header = "effects.hpp"} : () -> ()
     ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "explicit">, <kind = data_movement, identity = "reader", operation = "explicit">, <kind = data_movement, identity = "writer", operation = "explicit">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
-    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<4> members=[0, 1] cannot alias logical DFBs 0 and 1: unproven-quiescence}}
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<4> members=[0, 1] cannot alias logical DFBs 0 and 1: access-completion-not-proven}}
     %slot = ttl.cb_reserve %current
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
           -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -217,7 +217,7 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
     %current = ttl.bind_cb {cb_index = 1, block_count = 2}
         {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<3> members=[0, 1] cannot alias logical DFBs 0 and 1: unproven-quiescence}}
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<3> members=[0, 1] cannot alias logical DFBs 0 and 1: access-completion-not-proven}}
     ttl.opaque_call "opaque" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp", unknown_dfb_access} : () -> ()
     ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "unknown">, <kind = data_movement, identity = "reader", operation = "unknown">, <kind = data_movement, identity = "writer", operation = "unknown">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
     %slot = ttl.cb_reserve %current

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_opaque_reset_lifetime_invalid.mlir
@@ -1,0 +1,262 @@
+// Tests rejected opaque external DFB lifetime contracts.
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})'
+
+// A named opaque dependency remains unproved without a synchronized reset.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @missing_reset()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "missing_reset">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<0> members=[0, 1] cannot alias logical DFBs 0 and 1: unproven-quiescence}}
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "opaque" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A partial explicit effect summary remains subject to transaction analysis.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @explicit_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "explicit">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "reserve_only" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "explicit">, <kind = data_movement, identity = "reader", operation = "explicit">, <kind = data_movement, identity = "writer", operation = "explicit">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<4> members=[0, 1] cannot alias logical DFBs 0 and 1: unproven-quiescence}}
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @explicit_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "explicit">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "explicit">, <kind = data_movement, identity = "reader", operation = "explicit">, <kind = data_movement, identity = "writer", operation = "explicit">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @explicit_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "explicit">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<4>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "explicit">, <kind = data_movement, identity = "reader", operation = "explicit">, <kind = data_movement, identity = "writer", operation = "explicit">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}
+
+// -----
+
+// Two opaque lifetimes before the same reset cannot share storage.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @same_epoch_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "same_epoch">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "first" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<1> members=[0, 1] cannot alias logical DFBs 0 and 1: concurrent-lifetime}}
+    ttl.opaque_call "second" dfb_dependencies(%second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "same_epoch">, <kind = data_movement, identity = "reader", operation = "same_epoch">, <kind = data_movement, identity = "writer", operation = "same_epoch">]>(%first, %second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @same_epoch_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "same_epoch">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "same_epoch">, <kind = data_movement, identity = "reader", operation = "same_epoch">, <kind = data_movement, identity = "writer", operation = "same_epoch">]>(%first, %second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @same_epoch_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "same_epoch">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<1>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "same_epoch">, <kind = data_movement, identity = "reader", operation = "same_epoch">, <kind = data_movement, identity = "writer", operation = "same_epoch">]>(%first, %second : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}
+
+// -----
+
+// A reset does not reconfigure an opaque external DFB descriptor.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @descriptor_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "descriptor">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<2> members=[0, 1] cannot alias logical DFBs 0 and 1: descriptor-mismatch}}
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.opaque_call "opaque" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "descriptor">, <kind = data_movement, identity = "reader", operation = "descriptor">, <kind = data_movement, identity = "writer", operation = "descriptor">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    return
+  }
+
+  func.func @descriptor_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "descriptor">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "descriptor">, <kind = data_movement, identity = "reader", operation = "descriptor">, <kind = data_movement, identity = "writer", operation = "descriptor">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+
+  func.func @descriptor_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "descriptor">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 3}
+        {allocation_group = #ttl.dfb_allocation_group<2>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "descriptor">, <kind = data_movement, identity = "reader", operation = "descriptor">, <kind = data_movement, identity = "writer", operation = "descriptor">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 3>)
+    return
+  }
+}
+
+// -----
+
+// Unlisted DFB access remains unproved even when named DFBs are reset.
+
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @unknown_reader()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "unknown">,
+                  ttl.noc_index = 0 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{DFB allocation group #ttl.dfb_allocation_group<3> members=[0, 1] cannot alias logical DFBs 0 and 1: unproven-quiescence}}
+    ttl.opaque_call "opaque" dfb_dependencies(%old : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp", unknown_dfb_access} : () -> ()
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "unknown">, <kind = data_movement, identity = "reader", operation = "unknown">, <kind = data_movement, identity = "writer", operation = "unknown">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    %slot = ttl.cb_reserve %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %value = ttl.cb_wait %current
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %current : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+
+  func.func @unknown_compute()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "unknown">,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "unknown">, <kind = data_movement, identity = "reader", operation = "unknown">, <kind = data_movement, identity = "writer", operation = "unknown">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+
+  func.func @unknown_writer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "unknown">,
+                  ttl.noc_index = 1 : i32, ttl.base_cta_index = 2 : i32,
+                  ttl.crta_indices = []} {
+    %old = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %current = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {allocation_group = #ttl.dfb_allocation_group<3>, dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "unknown">, <kind = data_movement, identity = "reader", operation = "unknown">, <kind = data_movement, identity = "writer", operation = "unknown">]>(%old, %current : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>, !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
@@ -3,12 +3,13 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
 
 // A loop producer and an explicit external consumer describe the same four
-// transactions. The non-protocol producer access executes in the same loop.
+// transactions, but the unsummarized producer access may change protocol state.
+// Both DFBs therefore remain distinct.
 
 // REUSE-LABEL: func.func @loop_to_explicit
-// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
 
 module {
   func.func @loop_to_explicit()
@@ -76,6 +77,13 @@ module {
 // REPORT: node (0,0) quiescence=none
 // REPORT-SAME: occurrences=[0:4, 1:4, 2:1, 3:1, 4:1, 5:1, 6:1, 7:1, 8:1, 9:1]
 // REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: node (1,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: operation=ttl.cb_reserve kernel=@nested_explicit_consumer
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: node (1,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @nested_explicit_consumer()
@@ -109,12 +117,14 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// An explicit producer summary and a loop consumer normalize identically.
+// An explicit producer summary and a loop consumer describe matching
+// transactions, but the unsummarized consumer access may change protocol
+// state. Both DFBs therefore remain distinct.
 
 // REUSE-LABEL: func.func @explicit_to_loop
-// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
 
 module {
   func.func @explicit_to_loop()
@@ -150,7 +160,12 @@ module {
 // REUSE-SAME: ttl.base_cta_index = 1 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
 // REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
-// REPORT-COUNT-6: transactions=[4, 4, 4, 4]
+// REPORT: operation=ttl.cb_reserve kernel=@loop_to_loop
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
+// REPORT: operation=ttl.cb_reserve kernel=@loop_to_loop
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[4, 4, 4, 4]
 
 module {
   func.func @loop_to_loop()
@@ -183,8 +198,8 @@ module {
 
 // -----
 
-// Each straight-line acquisition owns only the direct DFB accesses before the
-// next same-kind acquisition. Both producer and consumer runs remain bounded.
+// Unsummarized accesses in the straight-line producer and consumer may change
+// protocol state, so the combined DFB lifetime remains unbounded.
 
 // REUSE-LABEL: func.func @straight_line_producer
 // REUSE-SAME: ttl.base_cta_index = 1 : i32
@@ -192,9 +207,10 @@ module {
 // REUSE-LABEL: func.func @straight_line_consumer
 // REUSE-SAME: ttl.base_cta_index = 1 : i32
 // REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// REPORT: DFB logical_id=0 bounded=1
-// REPORT: node (0,0) quiescence=none
-// REPORT-SAME: transactions=[1, 1]
+// REPORT: DFB logical_id=0 bounded=0
+// REPORT: node (0,0) quiescence=missing-protocol-effect
+// REPORT-SAME: evidence=ttl.opaque_call kernel=@straight_line_producer
+// REPORT-SAME: transactions=[]
 
 module {
   func.func @straight_line_producer()

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
@@ -10,7 +10,7 @@
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@differing_iteration_domains
 // REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@conditional_iteration
 // REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@nonuniform_exact_selection
-// REPORT: quiescence=incomplete-use-order {{.*}} kernel=@access_outside_interval
+// REPORT: quiescence=missing-protocol-effect {{.*}} kernel=@access_outside_interval
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@unrelated_opaque_access
 

--- a/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/finalize_dfb_indices_unknown_domain_debug.mlir
@@ -12,12 +12,10 @@
 // CHECK: DFB logical_id=0 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
 // CHECK: access 0 effect=reserve tiles=1 sequence=0 domain=unknown
-// CHECK: access 4 effect=none tiles=0 sequence=0 domain=unknown
+// CHECK: access 4 effect=none tiles=0 sequence=0 opaque_external=1 domain=unknown
 // CHECK-SAME: operation=ttl.opaque_call kernel=@unknown_domain
 // CHECK-SAME: unresolved_at=arith.cmpi kernel=@unknown_domain
-// CHECK: possible_nodes quiescence=incomplete-use-order domain_assumption=unknown-possible may_be_active=1 conditional_execution=1 node_count=1 nodes={(0,0)}
-// CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
-// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=9 exemplar=(1,0)
+// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:unresolved, 2:unresolved, 3:unresolved, 4:unresolved]
 // CHECK: DFB logical_id=1 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
@@ -31,7 +29,7 @@
 // CHECK-SAME: occurrences=[0:0, 1:0, 2:0, 3:0]
 // CHECK: DFB logical_id=3 bounded=0 compiler_created=0
 // CHECK-SAME: domain=unknown
-// CHECK: possible_nodes quiescence=unsupported-control-flow domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
+// CHECK: possible_nodes quiescence=missing-protocol-effect domain_assumption=unknown-possible may_be_active=1 conditional_execution=0 node_count=10 exemplar=(0,0)
 // CHECK-SAME: occurrences=[0:unresolved, 1:1, 2:1, 3:1, 4:1]
 // CHECK-SAME: transactions=[]
 // CHECK: DFB conflict lhs=0 rhs=1 reason=unknown-launch-node-domain node=none

--- a/test/ttlang/Translate/TTLToCpp/dfb_reset.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dfb_reset.mlir
@@ -8,7 +8,7 @@
 // CHECK: static_assert(releaseWord + 1 == stateWordCount);
 // CHECK: FORCE_INLINE void drainComputeEngine()
 // CHECK: TTI_STALLWAIT(p_stall::STALL_TDMA, waitResources);
-// CHECK: sync_regfile_write(completionGpr);
+// CHECK-NEXT: tensix_sync();
 // CHECK: FORCE_INLINE void enter(volatile uint32_t tt_l1_ptr *synchronizationState)
 // CHECK: noc_async_full_barrier();
 // CHECK: while (!participantsHaveState(synchronizationState, entryComplete))

--- a/test/ttlang/Translate/TTLToCpp/dfb_reset.mlir
+++ b/test/ttlang/Translate/TTLToCpp/dfb_reset.mlir
@@ -6,11 +6,12 @@
 // CHECK: constexpr uint32_t stateWordCount = 4;
 // CHECK: constexpr uint32_t participantCount = 3;
 // CHECK: static_assert(releaseWord + 1 == stateWordCount);
-// CHECK: FORCE_INLINE void drainComputeEngine()
+// CHECK: FORCE_INLINE void completeInterfaceWork()
+// CHECK: noc_async_full_barrier();
 // CHECK: TTI_STALLWAIT(p_stall::STALL_TDMA, waitResources);
 // CHECK-NEXT: tensix_sync();
 // CHECK: FORCE_INLINE void enter(volatile uint32_t tt_l1_ptr *synchronizationState)
-// CHECK: noc_async_full_barrier();
+// CHECK: completeInterfaceWork();
 // CHECK: while (!participantsHaveState(synchronizationState, entryComplete))
 // CHECK: FORCE_INLINE void exit(volatile uint32_t tt_l1_ptr *synchronizationState)
 // CHECK: while (!participantsHaveState(synchronizationState, exitComplete))
@@ -21,6 +22,8 @@
 // CHECK: *get_cb_tiles_received_ptr(dfbIndex) = 0;
 // CHECK: *get_cb_tiles_acked_ptr(dfbIndex) = 0;
 // CHECK: interface.fifo_wr_tile_ptr = 0;
+// CHECK: FORCE_INLINE void complete_dfb_interface_work()
+// CHECK: dfb_reset_detail::completeInterfaceWork();
 // CHECK: FORCE_INLINE void reset_dfb_interfaces(uint32_t synchronizationAddress,
 // CHECK: dfb_reset_detail::applyMask(lowMask, 0);
 // CHECK: dfb_reset_detail::applyMask(highMask, 32);


### PR DESCRIPTION
Depends on #904.

### Problem description

An external function may manage a DFB protocol that the compiler cannot summarize. Its protocol and asynchronous interface work may remain active after the call. A synchronized reset can complete that work, canonicalize the DFB state, and terminate the opaque storage lifetime, but the allocator previously could not prove later storage reuse.

### What's changed

~200 LOC implementation (tests and documentation excluded).

- Complete DM0, DM1, PACK, and UNPACK interface work before reset arrival.
- Expose the same per-RISC completion operation to custom reset protocols.
- Model each named unsummarized external DFB dependency from call entry through a matching synchronized reset in the same participating logical kernel.
- Permit later reuse only after reset completion and only for identical DFB descriptors.
- Continue rejecting missing resets, unknown DFB access, partial effect summaries, descriptor changes, nonparticipants, mismatched conditions, and concurrent lifetimes.

```python
ttl.call_extern_func(
    header,
    "external_compute",
    template_args=[ttl.dfb_descriptor(previous_result)],
)
ttl.reset_dfbs(reset, dfbs=[previous_result, current_result])
```

### Validation

- New device tests cover built-in and custom reset completion across BF16/FP32 and DRAM/L1, including repeat execution and allocation reuse.
- New MLIR tests cover reset-terminated opaque lifetimes, invalid incomplete lifetimes, conditional reset facts, and C++ lowering.

### Checklist

- [x] New tests provide coverage for the changes.
