### PR TITLE
[ttl] Validate DFB resources after packing

### DIFF
--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -327,10 +327,11 @@ ttlang-opt input.mlir -p 'func.func(ttl-subblock-compute-for-dst{subblock-sync=t
 Group eligible repeated PipeNet transfers and select bounded receiver storage.
 Later PipeTransport planning replaces proven-private grouped DFB lifecycles
 with transport-owned scratch; scalar residuals retain the original lifecycle.
-Selection uses a conservative upper bound for target-aligned DFB allocation,
-receiver-published addresses, transport scratch, GlobalSemaphore counters,
-record-selected callback resources, synchronized-reset state, and
-reconfiguration state. A group size of one validates and records the
+Selection uses a target-aligned logical DFB estimate and a conservative upper
+bound for receiver-published addresses, transport scratch, GlobalSemaphore
+counters, record-selected callback resources, synchronized-reset state, and
+reconfiguration state. The estimate selects a grouping size; it does not reject
+the finalized physical DFB allocation. A group size of one records the
 reservation without grouping. Exact combined validation occurs after PipeNet
 planning in `convert-ttl-to-ttkernel`.
 

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -126,16 +126,17 @@ def TTLFormPipeTransports
 
     `group-size = 0` prefers a bounded schedule with at least two receiver
     groups, then minimizes completion groups, capacity waits, and L1 allocation
-    bytes. Selection uses a target-aligned DFB allocation and a conservative
-    upper bound for PipeNet address storage, scratch, GlobalSemaphore counters,
-    record-selected callback resources, synchronized-reset scratch, and DFB
-    reconfiguration state. `group-size = 1` disables grouping but still
-    validates the combined allocation and records the conservative reservation
-    for physical DFB allocation. A larger value is an upper bound; the pass
-    selects a smaller group when the loop trip count or L1 capacity requires
-    it. Ineligible loops retain scalar transfer IR. After PipeNet lowering
-    chooses exact resources, `convert-ttl-to-ttkernel` validates the
-    authoritative combined per-core allocation.
+    bytes. Selection uses a target-aligned logical DFB estimate and a
+    conservative upper bound for PipeNet address storage, scratch,
+    GlobalSemaphore counters, record-selected callback resources,
+    synchronized-reset scratch, and DFB reconfiguration state. This estimate
+    selects a grouping size; it does not reject the finalized physical DFB
+    allocation. `group-size = 1` disables grouping and records the conservative
+    PipeNet reservation for physical DFB allocation. A larger value is an upper
+    bound; the pass selects a smaller group when the loop trip count or L1
+    capacity requires it. Ineligible loops retain scalar transfer IR. After
+    PipeNet lowering chooses exact resources, `convert-ttl-to-ttkernel`
+    validates the authoritative combined per-core allocation.
   }];
 
   let options = [

--- a/lib/Dialect/TTL/Transforms/TTLFormPipeTransports.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFormPipeTransports.cpp
@@ -1003,38 +1003,11 @@ struct TTLFormPipeTransportsPass
       }
       return std::make_pair(*resources, *semaphoreBytes);
     };
-    auto validateConservativeResources =
-        [&](const ConservativePipeResources &resources,
-            const DFBLogicalIdentityAnalysis &identities) -> LogicalResult {
-      FailureOr<DFBAllocationFootprint> allocationFootprint =
-          getLogicalDFBAllocationFootprint(module, identities);
-      std::optional<uint64_t> scratchBytes =
-          llvm::checkedAddUnsigned(resources.scratchBytes, *resetStateBytes);
-      if (failed(allocationFootprint) || !scratchBytes) {
-        module.emitOpError("combined L1 allocation size is not representable");
-        return failure();
-      }
-      return validateCombinedDFBResourceL1Bytes(
-          module, *allocationFootprint, *scratchBytes,
-          resources.globalSemaphoreCount, overrideBytes);
-    };
     if (groupSize == 1) {
       FailureOr<std::pair<ConservativePipeResources, uint64_t>> plan =
           planConservativeResources();
       if (failed(plan)) {
         module.emitOpError("conservative PipeNet L1 size is not representable");
-        signalPassFailure();
-        return;
-      }
-      DFBLogicalIdentityAnalysis identities(module);
-      if (!identities.succeeded()) {
-        Operation *errorOperation = identities.getErrorOperation();
-        (errorOperation ? errorOperation : module.getOperation())
-            ->emitOpError(identities.getErrorMessage());
-        signalPassFailure();
-        return;
-      }
-      if (failed(validateConservativeResources(plan->first, identities))) {
         signalPassFailure();
         return;
       }
@@ -1098,12 +1071,6 @@ struct TTLFormPipeTransportsPass
       signalPassFailure();
       return;
     }
