### PR TITLE
[ttl][pipes] Add per-node PipeNet destination counts [tree-reduce-2]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -698,7 +698,8 @@ correspondence, and synchronization schedules also remain mandatory. The
 program must ensure that at most one producer and at most one consumer controls
 the DFB on each active launch node. Every wait must still have a producer that
 publishes the required pages. The variable is unset by default, so all checks
-run unless the user sets it.
+run unless the user sets it. When set, the compiler emits a warning and records
+`ttl.relaxed_dfb_protocol_domain_verification` on the module.
 
 See `test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir` and
 `verify_dfb_spsc_missing_producer_invalid.mlir` and

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -1935,7 +1935,8 @@ each region according to the parent op:
 | `ttl.if_src %pipe` body | intersect with `pipe.src` |
 | `ttl.if_dst %pipe` body | intersect with `pipe.dst` |
 | `ttl.pipenet_scope` body | unchanged after checking current domain is contained in declared role union |
-| `scf.for`/`scf.while`/`affine.for`/`scf.execute_region`/`linalg.generic`/multi-block via `cf.cond_br` | unchanged (no predication, framework default) |
+| `scf.for` body | intersect with nodes whose statically evaluated trip count is nonzero; unchanged when any candidate node cannot be evaluated |
+| `scf.while`/`affine.for`/`scf.execute_region`/`linalg.generic`/multi-block via `cf.cond_br` | unchanged (no predication, framework default) |
 
 For `scf.if`, the condition's domain is determined structurally:
 

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -64,6 +64,14 @@ each launch node executes that body once for every record in which the node has
 the requested source or destination role. Multiple matching records execute in
 PipeNet construction order.
 
+`net.destination_count()` returns the number of records that select the
+current node as a destination. It counts records, including duplicate endpoint
+relations, rather than distinct sources or destination coordinates. The result
+therefore equals the number of `net.if_dst(callback)` executions on that node
+and can be used as a receive-loop bound. It does not perform synchronization.
+Local PipeNets lower the count to one launch-node-indexed constant-table lookup;
+graph PipeNets also match each record's logical destination device.
+
 TTKernel conversion uses two representations:
 
 - For one to four records, conversion emits one static pipe and one coordinate

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -94,7 +94,7 @@ They are independent of the code generation flags above.
 | `TTLANG_DEBUG_LOCATIONS` | `0`/`1` | `0` | Include source locations in printed MLIR (locations are always tracked internally for error messages). |
 | `TTLANG_VERBOSE_ERRORS` | `0`/`1` | `0` | Include raw MLIR diagnostics in error output. |
 | `TTLANG_SIM_ONLY` | `0`/`1` | `0` | Force `import ttl` to skip loading the compiled MLIR extension. Used when running the simulator from a source tree without an installed `tt-lang-sim` wheel (which ships the same signal as a marker module). |
-| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Skip per-launch-node verification that DFB producers, consumers, and waits execute on corresponding dynamically active nodes. The program must enforce those ownership and synchronization contracts. A waited DFB must still have a compiler-visible push or uncontracted external access that may contain one. Finalized DFB preconditions, PipeNet endpoint guards, transfer correspondence, and synchronization schedules remain enabled. |
+| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Skip per-launch-node verification that DFB producers, consumers, and waits execute on corresponding dynamically active nodes. The program must enforce those ownership and synchronization contracts. A waited DFB must still have a compiler-visible push or uncontracted external access that may contain one. Finalized DFB preconditions, PipeNet endpoint guards, transfer correspondence, and synchronization schedules remain enabled. The compiler emits a warning and records `ttl.relaxed_dfb_protocol_domain_verification` on the module. |
 
 Profiling-related environment variables (`TTLANG_AUTO_PROFILE`,
 `TTLANG_PERF_DUMP`, `TTLANG_PERF_SERV`, `TTLANG_SIGNPOST_PROFILE`,

--- a/docs/sphinx/specs/TTLangSpecification.externalized.md
+++ b/docs/sphinx/specs/TTLangSpecification.externalized.md
@@ -54,7 +54,6 @@
 | 0.18 | 06/16/2026 | Add `ttl.raw_element_read` and `ttl.raw_element_write` |
 | 0.19 | 06/15/2026 | Unified-body `ttl.operation` with thread assignment and composition; add multi-kernel operation with explicit kernels |
 | 0.20 | 06/23/2026 | Add `ttl.exp` hardware flags and scaled exponential canonicalization |
-| 0.21 | 08/27/2026 | Add `ttl.PipeNet.destination_count()` |
 
 
 ## Introduction
@@ -281,7 +280,6 @@ The active predicates are only required for code that includes pipe-coupled comp
 | `ttl.PipeNet[DstT].if_dst(self, cond_fun: Callable[[ttl.DstPipeIdentity], None])` | Call condition function for each pipe in the pipe net that is a destination. |
 | `ttl.PipeNet[DstT].is_src(self) -> bool` | Predicate: `True` on the current node if and only if it is a source coordinate of any pipe in the pipe net. |
 | `ttl.PipeNet[DstT].is_dst(self) -> bool` | Predicate: `True` on the current node if and only if it is in the destination range of any pipe in the pipe net. |
-| `ttl.PipeNet[DstT].destination_count(self) -> int` | Number of pipe records whose destination contains the current node; equal to the number of `if_dst` callback executions on that node. |
 | `ttl.PipeNet[DstT].is_active(self) -> bool` | Predicate: `True` on the current node if and only if `is_src()` or `is_dst()` is `True`. |
 | `@property ttl.SrcPipeIdentity[DstT].dst(self) -> DstT` | Get destination node or node range for pipe in `if_src`. |
 | `@property ttl.DstPipeIdentity.src(self) -> ttl.NodeCoord` | Get source node for pipe in `if_dst`. |

--- a/docs/sphinx/specs/TTLangSpecification.externalized.md
+++ b/docs/sphinx/specs/TTLangSpecification.externalized.md
@@ -54,6 +54,7 @@
 | 0.18 | 06/16/2026 | Add `ttl.raw_element_read` and `ttl.raw_element_write` |
 | 0.19 | 06/15/2026 | Unified-body `ttl.operation` with thread assignment and composition; add multi-kernel operation with explicit kernels |
 | 0.20 | 06/23/2026 | Add `ttl.exp` hardware flags and scaled exponential canonicalization |
+| 0.21 | 08/27/2026 | Add `ttl.PipeNet.destination_count()` |
 
 
 ## Introduction
@@ -280,6 +281,7 @@ The active predicates are only required for code that includes pipe-coupled comp
 | `ttl.PipeNet[DstT].if_dst(self, cond_fun: Callable[[ttl.DstPipeIdentity], None])` | Call condition function for each pipe in the pipe net that is a destination. |
 | `ttl.PipeNet[DstT].is_src(self) -> bool` | Predicate: `True` on the current node if and only if it is a source coordinate of any pipe in the pipe net. |
 | `ttl.PipeNet[DstT].is_dst(self) -> bool` | Predicate: `True` on the current node if and only if it is in the destination range of any pipe in the pipe net. |
+| `ttl.PipeNet[DstT].destination_count(self) -> int` | Number of pipe records whose destination contains the current node; equal to the number of `if_dst` callback executions on that node. |
 | `ttl.PipeNet[DstT].is_active(self) -> bool` | Predicate: `True` on the current node if and only if `is_src()` or `is_dst()` is `True`. |
 | `@property ttl.SrcPipeIdentity[DstT].dst(self) -> DstT` | Get destination node or node range for pipe in `if_src`. |
 | `@property ttl.DstPipeIdentity.src(self) -> ttl.NodeCoord` | Get source node for pipe in `if_dst`. |

--- a/docs/sphinx/specs/TTLangSpecification.md
+++ b/docs/sphinx/specs/TTLangSpecification.md
@@ -54,7 +54,6 @@
 | 0.18 | 06/16/2026 | Add `ttl.raw_element_read` and `ttl.raw_element_write` |
 | 0.19 | 06/15/2026 | Unified-body `ttl.operation` with thread assignment and composition; add multi-kernel operation with explicit kernels |
 | 0.20 | 06/23/2026 | Add `ttl.exp` hardware flags and scaled exponential canonicalization |
-| 0.21 | 08/27/2026 | Add `ttl.PipeNet.destination_count()` |
 
 
 ## Introduction
@@ -807,7 +806,6 @@ The active predicates are only required for code that includes pipe-coupled comp
 | `ttl.PipeNet[DstT].if_dst(self, cond_fun: Callable[[ttl.DstPipeIdentity], None])` | Call condition function for each pipe in the pipe net that is a destination. |
 | `ttl.PipeNet[DstT].is_src(self) -> bool` | Predicate: `True` on the current node if and only if it is a source coordinate of any pipe in the pipe net. |
 | `ttl.PipeNet[DstT].is_dst(self) -> bool` | Predicate: `True` on the current node if and only if it is in the destination range of any pipe in the pipe net. |
-| `ttl.PipeNet[DstT].destination_count(self) -> int` | Number of pipe records whose destination contains the current node; equal to the number of `if_dst` callback executions on that node. |
 | `ttl.PipeNet[DstT].is_active(self) -> bool` | Predicate: `True` on the current node if and only if `is_src()` or `is_dst()` is `True`. |
 | `@property ttl.SrcPipeIdentity[DstT].dst(self) -> DstT` | Get destination node or node range for pipe in `if_src`. |
 | `@property ttl.DstPipeIdentity.src(self) -> ttl.NodeCoord` | Get source node for pipe in `if_dst`. |

--- a/docs/sphinx/specs/TTLangSpecification.md
+++ b/docs/sphinx/specs/TTLangSpecification.md
@@ -54,6 +54,7 @@
 | 0.18 | 06/16/2026 | Add `ttl.raw_element_read` and `ttl.raw_element_write` |
 | 0.19 | 06/15/2026 | Unified-body `ttl.operation` with thread assignment and composition; add multi-kernel operation with explicit kernels |
 | 0.20 | 06/23/2026 | Add `ttl.exp` hardware flags and scaled exponential canonicalization |
+| 0.21 | 08/27/2026 | Add `ttl.PipeNet.destination_count()` |
 
 
 ## Introduction
@@ -806,6 +807,7 @@ The active predicates are only required for code that includes pipe-coupled comp
 | `ttl.PipeNet[DstT].if_dst(self, cond_fun: Callable[[ttl.DstPipeIdentity], None])` | Call condition function for each pipe in the pipe net that is a destination. |
 | `ttl.PipeNet[DstT].is_src(self) -> bool` | Predicate: `True` on the current node if and only if it is a source coordinate of any pipe in the pipe net. |
 | `ttl.PipeNet[DstT].is_dst(self) -> bool` | Predicate: `True` on the current node if and only if it is in the destination range of any pipe in the pipe net. |
+| `ttl.PipeNet[DstT].destination_count(self) -> int` | Number of pipe records whose destination contains the current node; equal to the number of `if_dst` callback executions on that node. |
 | `ttl.PipeNet[DstT].is_active(self) -> bool` | Predicate: `True` on the current node if and only if `is_src()` or `is_dst()` is `True`. |
 | `@property ttl.SrcPipeIdentity[DstT].dst(self) -> DstT` | Get destination node or node range for pipe in `if_src`. |
 | `@property ttl.DstPipeIdentity.src(self) -> ttl.NodeCoord` | Get source node for pipe in `if_dst`. |

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -165,6 +165,11 @@ constexpr llvm::StringLiteral kDFBAllocationsAttrName("ttl.dfb_allocations");
 constexpr llvm::StringLiteral
     kAssumedDFBAllocationGroupsAttrName("ttl.assumed_dfb_allocation_groups");
 
+/// Module attribute recording that per-launch-node DFB protocol-domain checks
+/// were skipped.
+constexpr llvm::StringLiteral kRelaxedDFBProtocolDomainVerificationAttrName(
+    "ttl.relaxed_dfb_protocol_domain_verification");
+
 /// Module attribute containing physical DFB configuration-epoch metadata.
 constexpr llvm::StringLiteral
     kDFBReconfigurationPlanAttrName("ttl.dfb_reconfiguration_plan");

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1100,6 +1100,22 @@ def TTL_IsDstOp : TTL_Op<"is_dst",
   let hasVerifier = 1;
 }
 
+def TTL_PipeNetDestinationCountOp : TTL_Op<"pipenet_destination_count", [Pure]> {
+  let summary = "Count PipeNet records targeting the current node";
+  let description = [{
+    Returns the number of records in the named PipeNet whose destination range
+    contains the current node. The count equals the number of times a
+    `ttl.pipenet_foreach_dst` region for the same PipeNet executes on that node.
+    For graph PipeNets, destination matching includes the current logical
+    device.
+  }];
+  let arguments = (ins I64Attr:$pipe_net_id,
+                        TTL_PipeNetRecordsAttr:$records);
+  let results = (outs Index:$result);
+  let assemblyFormat = "attr-dict `:` type($result)";
+  let hasVerifier = 1;
+}
+
 def TTL_IsActiveOp : TTL_Op<"is_active",
     [Pure, DeclareOpInterfaceMethods<TTL_PipeNetPredicateOpInterface>]> {
   let summary = "Predicate: current node is a source or destination in the PipeNet";

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1100,7 +1100,8 @@ def TTL_IsDstOp : TTL_Op<"is_dst",
   let hasVerifier = 1;
 }
 
-def TTL_PipeNetDestinationCountOp : TTL_Op<"pipenet_destination_count", [Pure]> {
+def TTL_PipeNetDestinationCountOp
+    : TTL_Op<"pipenet_destination_count", [Pure]> {
   let summary = "Count PipeNet records targeting the current node";
   let description = [{
     Returns the number of records in the named PipeNet whose destination range

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -901,7 +901,9 @@ def TTLVerifyPipeNetGuards
     program must enforce that correspondence. The later SPSC verifier still
     rejects a waited DFB with neither a compiler-visible push nor uncontracted
     external access that may contain one. PipeNet endpoint guards, transfer
-    correspondence, and synchronization schedules remain mandatory.
+    correspondence, and synchronization schedules remain mandatory. The
+    compiler emits a warning and records
+    `ttl.relaxed_dfb_protocol_domain_verification` on the module.
   }];
 }
 
@@ -1010,7 +1012,9 @@ def TTLVerifyDFBSPSC
     rejects every waited DFB without a compiler-visible push or uncontracted
     external access that may contain one. Finalized DFB identity,
     physical-index, and launch-grid preconditions remain mandatory. Strict
-    verification is the default.
+    verification is the default. When relaxation is enabled, the compiler
+    emits a warning and records
+    `ttl.relaxed_dfb_protocol_domain_verification` on the module.
   }];
 
   let dependentDialects = [];

--- a/include/ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h
+++ b/include/ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h
@@ -31,6 +31,25 @@ FailureOr<LocalPipeNetParticipantPlan>
 buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
                                  int64_t gridX, int64_t gridY);
 
