### PR TITLE
[ttl][pipes] Add byte-counted DFB and PipeNet transfers [tree-reduce-1]

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -162,9 +162,10 @@ def TTL_CopyOp : TTL_Op<"copy", [MemoryEffects<[MemRead, MemWrite]>]> {
     unchanged.
 
     Pipe copies may also specify `byte_count` to transfer a valid prefix of one
-    source block. The sender and every receiver must specify the same count,
-    and the count must fit both endpoint blocks. Omitting `byte_count`
-    preserves the complete-block transfer contract.
+    source block. Byte-counted pipe transfers require a one-block transfer
+    span. The sender and every receiver must specify the same count, and the
+    count must fit both endpoint blocks. Omitting `byte_count` preserves the
+    complete-block transfer contract.
 
     TODO(ttl): Add an optional TRID attribute (range 0..15) when TRID-specific
     TTKernel NOC ops are available. Issue: #87.

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -153,19 +153,20 @@ def TTL_CopyOp : TTL_Op<"copy", [MemoryEffects<[MemRead, MemWrite]>]> {
     remain equal to the block shape. The span must not exceed the dataflow
     buffer's block count.
 
-    An explicit positive `byte_count` permits a byte-preserving copy between
-    two acquired dataflow-buffer blocks with different tile geometry. The
-    source must be the exact block returned by `ttl.cb_wait`, and the
-    destination must be the exact block returned by `ttl.cb_reserve`. Both
-    dataflow buffers must use the same element data format, and the count must
-    fit both acquired blocks. Bytes beyond the count in the destination are
-    unchanged.
+    An explicit positive `byte_count` copies exactly that many consecutive
+    bytes starting at byte offset zero between two acquired dataflow-buffer
+    blocks with different tile geometry. The source must be the exact block
+    returned by `ttl.cb_wait`, and the destination must be the exact block
+    returned by `ttl.cb_reserve`. Both dataflow buffers must use the same
+    element data format, and the count must fit both acquired blocks. Later
+    destination bytes remain unchanged.
 
-    Pipe copies may also specify `byte_count` to transfer a valid prefix of one
-    source block. Byte-counted pipe transfers require a one-block transfer
-    span. The sender and every receiver must specify the same count, and the
-    count must fit both endpoint blocks and the unsigned 32-bit NoC transfer
-    size. Omitting `byte_count` preserves the complete-block transfer contract.
+    Pipe copies may also specify `byte_count` to transfer exactly that many
+    consecutive bytes starting at byte offset zero of one source block.
+    Byte-counted pipe transfers require a one-block transfer span. The sender
+    and every receiver must specify the same count, and the count must fit both
+    endpoint blocks and the unsigned 32-bit NoC transfer size. Omitting
+    `byte_count` transfers the entire block.
 
     TODO(ttl): Add an optional TRID attribute (range 0..15) when TRID-specific
     TTKernel NOC ops are available. Issue: #87.
@@ -977,8 +978,10 @@ def TTL_PipeTransferPostOp : TTL_Op<"pipe_transfer.post",
     Registers the receiver-owned destination DFB slot for a pipe transfer and
     returns the token that represents receiver-side completion. The selected
     address and synchronization protocols determine whether lowering publishes
-    the address or signals sender readiness. `byte_count`, when present, is the
-    valid byte prefix of each posted destination block.
+    the address or signals sender readiness. When `byte_count` is present, the
+    matching sender writes exactly that many consecutive bytes starting at byte
+    offset zero of the reserved destination block. Later bytes remain
+    unchanged.
   }];
   let arguments = (ins
     TTL_PipeTransfer:$transfer,
@@ -997,8 +1000,9 @@ def TTL_PipeTransferSendOp : TTL_Op<"pipe_transfer.send",
     Waits until the selected synchronization condition is satisfied, then
     writes the source DFB payload to the receiver-owned destination storage and
     signals receiver completion. The returned write handle preserves the
-    existing `ttl.wait` ordering contract for send-side code. `byte_count`,
-    when present, is the valid byte prefix of each source block.
+    existing `ttl.wait` ordering contract for send-side code. When `byte_count`
+    is present, the send reads exactly that many consecutive bytes starting at
+    byte offset zero of each source block.
   }];
   let arguments = (ins
     TTL_PipeTransfer:$transfer,

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -164,8 +164,8 @@ def TTL_CopyOp : TTL_Op<"copy", [MemoryEffects<[MemRead, MemWrite]>]> {
     Pipe copies may also specify `byte_count` to transfer a valid prefix of one
     source block. Byte-counted pipe transfers require a one-block transfer
     span. The sender and every receiver must specify the same count, and the
-    count must fit both endpoint blocks. Omitting `byte_count` preserves the
-    complete-block transfer contract.
+    count must fit both endpoint blocks and the unsigned 32-bit NoC transfer
+    size. Omitting `byte_count` preserves the complete-block transfer contract.
 
     TODO(ttl): Add an optional TRID attribute (range 0..15) when TRID-specific
     TTKernel NOC ops are available. Issue: #87.
@@ -190,7 +190,8 @@ def TTL_CopyOp : TTL_Op<"copy", [MemoryEffects<[MemRead, MemWrite]>]> {
   let arguments = (ins
     AnyType:$src,
     AnyType:$dst,
-    ConfinedAttr<OptionalAttr<I64Attr>, [IntPositive]>:$byte_count
+    ConfinedAttr<OptionalAttr<I64Attr>,
+                 [IntPositive, IntMaxValue<4294967295>]>:$byte_count
   );
   // The verifier selects the result type from the transfer direction.
   let results = (outs AnyType:$xf);
@@ -982,7 +983,8 @@ def TTL_PipeTransferPostOp : TTL_Op<"pipe_transfer.post",
   let arguments = (ins
     TTL_PipeTransfer:$transfer,
     AnyType:$dst,
-    ConfinedAttr<OptionalAttr<I64Attr>, [IntPositive]>:$byte_count
+    ConfinedAttr<OptionalAttr<I64Attr>,
+                 [IntPositive, IntMaxValue<4294967295>]>:$byte_count
   );
   let results = (outs TTL_PipeToken:$token);
   let assemblyFormat = "$transfer `,` $dst attr-dict `:` functional-type(operands, results)";
@@ -1001,7 +1003,8 @@ def TTL_PipeTransferSendOp : TTL_Op<"pipe_transfer.send",
   let arguments = (ins
     TTL_PipeTransfer:$transfer,
     TTL_CircularBuffer:$src,
-    ConfinedAttr<OptionalAttr<I64Attr>, [IntPositive]>:$byte_count
+    ConfinedAttr<OptionalAttr<I64Attr>,
+                 [IntPositive, IntMaxValue<4294967295>]>:$byte_count
   );
   let results = (outs TTL_TransferHandle:$xf);
   let assemblyFormat = "$transfer `,` $src attr-dict `:` functional-type(operands, results)";

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -153,6 +153,19 @@ def TTL_CopyOp : TTL_Op<"copy", [MemoryEffects<[MemRead, MemWrite]>]> {
     remain equal to the block shape. The span must not exceed the dataflow
     buffer's block count.
 
+    An explicit positive `byte_count` permits a byte-preserving copy between
+    two acquired dataflow-buffer blocks with different tile geometry. The
+    source must be the exact block returned by `ttl.cb_wait`, and the
+    destination must be the exact block returned by `ttl.cb_reserve`. Both
+    dataflow buffers must use the same element data format, and the count must
+    fit both acquired blocks. Bytes beyond the count in the destination are
+    unchanged.
+
+    Pipe copies may also specify `byte_count` to transfer a valid prefix of one
+    source block. The sender and every receiver must specify the same count,
+    and the count must fit both endpoint blocks. Omitting `byte_count`
+    preserves the complete-block transfer contract.
+
     TODO(ttl): Add an optional TRID attribute (range 0..15) when TRID-specific
     TTKernel NOC ops are available. Issue: #87.
 
@@ -175,7 +188,8 @@ def TTL_CopyOp : TTL_Op<"copy", [MemoryEffects<[MemRead, MemWrite]>]> {
   }];
   let arguments = (ins
     AnyType:$src,
-    AnyType:$dst
+    AnyType:$dst,
+    ConfinedAttr<OptionalAttr<I64Attr>, [IntPositive]>:$byte_count
   );
   // The verifier selects the result type from the transfer direction.
   let results = (outs AnyType:$xf);
@@ -961,11 +975,13 @@ def TTL_PipeTransferPostOp : TTL_Op<"pipe_transfer.post",
     Registers the receiver-owned destination DFB slot for a pipe transfer and
     returns the token that represents receiver-side completion. The selected
     address and synchronization protocols determine whether lowering publishes
-    the address or signals sender readiness.
+    the address or signals sender readiness. `byte_count`, when present, is the
+    valid byte prefix of each posted destination block.
   }];
   let arguments = (ins
     TTL_PipeTransfer:$transfer,
-    AnyType:$dst
+    AnyType:$dst,
+    ConfinedAttr<OptionalAttr<I64Attr>, [IntPositive]>:$byte_count
   );
   let results = (outs TTL_PipeToken:$token);
   let assemblyFormat = "$transfer `,` $dst attr-dict `:` functional-type(operands, results)";
@@ -978,11 +994,13 @@ def TTL_PipeTransferSendOp : TTL_Op<"pipe_transfer.send",
     Waits until the selected synchronization condition is satisfied, then
     writes the source DFB payload to the receiver-owned destination storage and
     signals receiver completion. The returned write handle preserves the
-    existing `ttl.wait` ordering contract for send-side code.
+    existing `ttl.wait` ordering contract for send-side code. `byte_count`,
+    when present, is the valid byte prefix of each source block.
   }];
   let arguments = (ins
     TTL_PipeTransfer:$transfer,
-    TTL_CircularBuffer:$src
+    TTL_CircularBuffer:$src,
+    ConfinedAttr<OptionalAttr<I64Attr>, [IntPositive]>:$byte_count
   );
   let results = (outs TTL_TransferHandle:$xf);
   let assemblyFormat = "$transfer `,` $src attr-dict `:` functional-type(operands, results)";

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -382,11 +382,9 @@ FailureOr<uint64_t> getDFBPagesPerBlock(CircularBufferType type);
 /// Scalar elements must occupy a positive whole number of bytes.
 FailureOr<uint64_t> getDFBPageSizeBytes(CircularBufferType type);
 
