### PR TITLE
[ci] Fix Galaxy reset and loudbox runner selection

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,6 @@ self-hosted-runner:
   labels:
     - mlir-large-runner-lang
     - n150
-    - bh-loudbox-viommu
+    - bh-loudbox
     - exabox-multihost-ci-sc1
     - tt-ubuntu-2204-*-stable

--- a/.github/scripts/reset-tt-cards.sh
+++ b/.github/scripts/reset-tt-cards.sh
@@ -5,8 +5,9 @@
 # Reset the runner's cards and verify tt-smi answers afterwards.
 #
 # A degraded cluster reports as unrelated failures in every device test rather
-# than as a device error, so fail here instead. -glx_reset is Galaxy-specific;
-# -r covers boards that do not implement it.
+# than as a device error, so fail here instead. Exabox Blackhole Galaxy workers
+# do not provide the IPMI utility required by -glx_reset; the UMD warm reset
+# supports these systems and the other CI devices.
 #
 # Env: TT_RESET_MAX_ATTEMPTS (10), TT_RESET_RETRY_SECONDS (30).
 #
@@ -20,7 +21,7 @@ RETRY_SECONDS="${TT_RESET_RETRY_SECONDS:-30}"
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     echo "=== Reset attempt $attempt of $MAX_ATTEMPTS ==="
 
-    if ! tt-smi -glx_reset && ! tt-smi -r; then
+    if ! tt-smi -r; then
         echo "reset failed on attempt $attempt"
         sleep "$RETRY_SECONDS"
         continue

--- a/.github/scripts/tests/test_reset_tt_cards.bats
+++ b/.github/scripts/tests/test_reset_tt_cards.bats
@@ -15,7 +15,6 @@ make_tt_smi_mock() {
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$FAKE_TT_SMI_ARGS"
 case "$1" in
-    -glx_reset) exit "${FAKE_TT_SMI_GLX_FAIL:-0}" ;;
     -r)         exit "${FAKE_TT_SMI_R_FAIL:-0}" ;;
     --snapshot_no_tty) exit "${FAKE_TT_SMI_SNAPSHOT_FAIL:-0}" ;;
 esac
@@ -35,26 +34,16 @@ setup() {
     export TT_RESET_RETRY_SECONDS=0
 }
 