+/// Record slices for each logical device in a grid-major device PipeNet.
+///
+/// Each transfer contributes one edge block containing one record per
+/// row-major launch node. Duplicate transfers remain distinct edge blocks.
+struct DevicePipeNetParticipantPlan {
+  int64_t gridX = 0;
+  int64_t gridArea = 0;
+  SmallVector<int64_t> edgeOffsetsByDevice;
+  SmallVector<int64_t> edgeBlocks;
+  SmallVector<int64_t> recordCountsByDevice;
+  SmallVector<int64_t> sourceDeviceIndices;
+  SmallVector<int64_t> destinationDeviceIndices;
+};
+
+/// Build logical-device edge-block slices for `role`.
+FailureOr<DevicePipeNetParticipantPlan>
+buildDevicePipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
+                                  int64_t gridX, int64_t gridY);
+
 } // namespace mlir::tt::ttl
 
 #endif // TTLANG_DIALECT_TTL_TRANSFORMS_PIPENETPARTICIPANTPLAN_H

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -3189,6 +3189,7 @@ mlir::LogicalResult mlir::tt::ttl::RawAddrOp::verify() {
 // PipeNetPredicateOpInterface implementations.
 //===----------------------------------------------------------------------===//
 
+// The ID and expanded records redundantly identify one PipeNet and must agree.
 template <typename PipeNetReferenceOp>
 static mlir::LogicalResult verifyPipeNetRecordIdentity(PipeNetReferenceOp op) {
   mlir::tt::ttl::PipeNetRecordsAttr records = op.getRecordsAttr();

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -3189,8 +3189,8 @@ mlir::LogicalResult mlir::tt::ttl::RawAddrOp::verify() {
 // PipeNetPredicateOpInterface implementations.
 //===----------------------------------------------------------------------===//
 
-template <typename PredicateOp>
-static mlir::LogicalResult verifyPipeNetPredicate(PredicateOp op) {
+template <typename PipeNetReferenceOp>
+static mlir::LogicalResult verifyPipeNetReference(PipeNetReferenceOp op) {
   mlir::tt::ttl::PipeNetRecordsAttr records = op.getRecordsAttr();
   int64_t pipeNetId = op.getPipeNetIdAttr().getInt();
   if (records && records.getPipeNetId() != pipeNetId) {
@@ -3206,15 +3206,19 @@ static mlir::LogicalResult verifyPipeNetPredicate(PredicateOp op) {
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsSrcOp::verify() {
-  return verifyPipeNetPredicate(*this);
+  return verifyPipeNetReference(*this);
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsDstOp::verify() {
-  return verifyPipeNetPredicate(*this);
+  return verifyPipeNetReference(*this);
+}
+
+mlir::LogicalResult mlir::tt::ttl::PipeNetDestinationCountOp::verify() {
+  return verifyPipeNetReference(*this);
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsActiveOp::verify() {
-  return verifyPipeNetPredicate(*this);
+  return verifyPipeNetReference(*this);
 }
 
 int64_t mlir::tt::ttl::IsSrcOp::getReferencedPipeNetId() {

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -3190,7 +3190,7 @@ mlir::LogicalResult mlir::tt::ttl::RawAddrOp::verify() {
 //===----------------------------------------------------------------------===//
 
 template <typename PipeNetReferenceOp>
-static mlir::LogicalResult verifyPipeNetReference(PipeNetReferenceOp op) {
+static mlir::LogicalResult verifyPipeNetRecordIdentity(PipeNetReferenceOp op) {
   mlir::tt::ttl::PipeNetRecordsAttr records = op.getRecordsAttr();
   int64_t pipeNetId = op.getPipeNetIdAttr().getInt();
   if (records && records.getPipeNetId() != pipeNetId) {
@@ -3198,6 +3198,15 @@ static mlir::LogicalResult verifyPipeNetReference(PipeNetReferenceOp op) {
            << "record table identifies PipeNet " << records.getPipeNetId()
            << ", but pipe_net_id is " << pipeNetId;
   }
+  return mlir::success();
+}
+
+template <typename PredicateOp>
+static mlir::LogicalResult verifyPipeNetPredicate(PredicateOp op) {
+  if (mlir::failed(verifyPipeNetRecordIdentity(op))) {
+    return mlir::failure();
+  }
+  mlir::tt::ttl::PipeNetRecordsAttr records = op.getRecordsAttr();
   if (records && !records.getPipes().front().getDeviceTransfer()) {
     return op.emitOpError()
            << "record table must identify logical-device transfers";
@@ -3206,19 +3215,19 @@ static mlir::LogicalResult verifyPipeNetReference(PipeNetReferenceOp op) {
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsSrcOp::verify() {
-  return verifyPipeNetReference(*this);
+  return verifyPipeNetPredicate(*this);
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsDstOp::verify() {
-  return verifyPipeNetReference(*this);
+  return verifyPipeNetPredicate(*this);
 }
 
 mlir::LogicalResult mlir::tt::ttl::PipeNetDestinationCountOp::verify() {
-  return verifyPipeNetReference(*this);
+  return verifyPipeNetRecordIdentity(*this);
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsActiveOp::verify() {
-  return verifyPipeNetReference(*this);
+  return verifyPipeNetPredicate(*this);
 }
 
 int64_t mlir::tt::ttl::IsSrcOp::getReferencedPipeNetId() {

--- a/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBAllocationLimits.cpp
@@ -132,6 +132,33 @@ FailureOr<uint64_t> getSynchronizedDFBResetStateBytes(ModuleOp module) {
   return *stateBytes;
 }
 
+// Both runtime mechanisms require the same resolved Blackhole architecture;
+// sharing this check prevents their diagnostics and accepted targets diverging.
+static LogicalResult validateBlackholeOnlyDFBTarget(ModuleOp module,
+                                                    Operation *operation,
+                                                    StringRef featureName) {
+  std::string failureReason;
+  FailureOr<std::optional<ttcore::Arch>> targetArch =
+      resolveTargetArch(module, failureReason);
+  if (failed(targetArch)) {
+    module.emitOpError(failureReason);
+    return failure();
+  }
+  if (!*targetArch) {
+    operation->emitOpError()
+        << "requires a resolved target architecture; " << featureName
+        << " is supported only for Blackhole";
+    return failure();
+  }
+  if (**targetArch == ttcore::Arch::Blackhole) {
+    return success();
+  }
+  operation->emitOpError()
+      << "is supported only for Blackhole; selected target is "
+      << ttcore::ArchAttr::get(module.getContext(), **targetArch);
+  return failure();
+}
+
 LogicalResult validateDFBReconfigurationTarget(ModuleOp module) {
   DFBReconfigurationOp firstBoundary;
   module.walk([&](DFBReconfigurationOp boundary) -> WalkResult {
@@ -141,21 +168,8 @@ LogicalResult validateDFBReconfigurationTarget(ModuleOp module) {
   if (!firstBoundary) {
     return success();
   }
-
-  std::string failureReason;
-  FailureOr<std::optional<ttcore::Arch>> targetArch =
-      resolveTargetArch(module, failureReason);
-  if (failed(targetArch)) {
-    module.emitOpError(failureReason);
-    return failure();
-  }
-  if (!*targetArch || **targetArch == ttcore::Arch::Blackhole) {
-    return success();
-  }
-  firstBoundary.emitOpError()
-      << "is supported only for Blackhole; selected target is "
-      << ttcore::ArchAttr::get(module.getContext(), **targetArch);
-  return failure();
+  return validateBlackholeOnlyDFBTarget(module, firstBoundary,
+                                        "DFB reconfiguration");
 }
 
 FailureOr<uint64_t> getDFBReconfigurationStateBytes(ModuleOp module) {
@@ -224,27 +238,8 @@ LogicalResult validateSynchronizedDFBResetTarget(ModuleOp module) {
   if (!firstReset) {
     return success();
   }
-
-  std::string failureReason;
-  FailureOr<std::optional<ttcore::Arch>> targetArch =
-      resolveTargetArch(module, failureReason);
-  if (failed(targetArch)) {
-    module.emitOpError(failureReason);
-    return failure();
-  }
-  if (!*targetArch) {
-    firstReset->emitOpError(
-        "requires a resolved target architecture; synchronized DFB reset is "
-        "supported only for Blackhole");
-    return failure();
-  }
-  if (**targetArch == ttcore::Arch::Blackhole) {
-    return success();
-  }
-  firstReset->emitOpError()
-      << "is supported only for Blackhole; selected target is "
-      << ttcore::ArchAttr::get(module.getContext(), **targetArch);
-  return failure();
+  return validateBlackholeOnlyDFBTarget(module, firstReset,
+                                        "synchronized DFB reset");
 }
 
 FailureOr<uint64_t> getDFBAllocationSizeBytes(CircularBufferType type,

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1348,8 +1348,8 @@ static LogicalResult collectLogicalDFBs(
       return WalkResult::interrupt();
     }
     dependsOnLaunchNode |=
-        isa<CoreXOp, CoreYOp, CreatePipeOp, PipeNetPredicateOpInterface>(
-            operation);
+        isa<CoreXOp, CoreYOp, CreatePipeOp, PipeNetPredicateOpInterface,
+            PipeNetDestinationCountOp>(operation);
     if (auto getId = dyn_cast<GetDfbIdOp>(operation);
         getId && failed(verifyPhysicalIndexUses(getId, identityAnalysis,
                                                 analysisFailure))) {

--- a/lib/Dialect/TTL/Transforms/DFBVerification.h
+++ b/lib/Dialect/TTL/Transforms/DFBVerification.h
@@ -5,13 +5,28 @@
 #ifndef TTLANG_LIB_DIALECT_TTL_TRANSFORMS_DFBVERIFICATION_H
 #define TTLANG_LIB_DIALECT_TTL_TRANSFORMS_DFBVERIFICATION_H
 
+#include "mlir/IR/BuiltinOps.h"
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+
 #include <cstdlib>
 
 namespace mlir::tt::ttl {
 
-/// Treats any defined `TTL_RELAX_DFB_SPSC` value as enabling relaxation.
-inline bool isDFBProtocolDomainVerificationRelaxed() {
-  return std::getenv("TTL_RELAX_DFB_SPSC") != nullptr;
+/// Returns whether protocol-domain verification is relaxed, recording one
+/// module marker and warning so the output cannot appear fully verified.
+inline bool applyDFBProtocolDomainVerificationRelaxation(ModuleOp module) {
+  if (std::getenv("TTL_RELAX_DFB_SPSC") == nullptr) {
+    return false;
+  }
+  if (!module->hasAttr(kRelaxedDFBProtocolDomainVerificationAttrName)) {
+    module->setAttr(kRelaxedDFBProtocolDomainVerificationAttrName,
+                    UnitAttr::get(module.getContext()));
+    module.emitWarning()
+        << "`TTL_RELAX_DFB_SPSC` disables per-launch-node DFB producer, "
+           "consumer, and wait correspondence checks; the program must "
+           "enforce the omitted ownership and synchronization requirements";
+  }
+  return true;
 }
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -10,6 +10,7 @@
 
 #include "ttlang/Analysis/ExecutionCountAnalysis.h"
 #include "ttlang/Analysis/IntegerExpressionEvaluator.h"
+#include "ttlang/Analysis/LoopIterationUtils.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttlang/Dialect/TTL/IR/TTL.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
@@ -1585,6 +1586,34 @@ getBranchLaunchNodeDomains(Value condition, const LaunchNodeDomain &current,
   return getBranchDomainsImpl(condition, current, state, coordCache);
 }
 
+static std::optional<LaunchNodeDomain>
+getSCFForLaunchNodeDomain(scf::ForOp forOp,
+                          const LaunchNodeDomain &current,
+                          const LaunchNodeDomainState &state) {
+  const std::set<LaunchNodeCoord> *candidateNodes =
+      current.getUpperBoundNodes();
+  if (!candidateNodes) {
+    return std::nullopt;
+  }
+
+  LaunchNodeDomain nonzeroTripCountDomain;
+  LoopInductionBindings emptyBindings;
+  for (LaunchNodeCoord node : *candidateNodes) {
+    std::optional<std::uint64_t> tripCount = tt::getLoopTripCount(
+        forOp, emptyBindings, [node, &state](Value value) {
+          return evaluateLaunchLocationContextValue(
+              value, LaunchExecutionLocation(node), &state);
+        });
+    if (!tripCount) {
+      return std::nullopt;
+    }
+    if (*tripCount > 0) {
+      nonzeroTripCountDomain.nodes.insert(node);
+    }
+  }
+  return current.intersectWith(nonzeroTripCountDomain);
+}
+
 /// Decode the PipeNet role metadata carried by one `ttl.pipenet_scope`.
 static std::optional<PipeNetScopeLaunchNodeDomains>
 getPipeNetScopeLaunchNodeDomains(PipeNetScopeOp scopeOp,
@@ -1740,6 +1769,12 @@ void LaunchNodeDomainAnalysis::visitRegionBranchControlFlowTransfer(
         unanalyzableOp =
             pickEarlierBySourceLoc(unanalyzableOp, domains.unanalyzableOp);
         narrowed = (*regionTo == 0) ? domains.thenDomain : domains.elseDomain;
+      })
+      .Case<scf::ForOp>([&](scf::ForOp forOp) {
+        if (std::optional<LaunchNodeDomain> loopDomain =
+                getSCFForLaunchNodeDomain(forOp, before.getDomain(), state)) {
+          narrowed = std::move(*loopDomain);
+        }
       })
       .Case<affine::AffineIfOp>([&](affine::AffineIfOp ifOp) {
         LaunchNodeDomainResult condDomain =

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -576,13 +576,13 @@ static std::optional<bool> evaluatePipeNetPredicateAtLaunchLocation(
 }
 
 static std::optional<std::uint64_t>
-evaluatePipeNetDestinationCountAtLaunchLocation(
-    PipeNetDestinationCountOp countOp,
+evaluatePipeNetRoleRecordCountAtLaunchLocation(
+    PipeNetRecordsAttr records, PipeRole role,
     const LaunchExecutionLocation &location) {
   std::uint64_t count = 0;
-  for (PipeRecordAttr record : countOp.getRecords().getPipes()) {
-    std::optional<bool> recordMatches = pipeRecordRoleMatchesAtLaunchLocation(
-        record, PipeRole::Destination, location);
+  for (PipeRecordAttr record : records.getPipes()) {
+    std::optional<bool> recordMatches =
+        pipeRecordRoleMatchesAtLaunchLocation(record, role, location);
     if (!recordMatches) {
       return std::nullopt;
     }
@@ -597,9 +597,10 @@ evaluateLaunchLocationContextValue(Value value,
                                    const LaunchNodeDomainState *state) {
   if (auto countOp = value.getDefiningOp<PipeNetDestinationCountOp>()) {
     std::optional<std::uint64_t> count =
-        evaluatePipeNetDestinationCountAtLaunchLocation(countOp, location);
-    return count ? std::optional<llvm::APInt>(llvm::APInt(
-                       IndexType::kInternalStorageBitWidth, *count))
+        evaluatePipeNetRoleRecordCountAtLaunchLocation(
+            countOp.getRecords(), PipeRole::Destination, location);
+    return count ? std::optional<llvm::APInt>(
+                       llvm::APInt(IndexType::kInternalStorageBitWidth, *count))
                  : std::nullopt;
   }
   if (auto predicate = value.getDefiningOp<PipeNetPredicateOpInterface>()) {
@@ -728,28 +729,12 @@ evaluateRegionInvocationCountAtLaunchLocation(
                : 0;
   }
   if (auto foreachSrcOp = dyn_cast<PipeNetForeachSrcOp>(parent)) {
-    std::uint64_t count = 0;
-    for (PipeRecordAttr record : foreachSrcOp.getRecords().getPipes()) {
-      std::optional<bool> matches = pipeRecordRoleMatchesAtLaunchLocation(
-          record, PipeRole::Source, location);
-      if (!matches) {
-        return std::nullopt;
-      }
-      count += *matches;
-    }
-    return count;
+    return evaluatePipeNetRoleRecordCountAtLaunchLocation(
+        foreachSrcOp.getRecords(), PipeRole::Source, location);
   }
   if (auto foreachDstOp = dyn_cast<PipeNetForeachDstOp>(parent)) {
-    std::uint64_t count = 0;
-    for (PipeRecordAttr record : foreachDstOp.getRecords().getPipes()) {
-      std::optional<bool> matches = pipeRecordRoleMatchesAtLaunchLocation(
-          record, PipeRole::Destination, location);
-      if (!matches) {
-        return std::nullopt;
-      }
-      count += *matches;
-    }
-    return count;
+    return evaluatePipeNetRoleRecordCountAtLaunchLocation(
+        foreachDstOp.getRecords(), PipeRole::Destination, location);
   }
   if (auto affineIfOp = dyn_cast<affine::AffineIfOp>(parent)) {
     LaunchNodeDomainResult trueDomain =
@@ -845,8 +830,8 @@ static bool dependsOnCoord(Value value, llvm::DenseMap<Value, bool> &cache) {
   bool result = false;
   if (op) {
     if (mlir::isa<CoreXOp, CoreYOp, PipeNetPredicateOpInterface,
-                  PipeNetDestinationCountOp,
-                  ttkernel::MyLogicalXOp, ttkernel::MyLogicalYOp>(op)) {
+                  PipeNetDestinationCountOp, ttkernel::MyLogicalXOp,
+                  ttkernel::MyLogicalYOp>(op)) {
       result = true;
     } else {
       for (Value operand : op->getOperands()) {
@@ -1587,8 +1572,7 @@ getBranchLaunchNodeDomains(Value condition, const LaunchNodeDomain &current,
 }
 
 static std::optional<LaunchNodeDomain>
-getSCFForLaunchNodeDomain(scf::ForOp forOp,
-                          const LaunchNodeDomain &current,
+getSCFForLaunchNodeDomain(scf::ForOp forOp, const LaunchNodeDomain &current,
                           const LaunchNodeDomainState &state) {
   const std::set<LaunchNodeCoord> *candidateNodes =
       current.getUpperBoundNodes();
@@ -1599,8 +1583,8 @@ getSCFForLaunchNodeDomain(scf::ForOp forOp,
   LaunchNodeDomain nonzeroTripCountDomain;
   LoopInductionBindings emptyBindings;
   for (LaunchNodeCoord node : *candidateNodes) {
-    std::optional<std::uint64_t> tripCount = tt::getLoopTripCount(
-        forOp, emptyBindings, [node, &state](Value value) {
+    std::optional<std::uint64_t> tripCount =
+        tt::getLoopTripCount(forOp, emptyBindings, [node, &state](Value value) {
           return evaluateLaunchLocationContextValue(
               value, LaunchExecutionLocation(node), &state);
         });

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -492,6 +492,9 @@ void LaunchNodeDomainState::initialize(ModuleOp module) {
   module.walk([&](PipeNetForeachDstOp op) {
     recordPipeNetRecords(op.getRecords(), op.getLoc());
   });
+  module.walk([&](PipeNetDestinationCountOp op) {
+    recordPipeNetRecords(op.getRecords(), op.getLoc());
+  });
   module.walk([&](SelectPipeSrcOp op) {
     recordPipeNetRecords(op.getRecords(), op.getLoc());
   });
@@ -571,10 +574,33 @@ static std::optional<bool> evaluatePipeNetPredicateAtLaunchLocation(
   return selected;
 }
 
+static std::optional<std::uint64_t>
+evaluatePipeNetDestinationCountAtLaunchLocation(
+    PipeNetDestinationCountOp countOp,
+    const LaunchExecutionLocation &location) {
+  std::uint64_t count = 0;
+  for (PipeRecordAttr record : countOp.getRecords().getPipes()) {
+    std::optional<bool> recordMatches = pipeRecordRoleMatchesAtLaunchLocation(
+        record, PipeRole::Destination, location);
+    if (!recordMatches) {
+      return std::nullopt;
+    }
+    count += *recordMatches;
+  }
+  return count;
+}
+
 static std::optional<llvm::APInt>
 evaluateLaunchLocationContextValue(Value value,
                                    const LaunchExecutionLocation &location,
                                    const LaunchNodeDomainState *state) {
+  if (auto countOp = value.getDefiningOp<PipeNetDestinationCountOp>()) {
+    std::optional<std::uint64_t> count =
+        evaluatePipeNetDestinationCountAtLaunchLocation(countOp, location);
+    return count ? std::optional<llvm::APInt>(llvm::APInt(
+                       IndexType::kInternalStorageBitWidth, *count))
+                 : std::nullopt;
+  }
   if (auto predicate = value.getDefiningOp<PipeNetPredicateOpInterface>()) {
     if (predicate.getReferencedRecords()) {
       std::optional<bool> selected =
@@ -818,6 +844,7 @@ static bool dependsOnCoord(Value value, llvm::DenseMap<Value, bool> &cache) {
   bool result = false;
   if (op) {
     if (mlir::isa<CoreXOp, CoreYOp, PipeNetPredicateOpInterface,
+                  PipeNetDestinationCountOp,
                   ttkernel::MyLogicalXOp, ttkernel::MyLogicalYOp>(op)) {
       result = true;
     } else {

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -575,6 +575,7 @@ static std::optional<bool> evaluatePipeNetPredicateAtLaunchLocation(
   return selected;
 }
 
+// Return no result unless every record's role is known at this location.
 static std::optional<std::uint64_t>
 evaluatePipeNetRoleRecordCountAtLaunchLocation(
     PipeNetRecordsAttr records, PipeRole role,
@@ -1571,6 +1572,7 @@ getBranchLaunchNodeDomains(Value condition, const LaunchNodeDomain &current,
   return getBranchDomainsImpl(condition, current, state, coordCache);
 }
 
+// Narrow only when every candidate node has an exact static trip count.
 static std::optional<LaunchNodeDomain>
 getSCFForLaunchNodeDomain(scf::ForOp forOp, const LaunchNodeDomain &current,
                           const LaunchNodeDomainState &state) {

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -3929,8 +3929,8 @@ static Value lowerDeviceRoleQuery(
                                   currentDevice, roleDevice);
         Value recordMatches = arith::AndIOp::create(
             builder, bodyLoc, coordinateMatches, deviceMatches);
-        Value accumulatedValue = accumulateRecord(
-            builder, bodyLoc, iterArgs.front(), recordMatches);
+        Value accumulatedValue =
+            accumulateRecord(builder, bodyLoc, iterArgs.front(), recordMatches);
         scf::YieldOp::create(builder, bodyLoc, accumulatedValue);
       });
   return loop.getResult(0);
@@ -3947,14 +3947,14 @@ static Value lowerSelectedRolePredicate(Operation *op,
       [](OpBuilder &builder, Location bodyLoc, Value accumulatedMatch,
          Value recordMatches) {
         return Value(arith::OrIOp::create(builder, bodyLoc, accumulatedMatch,
-                                         recordMatches));
+                                          recordMatches));
       },
       rewriter);
 }
 
-static Value lowerDeviceDestinationCount(
-    Operation *op, PipeNetRecordsAttr records,
-    ConversionPatternRewriter &rewriter) {
+static Value
+lowerDeviceDestinationCountByRecord(Operation *op, PipeNetRecordsAttr records,
+                                    ConversionPatternRewriter &rewriter) {
   Location loc = op->getLoc();
   Value initialCount = arith::ConstantIndexOp::create(rewriter, loc, 0);
   return lowerDeviceRoleQuery(
@@ -3964,27 +3964,51 @@ static Value lowerDeviceDestinationCount(
          Value recordMatches) {
         Value zero = arith::ConstantIndexOp::create(builder, bodyLoc, 0);
         Value one = arith::ConstantIndexOp::create(builder, bodyLoc, 1);
-        Value increment = arith::SelectOp::create(
-            builder, bodyLoc, recordMatches, one, zero);
+        Value increment =
+            arith::SelectOp::create(builder, bodyLoc, recordMatches, one, zero);
         return Value(arith::AddIOp::create(builder, bodyLoc, accumulatedCount,
-                                          increment));
+                                           increment));
       },
       rewriter);
 }
 
-static std::optional<Value>
+static FailureOr<Value>
+lowerPlannedDeviceDestinationCount(Operation *op, PipeNetRecordsAttr records,
+                                   ConversionPatternRewriter &rewriter) {
+  FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
+  if (failed(launchGrid)) {
+    return failure();
+  }
+  auto [gridX, gridY] = *launchGrid;
+  FailureOr<DevicePipeNetParticipantPlan> participantPlan =
+      buildDevicePipeNetParticipantPlan(records, PipeRole::Destination, gridX,
+                                        gridY);
+  if (failed(participantPlan)) {
+    return failure();
+  }
+
+  Location loc = op->getLoc();
+  DeviceDomainAttr deviceDomain =
+      records.getPipes().front().getDeviceTransfer().getDomain();
+  Value currentDevice = CurrentDeviceIndexOp::create(
+      rewriter, loc, rewriter.getIndexType(), deviceDomain);
+  return buildConstantIndexTableLookup(
+      rewriter, loc, participantPlan->recordCountsByDevice, currentDevice);
+}
+
+static FailureOr<Value>
 lowerLocalDestinationCount(Operation *op, PipeNetRecordsAttr records,
                            ConversionPatternRewriter &rewriter) {
   FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
   if (failed(launchGrid)) {
-    return std::nullopt;
+    return failure();
   }
   auto [gridX, gridY] = *launchGrid;
   FailureOr<LocalPipeNetParticipantPlan> participantPlan =
       buildLocalPipeNetParticipantPlan(records, PipeRole::Destination, gridX,
                                        gridY);
   if (failed(participantPlan)) {
-    return std::nullopt;
+    return failure();
   }
 
   Location loc = op->getLoc();
@@ -3994,10 +4018,8 @@ lowerLocalDestinationCount(Operation *op, PipeNetRecordsAttr records,
       ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
   Value gridXValue =
       arith::ConstantIndexOp::create(rewriter, loc, participantPlan->gridX);
-  Value nodeRowOffset =
-      arith::MulIOp::create(rewriter, loc, nodeY, gridXValue);
-  Value nodeIndex =
-      arith::AddIOp::create(rewriter, loc, nodeRowOffset, nodeX);
+  Value nodeRowOffset = arith::MulIOp::create(rewriter, loc, nodeY, gridXValue);
+  Value nodeIndex = arith::AddIOp::create(rewriter, loc, nodeRowOffset, nodeX);
   return buildConstantIndexTableLookup(
       rewriter, loc, participantPlan->recordCountsByNode, nodeIndex);
 }
@@ -4087,12 +4109,17 @@ struct PipeNetDestinationCountLowering
                   ConversionPatternRewriter &rewriter) const override {
     PipeNetRecordsAttr records = op.getRecords();
     if (records.getPipes().front().getDeviceTransfer()) {
-      rewriter.replaceOp(op,
-                         lowerDeviceDestinationCount(op, records, rewriter));
+      FailureOr<Value> plannedCount =
+          lowerPlannedDeviceDestinationCount(op, records, rewriter);
+      rewriter.replaceOp(
+          op, succeeded(plannedCount)
+                  ? *plannedCount
+                  : lowerDeviceDestinationCountByRecord(op, records, rewriter));
       return success();
     }
-    if (std::optional<Value> localCount =
-            lowerLocalDestinationCount(op, records, rewriter)) {
+    FailureOr<Value> localCount =
+        lowerLocalDestinationCount(op, records, rewriter);
+    if (succeeded(localCount)) {
       rewriter.replaceOp(op, *localCount);
       return success();
     }
@@ -4106,10 +4133,9 @@ struct PipeNetDestinationCountLowering
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
     Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
     for (PipeRecordAttr record : records.getPipes()) {
-      PipeType pipeType = getPipeTypeFromRecord(
-          rewriter.getContext(), record, records.getPipeNetId());
-      Value matches =
-          buildDstMatch(rewriter, loc, nodeX, nodeY, pipeType);
+      PipeType pipeType = getPipeTypeFromRecord(rewriter.getContext(), record,
+                                                records.getPipeNetId());
+      Value matches = buildDstMatch(rewriter, loc, nodeX, nodeY, pipeType);
       Value increment =
           arith::SelectOp::create(rewriter, loc, matches, one, zero);
       count = arith::AddIOp::create(rewriter, loc, count, increment);

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -3853,7 +3853,8 @@ struct PipeRoleTables {
 };
 
 static PipeRoleTables buildPipeRoleTables(PipeNetRecordsAttr records,
-                                          PipeRole role) {
+                                          PipeRole role,
+                                          bool deduplicateRecords) {
   using PipeRoleRecord =
       std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>;
   SmallVector<PipeRoleRecord> roleRecords;
@@ -3868,8 +3869,10 @@ static PipeRoleTables buildPipeRoleTables(PipeNetRecordsAttr records,
     }
   }
   llvm::sort(roleRecords);
-  roleRecords.erase(std::unique(roleRecords.begin(), roleRecords.end()),
-                    roleRecords.end());
+  if (deduplicateRecords) {
+    roleRecords.erase(std::unique(roleRecords.begin(), roleRecords.end()),
+                      roleRecords.end());
+  }
 
   PipeRoleTables tables;
   for (auto [minX, minY, maxX, maxY, deviceIndex] : roleRecords) {
@@ -3887,7 +3890,8 @@ static Value lowerSelectedRolePredicate(Operation *op,
                                         PipeRole role,
                                         ConversionPatternRewriter &rewriter) {
   Location loc = op->getLoc();
-  PipeRoleTables tables = buildPipeRoleTables(records, role);
+  PipeRoleTables tables =
+      buildPipeRoleTables(records, role, /*deduplicateRecords=*/true);
   DeviceTransferAttr transfer = records.getPipes().front().getDeviceTransfer();
   assert(transfer && "selected device role requires device transfer records");
 
@@ -3928,6 +3932,122 @@ static Value lowerSelectedRolePredicate(Operation *op,
         scf::YieldOp::create(builder, bodyLoc, accumulatedMatch);
       });
   return loop.getResult(0);
+}
+
+static Value lowerDeviceDestinationCount(
+    Operation *op, PipeNetRecordsAttr records,
+    ConversionPatternRewriter &rewriter) {
+  Location loc = op->getLoc();
+  PipeRoleTables tables = buildPipeRoleTables(
+      records, PipeRole::Destination, /*deduplicateRecords=*/false);
+  DeviceTransferAttr transfer = records.getPipes().front().getDeviceTransfer();
+  assert(transfer && "selected destination count requires device transfers");
+
+  Value nodeX =
+      ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+  Value nodeY =
+      ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+  Value currentDevice = CurrentDeviceIndexOp::create(
+      rewriter, loc, rewriter.getIndexType(), transfer.getDomain());
+  Value lower = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value upper = arith::ConstantIndexOp::create(rewriter, loc, tables.size());
+  Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
+  Value initialCount = arith::ConstantIndexOp::create(rewriter, loc, 0);
+
+  auto loop = scf::ForOp::create(
+      rewriter, loc, lower, upper, step, ValueRange{initialCount},
+      [&](OpBuilder &builder, Location bodyLoc, Value recordIndex,
+          ValueRange iterArgs) {
+        Value minX = buildConstantIndexTableLookup(builder, bodyLoc,
+                                                   tables.minX, recordIndex);
+        Value minY = buildConstantIndexTableLookup(builder, bodyLoc,
+                                                   tables.minY, recordIndex);
+        Value maxX = buildConstantIndexTableLookup(builder, bodyLoc,
+                                                   tables.maxX, recordIndex);
+        Value maxY = buildConstantIndexTableLookup(builder, bodyLoc,
+                                                   tables.maxY, recordIndex);
+        Value roleDevice = buildConstantIndexTableLookup(
+            builder, bodyLoc, tables.deviceIndex, recordIndex);
+        Value coordinateMatches = buildNodeRangeMatch(
+            builder, bodyLoc, nodeX, nodeY, minX, minY, maxX, maxY);
+        Value deviceMatches =
+            arith::CmpIOp::create(builder, bodyLoc, arith::CmpIPredicate::eq,
+                                  currentDevice, roleDevice);
+        Value recordMatches = arith::AndIOp::create(
+            builder, bodyLoc, coordinateMatches, deviceMatches);
+        Value zero = arith::ConstantIndexOp::create(builder, bodyLoc, 0);
+        Value one = arith::ConstantIndexOp::create(builder, bodyLoc, 1);
+        Value increment = arith::SelectOp::create(
+            builder, bodyLoc, recordMatches, one, zero);
+        Value count =
+            arith::AddIOp::create(builder, bodyLoc, iterArgs.front(), increment);
+        scf::YieldOp::create(builder, bodyLoc, count);
+      });
+  return loop.getResult(0);
+}
+
+struct LocalDestinationCountTable {
+  int64_t gridX = 0;
+  SmallVector<int64_t> counts;
+};
+
+static std::optional<LocalDestinationCountTable>
+buildLocalDestinationCountTable(Operation *op, PipeNetRecordsAttr records) {
+  std::optional<std::pair<int64_t, int64_t>> maybeGrid = getLaunchGrid(op);
+  if (!maybeGrid) {
+    return std::nullopt;
+  }
+  auto [gridX, gridY] = *maybeGrid;
+  std::optional<int64_t> maybeGridArea = llvm::checkedMul(gridX, gridY);
+  if (!maybeGridArea) {
+    return std::nullopt;
+  }
+
+  LocalDestinationCountTable table;
+  table.gridX = gridX;
+  table.counts.assign(static_cast<std::size_t>(*maybeGridArea), 0);
+  for (PipeRecordAttr record : records.getPipes()) {
+    if (record.getDeviceTransfer()) {
+      return std::nullopt;
+    }
+    PipeType pipeType = getPipeTypeFromRecord(
+        op->getContext(), record, records.getPipeNetId());
+    int64_t minX = std::min(pipeType.getDstStartX(), pipeType.getDstEndX());
+    int64_t minY = std::min(pipeType.getDstStartY(), pipeType.getDstEndY());
+    int64_t maxX = std::max(pipeType.getDstStartX(), pipeType.getDstEndX());
+    int64_t maxY = std::max(pipeType.getDstStartY(), pipeType.getDstEndY());
+    if (minX < 0 || minY < 0 || maxX >= gridX || maxY >= gridY) {
+      return std::nullopt;
+    }
+    for (int64_t nodeY = minY; nodeY <= maxY; ++nodeY) {
+      for (int64_t nodeX = minX; nodeX <= maxX; ++nodeX) {
+        ++table.counts[static_cast<std::size_t>(nodeY * gridX + nodeX)];
+      }
+    }
+  }
+  return table;
+}
+
+static std::optional<Value>
+lowerLocalDestinationCount(Operation *op, PipeNetRecordsAttr records,
+                           ConversionPatternRewriter &rewriter) {
+  std::optional<LocalDestinationCountTable> maybeTable =
+      buildLocalDestinationCountTable(op, records);
+  if (!maybeTable) {
+    return std::nullopt;
+  }
+  Location loc = op->getLoc();
+  Value nodeX =
+      ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+  Value nodeY =
+      ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+  Value gridX =
+      arith::ConstantIndexOp::create(rewriter, loc, maybeTable->gridX);
+  Value nodeRowOffset = arith::MulIOp::create(rewriter, loc, nodeY, gridX);
+  Value nodeIndex =
+      arith::AddIOp::create(rewriter, loc, nodeRowOffset, nodeX);
+  return buildConstantIndexTableLookup(rewriter, loc, maybeTable->counts,
+                                       nodeIndex);
 }
 
 // Lower a per-pipe-role predicate op to the OR of per-pipe matches in the
@@ -4003,6 +4123,47 @@ struct IsActiveLowering : IsRoleLoweringBase<IsActiveOp> {
           Value isDst = buildDstMatch(builder, loc, coreX, coreY, pipeType);
           return Value(arith::OrIOp::create(builder, loc, isSrc, isDst));
         });
+  }
+};
+
+struct PipeNetDestinationCountLowering
+    : OpConversionPattern<PipeNetDestinationCountOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(PipeNetDestinationCountOp op, OpAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    PipeNetRecordsAttr records = op.getRecords();
+    if (records.getPipes().front().getDeviceTransfer()) {
+      rewriter.replaceOp(op,
+                         lowerDeviceDestinationCount(op, records, rewriter));
+      return success();
+    }
+    if (std::optional<Value> localCount =
+            lowerLocalDestinationCount(op, records, rewriter)) {
+      rewriter.replaceOp(op, *localCount);
+      return success();
+    }
+
+    Location loc = op.getLoc();
+    Value nodeX =
+        ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
+    Value nodeY =
+        ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
+    Value count = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    for (PipeRecordAttr record : records.getPipes()) {
+      PipeType pipeType = getPipeTypeFromRecord(
+          rewriter.getContext(), record, records.getPipeNetId());
+      Value matches =
+          buildDstMatch(rewriter, loc, nodeX, nodeY, pipeType);
+      Value increment =
+          arith::SelectOp::create(rewriter, loc, matches, one, zero);
+      count = arith::AddIOp::create(rewriter, loc, count, increment);
+    }
+    rewriter.replaceOp(op, count);
+    return success();
   }
 };
 
@@ -5167,6 +5328,8 @@ void populatePipeLoweringPatterns(RewritePatternSet &patterns,
       typeConverter, patterns.getContext());
   patterns.add<IsSrcLowering, IsDstLowering, IsActiveLowering>(
       typeConverter, patterns.getContext(), &pipeNetIndex);
+  patterns.add<PipeNetDestinationCountLowering>(typeConverter,
+                                                patterns.getContext());
 }
 
 } // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -3854,7 +3854,8 @@ struct DevicePipeRoleTables {
   std::size_t size() const { return minX.size(); }
 };
 
-// Predicates collapse duplicates; counts retain one entry per callback.
+// Boolean predicates ignore duplicates, while counts retain each record
+// because every matching record executes one destination callback.
 static DevicePipeRoleTables
 buildDevicePipeRoleTables(PipeNetRecordsAttr records, PipeRole role,
                           bool deduplicateRecords) {
@@ -3888,7 +3889,8 @@ buildDevicePipeRoleTables(PipeNetRecordsAttr records, PipeRole role,
   return tables;
 }
 
-// Keep boolean predicates and counts on identical record-selection semantics.
+// Share coordinate and device matching between boolean predicates and counts;
+// callers select OR or addition and whether duplicate records contribute.
 static Value lowerDeviceRoleQuery(
     Operation *op, PipeNetRecordsAttr records, PipeRole role,
     bool deduplicateRecords, Value initialValue,
@@ -4114,8 +4116,8 @@ struct PipeNetDestinationCountLowering
   matchAndRewrite(PipeNetDestinationCountOp op, OpAdaptor,
                   ConversionPatternRewriter &rewriter) const override {
     PipeNetRecordsAttr records = op.getRecords();
-    // Prefer static tables for regular records and retain exact matching for
-    // every representation the participant planners reject.
+    // Regular records use one indexed lookup. Irregular records retain exact
+    // per-record matching because they cannot use the participant table.
     if (records.getPipes().front().getDeviceTransfer()) {
       FailureOr<Value> plannedCount =
           lowerPlannedDeviceDestinationCount(op, records, rewriter);

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -28,6 +28,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 #include "ttlang/Dialect/TTL/Transforms/LiveIntervalUtils.h"
 #include "ttlang/Dialect/TTL/Transforms/PipeConstants.h"
+#include "ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h"
 #include "ttlang/Dialect/TTL/Transforms/PipeRecordLoweringUtils.h"
 #include "ttlang/Dialect/TTL/Transforms/PipeTransferAnalysis.h"
 #include "ttlang/Dialect/TTL/Transforms/TransferProvenance.h"
@@ -3986,68 +3987,34 @@ static Value lowerDeviceDestinationCount(
   return loop.getResult(0);
 }
 
-struct LocalDestinationCountTable {
-  int64_t gridX = 0;
-  SmallVector<int64_t> counts;
-};
-
-static std::optional<LocalDestinationCountTable>
-buildLocalDestinationCountTable(Operation *op, PipeNetRecordsAttr records) {
-  std::optional<std::pair<int64_t, int64_t>> maybeGrid = getLaunchGrid(op);
-  if (!maybeGrid) {
-    return std::nullopt;
-  }
-  auto [gridX, gridY] = *maybeGrid;
-  std::optional<int64_t> maybeGridArea = llvm::checkedMul(gridX, gridY);
-  if (!maybeGridArea) {
-    return std::nullopt;
-  }
-
-  LocalDestinationCountTable table;
-  table.gridX = gridX;
-  table.counts.assign(static_cast<std::size_t>(*maybeGridArea), 0);
-  for (PipeRecordAttr record : records.getPipes()) {
-    if (record.getDeviceTransfer()) {
-      return std::nullopt;
-    }
-    PipeType pipeType = getPipeTypeFromRecord(
-        op->getContext(), record, records.getPipeNetId());
-    int64_t minX = std::min(pipeType.getDstStartX(), pipeType.getDstEndX());
-    int64_t minY = std::min(pipeType.getDstStartY(), pipeType.getDstEndY());
-    int64_t maxX = std::max(pipeType.getDstStartX(), pipeType.getDstEndX());
-    int64_t maxY = std::max(pipeType.getDstStartY(), pipeType.getDstEndY());
-    if (minX < 0 || minY < 0 || maxX >= gridX || maxY >= gridY) {
-      return std::nullopt;
-    }
-    for (int64_t nodeY = minY; nodeY <= maxY; ++nodeY) {
-      for (int64_t nodeX = minX; nodeX <= maxX; ++nodeX) {
-        ++table.counts[static_cast<std::size_t>(nodeY * gridX + nodeX)];
-      }
-    }
-  }
-  return table;
-}
-
 static std::optional<Value>
 lowerLocalDestinationCount(Operation *op, PipeNetRecordsAttr records,
                            ConversionPatternRewriter &rewriter) {
-  std::optional<LocalDestinationCountTable> maybeTable =
-      buildLocalDestinationCountTable(op, records);
-  if (!maybeTable) {
+  FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
+  if (failed(launchGrid)) {
     return std::nullopt;
   }
+  auto [gridX, gridY] = *launchGrid;
+  FailureOr<LocalPipeNetParticipantPlan> participantPlan =
+      buildLocalPipeNetParticipantPlan(records, PipeRole::Destination, gridX,
+                                       gridY);
+  if (failed(participantPlan)) {
+    return std::nullopt;
+  }
+
   Location loc = op->getLoc();
   Value nodeX =
       ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
   Value nodeY =
       ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
-  Value gridX =
-      arith::ConstantIndexOp::create(rewriter, loc, maybeTable->gridX);
-  Value nodeRowOffset = arith::MulIOp::create(rewriter, loc, nodeY, gridX);
+  Value gridXValue =
+      arith::ConstantIndexOp::create(rewriter, loc, participantPlan->gridX);
+  Value nodeRowOffset =
+      arith::MulIOp::create(rewriter, loc, nodeY, gridXValue);
   Value nodeIndex =
       arith::AddIOp::create(rewriter, loc, nodeRowOffset, nodeX);
-  return buildConstantIndexTableLookup(rewriter, loc, maybeTable->counts,
-                                       nodeIndex);
+  return buildConstantIndexTableLookup(
+      rewriter, loc, participantPlan->recordCountsByNode, nodeIndex);
 }
 
 // Lower a per-pipe-role predicate op to the OR of per-pipe matches in the

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -3843,7 +3843,7 @@ struct IfDstLowering : OpConversionPattern<IfDstOp> {
   }
 };
 
-struct PipeRoleTables {
+struct DevicePipeRoleTables {
   SmallVector<int64_t> minX;
   SmallVector<int64_t> minY;
   SmallVector<int64_t> maxX;
@@ -3853,9 +3853,9 @@ struct PipeRoleTables {
   std::size_t size() const { return minX.size(); }
 };
 
-static PipeRoleTables buildPipeRoleTables(PipeNetRecordsAttr records,
-                                          PipeRole role,
-                                          bool deduplicateRecords) {
+static DevicePipeRoleTables
+buildDevicePipeRoleTables(PipeNetRecordsAttr records, PipeRole role,
+                          bool deduplicateRecords) {
   using PipeRoleRecord =
       std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>;
   SmallVector<PipeRoleRecord> roleRecords;
@@ -3863,7 +3863,7 @@ static PipeRoleTables buildPipeRoleTables(PipeNetRecordsAttr records,
     for (const PipeRecordRoleFacts &facts :
          getPipeRecordRoleFacts(record, role)) {
       assert(facts.device &&
-             "selected device role requires device transfer records");
+             "device role query requires device transfer records");
       roleRecords.emplace_back(
           facts.minX, facts.minY, facts.maxX, facts.maxY,
           getLogicalDeviceIndex(facts.deviceDomain, facts.device));
@@ -3875,7 +3875,7 @@ static PipeRoleTables buildPipeRoleTables(PipeNetRecordsAttr records,
                       roleRecords.end());
   }
 
-  PipeRoleTables tables;
+  DevicePipeRoleTables tables;
   for (auto [minX, minY, maxX, maxY, deviceIndex] : roleRecords) {
     tables.minX.push_back(minX);
     tables.minY.push_back(minY);
@@ -3886,15 +3886,17 @@ static PipeRoleTables buildPipeRoleTables(PipeNetRecordsAttr records,
   return tables;
 }
 
-static Value lowerSelectedRolePredicate(Operation *op,
-                                        PipeNetRecordsAttr records,
-                                        PipeRole role,
-                                        ConversionPatternRewriter &rewriter) {
+static Value lowerDeviceRoleRecords(
+    Operation *op, PipeNetRecordsAttr records, PipeRole role,
+    bool deduplicateRecords, Value initialValue,
+    llvm::function_ref<Value(OpBuilder &, Location, Value, Value)>
+        accumulateRecord,
+    ConversionPatternRewriter &rewriter) {
   Location loc = op->getLoc();
-  PipeRoleTables tables =
-      buildPipeRoleTables(records, role, /*deduplicateRecords=*/true);
+  DevicePipeRoleTables tables =
+      buildDevicePipeRoleTables(records, role, deduplicateRecords);
   DeviceTransferAttr transfer = records.getPipes().front().getDeviceTransfer();
-  assert(transfer && "selected device role requires device transfer records");
+  assert(transfer && "device role query requires device transfer records");
 
   Value nodeX =
       ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
@@ -3905,10 +3907,9 @@ static Value lowerSelectedRolePredicate(Operation *op,
   Value lower = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value upper = arith::ConstantIndexOp::create(rewriter, loc, tables.size());
   Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
-  Value initialMatch = arith::ConstantIntOp::create(rewriter, loc, 0, 1);
 
   auto loop = scf::ForOp::create(
-      rewriter, loc, lower, upper, step, ValueRange{initialMatch},
+      rewriter, loc, lower, upper, step, ValueRange{initialValue},
       [&](OpBuilder &builder, Location bodyLoc, Value recordIndex,
           ValueRange iterArgs) {
         Value minX = buildConstantIndexTableLookup(builder, bodyLoc,
@@ -3928,63 +3929,47 @@ static Value lowerSelectedRolePredicate(Operation *op,
                                   currentDevice, roleDevice);
         Value recordMatches = arith::AndIOp::create(
             builder, bodyLoc, coordinateMatches, deviceMatches);
-        Value accumulatedMatch = arith::OrIOp::create(
+        Value accumulatedValue = accumulateRecord(
             builder, bodyLoc, iterArgs.front(), recordMatches);
-        scf::YieldOp::create(builder, bodyLoc, accumulatedMatch);
+        scf::YieldOp::create(builder, bodyLoc, accumulatedValue);
       });
   return loop.getResult(0);
+}
+
+static Value lowerSelectedRolePredicate(Operation *op,
+                                        PipeNetRecordsAttr records,
+                                        PipeRole role,
+                                        ConversionPatternRewriter &rewriter) {
+  Location loc = op->getLoc();
+  Value initialMatch = arith::ConstantIntOp::create(rewriter, loc, 0, 1);
+  return lowerDeviceRoleRecords(
+      op, records, role, /*deduplicateRecords=*/true, initialMatch,
+      [](OpBuilder &builder, Location bodyLoc, Value accumulatedMatch,
+         Value recordMatches) {
+        return Value(arith::OrIOp::create(builder, bodyLoc, accumulatedMatch,
+                                         recordMatches));
+      },
+      rewriter);
 }
 
 static Value lowerDeviceDestinationCount(
     Operation *op, PipeNetRecordsAttr records,
     ConversionPatternRewriter &rewriter) {
   Location loc = op->getLoc();
-  PipeRoleTables tables = buildPipeRoleTables(
-      records, PipeRole::Destination, /*deduplicateRecords=*/false);
-  DeviceTransferAttr transfer = records.getPipes().front().getDeviceTransfer();
-  assert(transfer && "selected destination count requires device transfers");
-
-  Value nodeX =
-      ttk::MyLogicalXOp::create(rewriter, loc, rewriter.getIndexType());
-  Value nodeY =
-      ttk::MyLogicalYOp::create(rewriter, loc, rewriter.getIndexType());
-  Value currentDevice = CurrentDeviceIndexOp::create(
-      rewriter, loc, rewriter.getIndexType(), transfer.getDomain());
-  Value lower = arith::ConstantIndexOp::create(rewriter, loc, 0);
-  Value upper = arith::ConstantIndexOp::create(rewriter, loc, tables.size());
-  Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
   Value initialCount = arith::ConstantIndexOp::create(rewriter, loc, 0);
-
-  auto loop = scf::ForOp::create(
-      rewriter, loc, lower, upper, step, ValueRange{initialCount},
-      [&](OpBuilder &builder, Location bodyLoc, Value recordIndex,
-          ValueRange iterArgs) {
-        Value minX = buildConstantIndexTableLookup(builder, bodyLoc,
-                                                   tables.minX, recordIndex);
-        Value minY = buildConstantIndexTableLookup(builder, bodyLoc,
-                                                   tables.minY, recordIndex);
-        Value maxX = buildConstantIndexTableLookup(builder, bodyLoc,
-                                                   tables.maxX, recordIndex);
-        Value maxY = buildConstantIndexTableLookup(builder, bodyLoc,
-                                                   tables.maxY, recordIndex);
-        Value roleDevice = buildConstantIndexTableLookup(
-            builder, bodyLoc, tables.deviceIndex, recordIndex);
-        Value coordinateMatches = buildNodeRangeMatch(
-            builder, bodyLoc, nodeX, nodeY, minX, minY, maxX, maxY);
-        Value deviceMatches =
-            arith::CmpIOp::create(builder, bodyLoc, arith::CmpIPredicate::eq,
-                                  currentDevice, roleDevice);
-        Value recordMatches = arith::AndIOp::create(
-            builder, bodyLoc, coordinateMatches, deviceMatches);
+  return lowerDeviceRoleRecords(
+      op, records, PipeRole::Destination, /*deduplicateRecords=*/false,
+      initialCount,
+      [](OpBuilder &builder, Location bodyLoc, Value accumulatedCount,
+         Value recordMatches) {
         Value zero = arith::ConstantIndexOp::create(builder, bodyLoc, 0);
         Value one = arith::ConstantIndexOp::create(builder, bodyLoc, 1);
         Value increment = arith::SelectOp::create(
             builder, bodyLoc, recordMatches, one, zero);
-        Value count =
-            arith::AddIOp::create(builder, bodyLoc, iterArgs.front(), increment);
-        scf::YieldOp::create(builder, bodyLoc, count);
-      });
-  return loop.getResult(0);
+        return Value(arith::AddIOp::create(builder, bodyLoc, accumulatedCount,
+                                          increment));
+      },
+      rewriter);
 }
 
 static std::optional<Value>

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -3843,6 +3843,7 @@ struct IfDstLowering : OpConversionPattern<IfDstOp> {
   }
 };
 
+// Parallel arrays map each record field to the constant-table lookup primitive.
 struct DevicePipeRoleTables {
   SmallVector<int64_t> minX;
   SmallVector<int64_t> minY;
@@ -3853,6 +3854,7 @@ struct DevicePipeRoleTables {
   std::size_t size() const { return minX.size(); }
 };
 
+// Predicates collapse duplicates; counts retain one entry per callback.
 static DevicePipeRoleTables
 buildDevicePipeRoleTables(PipeNetRecordsAttr records, PipeRole role,
                           bool deduplicateRecords) {
@@ -3886,6 +3888,7 @@ buildDevicePipeRoleTables(PipeNetRecordsAttr records, PipeRole role,
   return tables;
 }
 
+// Keep boolean predicates and counts on identical record-selection semantics.
 static Value lowerDeviceRoleQuery(
     Operation *op, PipeNetRecordsAttr records, PipeRole role,
     bool deduplicateRecords, Value initialValue,
@@ -3952,6 +3955,7 @@ static Value lowerSelectedRolePredicate(Operation *op,
       rewriter);
 }
 
+// Irregular graph records require matching each record at runtime.
 static Value
 lowerDeviceDestinationCountByRecord(Operation *op, PipeNetRecordsAttr records,
                                     ConversionPatternRewriter &rewriter) {
@@ -3972,6 +3976,7 @@ lowerDeviceDestinationCountByRecord(Operation *op, PipeNetRecordsAttr records,
       rewriter);
 }
 
+// Dense grid-major records permit one device-indexed count-table lookup.
 static FailureOr<Value>
 lowerPlannedDeviceDestinationCount(Operation *op, PipeNetRecordsAttr records,
                                    ConversionPatternRewriter &rewriter) {
@@ -3996,6 +4001,7 @@ lowerPlannedDeviceDestinationCount(Operation *op, PipeNetRecordsAttr records,
       rewriter, loc, participantPlan->recordCountsByDevice, currentDevice);
 }
 
+// Local records permit one launch-node-indexed count-table lookup.
 static FailureOr<Value>
 lowerLocalDestinationCount(Operation *op, PipeNetRecordsAttr records,
                            ConversionPatternRewriter &rewriter) {
@@ -4108,6 +4114,8 @@ struct PipeNetDestinationCountLowering
   matchAndRewrite(PipeNetDestinationCountOp op, OpAdaptor,
                   ConversionPatternRewriter &rewriter) const override {
     PipeNetRecordsAttr records = op.getRecords();
+    // Prefer static tables for regular records and retain exact matching for
+    // every representation the participant planners reject.
     if (records.getPipes().front().getDeviceTransfer()) {
       FailureOr<Value> plannedCount =
           lowerPlannedDeviceDestinationCount(op, records, rewriter);

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -3886,7 +3886,7 @@ buildDevicePipeRoleTables(PipeNetRecordsAttr records, PipeRole role,
   return tables;
 }
 
-static Value lowerDeviceRoleRecords(
+static Value lowerDeviceRoleQuery(
     Operation *op, PipeNetRecordsAttr records, PipeRole role,
     bool deduplicateRecords, Value initialValue,
     llvm::function_ref<Value(OpBuilder &, Location, Value, Value)>
@@ -3942,7 +3942,7 @@ static Value lowerSelectedRolePredicate(Operation *op,
                                         ConversionPatternRewriter &rewriter) {
   Location loc = op->getLoc();
   Value initialMatch = arith::ConstantIntOp::create(rewriter, loc, 0, 1);
-  return lowerDeviceRoleRecords(
+  return lowerDeviceRoleQuery(
       op, records, role, /*deduplicateRecords=*/true, initialMatch,
       [](OpBuilder &builder, Location bodyLoc, Value accumulatedMatch,
          Value recordMatches) {
@@ -3957,7 +3957,7 @@ static Value lowerDeviceDestinationCount(
     ConversionPatternRewriter &rewriter) {
   Location loc = op->getLoc();
   Value initialCount = arith::ConstantIndexOp::create(rewriter, loc, 0);
-  return lowerDeviceRoleRecords(
+  return lowerDeviceRoleQuery(
       op, records, PipeRole::Destination, /*deduplicateRecords=*/false,
       initialCount,
       [](OpBuilder &builder, Location bodyLoc, Value accumulatedCount,

--- a/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
@@ -241,6 +241,8 @@ tryLowerGridMajorPipeNetForeach(ForeachOp op, RewriterBase &rewriter,
   if (failed(tables)) {
     return false;
   }
+  // Retain direct matching when the dense table is not smaller than the
+  // original record list.
   if (tables->recordCountsByDevice.size() >= records.getPipes().size()) {
     return false;
   }

--- a/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
@@ -15,12 +15,9 @@
 #include "ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h"
 #include "ttlang/Dialect/TTL/Transforms/PipeRecordLoweringUtils.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/CheckedArithmetic.h"
 
 #include <cstdint>
-#include <limits>
 #include <map>
-#include <optional>
 #include <utility>
 
 namespace mlir::tt::ttl {
@@ -36,116 +33,6 @@ constexpr size_t kPipeNetForeachDirectRecordLimit = 4;
 static bool shouldLowerPipeNetForeachDirect(PipeNetRecordsAttr records) {
   return !records.getPipes().front().getDeviceTransfer() &&
          records.getPipes().size() <= kPipeNetForeachDirectRecordLimit;
-}
-
-struct GridMajorPipeRecordIndexTables {
-  int64_t gridX = 0;
-  int64_t gridArea = 0;
-  SmallVector<int64_t> edgeOffsetsByDevice;
-  SmallVector<int64_t> edgeBlocks;
-  SmallVector<int64_t> sourceDeviceIndices;
-  SmallVector<int64_t> destinationDeviceIndices;
-};
-
-static FailureOr<int64_t> getDeviceCount(DeviceDomainAttr domain) {
-  std::uint64_t deviceCount = 1;
-  for (DeviceDomainComponentAttr component : domain.getComponents()) {
-    for (int64_t extent : component.getExtent().asArrayRef()) {
-      if (extent <= 0) {
-        return failure();
-      }
-      std::optional<std::uint64_t> maybeDeviceCount = llvm::checkedMulUnsigned(
-          deviceCount, static_cast<std::uint64_t>(extent));
-      if (!maybeDeviceCount ||
-          *maybeDeviceCount >
-              static_cast<std::uint64_t>(std::numeric_limits<int64_t>::max())) {
-        return failure();
-      }
-      deviceCount = *maybeDeviceCount;
-    }
-  }
-  return static_cast<int64_t>(deviceCount);
-}
-
-static FailureOr<GridMajorPipeRecordIndexTables>
-buildGridMajorPipeRecordIndexTables(PipeNetRecordsAttr records, PipeRole role,
-                                    Operation *op) {
-  DeviceTransferAttr firstTransfer =
-      records.getPipes().front().getDeviceTransfer();
-  if (!firstTransfer) {
-    return failure();
-  }
-  FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
-  FailureOr<int64_t> deviceCount = getDeviceCount(firstTransfer.getDomain());
-  if (failed(launchGrid) || failed(deviceCount)) {
-    return failure();
-  }
-  auto [gridX, gridY] = *launchGrid;
-  std::optional<int64_t> maybeGridArea = llvm::checkedMul(gridX, gridY);
-  if (!maybeGridArea || records.getPipes().size() % *maybeGridArea != 0) {
-    return failure();
-  }
-  int64_t gridArea = *maybeGridArea;
-  if (records.getPipes().size() >
-      static_cast<std::size_t>(std::numeric_limits<int64_t>::max())) {
-    return failure();
-  }
-  int64_t recordCount = static_cast<int64_t>(records.getPipes().size());
-  int64_t edgeCount = recordCount / gridArea;
-  if (*deviceCount >= recordCount) {
-    return failure();
-  }
-
-  SmallVector<SmallVector<int64_t>> edgeBlocksByDevice(
-      static_cast<std::size_t>(*deviceCount));
-  GridMajorPipeRecordIndexTables tables;
-  tables.gridX = gridX;
-  tables.gridArea = gridArea;
-  tables.sourceDeviceIndices.reserve(edgeCount);
-  tables.destinationDeviceIndices.reserve(edgeCount);
-  for (int64_t edgeBlock = 0; edgeBlock < edgeCount; ++edgeBlock) {
-    int64_t blockStart = edgeBlock * gridArea;
-    PipeRecordAttr firstRecord = records.getPipes()[blockStart];
-    DeviceTransferAttr transfer = firstRecord.getDeviceTransfer();
-    if (!transfer || transfer.getDomain() != firstTransfer.getDomain()) {
-      return failure();
-    }
-    for (int64_t nodeIndex = 0; nodeIndex < gridArea; ++nodeIndex) {
-      PipeRecordAttr record = records.getPipes()[blockStart + nodeIndex];
-      int64_t expectedX = nodeIndex % gridX;
-      int64_t expectedY = nodeIndex / gridX;
-      if (record.getDeviceTransfer() != transfer ||
-          record.getSrcX() != expectedX || record.getSrcY() != expectedY ||
-          record.getDstStartX() != expectedX ||
-          record.getDstStartY() != expectedY ||
-          record.getDstEndX() != expectedX ||
-          record.getDstEndY() != expectedY) {
-        return failure();
-      }
-    }
-
-    int64_t sourceDeviceIndex = getLogicalDeviceIndex(
-        transfer.getDomain(), transfer.getEdge().getSource());
-    int64_t destinationDeviceIndex = getLogicalDeviceIndex(
-        transfer.getDomain(), transfer.getEdge().getDestination());
-    if (sourceDeviceIndex < 0 || sourceDeviceIndex >= *deviceCount ||
-        destinationDeviceIndex < 0 || destinationDeviceIndex >= *deviceCount) {
-      return failure();
-    }
-    tables.sourceDeviceIndices.push_back(sourceDeviceIndex);
-    tables.destinationDeviceIndices.push_back(destinationDeviceIndex);
-    int64_t endpointDeviceIndex =
-        role == PipeRole::Source ? sourceDeviceIndex : destinationDeviceIndex;
-    edgeBlocksByDevice[endpointDeviceIndex].push_back(edgeBlock);
-  }
-
-  tables.edgeOffsetsByDevice.push_back(0);
-  for (ArrayRef<int64_t> edgeBlocks : edgeBlocksByDevice) {
-    tables.edgeBlocks.append(edgeBlocks.begin(), edgeBlocks.end());
-    tables.edgeOffsetsByDevice.push_back(
-        static_cast<int64_t>(tables.edgeBlocks.size()));
-  }
-  return tables;
 }
 
 template <typename SelectOp, typename SelectedType>
@@ -179,7 +66,7 @@ buildSelectedPipe(OpBuilder &builder, Location loc, PipeNetRecordsAttr records,
 template <typename SelectOp, typename SelectedType>
 static SelectOp buildGridMajorSelectedPipe(
     OpBuilder &builder, Location loc, PipeNetRecordsAttr records,
-    const GridMajorPipeRecordIndexTables &tables, Value recordIndex,
+    const DevicePipeNetParticipantPlan &tables, Value recordIndex,
     Value edgeBlock, Value nodeX, Value nodeY) {
   Value one = arith::ConstantIndexOp::create(builder, loc, 1);
   Value sourceDeviceIndex = buildConstantIndexTableLookup(
@@ -256,7 +143,7 @@ static RecordInductionMap buildLocalRecordInductionValues(
 
 static RecordInductionMap buildGridMajorRecordInductionValues(
     PipeNetRecordsAttr records, PipeRole role,
-    const GridMajorPipeRecordIndexTables &tables) {
+    const DevicePipeNetParticipantPlan &tables) {
   RecordInductionMap inductionValues;
   for (auto [iterationIndex, edgeBlock] : llvm::enumerate(tables.edgeBlocks)) {
     int64_t blockStart = edgeBlock * tables.gridArea;
@@ -343,12 +230,21 @@ tryLowerGridMajorPipeNetForeach(ForeachOp op, RewriterBase &rewriter,
                                 PipeNetRecordSelection recordSelection,
                                 SmallVectorImpl<Operation *> &foreachWorklist) {
   PipeNetRecordsAttr records = op.getRecords();
-  FailureOr<GridMajorPipeRecordIndexTables> tables =
-      buildGridMajorPipeRecordIndexTables(records, role, op);
+  FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
+  if (failed(launchGrid)) {
+    return false;
+  }
+  auto [launchGridX, launchGridY] = *launchGrid;
+  FailureOr<DevicePipeNetParticipantPlan> tables =
+      buildDevicePipeNetParticipantPlan(records, role, launchGridX,
+                                        launchGridY);
   if (failed(tables)) {
     return false;
   }
-  const GridMajorPipeRecordIndexTables &tableData = *tables;
+  if (tables->recordCountsByDevice.size() >= records.getPipes().size()) {
+    return false;
+  }
+  const DevicePipeNetParticipantPlan &tableData = *tables;
   Location loc = op.getLoc();
   rewriter.setInsertionPoint(op);
   Value nodeX =

--- a/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
@@ -111,6 +111,11 @@ buildDevicePipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
   int64_t gridArea = *maybeGridArea;
   int64_t recordCount = static_cast<int64_t>(records.getPipes().size());
   int64_t edgeCount = recordCount / gridArea;
+  // Dense device tables must remain O(records); an N-device gather has N-1
+  // records and requires one additional zero-count table entry.
+  if (*deviceCount - 1 > recordCount) {
+    return failure();
+  }
   SmallVector<SmallVector<int64_t>> edgeBlocksByDevice(
       static_cast<std::size_t>(*deviceCount));
   DevicePipeNetParticipantPlan plan;

--- a/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
@@ -16,7 +16,9 @@
 
 namespace mlir::tt::ttl {
 
-static FailureOr<int64_t> getDeviceCount(DeviceDomainAttr domain) {
+// Planner table indices are int64_t, so domain products must fit that type.
+static FailureOr<int64_t>
+getRepresentableDeviceCount(DeviceDomainAttr domain) {
   std::uint64_t deviceCount = 1;
   for (DeviceDomainComponentAttr component : domain.getComponents()) {
     for (int64_t extent : component.getExtent().asArrayRef()) {
@@ -99,7 +101,8 @@ buildDevicePipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
   if (!firstTransfer) {
     return failure();
   }
-  FailureOr<int64_t> deviceCount = getDeviceCount(firstTransfer.getDomain());
+  FailureOr<int64_t> deviceCount =
+      getRepresentableDeviceCount(firstTransfer.getDomain());
   std::optional<int64_t> maybeGridArea = llvm::checkedMul(gridX, gridY);
   if (failed(deviceCount) || !maybeGridArea ||
       records.getPipes().size() % *maybeGridArea != 0 ||

--- a/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
@@ -17,8 +17,7 @@
 namespace mlir::tt::ttl {
 
 // Planner table indices are int64_t, so domain products must fit that type.
-static FailureOr<int64_t>
-getRepresentableDeviceCount(DeviceDomainAttr domain) {
+static FailureOr<int64_t> getRepresentableDeviceCount(DeviceDomainAttr domain) {
   std::uint64_t deviceCount = 1;
   for (DeviceDomainComponentAttr component : domain.getComponents()) {
     for (int64_t extent : component.getExtent().asArrayRef()) {

--- a/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
@@ -111,7 +111,7 @@ buildDevicePipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
   int64_t gridArea = *maybeGridArea;
   int64_t recordCount = static_cast<int64_t>(records.getPipes().size());
   int64_t edgeCount = recordCount / gridArea;
-  // Dense device tables must remain O(records); an N-device gather has N-1
+  // Dense device tables must remain O(records); a 1x1 N-device gather has N-1
   // records and requires one additional zero-count table entry.
   if (*deviceCount - 1 > recordCount) {
     return failure();

--- a/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
@@ -16,6 +16,26 @@
 
 namespace mlir::tt::ttl {
 
+static FailureOr<int64_t> getDeviceCount(DeviceDomainAttr domain) {
+  std::uint64_t deviceCount = 1;
+  for (DeviceDomainComponentAttr component : domain.getComponents()) {
+    for (int64_t extent : component.getExtent().asArrayRef()) {
+      if (extent <= 0) {
+        return failure();
+      }
+      std::optional<std::uint64_t> maybeDeviceCount = llvm::checkedMulUnsigned(
+          deviceCount, static_cast<std::uint64_t>(extent));
+      if (!maybeDeviceCount ||
+          *maybeDeviceCount >
+              static_cast<std::uint64_t>(std::numeric_limits<int64_t>::max())) {
+        return failure();
+      }
+      deviceCount = *maybeDeviceCount;
+    }
+  }
+  return static_cast<int64_t>(deviceCount);
+}
+
 FailureOr<LocalPipeNetParticipantPlan>
 buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
                                  int64_t gridX, int64_t gridY) {
@@ -62,6 +82,85 @@ buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
         static_cast<int64_t>(plan.recordIndices.size()));
     plan.recordCountsByNode.push_back(static_cast<int64_t>(nodeRecords.size()));
     plan.recordIndices.append(nodeRecords.begin(), nodeRecords.end());
+  }
+  return plan;
+}
+
+FailureOr<DevicePipeNetParticipantPlan>
+buildDevicePipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
+                                  int64_t gridX, int64_t gridY) {
+  if (records.getPipes().empty() ||
+      (role != PipeRole::Source && role != PipeRole::Destination) ||
+      gridX <= 0 || gridY <= 0) {
+    return failure();
+  }
+  DeviceTransferAttr firstTransfer =
+      records.getPipes().front().getDeviceTransfer();
+  if (!firstTransfer) {
+    return failure();
+  }
+  FailureOr<int64_t> deviceCount = getDeviceCount(firstTransfer.getDomain());
+  std::optional<int64_t> maybeGridArea = llvm::checkedMul(gridX, gridY);
+  if (failed(deviceCount) || !maybeGridArea ||
+      records.getPipes().size() % *maybeGridArea != 0 ||
+      records.getPipes().size() >
+          static_cast<std::size_t>(std::numeric_limits<int64_t>::max())) {
+    return failure();
+  }
+
+  int64_t gridArea = *maybeGridArea;
+  int64_t recordCount = static_cast<int64_t>(records.getPipes().size());
+  int64_t edgeCount = recordCount / gridArea;
+  SmallVector<SmallVector<int64_t>> edgeBlocksByDevice(
+      static_cast<std::size_t>(*deviceCount));
+  DevicePipeNetParticipantPlan plan;
+  plan.gridX = gridX;
+  plan.gridArea = gridArea;
+  plan.sourceDeviceIndices.reserve(edgeCount);
+  plan.destinationDeviceIndices.reserve(edgeCount);
+  for (int64_t edgeBlock = 0; edgeBlock < edgeCount; ++edgeBlock) {
+    int64_t blockStart = edgeBlock * gridArea;
+    PipeRecordAttr firstRecord = records.getPipes()[blockStart];
+    DeviceTransferAttr transfer = firstRecord.getDeviceTransfer();
+    if (!transfer || transfer.getDomain() != firstTransfer.getDomain()) {
+      return failure();
+    }
+    for (int64_t nodeIndex = 0; nodeIndex < gridArea; ++nodeIndex) {
+      PipeRecordAttr record = records.getPipes()[blockStart + nodeIndex];
+      int64_t expectedX = nodeIndex % gridX;
+      int64_t expectedY = nodeIndex / gridX;
+      if (record.getDeviceTransfer() != transfer ||
+          record.getSrcX() != expectedX || record.getSrcY() != expectedY ||
+          record.getDstStartX() != expectedX ||
+          record.getDstStartY() != expectedY ||
+          record.getDstEndX() != expectedX ||
+          record.getDstEndY() != expectedY) {
+        return failure();
+      }
+    }
+
+    int64_t sourceDeviceIndex = getLogicalDeviceIndex(
+        transfer.getDomain(), transfer.getEdge().getSource());
+    int64_t destinationDeviceIndex = getLogicalDeviceIndex(
+        transfer.getDomain(), transfer.getEdge().getDestination());
+    if (sourceDeviceIndex < 0 || sourceDeviceIndex >= *deviceCount ||
+        destinationDeviceIndex < 0 || destinationDeviceIndex >= *deviceCount) {
+      return failure();
+    }
+    plan.sourceDeviceIndices.push_back(sourceDeviceIndex);
+    plan.destinationDeviceIndices.push_back(destinationDeviceIndex);
+    int64_t endpointDeviceIndex =
+        role == PipeRole::Source ? sourceDeviceIndex : destinationDeviceIndex;
+    edgeBlocksByDevice[endpointDeviceIndex].push_back(edgeBlock);
+  }
+
+  plan.edgeOffsetsByDevice.push_back(0);
+  for (ArrayRef<int64_t> edgeBlocks : edgeBlocksByDevice) {
+    plan.edgeBlocks.append(edgeBlocks.begin(), edgeBlocks.end());
+    plan.recordCountsByDevice.push_back(
+        static_cast<int64_t>(edgeBlocks.size()));
+    plan.edgeOffsetsByDevice.push_back(
+        static_cast<int64_t>(plan.edgeBlocks.size()));
   }
   return plan;
 }

--- a/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
@@ -310,7 +310,7 @@ struct TTLVerifyDFBSPSCPass
       return;
     }
 
-    if (isDFBProtocolDomainVerificationRelaxed()) {
+    if (applyDFBProtocolDomainVerificationRelaxation(module)) {
       return;
     }
 

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -2476,6 +2476,8 @@ struct TTLVerifyPipeNetGuardsPass
     : impl::TTLVerifyPipeNetGuardsBase<TTLVerifyPipeNetGuardsPass> {
   void runOnOperation() override {
     ModuleOp module = getOperation();
+    bool protocolDomainVerificationRelaxed =
+        applyDFBProtocolDomainVerificationRelaxation(module);
 
     const PipeNetLaunchNodeDomainAnalysis &launchNodeAnalysis =
         getAnalysis<PipeNetLaunchNodeDomainAnalysis>();
@@ -2525,7 +2527,7 @@ struct TTLVerifyPipeNetGuardsPass
       }
     });
 
-    if (!isDFBProtocolDomainVerificationRelaxed()) {
+    if (!protocolDomainVerificationRelaxed) {
       verifyCBWaits(state);
     }
     if (state.sawError) {

--- a/python/sim/pipe.py
+++ b/python/sim/pipe.py
@@ -483,6 +483,10 @@ class PipeNet(Generic[DstT]):
                 return True
         return False
 
+    def destination_count(self) -> int:
+        """Return the number of records targeting the current node."""
+        return sum(1 for pipe in self._pipes if node_in_dst_range(pipe.dst))
+
     def if_src(self, cond_fun: Callable[[SrcPipeIdentity[DstT]], None]) -> None:
         """Execute condition function for each pipe where current node is source.
 

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -1164,9 +1164,7 @@ class TTLGenericCompiler(TTCompilerBase):
                 IntegerType.get_signless(64, self.ctx), pipenet.pipe_net_id
             )
         }
-        if method == "destination_count":
-            arguments["records"] = self._get_pipe_net_records_attr(pipenet)
-        elif pipenet.is_graph:
+        if method == "destination_count" or pipenet.is_graph:
             arguments["records"] = self._get_pipe_net_records_attr(pipenet)
         return self._PIPENET_QUERY_OPS[method](**arguments)
 

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -777,9 +777,9 @@ class TTLGenericCompiler(TTCompilerBase):
                 if self._is_pipenet_callback_call(node):
                     return self._handle_pipenet_callback(node)
 
-                # Check for PipeNet.is_src/is_dst/is_active predicate calls
-                if self._is_pipenet_predicate_call(node):
-                    return self._handle_pipenet_predicate(node)
+                # Check for PipeNet role and record-count query calls.
+                if self._is_pipenet_query_call(node):
+                    return self._handle_pipenet_query(node)
 
                 if self._is_device_domain_predicate_call(node):
                     return self._handle_device_domain_predicate(node)
@@ -1129,16 +1129,17 @@ class TTLGenericCompiler(TTCompilerBase):
 
         return isinstance(val, PipeNet)
 
-    _PIPENET_PREDICATE_OPS = {
+    _PIPENET_QUERY_OPS = {
         "is_src": ttl.is_src,
         "is_dst": ttl.is_dst,
         "is_active": ttl.is_active,
+        "destination_count": ttl.pipenet_destination_count,
     }
 
-    def _is_pipenet_predicate_call(self, node):
+    def _is_pipenet_query_call(self, node):
         if not isinstance(node.func, ast.Attribute):
             return False
-        if node.func.attr not in self._PIPENET_PREDICATE_OPS:
+        if node.func.attr not in self._PIPENET_QUERY_OPS:
             return False
         if not isinstance(node.func.value, ast.Name):
             return False
@@ -1149,7 +1150,7 @@ class TTLGenericCompiler(TTCompilerBase):
 
         return isinstance(tbl[node.func.value.id], PipeNet)
 
-    def _handle_pipenet_predicate(self, node):
+    def _handle_pipenet_query(self, node):
         from ..pipe import PipeNet
 
         method = node.func.attr
@@ -1158,14 +1159,16 @@ class TTLGenericCompiler(TTCompilerBase):
         assert isinstance(pipenet, PipeNet)
         if node.args or node.keywords:
             self._raise_error(node, f"PipeNet.{method}() takes no arguments")
-        return self._PIPENET_PREDICATE_OPS[method](
-            pipe_net_id=IntegerAttr.get(
+        arguments = {
+            "pipe_net_id": IntegerAttr.get(
                 IntegerType.get_signless(64, self.ctx), pipenet.pipe_net_id
-            ),
-            records=(
-                self._get_pipe_net_records_attr(pipenet) if pipenet.is_graph else None
-            ),
-        )
+            )
+        }
+        if method == "destination_count":
+            arguments["records"] = self._get_pipe_net_records_attr(pipenet)
+        elif pipenet.is_graph:
+            arguments["records"] = self._get_pipe_net_records_attr(pipenet)
+        return self._PIPENET_QUERY_OPS[method](**arguments)
 
     def _device_domain_call_receiver(self, node):
         if not isinstance(node.func, ast.Attribute):

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -777,7 +777,6 @@ class TTLGenericCompiler(TTCompilerBase):
                 if self._is_pipenet_callback_call(node):
                     return self._handle_pipenet_callback(node)
 
-                # Check for PipeNet role and record-count query calls.
                 if self._is_pipenet_query_call(node):
                     return self._handle_pipenet_query(node)
 

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -1136,6 +1136,7 @@ class TTLGenericCompiler(TTCompilerBase):
     }
 
     def _is_pipenet_query_call(self, node):
+        """Return whether node calls a supported query on a bound PipeNet."""
         if not isinstance(node.func, ast.Attribute):
             return False
         if node.func.attr not in self._PIPENET_QUERY_OPS:
@@ -1150,6 +1151,7 @@ class TTLGenericCompiler(TTCompilerBase):
         return isinstance(tbl[node.func.value.id], PipeNet)
 
     def _handle_pipenet_query(self, node):
+        """Lower a zero-argument PipeNet query with its static record table."""
         from ..pipe import PipeNet
 
         method = node.func.attr

--- a/python/ttl/pipe.py
+++ b/python/ttl/pipe.py
@@ -401,6 +401,17 @@ class PipeNet:
             "The compiler handles this method specially."
         )
 
+    def destination_count(self) -> int:
+        """Return the number of records targeting the current node.
+
+        The result equals the number of times ``if_dst`` executes its callback
+        on the current node.
+        """
+        raise RuntimeError(
+            "PipeNet.destination_count() should only be called inside a TTL "
+            "kernel. The compiler handles this method specially."
+        )
+
     def is_active(self) -> bool:
         """Boolean predicate: current node is either a source or a
         destination of any pipe in this net. Lowers to `ttl.is_active`."""

--- a/test/python/fabric/test_ccl.py
+++ b/test/python/fabric/test_ccl.py
@@ -252,6 +252,8 @@ def _make_point_to_point_operation(
 
 
 def _make_graph_destination_count_operation(mesh_shape: tuple[int, ...]):
+    device_count = prod(mesh_shape)
+    maximum_destination_count = device_count - 1
     device_domain = ttl.DeviceDomain(mesh_shape)
     root_device = tuple(0 for _extent in mesh_shape)
     gather_net = ttl.PipeNet(
@@ -260,23 +262,36 @@ def _make_graph_destination_count_operation(mesh_shape: tuple[int, ...]):
 
     @ttl.operation(grid=(1, 1), device_domain=device_domain)
     def graph_destination_count(inp, out):
-        output_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+        send_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+        receive_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(1, 1), block_count=maximum_destination_count
+        )
 
         @ttl.compute()
         def idle_compute():
             pass
 
         @ttl.datamovement()
-        def write_count():
-            destination_count = gather_net.destination_count()
-            with output_dfb.reserve() as output_block:
-                ttl.copy(inp[destination_count, 0], output_block).wait()
-            with output_dfb.wait() as output_block:
-                ttl.copy(output_block, out[0, 0]).wait()
+        def sender_node():
+            def send(pipe):
+                with send_dfb.reserve() as send_block:
+                    ttl.copy(inp[0, 0], send_block).wait()
+                with send_dfb.wait() as send_block:
+                    ttl.copy(send_block, pipe).wait()
+
+            gather_net.if_src(send)
 
         @ttl.datamovement()
-        def idle_brisc():
-            pass
+        def receiver_node():
+            def receive(pipe):
+                with receive_dfb.reserve() as receive_block:
+                    ttl.copy(pipe, receive_block).wait()
+
+            gather_net.if_dst(receive)
+
+            for receive_index in range(gather_net.destination_count()):
+                with receive_dfb.wait() as receive_block:
+                    ttl.copy(receive_block, out[receive_index, 0]).wait()
 
     return graph_destination_count
 
@@ -926,18 +941,22 @@ def test_graph_destination_count(
 ):
     device_count = prod(fabric_mesh_shape)
     operation = _make_graph_destination_count_operation(fabric_mesh_shape)
-    per_device_input = torch.cat(
+    inp_torch = torch.cat(
         [
             torch.full(
                 (TILE_SIZE, TILE_SIZE),
-                fill_value=destination_count,
+                fill_value=device_index + 1,
                 dtype=torch_dtype,
             )
-            for destination_count in range(device_count)
+            for device_index in range(device_count)
         ]
     )
-    inp_torch = per_device_input.repeat(device_count, 1)
-    out_torch = torch.zeros(device_count * TILE_SIZE, TILE_SIZE, dtype=torch_dtype)
+    maximum_destination_count = device_count - 1
+    out_torch = torch.zeros(
+        device_count * maximum_destination_count * TILE_SIZE,
+        TILE_SIZE,
+        dtype=torch_dtype,
+    )
 
     with _open_collective_mesh(fabric_mesh_shape) as mesh:
         inp = _mesh_tensor(mesh, inp_torch, ttnn_dtype)
@@ -948,7 +967,12 @@ def test_graph_destination_count(
         result = _compose(mesh, out)
 
     expected = torch.zeros_like(out_torch)
-    expected[:TILE_SIZE, :] = device_count - 1
+    for receive_index, source_device_index in enumerate(range(1, device_count)):
+        source_value = source_device_index + 1
+        expected[
+            receive_index * TILE_SIZE : (receive_index + 1) * TILE_SIZE,
+            :,
+        ] = source_value
     assert_allclose(result.float(), expected.float(), rtol=rtol, atol=atol)
 
 

--- a/test/python/fabric/test_ccl.py
+++ b/test/python/fabric/test_ccl.py
@@ -251,6 +251,36 @@ def _make_point_to_point_operation(
     return point_to_point
 
 
+def _make_graph_destination_count_operation(mesh_shape: tuple[int, ...]):
+    device_domain = ttl.DeviceDomain(mesh_shape)
+    root_device = tuple(0 for _extent in mesh_shape)
+    gather_net = ttl.PipeNet(
+        graph=ttl.TransferGraph.gather(device_domain, root=root_device)
+    )
+
+    @ttl.operation(grid=(1, 1), device_domain=device_domain)
+    def graph_destination_count(inp, out):
+        output_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+
+        @ttl.compute()
+        def idle_compute():
+            pass
+
+        @ttl.datamovement()
+        def write_count():
+            destination_count = gather_net.destination_count()
+            with output_dfb.reserve() as output_block:
+                ttl.copy(inp[destination_count, 0], output_block).wait()
+            with output_dfb.wait() as output_block:
+                ttl.copy(output_block, out[0, 0]).wait()
+
+        @ttl.datamovement()
+        def idle_brisc():
+            pass
+
+    return graph_destination_count
+
+
 def _flatten_device_index(coordinates, mesh_shape: tuple[int, ...]) -> int:
     device_index = 0
     for coordinate, extent in zip(coordinates, mesh_shape):
@@ -883,6 +913,42 @@ def test_point_to_point(
     assert len(set(program_cache_entry_counts)) == 1
     expected = torch.zeros_like(inp_torch)
     expected[(device_count - 1) * TILE_SIZE :, :] = inp_torch[:TILE_SIZE, :]
+    assert_allclose(result.float(), expected.float(), rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("torch_dtype,ttnn_dtype,rtol,atol", FABRIC_DTYPES)
+def test_graph_destination_count(
+    fabric_mesh_shape,
+    torch_dtype,
+    ttnn_dtype,
+    rtol,
+    atol,
+):
+    device_count = prod(fabric_mesh_shape)
+    operation = _make_graph_destination_count_operation(fabric_mesh_shape)
+    per_device_input = torch.cat(
+        [
+            torch.full(
+                (TILE_SIZE, TILE_SIZE),
+                fill_value=destination_count,
+                dtype=torch_dtype,
+            )
+            for destination_count in range(device_count)
+        ]
+    )
+    inp_torch = per_device_input.repeat(device_count, 1)
+    out_torch = torch.zeros(device_count * TILE_SIZE, TILE_SIZE, dtype=torch_dtype)
+
+    with _open_collective_mesh(fabric_mesh_shape) as mesh:
+        inp = _mesh_tensor(mesh, inp_torch, ttnn_dtype)
+        out = _mesh_tensor(mesh, out_torch, ttnn_dtype)
+
+        operation(inp, out)
+
+        result = _compose(mesh, out)
+
+    expected = torch.zeros_like(out_torch)
+    expected[:TILE_SIZE, :] = device_count - 1
     assert_allclose(result.float(), expected.float(), rtol=rtol, atol=atol)
 
 

--- a/test/python/fabric/test_ccl.py
+++ b/test/python/fabric/test_ccl.py
@@ -252,6 +252,7 @@ def _make_point_to_point_operation(
 
 
 def _make_graph_destination_count_operation(mesh_shape: tuple[int, ...]):
+    """Build a gather whose root consumes every expanded destination record."""
     device_count = prod(mesh_shape)
     maximum_destination_count = device_count - 1
     device_domain = ttl.DeviceDomain(mesh_shape)
@@ -931,6 +932,7 @@ def test_point_to_point(
     assert_allclose(result.float(), expected.float(), rtol=rtol, atol=atol)
 
 
+# Graph counts must select every record received by the gather root.
 @pytest.mark.parametrize("torch_dtype,ttnn_dtype,rtol,atol", FABRIC_DTYPES)
 def test_graph_destination_count(
     fabric_mesh_shape,

--- a/test/python/invalid/pipenet_destination_count_invalid.py
+++ b/test/python/invalid/pipenet_destination_count_invalid.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: ttnn
+# UNSUPPORTED: system-darwin
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_CASE=positional not %python %s 2>&1 | FileCheck %s --check-prefix=POSITIONAL
+# RUN: env TTLANG_COMPILE_ONLY=1 TTLANG_CASE=keyword not %python %s 2>&1 | FileCheck %s --check-prefix=KEYWORD
+
+"""Invalid PipeNet destination-count calls report source diagnostics."""
+
+import os
+
+import pytest
+import ttl
+
+pytest.importorskip("ttnn", exc_type=ImportError)
+
+GATHER_NET = ttl.PipeNet(
+    [
+        ttl.Pipe(src=(0, 0), dst=(2, 0)),
+        ttl.Pipe(src=(1, 0), dst=(2, 0)),
+    ]
+)
+
+
+@ttl.operation(grid=(3, 1))
+def positional_argument():
+    @ttl.datamovement()
+    def data_movement():
+        GATHER_NET.destination_count(0)
+
+
+@ttl.operation(grid=(3, 1))
+def keyword_argument():
+    @ttl.datamovement()
+    def data_movement():
+        GATHER_NET.destination_count(unexpected=0)
+
+
+if __name__ == "__main__":
+    if os.environ["TTLANG_CASE"] == "positional":
+        positional_argument()
+    else:
+        keyword_argument()
+
+
+# POSITIONAL: error: PipeNet.destination_count() takes no arguments
+# POSITIONAL: GATHER_NET.destination_count(0)
+# KEYWORD: error: PipeNet.destination_count() takes no arguments
+# KEYWORD: GATHER_NET.destination_count(unexpected=0)

--- a/test/python/invalid/pipenet_destination_count_invalid.py
+++ b/test/python/invalid/pipenet_destination_count_invalid.py
@@ -24,6 +24,7 @@ GATHER_NET = ttl.PipeNet(
 )
 
 
+# A positional argument must be rejected at its source call.
 @ttl.operation(grid=(3, 1))
 def positional_argument():
     @ttl.datamovement()
@@ -31,6 +32,7 @@ def positional_argument():
         GATHER_NET.destination_count(0)
 
 
+# A keyword argument must receive the same source diagnostic.
 @ttl.operation(grid=(3, 1))
 def keyword_argument():
     @ttl.datamovement()

--- a/test/python/pipe/test_pipenet_destination_count.py
+++ b/test/python/pipe/test_pipenet_destination_count.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device coverage for PipeNet destination-record multiplicity."""
+
+import pytest
+import torch
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import to_dram
+from utils.correctness import assert_allclose
+
+TILE = 32
+GRID_X = 4
+MAX_RECEIVES = 3
+
+
+@ttl.operation(grid=(GRID_X, 1))
+def destination_count_gather(inp, out):
+    net = ttl.PipeNet(
+        [
+            ttl.Pipe(src=(0, 0), dst=(3, 0)),
+            ttl.Pipe(src=(1, 0), dst=(3, 0)),
+            ttl.Pipe(src=(2, 0), dst=(3, 0)),
+            ttl.Pipe(src=(0, 0), dst=(2, 0)),
+        ]
+    )
+    send_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    receive_dfb = ttl.make_dataflow_buffer_like(
+        out, shape=(1, 1), block_count=MAX_RECEIVES
+    )
+
+    @ttl.compute()
+    def compute():
+        pass
+
+    @ttl.datamovement()
+    def dm():
+        node_x, _node_y = ttl.node(dims=2)
+
+        def receive(pipe):
+            with receive_dfb.reserve() as receive_block:
+                ttl.copy(pipe, receive_block).wait()
+
+        net.if_dst(receive)
+
+        def send(pipe):
+            with send_dfb.reserve() as send_block:
+                ttl.copy(inp[0, node_x], send_block).wait()
+            with send_dfb.wait() as send_block:
+                ttl.copy(send_block, pipe).wait()
+
+        net.if_src(send)
+
+        for receive_index in range(net.destination_count()):
+            with receive_dfb.wait() as receive_block:
+                ttl.copy(receive_block, out[receive_index, node_x]).wait()
+
+    @ttl.datamovement()
+    def dm_brisc():
+        pass
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"]
+)
+def test_destination_count_matches_receive_records(device, dtype):
+    inp_torch = torch.randn(TILE, GRID_X * TILE, dtype=dtype)
+    output = to_dram(
+        torch.zeros(MAX_RECEIVES * TILE, GRID_X * TILE, dtype=dtype), device
+    )
+
+    destination_count_gather(to_dram(inp_torch, device), output)
+    ttnn.synchronize_device(device)
+
+    expected = torch.zeros(MAX_RECEIVES * TILE, GRID_X * TILE, dtype=dtype)
+    expected[0:TILE, 2 * TILE : 3 * TILE] = inp_torch[:, 0:TILE]
+    for receive_index, source_x in enumerate((0, 1, 2)):
+        expected[
+            receive_index * TILE : (receive_index + 1) * TILE,
+            3 * TILE : 4 * TILE,
+        ] = inp_torch[:, source_x * TILE : (source_x + 1) * TILE]
+
+    assert_allclose(
+        expected.float(), ttnn.to_torch(output).float(), rtol=0.0, atol=0.0
+    )

--- a/test/python/pipe/test_pipenet_destination_count.py
+++ b/test/python/pipe/test_pipenet_destination_count.py
@@ -10,8 +10,10 @@ import ttl
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
-from ttlang_test_utils import to_dram
+from ttlang_test_utils import to_dram, to_l1
 from utils.correctness import assert_allclose
+
+pytestmark = pytest.mark.requires_device
 
 TILE = 32
 GRID_X = 4
@@ -67,13 +69,16 @@ def destination_count_gather(inp, out):
 @pytest.mark.parametrize(
     "dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"]
 )
-def test_destination_count_matches_receive_records(device, dtype):
+@pytest.mark.parametrize("to_device", [to_dram, to_l1], ids=["dram", "l1"])
+def test_destination_count_matches_receive_records(device, dtype, to_device):
+    torch.manual_seed(0)
     inp_torch = torch.randn(TILE, GRID_X * TILE, dtype=dtype)
-    output = to_dram(
+    input_tensor = to_device(inp_torch, device)
+    output = to_device(
         torch.zeros(MAX_RECEIVES * TILE, GRID_X * TILE, dtype=dtype), device
     )
 
-    destination_count_gather(to_dram(inp_torch, device), output)
+    destination_count_gather(input_tensor, output)
     ttnn.synchronize_device(device)
 
     expected = torch.zeros(MAX_RECEIVES * TILE, GRID_X * TILE, dtype=dtype)

--- a/test/python/pipe/test_pipenet_destination_count.py
+++ b/test/python/pipe/test_pipenet_destination_count.py
@@ -66,9 +66,7 @@ def destination_count_gather(inp, out):
         pass
 
 
-@pytest.mark.parametrize(
-    "dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"]
-)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
 @pytest.mark.parametrize("to_device", [to_dram, to_l1], ids=["dram", "l1"])
 def test_destination_count_matches_receive_records(device, dtype, to_device):
     torch.manual_seed(0)
@@ -89,6 +87,4 @@ def test_destination_count_matches_receive_records(device, dtype, to_device):
             3 * TILE : 4 * TILE,
         ] = inp_torch[:, source_x * TILE : (source_x + 1) * TILE]
 
-    assert_allclose(
-        expected.float(), ttnn.to_torch(output).float(), rtol=0.0, atol=0.0
-    )
+    assert_allclose(expected.float(), ttnn.to_torch(output).float(), rtol=0.0, atol=0.0)

--- a/test/python/pipe/test_pipenet_destination_count.py
+++ b/test/python/pipe/test_pipenet_destination_count.py
@@ -20,6 +20,7 @@ GRID_X = 4
 MAX_RECEIVES = 3
 
 
+# The receive loop uses the same record multiplicity as the PipeNet callbacks.
 @ttl.operation(grid=(GRID_X, 1))
 def destination_count_gather(inp, out):
     net = ttl.PipeNet(
@@ -66,6 +67,7 @@ def destination_count_gather(inp, out):
         pass
 
 
+# Destination counts must bound every receive across supported tensor storage.
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
 @pytest.mark.parametrize("to_device", [to_dram, to_l1], ids=["dram", "l1"])
 def test_destination_count_matches_receive_records(device, dtype, to_device):

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -5755,6 +5755,32 @@ def test_storage_group_partitions_disjoint_residency_signatures(
     assert _descriptor_cores(descriptors_by_index[1]) == {(1, 0)}
 
 
+def test_allocation_nodes_scope_unspecialized_segmented_dfb_descriptor(monkeypatch):
+    monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
+    full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))
+
+    descriptors = kernel_runner.build_cb_descriptors(
+        tensors=[_FakeTensorWithoutDevice()],
+        cb_configs=[
+            PhysicalDFBConfig(
+                0,
+                1,
+                "bfloat16",
+                1,
+                2048,
+                (32, 32),
+                storage_segments=(DFBStorageSegment(nodes=((1, 0),)),),
+                allocation_nodes=((1, 0),),
+            )
+        ],
+        core_ranges=full_grid,
+        kernel_specs=[_specialized_spec(full_grid, None)],
+    )
+
+    assert len(descriptors) == 1
+    assert _descriptor_cores(descriptors[0]) == {(1, 0)}
+
+
 # An exact empty allocation domain installs no runtime descriptor.
 def test_empty_allocation_nodes_omit_dfb_descriptor(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())

--- a/test/python/test_kernel_runner.py
+++ b/test/python/test_kernel_runner.py
@@ -5755,6 +5755,7 @@ def test_storage_group_partitions_disjoint_residency_signatures(
     assert _descriptor_cores(descriptors_by_index[1]) == {(1, 0)}
 
 
+# An unspecialized kernel still restricts a segmented descriptor to its nodes.
 def test_allocation_nodes_scope_unspecialized_segmented_dfb_descriptor(monkeypatch):
     monkeypatch.setattr(kernel_runner, "ttnn", _FakeTTNN())
     full_grid = _FakeExplicitCoreRanges((0, 0), (1, 0))

--- a/test/sim/test_pipe.py
+++ b/test/sim/test_pipe.py
@@ -24,8 +24,8 @@ from sim.program import _dedupe_pipe_nets  # type: ignore[reportPrivateUsage]
 _NET_OF_ANOTHER_OPERATION = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(0, 1))])
 
 
-class TestPipeNetPredicates:
-    """PipeNet.is_src / is_dst / is_active use ttl.node(); run inside @ttl.operation."""
+class TestPipeNetQueries:
+    """PipeNet role predicates and destination counts use ttl.node()."""
 
     @pytest.mark.parametrize(
         ("pipes", "expected_counts"),

--- a/test/sim/test_pipe.py
+++ b/test/sim/test_pipe.py
@@ -27,6 +27,38 @@ _NET_OF_ANOTHER_OPERATION = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(0, 1))])
 class TestPipeNetPredicates:
     """PipeNet.is_src / is_dst / is_active use ttl.node(); run inside @ttl.operation."""
 
+    def test_destination_count_matches_callback_multiplicity(self) -> None:
+        net = ttl.PipeNet(
+            [
+                ttl.Pipe((0, 0), (3, 0)),
+                ttl.Pipe((1, 0), (3, 0)),
+                ttl.Pipe((2, 0), (3, 0)),
+                ttl.Pipe((0, 0), (2, 0)),
+            ]
+        )
+
+        @ttl.operation(grid=(4, 1))
+        def op(_input_tensor: ttnn.Tensor, _output_tensor: ttnn.Tensor) -> None:
+            @ttl.compute()
+            def compute() -> None:
+                node_x, _node_y = ttl.node(dims=2)
+                expected_counts = (0, 0, 1, 3)
+                matching_sources = []
+                net.if_dst(lambda pipe: matching_sources.append(pipe.src))
+                assert net.destination_count() == expected_counts[node_x]
+                assert net.destination_count() == len(matching_sources)
+
+            @ttl.datamovement()
+            def dm0() -> None:
+                pass
+
+            @ttl.datamovement()
+            def dm1() -> None:
+                pass
+
+        tensor = make_zeros_tensor(32, 32)
+        op(tensor, tensor)
+
     def test_unicast_src_dst_inactive(self) -> None:
         """Unicast (0,0) -> (1,0): only those two nodes participate on a 2x2 grid."""
         pipe = ttl.Pipe((0, 0), (1, 0))

--- a/test/sim/test_pipe.py
+++ b/test/sim/test_pipe.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for sim PipeNet predicates: is_active, is_src, is_dst."""
+"""Tests for simulated PipeNet role predicates and destination counts."""
 
 from __future__ import annotations
 
@@ -27,6 +27,7 @@ _NET_OF_ANOTHER_OPERATION = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(0, 1))])
 class TestPipeNetQueries:
     """PipeNet role predicates and destination counts use ttl.node()."""
 
+    # Counts preserve callback multiplicity for unicast, ranges, and duplicates.
     @pytest.mark.parametrize(
         ("pipes", "expected_counts"),
         [

--- a/test/sim/test_pipe.py
+++ b/test/sim/test_pipe.py
@@ -27,22 +27,36 @@ _NET_OF_ANOTHER_OPERATION = ttl.PipeNet([ttl.Pipe(src=(0, 0), dst=(0, 1))])
 class TestPipeNetPredicates:
     """PipeNet.is_src / is_dst / is_active use ttl.node(); run inside @ttl.operation."""
 
-    def test_destination_count_matches_callback_multiplicity(self) -> None:
-        net = ttl.PipeNet(
-            [
-                ttl.Pipe((0, 0), (3, 0)),
-                ttl.Pipe((1, 0), (3, 0)),
-                ttl.Pipe((2, 0), (3, 0)),
-                ttl.Pipe((0, 0), (2, 0)),
-            ]
-        )
+    @pytest.mark.parametrize(
+        ("pipes", "expected_counts"),
+        [
+            pytest.param(
+                [
+                    ttl.Pipe((0, 0), (3, 0)),
+                    ttl.Pipe((1, 0), (3, 0)),
+                    ttl.Pipe((2, 0), (3, 0)),
+                    ttl.Pipe((0, 0), (2, 0)),
+                ],
+                (0, 0, 1, 3),
+                id="explicit-pipes",
+            ),
+            pytest.param(
+                [ttl.Pipe((0, 0), (slice(1, 4), 0))],
+                (0, 1, 1, 1),
+                id="collective-destination-range",
+            ),
+        ],
+    )
+    def test_destination_count_matches_callback_multiplicity(
+        self, pipes, expected_counts
+    ) -> None:
+        net = ttl.PipeNet(pipes)
 
         @ttl.operation(grid=(4, 1))
         def op(_input_tensor: ttnn.Tensor, _output_tensor: ttnn.Tensor) -> None:
             @ttl.compute()
             def compute() -> None:
                 node_x, _node_y = ttl.node(dims=2)
-                expected_counts = (0, 0, 1, 3)
                 matching_sources = []
                 net.if_dst(lambda pipe: matching_sources.append(pipe.src))
                 assert net.destination_count() == expected_counts[node_x]

--- a/test/sim/test_pipe.py
+++ b/test/sim/test_pipe.py
@@ -45,6 +45,11 @@ class TestPipeNetPredicates:
                 (0, 1, 1, 1),
                 id="collective-destination-range",
             ),
+            pytest.param(
+                [ttl.Pipe((0, 0), (3, 0)), ttl.Pipe((0, 0), (3, 0))],
+                (0, 0, 0, 2),
+                id="duplicate-records",
+            ),
         ],
     )
     def test_destination_count_matches_callback_multiplicity(

--- a/test/ttlang/Analysis/launch_node_domain_analysis.mlir
+++ b/test/ttlang/Analysis/launch_node_domain_analysis.mlir
@@ -12,6 +12,7 @@
 // CHECK-NEXT: full_bound_unknown = <unknown> within {(0,0), (0,1), (1,0), (1,1)}
 // CHECK-NEXT: undeclared_pipe = <unknown> within {(0,0), (0,1), (1,0), (1,1)}
 // CHECK-NEXT: destination_count_loop = {(1,0)}
+// CHECK-NEXT: graph_destination_count_loop = {(0,0), (0,1), (1,0), (1,1)}
 // CHECK-NEXT: kernel_argument_condition = equivalent
 // CHECK-NEXT: helper_argument_condition = not-equivalent
 // CHECK-NOT:  =
@@ -20,6 +21,19 @@
     net 0 name "destination_count" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
    dstEndX = 1, dstEndY = 0>
+]>
+
+#device_domain = #ttl.device_domain<
+    components = <name = "device", extent = [2]>>
+#graph_destination_records = #ttl.pipenet_records<
+    net 1 name "graph_destination_count" pipes [
+  #ttl.pipe_record<
+      srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+      dstEndX = 1, dstEndY = 0,
+      deviceTransfer = <
+        domain = #device_domain,
+        edge = <source = <coordinates = [0]>,
+                destination = <coordinates = [1]>>>>
 ]>
 
 module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
@@ -63,11 +77,20 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
       "test.observe"() {test.label = "undeclared_pipe"} : () -> ()
     }
 
+    // A local count removes nodes with no matching destination record.
     %destination_count = ttl.pipenet_destination_count {
         pipe_net_id = 0 : i64, records = #destination_records} : index
     %c1 = arith.constant 1 : index
     scf.for %iteration = %c0 to %destination_count step %c1 {
       "test.observe"() {test.label = "destination_count_loop"} : () -> ()
+    }
+
+    // Device identity is unavailable to this node-only analysis. Retaining the
+    // incoming domain prevents an unproven device match from removing nodes.
+    %graph_destination_count = ttl.pipenet_destination_count {
+        pipe_net_id = 1 : i64, records = #graph_destination_records} : index
+    scf.for %iteration = %c0 to %graph_destination_count step %c1 {
+      "test.observe"() {test.label = "graph_destination_count_loop"} : () -> ()
     }
     func.return
   }

--- a/test/ttlang/Analysis/launch_node_domain_analysis.mlir
+++ b/test/ttlang/Analysis/launch_node_domain_analysis.mlir
@@ -11,9 +11,16 @@
 // CHECK-NEXT: bounded_unknown = <unknown> within {(0,0), (0,1)}
 // CHECK-NEXT: full_bound_unknown = <unknown> within {(0,0), (0,1), (1,0), (1,1)}
 // CHECK-NEXT: undeclared_pipe = <unknown> within {(0,0), (0,1), (1,0), (1,1)}
+// CHECK-NEXT: destination_count_loop = {(1,0)}
 // CHECK-NEXT: kernel_argument_condition = equivalent
 // CHECK-NEXT: helper_argument_condition = not-equivalent
 // CHECK-NOT:  =
+
+#destination_records = #ttl.pipenet_records<
+    net 0 name "destination_count" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
 
 module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
   func.func @domains(%runtime: index)
@@ -54,6 +61,13 @@ module attributes {ttl.launch_grid = [2 : i64, 2 : i64]} {
     %undeclared = ttl.is_src {pipe_net_id = 7 : i64}
     scf.if %undeclared {
       "test.observe"() {test.label = "undeclared_pipe"} : () -> ()
+    }
+
+    %destination_count = ttl.pipenet_destination_count {
+        pipe_net_id = 0 : i64, records = #destination_records} : index
+    %c1 = arith.constant 1 : index
+    scf.for %iteration = %c0 to %destination_count step %c1 {
+      "test.observe"() {test.label = "destination_count_loop"} : () -> ()
     }
     func.return
   }

--- a/test/ttlang/Conversion/TTLToTTKernel/dfb_reconfiguration.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/dfb_reconfiguration.mlir
@@ -8,6 +8,7 @@
 // CHECK-NEXT: %[[ADDRESS:.*]] = ttkernel.get_arg_val(%[[INDEX]]) : (i32) -> ui32
 // CHECK: ttkernel.opaque_call "experimental::reconfigure_dfb_interfaces"(%[[ADDRESS]]) {header = "<cstdint>", unsigned_arg_indices = array<i32: 0>} : (ui32) -> ()
 module attributes {
+  ttl.target_arch = #ttcore.arch<blackhole>,
   ttl.dfb_reconfiguration_plan = {
     boundary_ordinals = array<i64: 0, 1>,
     dfbs = []

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
@@ -405,6 +405,54 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
+// A PipeNet-derived loop count narrows a previously full access domain to the
+// nodes with at least one destination record.
+
+// REUSE-LABEL: func.func @pipenet_count_loop
+// REUSE: %[[COUNTED:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2}
+// REUSE-SAME: {dfb_id = 25 : index}
+
+// REPORT: DFB logical_id=25 bounded=0 compiler_created=0
+// REPORT-SAME: domain={(2,0), (3,0)}
+// REPORT: access 0 effect=reserve tiles=1 sequence=0 domain={(2,0), (3,0)}
+
+#count_records = #ttl.pipenet_records<net 0 name "gather" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
+  <srcX = 1, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
+  <srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0,
+   dstEndX = 2, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+  func.func @pipenet_count_loop()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %counted = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 25 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %count = ttl.pipenet_destination_count {
+        pipe_net_id = 0 : i64, records = #count_records} : index
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    scf.for %iteration = %zero to %count step %one {
+      ttl.opaque_call "counted_access"
+          dfb_dependencies(
+            %counted : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>)
+          dfb_effects [
+            #ttl.dfb_protocol_effect<reserve, 0, 1>,
+            #ttl.dfb_protocol_effect<push, 0, 1>,
+            #ttl.dfb_protocol_effect<wait, 0, 1>,
+            #ttl.dfb_protocol_effect<pop, 0, 1>]
+          () {header = "counted_access.hpp"} : () -> ()
+    }
+    return
+  }
+}
+
+// -----
+
 // A generic external storage access receives the same exact-domain refinement
 // before it is conservatively attached to every user-managed DFB.
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_exact_execution_domain.mlir
@@ -49,22 +49,18 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// A coordinate-dependent loop may have a known launch domain but execute zero
-// times at a specific node. Its DFB is inactive at that node and may reuse the
-// physical index assigned to an active compatible DFB.
+// A coordinate-dependent loop with zero executions has an empty access domain.
+// Its DFB may reuse an active compatible DFB because they share no launch node.
 
 // REUSE-LABEL: func.func @exact_zero_at_known_node
 // REUSE: %[[INACTIVE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 32 : index}
 // REUSE-NEXT: %[[ACTIVE:.*]] = ttl.bind_cb{cb_index = 0, block_count = 2} {dfb_id = 33 : index}
 
-// REPORT: DFB logical_id=32 bounded=1 compiler_created=0
-// REPORT-SAME: access_completion_proven=1
-// REPORT-SAME: domain={(0,0)}
-// REPORT: node (0,0) lifecycle_completion=complete
-// REPORT-SAME: occurrences=[0:0]
-// REPORT-SAME: earliest_accesses=[] terminal_accesses=[]
+// REPORT: DFB logical_id=32 bounded=0 compiler_created=0
+// REPORT-SAME: access_completion_proven=0
+// REPORT-SAME: domain={}
 // REPORT: DFB logical_id=33 bounded=1 compiler_created=0
-// REPORT: DFB assignment: logical DFB 32 -> physical index 0 storage index 0 (bounded)
+// REPORT: DFB assignment: logical DFB 32 -> physical index 0 storage index 0 (unbounded)
 // REPORT-NEXT: DFB assignment: logical DFB 33 -> physical index 0 storage index 0 (bounded)
 
 module attributes {ttl.launch_grid = array<i64: 1, 1>} {

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_conditional_entry.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_conditional_entry.mlir
@@ -15,7 +15,7 @@
 // CHECK: DFB assignment: logical DFB 0 -> physical index 0 storage index 1 (bounded)
 // CHECK: DFB assignment: logical DFB 1 -> physical index 1 storage index 0 (unbounded)
 
-module attributes {ttl.launch_grid = [1, 1]} {
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_conditional_external_access.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_conditional_external_access.mlir
@@ -87,8 +87,8 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 
 // -----
 
-// Exact zero execution means the first DFB has no state to carry into a
-// reconfiguration boundary. The later compatible DFB may use the same index.
+// Exact zero execution gives the first DFB an empty access domain. The later
+// compatible DFB may use the same index because they share no launch node.
 
 #compute = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "operation">
 #reader = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "operation">
@@ -100,11 +100,9 @@ module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blac
 // IR-SAME: dfb_index = 0 : i32
 // IR-NOT: dfb_index = 1 : i32
 
-// DEBUG: DFB logical_id=0 bounded=1
-// DEBUG-SAME: access_completion_proven=1
-// DEBUG: node (0,0) lifecycle_completion=complete
-// DEBUG-SAME: occurrences=[0:0]
-// DEBUG-SAME: earliest_accesses=[] terminal_accesses=[]
+// DEBUG: DFB logical_id=0 bounded=0
+// DEBUG-SAME: access_completion_proven=0
+// DEBUG-SAME: domain={}
 // DEBUG: DFB logical_id=1 bounded=1
 // DEBUG: Total DFB count: 1
 

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_conditional_live_crossing.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_conditional_live_crossing.mlir
@@ -13,7 +13,7 @@
 // CHECK-SAME: active_configurations=[initial, 0]
 // CHECK-SAME: terminal_reconfiguration=none
 
-module attributes {ttl.launch_grid = [1, 1]} {
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_epochs.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_epochs.mlir
@@ -30,7 +30,7 @@
 // DEBUG: DFB assignment: logical DFB 1 -> physical index 0 storage index 0 (bounded)
 // DEBUG: DFB assignment: logical DFB 2 -> physical index 0 storage index 0 (bounded)
 
-module attributes {ttl.launch_grid = [1, 1]} {
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_epochs_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_epochs_invalid.mlir
@@ -6,7 +6,7 @@
 #writer = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "operation">
 #boundary = #ttl.dfb_reconfiguration<0, participants[#compute, #reader, #writer]>
 
-module attributes {ttl.launch_grid = [1, 1]} {
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute
@@ -44,6 +44,7 @@ module attributes {ttl.launch_grid = [1, 1]} {
 // expected-error @below {{selected DFB and fixed-state allocation uses 3136 L1 bytes, exceeding the 3000-byte budget (DFB=2048, reset scratch=0, reconfiguration state=1088)}}
 module attributes {
   ttl.launch_grid = [1, 1],
+  ttl.target_arch = #ttcore.arch<blackhole>,
   ttcore.system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <blackhole>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 3000, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 0, erisc_l1_unreserved_base = 0, dram_unreserved_base = 0, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>], supported_tile_sizes = [32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(0, 0)], dram_bank_to_logical_worker_noc1 = [(0, 0)]}], [0], [1 : i32], [ 0x0x0x0]>
 } {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_live_crossing.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_live_crossing.mlir
@@ -31,7 +31,7 @@
 // DEBUG: DFB assignment: logical DFB 2 -> physical index 1 storage index 0 (bounded)
 // DEBUG: DFB assignment: logical DFB 3 -> physical index 1 storage index 0 (bounded)
 
-module attributes {ttl.launch_grid = [1, 1]} {
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_target_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_target_invalid.mlir
@@ -7,6 +7,24 @@
 #writer = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "operation">
 #boundary = #ttl.dfb_reconfiguration<0, participants[#compute, #reader, #writer]>
 
+module {
+  func.func @compute() attributes {
+    ttl.kernel_thread = #ttkernel.thread<compute>,
+    ttl.logical_kernel = #compute
+  } {
+    // expected-error @below {{'ttl.dfb_reconfiguration' op requires a resolved target architecture; DFB reconfiguration is supported only for Blackhole}}
+    ttl.dfb_reconfiguration #boundary
+    return
+  }
+}
+
+// -----
+
+#compute = #ttl.logical_kernel<kind = compute, identity = "compute", operation = "operation">
+#reader = #ttl.logical_kernel<kind = data_movement, identity = "reader", operation = "operation">
+#writer = #ttl.logical_kernel<kind = data_movement, identity = "writer", operation = "operation">
+#boundary = #ttl.dfb_reconfiguration<0, participants[#compute, #reader, #writer]>
+
 module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_tensor_backing.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_reconfiguration_tensor_backing.mlir
@@ -23,7 +23,7 @@
 // CHECK-LABEL: func.func @compute
 // CHECK-SAME: ttl.base_cta_index = 2 : i32
 
-module attributes {ttl.launch_grid = [1, 1]} {
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.base_cta_index = 2 : i32,
     ttl.kernel_thread = #ttkernel.thread<compute>,
@@ -83,7 +83,7 @@ module attributes {ttl.launch_grid = [1, 1]} {
 // CHECK-SAME: entry_reconfiguration = 0 : i64
 // CHECK-SAME: nodes = {{\[\[1, 0\]\]}}
 // CHECK-SAME: tensor_backing = #ttl.tensor_backing<tensor_index = 0
-module attributes {ttl.launch_grid = [2, 1]} {
+module attributes {ttl.launch_grid = [2, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_storage_reuse_reconfiguration.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_storage_reuse_reconfiguration.mlir
@@ -14,7 +14,7 @@
 // CHECK-SAME: {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32, storage_index = 1 : i32},
 // CHECK-SAME: {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 1 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, f32>, num_tiles = 1 : i32, page_size = 4096 : i32, storage_index = 0 : i32}
 
-module attributes {ttl.launch_grid = [1, 1]} {
+module attributes {ttl.launch_grid = [1, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute
@@ -74,7 +74,7 @@ module attributes {ttl.launch_grid = [1, 1]} {
 // CHECK-SAME: {allocation_nodes = {{\[\[0, 0\]\]}}, block_count = 1 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<32x32, bf16>, num_tiles = 1 : i32, page_size = 2048 : i32, storage_index = 0 : i32},
 // CHECK-SAME: {allocation_nodes = {{\[\[1, 0\]\]}}, block_count = 1 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<32x32, f32>, num_tiles = 1 : i32, page_size = 4096 : i32, storage_index = 0 : i32}
 
-module attributes {ttl.launch_grid = [2, 1]} {
+module attributes {ttl.launch_grid = [2, 1], ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @compute_disjoint_nodes() attributes {
     ttl.kernel_thread = #ttkernel.thread<compute>,
     ttl.logical_kernel = #compute

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
@@ -52,6 +52,13 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
       dstEndX = 0, dstEndY = 0,
       deviceTransfer = <
         domain = #device_domain,
+        edge = <source = <coordinates = [0]>,
+                destination = <coordinates = [2]>>>>,
+  #ttl.pipe_record<
+      srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
+      dstEndX = 0, dstEndY = 0,
+      deviceTransfer = <
+        domain = #device_domain,
         edge = <source = <coordinates = [1]>,
                 destination = <coordinates = [2]>>>>,
   #ttl.pipe_record<
@@ -69,11 +76,41 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
   // CHECK-LABEL: func.func @device_destination_count
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.get_common_arg_val
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 1, 2]
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 1, 3]
   func.func @device_destination_count()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %count = ttl.pipenet_destination_count {
         pipe_net_id = 1 : i64, records = #device_records} : index
+    func.call @consume(%count) : (index) -> ()
+    func.return
+  }
+}
+
+// -----
+
+#sparse_device_domain = #ttl.device_domain<
+    components = <name = "device", extent = [4]>>
+#sparse_device_records = #ttl.pipenet_records<net 2 name "sparse_device" pipes [
+  #ttl.pipe_record<
+      srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
+      dstEndX = 0, dstEndY = 0,
+      deviceTransfer = <
+        domain = #sparse_device_domain,
+        edge = <source = <coordinates = [0]>,
+                destination = <coordinates = [3]>>>>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
+  func.func private @consume(index)
+
+  // CHECK-LABEL: func.func @sparse_device_destination_count
+  // CHECK: scf.for
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [3]
+  // CHECK: arith.addi
+  func.func @sparse_device_destination_count()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %count = ttl.pipenet_destination_count {
+        pipe_net_id = 2 : i64, records = #sparse_device_records} : index
     func.call @consume(%count) : (index) -> ()
     func.return
   }

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
@@ -1,4 +1,5 @@
-// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+// Verifies local and graph PipeNet destination-count lowering.
+// RUN: ttlang-opt %s --split-input-file -convert-ttl-to-ttkernel | FileCheck %s
 
 #records = #ttl.pipenet_records<net 0 name "gather" pipes [
   <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
@@ -9,6 +10,32 @@
    dstEndX = 3, dstEndY = 0>,
   <srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0,
    dstEndX = 2, dstEndY = 0>
+]>
+
+#device_domain = #ttl.device_domain<
+    components = <name = "device", extent = [3]>>
+#device_records = #ttl.pipenet_records<net 1 name "device_gather" pipes [
+  #ttl.pipe_record<
+      srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
+      dstEndX = 0, dstEndY = 0,
+      deviceTransfer = <
+        domain = #device_domain,
+        edge = <source = <coordinates = [0]>,
+                destination = <coordinates = [2]>>>>,
+  #ttl.pipe_record<
+      srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
+      dstEndX = 0, dstEndY = 0,
+      deviceTransfer = <
+        domain = #device_domain,
+        edge = <source = <coordinates = [1]>,
+                destination = <coordinates = [2]>>>>,
+  #ttl.pipe_record<
+      srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
+      dstEndX = 0, dstEndY = 0,
+      deviceTransfer = <
+        domain = #device_domain,
+        edge = <source = <coordinates = [0]>,
+                destination = <coordinates = [1]>>>>
 ]>
 
 // Local PipeNet records have no logical-device identity. Their destination
@@ -26,6 +53,21 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %count = ttl.pipenet_destination_count {
         pipe_net_id = 0 : i64, records = #records} : index
+    func.call @consume(%count) : (index) -> ()
+    func.return
+  }
+
+  // CHECK-LABEL: func.func @device_destination_count
+  // CHECK: scf.for
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [1, 2, 2]
+  // CHECK: arith.cmpi eq
+  // CHECK: arith.andi
+  // CHECK: arith.select
+  // CHECK: arith.addi
+  func.func @device_destination_count()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %count = ttl.pipenet_destination_count {
+        pipe_net_id = 1 : i64, records = #device_records} : index
     func.call @consume(%count) : (index) -> ()
     func.return
   }

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
@@ -63,6 +63,7 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
                 destination = <coordinates = [1]>>>>
 ]>
 
+// Dense graph records lower to one logical-device-indexed count lookup.
 module attributes {ttl.launch_grid = array<i64: 1, 1>} {
   func.func private @consume(index)
 
@@ -93,6 +94,7 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
                 destination = <coordinates = [3]>>>>
 ]>
 
+// Sparse graph records use per-record matching instead of a large device table.
 module attributes {ttl.launch_grid = array<i64: 1, 1>} {
   func.func private @consume(index)
 

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
@@ -8,6 +8,8 @@
    dstEndX = 3, dstEndY = 0>,
   <srcX = 2, srcY = 0, dstStartX = 3, dstStartY = 0,
    dstEndX = 3, dstEndY = 0>,
+  <srcX = 2, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
   <srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0,
    dstEndX = 2, dstEndY = 0>
 ]>
@@ -48,7 +50,7 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
   // CHECK: ttkernel.my_logical_y_
   // CHECK: arith.muli
   // CHECK: arith.addi
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 3]
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 4]
   func.func @local_destination_count()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %count = ttl.pipenet_destination_count {

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
@@ -38,7 +38,7 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
 // -----
 
 #device_domain = #ttl.device_domain<
-    components = <name = "device", extent = [3]>>
+    components = <name = "device", extent = [4]>>
 #device_records = #ttl.pipenet_records<net 1 name "device_gather" pipes [
   #ttl.pipe_record<
       srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
@@ -46,21 +46,14 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
       deviceTransfer = <
         domain = #device_domain,
         edge = <source = <coordinates = [0]>,
-                destination = <coordinates = [2]>>>>,
+                destination = <coordinates = [3]>>>>,
   #ttl.pipe_record<
       srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
       dstEndX = 0, dstEndY = 0,
       deviceTransfer = <
         domain = #device_domain,
         edge = <source = <coordinates = [0]>,
-                destination = <coordinates = [2]>>>>,
-  #ttl.pipe_record<
-      srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
-      dstEndX = 0, dstEndY = 0,
-      deviceTransfer = <
-        domain = #device_domain,
-        edge = <source = <coordinates = [1]>,
-                destination = <coordinates = [2]>>>>,
+                destination = <coordinates = [3]>>>>,
   #ttl.pipe_record<
       srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
       dstEndX = 0, dstEndY = 0,
@@ -76,7 +69,7 @@ module attributes {ttl.launch_grid = array<i64: 1, 1>} {
   // CHECK-LABEL: func.func @device_destination_count
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.get_common_arg_val
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 1, 3]
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 1, 0, 2]
   func.func @device_destination_count()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %count = ttl.pipenet_destination_count {

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
@@ -1,0 +1,32 @@
+// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+
+#records = #ttl.pipenet_records<net 0 name "gather" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
+  <srcX = 1, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
+  <srcX = 2, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
+  <srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0,
+   dstEndX = 2, dstEndY = 0>
+]>
+
+// Local PipeNet records have no logical-device identity. Their destination
+// count depends only on the launch-node coordinate.
+module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+  func.func private @consume(index)
+
+  // CHECK-LABEL: func.func @local_destination_count
+  // CHECK: ttkernel.my_logical_x_
+  // CHECK: ttkernel.my_logical_y_
+  // CHECK: arith.muli
+  // CHECK: arith.addi
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 3]
+  func.func @local_destination_count()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %count = ttl.pipenet_destination_count {
+        pipe_net_id = 0 : i64, records = #records} : index
+    func.call @consume(%count) : (index) -> ()
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count.mlir
@@ -14,6 +14,29 @@
    dstEndX = 2, dstEndY = 0>
 ]>
 
+// Local PipeNet records have no logical-device identity. Their destination
+// count depends only on the launch-node coordinate.
+module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+  func.func private @consume(index)
+
+  // CHECK-LABEL: func.func @local_destination_count
+  // CHECK: ttkernel.my_logical_x_
+  // CHECK: ttkernel.my_logical_y_
+  // CHECK: arith.muli
+  // CHECK: arith.addi
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 4]
+  func.func @local_destination_count()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %count = ttl.pipenet_destination_count {
+        pipe_net_id = 0 : i64, records = #records} : index
+    func.call @consume(%count) : (index) -> ()
+    func.return
+  }
+
+}
+
+// -----
+
 #device_domain = #ttl.device_domain<
     components = <name = "device", extent = [3]>>
 #device_records = #ttl.pipenet_records<net 1 name "device_gather" pipes [
@@ -40,32 +63,13 @@
                 destination = <coordinates = [1]>>>>
 ]>
 
-// Local PipeNet records have no logical-device identity. Their destination
-// count depends only on the launch-node coordinate.
-module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
   func.func private @consume(index)
 
-  // CHECK-LABEL: func.func @local_destination_count
-  // CHECK: ttkernel.my_logical_x_
-  // CHECK: ttkernel.my_logical_y_
-  // CHECK: arith.muli
-  // CHECK: arith.addi
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 4]
-  func.func @local_destination_count()
-      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    %count = ttl.pipenet_destination_count {
-        pipe_net_id = 0 : i64, records = #records} : index
-    func.call @consume(%count) : (index) -> ()
-    func.return
-  }
-
   // CHECK-LABEL: func.func @device_destination_count
-  // CHECK: scf.for
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [1, 2, 2]
-  // CHECK: arith.cmpi eq
-  // CHECK: arith.andi
-  // CHECK: arith.select
-  // CHECK: arith.addi
+  // CHECK-NOT: scf.for
+  // CHECK: ttkernel.get_common_arg_val
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 1, 2]
   func.func @device_destination_count()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     %count = ttl.pipenet_destination_count {

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count_invalid.mlir
@@ -6,6 +6,7 @@
    dstEndX = 1, dstEndY = 0>
 ]>
 
+// The operation and record table must identify the same PipeNet.
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @mismatched_pipe_net_id()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count_invalid.mlir
@@ -1,0 +1,17 @@
+// Verifies diagnostics for invalid PipeNet destination-count operations.
+// RUN: ttlang-opt %s --verify-diagnostics --split-input-file
+
+#records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @mismatched_pipe_net_id()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-error @below {{record table identifies PipeNet 7, but pipe_net_id is 3}}
+    %count = ttl.pipenet_destination_count {
+        pipe_net_id = 3 : i64, records = #records} : index
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_destination_count_invalid.mlir
@@ -9,7 +9,7 @@
 module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @mismatched_pipe_net_id()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    // expected-error @below {{record table identifies PipeNet 7, but pipe_net_id is 3}}
+    // expected-error @below {{PipeNet 7, but pipe_net_id is 3}}
     %count = ttl.pipenet_destination_count {
         pipe_net_id = 3 : i64, records = #records} : index
     func.return

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
@@ -1,7 +1,9 @@
-// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' | FileCheck %s --check-prefixes=CHECK,STRICT
 // RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' -o /dev/null
 
 // Producer in one thread, consumer in another: classic SPSC, accepted.
+// STRICT: module attributes
+// STRICT-NOT: ttl.relaxed_dfb_protocol_domain_verification
 // CHECK-LABEL: func.func @producer
 // CHECK-LABEL: func.func @consumer
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_relaxed.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_relaxed.mlir
@@ -1,6 +1,12 @@
-// Summary: Verifies the explicit external DFB domain proof override.
+// Summary: Verifies the explicit external DFB domain-check override.
 
-// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' -o /dev/null
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc,ttl-verify-pipenet-guards)' 2>%t.warning | FileCheck %s
+// RUN: FileCheck %s --check-prefix=WARNING < %t.warning
+
+// Both relaxed verifiers record one shared audit marker and warning.
+// CHECK: ttl.relaxed_dfb_protocol_domain_verification
+// WARNING-COUNT-1: warning: `TTL_RELAX_DFB_SPSC` disables per-launch-node DFB producer, consumer, and wait correspondence checks
+// WARNING-NOT: warning: `TTL_RELAX_DFB_SPSC`
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @consumer_all_nodes()

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed.mlir
@@ -1,6 +1,12 @@
 // Summary: Verifies the external DFB domain override in PipeNet guard analysis.
 
-// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s -ttl-verify-pipenet-guards -o /dev/null
+// RUN: env TTL_RELAX_DFB_SPSC=0 ttlang-opt %s -ttl-verify-pipenet-guards 2>%t.warning | FileCheck %s
+// RUN: FileCheck %s --check-prefix=WARNING < %t.warning
+
+// A standalone guard pass records the same audit marker and warning.
+// CHECK: ttl.relaxed_dfb_protocol_domain_verification
+// WARNING-COUNT-1: warning: `TTL_RELAX_DFB_SPSC` disables per-launch-node DFB producer, consumer, and wait correspondence checks
+// WARNING-NOT: warning: `TTL_RELAX_DFB_SPSC`
 
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
   func.func @wait_without_represented_producer()

--- a/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_pipenet_guards_relaxed_invalid.mlir
@@ -2,6 +2,7 @@
 
 // RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s --split-input-file --verify-diagnostics -ttl-verify-pipenet-guards
 
+// expected-warning @below {{`TTL_RELAX_DFB_SPSC` disables per-launch-node DFB producer, consumer, and wait correspondence checks}}
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
   func.func @unguarded_pipe_source()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {


### PR DESCRIPTION
### Problem description

Gather receivers need the exact number of incoming transfers to issue matching waits. TT-Lang exposes no per-node destination count. Programs must either wait for a uniform maximum, which hangs on nodes with fewer incoming transfers, or reproduce compiler-expanded PipeNet records in Python, which duplicates topology logic and risks mismatched counts.

```python
net.if_dst(receive)
for receive_index in range(net.destination_count()):
    with receive_dfb.wait() as receive_block:
        ttl.copy(receive_block, output[receive_index, node_x]).wait()
```

`TTL_RELAX_DFB_SPSC` also disables per-launch-node DFB ownership checks without a warning or IR marker, so relaxed output is indistinguishable from output that passed complete protocol-domain verification. Reset and reconfiguration also enforce the same Blackhole-only runtime constraint inconsistently when the target architecture is absent.

### What's changed

~500 LOC implementation.

- Adds `PipeNet.destination_count()` so each receiver waits for its exact per-node incoming-record count.
- Uses the shared participant plan for local and dense graph PipeNets, avoiding a second interpretation of the topology.
- Retains per-record matching for sparse or irregular graph records that cannot use a dense lookup table.
- Restricts the receive loop to nodes with a nonzero count so DFB analysis does not include nonexistent receives.
- Emits one warning and records `ttl.relaxed_dfb_protocol_domain_verification` when `TTL_RELAX_DFB_SPSC` disables protocol-domain checks, making relaxed output identifiable.
- Uses one Blackhole-only target validator for synchronized reset and reconfiguration, including consistent rejection when the target architecture is absent.

### Stack

Targets `main`.

### Checklist

- [x] New BF16 and FP32 device tests cover local and graph destination counts.
- [x] New simulator and MLIR tests cover duplicate records, dense and sparse graph plans, zero-count nodes, conservative graph analysis, and invalid uses.
- [x] New verifier tests cover strict output, one-time warning and metadata emission, presence-only environment-variable semantics, mandatory checks retained during relaxation, and missing reconfiguration targets.