-    if (failed(validateConservativeResources(conservativePipeResources,
-                                             identities))) {
-      signalPassFailure();
-      return;
-    }
-
     llvm::MapVector<Operation *, SmallVector<const PipeTransferNode *>>
         transfersByLoop;
     for (const PipeTransferNode &transfer : pipeGraph.getPipeTransferNodes()) {

--- a/test/python/test_user_dfb_reuse.py
+++ b/test/python/test_user_dfb_reuse.py
@@ -2249,8 +2249,13 @@ def test_allocation_group_reuses_interleaved_reset_epochs(
 
     final_mlir_path = tmp_path / "interleaved_allocation_group_epochs.mlir"
     monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+    l1_budget = 11000 if dtype == torch.bfloat16 else 20000
     for _ in range(2):
-        operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+        operation(
+            input_tensor,
+            output_tensor,
+            options=f"--ttl-reuse-user-dfbs --ttl-l1-budget {l1_budget}",
+        )
 
     assert _count_final_dfb_allocations(final_mlir_path) == 1
     actual = ttnn.to_torch(output_tensor).float()

--- a/test/ttlang/Conversion/TTLToTTKernel/pipe_reconfiguration_budget_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/pipe_reconfiguration_budget_invalid.mlir
@@ -1,7 +1,7 @@
 // Verifies exact combined-resource validation accepts the packed allocation
 // and rejects a one-byte-short budget.
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-form-pipe-transports{group-size=1 l1-budget-override=21760},ttl-finalize-dfb-indices{reuse-user-dfbs=true l1-budget-override=21760},convert-ttl-to-ttkernel{pipe-computed-addresses=false pipe-capacity-sync=true pipe-global-semaphores-only=true l1-budget-override=21760})' -o /dev/null
-// RUN: ttlang-opt %s --verify-diagnostics -pass-pipeline='builtin.module(ttl-form-pipe-transports{group-size=1 l1-budget-override=21759},ttl-finalize-dfb-indices{reuse-user-dfbs=true l1-budget-override=21759},convert-ttl-to-ttkernel{pipe-computed-addresses=false pipe-capacity-sync=true pipe-global-semaphores-only=true l1-budget-override=21759})'
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-form-pipe-transports{group-size=1 l1-budget-override=21760},ttl-finalize-dfb-indices{reuse-user-dfbs=true l1-budget-override=21760},convert-ttl-to-ttkernel{pipe-computed-addresses=false pipe-capacity-sync=true pipe-global-semaphores-only=true l1-budget-override=21760})' -o /dev/null
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-form-pipe-transports{group-size=1 l1-budget-override=21759},ttl-finalize-dfb-indices{reuse-user-dfbs=true l1-budget-override=21759},convert-ttl-to-ttkernel{pipe-computed-addresses=false pipe-capacity-sync=true pipe-global-semaphores-only=true l1-budget-override=21759})'
 
 #layout = #ttl.layout<
     shape = [32, 384], element_type = !ttcore.tile<32x32, f32>,

