### PR TITLE
[ci] Switch to qb2 runner for blackhole tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
   labels:
     - mlir-large-runner-lang
     - n150
-    - bh-loudbox
+    - BH-Quietbox-2
+    - in-service
     - exabox-multihost-ci-sc1
     - tt-ubuntu-2204-*-stable

--- a/.github/scripts/hardware-test-common.sh
+++ b/.github/scripts/hardware-test-common.sh
@@ -33,3 +33,41 @@ absolute_path() {
         *) printf '%s/%s\n' "$PWD" "$path" ;;
     esac
 }
+
+tt_device_group() {
+    local group_size="${1:?group size is required}"
+    local first_device="${2:-0}"
+    local device_index device_list=""
+    for ((device_index = first_device; device_index < first_device + group_size; device_index++)); do
+        if [ -n "$device_list" ]; then
+            device_list+=","
+        fi
+        device_list+="$device_index"
+    done
+    printf '%s\n' "$device_list"
+}
+
+resolve_tt_device_groups() {
+    local chip_count="${1:?chip count is required}"
+    local device_groups first_group group_size group_start
+    for ((group_size = 1; group_size <= chip_count; group_size++)); do
+        [ $((chip_count % group_size)) -eq 0 ] || continue
+        first_group="$(tt_device_group "$group_size")"
+        if ! TT_VISIBLE_DEVICES="$first_group" python3 -c \
+            'import sys, ttnn; raise SystemExit(ttnn.get_num_devices() != int(sys.argv[1]))' \
+            "$group_size" >/dev/null 2>&1; then
+            continue
+        fi
+
+        device_groups=""
+        for ((group_start = 0; group_start < chip_count; group_start += group_size)); do
+            if [ -n "$device_groups" ]; then
+                device_groups+=";"
+            fi
+            device_groups+="$(tt_device_group "$group_size" "$group_start")"
+        done
+        printf '%s\n' "$device_groups"
+        return 0
+    done
+    return 1
+}

--- a/.github/scripts/run-hardware-lit.sh
+++ b/.github/scripts/run-hardware-lit.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Run hardware Python lit tests in chip-pinned serial shards. Parallel shard
-# count can be capped below the chip count to preserve host CPU capacity.
+# Run hardware Python lit tests in topology-valid device-group shards. Parallel
+# shard count can be capped below the available group count to preserve host CPU capacity.
 # Multi-device lit tests run afterward in a serial process.
 #
 # Env:
@@ -54,14 +54,28 @@ if [ "$chips" -le 1 ]; then
     exit $?
 fi
 
-echo "Detected ${chips} chips: ${workers} Python lit shards in parallel, multi-device serial"
+device_groups_string="$(resolve_tt_device_groups "$chips")" || {
+    echo "No valid device grouping found; running Python lit serially with full topology visibility"
+    unset TT_VISIBLE_DEVICES
+    TTLANG_LIT_TEST_EXEC_ROOT="${lit_exec_root}/serial" \
+        llvm-lit "$TEST_DIR" "${lit_common[@]}" \
+        --xunit-xml-output="${REPORT_PREFIX}.xml"
+    exit $?
+}
+IFS=';' read -r -a device_groups <<< "$device_groups_string"
+device_group_count="${#device_groups[@]}"
+if [ "$workers" -gt "$device_group_count" ]; then
+    workers="$device_group_count"
+fi
+
+echo "Detected ${chips} chips as ${device_group_count} valid device groups: ${workers} Python lit shards in parallel, multi-device serial"
 
 rc=0
 pids=()