-@test "glx reset succeeds and health check passes -> exit 0" {
+@test "warm reset succeeds and health check passes -> exit 0" {
     run -0 "$SCRIPT"
     assert_output --partial "reset and health check passed on attempt 1"
-    grep -q -- "-glx_reset" "$FAKE_TT_SMI_ARGS"
+    grep -q '^-r$' "$FAKE_TT_SMI_ARGS"
     grep -q -- "--snapshot_no_tty" "$FAKE_TT_SMI_ARGS"
+    run -1 grep -q -- "-glx_reset" "$FAKE_TT_SMI_ARGS"
 }
 
-@test "glx reset unsupported -> falls back to tt-smi -r" {
-    FAKE_TT_SMI_GLX_FAIL=1 run -0 "$SCRIPT"
-    grep -q '^-r' "$FAKE_TT_SMI_ARGS"
-    assert_output --partial "reset and health check passed"
-}
-
-@test "successful glx reset does not also run tt-smi -r" {
-    run -0 "$SCRIPT"
-    run -1 grep -q '^-r$' "$FAKE_TT_SMI_ARGS"
-}
-
-@test "both resets fail -> retries then fails" {
-    TT_RESET_MAX_ATTEMPTS=2 FAKE_TT_SMI_GLX_FAIL=1 FAKE_TT_SMI_R_FAIL=1 run -1 "$SCRIPT"
+@test "reset keeps failing -> retries then fails" {
+    TT_RESET_MAX_ATTEMPTS=2 FAKE_TT_SMI_R_FAIL=1 run -1 "$SCRIPT"
     assert_output --partial "Reset attempt 2 of 2"
     assert_output --partial "failed after 2 attempts"
 }

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -140,13 +140,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                hardware: ${{ inputs.run_loudbox_tests && fromJSON('["n150","bh-loudbox-viommu"]') || fromJSON('["n150"]') }}
+                hardware: ${{ inputs.run_loudbox_tests && fromJSON('["n150","bh-loudbox"]') || fromJSON('["n150"]') }}
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:
-            defer_result_check: ${{ matrix.hardware != 'bh-loudbox-viommu' }}
+            defer_result_check: ${{ matrix.hardware != 'bh-loudbox' }}
             hardware: ${{ matrix.hardware }}
-            runner_label: ${{ matrix.hardware == 'bh-loudbox-viommu' && 'tt-ubuntu-2204-bh-loudbox-viommu-stable' || 'tt-ubuntu-2204-n150-stable' }}
+            runner_label: ${{ matrix.hardware == 'bh-loudbox' && 'tt-ubuntu-2204-bh-loudbox-stable' || 'tt-ubuntu-2204-n150-stable' }}
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}
 

--- a/.github/workflows/debug-hardware.yml
+++ b/.github/workflows/debug-hardware.yml
@@ -10,10 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       runs-on:
-        description: 'Hardware type (runner suffix), e.g. n150, bh-loudbox-viommu'
+        description: 'Hardware type (runner suffix), e.g. n150, bh-loudbox'
         required: false
         type: string
-        default: 'bh-loudbox-viommu'
+        default: 'bh-loudbox'
       pytest_args:
         description: 'Pytest selection, e.g. test/python/test_reduce.py -k "reduce_multi_tile and fp32"'
         required: true

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -69,14 +69,11 @@ def test_hardware_matrix_adds_manual_blackhole_loudbox() -> None:
     hardware_workflow = CALL_TEST_HARDWARE.read_text()
 
     assert "inputs.run_loudbox_tests && fromJSON" in call_build
-    assert '["n150","bh-loudbox-viommu"]' in call_build
-    assert "matrix.hardware == 'bh-loudbox-viommu'" in call_build
-    assert "tt-ubuntu-2204-bh-loudbox-viommu-stable" in call_build
+    assert '["n150","bh-loudbox"]' in call_build
+    assert "matrix.hardware == 'bh-loudbox'" in call_build
+    assert "tt-ubuntu-2204-bh-loudbox-stable" in call_build
     assert "tt-ubuntu-2204-n150-stable" in call_build
-    assert (
-        "defer_result_check: ${{ matrix.hardware != 'bh-loudbox-viommu' }}"
-        in call_build
-    )
+    assert "defer_result_check: ${{ matrix.hardware != 'bh-loudbox' }}" in call_build
     assert "--optional-runner" not in call_build
     assert "inputs.run_galaxy_tests && 3 || 2" in call_build
     assert "inputs.run_galaxy_tests && 2 || 1" in call_build

--- a/test/packaging/test_hardware_job_results.py
+++ b/test/packaging/test_hardware_job_results.py
@@ -136,7 +136,7 @@ def test_both_setup_failures_fail() -> None:
     assert "No hardware runner completed the test suite" in result.stdout
 
 
-@pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh", "bh-loudbox-viommu"])
+@pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh", "bh-loudbox"])
 def test_post_setup_failure_fails(failed_runner: str) -> None:
     other_runner = "galaxy-bh" if failed_runner == "n150" else "n150"
     result = _run_check(


### PR DESCRIPTION
### Problem description

Blackhole Galaxy jobs first invoke the legacy `tt-smi -glx_reset` mechanism, which requires `ipmitool` that is unavailable in Exabox workers. The fallback succeeds but emits reset failures and delays every scheduled run.

Loudbox CI still targets the viommu runner label instead of the current stable Blackhole loudbox runner.

### What's changed

- reset CI devices directly with `tt-smi -r` while preserving retries and the post-reset health check
- target `tt-ubuntu-2204-bh-loudbox-stable` in automatic and manual debug workflows
- rename the logical loudbox CI identifier to `bh-loudbox` and update aggregate-result and workflow contracts
- remove obsolete legacy Galaxy reset tests

### Checklist

- [x] New/Existing tests provide coverage for changes