--- a/test/ttlang/Conversion/TTLToTTKernel/pipe_reconfiguration_budget_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/pipe_reconfiguration_budget_invalid.mlir
@@ -1,6 +1,7 @@
-// Verifies that transport grouping rejects combined DFB and runtime storage
-// that exceeds the configured L1 budget.
-// RUN: ttlang-opt %s --verify-diagnostics -pass-pipeline='builtin.module(ttl-form-pipe-transports{group-size=1 l1-budget-override=25919})'
+// Verifies exact combined-resource validation accepts the packed allocation
+// and rejects a one-byte-short budget.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-form-pipe-transports{group-size=1 l1-budget-override=21760},ttl-finalize-dfb-indices{reuse-user-dfbs=true l1-budget-override=21760},convert-ttl-to-ttkernel{pipe-computed-addresses=false pipe-capacity-sync=true pipe-global-semaphores-only=true l1-budget-override=21760})' -o /dev/null
+// RUN: ttlang-opt %s --verify-diagnostics -pass-pipeline='builtin.module(ttl-form-pipe-transports{group-size=1 l1-budget-override=21759},ttl-finalize-dfb-indices{reuse-user-dfbs=true l1-budget-override=21759},convert-ttl-to-ttkernel{pipe-computed-addresses=false pipe-capacity-sync=true pipe-global-semaphores-only=true l1-budget-override=21759})'
 
 #layout = #ttl.layout<
     shape = [32, 384], element_type = !ttcore.tile<32x32, f32>,
@@ -10,10 +11,10 @@
 #writer = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "operation">
 #boundary = #ttl.dfb_reconfiguration<0, participants[#compute, #reader, #writer]>
 
-// DFB storage (24576), Pipe scratch (64), global semaphores (192), and
-// boundary state (1088) each fit separately, but their combined allocation
-// does not.
-// expected-error @below {{combined DFB and runtime resources require 25920 L1 bytes but the budget is 25919 (DFB=24576, scratch=64, global semaphores=192, reconfiguration state=1088)}}
+// Physical DFB storage on the busiest launch node (20480), PipeNet scratch
+// (64), two global semaphores (128), and boundary state (1088) fit separately,
+// but their 21760-byte total exceeds the budget by one byte.
+// expected-error @below {{combined DFB and runtime resources require 21760 L1 bytes but the budget is 21759 (DFB=20480, scratch=64, global semaphores=128, reconfiguration state=1088)}}
 module attributes {
   ttl.launch_grid = array<i64: 2, 1>,
   ttl.target_arch = #ttcore.arch<blackhole>
@@ -24,9 +25,11 @@ module attributes {
       attributes {ttl.base_cta_index = 2 : i32, ttl.crta_indices = [0, 1],
                   ttl.kernel_thread = #ttkernel.thread<noc>,
                   ttl.logical_kernel = #writer, ttl.noc_index = 1 : i32} {
-    %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 5} {dfb_id = 0 : index}
+    %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 5}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 5>
-    %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1} {dfb_id = 1 : index}
+    %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+        {allocation_group = #ttl.dfb_allocation_group<0>, dfb_id = 1 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
     %c0 = arith.constant 0 : index
     %c2 = arith.constant 2 : index


### PR DESCRIPTION
### Problem description

`ttl-form-pipe-transports` rejects logical DFB footprints before finalization. An allocation group can therefore exceed L1 logically even when its packed physical allocation and required runtime resources fit.

Kimi tracker: KTL-BLK-067.

Fixes #967.

### What's changed

~35 LOC implementation removed (tests and documentation excluded).

Logical DFB bytes remain a non-failing grouping estimate. DFB finalization validates the physical allocation, and TTKernel conversion validates the exact combined requirement.

```text
logical DFBs:         24,576 B
packed physical DFB:  20,480 B
runtime resources:     1,280 B
accepted total:       21,760 B
```

### Validation

- A new Blackhole allocation-group device regression covers BF16/FP32 with DRAM/L1 tensors.
- A new focused MLIR boundary test accepts 21,760 bytes and rejects 21,759 bytes with the exact resource breakdown.

### Checklist

- [x] New/Existing tests provide coverage for changes
