### PR TITLE
[ttl] Prove structural DFB transaction order [dfb-order-1]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1359,7 +1359,8 @@ order can pass through any number of intermediate kernels.
 
 #### Lifetimes with statically known transactions
 
-A logical DFB is bounded only when all of these conditions hold:
+For one-to-one transaction matching, a logical DFB is bounded only when all of
+these conditions hold:
 
 - a positive, equal number of reserve, push, wait, and pop executions reference
   it;
@@ -1378,6 +1379,9 @@ A logical DFB is bounded only when all of these conditions hold:
 - all reserve and push occurrences have one known write-pointer owner, and all
   wait and pop occurrences have one known read-pointer owner;
 - the final pop follows every active access occurrence on the DFB.
+
+Exact cumulative external effect sequences use the separate queue-state proof
+described under [External calls](#external-calls).
 
 Lifecycle operations inside a statically selected `scf.if`, `affine.if`,
 `ttl.if_src`, or `ttl.if_dst` region, or inside an exact static loop, may satisfy

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1385,8 +1385,9 @@ described under [External calls](#external-calls).
 
 Lifecycle operations inside a statically selected `scf.if`, `affine.if`,
 `ttl.if_src`, or `ttl.if_dst` region, or inside an exact static loop, may satisfy
-these conditions. Dynamic trip counts and conditionally repeated loop bodies
-remain unproven.
+these conditions. An at-most-once region inside a static loop also qualifies
+when exact counts prove that the region executes in every loop iteration.
+Dynamic trip counts and runtime-selected repeated regions remain unproven.
 
 An access with an unknown launch-node domain is refined to an exact domain when
 execution-count analysis proves a count on every base launch node. Nodes with
@@ -2092,11 +2093,13 @@ with releases before finalization.
   `scf.if`, `affine.if`, `ttl.if_src`, and `ttl.if_dst` can be bounded when
   launch-node and execution-count analysis prove one execution on the
   applicable node. Exact static loops can be bounded when matched runs share
-  one iteration domain and their operations have structural order. Nested
-  operations project to the enclosing kernel-body operation for inter-kernel
-  ordering. Dynamic or conditionally repeated regions and multi-block functions
-  remain conservative. More precise region-local ordering for those forms
-  requires occurrence-level entry and completion events.
+  one iteration domain and their operations have structural order. This
+  includes at-most-once regions proven to execute in every static iteration.
+  Nested operations project to the enclosing kernel-body operation for
+  inter-kernel ordering. Dynamic or runtime-selected repeated regions and
+  multi-block functions remain conservative. More precise region-local
+  ordering for those forms requires occurrence-level entry and completion
+  events.
   MLIR's
   [One-Shot Bufferize](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp)
   applies the same conservative restriction when repeated regions invalidate a
@@ -2104,7 +2107,7 @@ with releases before finalization.
 
 - **Unresolved repeated protocols.** Static loops with matched structured
   iteration domains and exact external cumulative sequences are supported.
-  Dynamic trip counts, conditionally repeated iterations, unknown external
+  Dynamic trip counts, runtime-selected iterations, unknown external
   effect order, and mixed native/external cumulative sequences remain
   conservative.
 

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -1357,16 +1357,20 @@ operation with the ID of the declaration reached from its DFB operand.
 Protocol edges from all logical DFBs share one module graph, so transitive
 order can pass through any number of intermediate kernels.
 
-#### Lifetimes with statically enumerated transactions
+#### Lifetimes with statically known transactions
 
 A logical DFB is bounded only when all of these conditions hold:
 
-- a positive, equal number of reserve, push, wait, and pop occurrences reference
+- a positive, equal number of reserve, push, wait, and pop executions reference
   it;
-- static execution analysis proves that the operation owning each occurrence
-  executes exactly once on the applicable launched node;
-- occurrences pair by order into reserve/push/wait/pop transactions;
+- static execution analysis proves exact counts and iteration domains for each
+  repeated run;
+- the normalized executions pair by order into reserve/push/wait/pop
+  transactions;
 - within every transaction, reserve precedes push and wait precedes pop;
+- adjacent transaction runs are ordered within one exact static iteration
+  domain, or every execution of the earlier run precedes every execution of the
+  later run;
 - each concrete push follows all uses owned by its reserve, and each concrete
   pop follows all uses owned by its wait;
 - all four actions in a transaction transfer the same tile count (`num_tiles`),
@@ -1376,8 +1380,9 @@ A logical DFB is bounded only when all of these conditions hold:
 - the final pop follows every active access occurrence on the DFB.
 
 Lifecycle operations inside a statically selected `scf.if`, `affine.if`,
-`ttl.if_src`, or `ttl.if_dst` region may satisfy these conditions. Repeated or
-unknown execution remains unproven.
+`ttl.if_src`, or `ttl.if_dst` region, or inside an exact static loop, may satisfy
+these conditions. Dynamic trip counts and conditionally repeated loop bodies
+remain unproven.
 
 An access with an unknown launch-node domain is refined to an exact domain when
 execution-count analysis proves a count on every base launch node. Nodes with
@@ -1617,8 +1622,10 @@ analyzeConcurrentLifetimes(module, logicalIdentities):
         add previous completion -> entry
 
     for each logical DFB active on the node:
-      if statically counted reserve, push, wait, and pop runs match, or one
-         reserve, push, wait, and pop share one at-most-once condition:
+      if statically counted reserve/push and wait/pop runs align within their
+         respective exact iteration domains, producer and consumer counts
+         match, and adjacent runs have proven order, or one reserve, push,
+         wait, and pop share one at-most-once condition:
         DFB.nodeLifetime.transactionRuns = normalized counted transactions
         DFB.nodeLifetime.pointerOwners = read and write hardware processors
         add DFB.push.completion -> DFB.wait.completion
@@ -2080,10 +2087,12 @@ with releases before finalization.
 - **Structured control flow and index reuse.** Lifecycle operations inside
   `scf.if`, `affine.if`, `ttl.if_src`, and `ttl.if_dst` can be bounded when
   launch-node and execution-count analysis prove one execution on the
-  applicable node. Nested operations project to the enclosing kernel-body
-  operation for inter-kernel ordering. Repeated regions and multi-block
-  functions remain conservative. More precise region-local ordering requires
-  occurrence-level entry and completion events.
+  applicable node. Exact static loops can be bounded when matched runs share
+  one iteration domain and their operations have structural order. Nested
+  operations project to the enclosing kernel-body operation for inter-kernel
+  ordering. Dynamic or conditionally repeated regions and multi-block functions
+  remain conservative. More precise region-local ordering for those forms
+  requires occurrence-level entry and completion events.
   MLIR's
   [One-Shot Bufferize](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp)
   applies the same conservative restriction when repeated regions invalidate a

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -416,6 +416,11 @@ struct AccessRun {
 
 using AccessRuns = DenseMap<const DFBAccessOccurrence *, AccessRun>;
 
+static bool isAtMostOnceRegionParent(Operation *operation) {
+  return isa<affine::AffineIfOp, scf::IfOp, scf::IndexSwitchOp,
+             scf::ExecuteRegionOp, IfSrcOp, IfDstOp>(operation);
+}
+
 static AccessDomain refineUnknownAccessDomainFromExecutionCounts(
     Operation *operation, AccessDomain accessDomain,
     const LivenessDomainState &domainState) {
@@ -438,8 +443,8 @@ static AccessDomain refineUnknownAccessDomainFromExecutionCounts(
 }
 
 // Proves that an access executes once in every iteration of one immutable
-// structured loop nest. Region selection between the loops and the access is
-// rejected because an aggregate count cannot prove per-iteration execution.
+// structured loop nest. At-most-once regions must be selected on every
+// enclosing-loop invocation.
 static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
     Operation *operation, std::uint64_t executionCount, LaunchNodeCoord node,
     const LivenessDomainState &domainState) {
@@ -469,7 +474,14 @@ static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
     if (!loop) {
       std::optional<std::uint64_t> parentExecutionCount =
           getExactExecutionCountAtLaunchNode(parent, node, domainState);
-      if (!parentExecutionCount || *parentExecutionCount != 1) {
+      // Equality proves that an at-most-once region was selected for every
+      // parent invocation, including each enclosing-loop iteration.
+      std::optional<std::uint64_t> selectedExecutionCount =
+          parentExecutionCount ? llvm::checkedMulUnsigned(*parentExecutionCount,
+                                                          domainExecutionCount)
+                               : std::nullopt;
+      if (!isAtMostOnceRegionParent(parent) || !selectedExecutionCount ||
+          *selectedExecutionCount != executionCount) {
         return std::nullopt;
       }
       nestedOperation = parent;
@@ -516,8 +528,7 @@ static bool structurallyExecutesAtMostOnce(Operation *operation) {
     Operation *parent = region ? region->getParentOp() : nullptr;
     if (!parent || !region->hasOneBlock() ||
         nestedOperation->getBlock() != &region->front() ||
-        !isa<affine::AffineIfOp, scf::IfOp, scf::IndexSwitchOp,
-             scf::ExecuteRegionOp>(parent)) {
+        !isAtMostOnceRegionParent(parent)) {
       return false;
     }
     nestedOperation = parent;
@@ -826,6 +837,17 @@ static SmallVector<llvm::BitVector> collectInconsistentAccessOrder(
   return inconsistent;
 }
 
+static bool
+accessOccurrencePrecedes(const DFBAccessOccurrence &before,
+                         const DFBAccessOccurrence &after,
+                         const StructuralOperationOrder &structuralOrder) {
+  if (before.operation == after.operation) {
+    return before.protocolEffect && after.protocolEffect &&
+           before.sequenceIndex < after.sequenceIndex;
+  }
+  return structuralOrder.precedes(before.operation, after.operation);
+}
+
 // Proves ordering between corresponding executions, not all-before-all
 // ordering across the complete runs.
 static bool runPrecedesWithinEachIteration(
@@ -836,18 +858,15 @@ static bool runPrecedesWithinEachIteration(
     return false;
   }
   if (before.access->operation == after.access->operation) {
-    return before.access->protocolEffect && after.access->protocolEffect &&
-           before.access->sequenceIndex < after.access->sequenceIndex;
+    return accessOccurrencePrecedes(*before.access, *after.access,
+                                    structuralOrder);
   }
-  if (before.conditionalExecution && after.conditionalExecution) {
-    return structuralOrder.precedes(before.access->operation,
-                                    after.access->operation);
-  }
-  if (before.executionCount <= 1) {
+  if (!(before.conditionalExecution && after.conditionalExecution) &&
+      before.executionCount <= 1) {
     return false;
   }
-  return structuralOrder.precedes(before.access->operation,
-                                  after.access->operation);
+  return accessOccurrencePrecedes(*before.access, *after.access,
+                                  structuralOrder);
 }
 
 // The middle edge preserves iteration-to-iteration order without one event per
@@ -863,15 +882,15 @@ static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
 // Requires a release to follow every use owned by its acquisition; textual
 // acquire/release order alone does not prove storage quiescence.
 // `sameKindAcquires` contains every same-DFB acquisition of the same kind.
-static bool
-releaseFollowsOwnedUses(Operation *acquire, Operation *release,
-                        ArrayRef<Operation *> sameKindAcquires,
-                        const StructuralOperationOrder &structuralOrder) {
+static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release,
+                                    ArrayRef<Operation *> sameKindAcquires) {
+  if (acquire->getBlock() != release->getBlock()) {
+    return false;
+  }
   DFBAcquireInterval interval =
       makeDFBAcquireInterval(acquire, sameKindAcquires);
   Operation *lastOwnedUse = findLastDFBAcquireOwnedUse(interval);
-  return lastOwnedUse == acquire ||
-         structuralOrder.precedes(lastOwnedUse, release);
+  return lastOwnedUse == acquire || lastOwnedUse->isBeforeInBlock(release);
 }
 
 // Finds every access without a proved predecessor so all possible lifetime
@@ -1760,12 +1779,7 @@ static void buildProgramOrderTopology(
         if (before == after) {
           continue;
         }
-        bool ordered =
-            before->operation == after->operation
-                ? before->protocolEffect && after->protocolEffect &&
-                      before->sequenceIndex < after->sequenceIndex
-                : structuralOrder.precedes(before->operation, after->operation);
-        if (ordered) {
+        if (accessOccurrencePrecedes(*before, *after, structuralOrder)) {
           graph.addEdge(accessEvents.at(before).last.completion,
                         accessEvents.at(after).first.entry);
         }
@@ -2166,8 +2180,9 @@ static bool acquireReleaseRunsAlign(
         isa<CBPushOp>(release.access->operation)) ||
        (isa<CBWaitOp>(acquire.access->operation) &&
         isa<CBPopOp>(release.access->operation))) &&
-      structuralOrder.precedes(acquire.access->operation,
-                               release.access->operation);
+      acquire.access->operation->getBlock() ==
+          release.access->operation->getBlock() &&
+      acquire.access->operation->isBeforeInBlock(release.access->operation);
   return acquire.executionCount == release.executionCount &&
          acquire.iterationDomain == release.iterationDomain &&
          (nativeAcquirePrecedesRelease ||
@@ -3037,8 +3052,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
       }
       if (isa<CBReserveOp>(reserve->access->operation) &&
           !releaseFollowsOwnedUses(reserve->access->operation,
-                                   push->access->operation, nativeReserves,
-                                   structuralOrder)) {
+                                   push->access->operation, nativeReserves)) {
         return {DFBQuiescenceFailureReason::IncompleteUseOrder,
                 push->access->operation};
       }
@@ -3060,8 +3074,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
       }
       if (isa<CBWaitOp>(wait->access->operation) &&
           !releaseFollowsOwnedUses(wait->access->operation,
-                                   pop->access->operation, nativeWaits,
-                                   structuralOrder)) {
+                                   pop->access->operation, nativeWaits)) {
         return {DFBQuiescenceFailureReason::IncompleteUseOrder,
                 pop->access->operation};
       }

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -828,8 +828,9 @@ static SmallVector<llvm::BitVector> collectInconsistentAccessOrder(
 
 // Proves ordering between corresponding executions, not all-before-all
 // ordering across the complete runs.
-static bool runPrecedesWithinEachIteration(const AccessRun &before,
-                                           const AccessRun &after) {
+static bool runPrecedesWithinEachIteration(
+    const AccessRun &before, const AccessRun &after,
+    const StructuralOperationOrder &structuralOrder) {
   if (!(before.iterationDomain == after.iterationDomain) ||
       before.executionCount != after.executionCount) {
     return false;
@@ -839,30 +840,28 @@ static bool runPrecedesWithinEachIteration(const AccessRun &before,
            before.access->sequenceIndex < after.access->sequenceIndex;
   }
   if (before.conditionalExecution && after.conditionalExecution) {
-    return before.access->operation->getBlock() ==
-               after.access->operation->getBlock() &&
-           before.access->operation->isBeforeInBlock(after.access->operation);
+    return structuralOrder.precedes(before.access->operation,
+                                    after.access->operation);
   }
   if (before.executionCount <= 1) {
     return false;
   }
-  return before.access->operation->getBlock() ==
-             after.access->operation->getBlock() &&
-         before.access->operation->isBeforeInBlock(after.access->operation);
+  return structuralOrder.precedes(before.access->operation,
+                                  after.access->operation);
 }
 
 // Requires a release to follow every use owned by its acquisition; textual
 // acquire/release order alone does not prove storage quiescence.
 // `sameKindAcquires` contains every same-DFB acquisition of the same kind.
-static bool releaseFollowsOwnedUses(Operation *acquire, Operation *release,
-                                    ArrayRef<Operation *> sameKindAcquires) {
-  if (acquire->getBlock() != release->getBlock()) {
-    return false;
-  }
+static bool
+releaseFollowsOwnedUses(Operation *acquire, Operation *release,
+                        ArrayRef<Operation *> sameKindAcquires,
+                        const StructuralOperationOrder &structuralOrder) {
   DFBAcquireInterval interval =
       makeDFBAcquireInterval(acquire, sameKindAcquires);
   Operation *lastOwnedUse = findLastDFBAcquireOwnedUse(interval);
-  return lastOwnedUse == acquire || lastOwnedUse->isBeforeInBlock(release);
+  return lastOwnedUse == acquire ||
+         structuralOrder.precedes(lastOwnedUse, release);
 }
 
 // Finds every access without a proved predecessor so all possible lifetime
@@ -1720,8 +1719,8 @@ static void buildProgramOrderTopology(
         if (afterRunIt == accessRuns.end() ||
             afterRunIt->second->executionCount <= 1 ||
             afterEventsIt == accessEvents.end() ||
-            !runPrecedesWithinEachIteration(*beforeRunIt->second,
-                                            *afterRunIt->second)) {
+            !runPrecedesWithinEachIteration(
+                *beforeRunIt->second, *afterRunIt->second, structuralOrder)) {
           continue;
         }
         graph.addEdge(beforeEventsIt->second.first.completion,
@@ -1966,6 +1965,7 @@ static bool matchAccessRuns(ArrayRef<const AccessRun *> sources,
 
 static FailureOr<SmallVector<const AccessRun *>> orderProtocolRuns(
     ArrayRef<const AccessRun *> runs, const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents);
 
@@ -1975,6 +1975,7 @@ static bool tryAddCumulativeQueueEdges(
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
     LaunchNodeCoord node, const LaunchNodeDomainState &domainState,
+    const StructuralOperationOrder &structuralOrder,
     bool includeUnknownDomains);
 
 static bool
@@ -2002,6 +2003,7 @@ static void addProtocolSynchronizationEdges(
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
     LaunchNodeCoord node, const LaunchNodeDomainState &domainState,
+    const StructuralOperationOrder &structuralOrder,
     bool includeUnknownDomains) {
   for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
     SmallVector<const AccessRun *> reserves;
@@ -2078,7 +2080,7 @@ static void addProtocolSynchronizationEdges(
   for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
     tryAddCumulativeQueueEdges(logicalDFB, graph, operationEvents, accessEvents,
                                executionCounts, accessRuns, node, domainState,
-                               includeUnknownDomains);
+                               structuralOrder, includeUnknownDomains);
   }
 }
 
@@ -2087,6 +2089,7 @@ static void addProtocolSynchronizationEdges(
 static bool proveRunBeforeWithinEachIteration(
     const AccessRun &before, const AccessRun &after,
     const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
@@ -2094,7 +2097,7 @@ static bool proveRunBeforeWithinEachIteration(
       !(before.iterationDomain == after.iterationDomain)) {
     return false;
   }
-  if (runPrecedesWithinEachIteration(before, after)) {
+  if (runPrecedesWithinEachIteration(before, after, structuralOrder)) {
     return true;
   }
   if (before.executionCount != 1 || after.executionCount != 1) {
@@ -2114,11 +2117,12 @@ static bool proveRunBeforeWithinEachIteration(
 static bool proveAllRunExecutionsBefore(
     const AccessRun &before, const AccessRun &after,
     const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
   if (before.executionCount == 1 && after.executionCount == 1 &&
-      runPrecedesWithinEachIteration(before, after)) {
+      runPrecedesWithinEachIteration(before, after, structuralOrder)) {
     return true;
   }
   std::optional<AccessEventSpan> beforeEvents =
@@ -2130,9 +2134,24 @@ static bool proveAllRunExecutionsBefore(
                                 afterEvents->first.entry);
 }
 
+static bool
+proveRunPrecedes(const AccessRun &before, const AccessRun &after,
+                 const HappensBeforeGraph &graph,
+                 const StructuralOperationOrder &structuralOrder,
+                 const DenseMap<Operation *, EventPair> &operationEvents,
+                 const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
+                     &accessEvents) {
+  return proveRunBeforeWithinEachIteration(before, after, graph,
+                                           structuralOrder, operationEvents,
+                                           accessEvents) ||
+         proveAllRunExecutionsBefore(before, after, graph, structuralOrder,
+                                     operationEvents, accessEvents);
+}
+
 static bool acquireReleaseRunsAlign(
     const AccessRun &acquire, const AccessRun &release,
     const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
@@ -2141,19 +2160,20 @@ static bool acquireReleaseRunsAlign(
         isa<CBPushOp>(release.access->operation)) ||
        (isa<CBWaitOp>(acquire.access->operation) &&
         isa<CBPopOp>(release.access->operation))) &&
-      acquire.access->operation->getBlock() ==
-          release.access->operation->getBlock() &&
-      acquire.access->operation->isBeforeInBlock(release.access->operation);
+      structuralOrder.precedes(acquire.access->operation,
+                               release.access->operation);
   return acquire.executionCount == release.executionCount &&
          acquire.iterationDomain == release.iterationDomain &&
          (nativeAcquirePrecedesRelease ||
           proveRunBeforeWithinEachIteration(acquire, release, graph,
-                                            operationEvents, accessEvents));
+                                            structuralOrder, operationEvents,
+                                            accessEvents));
 }
 
 static bool proveAlignedAcquireReleaseRuns(
     ArrayRef<const AccessRun *> acquires, ArrayRef<const AccessRun *> releases,
     const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
@@ -2165,16 +2185,15 @@ static bool proveAlignedAcquireReleaseRuns(
         const AccessRun &acquire = *std::get<0>(pair);
         const AccessRun &release = *std::get<1>(pair);
         return acquire.access->numTiles == release.access->numTiles &&
-               acquireReleaseRunsAlign(acquire, release, graph, operationEvents,
-                                       accessEvents);
+               acquireReleaseRunsAlign(acquire, release, graph, structuralOrder,
+                                       operationEvents, accessEvents);
       });
   if (!pairsAreAligned) {
     return false;
   }
   for (std::size_t runIndex = 1; runIndex < acquires.size(); ++runIndex) {
-    if (!proveAllRunExecutionsBefore(*releases[runIndex - 1],
-                                     *acquires[runIndex], graph,
-                                     operationEvents, accessEvents)) {
+    if (!proveRunPrecedes(*releases[runIndex - 1], *acquires[runIndex], graph,
+                          structuralOrder, operationEvents, accessEvents)) {
       return false;
     }
   }
@@ -2184,13 +2203,14 @@ static bool proveAlignedAcquireReleaseRuns(
 static bool
 runIsInsideInterval(const AccessRun &use, const AccessRun &acquire,
                     const AccessRun &release, const HappensBeforeGraph &graph,
+                    const StructuralOperationOrder &structuralOrder,
                     const DenseMap<Operation *, EventPair> &operationEvents,
                     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
                         &accessEvents) {
-  return proveRunBeforeWithinEachIteration(acquire, use, graph, operationEvents,
-                                           accessEvents) &&
-         proveRunBeforeWithinEachIteration(use, release, graph, operationEvents,
-                                           accessEvents);
+  return proveRunBeforeWithinEachIteration(acquire, use, graph, structuralOrder,
+                                           operationEvents, accessEvents) &&
+         proveRunBeforeWithinEachIteration(use, release, graph, structuralOrder,
+                                           operationEvents, accessEvents);
 }
 
 static void appendTransactionRun(SmallVectorImpl<DFBTransactionRun> &runs,
@@ -2222,6 +2242,7 @@ struct CumulativeQueueSideResult {
 static FailureOr<SmallVector<const AccessRun *>>
 orderProtocolRuns(ArrayRef<const AccessRun *> runs,
                   const HappensBeforeGraph &graph,
+                  const StructuralOperationOrder &structuralOrder,
                   const DenseMap<Operation *, EventPair> &operationEvents,
                   const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
                       &accessEvents) {
@@ -2244,16 +2265,10 @@ orderProtocolRuns(ArrayRef<const AccessRun *> runs,
   for (auto [lhsIndex, lhs] : llvm::enumerate(runs)) {
     for (unsigned rhsIndex = lhsIndex + 1; rhsIndex < runs.size(); ++rhsIndex) {
       const AccessRun *rhs = runs[rhsIndex];
-      bool lhsBeforeRhs =
-          proveRunBeforeWithinEachIteration(*lhs, *rhs, graph, operationEvents,
-                                            accessEvents) ||
-          proveAllRunExecutionsBefore(*lhs, *rhs, graph, operationEvents,
-                                      accessEvents);
-      bool rhsBeforeLhs =
-          proveRunBeforeWithinEachIteration(*rhs, *lhs, graph, operationEvents,
-                                            accessEvents) ||
-          proveAllRunExecutionsBefore(*rhs, *lhs, graph, operationEvents,
-                                      accessEvents);
+      bool lhsBeforeRhs = proveRunPrecedes(*lhs, *rhs, graph, structuralOrder,
+                                           operationEvents, accessEvents);
+      bool rhsBeforeLhs = proveRunPrecedes(*rhs, *lhs, graph, structuralOrder,
+                                           operationEvents, accessEvents);
       if (lhsBeforeRhs == rhsBeforeLhs) {
         return failure();
       }
@@ -2279,11 +2294,12 @@ static CumulativeQueueSideResult proveCumulativeQueueSide(
     DFBProtocolEffectKind acquireKind, DFBProtocolEffectKind releaseKind,
     int64_t physicalTileCount, LaunchNodeCoord node,
     const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
-  FailureOr<SmallVector<const AccessRun *>> orderedRuns =
-      orderProtocolRuns(unorderedRuns, graph, operationEvents, accessEvents);
+  FailureOr<SmallVector<const AccessRun *>> orderedRuns = orderProtocolRuns(
+      unorderedRuns, graph, structuralOrder, operationEvents, accessEvents);
   if (failed(orderedRuns)) {
     return {std::nullopt,
             {DFBQuiescenceFailureReason::IncompleteUseOrder,
@@ -2456,6 +2472,7 @@ static bool appendCumulativeEdge(
     SmallVectorImpl<std::pair<unsigned, unsigned>> &edges,
     const AccessRun &release, const AccessRun &acquire, LaunchNodeCoord node,
     const LaunchNodeDomainState &domainState,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
@@ -2470,7 +2487,7 @@ static bool appendCumulativeEdge(
     return false;
   }
   if (releaseEvents->last.completion == acquireEvents->last.completion) {
-    return runPrecedesWithinEachIteration(release, acquire);
+    return runPrecedesWithinEachIteration(release, acquire, structuralOrder);
   }
   edges.emplace_back(releaseEvents->last.completion,
                      acquireEvents->last.completion);
@@ -2482,6 +2499,7 @@ collectCumulativeSynchronizationEdges(
     const CumulativeQueueSide &producer, const CumulativeQueueSide &consumer,
     int64_t physicalTileCount, LaunchNodeCoord node,
     const LaunchNodeDomainState &domainState,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan>
         &accessEvents) {
@@ -2513,7 +2531,8 @@ collectCumulativeSynchronizationEdges(
         required ? findCumulativeRelease(*published, *required) : nullptr;
     if (!publishingPush ||
         !appendCumulativeEdge(synchronizationEdges, *publishingPush, *run, node,
-                              domainState, operationEvents, accessEvents)) {
+                              domainState, structuralOrder, operationEvents,
+                              accessEvents)) {
       return failure();
     }
   }
@@ -2542,7 +2561,8 @@ collectCumulativeSynchronizationEdges(
         findCumulativeRelease(*consumed, *reservationEnd - capacity);
     if (!enablingPop ||
         !appendCumulativeEdge(synchronizationEdges, *enablingPop, *run, node,
-                              domainState, operationEvents, accessEvents)) {
+                              domainState, structuralOrder, operationEvents,
+                              accessEvents)) {
       return failure();
     }
   }
@@ -2633,6 +2653,7 @@ static bool tryAddCumulativeQueueEdges(
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
     LaunchNodeCoord node, const LaunchNodeDomainState &domainState,
+    const StructuralOperationOrder &structuralOrder,
     bool includeUnknownDomains) {
   SmallVector<const AccessRun *> producerRuns;
   SmallVector<const AccessRun *> consumerRuns;
@@ -2669,10 +2690,12 @@ static bool tryAddCumulativeQueueEdges(
   }
   CumulativeQueueSideResult producer = proveCumulativeQueueSide(
       producerRuns, DFBProtocolEffectKind::Reserve, DFBProtocolEffectKind::Push,
-      physicalTileCount, node, graph, operationEvents, accessEvents);
+      physicalTileCount, node, graph, structuralOrder, operationEvents,
+      accessEvents);
   CumulativeQueueSideResult consumer = proveCumulativeQueueSide(
       consumerRuns, DFBProtocolEffectKind::Wait, DFBProtocolEffectKind::Pop,
-      physicalTileCount, node, graph, operationEvents, accessEvents);
+      physicalTileCount, node, graph, structuralOrder, operationEvents,
+      accessEvents);
   if (!producer.side || !consumer.side ||
       failed(normalizeCumulativeTransactions(producer.side->cursorRuns,
                                              consumer.side->cursorRuns))) {
@@ -2682,7 +2705,7 @@ static bool tryAddCumulativeQueueEdges(
   FailureOr<SmallVector<std::pair<unsigned, unsigned>>> synchronizationEdges =
       collectCumulativeSynchronizationEdges(
           *producer.side, *consumer.side, physicalTileCount, node, domainState,
-          operationEvents, accessEvents);
+          structuralOrder, operationEvents, accessEvents);
   if (failed(synchronizationEdges)) {
     return false;
   }
@@ -2754,6 +2777,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
     SmallVectorImpl<DFBPerNodeLifetime> &lifetimes,
     SmallVectorImpl<DFBPerNodeLifetimeDiagnostics> *lifetimeDiagnostics,
     const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
@@ -2907,11 +2931,11 @@ static DFBQuiescenceProof computeProtocolLifetime(
             reserves.front()->access->operation};
   }
   bool alignedTransactions =
-      proveAlignedAcquireReleaseRuns(reserves, pushes, graph, operationEvents,
-                                     accessEvents) &&
+      proveAlignedAcquireReleaseRuns(reserves, pushes, graph, structuralOrder,
+                                     operationEvents, accessEvents) &&
       (resetTerminatedProducer ||
-       proveAlignedAcquireReleaseRuns(waits, pops, graph, operationEvents,
-                                      accessEvents));
+       proveAlignedAcquireReleaseRuns(waits, pops, graph, structuralOrder,
+                                      operationEvents, accessEvents));
   SmallVector<const AccessRun *> producerProtocolRuns;
   llvm::append_range(producerProtocolRuns, reserves);
   llvm::append_range(producerProtocolRuns, pushes);
@@ -2942,14 +2966,14 @@ static DFBQuiescenceProof computeProtocolLifetime(
     CumulativeQueueSideResult producer = proveCumulativeQueueSide(
         producerProtocolRuns, DFBProtocolEffectKind::Reserve,
         DFBProtocolEffectKind::Push, physicalTileCount, node, graph,
-        operationEvents, accessEvents);
+        structuralOrder, operationEvents, accessEvents);
     if (!producer.side) {
       return producer.failure;
     }
     CumulativeQueueSideResult consumer = proveCumulativeQueueSide(
         consumerProtocolRuns, DFBProtocolEffectKind::Wait,
         DFBProtocolEffectKind::Pop, physicalTileCount, node, graph,
-        operationEvents, accessEvents);
+        structuralOrder, operationEvents, accessEvents);
     if (!consumer.side) {
       return consumer.failure;
     }
@@ -2969,7 +2993,7 @@ static DFBQuiescenceProof computeProtocolLifetime(
     FailureOr<SmallVector<std::pair<unsigned, unsigned>>> synchronizationEdges =
         collectCumulativeSynchronizationEdges(
             *producer.side, *consumer.side, physicalTileCount, node,
-            domainState, operationEvents, accessEvents);
+            domainState, structuralOrder, operationEvents, accessEvents);
     if (failed(synchronizationEdges) ||
         !llvm::all_of(*synchronizationEdges, [&](auto edge) {
           return graph.strictlyPrecedes(edge.first, edge.second);
@@ -3007,7 +3031,8 @@ static DFBQuiescenceProof computeProtocolLifetime(
       }
       if (isa<CBReserveOp>(reserve->access->operation) &&
           !releaseFollowsOwnedUses(reserve->access->operation,
-                                   push->access->operation, nativeReserves)) {
+                                   push->access->operation, nativeReserves,
+                                   structuralOrder)) {
         return {DFBQuiescenceFailureReason::IncompleteUseOrder,
                 push->access->operation};
       }
@@ -3029,7 +3054,8 @@ static DFBQuiescenceProof computeProtocolLifetime(
       }
       if (isa<CBWaitOp>(wait->access->operation) &&
           !releaseFollowsOwnedUses(wait->access->operation,
-                                   pop->access->operation, nativeWaits)) {
+                                   pop->access->operation, nativeWaits,
+                                   structuralOrder)) {
         return {DFBQuiescenceFailureReason::IncompleteUseOrder,
                 pop->access->operation};
       }
@@ -3132,12 +3158,13 @@ static DFBQuiescenceProof computeProtocolLifetime(
     const AccessRun &use = accessRuns.at(activeAccess);
     bool covered = false;
     for (auto [reserve, push] : producerIntervals) {
-      covered |= runIsInsideInterval(use, *reserve, *push, graph,
-                                     operationEvents, accessEvents);
+      covered |=
+          runIsInsideInterval(use, *reserve, *push, graph, structuralOrder,
+                              operationEvents, accessEvents);
     }
     for (auto [wait, pop] : consumerIntervals) {
-      covered |= runIsInsideInterval(use, *wait, *pop, graph, operationEvents,
-                                     accessEvents);
+      covered |= runIsInsideInterval(use, *wait, *pop, graph, structuralOrder,
+                                     operationEvents, accessEvents);
     }
     if (!covered) {
       return {DFBQuiescenceFailureReason::IncompleteUseOrder,
@@ -3221,6 +3248,7 @@ static DFBQuiescenceProof computePerNodeLifetime(
     ArrayRef<ValidatedSynchronizedReset> synchronizedResets,
     const ResetBoundaryEvents &resetBoundaryEvents,
     const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const AccessExecutionCounts &executionCounts, const AccessRuns &accessRuns,
@@ -3244,10 +3272,10 @@ static DFBQuiescenceProof computePerNodeLifetime(
     boundaries.push_back({&reset, eventsIt->second});
   }
   if (boundaries.empty()) {
-    return computeProtocolLifetime(logicalDFB, node, lifetimes,
-                                   lifetimeDiagnostics, graph, operationEvents,
-                                   accessEvents, executionCounts, accessRuns,
-                                   domainState, includeUnknownDomains);
+    return computeProtocolLifetime(
+        logicalDFB, node, lifetimes, lifetimeDiagnostics, graph,
+        structuralOrder, operationEvents, accessEvents, executionCounts,
+        accessRuns, domainState, includeUnknownDomains);
   }
 
   for (auto [lhsIndex, lhs] : llvm::enumerate(boundaries)) {
@@ -3341,8 +3369,8 @@ static DFBQuiescenceProof computePerNodeLifetime(
     SmallVector<DFBPerNodeLifetimeDiagnostics, 0> epochDiagnostics;
     DFBQuiescenceProof proof = computeProtocolLifetime(
         logicalDFB, node, epochLifetimes,
-        diagnostics ? &epochDiagnostics : nullptr, graph, operationEvents,
-        accessEvents, executionCounts, accessRuns, domainState,
+        diagnostics ? &epochDiagnostics : nullptr, graph, structuralOrder,
+        operationEvents, accessEvents, executionCounts, accessRuns, domainState,
         includeUnknownDomains, accesses,
         /*hasCanonicalResetTerminator=*/resetTerminated);
     assert(epochLifetimes.size() == 1 &&
@@ -3528,6 +3556,7 @@ static bool unprovenLifecycleIsOutsideReset(
     const DFBLogicalLifecycle &logicalDFB, LaunchNodeCoord node,
     const AccessExecutionCounts &executionCounts, bool includeUnknownDomains,
     EventPair resetEvents, const HappensBeforeGraph &graph,
+    const StructuralOperationOrder &structuralOrder,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
     const AccessRuns &accessRuns, const LaunchNodeDomainState &domainState) {
@@ -3558,7 +3587,8 @@ static bool unprovenLifecycleIsOutsideReset(
              domainState,
              [&](const AccessRun &reserve, const AccessRun &push) {
                return acquireReleaseRunsAlign(reserve, push, graph,
-                                              operationEvents, accessEvents);
+                                              structuralOrder, operationEvents,
+                                              accessEvents);
              }) &&
          !protocolRunsCrossReset(
              logicalDFB, DFBProtocolEffectKind::Push,
@@ -3569,8 +3599,8 @@ static bool unprovenLifecycleIsOutsideReset(
              logicalDFB, DFBProtocolEffectKind::Wait,
              DFBProtocolEffectKind::Pop, accessSides, accessRuns, node,
              domainState, [&](const AccessRun &wait, const AccessRun &pop) {
-               return acquireReleaseRunsAlign(wait, pop, graph, operationEvents,
-                                              accessEvents);
+               return acquireReleaseRunsAlign(wait, pop, graph, structuralOrder,
+                                              operationEvents, accessEvents);
              });
 }
 
@@ -3604,6 +3634,7 @@ static void collectResetAllocationConflicts(
     ArrayRef<ValidatedSynchronizedReset> synchronizedResets,
     const ResetBoundaryEvents &resetBoundaryEvents,
     const HappensBeforeGraph &graph, LaunchNodeCoord node,
+    const StructuralOperationOrder &structuralOrder,
     const AccessExecutionCounts &executionCounts,
     const DenseMap<Operation *, EventPair> &operationEvents,
     const DenseMap<const DFBAccessOccurrence *, AccessEventSpan> &accessEvents,
@@ -3644,8 +3675,8 @@ static void collectResetAllocationConflicts(
                 : unprovenLifecycleIsOutsideReset(
                       logicalDFB, node, executionCounts,
                       /*includeUnknownDomains=*/usePossibleLifetimes,
-                      resetEvents->second, graph, operationEvents, accessEvents,
-                      accessRuns, domainState);
+                      resetEvents->second, graph, structuralOrder,
+                      operationEvents, accessEvents, accessRuns, domainState);
         if (outsideReset) {
           continue;
         }
@@ -3909,9 +3940,10 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
         logicalDFBs, validatedResets, node, graph, operationEvents,
         accessEvents, resetBoundaryEvents, executionCounts, structuralOrder,
         /*includeUnknownDomains=*/false);
-    addProtocolSynchronizationEdges(
-        logicalDFBs, graph, operationEvents, accessEvents, executionCounts,
-        accessRuns, node, domainState, /*includeUnknownDomains=*/false);
+    addProtocolSynchronizationEdges(logicalDFBs, graph, operationEvents,
+                                    accessEvents, executionCounts, accessRuns,
+                                    node, domainState, structuralOrder,
+                                    /*includeUnknownDomains=*/false);
 
     for (auto [logicalIndex, logicalDFB] : llvm::enumerate(logicalDFBs)) {
       if (!knownLaunchNodeDomainContains(logicalDFB.launchDomain, node)) {
@@ -3924,15 +3956,17 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           allocationDiagnostics
               ? &allocationDiagnostics->nodeLifetimeDiagnostics
               : nullptr,
-          validatedResets, resetBoundaryEvents, graph, operationEvents,
-          accessEvents, executionCounts, accessRuns, domainState);
+          validatedResets, resetBoundaryEvents, graph, structuralOrder,
+          operationEvents, accessEvents, executionCounts, accessRuns,
+          domainState);
       logicalDFB.nodeLifetimes.back().quiescence = proof;
     }
 
     collectResetAllocationConflicts(
         logicalDFBs, validatedResets, resetBoundaryEvents, graph, node,
-        executionCounts, operationEvents, accessEvents, accessRuns, domainState,
-        /*usePossibleLifetimes=*/false, resetAllocationConflicts);
+        structuralOrder, executionCounts, operationEvents, accessEvents,
+        accessRuns, domainState, /*usePossibleLifetimes=*/false,
+        resetAllocationConflicts);
 
     SmallVector<llvm::BitVector> nodeOrdering(
         logicalDFBs.size(), llvm::BitVector(logicalDFBs.size()));
@@ -3983,7 +4017,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     addProtocolSynchronizationEdges(
         logicalDFBs, possibleGraph, possibleOperationEvents,
         possibleAccessEvents, executionCounts, *possibleAccessRuns, node,
-        domainState, /*includeUnknownDomains=*/true);
+        domainState, structuralOrder, /*includeUnknownDomains=*/true);
     for (auto [logicalIndex, logicalDFB] : llvm::enumerate(logicalDFBs)) {
       if (logicalDFB.launchDomain.known) {
         continue;
@@ -3996,16 +4030,17 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
               ? &allocationDiagnostics->possibleNodeLifetimeDiagnostics
               : nullptr,
           validatedResets, possibleResetBoundaryEvents, possibleGraph,
-          possibleOperationEvents, possibleAccessEvents, executionCounts,
-          *possibleAccessRuns, domainState,
+          structuralOrder, possibleOperationEvents, possibleAccessEvents,
+          executionCounts, *possibleAccessRuns, domainState,
           /*includeUnknownDomains=*/true);
       logicalDFB.possibleNodeLifetimes.back().quiescence = proof;
     }
 
     collectResetAllocationConflicts(
         logicalDFBs, validatedResets, possibleResetBoundaryEvents,
-        possibleGraph, node, executionCounts, possibleOperationEvents,
-        possibleAccessEvents, *possibleAccessRuns, domainState,
+        possibleGraph, node, structuralOrder, executionCounts,
+        possibleOperationEvents, possibleAccessEvents, *possibleAccessRuns,
+        domainState,
         /*usePossibleLifetimes=*/true, resetAllocationConflicts);
 
     SmallVector<llvm::BitVector> conditionalNodeOrdering(

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -850,6 +850,14 @@ static bool runPrecedesWithinEachIteration(
                                   after.access->operation);
 }
 
+static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
+                                     const AccessEventSpan &before,
+                                     const AccessEventSpan &after) {
+  graph.addEdge(before.first.completion, after.first.entry);
+  graph.addEdge(after.first.completion, before.last.entry);
+  graph.addEdge(before.last.completion, after.last.entry);
+}
+
 // Requires a release to follow every use owned by its acquisition; textual
 // acquire/release order alone does not prove storage quiescence.
 // `sameKindAcquires` contains every same-DFB acquisition of the same kind.
@@ -1723,12 +1731,8 @@ static void buildProgramOrderTopology(
                 *beforeRunIt->second, *afterRunIt->second, structuralOrder)) {
           continue;
         }
-        graph.addEdge(beforeEventsIt->second.first.completion,
-                      afterEventsIt->second.first.entry);
-        graph.addEdge(afterEventsIt->second.first.completion,
-                      beforeEventsIt->second.last.entry);
-        graph.addEdge(beforeEventsIt->second.last.completion,
-                      afterEventsIt->second.last.entry);
+        addPerIterationSpanOrder(graph, beforeEventsIt->second,
+                                 afterEventsIt->second);
       }
     }
   }

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -850,6 +850,8 @@ static bool runPrecedesWithinEachIteration(
                                   after.access->operation);
 }
 
+// The middle edge preserves iteration-to-iteration order without one event per
+// execution.
 static void addPerIterationSpanOrder(HappensBeforeGraph &graph,
                                      const AccessEventSpan &before,
                                      const AccessEventSpan &after) {

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -416,7 +416,9 @@ struct AccessRun {
 
 using AccessRuns = DenseMap<const DFBAccessOccurrence *, AccessRun>;
 
-static bool isAtMostOnceRegionParent(Operation *operation) {
+// The listed operations execute each nested region at most once per
+// invocation, so only enclosing loops can repeat an access.
+static bool executesRegionsAtMostOnce(Operation *operation) {
   return isa<affine::AffineIfOp, scf::IfOp, scf::IndexSwitchOp,
              scf::ExecuteRegionOp, IfSrcOp, IfDstOp>(operation);
 }
@@ -480,7 +482,7 @@ static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
           parentExecutionCount ? llvm::checkedMulUnsigned(*parentExecutionCount,
                                                           domainExecutionCount)
                                : std::nullopt;
-      if (!isAtMostOnceRegionParent(parent) || !selectedExecutionCount ||
+      if (!executesRegionsAtMostOnce(parent) || !selectedExecutionCount ||
           *selectedExecutionCount != executionCount) {
         return std::nullopt;
       }
@@ -528,7 +530,7 @@ static bool structurallyExecutesAtMostOnce(Operation *operation) {
     Operation *parent = region ? region->getParentOp() : nullptr;
     if (!parent || !region->hasOneBlock() ||
         nestedOperation->getBlock() != &region->front() ||
-        !isAtMostOnceRegionParent(parent)) {
+        !executesRegionsAtMostOnce(parent)) {
       return false;
     }
     nestedOperation = parent;
@@ -837,6 +839,8 @@ static SmallVector<llvm::BitVector> collectInconsistentAccessOrder(
   return inconsistent;
 }
 
+// A summarized call orders its effects by sequence index; accesses in
+// distinct operations use structural IR order.
 static bool
 accessOccurrencePrecedes(const DFBAccessOccurrence &before,
                          const DFBAccessOccurrence &after,
@@ -2154,6 +2158,8 @@ static bool proveAllRunExecutionsBefore(
                                 afterEvents->first.entry);
 }
 
+// Run order may be pointwise within each iteration or all-before-all across
+// the complete runs.
 static bool
 proveRunPrecedes(const AccessRun &before, const AccessRun &after,
                  const HappensBeforeGraph &graph,

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -353,12 +353,20 @@ def _make_repeated_transaction_kernel(data_format):
 
         @ttl.datamovement(kernel=reader_kernel)
         def read():
-            for transaction in range(4):
+            for transaction_pair in range(2):
                 with first_source.reserve() as destination:
                     ttl.copy(
                         input_tensor[
                             0:1,
-                            transaction * 4 : transaction * 4 + 4,
+                            transaction_pair * 8 : transaction_pair * 8 + 4,
+                        ],
+                        destination,
+                    ).wait()
+                with first_source.reserve() as destination:
+                    ttl.copy(
+                        input_tensor[
+                            0:1,
+                            transaction_pair * 8 + 4 : transaction_pair * 8 + 8,
                         ],
                         destination,
                     ).wait()
@@ -366,12 +374,20 @@ def _make_repeated_transaction_kernel(data_format):
             with completion.wait():
                 pass
 
-            for transaction in range(4):
+            for transaction_pair in range(2):
                 with second_source.reserve() as destination:
                     ttl.copy(
                         input_tensor[
                             0:1,
-                            transaction * 4 : transaction * 4 + 4,
+                            transaction_pair * 8 : transaction_pair * 8 + 4,
+                        ],
+                        destination,
+                    ).wait()
+                with second_source.reserve() as destination:
+                    ttl.copy(
+                        input_tensor[
+                            0:1,
+                            transaction_pair * 8 + 4 : transaction_pair * 8 + 8,
                         ],
                         destination,
                     ).wait()

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -353,44 +353,49 @@ def _make_repeated_transaction_kernel(data_format):
 
         @ttl.datamovement(kernel=reader_kernel)
         def read():
+            node_x, _ = ttl.node(dims=2)
             for transaction_pair in range(2):
-                with first_source.reserve() as destination:
-                    ttl.copy(
-                        input_tensor[
-                            0:1,
-                            transaction_pair * 8 : transaction_pair * 8 + 4,
-                        ],
-                        destination,
-                    ).wait()
-                with first_source.reserve() as destination:
-                    ttl.copy(
-                        input_tensor[
-                            0:1,
-                            transaction_pair * 8 + 4 : transaction_pair * 8 + 8,
-                        ],
-                        destination,
-                    ).wait()
+                if node_x == 0:
+                    with first_source.reserve() as destination:
+                        ttl.copy(
+                            input_tensor[
+                                0:1,
+                                transaction_pair * 8 : transaction_pair * 8 + 4,
+                            ],
+                            destination,
+                        ).wait()
+                if node_x == 0:
+                    with first_source.reserve() as destination:
+                        ttl.copy(
+                            input_tensor[
+                                0:1,
+                                transaction_pair * 8 + 4 : transaction_pair * 8 + 8,
+                            ],
+                            destination,
+                        ).wait()
 
             with completion.wait():
                 pass
 
             for transaction_pair in range(2):
-                with second_source.reserve() as destination:
-                    ttl.copy(
-                        input_tensor[
-                            0:1,
-                            transaction_pair * 8 : transaction_pair * 8 + 4,
-                        ],
-                        destination,
-                    ).wait()
-                with second_source.reserve() as destination:
-                    ttl.copy(
-                        input_tensor[
-                            0:1,
-                            transaction_pair * 8 + 4 : transaction_pair * 8 + 8,
-                        ],
-                        destination,
-                    ).wait()
+                if node_x == 0:
+                    with second_source.reserve() as destination:
+                        ttl.copy(
+                            input_tensor[
+                                0:1,
+                                transaction_pair * 8 : transaction_pair * 8 + 4,
+                            ],
+                            destination,
+                        ).wait()
+                if node_x == 0:
+                    with second_source.reserve() as destination:
+                        ttl.copy(
+                            input_tensor[
+                                0:1,
+                                transaction_pair * 8 + 4 : transaction_pair * 8 + 8,
+                            ],
+                            destination,
+                        ).wait()
 
         @ttl.compute(kernel=compute_kernel)
         def compute():

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
@@ -58,37 +58,6 @@ module {
 
 // -----
 
-// The analysis does not model operations inside nested regions, so the DFB's
-// lifetime remains unbounded even though the region executes exactly once.
-
-// CHECK-LABEL: func.func @nested_reserve
-// CHECK-SAME: ttl.base_cta_index = 2 : i32
-// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
-
-module {
-  func.func @nested_reserve()
-      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
-    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %first_reserved = scf.execute_region -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
-      %nested_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      scf.yield %nested_reserved : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    }
-    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    return
-  }
-}
-
-// -----
-
 // A multi-block function has no modeled linear program order.
 
 // CHECK-LABEL: func.func @multiple_blocks

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness_unbounded.mlir
@@ -58,6 +58,37 @@ module {
 
 // -----
 
+// An acquisition nested in a separate region from its release is not a valid
+// automatic synchronization interval.
+
+// CHECK-LABEL: func.func @nested_reserve
+// CHECK-SAME: ttl.base_cta_index = 2 : i32
+// CHECK: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// CHECK-NEXT: ttl.bind_cb{cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @nested_reserve()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = scf.execute_region -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+      %nested_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      scf.yield %nested_reserved : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
 // A multi-block function has no modeled linear program order.
 
 // CHECK-LABEL: func.func @multiple_blocks

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
@@ -224,3 +224,110 @@ module {
     return
   }
 }
+
+// -----
+
+// Two transactions in each loop iteration form one complete protocol run.
+
+// REPORT: operation=ttl.cb_reserve kernel=@two_transactions_per_iteration_producer
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[1, 1, 1, 1, 1, 1, 1, 1]
+
+module {
+  func.func @two_transactions_per_iteration_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      %reserved_0 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      %reserved_1 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+
+  func.func @two_transactions_per_iteration_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    scf.for %iteration = %lower to %upper step %step {
+      %waited_0 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      %waited_1 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// Ordered sibling regions preserve one native acquisition interval, including
+// the acquired tensor use before release.
+
+// REPORT: operation=ttl.cb_reserve kernel=@sibling_region_acquire_release
+// REPORT: node (0,0) quiescence=none
+// REPORT-SAME: transactions=[1]
+
+module {
+  func.func @sibling_region_acquire_release()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %enabled = arith.constant true
+    scf.if %enabled {
+      %reserved = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %producer_use = tensor.extract_slice %reserved[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    scf.if %enabled {
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.if %enabled {
+      %waited = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %consumer_use = tensor.extract_slice %waited[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    scf.if %enabled {
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    return
+  }
+}
+
+// -----
+
+// A single-instance nested acquisition retains structural order with its
+// top-level release and permits the following lifecycle to reuse the index.
+
+// REUSE-LABEL: func.func @nested_reserve
+// REUSE-SAME: ttl.base_cta_index = 1 : i32
+// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+
+module {
+  func.func @nested_reserve()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_reserved = scf.execute_region -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+      %nested_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      scf.yield %nested_reserved : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    }
+    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions.mlir
@@ -242,11 +242,16 @@ module {
     %lower = arith.constant 0 : index
     %upper = arith.constant 4 : index
     %step = arith.constant 1 : index
+    %enabled = arith.constant true
     scf.for %iteration = %lower to %upper step %step {
-      %reserved_0 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-      %reserved_1 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      scf.if %enabled {
+        %reserved_0 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      }
+      scf.if %enabled {
+        %reserved_1 = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      }
     }
     return
   }
@@ -258,76 +263,17 @@ module {
     %lower = arith.constant 0 : index
     %upper = arith.constant 4 : index
     %step = arith.constant 1 : index
-    scf.for %iteration = %lower to %upper step %step {
-      %waited_0 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-      %waited_1 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    }
-    return
-  }
-}
-
-// -----
-
-// Ordered sibling regions preserve one native acquisition interval, including
-// the acquired tensor use before release.
-
-// REPORT: operation=ttl.cb_reserve kernel=@sibling_region_acquire_release
-// REPORT: node (0,0) quiescence=none
-// REPORT-SAME: transactions=[1]
-
-module {
-  func.func @sibling_region_acquire_release()
-      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                  ttl.base_cta_index = 1 : i32, ttl.crta_indices = []} {
-    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %enabled = arith.constant true
-    scf.if %enabled {
-      %reserved = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      %producer_use = tensor.extract_slice %reserved[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
+    scf.for %iteration = %lower to %upper step %step {
+      scf.if %enabled {
+        %waited_0 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      }
+      scf.if %enabled {
+        %waited_1 = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      }
     }
-    scf.if %enabled {
-      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    }
-    scf.if %enabled {
-      %waited = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      %consumer_use = tensor.extract_slice %waited[0, 0] [1, 1] [1, 1] : tensor<1x1x!ttcore.tile<32x32, bf16>> to tensor<1x1x!ttcore.tile<32x32, bf16>>
-    }
-    scf.if %enabled {
-      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    }
-    return
-  }
-}
-
-// -----
-
-// A single-instance nested acquisition retains structural order with its
-// top-level release and permits the following lifecycle to reuse the index.
-
-// REUSE-LABEL: func.func @nested_reserve
-// REUSE-SAME: ttl.base_cta_index = 1 : i32
-// REUSE: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 0 : index}
-// REUSE-NEXT: ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 1 : index}
-
-module {
-  func.func @nested_reserve()
-      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
-                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
-    %first_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %first_reserved = scf.execute_region -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
-      %nested_reserved = ttl.cb_reserve %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-      scf.yield %nested_reserved : tensor<1x1x!ttcore.tile<32x32, bf16>>
-    }
-    ttl.cb_push %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %first_waited = ttl.cb_wait %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_pop %first_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_reserved = ttl.cb_reserve %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_push %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
-    %second_waited = ttl.cb_wait %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-    ttl.cb_pop %second_dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_repeated_transactions_conservative.mlir
@@ -2,13 +2,14 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' | FileCheck %s --check-prefix=ALLOC
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices{reuse-user-dfbs=true})' -debug-only=ttl-finalize-dfb-indices -o /dev/null 2>&1 | FileCheck %s --check-prefix=REPORT
 
-// ALLOC-COUNT-9: ttl.base_cta_index = 2 : i32
+// ALLOC-COUNT-10: ttl.base_cta_index = 2 : i32
 // REPORT: quiescence=mismatched-transaction {{.*}} kernel=@mismatched_count
 // REPORT: quiescence=mismatched-transaction {{.*}} kernel=@overlapping_consumer_acquires
 // REPORT: quiescence=mismatched-transaction {{.*}} kernel=@mismatched_tiles
 // REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@dynamic_trip_count
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@differing_iteration_domains
 // REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@conditional_iteration
+// REPORT: quiescence=unsupported-control-flow {{.*}} kernel=@nonuniform_exact_selection
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@access_outside_interval
 // REPORT: DFB conflict lhs=0 rhs=1 reason=pointer-owner-mismatch
 // REPORT: quiescence=incomplete-use-order {{.*}} kernel=@unrelated_opaque_access
@@ -160,6 +161,37 @@ module {
     ttl.cb_push %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
     %second_available = ttl.cb_wait %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x4x!ttcore.tile<32x32, bf16>>
     ttl.cb_pop %second : <[1, 4], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// A statically counted condition that selects only some loop iterations does
+// not define a uniform iteration domain.
+
+module {
+  func.func @nonuniform_exact_selection()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                  ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+    %first = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %lower = arith.constant 0 : index
+    %upper = arith.constant 4 : index
+    %step = arith.constant 1 : index
+    %selected_iterations = arith.constant 2 : index
+    scf.for %transaction = %lower to %upper step %step {
+      %selected = arith.cmpi ult, %transaction, %selected_iterations : index
+      scf.if %selected {
+        %reserved = ttl.cb_reserve %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+        ttl.cb_push %first : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      }
+    }
+    ttl.opaque_call "consumer" dfb_dependencies(%first : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>, #ttl.dfb_protocol_effect<wait, 0, 1>, #ttl.dfb_protocol_effect<pop, 0, 1>] () {header = "consumer.hpp"} : () -> ()
+    %second_reserved = ttl.cb_reserve %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %second_waited = ttl.cb_wait %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_pop %second : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/insert_cb_sync.mlir
@@ -1029,3 +1029,41 @@ func.func @wait_result_through_for_iter_args() attributes {ttl.kernel_thread = #
   }
   func.return
 }
+
+// -----
+
+// Explicit transaction pairs in sibling regions remain unchanged.
+
+// CHECK-LABEL: func.func @repeated_sibling_region_transactions
+// CHECK-COUNT-2: ttl.cb_push
+// CHECK-NOT: ttl.cb_push
+// CHECK-COUNT-2: ttl.cb_pop
+// CHECK-NOT: ttl.cb_pop
+// CHECK: return
+func.func @repeated_sibling_region_transactions()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %dfb = ttl.bind_cb{cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %lower = arith.constant 0 : index
+  %upper = arith.constant 4 : index
+  %step = arith.constant 1 : index
+  %enabled = arith.constant true
+  scf.for %iteration = %lower to %upper step %step {
+    scf.if %enabled {
+      %first_reserved = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.if %enabled {
+      %second_reserved = ttl.cb_reserve %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.if %enabled {
+      %first_waited = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    scf.if %enabled {
+      %second_waited = ttl.cb_wait %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+  }
+  func.return
+}


### PR DESCRIPTION
### Problem description

DFB liveness rejects valid lifecycles when complete transactions occur in ordered structured regions or repeat within each static loop iteration.

### What's changed

- ~150 LOC implementation.
- Reuse structural operation order throughout DFB lifetime proofs and the compressed event graph.
- Prove at-most-once regions selected in every static iteration while rejecting runtime-selected subsets.
- Keep native acquire/release ownership within one block.

For example, two complete transactions may occur in ordered sibling regions of
the same static iteration:

```text
repeat static count {
  if enabled { reserve -> push }
  if enabled { reserve -> push }
}
```

### Checklist

- [x] New MLIR tests cover sibling-region transaction pairs, synchronization idempotence, and nonuniform condition rejection.
- [x] Expanded device coverage runs two transactions per loop iteration across BF16/FP32 and DRAM/L1.
