### PR TITLE
[ttl][dfb] Cover loop and post-loop lifetime starts

### DIFF
--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
@@ -375,6 +375,14 @@ func.func @loop_lifecycle()
 // REUSE-SAME: ttl.base_cta_index = 2 : i32
 // REUSE: ttl.bind_cb{cb_index = 0,
 // REUSE: ttl.bind_cb{cb_index = 1,
+// DISABLED-LABEL: func.func @loop_and_post_loop_access
+// DISABLED-SAME: ttl.base_cta_index = 2 : i32
+// DISABLED: ttl.bind_cb{cb_index = 0,
+// DISABLED: ttl.bind_cb{cb_index = 1,
+// REPEAT-LABEL: func.func @loop_and_post_loop_access
+// REPEAT-SAME: ttl.base_cta_index = 2 : i32
+// REPEAT: ttl.bind_cb{cb_index = 0,
+// REPEAT: ttl.bind_cb{cb_index = 1,
 
 func.func @loop_and_post_loop_access()
     attributes {ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_concurrent_kernel_liveness.mlir
@@ -366,6 +366,47 @@ func.func @loop_lifecycle()
 
 // -----
 
+// Every access without a proved predecessor constrains the lifetime start.
+// Selecting one arbitrary bind use could otherwise treat the post-loop wait as
+// the first access and incorrectly alias two DFBs that overlap in the loop.
+
+// REUSE: module attributes {ttl.dfb_allocations = [{block_count = 2 : i32, dfb_index = 0 : i32, {{.*}}}, {block_count = 2 : i32, dfb_index = 1 : i32, {{.*}}}]}
+// REUSE-LABEL: func.func @loop_and_post_loop_access
+// REUSE-SAME: ttl.base_cta_index = 2 : i32
+// REUSE: ttl.bind_cb{cb_index = 0,
+// REUSE: ttl.bind_cb{cb_index = 1,
+
+func.func @loop_and_post_loop_access()
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>,
+                ttl.base_cta_index = 2 : i32, ttl.crta_indices = []} {
+  %total = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %partial = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %lower_bound = arith.constant 0 : index
+  %upper_bound = arith.constant 4 : index
+  %step = arith.constant 1 : index
+  scf.for %iteration = %lower_bound to %upper_bound step %step {
+    %first_iteration = arith.cmpi eq, %iteration, %lower_bound : index
+    scf.if %first_iteration {
+      %initial_total_view = ttl.cb_reserve %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    } else {
+      %partial_producer_view = ttl.cb_reserve %partial : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %partial : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      %total_consumer_view = ttl.cb_wait %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %next_total_view = ttl.cb_reserve %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %partial_consumer_view = ttl.cb_wait %partial : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_pop %partial : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      ttl.cb_pop %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      ttl.cb_push %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+  }
+  %final_total_view = ttl.cb_wait %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.cb_pop %total : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  return
+}
+
+// -----
+
 // Ordered lifetimes cannot share when the producer pointer changes from NOC0
 // to Pack. Lifecycle completion does not transfer write-pointer ownership.
 


### PR DESCRIPTION
### Problem description

It verifies that a DFB used inside and after a loop cannot alias another DFB with an overlapping loop lifetime.

### What's changed

~0 LOC implementation; focused regression coverage only.

Add a focused regression for the overlapping loop lifetimes.

### Checklist

- [x] The new MLIR regression verifies that explicit reuse, default reuse, disabled reuse, and repeated finalization retain two distinct physical DFB indices.