-/// Returns the byte capacity of one DFB block.
-FailureOr<uint64_t> getDFBBlockSizeBytes(CircularBufferType type);
-
-/// Returns the byte capacity of a statically shaped acquired DFB view.
-FailureOr<uint64_t> getDFBViewSizeBytes(Value view);
+/// Returns one block's capacity for a DFB operand and the static view capacity
+/// for an acquired DFB block operand.
+FailureOr<uint64_t> getDFBTransferCapacityBytes(Value endpoint);
 
 /// Selects the identity contract diagnosed by verifyDFBOperandIdentities.
 enum class DFBIdentityRequirement {

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -382,6 +382,12 @@ FailureOr<uint64_t> getDFBPagesPerBlock(CircularBufferType type);
 /// Scalar elements must occupy a positive whole number of bytes.
 FailureOr<uint64_t> getDFBPageSizeBytes(CircularBufferType type);
 
+/// Returns the byte capacity of one DFB block.
+FailureOr<uint64_t> getDFBBlockSizeBytes(CircularBufferType type);
+
+/// Returns the byte capacity of a statically shaped acquired DFB view.
+FailureOr<uint64_t> getDFBViewSizeBytes(Value view);
+
 /// Selects the identity contract diagnosed by verifyDFBOperandIdentities.
 enum class DFBIdentityRequirement {
   /// The caller's analysis can resolve logical identity before finalization.

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -803,46 +803,30 @@ mlir::LogicalResult mlir::tt::ttl::TensorSliceOp::verify() {
   return mlir::success();
 }
 
+// A DFB operand denotes one complete block; an acquired view may denote less.
 static mlir::LogicalResult
-verifyByteCountFitsDFBBlock(mlir::Operation *operation, mlir::Value dfb,
-                            uint64_t byteCount, llvm::StringRef endpoint) {
-  auto dfbType =
-      mlir::dyn_cast<mlir::tt::ttl::CircularBufferType>(dfb.getType());
-  if (!dfbType) {
-    return operation->emitOpError()
-           << endpoint << " operand is not a dataflow buffer";
+verifyByteCountFitsDFBEndpoint(mlir::Operation *operation, mlir::Value endpoint,
+                               uint64_t byteCount,
+                               llvm::StringRef endpointName) {
+  const bool isDFBBlock =
+      mlir::isa<mlir::tt::ttl::CircularBufferType>(endpoint.getType());
+  const llvm::StringRef capacityKind =
+      isDFBBlock ? "dataflow-buffer block" : "acquired dataflow-buffer view";
+  mlir::FailureOr<uint64_t> capacityBytes =
+      mlir::tt::ttl::getDFBTransferCapacityBytes(endpoint);
+  if (mlir::failed(capacityBytes)) {
+    return operation->emitOpError() << "cannot determine " << endpointName
+                                    << " " << capacityKind << " size";
   }
-  mlir::FailureOr<uint64_t> blockSizeBytes =
-      mlir::tt::ttl::getDFBBlockSizeBytes(dfbType);
-  if (mlir::failed(blockSizeBytes)) {
+  if (byteCount > *capacityBytes) {
     return operation->emitOpError()
-           << "cannot determine " << endpoint << " dataflow-buffer block size";
-  }
-  if (byteCount > *blockSizeBytes) {
-    return operation->emitOpError()
-           << "byte_count " << byteCount << " exceeds " << endpoint
-           << " dataflow-buffer block capacity " << *blockSizeBytes;
+           << "byte_count " << byteCount << " exceeds " << endpointName << " "
+           << capacityKind << " capacity " << *capacityBytes;
   }
   return mlir::success();
 }
 
-static mlir::LogicalResult
-verifyByteCountFitsAcquiredView(mlir::Operation *operation, mlir::Value view,
-                                uint64_t byteCount, llvm::StringRef endpoint) {
-  mlir::FailureOr<uint64_t> viewSizeBytes =
-      mlir::tt::ttl::getDFBViewSizeBytes(view);
-  if (mlir::failed(viewSizeBytes)) {
-    return operation->emitOpError() << "cannot determine " << endpoint
-                                    << " acquired dataflow-buffer view size";
-  }
-  if (byteCount > *viewSizeBytes) {
-    return operation->emitOpError()
-           << "byte_count " << byteCount << " exceeds " << endpoint
-           << " acquired dataflow-buffer view capacity " << *viewSizeBytes;
-  }
-  return mlir::success();
-}
-
+// Raw byte copies may change tile geometry but cannot reinterpret data formats.
 static mlir::LogicalResult verifyByteCopyDataFormats(mlir::Operation *operation,
                                                      mlir::Value srcDFB,
                                                      mlir::Value dstDFB) {
@@ -920,10 +904,10 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
     }
     if (failed(verifyByteCopyDataFormats(getOperation(), srcAttachedDFB,
                                          dstAttachedDFB)) ||
-        failed(verifyByteCountFitsAcquiredView(getOperation(), getSrc(),
-                                               byteCount, "source")) ||
-        failed(verifyByteCountFitsAcquiredView(getOperation(), getDst(),
-                                               byteCount, "destination"))) {
+        failed(verifyByteCountFitsDFBEndpoint(getOperation(), getSrc(),
+                                              byteCount, "source")) ||
+        failed(verifyByteCountFitsDFBEndpoint(getOperation(), getDst(),
+                                              byteCount, "destination"))) {
       return failure();
     }
     return success();
@@ -951,7 +935,7 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
         return emitOpError()
                << "pipe send requires !ttl.transfer_handle<write> result";
       }
-      return byteCountAttr ? verifyByteCountFitsDFBBlock(
+      return byteCountAttr ? verifyByteCountFitsDFBEndpoint(
                                  getOperation(), getSrc(), byteCount, "source")
                            : success();
     }
@@ -963,8 +947,8 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
              << "pipe receive requires !ttl.receive_request result";
     }
     return byteCountAttr
-               ? verifyByteCountFitsAcquiredView(getOperation(), getDst(),
-                                                 byteCount, "destination")
+               ? verifyByteCountFitsDFBEndpoint(getOperation(), getDst(),
+                                                byteCount, "destination")
                : success();
   }
 

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -803,10 +803,11 @@ mlir::LogicalResult mlir::tt::ttl::TensorSliceOp::verify() {
   return mlir::success();
 }
 
-static mlir::LogicalResult verifyByteCountFitsDFBBlock(
-    mlir::Operation *operation, mlir::Value dfb, uint64_t byteCount,
-    llvm::StringRef endpoint) {
-  auto dfbType = mlir::dyn_cast<mlir::tt::ttl::CircularBufferType>(dfb.getType());
+static mlir::LogicalResult
+verifyByteCountFitsDFBBlock(mlir::Operation *operation, mlir::Value dfb,
+                            uint64_t byteCount, llvm::StringRef endpoint) {
+  auto dfbType =
+      mlir::dyn_cast<mlir::tt::ttl::CircularBufferType>(dfb.getType());
   if (!dfbType) {
     return operation->emitOpError()
            << endpoint << " operand is not a dataflow buffer";
@@ -825,15 +826,14 @@ static mlir::LogicalResult verifyByteCountFitsDFBBlock(
   return mlir::success();
 }
 
-static mlir::LogicalResult verifyByteCountFitsAcquiredView(
-    mlir::Operation *operation, mlir::Value view, uint64_t byteCount,
-    llvm::StringRef endpoint) {
+static mlir::LogicalResult
+verifyByteCountFitsAcquiredView(mlir::Operation *operation, mlir::Value view,
+                                uint64_t byteCount, llvm::StringRef endpoint) {
   mlir::FailureOr<uint64_t> viewSizeBytes =
       mlir::tt::ttl::getDFBViewSizeBytes(view);
   if (mlir::failed(viewSizeBytes)) {
-    return operation->emitOpError()
-           << "cannot determine " << endpoint
-           << " acquired dataflow-buffer view size";
+    return operation->emitOpError() << "cannot determine " << endpoint
+                                    << " acquired dataflow-buffer view size";
   }
   if (byteCount > *viewSizeBytes) {
     return operation->emitOpError()
@@ -843,8 +843,9 @@ static mlir::LogicalResult verifyByteCountFitsAcquiredView(
   return mlir::success();
 }
 
-static mlir::LogicalResult verifyByteCopyDataFormats(
-    mlir::Operation *operation, mlir::Value srcDFB, mlir::Value dstDFB) {
+static mlir::LogicalResult verifyByteCopyDataFormats(mlir::Operation *operation,
+                                                     mlir::Value srcDFB,
+                                                     mlir::Value dstDFB) {
   auto srcType =
       mlir::cast<mlir::tt::ttl::CircularBufferType>(srcDFB.getType());
   auto dstType =
@@ -891,9 +892,8 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
     }
     auto handleType = mlir::dyn_cast<TransferHandleType>(getXf().getType());
     if (!handleType || handleType.getKind() != TransferKind::read) {
-      return emitOpError()
-             << "dataflow-buffer block copy requires "
-                "!ttl.transfer_handle<read> result";
+      return emitOpError() << "dataflow-buffer block copy requires "
+                              "!ttl.transfer_handle<read> result";
     }
     auto srcAttach = getSrc().getDefiningOp<AttachCBOp>();
     auto dstAttach = getDst().getDefiningOp<AttachCBOp>();
@@ -951,10 +951,9 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
         return emitOpError()
                << "pipe send requires !ttl.transfer_handle<write> result";
       }
-      return byteCountAttr
-                 ? verifyByteCountFitsDFBBlock(getOperation(), getSrc(),
-                                               byteCount, "source")
-                 : success();
+      return byteCountAttr ? verifyByteCountFitsDFBBlock(
+                                 getOperation(), getSrc(), byteCount, "source")
+                           : success();
     }
     if (!findCBReserveForPipeReceive(getDst())) {
       return emitOpError() << "pipe receive requires a cb_reserve destination";

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -803,6 +803,69 @@ mlir::LogicalResult mlir::tt::ttl::TensorSliceOp::verify() {
   return mlir::success();
 }
 
+static mlir::LogicalResult verifyByteCountFitsDFBBlock(
+    mlir::Operation *operation, mlir::Value dfb, uint64_t byteCount,
+    llvm::StringRef endpoint) {
+  auto dfbType = mlir::dyn_cast<mlir::tt::ttl::CircularBufferType>(dfb.getType());
+  if (!dfbType) {
+    return operation->emitOpError()
+           << endpoint << " operand is not a dataflow buffer";
+  }
+  mlir::FailureOr<uint64_t> blockSizeBytes =
+      mlir::tt::ttl::getDFBBlockSizeBytes(dfbType);
+  if (mlir::failed(blockSizeBytes)) {
+    return operation->emitOpError()
+           << "cannot determine " << endpoint << " dataflow-buffer block size";
+  }
+  if (byteCount > *blockSizeBytes) {
+    return operation->emitOpError()
+           << "byte_count " << byteCount << " exceeds " << endpoint
+           << " dataflow-buffer block capacity " << *blockSizeBytes;
+  }
+  return mlir::success();
+}
+
+static mlir::LogicalResult verifyByteCountFitsAcquiredView(
+    mlir::Operation *operation, mlir::Value view, uint64_t byteCount,
+    llvm::StringRef endpoint) {
+  mlir::FailureOr<uint64_t> viewSizeBytes =
+      mlir::tt::ttl::getDFBViewSizeBytes(view);
+  if (mlir::failed(viewSizeBytes)) {
+    return operation->emitOpError()
+           << "cannot determine " << endpoint
+           << " acquired dataflow-buffer view size";
+  }
+  if (byteCount > *viewSizeBytes) {
+    return operation->emitOpError()
+           << "byte_count " << byteCount << " exceeds " << endpoint
+           << " acquired dataflow-buffer view capacity " << *viewSizeBytes;
+  }
+  return mlir::success();
+}
+
+static mlir::LogicalResult verifyByteCopyDataFormats(
+    mlir::Operation *operation, mlir::Value srcDFB, mlir::Value dstDFB) {
+  auto srcType =
+      mlir::cast<mlir::tt::ttl::CircularBufferType>(srcDFB.getType());
+  auto dstType =
+      mlir::cast<mlir::tt::ttl::CircularBufferType>(dstDFB.getType());
+  auto srcTile =
+      mlir::dyn_cast<mlir::tt::ttcore::TileType>(srcType.getElementType());
+  auto dstTile =
+      mlir::dyn_cast<mlir::tt::ttcore::TileType>(dstType.getElementType());
+  if (!srcTile || !dstTile) {
+    return operation->emitOpError(
+        "byte-counted dataflow-buffer copies require tiled element types");
+  }
+  if (srcTile.getDataType() != dstTile.getDataType()) {
+    return operation->emitOpError()
+           << "byte-counted copy data formats must match; got source "
+           << srcType.getElementType() << " and destination "
+           << dstType.getElementType();
+  }
+  return mlir::success();
+}
+
 mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
   auto srcTy = getSrc().getType();
   auto dstTy = getDst().getType();
@@ -815,6 +878,50 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
       mlir::isa<PipeType, SelectedPipeSrcType, SelectedPipeDstType>(srcTy);
   const bool dstIsPipe =
       mlir::isa<PipeType, SelectedPipeSrcType, SelectedPipeDstType>(dstTy);
+  Value srcAttachedDFB = getAttachedCB(getSrc());
+  Value dstAttachedDFB = getAttachedCB(getDst());
+  IntegerAttr byteCountAttr = getByteCountAttr();
+  uint64_t byteCount =
+      byteCountAttr ? static_cast<uint64_t>(byteCountAttr.getInt()) : 0;
+
+  if (srcAttachedDFB && dstAttachedDFB) {
+    if (!byteCountAttr) {
+      return emitOpError(
+          "dataflow-buffer block copies require an explicit byte_count");
+    }
+    auto srcAttach = getSrc().getDefiningOp<AttachCBOp>();
+    auto dstAttach = getDst().getDefiningOp<AttachCBOp>();
+    mlir::Operation *srcAcquire =
+        srcAttach ? traceUnrealizedCasts(srcAttach.getTensor()).getDefiningOp()
+                  : nullptr;
+    mlir::Operation *dstAcquire =
+        dstAttach ? traceUnrealizedCasts(dstAttach.getTensor()).getDefiningOp()
+                  : nullptr;
+    if (!mlir::isa_and_nonnull<CBWaitOp>(srcAcquire)) {
+      return emitOpError(
+          "dataflow-buffer copy source must be the exact view returned by "
+          "ttl.cb_wait");
+    }
+    if (!mlir::isa_and_nonnull<CBReserveOp>(dstAcquire)) {
+      return emitOpError(
+          "dataflow-buffer copy destination must be the exact view returned "
+          "by ttl.cb_reserve");
+    }
+    if (srcAttachedDFB == dstAttachedDFB) {
+      return emitOpError(
+          "byte-counted copy requires distinct source and destination "
+          "dataflow buffers");
+    }
+    if (failed(verifyByteCopyDataFormats(getOperation(), srcAttachedDFB,
+                                         dstAttachedDFB)) ||
+        failed(verifyByteCountFitsAcquiredView(getOperation(), getSrc(),
+                                               byteCount, "source")) ||
+        failed(verifyByteCountFitsAcquiredView(getOperation(), getDst(),
+                                               byteCount, "destination"))) {
+      return failure();
+    }
+    return success();
+  }
 
   if (srcIsPipe || dstIsPipe) {
     if (srcIsPipe && dstIsPipe) {
@@ -838,7 +945,10 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
         return emitOpError()
                << "pipe send requires !ttl.transfer_handle<write> result";
       }
-      return success();
+      return byteCountAttr
+                 ? verifyByteCountFitsDFBBlock(getOperation(), getSrc(),
+                                               byteCount, "source")
+                 : success();
     }
     if (!findCBReserveForPipeReceive(getDst())) {
       return emitOpError() << "pipe receive requires a cb_reserve destination";
@@ -847,7 +957,16 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
       return emitOpError()
              << "pipe receive requires !ttl.receive_request result";
     }
-    return success();
+    return byteCountAttr
+               ? verifyByteCountFitsAcquiredView(getOperation(), getDst(),
+                                                 byteCount, "destination")
+               : success();
+  }
+
+  if (byteCountAttr) {
+    return emitOpError(
+        "byte_count is supported only for dataflow-buffer block copies and "
+        "pipe copies");
   }
 
   auto handleType = mlir::dyn_cast<TransferHandleType>(getXf().getType());

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -889,6 +889,12 @@ mlir::LogicalResult mlir::tt::ttl::CopyOp::verify() {
       return emitOpError(
           "dataflow-buffer block copies require an explicit byte_count");
     }
+    auto handleType = mlir::dyn_cast<TransferHandleType>(getXf().getType());
+    if (!handleType || handleType.getKind() != TransferKind::read) {
+      return emitOpError()
+             << "dataflow-buffer block copy requires "
+                "!ttl.transfer_handle<read> result";
+    }
     auto srcAttach = getSrc().getDefiningOp<AttachCBOp>();
     auto dstAttach = getDst().getDefiningOp<AttachCBOp>();
     mlir::Operation *srcAcquire =

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -179,6 +179,42 @@ FailureOr<uint64_t> getDFBPageSizeBytes(CircularBufferType type) {
   return bitWidth / 8;
 }
 
+FailureOr<uint64_t> getDFBBlockSizeBytes(CircularBufferType type) {
+  FailureOr<uint64_t> pagesPerBlock = getDFBPagesPerBlock(type);
+  FailureOr<uint64_t> pageSizeBytes = getDFBPageSizeBytes(type);
+  if (failed(pagesPerBlock) || failed(pageSizeBytes)) {
+    return failure();
+  }
+  std::optional<uint64_t> blockSizeBytes =
+      llvm::checkedMulUnsigned(*pagesPerBlock, *pageSizeBytes);
+  if (!blockSizeBytes) {
+    return failure();
+  }
+  return *blockSizeBytes;
+}
+
+FailureOr<uint64_t> getDFBViewSizeBytes(Value view) {
+  auto viewType = dyn_cast<RankedTensorType>(view.getType());
+  Value dfb = getAttachedCB(view);
+  if (!viewType || !viewType.hasStaticShape() || !dfb) {
+    return failure();
+  }
+  auto dfbType = dyn_cast<CircularBufferType>(dfb.getType());
+  if (!dfbType || viewType.getNumElements() < 0) {
+    return failure();
+  }
+  FailureOr<uint64_t> pageSizeBytes = getDFBPageSizeBytes(dfbType);
+  if (failed(pageSizeBytes)) {
+    return failure();
+  }
+  std::optional<uint64_t> viewSizeBytes = llvm::checkedMulUnsigned(
+      static_cast<uint64_t>(viewType.getNumElements()), *pageSizeBytes);
+  if (!viewSizeBytes) {
+    return failure();
+  }
+  return *viewSizeBytes;
+}
+
 LogicalResult verifyDFBOperandIdentities(
     ModuleOp moduleOp, StringRef consumerPass,
     llvm::function_ref<bool(Operation *)> operationFilter,

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -179,40 +179,38 @@ FailureOr<uint64_t> getDFBPageSizeBytes(CircularBufferType type) {
   return bitWidth / 8;
 }
 
-FailureOr<uint64_t> getDFBBlockSizeBytes(CircularBufferType type) {
-  FailureOr<uint64_t> pagesPerBlock = getDFBPagesPerBlock(type);
-  FailureOr<uint64_t> pageSizeBytes = getDFBPageSizeBytes(type);
-  if (failed(pagesPerBlock) || failed(pageSizeBytes)) {
-    return failure();
+FailureOr<uint64_t> getDFBTransferCapacityBytes(Value endpoint) {
+  auto dfbType = dyn_cast<CircularBufferType>(endpoint.getType());
+  uint64_t pageCount;
+  if (dfbType) {
+    FailureOr<uint64_t> pagesPerBlock = getDFBPagesPerBlock(dfbType);
+    if (failed(pagesPerBlock)) {
+      return failure();
+    }
+    pageCount = *pagesPerBlock;
+  } else {
+    auto viewType = dyn_cast<RankedTensorType>(endpoint.getType());
+    Value dfb = getAttachedCB(endpoint);
+    if (!viewType || !viewType.hasStaticShape() || !dfb ||
+        viewType.getNumElements() < 0) {
+      return failure();
+    }
+    dfbType = dyn_cast<CircularBufferType>(dfb.getType());
+    pageCount = static_cast<uint64_t>(viewType.getNumElements());
   }
-  std::optional<uint64_t> blockSizeBytes =
-      llvm::checkedMulUnsigned(*pagesPerBlock, *pageSizeBytes);
-  if (!blockSizeBytes) {
-    return failure();
-  }
-  return *blockSizeBytes;
-}
-
-FailureOr<uint64_t> getDFBViewSizeBytes(Value view) {
-  auto viewType = dyn_cast<RankedTensorType>(view.getType());
-  Value dfb = getAttachedCB(view);
-  if (!viewType || !viewType.hasStaticShape() || !dfb) {
-    return failure();
-  }
-  auto dfbType = dyn_cast<CircularBufferType>(dfb.getType());
-  if (!dfbType || viewType.getNumElements() < 0) {
+  if (!dfbType) {
     return failure();
   }
   FailureOr<uint64_t> pageSizeBytes = getDFBPageSizeBytes(dfbType);
   if (failed(pageSizeBytes)) {
     return failure();
   }
-  std::optional<uint64_t> viewSizeBytes = llvm::checkedMulUnsigned(
-      static_cast<uint64_t>(viewType.getNumElements()), *pageSizeBytes);
-  if (!viewSizeBytes) {
+  std::optional<uint64_t> capacityBytes =
+      llvm::checkedMulUnsigned(pageCount, *pageSizeBytes);
+  if (!capacityBytes) {
     return failure();
   }
-  return *viewSizeBytes;
+  return *capacityBytes;
 }
 
 LogicalResult verifyDFBOperandIdentities(

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1214,11 +1214,6 @@ static LogicalResult lowerDFBBlockCopy(CopyOp op,
   }
 
   uint64_t byteCount = static_cast<uint64_t>(byteCountAttr.getInt());
-  if (byteCount > std::numeric_limits<uint32_t>::max()) {
-    return rewriter.notifyMatchFailure(
-        op, "DFB block copy byte_count exceeds the TTKernel size operand");
-  }
-
   Location loc = op.getLoc();
   FailureOr<Value> srcCB =
       utils::convertTTLCBToTTKernel(srcDFB, rewriter, loc, &typeConverter);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1200,6 +1200,49 @@ static LogicalResult lowerTensorCBCopy(
   return success();
 }
 
+/// Lower an explicit byte-preserving copy between acquired DFB blocks.
+static LogicalResult lowerDFBBlockCopy(
+    CopyOp op, ConversionPatternRewriter &rewriter,
+    const TypeConverter &typeConverter) {
+  IntegerAttr byteCountAttr = op.getByteCountAttr();
+  Value srcDFB = getAttachedCB(op.getSrc());
+  Value dstDFB = getAttachedCB(op.getDst());
+  if (!byteCountAttr || !srcDFB || !dstDFB ||
+      !isa<CircularBufferType>(srcDFB.getType()) ||
+      !isa<CircularBufferType>(dstDFB.getType())) {
+    return rewriter.notifyMatchFailure(
+        op, "DFB block copy requires byte_count and two attached DFBs");
+  }
+
+  uint64_t byteCount = static_cast<uint64_t>(byteCountAttr.getInt());
+  if (byteCount > std::numeric_limits<uint32_t>::max()) {
+    return rewriter.notifyMatchFailure(
+        op, "DFB block copy byte_count exceeds the TTKernel size operand");
+  }
+
+  Location loc = op.getLoc();
+  FailureOr<Value> srcCB = utils::convertTTLCBToTTKernel(
+      srcDFB, rewriter, loc, &typeConverter);
+  FailureOr<Value> dstCB = utils::convertTTLCBToTTKernel(
+      dstDFB, rewriter, loc, &typeConverter);
+  assert(succeeded(srcCB) && succeeded(dstCB) &&
+         "preflight checked DFB types");
+
+  Value srcAddress = ttk::GetReadPtrOp::create(rewriter, loc, *srcCB);
+  Value dstAddress = ttk::GetWritePtrOp::create(rewriter, loc, *dstCB);
+  int64_t nocIndex = getNocIndex(op);
+  Value noc = arith::ConstantOp::create(rewriter, loc, rewriter.getI8Type(),
+                                        rewriter.getI8IntegerAttr(nocIndex));
+  Value srcX = ttk::MyXOp::create(rewriter, loc, noc);
+  Value srcY = ttk::MyYOp::create(rewriter, loc, noc);
+  Value size = arith::ConstantIntOp::create(rewriter, loc, byteCount, 32);
+  ttk::NocAsyncReadOp::create(rewriter, loc, ValueRange{srcX, srcY},
+                              ValueRange{}, srcAddress, dstAddress, size, noc);
+
+  rewriter.replaceOp(op, makeZeroI32(loc, rewriter));
+  return success();
+}
+
 struct TensorSliceLowering : OpConversionPattern<TensorSliceOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -1240,6 +1283,8 @@ struct CopyLowering : OpConversionPattern<CopyOp> {
     bool srcIsSlice = srcKind == CopyOperandKind::TensorSlice;
     bool srcIsCB = srcKind == CopyOperandKind::CircularBuffer;
     bool srcIsPipe = srcKind == CopyOperandKind::Pipe;
+    bool srcIsDFBAttachedTensor =
+        srcKind == CopyOperandKind::DFBAttachedTensor;
     bool dstIsSlice = dstKind == CopyOperandKind::TensorSlice;
     bool dstIsCB = dstKind == CopyOperandKind::CircularBuffer;
     bool dstIsPipe = dstKind == CopyOperandKind::Pipe;
@@ -1257,6 +1302,10 @@ struct CopyLowering : OpConversionPattern<CopyOp> {
     if (srcIsPipe || dstIsPipe) {
       return rewriter.notifyMatchFailure(
           op, "pipe copy requires CB <-> Pipe, got invalid combination");
+    }
+
+    if (srcIsDFBAttachedTensor && dstIsDFBAttachedTensor) {
+      return lowerDFBBlockCopy(op, rewriter, *typeConverter);
     }
 
     // Non-pipe transfers: validate exactly one TensorSlice and one CB.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1201,9 +1201,9 @@ static LogicalResult lowerTensorCBCopy(
 }
 
 /// Lower an explicit byte-preserving copy between acquired DFB blocks.
-static LogicalResult lowerDFBBlockCopy(
-    CopyOp op, ConversionPatternRewriter &rewriter,
-    const TypeConverter &typeConverter) {
+static LogicalResult lowerDFBBlockCopy(CopyOp op,
+                                       ConversionPatternRewriter &rewriter,
+                                       const TypeConverter &typeConverter) {
   IntegerAttr byteCountAttr = op.getByteCountAttr();
   Value srcDFB = getAttachedCB(op.getSrc());
   Value dstDFB = getAttachedCB(op.getDst());
@@ -1221,12 +1221,11 @@ static LogicalResult lowerDFBBlockCopy(
   }
 
   Location loc = op.getLoc();
-  FailureOr<Value> srcCB = utils::convertTTLCBToTTKernel(
-      srcDFB, rewriter, loc, &typeConverter);
-  FailureOr<Value> dstCB = utils::convertTTLCBToTTKernel(
-      dstDFB, rewriter, loc, &typeConverter);
-  assert(succeeded(srcCB) && succeeded(dstCB) &&
-         "preflight checked DFB types");
+  FailureOr<Value> srcCB =
+      utils::convertTTLCBToTTKernel(srcDFB, rewriter, loc, &typeConverter);
+  FailureOr<Value> dstCB =
+      utils::convertTTLCBToTTKernel(dstDFB, rewriter, loc, &typeConverter);
+  assert(succeeded(srcCB) && succeeded(dstCB) && "preflight checked DFB types");
 
   Value srcAddress = ttk::GetReadPtrOp::create(rewriter, loc, *srcCB);
   Value dstAddress = ttk::GetWritePtrOp::create(rewriter, loc, *dstCB);
@@ -1283,8 +1282,7 @@ struct CopyLowering : OpConversionPattern<CopyOp> {
     bool srcIsSlice = srcKind == CopyOperandKind::TensorSlice;
     bool srcIsCB = srcKind == CopyOperandKind::CircularBuffer;
     bool srcIsPipe = srcKind == CopyOperandKind::Pipe;
-    bool srcIsDFBAttachedTensor =
-        srcKind == CopyOperandKind::DFBAttachedTensor;
+    bool srcIsDFBAttachedTensor = srcKind == CopyOperandKind::DFBAttachedTensor;
     bool dstIsSlice = dstKind == CopyOperandKind::TensorSlice;
     bool dstIsCB = dstKind == CopyOperandKind::CircularBuffer;
     bool dstIsPipe = dstKind == CopyOperandKind::Pipe;

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1200,7 +1200,9 @@ static LogicalResult lowerTensorCBCopy(
   return success();
 }
 
-static LogicalResult lowerDFBBlockCopy(CopyOp op,
+// Tile-copy lowering cannot preserve a partial-page byte count or copy between
+// different tile geometries, so direct DFB copies use the raw NoC operation.
+static LogicalResult lowerDFBToDFBCopy(CopyOp op,
                                        ConversionPatternRewriter &rewriter,
                                        const TypeConverter &typeConverter) {
   IntegerAttr byteCountAttr = op.getByteCountAttr();
@@ -1297,7 +1299,7 @@ struct CopyLowering : OpConversionPattern<CopyOp> {
     }
 
     if (srcIsDFBAttachedTensor && dstIsDFBAttachedTensor) {
-      return lowerDFBBlockCopy(op, rewriter, *typeConverter);
+      return lowerDFBToDFBCopy(op, rewriter, *typeConverter);
     }
 
     // Non-pipe transfers: validate exactly one TensorSlice and one CB.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -1200,7 +1200,6 @@ static LogicalResult lowerTensorCBCopy(
   return success();
 }
 
-/// Lower an explicit byte-preserving copy between acquired DFB blocks.
 static LogicalResult lowerDFBBlockCopy(CopyOp op,
                                        ConversionPatternRewriter &rewriter,
                                        const TypeConverter &typeConverter) {

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -1100,6 +1100,8 @@ LogicalResult PipeGraph::verifyCollectiveReceiverAddresses() const {
   return success();
 }
 
+// A transfer node pairs one send with every receiver, allowing this check to
+// compare byte counts, formats, and capacities across all endpoints.
 static LogicalResult
 verifyTransferPayloadCompatibility(const PipeTransferNode &transferNode) {
   auto sendOp = llvm::cast<PipeTransferSendOp>(transferNode.sendOp);
@@ -1129,9 +1131,10 @@ verifyTransferPayloadCompatibility(const PipeTransferNode &transferNode) {
           dyn_cast<ttcore::TileType>(sourceDFBType.getElementType());
       auto destinationTile =
           dyn_cast<ttcore::TileType>(destinationDFBType.getElementType());
-      FailureOr<uint64_t> sourceCapacity = getDFBBlockSizeBytes(sourceDFBType);
+      FailureOr<uint64_t> sourceCapacity =
+          getDFBTransferCapacityBytes(sendOp.getSrc());
       FailureOr<uint64_t> destinationCapacity =
-          getDFBViewSizeBytes(postOp.getDst());
+          getDFBTransferCapacityBytes(postOp.getDst());
       uint64_t byteCount = static_cast<uint64_t>(sendByteCount.getInt());
       if (!sourceTile || !destinationTile ||
           sourceTile.getDataType() != destinationTile.getDataType() ||

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -1100,16 +1100,65 @@ LogicalResult PipeGraph::verifyCollectiveReceiverAddresses() const {
   return success();
 }
 
-/// Verify that every receiver destination can hold the sender's DFB block.
+/// Verify that every receiver agrees on the payload and has sufficient space.
 static LogicalResult
 verifyTransferPayloadCompatibility(const PipeTransferNode &transferNode) {
   auto sendOp = llvm::cast<PipeTransferSendOp>(transferNode.sendOp);
   auto sourceDFBType =
       mlir::cast<CircularBufferType>(sendOp.getSrc().getType());
   int64_t sourceElementCount = sourceDFBType.getElementsPerBlock();
+  IntegerAttr sendByteCount = sendOp.getByteCountAttr();
 
   for (Operation *postOperation : transferNode.receiverPostOps) {
     auto postOp = llvm::cast<PipeTransferPostOp>(postOperation);
+    IntegerAttr postByteCount = postOp.getByteCountAttr();
+    if (static_cast<bool>(sendByteCount) != static_cast<bool>(postByteCount) ||
+        (sendByteCount && sendByteCount.getInt() != postByteCount.getInt())) {
+      auto diag = postOp.emitError(
+          "pipe sender and receiver must use the same byte_count");
+      diag.attachNote(sendOp.getLoc()) << "corresponding pipe send is here";
+      return failure();
+    }
+
+    if (sendByteCount) {
+      Value destinationDFB = getAttachedCB(postOp.getDst());
+      if (!destinationDFB) {
+        auto diag = postOp.emitError(
+            "byte-counted pipe receiver requires an attached dataflow buffer");
+        diag.attachNote(sendOp.getLoc()) << "corresponding pipe send is here";
+        return failure();
+      }
+      auto destinationDFBType =
+          dyn_cast<CircularBufferType>(destinationDFB.getType());
+      if (!destinationDFBType) {
+        auto diag = postOp.emitError(
+            "byte-counted pipe receiver has an invalid dataflow-buffer type");
+        diag.attachNote(sendOp.getLoc()) << "corresponding pipe send is here";
+        return failure();
+      }
+      auto sourceTile =
+          dyn_cast<ttcore::TileType>(sourceDFBType.getElementType());
+      auto destinationTile =
+          dyn_cast<ttcore::TileType>(destinationDFBType.getElementType());
+      FailureOr<uint64_t> sourceCapacity =
+          getDFBBlockSizeBytes(sourceDFBType);
+      FailureOr<uint64_t> destinationCapacity =
+          getDFBViewSizeBytes(postOp.getDst());
+      uint64_t byteCount = static_cast<uint64_t>(sendByteCount.getInt());
+      if (!sourceTile || !destinationTile ||
+          sourceTile.getDataType() != destinationTile.getDataType() ||
+          failed(sourceCapacity) || failed(destinationCapacity) ||
+          byteCount > *sourceCapacity || byteCount > *destinationCapacity) {
+        auto diag = postOp.emitError()
+                    << "pipe receiver cannot accept the sender's byte-counted "
+                       "payload of "
+                    << byteCount << " byte(s)";
+        diag.attachNote(sendOp.getLoc()) << "corresponding pipe send is here";
+        return failure();
+      }
+      continue;
+    }
+
     auto destinationType =
         mlir::dyn_cast<RankedTensorType>(postOp.getDst().getType());
     if (!destinationType || !destinationType.hasStaticShape()) {

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -1140,8 +1140,7 @@ verifyTransferPayloadCompatibility(const PipeTransferNode &transferNode) {
           dyn_cast<ttcore::TileType>(sourceDFBType.getElementType());
       auto destinationTile =
           dyn_cast<ttcore::TileType>(destinationDFBType.getElementType());
-      FailureOr<uint64_t> sourceCapacity =
-          getDFBBlockSizeBytes(sourceDFBType);
+      FailureOr<uint64_t> sourceCapacity = getDFBBlockSizeBytes(sourceDFBType);
       FailureOr<uint64_t> destinationCapacity =
           getDFBViewSizeBytes(postOp.getDst());
       uint64_t byteCount = static_cast<uint64_t>(sendByteCount.getInt());

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -1100,7 +1100,6 @@ LogicalResult PipeGraph::verifyCollectiveReceiverAddresses() const {
   return success();
 }
 
-/// Verify that every receiver agrees on the payload and has sufficient space.
 static LogicalResult
 verifyTransferPayloadCompatibility(const PipeTransferNode &transferNode) {
   auto sendOp = llvm::cast<PipeTransferSendOp>(transferNode.sendOp);

--- a/lib/Dialect/TTL/Transforms/PipeGraph.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeGraph.cpp
@@ -1121,20 +1121,10 @@ verifyTransferPayloadCompatibility(const PipeTransferNode &transferNode) {
 
     if (sendByteCount) {
       Value destinationDFB = getAttachedCB(postOp.getDst());
-      if (!destinationDFB) {
-        auto diag = postOp.emitError(
-            "byte-counted pipe receiver requires an attached dataflow buffer");
-        diag.attachNote(sendOp.getLoc()) << "corresponding pipe send is here";
-        return failure();
-      }
+      assert(destinationDFB &&
+             "pipe transfer verifier requires an attached receiver DFB");
       auto destinationDFBType =
-          dyn_cast<CircularBufferType>(destinationDFB.getType());
-      if (!destinationDFBType) {
-        auto diag = postOp.emitError(
-            "byte-counted pipe receiver has an invalid dataflow-buffer type");
-        diag.attachNote(sendOp.getLoc()) << "corresponding pipe send is here";
-        return failure();
-      }
+          cast<CircularBufferType>(destinationDFB.getType());
       auto sourceTile =
           dyn_cast<ttcore::TileType>(sourceDFBType.getElementType());
       auto destinationTile =

--- a/lib/Dialect/TTL/Transforms/PipePlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.cpp
@@ -133,6 +133,17 @@ FailureOr<PipeTransferPayload> getPipeTransferPayload(PipeTransferSendOp sendOp,
     return failure();
   }
 
+  if (IntegerAttr byteCountAttr = sendOp.getByteCountAttr()) {
+    int64_t byteCount = byteCountAttr.getInt();
+    std::optional<int64_t> maybeSizeBytes =
+        llvm::checkedMul(byteCount, blockSpan);
+    if (!maybeSizeBytes) {
+      sendOp.emitError("byte-counted pipe transfer payload exceeds int64_t");
+      return failure();
+    }
+    return PipeTransferPayload{blockSpan, byteCount, *maybeSizeBytes};
+  }
+
   std::optional<int64_t> maybeElementCount =
       llvm::checkedMul(dfbType.getElementsPerBlock(), blockSpan);
   if (!maybeElementCount) {

--- a/lib/Dialect/TTL/Transforms/PipePlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.cpp
@@ -134,31 +134,31 @@ FailureOr<PipeTransferPayload> getPipeTransferPayload(PipeTransferSendOp sendOp,
   }
 
   if (IntegerAttr byteCountAttr = sendOp.getByteCountAttr()) {
-    int64_t byteCount = byteCountAttr.getInt();
-    std::optional<int64_t> maybeSizeBytes =
-        llvm::checkedMul(byteCount, blockSpan);
-    if (!maybeSizeBytes) {
-      sendOp.emitError("byte-counted pipe transfer payload exceeds int64_t");
+    if (blockSpan != 1) {
+      sendOp.emitError(
+          "byte-counted pipe transfers require a one-block transfer span");
       return failure();
     }
-    return PipeTransferPayload{blockSpan, byteCount, *maybeSizeBytes};
+    int64_t byteCount = byteCountAttr.getInt();
+    return PipeTransferPayload{/*pageCount=*/1,
+                               /*pageSizeBytes=*/byteCount,
+                               /*sizeBytes=*/byteCount};
   }
 
-  std::optional<int64_t> maybeElementCount =
+  std::optional<int64_t> maybePageCount =
       llvm::checkedMul(dfbType.getElementsPerBlock(), blockSpan);
-  if (!maybeElementCount) {
-    sendOp.emitError("pipe transfer element count exceeds int64_t");
+  if (!maybePageCount) {
+    sendOp.emitError("pipe transfer page count exceeds int64_t");
     return failure();
   }
-  int64_t elementSizeBytes = tileType.getSizeBytes();
+  int64_t pageSizeBytes = tileType.getSizeBytes();
   std::optional<int64_t> maybeSizeBytes =
-      llvm::checkedMul(*maybeElementCount, elementSizeBytes);
+      llvm::checkedMul(*maybePageCount, pageSizeBytes);
   if (!maybeSizeBytes) {
     sendOp.emitError("pipe transfer payload size exceeds int64_t");
     return failure();
   }
-  return PipeTransferPayload{*maybeElementCount, elementSizeBytes,
-                             *maybeSizeBytes};
+  return PipeTransferPayload{*maybePageCount, pageSizeBytes, *maybeSizeBytes};
 }
 
 static FailureOr<PipeSendPlan>

--- a/lib/Dialect/TTL/Transforms/PipePlanning.h
+++ b/lib/Dialect/TTL/Transforms/PipePlanning.h
@@ -155,10 +155,10 @@ private:
   PipeCounterAllocator counterAllocator;
 };
 
-/// Element count and byte size transferred by one sender operation.
+/// Page decomposition and total byte size transferred by one sender operation.
 struct PipeTransferPayload {
-  int64_t elementCount = 0;
-  int64_t elementSizeBytes = 0;
+  int64_t pageCount = 0;
+  int64_t pageSizeBytes = 0;
   int64_t sizeBytes = 0;
 };
 

--- a/lib/Dialect/TTL/Transforms/PipeTransferExpansion.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeTransferExpansion.cpp
@@ -443,7 +443,7 @@ applyPipeTransferExpansionPlan(ModuleOp module,
     auto postOp = PipeTransferPostOp::create(
         builder, copyOp.getLoc(),
         PipeTokenType::get(builder.getContext(), *expansion.pipeNetId),
-        transfer, copyOp.getDst());
+        transfer, copyOp.getDst(), copyOp.getByteCountAttr());
     auto handleCast = UnrealizedConversionCastOp::create(
         builder, copyOp.getLoc(), copyOp.getResult().getType(),
         ValueRange{postOp.getToken()});
@@ -459,7 +459,8 @@ applyPipeTransferExpansionPlan(ModuleOp module,
         expansion.deviceTransfer, transferByDirectCreatePipe);
     auto sendOp = PipeTransferSendOp::create(builder, copyOp.getLoc(),
                                              copyOp.getResult().getType(),
-                                             transfer, copyOp.getSrc());
+                                             transfer, copyOp.getSrc(),
+                                             copyOp.getByteCountAttr());
     copyOp.getResult().replaceAllUsesWith(sendOp.getXf());
     copyOp->erase();
   }

--- a/lib/Dialect/TTL/Transforms/PipeTransferExpansion.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeTransferExpansion.cpp
@@ -457,10 +457,9 @@ applyPipeTransferExpansionPlan(ModuleOp module,
     Value transfer = getOrCreatePipeTransfer(
         builder, copyOp.getLoc(), copyOp.getDst(), expansion.contract,
         expansion.deviceTransfer, transferByDirectCreatePipe);
-    auto sendOp = PipeTransferSendOp::create(builder, copyOp.getLoc(),
-                                             copyOp.getResult().getType(),
-                                             transfer, copyOp.getSrc(),
-                                             copyOp.getByteCountAttr());
+    auto sendOp = PipeTransferSendOp::create(
+        builder, copyOp.getLoc(), copyOp.getResult().getType(), transfer,
+        copyOp.getSrc(), copyOp.getByteCountAttr());
     copyOp.getResult().replaceAllUsesWith(sendOp.getXf());
     copyOp->erase();
   }

--- a/lib/Dialect/TTL/Transforms/PipeTransportPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeTransportPlan.cpp
@@ -351,7 +351,7 @@ FailureOr<PipeTransportPlan> buildPipeTransportPlan(
       return failure();
     }
     stream.packetization = PipeTransportPacketization{
-        maybePayload->elementCount, maybePayload->elementSizeBytes,
+        maybePayload->pageCount, maybePayload->pageSizeBytes,
         maybePayload->sizeBytes};
     stream.sourceReuse = PipeTransportSourceReuse::AfterCompletionGroup;
 

--- a/python/sim/context_types.py
+++ b/python/sim/context_types.py
@@ -62,6 +62,7 @@ class PipeMessage:
 
     grid_shape: Shape
     data: Optional[Tensor] = None
+    byte_count: Optional[int] = None
 
 
 class PipeEntry(TypedDict):

--- a/python/sim/context_types.py
+++ b/python/sim/context_types.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Deque, Dict, Optional, Set, Tuple, TypedDict
 from .pipe import AnyPipe
-from .typedefs import Count, Shape, BindableTemplate
+from .typedefs import BindableTemplate, Count, IndexType, Shape
 from .kernel import KernelKind
 
 if TYPE_CHECKING:
@@ -51,19 +51,27 @@ class TraceEvent:
 
 
 @dataclass(frozen=True)
+class ByteCopyFormat:
+    """Layout and dtype facts retained when a byte-counted payload is absent."""
+
+    layout: IndexType
+    dtype: Any
+
+
+@dataclass(frozen=True)
 class PipeMessage:
     """A single message queued on a pipe.
 
     ``grid_shape`` (the tile-grid shape of the sent block) is always populated
     so the destination shape check runs identically in dry-run and normal mode.
-    ``payload_spec`` preserves the source DFB data format and layout when
-    ``data`` is ``None`` in dry-run mode.
+    ``byte_copy_format`` preserves the source DFB format when ``data`` is
+    ``None`` in dry-run mode.
     """
 
     grid_shape: Shape
     data: Optional[Tensor] = None
     byte_count: Optional[int] = None
-    payload_spec: Optional[Tensor] = None
+    byte_copy_format: Optional[ByteCopyFormat] = None
 
 
 class PipeEntry(TypedDict):

--- a/python/sim/context_types.py
+++ b/python/sim/context_types.py
@@ -56,13 +56,14 @@ class PipeMessage:
 
     ``grid_shape`` (the tile-grid shape of the sent block) is always populated
     so the destination shape check runs identically in dry-run and normal mode.
-    ``data`` holds the backing tile tensor, or is ``None`` in dry-run mode where
-    the payload bytes are not moved.
+    ``payload_spec`` preserves the source DFB data format and layout when
+    ``data`` is ``None`` in dry-run mode.
     """
 
     grid_shape: Shape
     data: Optional[Tensor] = None
     byte_count: Optional[int] = None
+    payload_spec: Optional[Tensor] = None
 
 
 class PipeEntry(TypedDict):

--- a/python/sim/copy.py
+++ b/python/sim/copy.py
@@ -14,6 +14,8 @@ import sys
 import types
 from typing import Optional, Sequence, Tuple
 
+from ttl.constants import MAX_NOC_TRANSFER_BYTES
+
 from .context import get_context
 from .copyhandlers import (
     CopyEndpoint,
@@ -108,6 +110,11 @@ class CopyTransaction:
         ):
             raise ValueError(
                 f"copy() byte_count must be a positive int, got {byte_count}"
+            )
+        if byte_count is not None and byte_count > MAX_NOC_TRANSFER_BYTES:
+            raise ValueError(
+                "copy() byte_count must fit the unsigned 32-bit NoC transfer "
+                f"size, got {byte_count}"
             )
         self._byte_count = byte_count
         self._completed = False

--- a/python/sim/copy.py
+++ b/python/sim/copy.py
@@ -121,8 +121,10 @@ class CopyTransaction:
         handler = self._lookup_handler(type(src), type(dst))
         self._handler = handler
 
-        # Mark blocks in state machine BEFORE validation - this transitions them to appropriate states
-        # that prevent user access during the copy operation
+        # Validation must not change block state so callers can recover from an
+        # invalid request and issue a corrected transfer on the same blocks.
+        handler.validate(src, dst, byte_count)
+
         match src:
             case Block():
                 src.mark_copy_as_source(user_location)
@@ -133,9 +135,6 @@ class CopyTransaction:
                 dst.mark_copy_as_dest(user_location)
             case _:
                 pass
-
-        # Validate immediately - let exceptions propagate to scheduler for context
-        handler.validate(src, dst, byte_count)
 
         if TRACE.enabled:
             trace(

--- a/python/sim/copy.py
+++ b/python/sim/copy.py
@@ -80,6 +80,7 @@ class CopyTransaction:
         self,
         src: CopyEndpoint,
         dst: CopyEndpoint,
+        byte_count: Optional[int] = None,
         user_location: Optional[Tuple[str, int]] = None,
     ):
         """
@@ -88,6 +89,8 @@ class CopyTransaction:
         Args:
             src: Source data (tensor, Block, or Pipe)
             dst: Destination (tensor, Block, or Pipe)
+            byte_count: Positive byte count for DFB block-to-block and pipe
+                transfers.
             user_location: Pre-captured ``(filename, lineno)`` for the user
                 code initiating this copy.  Passed in by :func:`copy` so that
                 ``Block.mark_copy_as_{source,dest}`` can skip the per-call
@@ -99,6 +102,14 @@ class CopyTransaction:
         """
         self._src = src
         self._dst = dst
+        if isinstance(byte_count, bool) or (
+            byte_count is not None
+            and (not isinstance(byte_count, int) or byte_count <= 0)
+        ):
+            raise ValueError(
+                f"copy() byte_count must be a positive int, got {byte_count}"
+            )
+        self._byte_count = byte_count
         self._completed = False
         self._transfer_performed = False
         # Stable trace label, computed once at construction so the scheduler
@@ -124,18 +135,19 @@ class CopyTransaction:
                 pass
 
         # Validate immediately - let exceptions propagate to scheduler for context
-        handler.validate(src, dst)
+        handler.validate(src, dst, byte_count)
 
         if TRACE.enabled:
             trace(
                 "copy_start",
                 src=type(src).__name__,
                 dst=type(dst).__name__,
+                byte_count=byte_count,
                 **_copy_trace_fields(src, dst),
             )
 
         if self._starts_on_copy():
-            self._handler.transfer(self._src, self._dst)
+            self._handler.transfer(self._src, self._dst, self._byte_count)
             self._transfer_performed = True
 
     def _starts_on_copy(self) -> bool:
@@ -194,7 +206,7 @@ class CopyTransaction:
             # bookkeeping so pipe sequencing is exercised symmetrically. The
             # block state transitions below always fire so structural checks
             # (state machine, deadlock) remain fully exercised.
-            self._handler.transfer(self._src, self._dst)
+            self._handler.transfer(self._src, self._dst, self._byte_count)
             self._transfer_performed = True
         self._completed = True
 
@@ -215,6 +227,7 @@ class CopyTransaction:
                 "copy_end",
                 src=type(self._src).__name__,
                 dst=type(self._dst).__name__,
+                byte_count=self._byte_count,
                 **_copy_trace_fields(self._src, self._dst),
             )
 
@@ -230,7 +243,7 @@ class CopyTransaction:
         Returns:
             True if wait() can proceed without blocking
         """
-        return self._handler.can_wait(self._src, self._dst)
+        return self._handler.can_wait(self._src, self._dst, self._byte_count)
 
     @property
     def is_completed(self) -> bool:
@@ -346,6 +359,8 @@ class GroupTransfer:
 def copy(
     src: CopyEndpoint,
     dst: CopyEndpoint,
+    *,
+    byte_count: Optional[int] = None,
 ) -> CopyTransaction:
     """
     Create a copy transaction from source to destination.
@@ -362,6 +377,8 @@ def copy(
     Args:
         src: Source data (tensor, Block, or Pipe)
         dst: Destination (tensor, Block, or Pipe)
+        byte_count: Positive byte count for DFB block-to-block and pipe
+            transfers.
 
     Returns:
         CopyTransaction object that can be waited on
@@ -397,7 +414,9 @@ def copy(
         if isinstance(src, (Pipe, DstPipeIdentity)) and isinstance(dst, Block)
         else CopyTransaction
     )
-    handle = transaction_type(src, dst, user_location=user_location)
+    handle = transaction_type(
+        src, dst, byte_count=byte_count, user_location=user_location
+    )
     _register_deferred_copy_wait(frame, handle)
 
     # Case A: bare ttl.copy(...) with no assignment — auto-wait immediately.

--- a/python/sim/copyhandlers.py
+++ b/python/sim/copyhandlers.py
@@ -17,6 +17,7 @@ from typing import (
     Dict,
     Final,
     List,
+    Optional,
     Protocol,
     Tuple,
     Type,
@@ -25,7 +26,7 @@ from typing import (
 
 from .context import get_context
 from .context_types import PipeEntry, PipeMessage
-from .dfb import Block
+from .dfb import Block, BlockAcquisition
 from .pipe import (
     AnySrcPipeIdentity,
     AnyDst,
@@ -87,7 +88,7 @@ def _get_or_create_pipe_entry(pipe: AnyPipe) -> PipeEntry:
 class CopyTransferHandler(Protocol):
     """Protocol for copy transfer handlers."""
 
-    def validate(self, src: Any, dst: Any) -> None:
+    def validate(self, src: Any, dst: Any, byte_count: Optional[int]) -> None:
         """
         Validate that the transfer can be performed.
 
@@ -100,7 +101,7 @@ class CopyTransferHandler(Protocol):
         """
         ...
 
-    def transfer(self, src: Any, dst: Any) -> None:
+    def transfer(self, src: Any, dst: Any, byte_count: Optional[int]) -> None:
         """
         Perform the actual data transfer.
 
@@ -113,7 +114,7 @@ class CopyTransferHandler(Protocol):
         """
         ...
 
-    def can_wait(self, src: Any, dst: Any) -> bool:
+    def can_wait(self, src: Any, dst: Any, byte_count: Optional[int]) -> bool:
         """
         Check if wait() can proceed without blocking.
 
@@ -192,6 +193,52 @@ def _validate_block_to_tensor_shapes(
     )
 
 
+def _validate_byte_count_for_tensor(
+    tensor: Tensor, byte_count: int, endpoint: str
+) -> None:
+    element_count = math.prod(tensor.padded_shape)
+    capacity = tensor.size_in_bytes(element_count)
+    if byte_count > capacity:
+        raise ValueError(
+            f"byte_count {byte_count} exceeds {endpoint} capacity {capacity}"
+        )
+    element_size = tensor.element_size
+    if capacity != element_count * element_size:
+        raise ValueError(
+            "byte-counted simulation requires an element-addressable data type"
+        )
+    if byte_count % element_size != 0:
+        raise ValueError(
+            f"byte_count {byte_count} is not aligned to the {element_size}-byte "
+            f"{endpoint} element size"
+        )
+
+
+def _validate_byte_copy_tensors(
+    src: Tensor, dst: Tensor, byte_count: int
+) -> None:
+    if src.layout != dst.layout:
+        raise ValueError(
+            "byte-counted copy requires matching layouts; got "
+            f"source {src.layout.name} and destination {dst.layout.name}"
+        )
+    if src.dtype != dst.dtype:
+        raise ValueError(
+            "byte-counted copy requires matching data types; got "
+            f"source {src.dtype} and destination {dst.dtype}"
+        )
+    _validate_byte_count_for_tensor(src, byte_count, "source")
+    _validate_byte_count_for_tensor(dst, byte_count, "destination")
+
+
+def _copy_tensor_prefix(src: Tensor, dst: Tensor, byte_count: int) -> None:
+    _validate_byte_copy_tensors(src, dst, byte_count)
+    element_count = byte_count // src.element_size
+    dst.to_torch().reshape(-1)[:element_count].copy_(
+        src.to_torch().reshape(-1)[:element_count]
+    )
+
+
 def register_copy_handler(src_type: CopyEndpointType, dst_type: CopyEndpointType):
     """
     Decorator to register a copy transfer handler for a specific (src_type, dst_type) pair.
@@ -222,11 +269,17 @@ def register_copy_handler(src_type: CopyEndpointType, dst_type: CopyEndpointType
 class BlockToPipeHandler:
     """Handler for Block → Pipe (pipe send)."""
 
-    def validate(self, src: Block, dst: AnyPipe) -> None:
-        """Validate pipe send - no specific validation needed."""
-        pass
+    def validate(
+        self, src: Block, dst: AnyPipe, byte_count: Optional[int]
+    ) -> None:
+        """Validate the pipe send payload."""
+        del dst
+        if byte_count is not None:
+            _validate_byte_count_for_tensor(src.raw_tensor, byte_count, "source")
 
-    def transfer(self, src: Block, dst: AnyPipe) -> None:
+    def transfer(
+        self, src: Block, dst: AnyPipe, byte_count: Optional[int]
+    ) -> None:
         """Pipe send: store data in shared buffer accessible by all nodes.
 
         The queued ``PipeMessage`` always records the sent block's tile-grid
@@ -238,6 +291,7 @@ class BlockToPipeHandler:
         message = PipeMessage(
             grid_shape=src.shape,
             data=None if _is_dry_run() else src.raw_tensor,
+            byte_count=byte_count,
         )
 
         # Get or create pipe entry atomically
@@ -278,10 +332,14 @@ class BlockToPipeHandler:
                 "pipe_send",
                 pipe=get_pipe_name(dst),
                 tiles=math.prod(message.grid_shape),
+                byte_count=byte_count,
             )
 
-    def can_wait(self, src: Block, dst: AnyPipe) -> bool:
+    def can_wait(
+        self, src: Block, dst: AnyPipe, byte_count: Optional[int]
+    ) -> bool:
         """Block to Pipe copy completes immediately on wait()."""
+        del src, dst, byte_count
         return True
 
 
@@ -289,18 +347,28 @@ class BlockToPipeHandler:
 class TensorToBlockHandler:
     """Handler for TTNN.Tensor -> Block transfers using tile-level indexing."""
 
-    def validate(self, src: Tensor, dst: Block) -> None:
+    def validate(
+        self, src: Tensor, dst: Block, byte_count: Optional[int]
+    ) -> None:
+        if byte_count is not None:
+            raise ValueError("Tensor-to-block copy does not accept byte_count")
         _validate_tensor_to_block_shapes(
             src.layout, src.padded_shape, dst.layout, dst.shape
         )
 
-    def transfer(self, src: Tensor, dst: Block) -> None:
+    def transfer(
+        self, src: Tensor, dst: Block, byte_count: Optional[int]
+    ) -> None:
         """Transfer tensor data into Block."""
+        del byte_count
         if _is_dry_run():
             return
         dst.copy_as_dest(src)
 
-    def can_wait(self, src: Tensor, dst: Block) -> bool:
+    def can_wait(
+        self, src: Tensor, dst: Block, byte_count: Optional[int]
+    ) -> bool:
+        del src, dst, byte_count
         return True
 
 
@@ -308,20 +376,67 @@ class TensorToBlockHandler:
 class BlockToTensorHandler:
     """Handler for Block -> TTNN.Tensor transfers using tile-level indexing."""
 
-    def validate(self, src: Block, dst: Tensor) -> None:
+    def validate(
+        self, src: Block, dst: Tensor, byte_count: Optional[int]
+    ) -> None:
+        if byte_count is not None:
+            raise ValueError("Block-to-tensor copy does not accept byte_count")
         _validate_block_to_tensor_shapes(
             src.layout, src.shape, dst.layout, dst.padded_shape
         )
 
-    def transfer(self, src: Block, dst: Tensor) -> None:
+    def transfer(
+        self, src: Block, dst: Tensor, byte_count: Optional[int]
+    ) -> None:
         """Transfer Block data into tensor."""
+        del byte_count
         if _is_dry_run():
             return
         dst_raw = dst.to_torch()
         src_raw = src.raw_tensor.to_torch()
         dst_raw.copy_(src_raw.reshape(dst_raw.shape))
 
-    def can_wait(self, src: Block, dst: Tensor) -> bool:
+    def can_wait(
+        self, src: Block, dst: Tensor, byte_count: Optional[int]
+    ) -> bool:
+        del src, dst, byte_count
+        return True
+
+
+@register_copy_handler(Block, Block)
+class BlockToBlockHandler:
+    """Handler for explicit byte-preserving copies between acquired blocks."""
+
+    def validate(
+        self, src: Block, dst: Block, byte_count: Optional[int]
+    ) -> None:
+        if byte_count is None:
+            raise ValueError("Block-to-block copy requires byte_count")
+        if src.acquisition != BlockAcquisition.WAIT:
+            raise ValueError(
+                "Block-to-block copy source must come from DFB wait()"
+            )
+        if dst.acquisition != BlockAcquisition.RESERVE:
+            raise ValueError(
+                "Block-to-block copy destination must come from DFB reserve()"
+            )
+        if src.dfb is None or dst.dfb is None or src.dfb is dst.dfb:
+            raise ValueError(
+                "Block-to-block copy requires distinct source and destination DFBs"
+            )
+        _validate_byte_copy_tensors(src.raw_tensor, dst.raw_tensor, byte_count)
+
+    def transfer(
+        self, src: Block, dst: Block, byte_count: Optional[int]
+    ) -> None:
+        assert byte_count is not None
+        if not _is_dry_run():
+            _copy_tensor_prefix(src.raw_tensor, dst.raw_tensor, byte_count)
+
+    def can_wait(
+        self, src: Block, dst: Block, byte_count: Optional[int]
+    ) -> bool:
+        del src, dst, byte_count
         return True
 
 
@@ -329,17 +444,26 @@ class BlockToTensorHandler:
 class PipeToBlockHandler:
     """Handler for Pipe → Block (pipe receive)."""
 
-    def validate(self, src: AnyPipe, dst: Block) -> None:
-        """Validate pipe receive - validation happens during transfer when data is available."""
-        pass
+    def validate(
+        self, src: AnyPipe, dst: Block, byte_count: Optional[int]
+    ) -> None:
+        """Validate the receiver's declared payload capacity."""
+        del src
+        if byte_count is not None:
+            _validate_byte_count_for_tensor(
+                dst.raw_tensor, byte_count, "destination"
+            )
 
-    def can_wait(self, src: AnyPipe, dst: Block) -> bool:
+    def can_wait(
+        self, src: AnyPipe, dst: Block, byte_count: Optional[int]
+    ) -> bool:
         """Pipe to Block copy can only proceed when pipe has data for this node.
 
         Returns True only when there is at least one queued message that the
         current node has not yet received.  The greenlet scheduler polls this
         before calling transfer(), so transfer() can assume data is available.
         """
+        del dst, byte_count
         pipe_buffer = get_context().copy_state.pipe_buffer
         entry = pipe_buffer.get(src)
         if entry is None or len(entry["queue"]) == 0:
@@ -355,7 +479,9 @@ class PipeToBlockHandler:
             # Non-kernel context: any queued message is receivable.
             return True
 
-    def transfer(self, src: AnyPipe, dst: Block) -> None:
+    def transfer(
+        self, src: AnyPipe, dst: Block, byte_count: Optional[int]
+    ) -> None:
         """Pipe receive: dequeue one message from the pipe buffer.
 
         The greenlet scheduler guarantees can_wait() returned True immediately
@@ -377,7 +503,12 @@ class PipeToBlockHandler:
         # Find the first message this node has not yet received.
         for idx, (message, remaining_recv, msg_id, recv_set) in enumerate(queue):
             if not node_id_available or node_id not in recv_set:
-                if message.grid_shape != dst.shape:
+                if message.byte_count != byte_count:
+                    raise ValueError(
+                        "Pipe sender and receiver must use the same byte_count; "
+                        f"got sender {message.byte_count} and receiver {byte_count}"
+                    )
+                if byte_count is None and message.grid_shape != dst.shape:
                     raise ValueError(
                         f"Destination Block shape {dst.shape} "
                         f"does not match pipe data shape {message.grid_shape}"
@@ -387,13 +518,19 @@ class PipeToBlockHandler:
                 # message carries no bytes (data is None) and the copy is skipped
                 # while the queue bookkeeping below still runs.
                 if message.data is not None:
-                    dst.copy_as_dest(message.data)
+                    if byte_count is None:
+                        dst.copy_as_dest(message.data)
+                    else:
+                        _copy_tensor_prefix(
+                            message.data, dst.raw_tensor, byte_count
+                        )
 
                 if TRACE.enabled:
                     trace(
                         "pipe_recv",
                         pipe=get_pipe_name(src),
                         tiles=math.prod(message.grid_shape),
+                        byte_count=byte_count,
                     )
 
                 if node_id_available:
@@ -431,16 +568,22 @@ class BlockToSrcPipeIdentityHandler:
             self._delegate = HANDLER_REGISTRY[(Block, Pipe)]
         return self._delegate
 
-    def validate(self, src: Block, dst: AnySrcPipeIdentity) -> None:
+    def validate(
+        self, src: Block, dst: AnySrcPipeIdentity, byte_count: Optional[int]
+    ) -> None:
         # Delegate to the Pipe handler
-        self._get_delegate().validate(src, dst.pipe)
+        self._get_delegate().validate(src, dst.pipe, byte_count)
 
-    def transfer(self, src: Block, dst: AnySrcPipeIdentity) -> None:
+    def transfer(
+        self, src: Block, dst: AnySrcPipeIdentity, byte_count: Optional[int]
+    ) -> None:
         # Delegate to the Pipe handler
-        self._get_delegate().transfer(src, dst.pipe)
+        self._get_delegate().transfer(src, dst.pipe, byte_count)
 
-    def can_wait(self, src: Block, dst: AnySrcPipeIdentity) -> bool:
-        return self._get_delegate().can_wait(src, dst.pipe)
+    def can_wait(
+        self, src: Block, dst: AnySrcPipeIdentity, byte_count: Optional[int]
+    ) -> bool:
+        return self._get_delegate().can_wait(src, dst.pipe, byte_count)
 
 
 @register_copy_handler(DstPipeIdentity, Block)
@@ -456,13 +599,19 @@ class DstPipeIdentityToBlockHandler:
             self._delegate = HANDLER_REGISTRY[(Pipe, Block)]
         return self._delegate
 
-    def validate(self, src: DstPipeIdentity, dst: Block) -> None:
+    def validate(
+        self, src: DstPipeIdentity, dst: Block, byte_count: Optional[int]
+    ) -> None:
         # Delegate to the Pipe handler
-        self._get_delegate().validate(src.pipe, dst)
+        self._get_delegate().validate(src.pipe, dst, byte_count)
 
-    def transfer(self, src: DstPipeIdentity, dst: Block) -> None:
+    def transfer(
+        self, src: DstPipeIdentity, dst: Block, byte_count: Optional[int]
+    ) -> None:
         # Delegate to the Pipe handler
-        self._get_delegate().transfer(src.pipe, dst)
+        self._get_delegate().transfer(src.pipe, dst, byte_count)
 
-    def can_wait(self, src: DstPipeIdentity, dst: Block) -> bool:
-        return self._get_delegate().can_wait(src.pipe, dst)
+    def can_wait(
+        self, src: DstPipeIdentity, dst: Block, byte_count: Optional[int]
+    ) -> bool:
+        return self._get_delegate().can_wait(src.pipe, dst, byte_count)

--- a/python/sim/copyhandlers.py
+++ b/python/sim/copyhandlers.py
@@ -24,6 +24,8 @@ from typing import (
     Union,
 )
 
+import torch
+
 from .context import get_context
 from .context_types import PipeEntry, PipeMessage
 from .dfb import Block, BlockAcquisition
@@ -88,39 +90,42 @@ def _get_or_create_pipe_entry(pipe: AnyPipe) -> PipeEntry:
 class CopyTransferHandler(Protocol):
     """Protocol for copy transfer handlers."""
 
-    def validate(self, src: Any, dst: Any, byte_count: Optional[int]) -> None:
+    def validate(self, src: Any, dst: Any, byte_count: Optional[int] = None) -> None:
         """
         Validate that the transfer can be performed.
 
         Args:
             src: Source object
             dst: Destination object
+            byte_count: Optional valid-byte prefix for DFB and pipe copies
 
         Raises:
             ValueError: If the transfer is not valid (shape mismatch, etc.)
         """
         ...
 
-    def transfer(self, src: Any, dst: Any, byte_count: Optional[int]) -> None:
+    def transfer(self, src: Any, dst: Any, byte_count: Optional[int] = None) -> None:
         """
         Perform the actual data transfer.
 
         Args:
             src: Source object
             dst: Destination object
+            byte_count: Optional valid-byte prefix for DFB and pipe copies
 
         Raises:
             ValueError: If the transfer fails
         """
         ...
 
-    def can_wait(self, src: Any, dst: Any, byte_count: Optional[int]) -> bool:
+    def can_wait(self, src: Any, dst: Any, byte_count: Optional[int] = None) -> bool:
         """
         Check if wait() can proceed without blocking.
 
         Args:
             src: Source object
             dst: Destination object
+            byte_count: Optional valid-byte prefix for DFB and pipe copies
 
         Returns:
             True if the transfer can complete without blocking
@@ -207,16 +212,9 @@ def _validate_byte_count_for_tensor(
         raise ValueError(
             "byte-counted simulation requires an element-addressable data type"
         )
-    if byte_count % element_size != 0:
-        raise ValueError(
-            f"byte_count {byte_count} is not aligned to the {element_size}-byte "
-            f"{endpoint} element size"
-        )
 
 
-def _validate_byte_copy_tensors(
-    src: Tensor, dst: Tensor, byte_count: int
-) -> None:
+def _validate_byte_copy_tensors(src: Tensor, dst: Tensor, byte_count: int) -> None:
     if src.layout != dst.layout:
         raise ValueError(
             "byte-counted copy requires matching layouts; got "
@@ -233,10 +231,23 @@ def _validate_byte_copy_tensors(
 
 def _copy_tensor_prefix(src: Tensor, dst: Tensor, byte_count: int) -> None:
     _validate_byte_copy_tensors(src, dst, byte_count)
-    element_count = byte_count // src.element_size
-    dst.to_torch().reshape(-1)[:element_count].copy_(
-        src.to_torch().reshape(-1)[:element_count]
+    complete_elements, partial_bytes = divmod(byte_count, src.element_size)
+    src_values = src.to_torch().reshape(-1)
+    dst_values = dst.to_torch().reshape(-1)
+    dst_values[:complete_elements].copy_(src_values[:complete_elements])
+    if partial_bytes == 0:
+        return
+
+    src_partial = src_values[complete_elements : complete_elements + 1].to(
+        dtype=src.dtype
     )
+    dst_partial = dst_values[complete_elements : complete_elements + 1].to(
+        dtype=dst.dtype
+    )
+    src_partial_bytes = src_partial.view(dtype=torch.uint8).reshape(-1)
+    dst_partial_bytes = dst_partial.view(dtype=torch.uint8).reshape(-1)
+    dst_partial_bytes[:partial_bytes].copy_(src_partial_bytes[:partial_bytes])
+    dst_values[complete_elements] = dst_partial.to(dtype=dst.underlying_dtype).item()
 
 
 def register_copy_handler(src_type: CopyEndpointType, dst_type: CopyEndpointType):
@@ -253,8 +264,8 @@ def register_copy_handler(src_type: CopyEndpointType, dst_type: CopyEndpointType
     Example:
         @register_copy_handler(Tensor, Block)
         class TensorToBlockHandler:
-            def validate(self, src, dst): ...
-            def transfer(self, src, dst): ...
+            def validate(self, src, dst, byte_count=None): ...
+            def transfer(self, src, dst, byte_count=None): ...
     """
 
     def decorator(handler_cls: Type[CopyTransferHandler]):
@@ -270,7 +281,7 @@ class BlockToPipeHandler:
     """Handler for Block → Pipe (pipe send)."""
 
     def validate(
-        self, src: Block, dst: AnyPipe, byte_count: Optional[int]
+        self, src: Block, dst: AnyPipe, byte_count: Optional[int] = None
     ) -> None:
         """Validate the pipe send payload."""
         del dst
@@ -278,7 +289,7 @@ class BlockToPipeHandler:
             _validate_byte_count_for_tensor(src.raw_tensor, byte_count, "source")
 
     def transfer(
-        self, src: Block, dst: AnyPipe, byte_count: Optional[int]
+        self, src: Block, dst: AnyPipe, byte_count: Optional[int] = None
     ) -> None:
         """Pipe send: store data in shared buffer accessible by all nodes.
 
@@ -336,7 +347,7 @@ class BlockToPipeHandler:
             )
 
     def can_wait(
-        self, src: Block, dst: AnyPipe, byte_count: Optional[int]
+        self, src: Block, dst: AnyPipe, byte_count: Optional[int] = None
     ) -> bool:
         """Block to Pipe copy completes immediately on wait()."""
         del src, dst, byte_count
@@ -348,7 +359,7 @@ class TensorToBlockHandler:
     """Handler for TTNN.Tensor -> Block transfers using tile-level indexing."""
 
     def validate(
-        self, src: Tensor, dst: Block, byte_count: Optional[int]
+        self, src: Tensor, dst: Block, byte_count: Optional[int] = None
     ) -> None:
         if byte_count is not None:
             raise ValueError("Tensor-to-block copy does not accept byte_count")
@@ -357,7 +368,7 @@ class TensorToBlockHandler:
         )
 
     def transfer(
-        self, src: Tensor, dst: Block, byte_count: Optional[int]
+        self, src: Tensor, dst: Block, byte_count: Optional[int] = None
     ) -> None:
         """Transfer tensor data into Block."""
         del byte_count
@@ -366,7 +377,7 @@ class TensorToBlockHandler:
         dst.copy_as_dest(src)
 
     def can_wait(
-        self, src: Tensor, dst: Block, byte_count: Optional[int]
+        self, src: Tensor, dst: Block, byte_count: Optional[int] = None
     ) -> bool:
         del src, dst, byte_count
         return True
@@ -377,7 +388,7 @@ class BlockToTensorHandler:
     """Handler for Block -> TTNN.Tensor transfers using tile-level indexing."""
 
     def validate(
-        self, src: Block, dst: Tensor, byte_count: Optional[int]
+        self, src: Block, dst: Tensor, byte_count: Optional[int] = None
     ) -> None:
         if byte_count is not None:
             raise ValueError("Block-to-tensor copy does not accept byte_count")
@@ -386,7 +397,7 @@ class BlockToTensorHandler:
         )
 
     def transfer(
-        self, src: Block, dst: Tensor, byte_count: Optional[int]
+        self, src: Block, dst: Tensor, byte_count: Optional[int] = None
     ) -> None:
         """Transfer Block data into tensor."""
         del byte_count
@@ -397,7 +408,7 @@ class BlockToTensorHandler:
         dst_raw.copy_(src_raw.reshape(dst_raw.shape))
 
     def can_wait(
-        self, src: Block, dst: Tensor, byte_count: Optional[int]
+        self, src: Block, dst: Tensor, byte_count: Optional[int] = None
     ) -> bool:
         del src, dst, byte_count
         return True
@@ -408,14 +419,12 @@ class BlockToBlockHandler:
     """Handler for explicit byte-preserving copies between acquired blocks."""
 
     def validate(
-        self, src: Block, dst: Block, byte_count: Optional[int]
+        self, src: Block, dst: Block, byte_count: Optional[int] = None
     ) -> None:
         if byte_count is None:
             raise ValueError("Block-to-block copy requires byte_count")
         if src.acquisition != BlockAcquisition.WAIT:
-            raise ValueError(
-                "Block-to-block copy source must come from DFB wait()"
-            )
+            raise ValueError("Block-to-block copy source must come from DFB wait()")
         if dst.acquisition != BlockAcquisition.RESERVE:
             raise ValueError(
                 "Block-to-block copy destination must come from DFB reserve()"
@@ -427,14 +436,14 @@ class BlockToBlockHandler:
         _validate_byte_copy_tensors(src.raw_tensor, dst.raw_tensor, byte_count)
 
     def transfer(
-        self, src: Block, dst: Block, byte_count: Optional[int]
+        self, src: Block, dst: Block, byte_count: Optional[int] = None
     ) -> None:
         assert byte_count is not None
         if not _is_dry_run():
             _copy_tensor_prefix(src.raw_tensor, dst.raw_tensor, byte_count)
 
     def can_wait(
-        self, src: Block, dst: Block, byte_count: Optional[int]
+        self, src: Block, dst: Block, byte_count: Optional[int] = None
     ) -> bool:
         del src, dst, byte_count
         return True
@@ -445,17 +454,15 @@ class PipeToBlockHandler:
     """Handler for Pipe → Block (pipe receive)."""
 
     def validate(
-        self, src: AnyPipe, dst: Block, byte_count: Optional[int]
+        self, src: AnyPipe, dst: Block, byte_count: Optional[int] = None
     ) -> None:
         """Validate the receiver's declared payload capacity."""
         del src
         if byte_count is not None:
-            _validate_byte_count_for_tensor(
-                dst.raw_tensor, byte_count, "destination"
-            )
+            _validate_byte_count_for_tensor(dst.raw_tensor, byte_count, "destination")
 
     def can_wait(
-        self, src: AnyPipe, dst: Block, byte_count: Optional[int]
+        self, src: AnyPipe, dst: Block, byte_count: Optional[int] = None
     ) -> bool:
         """Pipe to Block copy can only proceed when pipe has data for this node.
 
@@ -480,7 +487,7 @@ class PipeToBlockHandler:
             return True
 
     def transfer(
-        self, src: AnyPipe, dst: Block, byte_count: Optional[int]
+        self, src: AnyPipe, dst: Block, byte_count: Optional[int] = None
     ) -> None:
         """Pipe receive: dequeue one message from the pipe buffer.
 
@@ -521,9 +528,7 @@ class PipeToBlockHandler:
                     if byte_count is None:
                         dst.copy_as_dest(message.data)
                     else:
-                        _copy_tensor_prefix(
-                            message.data, dst.raw_tensor, byte_count
-                        )
+                        _copy_tensor_prefix(message.data, dst.raw_tensor, byte_count)
 
                 if TRACE.enabled:
                     trace(
@@ -569,19 +574,26 @@ class BlockToSrcPipeIdentityHandler:
         return self._delegate
 
     def validate(
-        self, src: Block, dst: AnySrcPipeIdentity, byte_count: Optional[int]
+        self,
+        src: Block,
+        dst: AnySrcPipeIdentity,
+        byte_count: Optional[int] = None,
     ) -> None:
-        # Delegate to the Pipe handler
         self._get_delegate().validate(src, dst.pipe, byte_count)
 
     def transfer(
-        self, src: Block, dst: AnySrcPipeIdentity, byte_count: Optional[int]
+        self,
+        src: Block,
+        dst: AnySrcPipeIdentity,
+        byte_count: Optional[int] = None,
     ) -> None:
-        # Delegate to the Pipe handler
         self._get_delegate().transfer(src, dst.pipe, byte_count)
 
     def can_wait(
-        self, src: Block, dst: AnySrcPipeIdentity, byte_count: Optional[int]
+        self,
+        src: Block,
+        dst: AnySrcPipeIdentity,
+        byte_count: Optional[int] = None,
     ) -> bool:
         return self._get_delegate().can_wait(src, dst.pipe, byte_count)
 
@@ -600,18 +612,25 @@ class DstPipeIdentityToBlockHandler:
         return self._delegate
 
     def validate(
-        self, src: DstPipeIdentity, dst: Block, byte_count: Optional[int]
+        self,
+        src: DstPipeIdentity,
+        dst: Block,
+        byte_count: Optional[int] = None,
     ) -> None:
-        # Delegate to the Pipe handler
         self._get_delegate().validate(src.pipe, dst, byte_count)
 
     def transfer(
-        self, src: DstPipeIdentity, dst: Block, byte_count: Optional[int]
+        self,
+        src: DstPipeIdentity,
+        dst: Block,
+        byte_count: Optional[int] = None,
     ) -> None:
-        # Delegate to the Pipe handler
         self._get_delegate().transfer(src.pipe, dst, byte_count)
 
     def can_wait(
-        self, src: DstPipeIdentity, dst: Block, byte_count: Optional[int]
+        self,
+        src: DstPipeIdentity,
+        dst: Block,
+        byte_count: Optional[int] = None,
     ) -> bool:
         return self._get_delegate().can_wait(src.pipe, dst, byte_count)

--- a/python/sim/copyhandlers.py
+++ b/python/sim/copyhandlers.py
@@ -39,6 +39,7 @@ from .pipe import (
 )
 from .trace import TRACE, get_pipe_name, trace
 from .ttnnsim import (
+    TILE_LAYOUT,
     Tensor,
     check_count_match,
     tile_count_from_shape,
@@ -214,7 +215,34 @@ def _validate_byte_count_for_tensor(
         )
 
 
-def _validate_byte_copy_tensors(src: Tensor, dst: Tensor, byte_count: int) -> None:
+def _get_dfb_block_payload_spec(block: Block, endpoint: str) -> Tensor:
+    if block.dfb is None:
+        raise ValueError(
+            f"byte-counted {endpoint} block must be acquired from a dataflow buffer"
+        )
+    payload_spec = block.dfb.likeness_tensor
+    if payload_spec.layout != TILE_LAYOUT:
+        raise ValueError(
+            f"byte-counted {endpoint} dataflow-buffer block must use TILE layout"
+        )
+    return payload_spec
+
+
+def _validate_byte_count_for_block(
+    block: Block, byte_count: int, endpoint: str
+) -> None:
+    _get_dfb_block_payload_spec(block, endpoint)
+    assert block.dfb is not None
+    capacity = block.dfb.capacity_bytes // block.dfb.block_count
+    if byte_count > capacity:
+        raise ValueError(
+            f"byte_count {byte_count} exceeds {endpoint} capacity {capacity}"
+        )
+    if not _is_dry_run():
+        _validate_byte_count_for_tensor(block.raw_tensor, byte_count, endpoint)
+
+
+def _validate_byte_copy_formats(src: Tensor, dst: Tensor) -> None:
     if src.layout != dst.layout:
         raise ValueError(
             "byte-counted copy requires matching layouts; got "
@@ -225,6 +253,10 @@ def _validate_byte_copy_tensors(src: Tensor, dst: Tensor, byte_count: int) -> No
             "byte-counted copy requires matching data types; got "
             f"source {src.dtype} and destination {dst.dtype}"
         )
+
+
+def _validate_byte_copy_tensors(src: Tensor, dst: Tensor, byte_count: int) -> None:
+    _validate_byte_copy_formats(src, dst)
     _validate_byte_count_for_tensor(src, byte_count, "source")
     _validate_byte_count_for_tensor(dst, byte_count, "destination")
 
@@ -286,7 +318,7 @@ class BlockToPipeHandler:
         """Validate the pipe send payload."""
         del dst
         if byte_count is not None:
-            _validate_byte_count_for_tensor(src.raw_tensor, byte_count, "source")
+            _validate_byte_count_for_block(src, byte_count, "source")
 
     def transfer(
         self, src: Block, dst: AnyPipe, byte_count: Optional[int] = None
@@ -303,6 +335,11 @@ class BlockToPipeHandler:
             grid_shape=src.shape,
             data=None if _is_dry_run() else src.raw_tensor,
             byte_count=byte_count,
+            payload_spec=(
+                _get_dfb_block_payload_spec(src, "source")
+                if byte_count is not None
+                else None
+            ),
         )
 
         # Get or create pipe entry atomically
@@ -433,7 +470,12 @@ class BlockToBlockHandler:
             raise ValueError(
                 "Block-to-block copy requires distinct source and destination DFBs"
             )
-        _validate_byte_copy_tensors(src.raw_tensor, dst.raw_tensor, byte_count)
+        _validate_byte_copy_formats(
+            _get_dfb_block_payload_spec(src, "source"),
+            _get_dfb_block_payload_spec(dst, "destination"),
+        )
+        _validate_byte_count_for_block(src, byte_count, "source")
+        _validate_byte_count_for_block(dst, byte_count, "destination")
 
     def transfer(
         self, src: Block, dst: Block, byte_count: Optional[int] = None
@@ -459,7 +501,7 @@ class PipeToBlockHandler:
         """Validate the receiver's declared payload capacity."""
         del src
         if byte_count is not None:
-            _validate_byte_count_for_tensor(dst.raw_tensor, byte_count, "destination")
+            _validate_byte_count_for_block(dst, byte_count, "destination")
 
     def can_wait(
         self, src: AnyPipe, dst: Block, byte_count: Optional[int] = None
@@ -514,6 +556,12 @@ class PipeToBlockHandler:
                     raise ValueError(
                         "Pipe sender and receiver must use the same byte_count; "
                         f"got sender {message.byte_count} and receiver {byte_count}"
+                    )
+                if byte_count is not None:
+                    assert message.payload_spec is not None
+                    _validate_byte_copy_formats(
+                        message.payload_spec,
+                        _get_dfb_block_payload_spec(dst, "destination"),
                     )
                 if byte_count is None and message.grid_shape != dst.shape:
                     raise ValueError(

--- a/python/sim/copyhandlers.py
+++ b/python/sim/copyhandlers.py
@@ -27,7 +27,7 @@ from typing import (
 import torch
 
 from .context import get_context
-from .context_types import PipeEntry, PipeMessage
+from .context_types import ByteCopyFormat, PipeEntry, PipeMessage
 from .dfb import Block, BlockAcquisition
 from .pipe import (
     AnySrcPipeIdentity,
@@ -98,7 +98,7 @@ class CopyTransferHandler(Protocol):
         Args:
             src: Source object
             dst: Destination object
-            byte_count: Optional valid-byte prefix for DFB and pipe copies
+            byte_count: Optional byte count for DFB and pipe copies
 
         Raises:
             ValueError: If the transfer is not valid (shape mismatch, etc.)
@@ -112,7 +112,7 @@ class CopyTransferHandler(Protocol):
         Args:
             src: Source object
             dst: Destination object
-            byte_count: Optional valid-byte prefix for DFB and pipe copies
+            byte_count: Optional byte count for DFB and pipe copies
 
         Raises:
             ValueError: If the transfer fails
@@ -126,7 +126,7 @@ class CopyTransferHandler(Protocol):
         Args:
             src: Source object
             dst: Destination object
-            byte_count: Optional valid-byte prefix for DFB and pipe copies
+            byte_count: Optional byte count for DFB and pipe copies
 
         Returns:
             True if the transfer can complete without blocking
@@ -202,6 +202,8 @@ def _validate_block_to_tensor_shapes(
 def _validate_byte_count_for_tensor(
     tensor: Tensor, byte_count: int, endpoint: str
 ) -> None:
+    """Require addressable storage large enough for the requested byte range."""
+
     element_count = math.prod(tensor.padded_shape)
     capacity = tensor.size_in_bytes(element_count)
     if byte_count > capacity:
@@ -215,23 +217,27 @@ def _validate_byte_count_for_tensor(
         )
 
 
-def _get_dfb_block_payload_spec(block: Block, endpoint: str) -> Tensor:
+def _require_dfb_block_format(block: Block, endpoint: str) -> ByteCopyFormat:
+    """Use owning-DFB metadata because dry-run blocks contain sentinel tensors."""
+
     if block.dfb is None:
         raise ValueError(
             f"byte-counted {endpoint} block must be acquired from a dataflow buffer"
         )
-    payload_spec = block.dfb.likeness_tensor
-    if payload_spec.layout != TILE_LAYOUT:
+    likeness = block.dfb.likeness_tensor
+    if likeness.layout != TILE_LAYOUT:
         raise ValueError(
             f"byte-counted {endpoint} dataflow-buffer block must use TILE layout"
         )
-    return payload_spec
+    return ByteCopyFormat(layout=likeness.layout, dtype=likeness.dtype)
 
 
 def _validate_byte_count_for_block(
     block: Block, byte_count: int, endpoint: str
-) -> None:
-    _get_dfb_block_payload_spec(block, endpoint)
+) -> ByteCopyFormat:
+    """Use declared DFB capacity because dry-run storage has zero elements."""
+
+    block_format = _require_dfb_block_format(block, endpoint)
     assert block.dfb is not None
     capacity = block.dfb.capacity_bytes // block.dfb.block_count
     if byte_count > capacity:
@@ -240,9 +246,12 @@ def _validate_byte_count_for_block(
         )
     if not _is_dry_run():
         _validate_byte_count_for_tensor(block.raw_tensor, byte_count, endpoint)
+    return block_format
 
 
-def _validate_byte_copy_formats(src: Tensor, dst: Tensor) -> None:
+def _validate_byte_copy_formats(src: ByteCopyFormat, dst: ByteCopyFormat) -> None:
+    """Allow different tile geometry without reinterpreting payload bytes."""
+
     if src.layout != dst.layout:
         raise ValueError(
             "byte-counted copy requires matching layouts; got "
@@ -256,12 +265,19 @@ def _validate_byte_copy_formats(src: Tensor, dst: Tensor) -> None:
 
 
 def _validate_byte_copy_tensors(src: Tensor, dst: Tensor, byte_count: int) -> None:
-    _validate_byte_copy_formats(src, dst)
+    """Require element-addressable storage before copying individual bytes."""
+
+    _validate_byte_copy_formats(
+        ByteCopyFormat(layout=src.layout, dtype=src.dtype),
+        ByteCopyFormat(layout=dst.layout, dtype=dst.dtype),
+    )
     _validate_byte_count_for_tensor(src, byte_count, "source")
     _validate_byte_count_for_tensor(dst, byte_count, "destination")
 
 
-def _copy_tensor_prefix(src: Tensor, dst: Tensor, byte_count: int) -> None:
+def _copy_initial_tensor_bytes(src: Tensor, dst: Tensor, byte_count: int) -> None:
+    """Copy exactly the initial byte range and preserve all later bytes."""
+
     _validate_byte_copy_tensors(src, dst, byte_count)
     complete_elements, partial_bytes = divmod(byte_count, src.element_size)
     src_values = src.to_torch().reshape(-1)
@@ -335,8 +351,8 @@ class BlockToPipeHandler:
             grid_shape=src.shape,
             data=None if _is_dry_run() else src.raw_tensor,
             byte_count=byte_count,
-            payload_spec=(
-                _get_dfb_block_payload_spec(src, "source")
+            byte_copy_format=(
+                _require_dfb_block_format(src, "source")
                 if byte_count is not None
                 else None
             ),
@@ -470,19 +486,16 @@ class BlockToBlockHandler:
             raise ValueError(
                 "Block-to-block copy requires distinct source and destination DFBs"
             )
-        _validate_byte_copy_formats(
-            _get_dfb_block_payload_spec(src, "source"),
-            _get_dfb_block_payload_spec(dst, "destination"),
-        )
-        _validate_byte_count_for_block(src, byte_count, "source")
-        _validate_byte_count_for_block(dst, byte_count, "destination")
+        src_format = _validate_byte_count_for_block(src, byte_count, "source")
+        dst_format = _validate_byte_count_for_block(dst, byte_count, "destination")
+        _validate_byte_copy_formats(src_format, dst_format)
 
     def transfer(
         self, src: Block, dst: Block, byte_count: Optional[int] = None
     ) -> None:
         assert byte_count is not None
         if not _is_dry_run():
-            _copy_tensor_prefix(src.raw_tensor, dst.raw_tensor, byte_count)
+            _copy_initial_tensor_bytes(src.raw_tensor, dst.raw_tensor, byte_count)
 
     def can_wait(
         self, src: Block, dst: Block, byte_count: Optional[int] = None
@@ -558,10 +571,10 @@ class PipeToBlockHandler:
                         f"got sender {message.byte_count} and receiver {byte_count}"
                     )
                 if byte_count is not None:
-                    assert message.payload_spec is not None
+                    assert message.byte_copy_format is not None
                     _validate_byte_copy_formats(
-                        message.payload_spec,
-                        _get_dfb_block_payload_spec(dst, "destination"),
+                        message.byte_copy_format,
+                        _require_dfb_block_format(dst, "destination"),
                     )
                 if byte_count is None and message.grid_shape != dst.shape:
                     raise ValueError(
@@ -576,7 +589,9 @@ class PipeToBlockHandler:
                     if byte_count is None:
                         dst.copy_as_dest(message.data)
                     else:
-                        _copy_tensor_prefix(message.data, dst.raw_tensor, byte_count)
+                        _copy_initial_tensor_bytes(
+                            message.data, dst.raw_tensor, byte_count
+                        )
 
                 if TRACE.enabled:
                     trace(

--- a/python/ttl/constants.py
+++ b/python/ttl/constants.py
@@ -5,6 +5,7 @@
 """Constants used throughout the DSL."""
 
 DEFAULT_TILE_SIZE = 32
+MAX_NOC_TRANSFER_BYTES = (1 << 32) - 1
 SUPPORTED_MEMORY_SPACES = frozenset(["L1", "DRAM"])
 SUPPORTED_MATH_FIDELITIES = ("LoFi", "HiFi2", "HiFi3", "HiFi4")
 SUPPORTED_TENSOR_BACKED_DFB_MEMORY_LAYOUTS = frozenset(

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -786,14 +786,29 @@ def _get_pipe_mlir_value(pipe):
     return pipe._mlir_value
 
 
+def _copy_byte_count_attr(byte_count, ctx):
+    if byte_count is None:
+        return None
+    byte_count_value = _get_constant_int(byte_count)
+    if byte_count_value <= 0:
+        raise ValueError(
+            f"copy() byte_count must be positive, got {byte_count_value}"
+        )
+    return IntegerAttr.get(IntegerType.get_signless(64, ctx), byte_count_value)
+
+
 @syntax("copy")
-def copy(src, dst) -> Union[CopyTransferHandler, ReceiveRequest]:
+def copy(
+    src, dst, *, byte_count=None
+) -> Union[CopyTransferHandler, ReceiveRequest]:
     """
     Initiate an asynchronous data transfer using ttl.copy.
 
     Args:
         src: Source tensor/slice (for reads), block (for writes), or Pipe (for pipe receive)
         dst: Destination block (for reads), tensor/slice (for writes), or Pipe (for pipe send)
+        byte_count: Positive static byte count for DFB block-to-block and pipe
+            transfers. Tensor-slice transfers always copy complete tiles.
 
     Returns:
         ReceiveRequest for a PipeNet receive; CopyTransferHandler otherwise.
@@ -824,7 +839,12 @@ def copy(src, dst) -> Union[CopyTransferHandler, ReceiveRequest]:
             pipe_val = _get_pipe_mlir_value(dst)
             ctx = src_cb.type.context
             xf_type = Type.parse("!ttl.transfer_handle<write>", ctx)
-            return ttl.copy(xf_type, src_cb, pipe_val)
+            return ttl.copy(
+                xf_type,
+                src_cb,
+                pipe_val,
+                byte_count=_copy_byte_count_attr(byte_count, ctx),
+            )
         else:
             # Pipe -> DFB receive. The sender writes into the receiver-owned block.
             if not _is_block(dst):
@@ -834,7 +854,34 @@ def copy(src, dst) -> Union[CopyTransferHandler, ReceiveRequest]:
             pipe_val = _get_pipe_mlir_value(src)
             ctx = dst.type.context
             xf_type = ttl.ReceiveRequestType.get(ctx)
-            return ttl.copy(xf_type, pipe_val, dst)
+            return ttl.copy(
+                xf_type,
+                pipe_val,
+                dst,
+                byte_count=_copy_byte_count_attr(byte_count, ctx),
+            )
+
+    src_is_block = _is_block(src)
+    dst_is_block = _is_block(dst)
+    if src_is_block and dst_is_block:
+        if byte_count is None:
+            raise ValueError(
+                "copy() between dataflow-buffer blocks requires byte_count"
+            )
+        ctx = src.type.context
+        xf_type = Type.parse("!ttl.transfer_handle<read>", ctx)
+        return ttl.copy(
+            xf_type,
+            src,
+            dst,
+            byte_count=_copy_byte_count_attr(byte_count, ctx),
+        )
+
+    if byte_count is not None:
+        raise ValueError(
+            "copy() byte_count is supported only for dataflow-buffer "
+            "block-to-block and pipe transfers"
+        )
 
     # Non-pipe transfers: tensor subscript <-> block
     src_is_subscript = isinstance(src, tuple)

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -787,6 +787,8 @@ def _get_pipe_mlir_value(pipe):
 
 
 def _copy_byte_count_attr(byte_count, ctx):
+    """Materialize the static transfer size required by byte-counted lowering."""
+
     if byte_count is None:
         return None
     byte_count_value = _get_constant_int(byte_count)

--- a/python/ttl/operators.py
+++ b/python/ttl/operators.py
@@ -791,16 +791,12 @@ def _copy_byte_count_attr(byte_count, ctx):
         return None
     byte_count_value = _get_constant_int(byte_count)
     if byte_count_value <= 0:
-        raise ValueError(
-            f"copy() byte_count must be positive, got {byte_count_value}"
-        )
+        raise ValueError(f"copy() byte_count must be positive, got {byte_count_value}")
     return IntegerAttr.get(IntegerType.get_signless(64, ctx), byte_count_value)
 
 
 @syntax("copy")
-def copy(
-    src, dst, *, byte_count=None
-) -> Union[CopyTransferHandler, ReceiveRequest]:
+def copy(src, dst, *, byte_count=None) -> Union[CopyTransferHandler, ReceiveRequest]:
     """
     Initiate an asynchronous data transfer using ttl.copy.
 

--- a/test/python/test_byte_counted_dfb_copy.py
+++ b/test/python/test_byte_counted_dfb_copy.py
@@ -32,9 +32,7 @@ COMPACT_TILE = (1, TILE_WIDTH)
 FULL_TILE = (32, TILE_WIDTH)
 
 
-def _make_byte_counted_round_trip(data_format, bytes_per_element):
-    byte_count = VALID_ROWS * TILE_WIDTH * bytes_per_element
-
+def _make_byte_counted_round_trip(data_format, byte_count):
     @ttl.operation(grid=(2, 1))
     def byte_counted_round_trip(inp, out):
         pipe_net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(1, 0))])
@@ -59,9 +57,7 @@ def _make_byte_counted_round_trip(data_format, bytes_per_element):
         def dm():
             def send(pipe):
                 with compact_input_dfb.reserve() as compact_input_block:
-                    ttl.copy(
-                        inp[0:VALID_ROWS, 0:1], compact_input_block
-                    ).wait()
+                    ttl.copy(inp[0:VALID_ROWS, 0:1], compact_input_block).wait()
 
                 with compact_input_dfb.wait() as compact_input_block:
                     with send_dfb.reserve() as send_block:
@@ -89,9 +85,7 @@ def _make_byte_counted_round_trip(data_format, bytes_per_element):
                         ).wait()
 
                 with compact_output_dfb.wait() as compact_output_block:
-                    ttl.copy(
-                        compact_output_block, out[0:VALID_ROWS, 0:1]
-                    ).wait()
+                    ttl.copy(compact_output_block, out[0:VALID_ROWS, 0:1]).wait()
 
             pipe_net.if_dst(receive)
 
@@ -104,29 +98,54 @@ def _make_byte_counted_round_trip(data_format, bytes_per_element):
 
 BYTE_COUNTED_ROUND_TRIP_CASES = [
     pytest.param(
-        _make_byte_counted_round_trip("bf16", 2),
+        _make_byte_counted_round_trip("bf16", VALID_ROWS * TILE_WIDTH * 2),
         torch.bfloat16,
+        2,
+        VALID_ROWS * TILE_WIDTH * 2,
         5e-2,
         1.0,
-        id="bf16",
+        id="bf16-full-rows",
     ),
     pytest.param(
-        _make_byte_counted_round_trip("float32", 4),
+        _make_byte_counted_round_trip("bf16", 3),
+        torch.bfloat16,
+        2,
+        3,
+        5e-2,
+        1.0,
+        id="bf16-partial-element",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip("float32", VALID_ROWS * TILE_WIDTH * 4),
         torch.float32,
+        4,
+        VALID_ROWS * TILE_WIDTH * 4,
         1e-5,
         1e-5,
-        id="fp32",
+        id="fp32-full-rows",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip("float32", 5),
+        torch.float32,
+        4,
+        5,
+        1e-5,
+        1e-5,
+        id="fp32-partial-element",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    ("operation", "dtype", "rtol", "atol"), BYTE_COUNTED_ROUND_TRIP_CASES
+    ("operation", "dtype", "bytes_per_element", "byte_count", "rtol", "atol"),
+    BYTE_COUNTED_ROUND_TRIP_CASES,
 )
-def test_byte_counted_dfb_round_trip(device, operation, dtype, rtol, atol):
-    element_indices = torch.arange(
-        VALID_ROWS * TILE_WIDTH, dtype=torch.int64
-    ).reshape(VALID_ROWS, TILE_WIDTH)
+def test_byte_counted_dfb_round_trip(
+    device, operation, dtype, bytes_per_element, byte_count, rtol, atol
+):
+    element_indices = torch.arange(VALID_ROWS * TILE_WIDTH, dtype=torch.int64).reshape(
+        VALID_ROWS, TILE_WIDTH
+    )
     input_torch = (element_indices.remainder(97) - 48).to(dtype)
     output_torch = torch.zeros_like(input_torch)
 
@@ -137,8 +156,21 @@ def test_byte_counted_dfb_round_trip(device, operation, dtype, rtol, atol):
     ttnn.synchronize_device(device)
 
     result = ttnn.to_torch(out).reshape(VALID_ROWS, TILE_WIDTH).to(dtype)
-    assert_allclose(result.float(), input_torch.float(), rtol=rtol, atol=atol)
-    assert torch.equal(result, input_torch)
+    full_byte_count = input_torch.numel() * bytes_per_element
+    if byte_count == full_byte_count:
+        assert_allclose(result.float(), input_torch.float(), rtol=rtol, atol=atol)
+        assert torch.equal(result, input_torch)
+    else:
+        complete_element_count = byte_count // bytes_per_element
+        assert_allclose(
+            result.reshape(-1)[:complete_element_count].float(),
+            input_torch.reshape(-1)[:complete_element_count].float(),
+            rtol=rtol,
+            atol=atol,
+        )
+        result_bytes = result.view(dtype=torch.uint8).reshape(-1)
+        input_bytes = input_torch.view(dtype=torch.uint8).reshape(-1)
+        assert torch.equal(result_bytes[:byte_count], input_bytes[:byte_count])
 
     ttnn.deallocate(inp)
     ttnn.deallocate(out)

--- a/test/python/test_byte_counted_dfb_copy.py
+++ b/test/python/test_byte_counted_dfb_copy.py
@@ -34,7 +34,15 @@ FULL_TILE = (32, TILE_WIDTH)
 
 def _make_byte_counted_round_trip(data_format, byte_count):
     @ttl.operation(grid=(2, 1))
-    def byte_counted_round_trip(inp, out):
+    def byte_counted_round_trip(
+        inp,
+        send_seed,
+        receive_seed,
+        compact_seed,
+        local_out,
+        pipe_out,
+        compact_out,
+    ):
         pipe_net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(1, 0))])
         compact_input_dfb = ttl.make_dataflow_buffer_like(
             inp, shape=(VALID_ROWS, 1), block_count=1
@@ -46,7 +54,7 @@ def _make_byte_counted_round_trip(data_format, byte_count):
             data_format, shape=(1, 1), block_count=1, tile=FULL_TILE
         )
         compact_output_dfb = ttl.make_dataflow_buffer_like(
-            out, shape=(VALID_ROWS, 1), block_count=1
+            compact_out, shape=(VALID_ROWS, 1), block_count=1
         )
 
         @ttl.compute()
@@ -56,6 +64,11 @@ def _make_byte_counted_round_trip(data_format, byte_count):
         @ttl.datamovement()
         def dm():
             def send(pipe):
+                with send_dfb.reserve() as send_block:
+                    ttl.copy(send_seed[0:1, 0:1], send_block).wait()
+                with send_dfb.wait():
+                    pass
+
                 with compact_input_dfb.reserve() as compact_input_block:
                     ttl.copy(inp[0:VALID_ROWS, 0:1], compact_input_block).wait()
 
@@ -68,15 +81,29 @@ def _make_byte_counted_round_trip(data_format, byte_count):
                         ).wait()
 
                 with send_dfb.wait() as send_block:
+                    ttl.copy(send_block, local_out[0:1, 0:1]).wait()
                     ttl.copy(send_block, pipe, byte_count=byte_count).wait()
 
             pipe_net.if_src(send)
 
             def receive(pipe):
                 with receive_dfb.reserve() as receive_block:
+                    ttl.copy(receive_seed[0:1, 0:1], receive_block).wait()
+                with receive_dfb.wait():
+                    pass
+
+                with compact_output_dfb.reserve() as compact_output_block:
+                    ttl.copy(
+                        compact_seed[0:VALID_ROWS, 0:1], compact_output_block
+                    ).wait()
+                with compact_output_dfb.wait():
+                    pass
+
+                with receive_dfb.reserve() as receive_block:
                     ttl.copy(pipe, receive_block, byte_count=byte_count).wait()
 
                 with receive_dfb.wait() as receive_block:
+                    ttl.copy(receive_block, pipe_out[0:1, 0:1]).wait()
                     with compact_output_dfb.reserve() as compact_output_block:
                         ttl.copy(
                             receive_block,
@@ -85,7 +112,9 @@ def _make_byte_counted_round_trip(data_format, byte_count):
                         ).wait()
 
                 with compact_output_dfb.wait() as compact_output_block:
-                    ttl.copy(compact_output_block, out[0:VALID_ROWS, 0:1]).wait()
+                    ttl.copy(
+                        compact_output_block, compact_out[0:VALID_ROWS, 0:1]
+                    ).wait()
 
             pipe_net.if_dst(receive)
 
@@ -147,30 +176,86 @@ def test_byte_counted_dfb_round_trip(
         VALID_ROWS, TILE_WIDTH
     )
     input_torch = (element_indices.remainder(97) - 48).to(dtype)
-    output_torch = torch.zeros_like(input_torch)
+    seed_magnitude = 1024.0001220703125
+    send_seed_torch = torch.full(FULL_TILE, -seed_magnitude, dtype=dtype)
+    receive_seed_torch = torch.full(FULL_TILE, seed_magnitude, dtype=dtype)
+    compact_seed_torch = torch.full_like(input_torch, -2 * seed_magnitude)
 
     inp = to_dram(input_torch, device, tile=COMPACT_TILE)
-    out = to_dram(output_torch, device, tile=COMPACT_TILE)
+    send_seed = to_dram(send_seed_torch, device, tile=FULL_TILE)
+    receive_seed = to_dram(receive_seed_torch, device, tile=FULL_TILE)
+    compact_seed = to_dram(compact_seed_torch, device, tile=COMPACT_TILE)
+    local_out = to_dram(torch.zeros_like(send_seed_torch), device, tile=FULL_TILE)
+    pipe_out = to_dram(torch.zeros_like(receive_seed_torch), device, tile=FULL_TILE)
+    compact_out = to_dram(
+        torch.zeros_like(compact_seed_torch), device, tile=COMPACT_TILE
+    )
 
-    operation(inp, out)
+    operation(
+        inp,
+        send_seed,
+        receive_seed,
+        compact_seed,
+        local_out,
+        pipe_out,
+        compact_out,
+    )
     ttnn.synchronize_device(device)
 
-    result = ttnn.to_torch(out).reshape(VALID_ROWS, TILE_WIDTH).to(dtype)
-    full_byte_count = input_torch.numel() * bytes_per_element
-    if byte_count == full_byte_count:
-        assert_allclose(result.float(), input_torch.float(), rtol=rtol, atol=atol)
-        assert torch.equal(result, input_torch)
-    else:
-        complete_element_count = byte_count // bytes_per_element
+    def replace_byte_prefix(seed):
+        expected = seed.clone()
+        expected_bytes = expected.view(dtype=torch.uint8).reshape(-1)
+        input_bytes = input_torch.view(dtype=torch.uint8).reshape(-1)
+        expected_bytes[:byte_count].copy_(input_bytes[:byte_count])
+        return expected
+
+    def assert_same_element_bits(actual, expected):
+        bit_dtype = torch.int16 if bytes_per_element == 2 else torch.int32
+        actual_bits = actual.contiguous().view(dtype=bit_dtype).reshape(-1)
+        expected_bits = expected.contiguous().view(dtype=bit_dtype).reshape(-1)
+        assert torch.equal(
+            torch.sort(actual_bits).values, torch.sort(expected_bits).values
+        )
+
+    local_result = ttnn.to_torch(local_out).reshape(FULL_TILE).to(dtype)
+    pipe_result = ttnn.to_torch(pipe_out).reshape(FULL_TILE).to(dtype)
+    local_expected = replace_byte_prefix(send_seed_torch)
+    pipe_expected = replace_byte_prefix(receive_seed_torch)
+    assert_same_element_bits(local_result, local_expected)
+    assert_same_element_bits(pipe_result, pipe_expected)
+
+    compact_result = (
+        ttnn.to_torch(compact_out).reshape(VALID_ROWS, TILE_WIDTH).to(dtype)
+    )
+    compact_expected = replace_byte_prefix(compact_seed_torch)
+    assert_allclose(
+        compact_result.float(),
+        compact_expected.float(),
+        rtol=rtol,
+        atol=atol,
+    )
+    result_bytes = compact_result.view(dtype=torch.uint8).reshape(-1)
+    expected_bytes = compact_expected.view(dtype=torch.uint8).reshape(-1)
+    assert torch.equal(result_bytes, expected_bytes)
+
+    for full_result, full_expected in (
+        (local_result, local_expected),
+        (pipe_result, pipe_expected),
+    ):
         assert_allclose(
-            result.reshape(-1)[:complete_element_count].float(),
-            input_torch.reshape(-1)[:complete_element_count].float(),
+            torch.sort(full_result.float().reshape(-1)).values,
+            torch.sort(full_expected.float().reshape(-1)).values,
             rtol=rtol,
             atol=atol,
         )
-        result_bytes = result.view(dtype=torch.uint8).reshape(-1)
-        input_bytes = input_torch.view(dtype=torch.uint8).reshape(-1)
-        assert torch.equal(result_bytes[:byte_count], input_bytes[:byte_count])
 
-    ttnn.deallocate(inp)
-    ttnn.deallocate(out)
+    for tensor in (
+        inp,
+        send_seed,
+        receive_seed,
+        compact_seed,
+        local_out,
+        pipe_out,
+        compact_out,
+    ):
+        ttnn.deallocate(tensor)

--- a/test/python/test_byte_counted_dfb_copy.py
+++ b/test/python/test_byte_counted_dfb_copy.py
@@ -9,7 +9,7 @@
 """Device coverage for byte-counted local and PipeNet DFB copies.
 
 BF16 and FP32 transfer fourteen 1x32 pages through full 32x32 pages. Integer
-formats transfer the equivalent byte prefix between full pages because tile
+formats transfer the same initial byte range between full pages because tile
 shape changes may alter their physical padding and face order. Packed formats
 transfer a complete encoded page because their shared exponents have no host
 byte representation. Every case traverses both a local DFB copy and a two-core
@@ -351,7 +351,7 @@ def test_byte_counted_dfb_round_trip(
         ttnn.to_torch(compact_seed).reshape(compact_shape).to(torch_dtype)
     )
 
-    def replace_byte_prefix(seed):
+    def replace_initial_bytes(seed):
         expected = seed.clone()
         expected_bytes = expected.view(dtype=torch.uint8).reshape(-1)
         input_bytes = input_expected.view(dtype=torch.uint8).reshape(-1)
@@ -373,8 +373,8 @@ def test_byte_counted_dfb_round_trip(
         local_expected = input_expected
         pipe_expected = input_expected
     else:
-        local_expected = replace_byte_prefix(send_seed_expected)
-        pipe_expected = replace_byte_prefix(receive_seed_expected)
+        local_expected = replace_initial_bytes(send_seed_expected)
+        pipe_expected = replace_initial_bytes(receive_seed_expected)
         assert_same_element_bit_multiset(local_result, local_expected)
         assert_same_element_bit_multiset(pipe_result, pipe_expected)
 
@@ -382,7 +382,7 @@ def test_byte_counted_dfb_round_trip(
     compact_expected = (
         input_expected
         if bytes_per_element is None
-        else replace_byte_prefix(compact_seed_expected)
+        else replace_initial_bytes(compact_seed_expected)
     )
     if bytes_per_element is not None and compact_tile == FULL_TILE:
         assert_same_element_bit_multiset(compact_result, compact_expected)

--- a/test/python/test_byte_counted_dfb_copy.py
+++ b/test/python/test_byte_counted_dfb_copy.py
@@ -8,20 +8,22 @@
 
 """Device coverage for byte-counted local and PipeNet DFB copies.
 
-The transfer stages fourteen 1x32 pages into a full 32x32 page, sends only the
-valid byte prefix to another core, and restores the compact representation.
-This is the representation change required by TreeReduce: compute can retain a
-full-tile accumulator while each communication stage transfers only valid rows.
+BF16 and FP32 transfer fourteen 1x32 pages through full 32x32 pages. Integer
+formats transfer the equivalent byte prefix between full pages because tile
+shape changes may alter their physical padding and face order. Packed formats
+transfer a complete encoded page because their shared exponents have no host
+byte representation. Every case traverses both a local DFB copy and a two-core
+PipeNet transfer.
 """
 
 import pytest
 import torch
 
 import ttl
+from ttl.dtype_utils import tile_bytes_from_dtype
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
-from ttlang_test_utils import to_dram  # noqa: E402
 from utils.correctness import assert_allclose  # noqa: E402
 
 pytestmark = pytest.mark.requires_device
@@ -30,9 +32,11 @@ VALID_ROWS = 14
 TILE_WIDTH = 32
 COMPACT_TILE = (1, TILE_WIDTH)
 FULL_TILE = (32, TILE_WIDTH)
+BFP4_FULL_TILE_BYTES = tile_bytes_from_dtype(ttnn.bfloat4_b, FULL_TILE)
+BFP8_FULL_TILE_BYTES = tile_bytes_from_dtype(ttnn.bfloat8_b, FULL_TILE)
 
 
-def _make_byte_counted_round_trip(data_format, byte_count):
+def _make_byte_counted_round_trip(data_format, byte_count, compact_tile_rows):
     @ttl.operation(grid=(2, 1))
     def byte_counted_round_trip(
         inp,
@@ -45,7 +49,7 @@ def _make_byte_counted_round_trip(data_format, byte_count):
     ):
         pipe_net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(1, 0))])
         compact_input_dfb = ttl.make_dataflow_buffer_like(
-            inp, shape=(VALID_ROWS, 1), block_count=1
+            inp, shape=(compact_tile_rows, 1), block_count=1
         )
         send_dfb = ttl.make_dfb(
             data_format, shape=(1, 1), block_count=1, tile=FULL_TILE
@@ -54,7 +58,7 @@ def _make_byte_counted_round_trip(data_format, byte_count):
             data_format, shape=(1, 1), block_count=1, tile=FULL_TILE
         )
         compact_output_dfb = ttl.make_dataflow_buffer_like(
-            compact_out, shape=(VALID_ROWS, 1), block_count=1
+            compact_out, shape=(compact_tile_rows, 1), block_count=1
         )
 
         @ttl.compute()
@@ -70,7 +74,7 @@ def _make_byte_counted_round_trip(data_format, byte_count):
                     pass
 
                 with compact_input_dfb.reserve() as compact_input_block:
-                    ttl.copy(inp[0:VALID_ROWS, 0:1], compact_input_block).wait()
+                    ttl.copy(inp[0:compact_tile_rows, 0:1], compact_input_block).wait()
 
                 with compact_input_dfb.wait() as compact_input_block:
                     with send_dfb.reserve() as send_block:
@@ -94,7 +98,8 @@ def _make_byte_counted_round_trip(data_format, byte_count):
 
                 with compact_output_dfb.reserve() as compact_output_block:
                     ttl.copy(
-                        compact_seed[0:VALID_ROWS, 0:1], compact_output_block
+                        compact_seed[0:compact_tile_rows, 0:1],
+                        compact_output_block,
                     ).wait()
                 with compact_output_dfb.wait():
                     pass
@@ -113,7 +118,8 @@ def _make_byte_counted_round_trip(data_format, byte_count):
 
                 with compact_output_dfb.wait() as compact_output_block:
                     ttl.copy(
-                        compact_output_block, compact_out[0:VALID_ROWS, 0:1]
+                        compact_output_block,
+                        compact_out[0:compact_tile_rows, 0:1],
                     ).wait()
 
             pipe_net.if_dst(receive)
@@ -127,69 +133,203 @@ def _make_byte_counted_round_trip(data_format, byte_count):
 
 BYTE_COUNTED_ROUND_TRIP_CASES = [
     pytest.param(
-        _make_byte_counted_round_trip("bf16", VALID_ROWS * TILE_WIDTH * 2),
+        _make_byte_counted_round_trip("bf16", VALID_ROWS * TILE_WIDTH * 2, VALID_ROWS),
+        ttnn.bfloat16,
         torch.bfloat16,
         2,
         VALID_ROWS * TILE_WIDTH * 2,
+        COMPACT_TILE,
+        VALID_ROWS,
         5e-2,
         1.0,
         id="bf16-full-rows",
     ),
     pytest.param(
-        _make_byte_counted_round_trip("bf16", 3),
+        _make_byte_counted_round_trip("bf16", 3, VALID_ROWS),
+        ttnn.bfloat16,
         torch.bfloat16,
         2,
         3,
+        COMPACT_TILE,
+        VALID_ROWS,
         5e-2,
         1.0,
         id="bf16-partial-element",
     ),
     pytest.param(
-        _make_byte_counted_round_trip("float32", VALID_ROWS * TILE_WIDTH * 4),
+        _make_byte_counted_round_trip(
+            "float32", VALID_ROWS * TILE_WIDTH * 4, VALID_ROWS
+        ),
+        ttnn.float32,
         torch.float32,
         4,
         VALID_ROWS * TILE_WIDTH * 4,
+        COMPACT_TILE,
+        VALID_ROWS,
         1e-5,
         1e-5,
         id="fp32-full-rows",
     ),
     pytest.param(
-        _make_byte_counted_round_trip("float32", 5),
+        _make_byte_counted_round_trip("float32", 5, VALID_ROWS),
+        ttnn.float32,
         torch.float32,
         4,
         5,
+        COMPACT_TILE,
+        VALID_ROWS,
         1e-5,
         1e-5,
         id="fp32-partial-element",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip("bfloat4_b", BFP4_FULL_TILE_BYTES, 1),
+        ttnn.bfloat4_b,
+        torch.bfloat16,
+        None,
+        BFP4_FULL_TILE_BYTES,
+        FULL_TILE,
+        1,
+        0.0,
+        0.0,
+        id="bfp4-full-page",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip("bfloat8_b", BFP8_FULL_TILE_BYTES, 1),
+        ttnn.bfloat8_b,
+        torch.bfloat16,
+        None,
+        BFP8_FULL_TILE_BYTES,
+        FULL_TILE,
+        1,
+        0.0,
+        0.0,
+        id="bfp8-full-page",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip("int32", VALID_ROWS * TILE_WIDTH * 4, VALID_ROWS),
+        ttnn.int32,
+        torch.int32,
+        4,
+        VALID_ROWS * TILE_WIDTH * 4,
+        FULL_TILE,
+        1,
+        0.0,
+        0.0,
+        id="i32-full-rows",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip(
+            "uint32", VALID_ROWS * TILE_WIDTH * 4, VALID_ROWS
+        ),
+        ttnn.uint32,
+        torch.uint32,
+        4,
+        VALID_ROWS * TILE_WIDTH * 4,
+        FULL_TILE,
+        1,
+        0.0,
+        0.0,
+        id="u32-full-rows",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip(
+            "uint16", VALID_ROWS * TILE_WIDTH * 2, VALID_ROWS
+        ),
+        ttnn.uint16,
+        torch.uint16,
+        2,
+        VALID_ROWS * TILE_WIDTH * 2,
+        FULL_TILE,
+        1,
+        0.0,
+        0.0,
+        id="u16-full-rows",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip("uint8", VALID_ROWS * TILE_WIDTH, VALID_ROWS),
+        ttnn.uint8,
+        torch.uint8,
+        1,
+        VALID_ROWS * TILE_WIDTH,
+        FULL_TILE,
+        1,
+        0.0,
+        0.0,
+        id="u8-full-rows",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    ("operation", "dtype", "bytes_per_element", "byte_count", "rtol", "atol"),
+    (
+        "operation",
+        "ttnn_dtype",
+        "torch_dtype",
+        "bytes_per_element",
+        "byte_count",
+        "compact_tile",
+        "compact_tile_rows",
+        "rtol",
+        "atol",
+    ),
     BYTE_COUNTED_ROUND_TRIP_CASES,
 )
+@pytest.mark.parametrize(
+    "memory_config",
+    [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    ids=["dram", "l1"],
+)
 def test_byte_counted_dfb_round_trip(
-    device, operation, dtype, bytes_per_element, byte_count, rtol, atol
+    device,
+    operation,
+    ttnn_dtype,
+    torch_dtype,
+    bytes_per_element,
+    byte_count,
+    compact_tile,
+    compact_tile_rows,
+    rtol,
+    atol,
+    memory_config,
 ):
-    element_indices = torch.arange(VALID_ROWS * TILE_WIDTH, dtype=torch.int64).reshape(
-        VALID_ROWS, TILE_WIDTH
+    compact_shape = (
+        compact_tile_rows * compact_tile[0],
+        compact_tile[1],
     )
-    input_torch = (element_indices.remainder(97) - 48).to(dtype)
-    seed_magnitude = 1024.0001220703125
-    send_seed_torch = torch.full(FULL_TILE, -seed_magnitude, dtype=dtype)
-    receive_seed_torch = torch.full(FULL_TILE, seed_magnitude, dtype=dtype)
-    compact_seed_torch = torch.full_like(input_torch, -2 * seed_magnitude)
+    if torch_dtype.is_floating_point:
+        element_indices = torch.arange(
+            compact_shape[0] * compact_shape[1], dtype=torch.int64
+        ).reshape(compact_shape)
+        input_torch = ((element_indices.remainder(97) - 48).float() / 7).to(torch_dtype)
+        send_seed_torch = torch.full(FULL_TILE, -16.0, dtype=torch_dtype)
+        receive_seed_torch = torch.full(FULL_TILE, 16.0, dtype=torch_dtype)
+        compact_seed_torch = torch.full(compact_shape, -24.0, dtype=torch_dtype)
+    else:
+        # A constant payload verifies byte counts without assuming that compact
+        # and full tiles use the same format-specific face order.
+        input_torch = torch.full(compact_shape, 17, dtype=torch_dtype)
+        send_seed_torch = torch.full(FULL_TILE, 101, dtype=torch_dtype)
+        receive_seed_torch = torch.full(FULL_TILE, 103, dtype=torch_dtype)
+        compact_seed_torch = torch.full(compact_shape, 107, dtype=torch_dtype)
 
-    inp = to_dram(input_torch, device, tile=COMPACT_TILE)
-    send_seed = to_dram(send_seed_torch, device, tile=FULL_TILE)
-    receive_seed = to_dram(receive_seed_torch, device, tile=FULL_TILE)
-    compact_seed = to_dram(compact_seed_torch, device, tile=COMPACT_TILE)
-    local_out = to_dram(torch.zeros_like(send_seed_torch), device, tile=FULL_TILE)
-    pipe_out = to_dram(torch.zeros_like(receive_seed_torch), device, tile=FULL_TILE)
-    compact_out = to_dram(
-        torch.zeros_like(compact_seed_torch), device, tile=COMPACT_TILE
-    )
+    def to_device(host_tensor, tile):
+        return ttnn.from_torch(
+            host_tensor,
+            dtype=ttnn_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            tile=ttnn.Tile(tile),
+            device=device,
+            memory_config=memory_config,
+        )
+
+    inp = to_device(input_torch, compact_tile)
+    send_seed = to_device(send_seed_torch, FULL_TILE)
+    receive_seed = to_device(receive_seed_torch, FULL_TILE)
+    compact_seed = to_device(compact_seed_torch, compact_tile)
+    local_out = to_device(torch.zeros_like(send_seed_torch), FULL_TILE)
+    pipe_out = to_device(torch.zeros_like(receive_seed_torch), FULL_TILE)
+    compact_out = to_device(torch.zeros_like(compact_seed_torch), compact_tile)
 
     operation(
         inp,
@@ -202,41 +342,58 @@ def test_byte_counted_dfb_round_trip(
     )
     ttnn.synchronize_device(device)
 
+    input_expected = ttnn.to_torch(inp).reshape(compact_shape).to(torch_dtype)
+    send_seed_expected = ttnn.to_torch(send_seed).reshape(FULL_TILE).to(torch_dtype)
+    receive_seed_expected = (
+        ttnn.to_torch(receive_seed).reshape(FULL_TILE).to(torch_dtype)
+    )
+    compact_seed_expected = (
+        ttnn.to_torch(compact_seed).reshape(compact_shape).to(torch_dtype)
+    )
+
     def replace_byte_prefix(seed):
         expected = seed.clone()
         expected_bytes = expected.view(dtype=torch.uint8).reshape(-1)
-        input_bytes = input_torch.view(dtype=torch.uint8).reshape(-1)
+        input_bytes = input_expected.view(dtype=torch.uint8).reshape(-1)
         expected_bytes[:byte_count].copy_(input_bytes[:byte_count])
         return expected
 
-    def assert_same_element_bits(actual, expected):
-        bit_dtype = torch.int16 if bytes_per_element == 2 else torch.int32
+    def assert_same_element_bit_multiset(actual, expected):
+        """Ignore format-specific tile face order while checking exact values."""
+        bit_dtype = {1: torch.uint8, 2: torch.int16, 4: torch.int32}[bytes_per_element]
         actual_bits = actual.contiguous().view(dtype=bit_dtype).reshape(-1)
         expected_bits = expected.contiguous().view(dtype=bit_dtype).reshape(-1)
         assert torch.equal(
             torch.sort(actual_bits).values, torch.sort(expected_bits).values
         )
 
-    local_result = ttnn.to_torch(local_out).reshape(FULL_TILE).to(dtype)
-    pipe_result = ttnn.to_torch(pipe_out).reshape(FULL_TILE).to(dtype)
-    local_expected = replace_byte_prefix(send_seed_torch)
-    pipe_expected = replace_byte_prefix(receive_seed_torch)
-    assert_same_element_bits(local_result, local_expected)
-    assert_same_element_bits(pipe_result, pipe_expected)
+    local_result = ttnn.to_torch(local_out).reshape(FULL_TILE).to(torch_dtype)
+    pipe_result = ttnn.to_torch(pipe_out).reshape(FULL_TILE).to(torch_dtype)
+    if bytes_per_element is None:
+        local_expected = input_expected
+        pipe_expected = input_expected
+    else:
+        local_expected = replace_byte_prefix(send_seed_expected)
+        pipe_expected = replace_byte_prefix(receive_seed_expected)
+        assert_same_element_bit_multiset(local_result, local_expected)
+        assert_same_element_bit_multiset(pipe_result, pipe_expected)
 
-    compact_result = (
-        ttnn.to_torch(compact_out).reshape(VALID_ROWS, TILE_WIDTH).to(dtype)
+    compact_result = ttnn.to_torch(compact_out).reshape(compact_shape).to(torch_dtype)
+    compact_expected = (
+        input_expected
+        if bytes_per_element is None
+        else replace_byte_prefix(compact_seed_expected)
     )
-    compact_expected = replace_byte_prefix(compact_seed_torch)
-    assert_allclose(
-        compact_result.float(),
-        compact_expected.float(),
-        rtol=rtol,
-        atol=atol,
-    )
-    result_bytes = compact_result.view(dtype=torch.uint8).reshape(-1)
-    expected_bytes = compact_expected.view(dtype=torch.uint8).reshape(-1)
-    assert torch.equal(result_bytes, expected_bytes)
+    if bytes_per_element is not None and compact_tile == FULL_TILE:
+        assert_same_element_bit_multiset(compact_result, compact_expected)
+    else:
+        assert_allclose(
+            compact_result.float(),
+            compact_expected.float(),
+            rtol=rtol,
+            atol=atol,
+        )
+        assert torch.equal(compact_result, compact_expected)
 
     for full_result, full_expected in (
         (local_result, local_expected),

--- a/test/python/test_byte_counted_dfb_copy.py
+++ b/test/python/test_byte_counted_dfb_copy.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: %python -m pytest %s -v
+
+"""Device coverage for byte-counted local and PipeNet DFB copies.
+
+The transfer stages fourteen 1x32 pages into a full 32x32 page, sends only the
+valid byte prefix to another core, and restores the compact representation.
+This is the representation change required by TreeReduce: compute can retain a
+full-tile accumulator while each communication stage transfers only valid rows.
+"""
+
+import pytest
+import torch
+
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import to_dram  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+VALID_ROWS = 14
+TILE_WIDTH = 32
+COMPACT_TILE = (1, TILE_WIDTH)
+FULL_TILE = (32, TILE_WIDTH)
+
+
+def _make_byte_counted_round_trip(data_format, bytes_per_element):
+    byte_count = VALID_ROWS * TILE_WIDTH * bytes_per_element
+
+    @ttl.operation(grid=(2, 1))
+    def byte_counted_round_trip(inp, out):
+        pipe_net = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(1, 0))])
+        compact_input_dfb = ttl.make_dataflow_buffer_like(
+            inp, shape=(VALID_ROWS, 1), block_count=1
+        )
+        send_dfb = ttl.make_dfb(
+            data_format, shape=(1, 1), block_count=1, tile=FULL_TILE
+        )
+        receive_dfb = ttl.make_dfb(
+            data_format, shape=(1, 1), block_count=1, tile=FULL_TILE
+        )
+        compact_output_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(VALID_ROWS, 1), block_count=1
+        )
+
+        @ttl.compute()
+        def compute():
+            pass
+
+        @ttl.datamovement()
+        def dm():
+            def send(pipe):
+                with compact_input_dfb.reserve() as compact_input_block:
+                    ttl.copy(
+                        inp[0:VALID_ROWS, 0:1], compact_input_block
+                    ).wait()
+
+                with compact_input_dfb.wait() as compact_input_block:
+                    with send_dfb.reserve() as send_block:
+                        ttl.copy(
+                            compact_input_block,
+                            send_block,
+                            byte_count=byte_count,
+                        ).wait()
+
+                with send_dfb.wait() as send_block:
+                    ttl.copy(send_block, pipe, byte_count=byte_count).wait()
+
+            pipe_net.if_src(send)
+
+            def receive(pipe):
+                with receive_dfb.reserve() as receive_block:
+                    ttl.copy(pipe, receive_block, byte_count=byte_count).wait()
+
+                with receive_dfb.wait() as receive_block:
+                    with compact_output_dfb.reserve() as compact_output_block:
+                        ttl.copy(
+                            receive_block,
+                            compact_output_block,
+                            byte_count=byte_count,
+                        ).wait()
+
+                with compact_output_dfb.wait() as compact_output_block:
+                    ttl.copy(
+                        compact_output_block, out[0:VALID_ROWS, 0:1]
+                    ).wait()
+
+            pipe_net.if_dst(receive)
+
+        @ttl.datamovement()
+        def dm_brisc():
+            pass
+
+    return byte_counted_round_trip
+
+
+BYTE_COUNTED_ROUND_TRIP_CASES = [
+    pytest.param(
+        _make_byte_counted_round_trip("bf16", 2),
+        torch.bfloat16,
+        5e-2,
+        1.0,
+        id="bf16",
+    ),
+    pytest.param(
+        _make_byte_counted_round_trip("float32", 4),
+        torch.float32,
+        1e-5,
+        1e-5,
+        id="fp32",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("operation", "dtype", "rtol", "atol"), BYTE_COUNTED_ROUND_TRIP_CASES
+)
+def test_byte_counted_dfb_round_trip(device, operation, dtype, rtol, atol):
+    element_indices = torch.arange(
+        VALID_ROWS * TILE_WIDTH, dtype=torch.int64
+    ).reshape(VALID_ROWS, TILE_WIDTH)
+    input_torch = (element_indices.remainder(97) - 48).to(dtype)
+    output_torch = torch.zeros_like(input_torch)
+
+    inp = to_dram(input_torch, device, tile=COMPACT_TILE)
+    out = to_dram(output_torch, device, tile=COMPACT_TILE)
+
+    operation(inp, out)
+    ttnn.synchronize_device(device)
+
+    result = ttnn.to_torch(out).reshape(VALID_ROWS, TILE_WIDTH).to(dtype)
+    assert_allclose(result.float(), input_torch.float(), rtol=rtol, atol=atol)
+    assert torch.equal(result, input_torch)
+
+    ttnn.deallocate(inp)
+    ttnn.deallocate(out)

--- a/test/sim/test_copy.py
+++ b/test/sim/test_copy.py
@@ -22,7 +22,7 @@ from test_utils import (
 from sim.blockstate import BlockAcquisition
 from sim.context import set_current_kernel_type
 from sim.dfb import Block, DataflowBuffer
-from sim.ttnnsim import Tensor
+from sim.ttnnsim import ROW_MAJOR_LAYOUT, Tensor
 from sim.copy import CopyTransaction, GroupTransfer, copy
 from sim.pipe import Pipe
 from sim.kernel import KernelKind
@@ -40,6 +40,96 @@ def setup_scheduler_context(dm_kernel_context):
 
 class TestCopyTransaction:
     """Test CopyTransaction class functionality."""
+
+    @pytest.mark.parametrize(
+        "byte_count",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+            pytest.param(True, id="boolean"),
+            pytest.param(1.5, id="non-integer"),
+        ],
+    )
+    def test_byte_count_must_be_a_positive_integer(self, byte_count: object) -> None:
+        """Reject values that do not denote a positive byte count."""
+
+        with pytest.raises(ValueError, match="must be a positive int"):
+            CopyTransaction(
+                make_ones_tile(),
+                make_zeros_tile(),
+                byte_count=byte_count,
+            )
+
+    def test_byte_count_must_fit_noc_transfer_size(self) -> None:
+        """Reject counts that the TTKernel NoC size operand cannot represent."""
+
+        with pytest.raises(ValueError, match="unsigned 32-bit NoC transfer size"):
+            CopyTransaction(
+                make_ones_tile(),
+                make_zeros_tile(),
+                byte_count=1 << 32,
+            )
+
+    @pytest.mark.parametrize(
+        ("source_shape", "destination_shape", "endpoint"),
+        [
+            pytest.param((1, 1), (2, 1), "source", id="source"),
+            pytest.param((2, 1), (1, 1), "destination", id="destination"),
+        ],
+    )
+    def test_byte_count_must_fit_each_dfb_block(
+        self,
+        source_shape: tuple[int, int],
+        destination_shape: tuple[int, int],
+        endpoint: str,
+    ) -> None:
+        """Reject a count that exceeds either acquired DFB block."""
+
+        source_tensor = make_element_for_buffer_shape(source_shape)
+        destination_tensor = make_element_for_buffer_shape(destination_shape)
+        source_dfb = DataflowBuffer(
+            likeness_tensor=source_tensor, shape=source_shape, block_count=1
+        )
+        destination_dfb = DataflowBuffer(
+            likeness_tensor=destination_tensor,
+            shape=destination_shape,
+            block_count=1,
+        )
+        source_block = Block(
+            tensor=source_tensor,
+            shape=source_shape,
+            acquisition=BlockAcquisition.WAIT,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=source_dfb,
+        )
+        destination_block = Block(
+            tensor=destination_tensor,
+            shape=destination_shape,
+            acquisition=BlockAcquisition.RESERVE,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=destination_dfb,
+        )
+
+        with pytest.raises(ValueError, match=f"exceeds {endpoint} capacity"):
+            CopyTransaction(source_block, destination_block, byte_count=2049)
+
+    def test_byte_count_requires_tiled_dfb_blocks(self) -> None:
+        """Reject byte-counted transfers from row-major DFB storage."""
+
+        source_tensor = Tensor(torch.zeros(8, dtype=torch.float32), ROW_MAJOR_LAYOUT)
+        source_dfb = DataflowBuffer(
+            likeness_tensor=source_tensor, shape=(8,), block_count=1
+        )
+        source_block = Block(
+            source_tensor,
+            shape=(8,),
+            acquisition=BlockAcquisition.WAIT,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=source_dfb,
+        )
+
+        with pytest.raises(ValueError, match="must use TILE layout"):
+            CopyTransaction(source_block, Pipe(7000, 7001), byte_count=4)
 
     def test_copy_transaction_unsupported_types(self) -> None:
         """Test that unsupported type combinations raise ValueError."""
@@ -364,7 +454,7 @@ class TestCopyWithStateMachine:
                 assert tensors_equal(block_data[i], source[i : i + 1, 0:1])
 
     def test_byte_counted_block_copy_preserves_destination_tail(self) -> None:
-        """Copy only the declared byte prefix between acquired DFB blocks."""
+        """Copy the declared number of bytes from the start of each DFB block."""
         set_current_kernel_type(KernelKind.DATA_MOVEMENT)
 
         source = make_rand_tensor(64, 32)

--- a/test/sim/test_copy.py
+++ b/test/sim/test_copy.py
@@ -473,6 +473,106 @@ class TestCopyWithStateMachine:
                     copy(source_block, destination_block)
                 copy(source_block, destination_block, byte_count=64).wait()
 
+    @pytest.mark.parametrize(
+        ("source_acquisition", "destination_acquisition", "expected_error"),
+        [
+            pytest.param(
+                BlockAcquisition.RESERVE,
+                BlockAcquisition.RESERVE,
+                "source must come from DFB wait",
+                id="source-not-waited",
+            ),
+            pytest.param(
+                BlockAcquisition.WAIT,
+                BlockAcquisition.WAIT,
+                "destination must come from DFB reserve",
+                id="destination-not-reserved",
+            ),
+        ],
+    )
+    def test_byte_counted_block_copy_requires_acquired_directions(
+        self,
+        source_acquisition,
+        destination_acquisition,
+        expected_error,
+    ) -> None:
+        """Reject block copies that reverse the producer/consumer roles."""
+        source_dfb = DataflowBuffer(
+            likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+        )
+        destination_dfb = DataflowBuffer(
+            likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+        )
+        source_block = Block(
+            make_ones_tile(),
+            shape=(1, 1),
+            acquisition=source_acquisition,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=source_dfb,
+        )
+        destination_block = Block(
+            make_zeros_tile(),
+            shape=(1, 1),
+            acquisition=destination_acquisition,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=destination_dfb,
+        )
+
+        with pytest.raises(ValueError, match=expected_error):
+            CopyTransaction(source_block, destination_block, byte_count=64)
+
+    def test_byte_counted_block_copy_requires_distinct_dfbs(self) -> None:
+        """Reject local byte copies within one DFB lifecycle."""
+        dfb = DataflowBuffer(
+            likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=2
+        )
+        source_block = Block(
+            make_ones_tile(),
+            shape=(1, 1),
+            acquisition=BlockAcquisition.WAIT,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=dfb,
+        )
+        destination_block = Block(
+            make_zeros_tile(),
+            shape=(1, 1),
+            acquisition=BlockAcquisition.RESERVE,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=dfb,
+        )
+
+        with pytest.raises(
+            ValueError, match="requires distinct source and destination"
+        ):
+            CopyTransaction(source_block, destination_block, byte_count=64)
+
+    def test_byte_counted_pipe_copy_requires_matching_counts(self) -> None:
+        """Reject a receiver count that differs from the queued send count."""
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
+
+        source_dfb = DataflowBuffer(
+            likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+        )
+        destination_dfb = DataflowBuffer(
+            likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+        )
+        pipe = Pipe(214, 215)
+        with source_dfb.reserve() as source_block:
+            copy(make_ones_tile(), source_block).wait()
+        with source_dfb.wait() as source_block:
+            copy(source_block, pipe, byte_count=64).wait()
+
+        destination_block = Block(
+            make_zeros_tile(),
+            shape=(1, 1),
+            acquisition=BlockAcquisition.RESERVE,
+            kernel_type=KernelKind.DATA_MOVEMENT,
+            dfb=destination_dfb,
+        )
+        transaction = CopyTransaction(pipe, destination_block, byte_count=32)
+        with pytest.raises(ValueError, match="sender and receiver must use the same"):
+            transaction.wait()
+
     def test_byte_counted_pipe_copy_preserves_destination_tail(self) -> None:
         """Use the same byte count on pipe send and receive."""
         set_current_kernel_type(KernelKind.DATA_MOVEMENT)

--- a/test/sim/test_copy.py
+++ b/test/sim/test_copy.py
@@ -52,25 +52,6 @@ class TestCopyTransaction:
         ):
             CopyTransaction(tensor1, tensor2)
 
-        # Block → Block not supported
-        block1 = Block(
-            make_rand_tensor(64, 32),
-            shape=(2, 1),
-            acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelKind.DATA_MOVEMENT,
-        )
-        block2 = Block(
-            make_rand_tensor(64, 32),
-            shape=(2, 1),
-            acquisition=BlockAcquisition.RESERVE,
-            kernel_type=KernelKind.DATA_MOVEMENT,
-        )
-        with pytest.raises(
-            ValueError, match="No copy handler registered for \\(Block, Block\\)"
-        ):
-            CopyTransaction(block1, block2)
-
-
 class TestTensorToBlockCopy:
     """Test copy operations from tensor to Block."""
 
@@ -380,6 +361,72 @@ class TestCopyWithStateMachine:
             block_data = block.to_list()
             for i in range(4):
                 assert tensors_equal(block_data[i], source[i : i + 1, 0:1])
+
+    def test_byte_counted_block_copy_preserves_destination_tail(self) -> None:
+        """Copy only the declared byte prefix between acquired DFB blocks."""
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
+
+        source = make_rand_tensor(64, 32)
+        source_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((2, 1)),
+            shape=(2, 1),
+            block_count=1,
+        )
+        destination_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((2, 1)),
+            shape=(2, 1),
+            block_count=1,
+        )
+
+        with source_dfb.reserve() as source_block:
+            copy(source, source_block).wait()
+
+        with source_dfb.wait() as source_block:
+            with destination_dfb.reserve() as destination_block:
+                destination_block.raw_tensor.to_torch().fill_(-7.0)
+                bytes_per_tile = source_block.raw_tensor.size_in_bytes(32 * 32)
+                copy(
+                    source_block,
+                    destination_block,
+                    byte_count=bytes_per_tile,
+                ).wait()
+
+                result = destination_block.raw_tensor.to_torch().reshape(-1)
+                expected = source.to_torch().reshape(-1)
+                assert torch.equal(result[: 32 * 32], expected[: 32 * 32])
+                assert torch.all(result[32 * 32 :] == -7.0)
+
+    def test_byte_counted_pipe_copy_preserves_destination_tail(self) -> None:
+        """Use the same byte count on pipe send and receive."""
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
+
+        source = make_rand_tensor(64, 32)
+        source_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((2, 1)),
+            shape=(2, 1),
+            block_count=1,
+        )
+        destination_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((2, 1)),
+            shape=(2, 1),
+            block_count=1,
+        )
+        pipe = Pipe(212, 213)
+
+        with source_dfb.reserve() as source_block:
+            copy(source, source_block).wait()
+
+        with source_dfb.wait() as source_block:
+            with destination_dfb.reserve() as destination_block:
+                destination_block.raw_tensor.to_torch().fill_(-11.0)
+                bytes_per_tile = source_block.raw_tensor.size_in_bytes(32 * 32)
+                copy(source_block, pipe, byte_count=bytes_per_tile).wait()
+                copy(pipe, destination_block, byte_count=bytes_per_tile).wait()
+
+                result = destination_block.raw_tensor.to_torch().reshape(-1)
+                expected = source.to_torch().reshape(-1)
+                assert torch.equal(result[: 32 * 32], expected[: 32 * 32])
+                assert torch.all(result[32 * 32 :] == -11.0)
 
     def test_copy_with_pipe_single_tile(self) -> None:
         """Test Block -> Pipe -> Block copy with single tile."""

--- a/test/sim/test_copy.py
+++ b/test/sim/test_copy.py
@@ -52,6 +52,7 @@ class TestCopyTransaction:
         ):
             CopyTransaction(tensor1, tensor2)
 
+
 class TestTensorToBlockCopy:
     """Test copy operations from tensor to Block."""
 
@@ -395,6 +396,82 @@ class TestCopyWithStateMachine:
                 expected = source.to_torch().reshape(-1)
                 assert torch.equal(result[: 32 * 32], expected[: 32 * 32])
                 assert torch.all(result[32 * 32 :] == -7.0)
+
+    def test_byte_counted_block_copy_preserves_partial_element_bytes(
+        self,
+    ) -> None:
+        """Model the operation's byte granularity, including partial elements."""
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
+
+        source = make_rand_tensor(32, 32)
+        source_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((1, 1)),
+            shape=(1, 1),
+            block_count=1,
+        )
+        destination_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((1, 1)),
+            shape=(1, 1),
+            block_count=1,
+        )
+
+        with source_dfb.reserve() as source_block:
+            copy(source, source_block).wait()
+
+        with source_dfb.wait() as source_block:
+            with destination_dfb.reserve() as destination_block:
+                destination_block.raw_tensor.to_torch().fill_(-7.0)
+                source_values = source_block.raw_tensor.to_torch().reshape(-1)
+                expected = destination_block.raw_tensor.to_torch().reshape(-1).clone()
+                expected[0] = source_values[0]
+                source_partial = source_values[1:2].to(
+                    dtype=source_block.raw_tensor.dtype
+                )
+                expected_partial = expected[1:2].to(
+                    dtype=destination_block.raw_tensor.dtype
+                )
+                source_partial_bytes = source_partial.view(dtype=torch.uint8).reshape(
+                    -1
+                )
+                expected_partial_bytes = expected_partial.view(
+                    dtype=torch.uint8
+                ).reshape(-1)
+                expected_partial_bytes[0] = source_partial_bytes[0]
+                expected[1] = expected_partial.to(
+                    dtype=destination_block.raw_tensor.underlying_dtype
+                ).item()
+
+                copy(source_block, destination_block, byte_count=3).wait()
+
+                destination_after = destination_block.raw_tensor.to_torch().reshape(-1)
+                assert torch.equal(destination_after, expected)
+
+    def test_block_copy_requires_byte_count(self) -> None:
+        """Reject block-to-block copies without an explicit byte count."""
+        set_current_kernel_type(KernelKind.DATA_MOVEMENT)
+
+        source = make_rand_tensor(32, 32)
+        source_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((1, 1)),
+            shape=(1, 1),
+            block_count=1,
+        )
+        destination_dfb = DataflowBuffer(
+            likeness_tensor=make_element_for_buffer_shape((1, 1)),
+            shape=(1, 1),
+            block_count=1,
+        )
+
+        with source_dfb.reserve() as source_block:
+            copy(source, source_block).wait()
+
+        with source_dfb.wait() as source_block:
+            with destination_dfb.reserve() as destination_block:
+                with pytest.raises(
+                    ValueError, match="Block-to-block copy requires byte_count"
+                ):
+                    copy(source_block, destination_block)
+                copy(source_block, destination_block, byte_count=64).wait()
 
     def test_byte_counted_pipe_copy_preserves_destination_tail(self) -> None:
         """Use the same byte count on pipe send and receive."""

--- a/test/sim/test_dry_run.py
+++ b/test/sim/test_dry_run.py
@@ -515,6 +515,63 @@ def test_pipe_send_receive_drains_queue_in_dry_run(dm_kernel_context):
     assert len(pipe_buffer[pipe]["queue"]) == 0
 
 
+def test_byte_counted_dfb_and_pipe_copies_in_dry_run(dm_kernel_context):
+    """Byte-counted copies use DFB metadata instead of sentinel capacity."""
+    set_dry_run(True)
+
+    pipe = Pipe(6050, 6051)
+    source_dfb = DataflowBuffer(
+        likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+    )
+    local_dfb = DataflowBuffer(
+        likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+    )
+    receiver_dfb = DataflowBuffer(
+        likeness_tensor=make_ones_tile(), shape=(1, 1), block_count=1
+    )
+
+    with source_dfb.reserve() as source_block:
+        copy(make_ones_tile(), source_block).wait()
+    with source_dfb.wait() as source_block:
+        with local_dfb.reserve() as local_block:
+            copy(source_block, local_block, byte_count=64).wait()
+    with local_dfb.wait() as local_block:
+        copy(local_block, pipe, byte_count=64).wait()
+    with receiver_dfb.reserve() as receiver_block:
+        copy(pipe, receiver_block, byte_count=64).wait()
+
+    assert len(get_context().copy_state.pipe_buffer[pipe]["queue"]) == 0
+
+
+def test_byte_counted_pipe_format_mismatch_in_dry_run(dm_kernel_context):
+    """Dry-run messages retain enough metadata to reject format changes."""
+    set_dry_run(True)
+
+    pipe = Pipe(6060, 6061)
+    source_dfb = DataflowBuffer(
+        likeness_tensor=Tensor(torch.ones(32, 32), dtype=ttnn.bfloat16),
+        shape=(1, 1),
+        block_count=1,
+    )
+    receiver_dfb = DataflowBuffer(
+        likeness_tensor=Tensor(torch.ones(32, 32, dtype=torch.float32)),
+        shape=(1, 1),
+        block_count=1,
+    )
+
+    with source_dfb.reserve() as source_block:
+        copy(
+            Tensor(torch.ones(32, 32), dtype=ttnn.bfloat16),
+            source_block,
+        ).wait()
+    with source_dfb.wait() as source_block:
+        copy(source_block, pipe, byte_count=64).wait()
+
+    with pytest.raises(ValueError, match="requires matching data types"):
+        with receiver_dfb.reserve() as receiver_block:
+            copy(pipe, receiver_block, byte_count=64).wait()
+
+
 def test_pipe_shape_mismatch_caught_in_dry_run(dm_kernel_context):
     """The structural pipe shape check runs in dry-run, not just in normal mode.
 

--- a/test/ttlang/Conversion/TTLToTTKernel/byte_counted_dfb_copy.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/byte_counted_dfb_copy.mlir
@@ -1,0 +1,40 @@
+// RUN: ttlang-opt %s --convert-ttl-to-ttkernel --canonicalize -cse | FileCheck %s
+
+// CHECK-LABEL: func.func @copy_valid_prefix_between_dfb_blocks
+// CHECK-DAG: %[[NOC:.*]] = arith.constant 0 : i8
+// CHECK-DAG: %[[SIZE:.*]] = arith.constant 896 : i32
+// CHECK: %[[SRC_DFB:.*]] = ttkernel.get_compile_time_arg_val(0)
+// CHECK: %[[DST_DFB:.*]] = ttkernel.get_compile_time_arg_val(1)
+// CHECK: %[[SRC_ADDR:.*]] = ttkernel.get_read_ptr(%[[SRC_DFB]])
+// CHECK: %[[DST_ADDR:.*]] = ttkernel.get_write_ptr(%[[DST_DFB]])
+// CHECK: %[[SRC_X:.*]] = ttkernel.my_x(%[[NOC]])
+// CHECK: %[[SRC_Y:.*]] = ttkernel.my_y(%[[NOC]])
+// CHECK: ttkernel.noc_async_read core[%[[SRC_X]], %[[SRC_Y]]], %[[SRC_ADDR]], %[[DST_ADDR]], %[[SIZE]], noc %[[NOC]]
+// CHECK: ttkernel.noc_async_read_barrier(%[[NOC]])
+func.func @copy_valid_prefix_between_dfb_blocks()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %compact_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>
+  %full_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %compact_wait = ttl.cb_wait %compact_dfb
+      : <[14, 1], !ttcore.tile<1x32, bf16>, 1>
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %compact_block = ttl.attach_cb %compact_wait, %compact_dfb
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>)
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %full_reserve = ttl.cb_reserve %full_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %full_block = ttl.attach_cb %full_reserve, %full_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %transfer = ttl.copy %compact_block, %full_block {byte_count = 896 : i64}
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle<read>
+  ttl.wait %transfer : !ttl.transfer_handle<read>
+  func.return
+}

--- a/test/ttlang/Conversion/TTLToTTKernel/byte_counted_dfb_copy.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/byte_counted_dfb_copy.mlir
@@ -1,5 +1,7 @@
 // RUN: ttlang-opt %s --convert-ttl-to-ttkernel --canonicalize -cse | FileCheck %s
 
+// Verify that a byte-counted DFB block copy lowers to one local NoC read.
+
 // CHECK-LABEL: func.func @copy_valid_prefix_between_dfb_blocks
 // CHECK-DAG: %[[NOC:.*]] = arith.constant 0 : i8
 // CHECK-DAG: %[[SIZE:.*]] = arith.constant 896 : i32

--- a/test/ttlang/Conversion/TTLToTTKernel/byte_counted_dfb_copy.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/byte_counted_dfb_copy.mlir
@@ -2,7 +2,7 @@
 
 // Verify that a byte-counted DFB block copy lowers to one local NoC read.
 
-// CHECK-LABEL: func.func @copy_valid_prefix_between_dfb_blocks
+// CHECK-LABEL: func.func @copy_initial_bytes_between_dfb_blocks
 // CHECK-DAG: %[[NOC:.*]] = arith.constant 0 : i8
 // CHECK-DAG: %[[SIZE:.*]] = arith.constant 896 : i32
 // CHECK: %[[SRC_DFB:.*]] = ttkernel.get_compile_time_arg_val(0)
@@ -13,7 +13,7 @@
 // CHECK: %[[SRC_Y:.*]] = ttkernel.my_y(%[[NOC]])
 // CHECK: ttkernel.noc_async_read core[%[[SRC_X]], %[[SRC_Y]]], %[[SRC_ADDR]], %[[DST_ADDR]], %[[SIZE]], noc %[[NOC]]
 // CHECK: ttkernel.noc_async_read_barrier(%[[NOC]])
-func.func @copy_valid_prefix_between_dfb_blocks()
+func.func @copy_initial_bytes_between_dfb_blocks()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %compact_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
       : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>

--- a/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
@@ -1,0 +1,207 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics
+
+func.func @missing_byte_count()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %src_wait = ttl.cb_wait %src_dfb
+      : <[14, 1], !ttcore.tile<1x32, bf16>, 1>
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %src = ttl.attach_cb %src_wait, %src_dfb
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>)
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst = ttl.attach_cb %dst_reserve, %dst_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{dataflow-buffer block copies require an explicit byte_count}}
+  %copy = ttl.copy %src, %dst
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+func.func @source_must_be_wait_view()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %src_reserve = ttl.cb_reserve %src_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %src = ttl.attach_cb %src_reserve, %src_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst = ttl.attach_cb %dst_reserve, %dst_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{dataflow-buffer copy source must be the exact view returned by ttl.cb_wait}}
+  %copy = ttl.copy %src, %dst {byte_count = 896 : i64}
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+func.func @destination_must_be_reserve_view()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %src_wait = ttl.cb_wait %src_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %src = ttl.attach_cb %src_wait, %src_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst_wait = ttl.cb_wait %dst_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst = ttl.attach_cb %dst_wait, %dst_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{dataflow-buffer copy destination must be the exact view returned by ttl.cb_reserve}}
+  %copy = ttl.copy %src, %dst {byte_count = 896 : i64}
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+func.func @distinct_dataflow_buffers_required()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %src_wait = ttl.cb_wait %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %src = ttl.attach_cb %src_wait, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst_reserve = ttl.cb_reserve %dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst = ttl.attach_cb %dst_reserve, %dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{byte-counted copy requires distinct source and destination dataflow buffers}}
+  %copy = ttl.copy %src, %dst {byte_count = 896 : i64}
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+func.func @matching_data_formats_required()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %src_wait = ttl.cb_wait %src_dfb
+      : <[14, 1], !ttcore.tile<1x32, bf16>, 1>
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %src = ttl.attach_cb %src_wait, %src_dfb
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>)
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %dst = ttl.attach_cb %dst_reserve, %dst_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{byte-counted copy data formats must match}}
+  %copy = ttl.copy %src, %dst {byte_count = 896 : i64}
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, f32>>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+func.func @source_view_capacity_required()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %src_wait = ttl.cb_wait %src_dfb
+      : <[14, 1], !ttcore.tile<1x32, bf16>, 1>
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %src = ttl.attach_cb %src_wait, %src_dfb
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>)
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst = ttl.attach_cb %dst_reserve, %dst_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{byte_count 897 exceeds source acquired dataflow-buffer view capacity 896}}
+  %copy = ttl.copy %src, %dst {byte_count = 897 : i64}
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+func.func @destination_view_capacity_required()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>
+  %src_wait = ttl.cb_wait %src_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %src = ttl.attach_cb %src_wait, %src_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[14, 1], !ttcore.tile<1x32, bf16>, 1>
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %dst = ttl.attach_cb %dst_reserve, %dst_dfb
+      : (tensor<14x1x!ttcore.tile<1x32, bf16>>,
+         !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>)
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  // expected-error @below {{byte_count 897 exceeds destination acquired dataflow-buffer view capacity 896}}
+  %copy = ttl.copy %src, %dst {byte_count = 897 : i64}
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         tensor<14x1x!ttcore.tile<1x32, bf16>>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
@@ -2,6 +2,7 @@
 
 // Verify the structural, type, and capacity contracts for byte-counted copies.
 
+// A local DFB-to-DFB copy requires an explicit transfer size.
 func.func @missing_byte_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -32,6 +33,7 @@ func.func @missing_byte_count()
 
 // -----
 
+// A local DFB-to-DFB copy returns a read handle for NoC completion.
 func.func @block_copy_requires_read_handle()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -62,6 +64,7 @@ func.func @block_copy_requires_read_handle()
 
 // -----
 
+// The source must be the current readable block from the source DFB.
 func.func @source_must_be_wait_view()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -92,6 +95,7 @@ func.func @source_must_be_wait_view()
 
 // -----
 
+// The destination must be the current writable block from the destination DFB.
 func.func @destination_must_be_reserve_view()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -122,6 +126,7 @@ func.func @destination_must_be_reserve_view()
 
 // -----
 
+// A raw local copy cannot read and write the same DFB interface.
 func.func @distinct_dataflow_buffers_required()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
@@ -150,6 +155,7 @@ func.func @distinct_dataflow_buffers_required()
 
 // -----
 
+// Raw bytes cannot be reinterpreted as a different data format.
 func.func @matching_data_formats_required()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -180,6 +186,7 @@ func.func @matching_data_formats_required()
 
 // -----
 
+// The requested bytes must fit the acquired source view.
 func.func @source_view_capacity_required()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -210,6 +217,7 @@ func.func @source_view_capacity_required()
 
 // -----
 
+// The requested bytes must fit the acquired destination view.
 func.func @destination_view_capacity_required()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -240,6 +248,7 @@ func.func @destination_view_capacity_required()
 
 // -----
 
+// A zero-byte transfer has no supported asynchronous-copy meaning.
 func.func @byte_count_must_be_positive() {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
@@ -255,6 +264,7 @@ func.func @byte_count_must_be_positive() {
 
 // -----
 
+// The transfer size must fit the unsigned 32-bit TTKernel NoC operand.
 func.func @byte_count_must_fit_noc_size() {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
       : !ttl.cb<[2097153, 1], !ttcore.tile<32x32, bf16>, 1>
@@ -270,6 +280,7 @@ func.func @byte_count_must_fit_noc_size() {
 
 // -----
 
+// A PipeNet send cannot read beyond one source DFB block.
 func.func @pipe_source_capacity_required() {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
@@ -285,6 +296,7 @@ func.func @pipe_source_capacity_required() {
 
 // -----
 
+// A PipeNet receive cannot write beyond its acquired destination view.
 func.func @pipe_receiver_capacity_required() {
   %dst_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
       : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>
@@ -303,6 +315,7 @@ func.func @pipe_receiver_capacity_required() {
 
 // -----
 
+// Byte-counted DFB copies require a tiled DFB data format.
 func.func @block_copy_requires_tiled_elements()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -326,6 +339,7 @@ func.func @block_copy_requires_tiled_elements()
 
 // -----
 
+// Ordinary tensor copies continue to use tile counts rather than byte counts.
 func.func @byte_count_rejects_ordinary_tensor_copy() {
   %src = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
   %dst = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>

--- a/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
@@ -30,6 +30,36 @@ func.func @missing_byte_count()
 
 // -----
 
+func.func @block_copy_requires_read_handle()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %src_wait = ttl.cb_wait %src_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %src = ttl.attach_cb %src_wait, %src_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst = ttl.attach_cb %dst_reserve, %dst_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+      -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{dataflow-buffer block copy requires !ttl.transfer_handle<read> result}}
+  %copy = ttl.copy %src, %dst {byte_count = 896 : i64}
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.receive_request
+  func.return
+}
+
+// -----
+
 func.func @source_must_be_wait_view()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}

--- a/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
@@ -235,3 +235,51 @@ func.func @destination_view_capacity_required()
       -> !ttl.transfer_handle<read>
   func.return
 }
+
+// -----
+
+func.func @byte_count_must_be_positive() {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  // expected-error @below {{'ttl.copy' op attribute 'byte_count' failed to satisfy constraint: 64-bit signless integer attribute whose value is positive}}
+  %send = ttl.copy %src_dfb, %pipe {byte_count = 0 : i64}
+      : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>,
+         !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>)
+      -> !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
+func.func @pipe_source_capacity_required() {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  // expected-error @below {{byte_count 2049 exceeds source dataflow-buffer block capacity 2048}}
+  %send = ttl.copy %src_dfb, %pipe {byte_count = 2049 : i64}
+      : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>,
+         !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>)
+      -> !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
+func.func @pipe_receiver_capacity_required() {
+  %dst_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[14, 1], !ttcore.tile<1x32, bf16>, 1>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[14, 1], !ttcore.tile<1x32, bf16>, 1>
+      -> tensor<14x1x!ttcore.tile<1x32, bf16>>
+  %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  // expected-error @below {{byte_count 897 exceeds destination acquired dataflow-buffer view capacity 896}}
+  %receive = ttl.copy %pipe, %dst_reserve {byte_count = 897 : i64}
+      : (!ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>,
+         tensor<14x1x!ttcore.tile<1x32, bf16>>)
+      -> !ttl.receive_request
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
@@ -255,6 +255,21 @@ func.func @byte_count_must_be_positive() {
 
 // -----
 
+func.func @byte_count_must_fit_noc_size() {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[2097153, 1], !ttcore.tile<32x32, bf16>, 1>
+  %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+      : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+  // expected-error @below {{'ttl.copy' op attribute 'byte_count' failed to satisfy constraint: 64-bit signless integer attribute whose value is positive whose maximum value is 4294967295}}
+  %send = ttl.copy %src_dfb, %pipe {byte_count = 4294967296 : i64}
+      : (!ttl.cb<[2097153, 1], !ttcore.tile<32x32, bf16>, 1>,
+         !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>)
+      -> !ttl.transfer_handle<write>
+  func.return
+}
+
+// -----
+
 func.func @pipe_source_capacity_required() {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>

--- a/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/byte_counted_copy_invalid.mlir
@@ -1,5 +1,7 @@
 // RUN: ttlang-opt %s --split-input-file --verify-diagnostics
 
+// Verify the structural, type, and capacity contracts for byte-counted copies.
+
 func.func @missing_byte_count()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
@@ -281,5 +283,41 @@ func.func @pipe_receiver_capacity_required() {
       : (!ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>,
          tensor<14x1x!ttcore.tile<1x32, bf16>>)
       -> !ttl.receive_request
+  func.return
+}
+
+// -----
+
+func.func @block_copy_requires_tiled_elements()
+    attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], f32, 1>
+  %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], f32, 1>
+  %src_wait = ttl.cb_wait %src_dfb
+      : <[1, 1], f32, 1> -> tensor<1x1xf32>
+  %src = ttl.attach_cb %src_wait, %src_dfb
+      : (tensor<1x1xf32>, !ttl.cb<[1, 1], f32, 1>) -> tensor<1x1xf32>
+  %dst_reserve = ttl.cb_reserve %dst_dfb
+      : <[1, 1], f32, 1> -> tensor<1x1xf32>
+  %dst = ttl.attach_cb %dst_reserve, %dst_dfb
+      : (tensor<1x1xf32>, !ttl.cb<[1, 1], f32, 1>) -> tensor<1x1xf32>
+  // expected-error @below {{byte-counted dataflow-buffer copies require tiled element types}}
+  %copy = ttl.copy %src, %dst {byte_count = 4 : i64}
+      : (tensor<1x1xf32>, tensor<1x1xf32>)
+      -> !ttl.transfer_handle<read>
+  func.return
+}
+
+// -----
+
+func.func @byte_count_rejects_ordinary_tensor_copy() {
+  %src = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %dst = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  // expected-error @below {{byte_count is supported only for dataflow-buffer block copies and pipe copies}}
+  %copy = ttl.copy %src, %dst {byte_count = 896 : i64}
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         tensor<1x1x!ttcore.tile<32x32, bf16>>)
+      -> !ttl.transfer_handle<read>
   func.return
 }

--- a/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer.mlir
@@ -1,6 +1,8 @@
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(convert-ttl-to-ttkernel{pipe-computed-addresses=true pipe-capacity-sync=false})' -debug-only=ttl-pipe-transport-plan 2>&1 >/dev/null | FileCheck %s --check-prefix=PLAN
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(convert-ttl-to-ttkernel{pipe-computed-addresses=true pipe-capacity-sync=false})' | FileCheck %s --check-prefix=LOWER
 
+// Verify one-page planning and lowering for a byte-counted PipeNet transfer.
+
 // PLAN: PipeTransport: stream 0 transfer 0 src(0, 0) -> dst(1, 0)
 // PLAN-NEXT: PipeTransport:   source {{.*}} pages=1 page_bytes=896
 // PLAN-NEXT: PipeTransport:   endpoint 0 {{.*}}

--- a/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer.mlir
@@ -1,0 +1,48 @@
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(convert-ttl-to-ttkernel{pipe-computed-addresses=true pipe-capacity-sync=false})' -debug-only=ttl-pipe-transport-plan 2>&1 >/dev/null | FileCheck %s --check-prefix=PLAN
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(convert-ttl-to-ttkernel{pipe-computed-addresses=true pipe-capacity-sync=false})' | FileCheck %s --check-prefix=LOWER
+
+// PLAN: PipeTransport: stream 0 transfer 0 src(0, 0) -> dst(1, 0)
+// PLAN-NEXT: PipeTransport:   source {{.*}} pages=1 page_bytes=896
+// PLAN-NEXT: PipeTransport:   endpoint 0 {{.*}}
+// LOWER-LABEL: func.func @byte_counted_pipe_transfer
+// LOWER: %[[SIZE:.*]] = arith.constant 896 : i32
+// LOWER: ttkernel.noc_async_write {{.*}}, core[{{.*}}, {{.*}}], {{.*}}, %[[SIZE]], noc {{.*}}
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @byte_counted_pipe_transfer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    %transfer = ttl.pipe_transfer.create %pipe {
+        kind = #ttl.pipe_transfer_kind<point_to_point>}
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+        -> !ttl.pipe_transfer
+    ttl.if_dst %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      %recv = ttl.cb_reserve %dst_dfb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      %token = ttl.pipe_transfer.post %transfer, %recv {
+          byte_count = 896 : i64}
+          : (!ttl.pipe_transfer,
+             tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> !ttl.pipe_token<net 0>
+      ttl.pipe_transfer.wait %token : !ttl.pipe_token<net 0>
+      ttl.cb_push %dst_dfb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    }
+    ttl.if_src %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      %send = ttl.pipe_transfer.send %transfer, %src_dfb {
+          byte_count = 896 : i64}
+          : (!ttl.pipe_transfer,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+    }
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
@@ -2,6 +2,7 @@
 
 // Verify byte-count agreement, compatibility, and one-block PipeNet transfers.
 
+// Sender and receiver planning requires one exact transfer size.
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @sender_receiver_count_mismatch()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -44,6 +45,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
+// PipeNet endpoints must preserve the source DFB data format.
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @byte_counted_receiver_data_format_mismatch()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -86,6 +88,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
+// A byte-counted transfer represents one DFB block per execution.
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @byte_counted_grouped_transfer()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
@@ -1,0 +1,41 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(convert-ttl-to-ttkernel{pipe-computed-addresses=true pipe-capacity-sync=false})'
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @sender_receiver_count_mismatch()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    %transfer = ttl.pipe_transfer.create %pipe {
+        kind = #ttl.pipe_transfer_kind<point_to_point>}
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+        -> !ttl.pipe_transfer
+    ttl.if_dst %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      %recv = ttl.cb_reserve %dst_dfb
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      // expected-error @below {{pipe sender and receiver must use the same byte_count}}
+      %token = ttl.pipe_transfer.post %transfer, %recv {
+          byte_count = 1792 : i64}
+          : (!ttl.pipe_transfer,
+             tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> !ttl.pipe_token<net 0>
+      ttl.pipe_transfer.wait %token : !ttl.pipe_token<net 0>
+    }
+    ttl.if_src %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      // expected-note @below {{corresponding pipe send is here}}
+      %send = ttl.pipe_transfer.send %transfer, %src_dfb {
+          byte_count = 896 : i64}
+          : (!ttl.pipe_transfer,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+    }
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
@@ -1,5 +1,7 @@
 // RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(convert-ttl-to-ttkernel{pipe-computed-addresses=true pipe-capacity-sync=false})'
 
+// Verify byte-count agreement, compatibility, and one-block PipeNet transfers.
+
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @sender_receiver_count_mismatch()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
@@ -43,6 +43,48 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 // -----
 
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @byte_counted_receiver_data_format_mismatch()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    %transfer = ttl.pipe_transfer.create %pipe {
+        kind = #ttl.pipe_transfer_kind<point_to_point>}
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+        -> !ttl.pipe_transfer
+    ttl.if_dst %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      %recv = ttl.cb_reserve %dst_dfb
+          : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      // expected-error @below {{pipe receiver cannot accept the sender's byte-counted payload of 896 byte}}
+      %token = ttl.pipe_transfer.post %transfer, %recv {
+          byte_count = 896 : i64}
+          : (!ttl.pipe_transfer,
+             tensor<1x1x!ttcore.tile<32x32, f32>>)
+          -> !ttl.pipe_token<net 0>
+      ttl.pipe_transfer.wait %token : !ttl.pipe_token<net 0>
+    }
+    ttl.if_src %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      // expected-note @below {{corresponding pipe send is here}}
+      %send = ttl.pipe_transfer.send %transfer, %src_dfb {
+          byte_count = 896 : i64}
+          : (!ttl.pipe_transfer,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+    }
+    func.return
+  }
+}
+
+// -----
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @byte_counted_grouped_transfer()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 4} {dfb_id = 0 : index}

--- a/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/byte_counted_pipe_transfer_invalid.mlir
@@ -39,3 +39,45 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
     func.return
   }
 }
+
+// -----
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @byte_counted_grouped_transfer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %src_dfb = ttl.bind_cb {cb_index = 0, block_count = 4} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+    %dst_dfb = ttl.bind_cb {cb_index = 1, block_count = 4} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>
+    %pipe = ttl.create_pipe src(0, 0) dst(1, 0) to(1, 0) net 0
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+    %transfer = ttl.pipe_transfer.create %pipe {
+        block_span = 2 : i64,
+        kind = #ttl.pipe_transfer_kind<point_to_point>}
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0>
+        -> !ttl.pipe_transfer
+    ttl.if_dst %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      %recv = ttl.cb_reserve %dst_dfb {num_tiles = 2 : i64}
+          : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
+          -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+      %token = ttl.pipe_transfer.post %transfer, %recv {
+          byte_count = 896 : i64}
+          : (!ttl.pipe_transfer,
+             tensor<1x2x!ttcore.tile<32x32, bf16>>)
+          -> !ttl.pipe_token<net 0>
+      ttl.pipe_transfer.wait %token : !ttl.pipe_token<net 0>
+    }
+    ttl.if_src %pipe
+        : !ttl.pipe<src(0, 0) dst(1, 0) to(1, 0) net 0> {
+      // expected-error @below {{byte-counted pipe transfers require a one-block transfer span}}
+      %send = ttl.pipe_transfer.send %transfer, %src_dfb {
+          byte_count = 896 : i64}
+          : (!ttl.pipe_transfer,
+             !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 4>)
+          -> !ttl.transfer_handle<write>
+      ttl.wait %send : !ttl.transfer_handle<write>
+    }
+    func.return
+  }
+}


### PR DESCRIPTION
### Problem description

PipeNet transfers currently copy complete DFB blocks. TreeReduce accumulates into a 32 x 32 tile but may need to communicate only 14 rows. Copying the complete tile transfers unused data, while staging through a second 14 x 32 DFB consumes additional L1 and adds another transfer.

This PR lets the program specify the exact number of bytes to copy from byte offset zero:

```python
valid_bytes = 14 * 32 * 2
ttl.copy(accumulator_block, pipe, byte_count=valid_bytes).wait()
```

### What's changed

~660 LOC implementation.

- Adds an optional positive `byte_count` to local acquired-DFB copies and PipeNet sends and receives, allowing the first N bytes of one block to be transferred while later destination bytes remain unchanged.
- Allows source and destination DFBs to use different tile geometry when their data format matches and each block can hold the requested byte count, eliminating the staging DFB in the example.
- Requires every endpoint of a PipeNet transfer to use the same byte count so sender and receiver planning agree on the exact payload size.
- Uses a raw NoC read for direct DFB-to-DFB copies because tile-copy operations always transfer complete tiles.
- Enforces the same size, layout, and data-format contract in compilation and simulation, including dry-run simulation.

### Stack

Targets `main` and begins the TreeReduce PipeNet stack.

### Checklist

- [x] New device tests cover every supported DFB data format in DRAM and L1, including partial-element BF16 and FP32 copies and unchanged destination bytes.
- [x] New simulator tests cover valid copies, dry-run metadata, invalid byte counts, capacity, layout, data-format, and endpoint-role errors.
- [x] New MLIR tests cover local and PipeNet lowering and invalid byte-count contracts.
