### PR TITLE
[ttl.exp] reject unsupported iterations in exp

### DIFF
--- a/docs/sphinx/specs/TTLangSpecification.externalized.md
+++ b/docs/sphinx/specs/TTLangSpecification.externalized.md
@@ -460,7 +460,7 @@ TT-Lang includes ability to print information to the standard output for debuggi
 | `ttl.BlockExpr.__abs__(self) -> ttl.BlockExpr`<br><br>`ttl.math.abs(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Absolute value. Example: `abs(a)`, `ttl.math.abs(a)`. |
 | `ttl.BlockExpr.__neg__(self) -> ttl.BlockExpr`<br><br>`ttl.math.neg(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Negation. Example: `-a`, `ttl.math.neg(a)`. |
 | `ttl.BlockExpr.__pow__(self, exponent: ttl.NaturalInt) -> ttl.BlockExpr`<br><br>`ttl.math.pow(expr: ttl.BlockExpr, exponent: ttl.NaturalInt) -> ttl.BlockExpr` | Power with scalar unsigned integer exponent. Example; `a ** 2`, `ttl.math.pow(a, 2)`. |
-| `ttl.math.exp(expr: ttl.BlockExpr, *, approx: bool = False, scale: Optional[float] = None, skip_clamp_check: bool = False, iterations: ttl.PositiveInt = 8) -> ttl.BlockExpr` | Natural base exponential. Computes `e^x` by default. When `scale` is provided, computes `e^(scale * x)`. |
+| `ttl.math.exp(expr: ttl.BlockExpr, *, approx: bool = False, scale: Optional[float] = None, skip_clamp_check: bool = False, iterations: Literal[8] = 8) -> ttl.BlockExpr` | Natural base exponential. Computes `e^x` by default. When `scale` is provided, computes `e^(scale * x)`. |
 | `ttl.math.exp2(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Base 2 exponential (`2^x`) |
 | `ttl.math.expm1(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural base exponential minus one (`ttl.math.exp(x) - 1`) |
 | `ttl.math.log(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural logarithm |
@@ -476,8 +476,9 @@ flag enables approximate exponential evaluation. The `scale` argument applies
 a compile-time scalar multiplier before the exponential. The
 `skip_clamp_check` flag disables clamping of very negative inputs in
 approximate mode. This is faster, but inputs below approximately `-88.5` can
-produce incorrect negative outputs. The `iterations` argument controls the
-number of SFPU lane iterations and defaults to 8.
+produce incorrect negative outputs. The `iterations` argument is retained for
+hardware API parity, but only 8 is supported because this count evaluates one
+complete TT-Lang tile. Other values are rejected before kernel lowering.
 
 ### Trigonometric unary math functions
 

--- a/docs/sphinx/specs/TTLangSpecification.md
+++ b/docs/sphinx/specs/TTLangSpecification.md
@@ -1424,7 +1424,7 @@ def matmul_read():
 | `ttl.BlockExpr.__abs__(self) -> ttl.BlockExpr`<br><br>`ttl.math.abs(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Absolute value. Example: `abs(a)`, `ttl.math.abs(a)`. |
 | `ttl.BlockExpr.__neg__(self) -> ttl.BlockExpr`<br><br>`ttl.math.neg(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Negation. Example: `-a`, `ttl.math.neg(a)`. |
 | `ttl.BlockExpr.__pow__(self, exponent: ttl.NaturalInt) -> ttl.BlockExpr`<br><br>`ttl.math.pow(expr: ttl.BlockExpr, exponent: ttl.NaturalInt) -> ttl.BlockExpr` | Power with scalar unsigned integer exponent. Example; `a ** 2`, `ttl.math.pow(a, 2)`. |
-| `ttl.math.exp(expr: ttl.BlockExpr, *, approx: bool = False, scale: Optional[float] = None, skip_clamp_check: bool = False, iterations: ttl.PositiveInt = 8) -> ttl.BlockExpr` | Natural base exponential. Computes `e^x` by default. When `scale` is provided, computes `e^(scale * x)`. |
+| `ttl.math.exp(expr: ttl.BlockExpr, *, approx: bool = False, scale: Optional[float] = None, skip_clamp_check: bool = False, iterations: Literal[8] = 8) -> ttl.BlockExpr` | Natural base exponential. Computes `e^x` by default. When `scale` is provided, computes `e^(scale * x)`. |
 | `ttl.math.exp2(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Base 2 exponential (`2^x`) |
 | `ttl.math.expm1(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural base exponential minus one (`ttl.math.exp(x) - 1`) |
 | `ttl.math.log(expr: ttl.BlockExpr) -> ttl.BlockExpr` | Natural logarithm |
@@ -1440,8 +1440,9 @@ flag enables approximate exponential evaluation. The `scale` argument applies
 a compile-time scalar multiplier before the exponential. The
 `skip_clamp_check` flag disables clamping of very negative inputs in
 approximate mode. This is faster, but inputs below approximately `-88.5` can
-produce incorrect negative outputs. The `iterations` argument controls the
-number of SFPU lane iterations and defaults to 8.
+produce incorrect negative outputs. The `iterations` argument is retained for
+hardware API parity, but only 8 is supported because this count evaluates one
+complete TT-Lang tile. Other values are rejected before kernel lowering.
 
 ### Trigonometric unary math functions
 

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1335,7 +1335,7 @@ defm TTL_Trunc : TTL_UnaryElementwisePair<"trunc", "trunc_tile">;
 //                     exp(s * x) (sets scale_en at the TTKernel level).
 //   input_clamping  - clamp behaviour for very negative inputs (only relevant
 //                     for approximate mode); defaults to ClampToNegative.
-//   iterations      - number of SFPU lane iterations (default 8).
+//   iterations      - number of SFPU lane iterations. Only 8 is supported.
 
 // Shared flag arguments for both the tensor and tile exp ops.
 defvar TTL_ExpFlags = (ins
@@ -1343,7 +1343,7 @@ defvar TTL_ExpFlags = (ins
     OptionalAttr<F32Attr>:$scale,
     DefaultValuedAttr<TTL_InputClampingAttr,
         "::mlir::tt::ttl::InputClamping::ClampToNegative">:$input_clamping,
-    DefaultValuedAttr<I32Attr, "8">:$iterations);
+    DefaultValuedAttr<ConfinedAttr<I32Attr, [IntIsOneOf<[8]>]>, "8">:$iterations);
 
 def TTL_ExpOp : TTL_ElementWiseUnary<"exp"> {
   let description = [{

--- a/python/sim/math.py
+++ b/python/sim/math.py
@@ -15,7 +15,7 @@ are implemented manually.
 
 import math as _math
 from itertools import product as _iter_product
-from typing import Callable, List, Optional, Set, Tuple
+from typing import Callable, List, Literal, Optional, Set, Tuple
 
 import torch
 
@@ -202,17 +202,19 @@ def exp(
     approx: bool = False,
     scale: Optional[float] = None,
     skip_clamp_check: bool = False,
-    iterations: int = 8,
+    iterations: Literal[8] = 8,
 ) -> Block:
     """Element-wise exponential (simulator reference).
 
-    Mirrors the ``ttl.exp`` DSL signature. ``scale`` is numerically meaningful
-    (computes ``exp(scale * x)``); the remaining flags (``approx``,
-    ``skip_clamp_check``, ``iterations``) only control the hardware SFPU
-    approximation and are accepted for API parity but do not change the exact
-    reference result.
+    Mirrors the ``ttl.math.exp`` DSL signature. ``scale`` is numerically
+    meaningful (computes ``exp(scale * x)``); ``approx`` and
+    ``skip_clamp_check`` control hardware SFPU behavior but do not change the
+    exact reference result. Only the full-tile iteration count of 8 is
+    supported.
     """
-    del approx, skip_clamp_check, iterations  # hardware-only knobs
+    if iterations != 8:
+        raise ValueError(f"ttl.math.exp iterations must be 8, got {iterations}")
+    del approx, skip_clamp_check  # hardware-only knobs
 
     def _op(t: torch.Tensor) -> torch.Tensor:
         if scale is not None:

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import List, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 from ttl.dialects import arith, ttl
 from ttl.ir import (
@@ -1329,7 +1329,7 @@ def exp(
     approx: bool = False,
     scale: Optional[float] = None,
     skip_clamp_check: bool = False,
-    iterations: int = 8,
+    iterations: Literal[8] = 8,
 ) -> TensorBlock:
     """Element-wise exponential.
 
@@ -1346,7 +1346,7 @@ def exp(
             inputs (``InputClamping::None``): faster, but inputs below ~-88.5
             produce incorrect (guaranteed-negative) outputs. Only meaningful
             with ``approx=True``. Defaults to ``False`` (``ClampToNegative``).
-        iterations: Number of SFPU lane iterations (default 8).
+        iterations: Number of SFPU lane iterations. Only 8 is supported.
 
     Returns:
         Result tensor with the same shape and dtype as ``input``.
@@ -1362,13 +1362,14 @@ def exp(
     skip_clamp_b = _get_constant_bool(skip_clamp_check)
     iterations_i = _get_constant_int(iterations)
     scale_f = None if scale is None else _get_constant_float(scale)
+    if iterations_i != 8:
+        raise ValueError(f"ttl.math.exp iterations must be 8, got {iterations_i}")
 
     # Pass None for any flag left at its default so the op keeps its plain
     # spelling (the ODS default applies). input_clamping is an integer-backed
     # enum attribute (built like ttl.reduce's reduce_type); None=0,
     # ClampToNegative=1.
     approx_attr = BoolAttr.get(True) if approx_b else None
-    iterations_attr = IntegerAttr.get(i32, iterations_i) if iterations_i != 8 else None
     clamping_attr = IntegerAttr.get(i32, 0) if skip_clamp_b else None
     scale_attr = None if scale_f is None else FloatAttr.get(F32Type.get(ctx), scale_f)
 
@@ -1377,7 +1378,7 @@ def exp(
         approx=approx_attr,
         scale=scale_attr,
         input_clamping=clamping_attr,
-        iterations=iterations_attr,
+        iterations=None,
     )
 
 

--- a/test/python/dprint/runtime.py
+++ b/test/python/dprint/runtime.py
@@ -141,8 +141,8 @@ def dprint_f32_kernel(inp_f32, out_f32):
 # CHECK-DAG: cb_id
 # CHECK-DAG: bf16 dm hello
 # CHECK-DAG: core:
-# CHECK-DAG: math thread
-# CHECK-DAG: unpack thread
+# CHECK-DAG: TR1: math thread
+# CHECK-DAG: TR0: unpack thread
 
 # DST and tile dprints are inside the fused compute body (pack thread).
 # They appear after the scalar/thread output since the fused compute
@@ -155,11 +155,11 @@ def dprint_f32_kernel(inp_f32, out_f32):
 # XXX: === after add ===
 # XXX: DST[0] (ttl.tile_add)
 # XXX: DST[1] (ttl.tile_exp)
-# CHECK: pack thread
+# CHECK-DAG: TR2: pack thread
 
 # Tensor pages print in dm_write (bf16 page from L1 CB)
 # The page output starts with page number followed by BF16 values.
-# CHECK: 0:
+# CHECK-DAG: BR: 0:
 
 # =============================================================================
 # FileCheck patterns -- f32 kernel (runs after bf16 kernel)

--- a/test/python/invalid/invalid_exp_iterations.py
+++ b/test/python/invalid/invalid_exp_iterations.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: tt-device
+# RUN: not %python %s 2>&1 | FileCheck %s
+
+"""Validation test: ttl.math.exp rejects unsupported iteration counts."""
+
+import os
+
+os.environ["TTLANG_COMPILE_ONLY"] = "1"
+
+import torch
+import ttl
+import ttnn
+
+from ttlang_test_utils import to_l1
+
+
+# CHECK: ttl.math.exp iterations must be 8, got 4
+@ttl.operation(grid=(1, 1))
+def invalid_exp_iterations_kernel(inp, out):
+    inp_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+    @ttl.compute()
+    def compute_fn():
+        with inp_dfb.wait() as inp_blk, out_dfb.reserve() as out_blk:
+            out_blk.store(ttl.math.exp(inp_blk, iterations=4))
+
+    @ttl.datamovement()
+    def dm_read():
+        ttl.copy(inp[0, 0], inp_dfb.reserve()).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        ttl.copy(out_dfb.wait(), out[0, 0]).wait()
+
+
+if __name__ == "__main__":
+    device = ttnn.open_device(device_id=0)
+    try:
+        inp = to_l1(torch.ones(32, 32, dtype=torch.bfloat16), device)
+        out = to_l1(torch.zeros(32, 32, dtype=torch.bfloat16), device)
+        invalid_exp_iterations_kernel(inp, out)
+    finally:
+        ttnn.close_device(device)

--- a/test/sim/test_math.py
+++ b/test/sim/test_math.py
@@ -680,15 +680,23 @@ def test_exp_scale_flag():
 
 
 def test_exp_approx_flags_ignored_numerically():
-    """Approximation-only flags are accepted and do not change the exact
-    reference result in the simulator."""
+    """Approximation flags do not change the simulator's exact result."""
     t1 = [Tensor(torch.tensor([[0.0, 1.0, -1.0]]))]
     block1 = Block.from_list(t1, shape=(1, 1))
 
-    result = ttl.math.exp(block1, approx=True, skip_clamp_check=True, iterations=4)
+    result = ttl.math.exp(block1, approx=True, skip_clamp_check=True, iterations=8)
 
     expected = torch.exp(torch.tensor([[0.0, 1.0, -1.0]]))
     assert torch.allclose(result.to_list()[0].to_torch(), expected)
+
+
+@pytest.mark.parametrize("iterations", [0, -1, 4, 2147483647])
+def test_exp_rejects_unsupported_iterations(iterations):
+    """The simulator rejects iteration counts unsupported by device kernels."""
+    block = Block.from_list([Tensor(torch.tensor([[0.0]]))], shape=(1, 1))
+
+    with pytest.raises(ValueError, match="ttl.math.exp iterations must be 8"):
+        ttl.math.exp(block, iterations=iterations)
 
 
 # Tests for reduce_max function

--- a/test/ttlang/Conversion/TTLToCompute/exp_flags.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/exp_flags.mlir
@@ -1,19 +1,20 @@
 // RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute))' | FileCheck %s
 
-// The exp hardware flags (approx / scale / input_clamping / iterations) on the
+// The configurable exp hardware flags (approx / scale / input_clamping) on the
 // tensor-level ttl.exp are forwarded unchanged to the ttl.tile_exp op created
-// inside the ttl.compute body.
+// inside the ttl.compute body. The only supported iteration count, 8, is
+// canonicalized to the hardware default.
 
 // CHECK-LABEL: func.func @exp_flags_forwarded
 func.func @exp_flags_forwarded(%arg0: tensor<4x4x!ttcore.tile<32x32, f32>>) -> tensor<4x4x!ttcore.tile<32x32, f32>> {
   // CHECK: ttl.compute
-  // CHECK: %[[EXP:.*]] = ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}iterations = 4 : i32{{.*}}scale = 5.000000e-01 : f32{{.*[}]}}
+  // CHECK: %[[EXP:.*]] = ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}scale = 5.000000e-01 : f32{{.*[}]}}
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>
   %a = ttl.attach_cb %arg0, %cb0 : (tensor<4x4x!ttcore.tile<32x32, f32>>, !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>) -> tensor<4x4x!ttcore.tile<32x32, f32>>
   %reserve = ttl.cb_reserve %cb1 : <[4, 4], !ttcore.tile<32x32, f32>, 2> -> tensor<4x4x!ttcore.tile<32x32, f32>>
   %0 = ttl.exp %a {approx = true, scale = 5.000000e-01 : f32,
-                   input_clamping = 0 : i32, iterations = 4 : i32}
+                   input_clamping = 0 : i32, iterations = 8 : i32}
       : tensor<4x4x!ttcore.tile<32x32, f32>> -> tensor<4x4x!ttcore.tile<32x32, f32>>
   ttl.store %0, %reserve : tensor<4x4x!ttcore.tile<32x32, f32>>, tensor<4x4x!ttcore.tile<32x32, f32>>
   func.return %0 : tensor<4x4x!ttcore.tile<32x32, f32>>

--- a/test/ttlang/Conversion/TTLToTTKernel/exp_flags.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/exp_flags.mlir
@@ -10,14 +10,14 @@
 // CHECK-LABEL: func.func @tile_exp_flags
 // CHECK: ttkernel.tile_regs_acquire
 // CHECK: ttkernel.exp_tile_init() {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}scale = 1073741824 : i32{{.*[}]}}
-// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}iterations = 4 : i32{{.*}}scale = 1073741824 : i32{{.*[}]}}
+// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}scale = 1073741824 : i32{{.*[}]}}
 // CHECK: ttkernel.tile_regs_release
 func.func @tile_exp_flags(%a: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   ttkernel.tile_regs_acquire() : () -> ()
   %exp = ttl.tile_exp %a into dst[%c0] {approx = true, scale = 2.000000e+00 : f32,
                                         input_clamping = 0 : i32,
-                                        iterations = 4 : i32}
+                                        iterations = 8 : i32}
       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %exp : !ttcore.tile<32x32, f32>

--- a/test/ttlang/Dialect/TTL/IR/exp_flags.mlir
+++ b/test/ttlang/Dialect/TTL/IR/exp_flags.mlir
@@ -17,13 +17,13 @@ func.func @exp_no_flags(
 // -----
 
 // CHECK-LABEL: func.func @exp_with_flags
-// CHECK: ttl.exp %{{.*}} {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}iterations = 4 : i32{{.*}}scale = 2.000000e+00 : f32{{.*[}]}} : tensor<2x2x!ttcore.tile<32x32, f32>> -> tensor<2x2x!ttcore.tile<32x32, f32>>
+// CHECK: ttl.exp %{{.*}} {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}scale = 2.000000e+00 : f32{{.*[}]}} : tensor<2x2x!ttcore.tile<32x32, f32>> -> tensor<2x2x!ttcore.tile<32x32, f32>>
 func.func @exp_with_flags(
     %arg0: tensor<2x2x!ttcore.tile<32x32, f32>>)
     -> tensor<2x2x!ttcore.tile<32x32, f32>> {
   %0 = ttl.exp %arg0 {approx = true, scale = 2.000000e+00 : f32,
                       input_clamping = 0 : i32,
-                      iterations = 4 : i32}
+                      iterations = 8 : i32}
       : tensor<2x2x!ttcore.tile<32x32, f32>> -> tensor<2x2x!ttcore.tile<32x32, f32>>
   return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
 }
@@ -43,13 +43,13 @@ func.func @tile_exp_no_flags(%a: !ttcore.tile<32x32, f32>)
 // -----
 
 // CHECK-LABEL: func.func @tile_exp_with_flags
-// CHECK: ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}iterations = 4 : i32{{.*}}scale = 2.000000e+00 : f32{{.*[}]}} : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+// CHECK: ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}scale = 2.000000e+00 : f32{{.*[}]}} : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
 func.func @tile_exp_with_flags(%a: !ttcore.tile<32x32, f32>)
     -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   %0 = ttl.tile_exp %a into dst[%c0] {approx = true, scale = 2.000000e+00 : f32,
                                       input_clamping = 0 : i32,
-                                      iterations = 4 : i32}
+                                      iterations = 8 : i32}
        : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   return %0 : !ttcore.tile<32x32, f32>
 }

--- a/test/ttlang/Dialect/TTL/IR/exp_flags_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/exp_flags_invalid.mlir
@@ -1,0 +1,80 @@
+// Summary: Verify ttl.exp and ttl.tile_exp reject iteration counts that do not
+// cover exactly one full tile.
+//
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics
+
+// Zero iterations leave the complete tile unevaluated.
+func.func @exp_zero_iterations(
+    %arg0: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  // expected-error @below {{attribute 'iterations' failed to satisfy constraint}}
+  %0 = ttl.exp %arg0 {iterations = 0 : i32}
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  return %0 : tensor<1x1x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Negative iterations are invalid loop bounds.
+func.func @exp_negative_iterations(
+    %arg0: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  // expected-error @below {{attribute 'iterations' failed to satisfy constraint}}
+  %0 = ttl.exp %arg0 {iterations = -1 : i32}
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  return %0 : tensor<1x1x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Four iterations evaluate only part of a full tile.
+func.func @exp_unsupported_positive_iterations(
+    %arg0: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  // expected-error @below {{attribute 'iterations' failed to satisfy constraint}}
+  %0 = ttl.exp %arg0 {iterations = 4 : i32}
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  return %0 : tensor<1x1x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Tile-level operations enforce the same zero-iteration constraint.
+func.func @tile_exp_zero_iterations(
+    %arg0: !ttcore.tile<32x32, f32>)
+    -> !ttcore.tile<32x32, f32> {
+  %c0 = arith.constant 0 : index
+  // expected-error @below {{attribute 'iterations' failed to satisfy constraint}}
+  %0 = ttl.tile_exp %arg0 into dst[%c0] {iterations = 0 : i32}
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return %0 : !ttcore.tile<32x32, f32>
+}
+
+// -----
+
+// Tile-level operations reject negative iteration counts.
+func.func @tile_exp_negative_iterations(
+    %arg0: !ttcore.tile<32x32, f32>)
+    -> !ttcore.tile<32x32, f32> {
+  %c0 = arith.constant 0 : index
+  // expected-error @below {{attribute 'iterations' failed to satisfy constraint}}
+  %0 = ttl.tile_exp %arg0 into dst[%c0] {iterations = -1 : i32}
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return %0 : !ttcore.tile<32x32, f32>
+}
+
+// -----
+
+// Tile-level operations reject unsupported positive iteration counts.
+func.func @tile_exp_unsupported_positive_iterations(
+    %arg0: !ttcore.tile<32x32, f32>)
+    -> !ttcore.tile<32x32, f32> {
+  %c0 = arith.constant 0 : index
+  // expected-error @below {{attribute 'iterations' failed to satisfy constraint}}
+  %0 = ttl.tile_exp %arg0 into dst[%c0] {iterations = 2147483647 : i32}
+      : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
+  return %0 : !ttcore.tile<32x32, f32>
+}


### PR DESCRIPTION
### Problem description
No validation for iterations parameter in exp.

### What's changed

1. Allow only 8 as a valid parameter.
An alternative would be to entirely remove parameter. I decided to keep it, because in future we may decide to add 32, which is also valid in some rare cases.
2. `dprint/runtime.py` checks now use CHECK-DAG with runtime thread prefixes.

### Ticket
[[ttl.exp] Reject unsupported iterations before kernel lowering](https://github.com/tenstorrent/tt-lang/issues/819)

### Checklist
- [X] New & Existing tests provide coverage for changes

1. cmake --build build --target check-ttlang check-ttlang-python-lit
2. pytest test/sim/test_math.py
3. python test/python/invalid/invalid_exp_iterations.py (should fail)