-for ((chip_index = 0; chip_index < workers; chip_index++)); do
-    shard_number=$((chip_index + 1))
+for ((worker_index = 0; worker_index < workers; worker_index++)); do
+    shard_number=$((worker_index + 1))
     (
-        export TT_VISIBLE_DEVICES="${chip_index}"
+        export TT_VISIBLE_DEVICES="${device_groups[$worker_index]}"
         export TT_METAL_CACHE="${cache_root}/shard-${shard_number}"
         export TTLANG_LIT_TEST_EXEC_ROOT="${lit_exec_root}/shard-${shard_number}"
         mkdir -p "$TT_METAL_CACHE"

--- a/.github/scripts/run-hardware-pytests.sh
+++ b/.github/scripts/run-hardware-pytests.sh
@@ -7,10 +7,11 @@
 #
 # Chip count is the number of digit-named nodes under /dev/tenstorrent (matching
 # test/lit.cfg.py). With more than one chip, single-device tests run under
-# pytest-xdist with each worker restricted to one chip through
-# TT_VISIBLE_DEVICES. Compile-only tests then run without xdist so concurrent
-# compiler subprocesses do not contend for host resources. The multi_device
-# tests run serially after that. With one chip the whole suite runs serially.
+# pytest-xdist with each worker restricted to the smallest topology-valid
+# device group through TT_VISIBLE_DEVICES. Compile-only tests then run without
+# xdist so concurrent compiler subprocesses do not contend for host resources.
+# The multi_device tests run serially after that. With one chip the whole suite
+# runs serially.
 #
 # Env: HW_PYTEST_CHIPS overrides the detected chip count.
 # Env: HW_TEST_WORKERS caps xdist concurrency at no more than the chip count.
@@ -91,8 +92,24 @@ run_multi_device_phase() {
     run_pytest_phase "$@"
 }
 
+run_full_suite_serially() {
+    python3 -m pytest "$TEST_DIR" "${common[@]}" --junitxml="${REPORT_PREFIX}.xml"
+}
+
 if [ "$chips" -gt 1 ]; then
-    echo "Detected ${chips} chips: single-device tests in parallel (-n ${workers}), compile_only and multi_device serial"
+    device_groups_string="$(resolve_tt_device_groups "$chips")" || {
+        echo "No valid device grouping found; running the full suite serially with full topology visibility"
+        unset TT_VISIBLE_DEVICES
+        run_full_suite_serially
+        exit
+    }
+    IFS=';' read -r -a device_groups <<< "$device_groups_string"
+    device_group_count="${#device_groups[@]}"
+    if [ "$workers" -gt "$device_group_count" ]; then
+        workers="$device_group_count"
+    fi
+
+    echo "Detected ${chips} chips as ${device_group_count} valid device groups: single-device tests in parallel (-n ${workers}), compile_only and multi_device serial"
     unset TT_VISIBLE_DEVICES
     cache_root="$(absolute_path "${TT_METAL_CACHE:-${REPORT_PREFIX}-tt-metal-cache}")"
     rc=0
@@ -100,6 +117,7 @@ if [ "$chips" -gt 1 ]; then
     # the original crash and invalidate the crash guard's completeness check.
     TTLANG_PIN_XDIST_WORKERS_TO_DEVICES=1 \
         TTLANG_XDIST_TT_METAL_CACHE_ROOT="$cache_root" \
+        TTLANG_XDIST_VISIBLE_DEVICE_GROUPS="$device_groups_string" \
         run_pytest_phase "$TEST_DIR" -m "not multi_device and not compile_only" -n "$workers" \
         --max-worker-restart=0 "${common[@]}" \
         --junitxml="${REPORT_PREFIX}-parallel.xml" || rc=1
@@ -115,4 +133,4 @@ if [ "$chips" -gt 1 ]; then
 fi
 
 echo "Detected ${chips} chip(s): running the full suite serially"
-python3 -m pytest "$TEST_DIR" "${common[@]}" --junitxml="${REPORT_PREFIX}.xml"
+run_full_suite_serially

--- a/.github/scripts/tests/test_run_hardware_lit.bats
+++ b/.github/scripts/tests/test_run_hardware_lit.bats
@@ -17,6 +17,17 @@ setup() {
     unset TT_VISIBLE_DEVICES
     unset TT_METAL_CACHE
     unset HW_TEST_WORKERS
+    write_fake_group_probe 1
+}
+
+write_fake_group_probe() {
+    local minimum_group_size="$1"
+    cat > "$BIN/python3" <<EOF
+#!/usr/bin/env bash
+[ "\${1:-}" = "-c" ] || exit 2
+[ "\${3:-0}" -ge "$minimum_group_size" ]
+EOF
+    chmod +x "$BIN/python3"
 }
 
 write_fake_lit() {
@@ -40,7 +51,7 @@ EOF
         build/test/python build/test/python-lit-report
 
     assert_success
-    assert_output --partial "Detected 4 chips: 2 Python lit shards in parallel"
+    assert_output --partial "Detected 4 chips as 4 valid device groups: 2 Python lit shards in parallel"
     run cat "$CALLS"
     assert_line --partial "env:0"
     assert_line --partial "--num-shards 2 --run-shard 1"
@@ -64,6 +75,42 @@ EOF
     assert_line --partial "python-lit-report-shard-1.xml"
     assert_line --partial "python-lit-report-multidevice.xml"
     [ "${#lines[@]}" -eq 4 ]
+}
+
+@test "multi-chip: paired-chip topology runs one shard per valid device group" {
+    write_fake_lit 0
+    write_fake_group_probe 2
+
+    HW_LIT_CHIPS=4 run "$SCRIPT" \
+        build/test/python build/test/python-lit-report
+
+    assert_success
+    assert_output --partial "Detected 4 chips as 2 valid device groups: 2 Python lit shards in parallel"
+    run cat "$CALLS"
+    assert_line --partial "env:0,1"
+    assert_line --partial "--num-shards 2 --run-shard 1"
+    assert_line --partial "env:2,3"
+    assert_line --partial "--num-shards 2 --run-shard 2"
+    assert_line --partial "env: cache:"
+    assert_line --partial "python-lit-report-multidevice.xml"
+    [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "multi-chip: no valid device grouping runs once with full topology visibility" {
+    write_fake_lit 0
+    write_fake_group_probe 5
+
+    TT_VISIBLE_DEVICES=2 HW_LIT_CHIPS=4 run "$SCRIPT" \
+        build/test/python build/test/python-lit-report
+
+    assert_success
+    assert_output --partial "No valid device grouping found"
+    run cat "$CALLS"
+    assert_output --partial "env:"
+    assert_output --partial "python-lit-report.xml"
+    refute_output --partial "env:2"
+    refute_output --partial "--num-shards"
+    [ "${#lines[@]}" -eq 1 ]
 }
 
 @test "single chip: one serial lit run over the whole suite" {

--- a/.github/scripts/tests/test_run_hardware_pytests.bats
+++ b/.github/scripts/tests/test_run_hardware_pytests.bats
@@ -19,6 +19,7 @@ setup() {
     unset TT_METAL_CACHE
     unset TTLANG_PIN_XDIST_WORKERS_TO_DEVICES
     unset TTLANG_XDIST_TT_METAL_CACHE_ROOT
+    unset TTLANG_XDIST_VISIBLE_DEVICE_GROUPS
     unset HW_TEST_WORKERS
     unset HW_PYTEST_TIMEOUT
 }
@@ -26,9 +27,14 @@ setup() {
 # Fake python3 recording each invocation's args, exiting with $1 (default 0).
 write_fake_python() {
     local exit_code="${1:-0}"
+    local minimum_group_size="${2:-1}"
     cat > "$BIN/python3" <<EOF
 #!/usr/bin/env bash
-printf 'env:%s cache-root:%s args:%s vis:%s\n' "\${TTLANG_PIN_XDIST_WORKERS_TO_DEVICES:-}" "\${TTLANG_XDIST_TT_METAL_CACHE_ROOT:-}" "\$*" "\${TT_VISIBLE_DEVICES:-}" >> "$CALLS"
+if [ "\${1:-}" = "-c" ]; then
+    [ "\${3:-0}" -ge "$minimum_group_size" ]
+    exit
+fi
+printf 'env:%s cache-root:%s groups:%s args:%s vis:%s\n' "\${TTLANG_PIN_XDIST_WORKERS_TO_DEVICES:-}" "\${TTLANG_XDIST_TT_METAL_CACHE_ROOT:-}" "\${TTLANG_XDIST_VISIBLE_DEVICE_GROUPS:-}" "\$*" "\${TT_VISIBLE_DEVICES:-}" >> "$CALLS"
 exit $exit_code
 EOF
     chmod +x "$BIN/python3"
@@ -41,11 +47,14 @@ write_fake_python_sequence() {
     local count_file="$BATS_TEST_TMPDIR/python-call-count"
     cat > "$BIN/python3" <<EOF
 #!/usr/bin/env bash
+if [ "\${1:-}" = "-c" ]; then
+    exit 0
+fi
 call_count=0
 [ -f "$count_file" ] && call_count=\$(cat "$count_file")
 call_count=\$((call_count + 1))
 printf '%s\n' "\$call_count" > "$count_file"
-printf 'env:%s cache-root:%s args:%s vis:%s\n' "\${TTLANG_PIN_XDIST_WORKERS_TO_DEVICES:-}" "\${TTLANG_XDIST_TT_METAL_CACHE_ROOT:-}" "\$*" "\${TT_VISIBLE_DEVICES:-}" >> "$CALLS"
+printf 'env:%s cache-root:%s groups:%s args:%s vis:%s\n' "\${TTLANG_PIN_XDIST_WORKERS_TO_DEVICES:-}" "\${TTLANG_XDIST_TT_METAL_CACHE_ROOT:-}" "\${TTLANG_XDIST_VISIBLE_DEVICE_GROUPS:-}" "\$*" "\${TT_VISIBLE_DEVICES:-}" >> "$CALLS"
 case "\$call_count" in
     1) exit $first_exit ;;
     2) exit $second_exit ;;
@@ -62,15 +71,15 @@ EOF
 
     assert_success
     run cat "$CALLS"
-    assert_line --partial "env:1 cache-root:$PWD/build/test/pytest-report-tt-metal-cache args:-m pytest"
+    assert_line --partial "env:1 cache-root:$PWD/build/test/pytest-report-tt-metal-cache groups:0;1;2;3 args:-m pytest"
     assert_line --partial "pytest test/python -m not multi_device and not compile_only -n 4"
     # Crash-restart disabled and flaky-retry enabled on the parallel phase.
     assert_line --partial "-n 4 --max-worker-restart=0"
     assert_line --partial "--reruns 3"
     assert_line --partial "pytest-report-parallel.xml"
-    assert_line --partial "env: cache-root: args:-m pytest test/python -m compile_only"
+    assert_line --partial "env: cache-root: groups: args:-m pytest test/python -m compile_only"
     assert_line --partial "pytest-report-compile-only.xml"
-    assert_line --partial "env: cache-root: args:-m pytest test/python -m multi_device"
+    assert_line --partial "env: cache-root: groups: args:-m pytest test/python -m multi_device"
     assert_line --partial "pytest-report-multidevice.xml"
     [ "${#lines[@]}" -eq 3 ]
 }
@@ -82,9 +91,42 @@ EOF
         test/python build/test/pytest-report
 
     assert_success
-    assert_output --partial "Detected 4 chips: single-device tests in parallel (-n 2)"
+    assert_output --partial "Detected 4 chips as 4 valid device groups: single-device tests in parallel (-n 2)"
     run cat "$CALLS"
     assert_line --partial "pytest test/python -m not multi_device and not compile_only -n 2"
+}
+
+@test "multi-chip: paired-chip topology runs one worker per valid device group" {
+    write_fake_python 0 2
+
+    HW_PYTEST_CHIPS=4 run "$SCRIPT" \
+        test/python build/test/pytest-report
+
+    assert_success
+    assert_output --partial "Detected 4 chips as 2 valid device groups: single-device tests in parallel (-n 2)"
+    run cat "$CALLS"
+    assert_line --partial "env:1 cache-root:$PWD/build/test/pytest-report-tt-metal-cache groups:0,1;2,3 args:-m pytest"
+    assert_line --partial "pytest test/python -m not multi_device and not compile_only -n 2"
+    assert_line --partial "env: cache-root: groups: args:-m pytest test/python -m compile_only"
+    assert_line --partial "env: cache-root: groups: args:-m pytest test/python -m multi_device"
+    [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "multi-chip: no valid device grouping runs once with full topology visibility" {
+    write_fake_python 0 5
+
+    TT_VISIBLE_DEVICES=2 HW_PYTEST_CHIPS=4 run "$SCRIPT" \
+        test/python build/test/pytest-report
+
+    assert_success
+    assert_output --partial "No valid device grouping found"
+    run cat "$CALLS"
+    assert_output --partial "vis:"
+    assert_output --partial "pytest test/python"
+    assert_output --partial "pytest-report.xml"
+    refute_output --partial "vis:2"
+    refute_output --partial " -n "
+    [ "${#lines[@]}" -eq 1 ]
 }
 
 @test "per-test timeout is configurable" {

--- a/.github/scripts/tests/test_ttlang_test_utils.bats
+++ b/.github/scripts/tests/test_ttlang_test_utils.bats
@@ -11,6 +11,7 @@ setup() {
     unset TT_METAL_CACHE
     unset TTLANG_PIN_XDIST_WORKERS_TO_DEVICES
     unset TTLANG_XDIST_TT_METAL_CACHE_ROOT
+    unset TTLANG_XDIST_VISIBLE_DEVICE_GROUPS
 }
 
 @test "xdist worker pinning assigns one visible chip and cache directory" {
@@ -24,6 +25,20 @@ setup() {
     assert_success
     assert_line "3"
     assert_line "$BATS_TEST_TMPDIR/cache/worker-3"
+}
+
+@test "xdist worker pinning assigns a topology-valid device group" {
+    run env \
+        PYTHONPATH="$TTLANG_REPO_ROOT/test" \
+        TTLANG_PIN_XDIST_WORKERS_TO_DEVICES=1 \
+        PYTEST_XDIST_WORKER=gw1 \
+        TTLANG_XDIST_VISIBLE_DEVICE_GROUPS='0,1;2,3' \
+        TTLANG_XDIST_TT_METAL_CACHE_ROOT="$BATS_TEST_TMPDIR/cache" \
+        python3 -c 'import os; from ttlang_test_utils import pin_xdist_worker_to_device; pin_xdist_worker_to_device(); print(os.environ["TT_VISIBLE_DEVICES"]); print(os.environ["TT_METAL_CACHE"])'
+
+    assert_success
+    assert_line "2,3"
+    assert_line "$BATS_TEST_TMPDIR/cache/worker-1"
 }
 
 @test "xdist worker pinning preserves an existing visible chip and still isolates cache" {

--- a/.github/scripts/tests/test_ttlang_test_utils.bats
+++ b/.github/scripts/tests/test_ttlang_test_utils.bats
@@ -32,13 +32,25 @@ setup() {
         PYTHONPATH="$TTLANG_REPO_ROOT/test" \
         TTLANG_PIN_XDIST_WORKERS_TO_DEVICES=1 \
         PYTEST_XDIST_WORKER=gw1 \
-        TTLANG_XDIST_VISIBLE_DEVICE_GROUPS='0,1;2,3' \
+        TTLANG_XDIST_VISIBLE_DEVICE_GROUPS='0,1;2,3;' \
         TTLANG_XDIST_TT_METAL_CACHE_ROOT="$BATS_TEST_TMPDIR/cache" \
         python3 -c 'import os; from ttlang_test_utils import pin_xdist_worker_to_device; pin_xdist_worker_to_device(); print(os.environ["TT_VISIBLE_DEVICES"]); print(os.environ["TT_METAL_CACHE"])'
 
     assert_success
     assert_line "2,3"
     assert_line "$BATS_TEST_TMPDIR/cache/worker-1"
+}
+
+@test "xdist worker pinning rejects a missing device group" {
+    run env \
+        PYTHONPATH="$TTLANG_REPO_ROOT/test" \
+        TTLANG_PIN_XDIST_WORKERS_TO_DEVICES=1 \
+        PYTEST_XDIST_WORKER=gw2 \
+        TTLANG_XDIST_VISIBLE_DEVICE_GROUPS='0,1;2,3' \
+        python3 -c 'from ttlang_test_utils import pin_xdist_worker_to_device; pin_xdist_worker_to_device()'
+
+    assert_failure
+    assert_output --partial "TTLANG_XDIST_VISIBLE_DEVICE_GROUPS does not define a group for xdist worker gw2"
 }
 
 @test "xdist worker pinning preserves an existing visible chip and still isolates cache" {

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -11,8 +11,8 @@ on:
                 description: "Run hardware tests on a shared Exabox Galaxy."
                 type: boolean
                 default: false
-            run_loudbox_tests:
-                description: "Run hardware tests on the Blackhole loudbox."
+            run_quietbox_tests:
+                description: "Run hardware tests on the Blackhole Quietbox."
                 type: boolean
                 default: false
             docker_tag:
@@ -31,8 +31,8 @@ on:
                 type: boolean
                 required: false
                 default: false
-            run_loudbox_tests:
-                description: "Run hardware tests on the Blackhole loudbox."
+            run_quietbox_tests:
+                description: "Run hardware tests on the Blackhole Quietbox."
                 type: boolean
                 required: false
                 default: false
@@ -140,13 +140,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                hardware: ${{ inputs.run_loudbox_tests && fromJSON('["n150","bh-loudbox"]') || fromJSON('["n150"]') }}
+                hardware: ${{ inputs.run_quietbox_tests && fromJSON('["n150","BH-Quietbox-2"]') || fromJSON('["n150"]') }}
         uses: ./.github/workflows/call-test-hardware.yml
         secrets: inherit
         with:
-            defer_result_check: ${{ matrix.hardware != 'bh-loudbox' }}
+            defer_result_check: ${{ matrix.hardware != 'BH-Quietbox-2' }}
             hardware: ${{ matrix.hardware }}
-            runner_labels_json: ${{ matrix.hardware == 'bh-loudbox' && '["BH-Quietbox-2","in-service"]' || '["tt-ubuntu-2204-n150-stable"]' }}
+            runner_labels_json: ${{ matrix.hardware == 'BH-Quietbox-2' && '["BH-Quietbox-2","in-service"]' || '["tt-ubuntu-2204-n150-stable"]' }}
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}
 
@@ -191,4 +191,4 @@ jobs:
                   gh api --paginate \
                       "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" |
                       python3 .github/scripts/check-hardware-job-results.py \
-                          --expected-job-count "${{ inputs.run_loudbox_tests && (inputs.run_galaxy_tests && 3 || 2) || (inputs.run_galaxy_tests && 2 || 1) }}"
+                          --expected-job-count "${{ inputs.run_quietbox_tests && (inputs.run_galaxy_tests && 3 || 2) || (inputs.run_galaxy_tests && 2 || 1) }}"

--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -146,7 +146,7 @@ jobs:
         with:
             defer_result_check: ${{ matrix.hardware != 'bh-loudbox' }}
             hardware: ${{ matrix.hardware }}
-            runner_label: ${{ matrix.hardware == 'bh-loudbox' && 'tt-ubuntu-2204-bh-loudbox-stable' || 'tt-ubuntu-2204-n150-stable' }}
+            runner_labels_json: ${{ matrix.hardware == 'bh-loudbox' && '["BH-Quietbox-2","in-service"]' || '["tt-ubuntu-2204-n150-stable"]' }}
             timeout: 90
             docker_tag: ${{ inputs.docker_tag }}
 

--- a/.github/workflows/call-test-hardware.yml
+++ b/.github/workflows/call-test-hardware.yml
@@ -8,11 +8,11 @@ on:
         required: false
         type: string
         default: 'n150'
-      runner_label:
-        description: 'GitHub Actions runner label.'
+      runner_labels_json:
+        description: 'JSON array of GitHub Actions runner labels.'
         required: false
         type: string
-        default: 'tt-ubuntu-2204-n150-stable'
+        default: '["tt-ubuntu-2204-n150-stable"]'
       timeout:
         description: 'Job timeout in minutes'
         required: false
@@ -29,11 +29,11 @@ on:
         required: false
         type: string
         default: 'n150'
-      runner_label:
-        description: 'GitHub Actions runner label.'
+      runner_labels_json:
+        description: 'JSON array of GitHub Actions runner labels.'
         required: false
         type: string
-        default: 'tt-ubuntu-2204-n150-stable'
+        default: '["tt-ubuntu-2204-n150-stable"]'
       defer_result_check:
         description: 'Allow the calling workflow to check the aggregate hardware result.'
         required: false
@@ -56,7 +56,7 @@ permissions:
 jobs:
   test-hardware:
     name: "Hardware Tests (${{ inputs.hardware }})"
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ fromJSON(inputs.runner_labels_json) }}
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     continue-on-error: ${{ inputs.defer_result_check }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ on:
         required: false
         type: boolean
         default: false
-      run_loudbox_tests:
-        description: "Run hardware tests on the Blackhole loudbox."
+      run_quietbox_tests:
+        description: "Run hardware tests on the Blackhole Quietbox."
         required: false
         type: boolean
         default: false
@@ -172,7 +172,7 @@ jobs:
     with:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
       run_galaxy_tests: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}
-      run_loudbox_tests: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.run_loudbox_tests) }}
+      run_quietbox_tests: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.run_quietbox_tests) }}
 
   build-docs:
     name: Build documentation

--- a/.github/workflows/debug-hardware.yml
+++ b/.github/workflows/debug-hardware.yml
@@ -10,10 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       runs-on:
-        description: 'Hardware type (runner suffix), e.g. n150, bh-loudbox'
+        description: 'Primary GitHub Actions runner label'
         required: false
         type: string
-        default: 'bh-loudbox'
+        default: 'BH-Quietbox-2'
       pytest_args:
         description: 'Pytest selection, e.g. test/python/test_reduce.py -k "reduce_multi_tile and fp32"'
         required: true
@@ -49,7 +49,9 @@ permissions:
 jobs:
   debug:
     name: "Debug Hardware (${{ inputs.runs-on }})"
-    runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runs-on) }}
+    runs-on:
+      - "${{ inputs.runs-on }}"
+      - "in-service"
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
 
     container:

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -13,6 +13,7 @@ CALL_BUILD_DOCKER = REPO_ROOT / ".github" / "workflows" / "call-build-docker.yml
 CALL_TEST_EXABOX = REPO_ROOT / ".github" / "workflows" / "call-test-exabox.yml"
 CALL_TEST_HARDWARE = REPO_ROOT / ".github" / "workflows" / "call-test-hardware.yml"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DEBUG_HARDWARE = REPO_ROOT / ".github" / "workflows" / "debug-hardware.yml"
 MANUAL_TEST_EXABOX = REPO_ROOT / ".github" / "workflows" / "manual-test-exabox.yml"
 IRD_DOCKERFILE = REPO_ROOT / ".github" / "containers" / "Dockerfile"
 INSTALL_EXABOX_WORKER = (
@@ -64,22 +65,26 @@ def test_exabox_configuration_remains_available() -> None:
     assert "timeout: 90" in test_exabox
 
 
-def test_hardware_matrix_adds_manual_blackhole_loudbox() -> None:
+def test_hardware_matrix_adds_blackhole_quietbox_runner() -> None:
     call_build = CALL_BUILD.read_text()
+    debug_hardware = DEBUG_HARDWARE.read_text()
     hardware_workflow = CALL_TEST_HARDWARE.read_text()
 
     assert "inputs.run_loudbox_tests && fromJSON" in call_build
     assert '["n150","bh-loudbox"]' in call_build
     assert "matrix.hardware == 'bh-loudbox'" in call_build
-    assert "tt-ubuntu-2204-bh-loudbox-stable" in call_build
+    assert '["BH-Quietbox-2","in-service"]' in call_build
     assert "tt-ubuntu-2204-n150-stable" in call_build
     assert "defer_result_check: ${{ matrix.hardware != 'bh-loudbox' }}" in call_build
     assert "--optional-runner" not in call_build
     assert "inputs.run_galaxy_tests && 3 || 2" in call_build
     assert "inputs.run_galaxy_tests && 2 || 1" in call_build
     assert 'name: "Hardware Tests (${{ inputs.hardware }})"' in hardware_workflow
-    assert "runs-on: ${{ inputs.runner_label }}" in hardware_workflow
+    assert "runs-on: ${{ fromJSON(inputs.runner_labels_json) }}" in hardware_workflow
     assert "RUNS_ON: ${{ inputs.hardware }}" in hardware_workflow
+    assert "default: 'BH-Quietbox-2'" in debug_hardware
+    assert '- "${{ inputs.runs-on }}"' in debug_hardware
+    assert '- "in-service"' in debug_hardware
 
 
 def test_exabox_workflow_dispatches_all_worker_operations_through_scripts() -> None:

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -37,20 +37,20 @@ def test_hardware_event_policy_and_manual_controls() -> None:
     call_build = CALL_BUILD.read_text()
 
     assert ci_workflow.count("run_galaxy_tests:") == 2
-    assert ci_workflow.count("run_loudbox_tests:") == 2
+    assert ci_workflow.count("run_quietbox_tests:") == 2
     assert (
         "run_galaxy_tests: ${{ github.event_name == 'schedule' || "
         "(github.event_name == 'workflow_dispatch' && inputs.run_galaxy_tests) }}"
         in ci_workflow
     )
     assert (
-        "run_loudbox_tests: ${{ github.event_name == 'pull_request' || "
+        "run_quietbox_tests: ${{ github.event_name == 'pull_request' || "
         "(github.event_name == 'push' && github.ref == 'refs/heads/main') || "
-        "(github.event_name == 'workflow_dispatch' && inputs.run_loudbox_tests) }}"
+        "(github.event_name == 'workflow_dispatch' && inputs.run_quietbox_tests) }}"
         in ci_workflow
     )
     assert call_build.count("run_galaxy_tests:") == 2
-    assert call_build.count("run_loudbox_tests:") == 2
+    assert call_build.count("run_quietbox_tests:") == 2
 
 
 def test_exabox_configuration_remains_available() -> None:
@@ -70,12 +70,12 @@ def test_hardware_matrix_adds_blackhole_quietbox_runner() -> None:
     debug_hardware = DEBUG_HARDWARE.read_text()
     hardware_workflow = CALL_TEST_HARDWARE.read_text()
 
-    assert "inputs.run_loudbox_tests && fromJSON" in call_build
-    assert '["n150","bh-loudbox"]' in call_build
-    assert "matrix.hardware == 'bh-loudbox'" in call_build
+    assert "inputs.run_quietbox_tests && fromJSON" in call_build
+    assert '["n150","BH-Quietbox-2"]' in call_build
+    assert "matrix.hardware == 'BH-Quietbox-2'" in call_build
     assert '["BH-Quietbox-2","in-service"]' in call_build
     assert "tt-ubuntu-2204-n150-stable" in call_build
-    assert "defer_result_check: ${{ matrix.hardware != 'bh-loudbox' }}" in call_build
+    assert "defer_result_check: ${{ matrix.hardware != 'BH-Quietbox-2' }}" in call_build
     assert "--optional-runner" not in call_build
     assert "inputs.run_galaxy_tests && 3 || 2" in call_build
     assert "inputs.run_galaxy_tests && 2 || 1" in call_build

--- a/test/packaging/test_hardware_job_results.py
+++ b/test/packaging/test_hardware_job_results.py
@@ -136,7 +136,7 @@ def test_both_setup_failures_fail() -> None:
     assert "No hardware runner completed the test suite" in result.stdout
 
 
-@pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh", "bh-loudbox"])
+@pytest.mark.parametrize("failed_runner", ["n150", "galaxy-bh", "BH-Quietbox-2"])
 def test_post_setup_failure_fails(failed_runner: str) -> None:
     other_runner = "galaxy-bh" if failed_runner == "n150" else "n150"
     result = _run_check(

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -106,7 +106,7 @@ def is_hardware_available() -> bool:
 
 
 def pin_xdist_worker_to_device() -> None:
-    """Restrict a pytest-xdist worker to one chip and cache directory."""
+    """Restrict a pytest-xdist worker to its device group and cache directory."""
     if os.environ.get("TTLANG_PIN_XDIST_WORKERS_TO_DEVICES") != "1":
         return
     worker_name = os.environ.get("PYTEST_XDIST_WORKER")
@@ -117,8 +117,16 @@ def pin_xdist_worker_to_device() -> None:
     )
     if not worker_index:
         return
+    visible_device_groups = os.environ.get("TTLANG_XDIST_VISIBLE_DEVICE_GROUPS")
+    if visible_device_groups:
+        device_groups = visible_device_groups.split(";")
+        worker_number = int(worker_index)
+        assert worker_number < len(device_groups)
+        visible_devices = device_groups[worker_number]
+    else:
+        visible_devices = worker_index
     if "TT_VISIBLE_DEVICES" not in os.environ:
-        os.environ["TT_VISIBLE_DEVICES"] = worker_index
+        os.environ["TT_VISIBLE_DEVICES"] = visible_devices
     cache_root = os.environ.get("TTLANG_XDIST_TT_METAL_CACHE_ROOT")
     if cache_root:
         cache_root = os.path.abspath(cache_root)

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -119,9 +119,13 @@ def pin_xdist_worker_to_device() -> None:
         return
     visible_device_groups = os.environ.get("TTLANG_XDIST_VISIBLE_DEVICE_GROUPS")
     if visible_device_groups:
-        device_groups = visible_device_groups.split(";")
+        device_groups = [group for group in visible_device_groups.split(";") if group]
         worker_number = int(worker_index)
-        assert worker_number < len(device_groups)
+        if worker_number >= len(device_groups):
+            raise RuntimeError(
+                "TTLANG_XDIST_VISIBLE_DEVICE_GROUPS does not define a group "
+                f"for xdist worker {worker_name}: {visible_device_groups!r}"
+            )
         visible_devices = device_groups[worker_number]
     else:
         visible_devices = worker_index


### PR DESCRIPTION
### Problem description

Blackhole CI must select the replacement runner with both `BH-Quietbox-2` and `in-service` labels.

The existing per-chip sharding also exposes an invalid partial topology on multi-chip Blackhole boards. On Quietbox, selecting one chip from a P300 pair causes TT-Metal to classify the cluster as `CUSTOM` and abort topology discovery. The shared hardware scripts must remain valid for Quietbox, Loudbox, and scheduled Galaxy jobs without runner-specific topology logic.

### What's changed

- accept runner labels as a JSON array and select `BH-Quietbox-2` plus `in-service` for Blackhole PR jobs
- rename the Blackhole workflow target and manual input from Loudbox to Quietbox
- discover the smallest topology-valid visible-device group and shard tests across those groups
- run Quietbox with two parallel P300 device groups while retaining single-chip sharding where supported
- retain full topology visibility for multi-device tests and as the serial fallback
- preserve the scheduled Galaxy workflow selection
- add workflow, shell, pytest, and device-group pinning coverage

### Checklist

- [x] New/Existing tests provide coverage for changes
