### PR TITLE
[ttl][pipes] Plan local PipeNet role queries [tree-reduce-3]

### DIFF
--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -1934,11 +1934,11 @@ static records and requires both the launch-node coordinates and logical device
 to match the selected source or destination endpoint.
 
 The Python frontend now adds `records` to every `ttl.is_src`, `ttl.is_dst`, and
-`ttl.is_active` operation. The attribute remains optional because requiring it
-would reject TTL modules using the preexisting form, which identifies the
-PipeNet only by `pipe_net_id`. For that form, lowering finds the module's
-`ttl.create_pipe` operations with the same PipeNet id and emits one source or
-destination coordinate comparison per pipe.
+`ttl.is_active` operation. The attribute remains optional for compatibility
+with older generated or serialized TTL modules, whose role-query operations
+identify the PipeNet only by `pipe_net_id`. For that form, lowering finds the
+module's `ttl.create_pipe` operations with the same PipeNet id and emits one
+source or destination coordinate comparison per pipe.
 
 `visitRegionBranchControlFlowTransfer` narrows the lattice on entry to
 each region according to the parent op:

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -1915,19 +1915,25 @@ receiver-authored publication. Collective verification cannot accept an
 unknown or multi-class receiver address partition and reports a user-facing
 error before any lowering mutation.
 
-## Predicate recognition
+## PipeNet role queries
 
-Three predicate ops - `ttl.is_src`, `ttl.is_dst`, `ttl.is_active`
-(the union of source and destination roles) - let user code carry
-per-PipeNet guards that the verifier recognizes structurally. Frontend
-methods `net.is_src()`, `net.is_dst()`, `net.is_active()` lower to
-these ops; coordinate comparisons over `ttl.node(dims=2)` against
-integer constants also work and are evaluated per coord.
+`ttl.is_src` returns whether the current node is the source of at least one
+pipe in a PipeNet. `ttl.is_dst` returns whether the current node is in at least
+one destination range. `ttl.is_active` returns the union of those results.
+Frontend calls to `net.is_src()`, `net.is_dst()`, and `net.is_active()` create
+these operations. An `scf.if` condition may also compare coordinates from
+`ttl.node(dims=2)` with integer constants; launch-node analysis evaluates those
+comparisons for every coordinate.
 
-Frontend predicate ops carry their static PipeNet record table. Local
-predicates reuse the participant plan to load one per-node record count and
-compare it with zero. Logical-device predicates additionally match the current
-device. Predicates without a record table retain PipeNet-index lowering.
+For a local PipeNet, each role-query operation includes a `records` attribute
+containing the PipeNet's static transfer records. Lowering computes the number
+of matching source or destination records for every launch coordinate, indexes
+that table with the current logical X and Y coordinates, and compares the count
+with zero. For a graph PipeNet spanning logical devices, lowering evaluates the
+static records and requires both the launch-node coordinates and logical device
+to match the selected source or destination endpoint. Without a `records`
+attribute, lowering emits coordinate comparisons for the `ttl.create_pipe`
+operations associated with the operation's `pipe_net_id`.
 
 `visitRegionBranchControlFlowTransfer` narrows the lattice on entry to
 each region according to the parent op:
@@ -1943,7 +1949,7 @@ each region according to the parent op:
 | `scf.for` body | intersect with nodes whose statically evaluated trip count is nonzero; unchanged when any candidate node cannot be evaluated |
 | `scf.while`/`affine.for`/`scf.execute_region`/`linalg.generic`/multi-block via `cf.cond_br` | unchanged (no predication, framework default) |
 
-For `scf.if`, the condition's domain is determined structurally:
+For `scf.if`, the condition's launch-node domain is determined structurally:
 
 - `PipeNetPredicateOpInterface` (i.e. `ttl.is_src` / `ttl.is_dst` /
   `ttl.is_active`) -> that PipeNet's role domain via the interface
@@ -2022,8 +2028,8 @@ user code.
 ## `ttl.pipenet_scope`
 
 `ttl.pipenet_scope` is one of the IR additions this feature introduces
-(alongside the `ttl.is_src` / `ttl.is_dst` / `ttl.is_active` predicate
-ops described in [Predicate recognition](#predicate-recognition)). It
+(alongside the `ttl.is_src` / `ttl.is_dst` / `ttl.is_active` role-query
+operations described in [PipeNet role queries](#pipenet-role-queries)). It
 exists only after frontend emission and before the verifier inlines and
 erases it. During that interval, the verifier can recognize user code
 that performs PipeNet role traffic without re-deriving the role
@@ -2034,7 +2040,7 @@ The frontend emits this region op around DFB-context blocks
 (`with cb.reserve()`) whose body contains pipe role work. It carries
 two parallel attributes: `ttl.pipe_net_ids` (`DenseI64ArrayAttr`) and
 `ttl.pipe_net_roles` (`DenseI64ArrayAttr`, one entry per id; 0 =
-Source, 1 = Destination - `Active` is a *predicate* via
+Source, 1 = Destination - `Active` is a runtime condition via
 `ttl.is_active` and is not valid as a scope role). The verifier checks
 that the scope's effective execution domain is a subset of the union
 of declared role domains, then walks its body with the same incoming
@@ -2135,7 +2141,7 @@ and `"full"` as the device compute grid. The compiled kernel launches on
 the resolved launch grid. The simulator filters execution to the union
 of all PipeNet source and destination nodes when PipeNets are present;
 that filter is not a per-operation role check, so user guards
-(`net.is_active()` or coordinate predicates) remain part of the compiler
+(`net.is_active()` or coordinate comparisons) remain part of the compiler
 contract.
 
 ## Example: 2D collective matmul

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -1931,9 +1931,14 @@ of matching source or destination records for every launch coordinate, indexes
 that table with the current logical X and Y coordinates, and compares the count
 with zero. For a graph PipeNet spanning logical devices, lowering evaluates the
 static records and requires both the launch-node coordinates and logical device
-to match the selected source or destination endpoint. Without a `records`
-attribute, lowering emits coordinate comparisons for the `ttl.create_pipe`
-operations associated with the operation's `pipe_net_id`.
+to match the selected source or destination endpoint.
+
+The Python frontend now adds `records` to every `ttl.is_src`, `ttl.is_dst`, and
+`ttl.is_active` operation. The attribute remains optional because requiring it
+would reject TTL modules using the preexisting form, which identifies the
+PipeNet only by `pipe_net_id`. For that form, lowering finds the module's
+`ttl.create_pipe` operations with the same PipeNet id and emits one source or
+destination coordinate comparison per pipe.
 
 `visitRegionBranchControlFlowTransfer` narrows the lattice on entry to
 each region according to the parent op:

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -1951,9 +1951,9 @@ each region according to the parent op:
 
 For `scf.if`, the condition's launch-node domain is determined structurally:
 
-- `PipeNetPredicateOpInterface` (i.e. `ttl.is_src` / `ttl.is_dst` /
-  `ttl.is_active`) -> that PipeNet's role domain via the interface
-  methods `getReferencedPipeNetId` / `getReferencedRole`.
+- A result from `ttl.is_src`, `ttl.is_dst`, or `ttl.is_active` uses the source,
+  destination, or combined role domain identified by the operation's
+  `pipe_net_id` and optional `records` attributes.
 - `arith.andi` / `arith.ori` decompose: each operand contributes its
   own domain (intersection or union). A coord-independent operand
   (loop iv, runtime flag) acts as identity instead of making the branch

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -1936,9 +1936,11 @@ to match the selected source or destination endpoint.
 The Python frontend now adds `records` to every `ttl.is_src`, `ttl.is_dst`, and
 `ttl.is_active` operation. The attribute remains optional for compatibility
 with older generated or serialized TTL modules, whose role-query operations
-identify the PipeNet only by `pipe_net_id`. For that form, lowering finds the
-module's `ttl.create_pipe` operations with the same PipeNet id and emits one
-source or destination coordinate comparison per pipe.
+identify the PipeNet only by `pipe_net_id`. For that form, lowering collects
+the pipes declared by `ttl.create_pipe`, `ttl.pipenet_foreach_src`, and
+`ttl.pipenet_foreach_dst` with the same PipeNet id, removes duplicate endpoint
+relations, and emits source or destination coordinate comparisons for each
+remaining pipe.
 
 `visitRegionBranchControlFlowTransfer` narrows the lattice on entry to
 each region according to the parent op:

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -39,9 +39,9 @@ A PipeNet's active nodes are the union of its source and destination
 coordinates. This is the node set tested by `net.is_active()`. Whenever
 the launch is wider than those active nodes, the user must guard
 pipe-coupled regions with `net.is_src()`, `net.is_dst()`,
-`net.is_active()`, or coordinate predicates that express the same role
-tests. The verifier rejects any pipe-coupled operation reachable from a
-node outside its declared role. The diagnostic names the offending
+`net.is_active()`, or coordinate comparisons that test the same source or
+destination membership. The verifier rejects any pipe-coupled operation
+reachable from a node outside its declared role. The diagnostic names the offending
 operation, an example offending coordinate, the contributing PipeNet or
 PipeNets, and a suggested guard.
 
@@ -176,11 +176,11 @@ reservation sequence whose advance exceeds `block_count` in both address modes.
 Multicast is not itself a restriction. A collective transfer whose receiver
 endpoints form one address-sequence equivalence class uses `CA/RP` when the
 sender can materialize that sequence. `RA/RP` remains available when computed
-addressing is disabled or another computed-address predicate fails. It does not
-make an invalid receiver reservation sequence valid. Both modes
-require the same graph proof because TT-Metal NoC multicast has one destination
-SRAM address operand. A collective transfer is rejected unless every receiver
-address is proven equal for every occurrence.
+addressing is disabled or a computed-address eligibility condition is not
+satisfied. It does not make an invalid receiver reservation sequence valid.
+Both modes require the same graph proof because TT-Metal NoC multicast has one
+destination SRAM address operand. A collective transfer is rejected unless
+every receiver address is proven equal for every occurrence.
 
 Pipe transfers have the following operational semantics:
 
@@ -863,12 +863,11 @@ uniform across the participating nodes. Changes controlled by values that may
 differ between nodes produce `FullyDynamic`.
 
 The execution point includes both the logical device, when a device domain is
-present, and the launch node within that device. A device predicate emitted for
-a graph PipeNet callback is evaluated against that logical device before the
-schedule is classified. It is not `FullyDynamic` merely because one generic
-kernel module is instantiated on several devices. A condition remains fully
-dynamic only when it cannot be resolved after both device and launch-node
-coordinates are fixed.
+present, and the launch node within that device. Schedule classification
+evaluates a graph PipeNet callback's logical-device comparison first. One
+generic kernel module instantiated on several devices is therefore not
+`FullyDynamic`. A condition remains fully dynamic only when it cannot be
+resolved after both device and launch-node coordinates are fixed.
 
 Execution-count specialization shares one immutable baseline dataflow solution
 per function or selected-record loop. Each logical-device-qualified execution
@@ -983,8 +982,8 @@ proven equal across participating nodes. Equal execution counts do not create
 an order between different functions, branch regions, or loop nests. Such
 schedules are `FullyDynamic`.
 Scopes known to execute only at the receiver, such as a matching
-`ttl.if_dst`, `ttl.pipenet_scope`, or logical-device predicate, do not add an
-unresolved runtime condition.
+`ttl.if_dst`, `ttl.pipenet_scope`, or resolved `ttl.is_device` condition, do
+not add an unresolved runtime condition.
 
 The analysis is:
 
@@ -1094,9 +1093,9 @@ If `A` is `KnownCount(1)`, every endpoint address is compared only at `i = 0`,
 so the collective is legal. If a statically known loop makes `A`
 `KnownCount(N)` for `N > 1`, or an unknown-count periodic loop makes it
 `PeriodicUnknownCount`, the sequences differ at `i = 1`, so the graph produces
-two address classes and rejects the multicast. A uniform-repeat-stride
-predicate would reject all cases; pointwise equivalence accepts exactly the
-legal one.
+two address classes and rejects the multicast. Requiring one repeat stride for
+all receivers would reject every case; pointwise equivalence accepts exactly
+the legal one.
 
 #### CA/CC capacity proof
 
@@ -1763,10 +1762,10 @@ may execute there.
   DFB producer-domain check.
 - `visitRegionBranchControlFlowTransfer`: when entering a region of
   `scf.if`, `affine.if`, `ttl.if_src`, `ttl.if_dst`, or
-  `ttl.pipenet_scope`, the lattice at the region entry is set to
-  `current` intersected with `predicate-domain`. The framework's
-  `RegionBranchOpInterface` machinery handles join points after the
-  op (the post-op lattice is the union of region exits and skip).
+  `ttl.pipenet_scope`, the lattice at the region entry is set to `current`
+  intersected with the coordinates where the condition is true. The
+  framework's `RegionBranchOpInterface` machinery handles join points after
+  the op (the post-op lattice is the union of region exits and skip).
 
 The TTL custom region ops use a `ttl.yield` implicit terminator
 (`SingleBlockImplicitTerminator<"YieldOp">`) so the framework can
@@ -1789,8 +1788,8 @@ the role required by the op:
 | --- | --- |
 | `ttl.copy(buffer, pipe)` | `pipe.src` (single coord) |
 | `ttl.copy(pipe, buffer)` | `pipe.dst` (receiver set) |
-| `ttl.if_src %pipe` body | `pipe.src` (op carries the predicate intrinsically) |
-| `ttl.if_dst %pipe` body | `pipe.dst` (op carries the predicate intrinsically) |
+| `ttl.if_src %pipe` body | `pipe.src` (the operation executes its body only at the source coordinate) |
+| `ttl.if_dst %pipe` body | `pipe.dst` (the operation executes its body only in the destination range) |
 | `cb_wait` on pipe-coupled DFB | union of producer domains across all `cb_push` to the same DFB index |
 
 DFB wait checking is module-global: producer domains accumulate by
@@ -1827,9 +1826,10 @@ its events from the schedule.
 
 Cross-device correspondence includes the logical-device transfer in the pipe
 identity. Send counts are evaluated at the transfer's source device; receiver
-post and wait counts are evaluated at its destination device. Device predicates
-that are mutually exclusive in the generic kernel can therefore prove matching
-endpoint counts. Local pipes use the existing launch-node-only queries.
+post and wait counts are evaluated at its destination device. Mutually
+exclusive `ttl.is_device` conditions in the generic kernel can therefore prove
+matching endpoint counts. Local pipes use the existing launch-node-only
+queries.
 
 ### Pipe transfer and receiver-address graph
 
@@ -2022,7 +2022,7 @@ note: suggested guard: `net_0.is_src()`
 | collective pipe receiver payload layouts are incompatible | Collective endpoints use incompatible DFB element types, block sizes, reserve spans, or destination subviews. | use compatible receiver payload layouts, or use separate point-to-point transfers |
 | collective pipe receiver address sequences are not proven equal | The graph cannot prove one pointwise destination-address class over all occurrences of a collective transfer. | use receiver schedules that produce the same address for every occurrence, or use separate point-to-point transfers |
 | this `cb_wait` reads from a dataflow buffer that no other thread fills | A `cb_wait` references a DFB index that no `cb_push` anywhere in the module writes to. | check that another `@ttl.compute()` or `@ttl.datamovement()` thread reserves and pushes the same buffer |
-| this `cb_wait` runs on launched nodes where no thread pushes data to the buffer (would deadlock) | A `cb_wait` is reachable from nodes outside the union of `cb_push` producer domains for the same DFB index. | guard the wait with the same `if net.is_active(): ...` predicate the producer uses |
+| this `cb_wait` runs on launched nodes where no thread pushes data to the buffer (would deadlock) | A `cb_wait` is reachable from nodes outside the union of `cb_push` producer domains for the same DFB index. | guard the wait with the same `if net.is_active(): ...` role condition the producer uses |
 | could not statically analyze the PipeNet guard around this op | A surrounding condition uses runtime values or arithmetic the verifier can't enumerate per coordinate (e.g. multiplying a node coordinate by a runtime value). | rewrite using `net.is_src()` / `net.is_dst()` / `net.is_active()`, or compare `ttl.node(dims=2)` coordinates against integer constants |
 
 Internal-invariant diagnostics also exist (`references unknown PipeNet
@@ -2042,14 +2042,14 @@ declarations from each pipe-coupled op individually. The op never
 reaches TTL -> TTKernel lowering.
 
 The frontend emits this region op around DFB-context blocks
-(`with cb.reserve()`) whose body contains pipe role work. It carries
-two parallel attributes: `ttl.pipe_net_ids` (`DenseI64ArrayAttr`) and
+(`with cb.reserve()`) whose body contains pipe role work. It has two parallel
+attributes: `ttl.pipe_net_ids` (`DenseI64ArrayAttr`) and
 `ttl.pipe_net_roles` (`DenseI64ArrayAttr`, one entry per id; 0 =
 Source, 1 = Destination - `Active` is a runtime condition via
 `ttl.is_active` and is not valid as a scope role). The verifier checks
 that the scope's effective execution domain is a subset of the union
 of declared role domains, then walks its body with the same incoming
-domain because the scope has no runtime predicate. After verification
+domain because the scope adds no runtime condition. After verification
 the verifier inlines and erases the scope so downstream lowering sees a
 `pipenet_scope`-free IR.
 
@@ -2081,18 +2081,17 @@ A `ttl.copy(buffer, %pipe_a)` reachable from a node that is in
 diagnostic that names `net_a`, not the active nodes of some other
 PipeNet.
 
-Two mechanisms together carry per-PipeNet correctness in user code
+Two mechanisms enforce per-PipeNet correctness in user code
 when an operation defines multiple PipeNets over different node groups:
 
-1. `ttl.if_src %pipe { ... }` and `ttl.if_dst %pipe { ... }` carry
-   their own per-node predicate: the inner block executes only when
-   the current node matches that pipe's source or is in its
-   destination range. Per-pipe data movement is therefore correctly
-   conditional without any per-PipeNet wrapper.
+1. `ttl.if_src %pipe { ... }` executes only at the pipe's source, and
+   `ttl.if_dst %pipe { ... }` executes only in its destination range.
+   Per-pipe data movement is therefore conditional without a per-PipeNet
+   wrapper.
 
 2. Non-pipe work (dataflow-buffer reserves, compute, address
-   arithmetic) is guarded by the user with explicit role-based
-   predicates: `if net.is_src()`, `if net.is_dst()`,
+   arithmetic) is guarded by explicit role queries:
+   `if net.is_src()`, `if net.is_dst()`,
    `if net.is_active()`, or coordinate comparisons over
    `ttl.node(dims=2)` against integer constants.
 
@@ -2132,7 +2131,7 @@ that the two diverge:
 | Same-thread PipeNet wait-for cycles | yes (`ttl-verify-pipenet-schedule`) | runtime only |
 | `ttl.pipenet_scope` domain is a subset of declared role union | yes | no |
 | `cb_wait` covered by `cb_push` producer domain | yes (static) | runtime only (deadlock detector in `greenlet_scheduler.py`) |
-| Unanalyzable coord-dependent predicate diagnosed | yes | no |
+| Unanalyzable coordinate-dependent condition diagnosed | yes | no |
 | Missing/malformed `ttl.launch_grid`, unknown PipeNet ids | yes | n/a (no IR) |
 
 Consequently a guard bug that the compiler rejects with a precise
@@ -2183,7 +2182,7 @@ Pipe sources contribute `{(0, 0), (0, 1), (0, 2), (0, 3), (0, 0), (1, 0),
 (2, 0)}` and destinations contribute the rectangles `[0,3) x {row}` for
 each row plus `{col} x [0,4)` for each col. `a_net.is_active()` covers
 exactly `[0, 3) x [0, 4)`, twelve nodes; the remaining 8x7 - 12 = 44
-launched nodes evaluate the predicate to `false` and skip the
+launched nodes evaluate the role query to `false` and skip the
 pipe-coupled work.
 
 ## Test coverage
@@ -2256,7 +2255,7 @@ compile-time properties not runtime-observable.
 | 47 | Verifier names per-PipeNet role in cross-net diagnostics  |     |     |  X  |
 | 48 | `CreatePipeOp::verify` rejects `dstStart > dstEnd` (x)    |     |     |  X  |
 | 49 | `CreatePipeOp::verify` rejects `dstStart > dstEnd` (y)    |     |     |  X  |
-| 50 | Verifier rejects unanalyzable predicates with location note |   |     |  X  |
+| 50 | Verifier rejects unanalyzable coordinate conditions with location note |   |     |  X  |
 | 50a| Verifier rejects missing `ttl.launch_grid` module attribute |   |     |  X  |
 | 50b| Pipeline lit confirms `pipenet_scope` is gone post-verifier |   |     |  X  |
 | 51 | OperationPipeNets.work_extent: empty / point-to-point / collective |     |  X  |     |
@@ -2428,7 +2427,7 @@ resolves logical device edges to physical fabric routes.
 
 The shared graph and proof must preserve these fabric invariants:
 
-* logical-device predicates are evaluated as part of the execution coordinate;
+* logical-device comparisons are evaluated as part of the execution coordinate;
 * corresponding send and receiver-post declarations identify the same logical
   device transfer;
 * fabric transfers require a proven computed receiver address;

--- a/docs/development/PipeNets.md
+++ b/docs/development/PipeNets.md
@@ -1924,6 +1924,11 @@ methods `net.is_src()`, `net.is_dst()`, `net.is_active()` lower to
 these ops; coordinate comparisons over `ttl.node(dims=2)` against
 integer constants also work and are evaluated per coord.
 
+Frontend predicate ops carry their static PipeNet record table. Local
+predicates reuse the participant plan to load one per-node record count and
+compare it with zero. Logical-device predicates additionally match the current
+device. Predicates without a record table retain PipeNet-index lowering.
+
 `visitRegionBranchControlFlowTransfer` narrows the lattice on entry to
 each region according to the parent op:
 

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -46,8 +46,8 @@ constexpr llvm::StringLiteral
 /// Selected strategy on tile operations with execution alternatives.
 constexpr llvm::StringLiteral
     kTileExecutionStrategyAttrName("ttl.tile_execution_strategy");
-/// PipeNet role exposed by `is_src` / `is_dst` / `is_active` predicate ops
-/// and by `pipenet_scope` declarations.
+/// PipeNet role queried by `is_src`, `is_dst`, and `is_active` operations and
+/// declared by `pipenet_scope`.
 enum class PipeRole : int64_t {
   Source = 0,
   Destination = 1,

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -90,8 +90,9 @@ def TTL_PipeNetPredicateOpInterface
     union. When the operation has a `records` attribute, those static transfer
     records define the selected nodes. Logical-device records match both the
     launch node and endpoint device; local records match the launch node alone.
-    Without `records`, `pipe_net_id` refers to the module's `ttl.create_pipe`
-    declarations for that PipeNet.
+    For compatibility with older generated or serialized TTL modules,
+    `records` is optional. Without it, `pipe_net_id` refers to the module's
+    `ttl.create_pipe` declarations for that PipeNet.
   }];
 
   let cppNamespace = "::mlir::tt::ttl";

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -87,8 +87,9 @@ def TTL_PipeNetPredicateOpInterface
   let description = [{
     Predicate ops (`ttl.is_src`, `ttl.is_dst`, `ttl.is_active`) whose `i1`
     result evaluates to `true` on a per-PipeNet role-defined execution set.
-    Predicates with graph records match both the launch node and logical-device
-    endpoint; predicates without graph records match the launch node alone.
+    Predicates with records use that table directly. Logical-device records
+    match both the launch node and endpoint device; local records match the
+    launch node alone.
   }];
 
   let cppNamespace = "::mlir::tt::ttl";
@@ -105,7 +106,7 @@ def TTL_PipeNetPredicateOpInterface
       /*methodName=*/"getReferencedRole",
       /*args=*/(ins)>,
     InterfaceMethod<
-      /*desc=*/"Return the graph record table, when the predicate is device-aware.",
+      /*desc=*/"Return the record table when it is carried by the predicate.",
       /*retTy=*/"::mlir::tt::ttl::PipeNetRecordsAttr",
       /*methodName=*/"getReferencedRecords",
       /*args=*/(ins),

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -91,8 +91,9 @@ def TTL_PipeNetPredicateOpInterface
     records define the selected nodes. Logical-device records match both the
     launch node and endpoint device; local records match the launch node alone.
     For compatibility with older generated or serialized TTL modules,
-    `records` is optional. Without it, `pipe_net_id` refers to the module's
-    `ttl.create_pipe` declarations for that PipeNet.
+    `records` is optional. Without it, `pipe_net_id` identifies the pipes
+    declared by `ttl.create_pipe`, `ttl.pipenet_foreach_src`, and
+    `ttl.pipenet_foreach_dst` for that PipeNet.
   }];
 
   let cppNamespace = "::mlir::tt::ttl";

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -85,28 +85,28 @@ def TTL_DFBInputOpInterface : OpInterface<"DFBInputOpInterface"> {
 def TTL_PipeNetPredicateOpInterface
     : OpInterface<"PipeNetPredicateOpInterface"> {
   let description = [{
-    Predicate ops (`ttl.is_src`, `ttl.is_dst`, `ttl.is_active`) whose `i1`
-    result evaluates to `true` on a per-PipeNet role-defined execution set.
-    Predicates with records use that table directly. Logical-device records
-    match both the launch node and endpoint device; local records match the
-    launch node alone.
+    PipeNet role-query operations. `ttl.is_src` selects source nodes,
+    `ttl.is_dst` selects destination nodes, and `ttl.is_active` selects their
+    union. When the operation has a `records` attribute, those static transfer
+    records define the selected nodes. Logical-device records match both the
+    launch node and endpoint device; local records match the launch node alone.
   }];
 
   let cppNamespace = "::mlir::tt::ttl";
 
   let methods = [
     InterfaceMethod<
-      /*desc=*/"Return the PipeNet id this predicate references.",
+      /*desc=*/"Return the PipeNet id this role-query operation references.",
       /*retTy=*/"int64_t",
       /*methodName=*/"getReferencedPipeNetId",
       /*args=*/(ins)>,
     InterfaceMethod<
-      /*desc=*/"Return the PipeNet role this predicate selects.",
+      /*desc=*/"Return the PipeNet role this operation queries.",
       /*retTy=*/"::mlir::tt::ttl::PipeRole",
       /*methodName=*/"getReferencedRole",
       /*args=*/(ins)>,
     InterfaceMethod<
-      /*desc=*/"Return the record table when it is carried by the predicate.",
+      /*desc=*/"Return the operation's static PipeNet records, when present.",
       /*retTy=*/"::mlir::tt::ttl::PipeNetRecordsAttr",
       /*methodName=*/"getReferencedRecords",
       /*args=*/(ins),

--- a/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLInterfaces.td
@@ -90,6 +90,8 @@ def TTL_PipeNetPredicateOpInterface
     union. When the operation has a `records` attribute, those static transfer
     records define the selected nodes. Logical-device records match both the
     launch node and endpoint device; local records match the launch node alone.
+    Without `records`, `pipe_net_id` refers to the module's `ttl.create_pipe`
+    declarations for that PipeNet.
   }];
 
   let cppNamespace = "::mlir::tt::ttl";

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1073,8 +1073,9 @@ def TTL_IsSrcOp : TTL_Op<"is_src",
     Returns `true` on nodes that match the `src` of at least one pipe in the
     named PipeNet, `false` elsewhere. The value-returning sibling of
     `ttl.if_src`; used as the condition of an `scf.if` to guard pipe-coupled
-    work without entering a region. When `records` is present, the current
-    logical device must also match the source endpoint in a record.
+    work without entering a region. When `records` is present, the predicate
+    uses that table directly; logical-device records also require the current
+    device to match the source endpoint.
   }];
   let arguments = (ins I64Attr:$pipe_net_id,
                         OptionalAttr<TTL_PipeNetRecordsAttr>:$records);
@@ -1090,8 +1091,8 @@ def TTL_IsDstOp : TTL_Op<"is_dst",
     Returns `true` on nodes whose coordinate falls within the `dst` range of
     at least one pipe in the named PipeNet, `false` elsewhere. The
     value-returning sibling of `ttl.if_dst`. When `records` is present, the
-    current logical device must also match the destination endpoint in a
-    record.
+    predicate uses that table directly; logical-device records also require
+    the current device to match the destination endpoint.
   }];
   let arguments = (ins I64Attr:$pipe_net_id,
                         OptionalAttr<TTL_PipeNetRecordsAttr>:$records);
@@ -1123,8 +1124,8 @@ def TTL_IsActiveOp : TTL_Op<"is_active",
   let description = [{
     Returns `true` on nodes that are either a source or a destination of at
     least one pipe in the named PipeNet (the union of `is_src` and `is_dst`).
-    When `records` is present, node roles also include the corresponding
-    logical-device endpoints.
+    When `records` is present, the predicate uses that table directly;
+    logical-device records also require the corresponding endpoint device.
   }];
   let arguments = (ins I64Attr:$pipe_net_id,
                         OptionalAttr<TTL_PipeNetRecordsAttr>:$records);

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -1068,14 +1068,14 @@ def TTL_PipeNetScopeOp : TTL_Op<"pipenet_scope",
 
 def TTL_IsSrcOp : TTL_Op<"is_src",
     [Pure, DeclareOpInterfaceMethods<TTL_PipeNetPredicateOpInterface>]> {
-  let summary = "Predicate: current node is a source of any pipe in the PipeNet";
+  let summary = "Return whether the current node is a PipeNet source";
   let description = [{
     Returns `true` on nodes that match the `src` of at least one pipe in the
     named PipeNet, `false` elsewhere. The value-returning sibling of
     `ttl.if_src`; used as the condition of an `scf.if` to guard pipe-coupled
-    work without entering a region. When `records` is present, the predicate
-    uses that table directly; logical-device records also require the current
-    device to match the source endpoint.
+    work without entering a region. When `records` is present, the operation
+    uses those records directly; logical-device records also require the
+    current device to match the source endpoint.
   }];
   let arguments = (ins I64Attr:$pipe_net_id,
                         OptionalAttr<TTL_PipeNetRecordsAttr>:$records);
@@ -1086,12 +1086,12 @@ def TTL_IsSrcOp : TTL_Op<"is_src",
 
 def TTL_IsDstOp : TTL_Op<"is_dst",
     [Pure, DeclareOpInterfaceMethods<TTL_PipeNetPredicateOpInterface>]> {
-  let summary = "Predicate: current node is a destination of any pipe in the PipeNet";
+  let summary = "Return whether the current node is a PipeNet destination";
   let description = [{
     Returns `true` on nodes whose coordinate falls within the `dst` range of
     at least one pipe in the named PipeNet, `false` elsewhere. The
     value-returning sibling of `ttl.if_dst`. When `records` is present, the
-    predicate uses that table directly; logical-device records also require
+    operation uses those records directly; logical-device records also require
     the current device to match the destination endpoint.
   }];
   let arguments = (ins I64Attr:$pipe_net_id,
@@ -1120,11 +1120,11 @@ def TTL_PipeNetDestinationCountOp
 
 def TTL_IsActiveOp : TTL_Op<"is_active",
     [Pure, DeclareOpInterfaceMethods<TTL_PipeNetPredicateOpInterface>]> {
-  let summary = "Predicate: current node is a source or destination in the PipeNet";
+  let summary = "Return whether the current node participates in a PipeNet";
   let description = [{
     Returns `true` on nodes that are either a source or a destination of at
     least one pipe in the named PipeNet (the union of `is_src` and `is_dst`).
-    When `records` is present, the predicate uses that table directly;
+    When `records` is present, the operation uses those records directly;
     logical-device records also require the corresponding endpoint device.
   }];
   let arguments = (ins I64Attr:$pipe_net_id,

--- a/include/ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h
+++ b/include/ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h
@@ -28,13 +28,19 @@ struct LocalPipeNetParticipantPlan {
   SmallVector<int64_t> recordIndices;
 };
 
-/// Group `records` by nodes with `role` in the grid (`gridX`, `gridY`).
-/// On failure, report the invalid grid or record through `emitError` if
-/// supplied; callers trying an optional optimization may omit it and use
-/// another lowering.
-FailureOr<LocalPipeNetParticipantPlan> buildLocalPipeNetParticipantPlan(
+/// Check that `records` selects local nodes within (`gridX`, `gridY`) for
+/// `role` and that the grid area and record count fit signed 64-bit indices.
+/// Report invalid inputs through `emitError` when supplied, without building
+/// the node tables; optional optimizations may omit diagnostics.
+LogicalResult validateLocalPipeNetParticipantPlanInputs(
     PipeNetRecordsAttr records, PipeRole role, int64_t gridX, int64_t gridY,
     llvm::function_ref<InFlightDiagnostic()> emitError = {});
+
+/// Group `records` by nodes with `role` in the grid (`gridX`, `gridY`).
+/// Fail if the inputs do not satisfy validateLocalPipeNetParticipantPlanInputs.
+FailureOr<LocalPipeNetParticipantPlan>
+buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
+                                 int64_t gridX, int64_t gridY);
 
 /// Record slices for each logical device in a grid-major device PipeNet.
 ///

--- a/include/ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h
+++ b/include/ttlang/Dialect/TTL/Transforms/PipeNetParticipantPlan.h
@@ -7,7 +7,9 @@
 
 #include "ttlang/Dialect/TTL/IR/TTLOps.h"
 
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <cstdint>
@@ -26,10 +28,13 @@ struct LocalPipeNetParticipantPlan {
   SmallVector<int64_t> recordIndices;
 };
 
-/// Build local launch-node record slices for `role`.
-FailureOr<LocalPipeNetParticipantPlan>
-buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
-                                 int64_t gridX, int64_t gridY);
+/// Group `records` by nodes with `role` in the grid (`gridX`, `gridY`).
+/// On failure, report the invalid grid or record through `emitError` if
+/// supplied; callers trying an optional optimization may omit it and use
+/// another lowering.
+FailureOr<LocalPipeNetParticipantPlan> buildLocalPipeNetParticipantPlan(
+    PipeNetRecordsAttr records, PipeRole role, int64_t gridX, int64_t gridY,
+    llvm::function_ref<InFlightDiagnostic()> emitError = {});
 
 /// Record slices for each logical device in a grid-major device PipeNet.
 ///

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -3202,25 +3202,12 @@ static mlir::LogicalResult verifyPipeNetRecordIdentity(PipeNetReferenceOp op) {
   return mlir::success();
 }
 
-template <typename PredicateOp>
-static mlir::LogicalResult verifyPipeNetPredicate(PredicateOp op) {
-  if (mlir::failed(verifyPipeNetRecordIdentity(op))) {
-    return mlir::failure();
-  }
-  mlir::tt::ttl::PipeNetRecordsAttr records = op.getRecordsAttr();
-  if (records && !records.getPipes().front().getDeviceTransfer()) {
-    return op.emitOpError()
-           << "record table must identify logical-device transfers";
-  }
-  return mlir::success();
-}
-
 mlir::LogicalResult mlir::tt::ttl::IsSrcOp::verify() {
-  return verifyPipeNetPredicate(*this);
+  return verifyPipeNetRecordIdentity(*this);
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsDstOp::verify() {
-  return verifyPipeNetPredicate(*this);
+  return verifyPipeNetRecordIdentity(*this);
 }
 
 mlir::LogicalResult mlir::tt::ttl::PipeNetDestinationCountOp::verify() {
@@ -3228,7 +3215,7 @@ mlir::LogicalResult mlir::tt::ttl::PipeNetDestinationCountOp::verify() {
 }
 
 mlir::LogicalResult mlir::tt::ttl::IsActiveOp::verify() {
-  return verifyPipeNetPredicate(*this);
+  return verifyPipeNetRecordIdentity(*this);
 }
 
 int64_t mlir::tt::ttl::IsSrcOp::getReferencedPipeNetId() {

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -343,14 +343,14 @@ LaunchNodeDomain getPipeRecordsRoleLaunchNodeDomain(PipeNetRecordsAttr records,
   return result;
 }
 
-/// Device-qualified records require device identity because one launch node
-/// can participate on one logical device and not another.
+// Device-qualified records require device identity because one launch node
+// can participate on one logical device and not another.
 static bool hasDeviceQualifiedPipeNetRecords(PipeNetRecordsAttr records) {
   return records && records.getPipes().front().getDeviceTransfer();
 }
 
-/// Record predicates own their endpoint set; a module-wide PipeNet domain can
-/// include other declarations sharing the same id.
+// Record predicates own their endpoint set; a module-wide PipeNet domain can
+// include other declarations sharing the same id.
 static LaunchNodeDomain
 getPipeNetPredicateRoleLaunchNodeDomain(PipeNetPredicateOpInterface predicate,
                                         const LaunchNodeDomainState &state) {

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -343,14 +343,15 @@ LaunchNodeDomain getPipeRecordsRoleLaunchNodeDomain(PipeNetRecordsAttr records,
   return result;
 }
 
-// Device-qualified records require device identity because one launch node
-// can participate on one logical device and not another.
+// Return true if `records` specifies logical-device transfers, and false for
+// absent or local records. Attribute verification ensures all entries agree.
 static bool hasDeviceQualifiedPipeNetRecords(PipeNetRecordsAttr records) {
   return records && records.getPipes().front().getDeviceTransfer();
 }
 
-// A role query's records define its exact endpoint set; the module-wide domain
-// can include other declarations sharing the same id.
+// Return the source, destination, or combined node coordinates requested by
+// `predicate`. Use its records when present, otherwise the declarations in
+// `state`. The returned coordinate set does not distinguish logical devices.
 static LaunchNodeDomain
 getPipeNetPredicateRoleLaunchNodeDomain(PipeNetPredicateOpInterface predicate,
                                         const LaunchNodeDomainState &state) {
@@ -498,33 +499,28 @@ void LaunchNodeDomainState::initialize(ModuleOp module) {
     baseDomain = getFullLaunchNodeDomain(launchGrid->first, launchGrid->second);
   }
 
-  module.walk([&](CreatePipeOp pipe) {
-    std::optional<StringRef> name;
-    if (auto attr = pipe.getPipeNetNameAttr()) {
-      name = attr.getValue();
-    }
-    recordPipeNet(mlir::cast<PipeType>(pipe.getResult().getType()),
-                  pipe.getLoc(), name);
-  });
-  module.walk([&](PipeNetForeachSrcOp op) {
-    recordPipeNetRecords(op.getRecords(), op.getLoc());
-  });
-  module.walk([&](PipeNetForeachDstOp op) {
-    recordPipeNetRecords(op.getRecords(), op.getLoc());
-  });
-  module.walk([&](PipeNetDestinationCountOp op) {
-    recordPipeNetRecords(op.getRecords(), op.getLoc());
-  });
-  module.walk([&](SelectPipeSrcOp op) {
-    recordPipeNetRecords(op.getRecords(), op.getLoc());
-  });
-  module.walk([&](SelectPipeDstOp op) {
-    recordPipeNetRecords(op.getRecords(), op.getLoc());
-  });
-  module.walk([&](PipeNetPredicateOpInterface predicate) {
-    if (PipeNetRecordsAttr records = predicate.getReferencedRecords()) {
-      recordPipeNetRecords(records, predicate->getLoc());
-    }
+  // Collect all declarations together: their coordinate sets are combined by
+  // union, so no declaration needs to be processed before another.
+  module.walk([&](Operation *op) {
+    llvm::TypeSwitch<Operation *>(op)
+        .Case<CreatePipeOp>([&](CreatePipeOp pipe) {
+          std::optional<StringRef> name;
+          if (auto attr = pipe.getPipeNetNameAttr()) {
+            name = attr.getValue();
+          }
+          recordPipeNet(mlir::cast<PipeType>(pipe.getResult().getType()),
+                        pipe.getLoc(), name);
+        })
+        .Case<PipeNetForeachSrcOp, PipeNetForeachDstOp,
+              PipeNetDestinationCountOp, SelectPipeSrcOp, SelectPipeDstOp>(
+            [&](auto recordsOp) {
+              recordPipeNetRecords(recordsOp.getRecords(), recordsOp.getLoc());
+            })
+        .Case<PipeNetPredicateOpInterface>([&](auto query) {
+          if (PipeNetRecordsAttr records = query.getReferencedRecords()) {
+            recordPipeNetRecords(records, query->getLoc());
+          }
+        });
   });
 }
 
@@ -1539,8 +1535,7 @@ getBranchDomainsImpl(Value condition, const LaunchNodeDomain &current,
     LaunchNodeDomain roleDomain =
         getPipeNetPredicateRoleLaunchNodeDomain(pred, state);
     PipeNetRecordsAttr records = pred.getReferencedRecords();
-    // Device-qualified records require a logical-device location to exclude
-    // the role's launch nodes from the false branch.
+    // Without knowing the device, any node may take the false branch.
     if (hasDeviceQualifiedPipeNetRecords(records)) {
       return {current.intersectWith(roleDomain), current};
     }

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -349,8 +349,8 @@ static bool hasDeviceQualifiedPipeNetRecords(PipeNetRecordsAttr records) {
   return records && records.getPipes().front().getDeviceTransfer();
 }
 
-// Record predicates own their endpoint set; a module-wide PipeNet domain can
-// include other declarations sharing the same id.
+// A role query's records define its exact endpoint set; the module-wide domain
+// can include other declarations sharing the same id.
 static LaunchNodeDomain
 getPipeNetPredicateRoleLaunchNodeDomain(PipeNetPredicateOpInterface predicate,
                                         const LaunchNodeDomainState &state) {

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -502,6 +502,11 @@ void LaunchNodeDomainState::initialize(ModuleOp module) {
   module.walk([&](SelectPipeDstOp op) {
     recordPipeNetRecords(op.getRecords(), op.getLoc());
   });
+  module.walk([&](PipeNetPredicateOpInterface predicate) {
+    if (PipeNetRecordsAttr records = predicate.getReferencedRecords()) {
+      recordPipeNetRecords(records, predicate->getLoc());
+    }
+  });
 }
 
 static std::optional<llvm::APInt>

--- a/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/LaunchNodeDomainAnalysis.cpp
@@ -343,6 +343,25 @@ LaunchNodeDomain getPipeRecordsRoleLaunchNodeDomain(PipeNetRecordsAttr records,
   return result;
 }
 
+/// Device-qualified records require device identity because one launch node
+/// can participate on one logical device and not another.
+static bool hasDeviceQualifiedPipeNetRecords(PipeNetRecordsAttr records) {
+  return records && records.getPipes().front().getDeviceTransfer();
+}
+
+/// Record predicates own their endpoint set; a module-wide PipeNet domain can
+/// include other declarations sharing the same id.
+static LaunchNodeDomain
+getPipeNetPredicateRoleLaunchNodeDomain(PipeNetPredicateOpInterface predicate,
+                                        const LaunchNodeDomainState &state) {
+  if (PipeNetRecordsAttr records = predicate.getReferencedRecords()) {
+    return getPipeRecordsRoleLaunchNodeDomain(records,
+                                              predicate.getReferencedRole());
+  }
+  return state.getRoleDomain(predicate.getReferencedPipeNetId(),
+                             predicate.getReferencedRole());
+}
+
 /// Normalize integer-array attributes before verifier-specific interpretation.
 static bool readI64ArrayAttr(Operation *op, llvm::StringLiteral name,
                              SmallVectorImpl<int64_t> &values) {
@@ -522,13 +541,12 @@ evaluateLaunchNodeContextValue(Value value, LaunchNodeCoord coord,
   }
   if (state) {
     if (auto predicate = value.getDefiningOp<PipeNetPredicateOpInterface>()) {
-      if (predicate.getReferencedRecords()) {
+      PipeNetRecordsAttr records = predicate.getReferencedRecords();
+      if (hasDeviceQualifiedPipeNetRecords(records)) {
         return std::nullopt;
       }
       bool selected = knownLaunchNodeDomainContains(
-          state->getRoleDomain(predicate.getReferencedPipeNetId(),
-                               predicate.getReferencedRole()),
-          coord);
+          getPipeNetPredicateRoleLaunchNodeDomain(predicate, *state), coord);
       return llvm::APInt(/*numBits=*/1, selected);
     }
   }
@@ -1518,9 +1536,12 @@ getBranchDomainsImpl(Value condition, const LaunchNodeDomain &current,
                      const LaunchNodeDomainState &state,
                      llvm::DenseMap<Value, bool> &coordCache) {
   if (auto pred = condition.getDefiningOp<PipeNetPredicateOpInterface>()) {
-    LaunchNodeDomain roleDomain = state.getRoleDomain(
-        pred.getReferencedPipeNetId(), pred.getReferencedRole());
-    if (pred.getReferencedRecords()) {
+    LaunchNodeDomain roleDomain =
+        getPipeNetPredicateRoleLaunchNodeDomain(pred, state);
+    PipeNetRecordsAttr records = pred.getReferencedRecords();
+    // Device-qualified records require a logical-device location to exclude
+    // the role's launch nodes from the false branch.
+    if (hasDeviceQualifiedPipeNetRecords(records)) {
       return {current.intersectWith(roleDomain), current};
     }
     return exactBranches(roleDomain, current, state.baseDomain);

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -4005,16 +4005,16 @@ lowerPlannedDeviceDestinationCount(Operation *op, PipeNetRecordsAttr records,
 
 // Local records permit one launch-node-indexed count-table lookup.
 static FailureOr<Value>
-lowerLocalDestinationCount(Operation *op, PipeNetRecordsAttr records,
-                           ConversionPatternRewriter &rewriter) {
+lowerLocalRoleRecordCount(Operation *op, PipeNetRecordsAttr records,
+                          PipeRole role,
+                          ConversionPatternRewriter &rewriter) {
   FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
   if (failed(launchGrid)) {
     return failure();
   }
   auto [gridX, gridY] = *launchGrid;
   FailureOr<LocalPipeNetParticipantPlan> participantPlan =
-      buildLocalPipeNetParticipantPlan(records, PipeRole::Destination, gridX,
-                                       gridY);
+      buildLocalPipeNetParticipantPlan(records, role, gridX, gridY);
   if (failed(participantPlan)) {
     return failure();
   }
@@ -4032,6 +4032,21 @@ lowerLocalDestinationCount(Operation *op, PipeNetRecordsAttr records,
       rewriter, loc, participantPlan->recordCountsByNode, nodeIndex);
 }
 
+static FailureOr<Value>
+lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
+                        PipeRole role,
+                        ConversionPatternRewriter &rewriter) {
+  FailureOr<Value> recordCount =
+      lowerLocalRoleRecordCount(op, records, role, rewriter);
+  if (failed(recordCount)) {
+    return failure();
+  }
+  Value zero = arith::ConstantIndexOp::create(rewriter, op->getLoc(), 0);
+  return arith::CmpIOp::create(rewriter, op->getLoc(),
+                              arith::CmpIPredicate::ne, *recordCount, zero)
+      .getResult();
+}
+
 // Lower a per-pipe-role predicate op to the OR of per-pipe matches in the
 // named PipeNet. `roleBuilder` produces the i1 match for one static pipe.
 template <typename Op>
@@ -4042,8 +4057,18 @@ static LogicalResult lowerRolePredicate(
         roleBuilder) {
   auto loc = op.getLoc();
   if (PipeNetRecordsAttr records = op.getRecordsAttr()) {
-    rewriter.replaceOp(op,
-                       lowerSelectedRolePredicate(op, records, role, rewriter));
+    if (records.getPipes().front().getDeviceTransfer()) {
+      rewriter.replaceOp(
+          op, lowerSelectedRolePredicate(op, records, role, rewriter));
+      return success();
+    }
+    FailureOr<Value> localPredicate =
+        lowerLocalRolePredicate(op, records, role, rewriter);
+    if (failed(localPredicate)) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot build a local PipeNet participant plan");
+    }
+    rewriter.replaceOp(op, *localPredicate);
     return success();
   }
   int64_t netId = op.getPipeNetId();
@@ -4127,8 +4152,8 @@ struct PipeNetDestinationCountLowering
                   : lowerDeviceDestinationCountByRecord(op, records, rewriter));
       return success();
     }
-    FailureOr<Value> localCount =
-        lowerLocalDestinationCount(op, records, rewriter);
+    FailureOr<Value> localCount = lowerLocalRoleRecordCount(
+        op, records, PipeRole::Destination, rewriter);
     if (succeeded(localCount)) {
       rewriter.replaceOp(op, *localCount);
       return success();

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -4031,6 +4031,7 @@ lowerLocalRoleRecordCount(Operation *op, PipeNetRecordsAttr records,
       rewriter, loc, participantPlan->recordCountsByNode, nodeIndex);
 }
 
+// Reuse the count query so duplicate records still produce one boolean match.
 static FailureOr<Value>
 lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
                         PipeRole role, ConversionPatternRewriter &rewriter) {
@@ -4045,6 +4046,8 @@ lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
       .getResult();
 }
 
+// Record attributes define the exact queried endpoints; older recordless
+// operations instead query every pipe declaration with the referenced id.
 template <typename Op>
 static LogicalResult lowerRolePredicate(
     Op op, ConversionPatternRewriter &rewriter,

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -4006,24 +4006,16 @@ lowerPlannedDeviceDestinationCount(Operation *op, PipeNetRecordsAttr records,
 // Emit an index value counting entries in `records` for which the current node
 // has `role` (source, destination, or either). Use the launch grid enclosing
 // `op`; fail before emitting IR if that grid or the local records are invalid.
-// If supplied, `emitError` reports the invalid input at the caller's location.
-static FailureOr<Value> lowerLocalRoleRecordCount(
-    Operation *op, PipeNetRecordsAttr records, PipeRole role,
-    ConversionPatternRewriter &rewriter,
-    llvm::function_ref<InFlightDiagnostic()> emitError = {}) {
+static FailureOr<Value>
+lowerLocalRoleRecordCount(Operation *op, PipeNetRecordsAttr records,
+                          PipeRole role, ConversionPatternRewriter &rewriter) {
   FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
   if (failed(launchGrid)) {
-    if (emitError) {
-      emitError()
-          << "local PipeNet role query requires a valid ttl.launch_grid "
-             "with two positive integer extents; set the operation's "
-             "launch grid to include its PipeNet endpoints";
-    }
     return failure();
   }
   auto [gridX, gridY] = *launchGrid;
   FailureOr<LocalPipeNetParticipantPlan> participantPlan =
-      buildLocalPipeNetParticipantPlan(records, role, gridX, gridY, emitError);
+      buildLocalPipeNetParticipantPlan(records, role, gridX, gridY);
   if (failed(participantPlan)) {
     return failure();
   }
@@ -4047,8 +4039,8 @@ static FailureOr<Value> lowerLocalRoleRecordCount(
 static FailureOr<Value>
 lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
                         PipeRole role, ConversionPatternRewriter &rewriter) {
-  FailureOr<Value> recordCount = lowerLocalRoleRecordCount(
-      op, records, role, rewriter, [&]() { return op->emitError(); });
+  FailureOr<Value> recordCount =
+      lowerLocalRoleRecordCount(op, records, role, rewriter);
   if (failed(recordCount)) {
     return failure();
   }
@@ -4255,8 +4247,28 @@ LogicalResult buildPipeNetIndex(ModuleOp mod, PipeNetIndex &index) {
   mod.walk([&](PipeNetForeachSrcOp op) { addRecords(op.getRecords()); });
   mod.walk([&](PipeNetForeachDstOp op) { addRecords(op.getRecords()); });
 
+  // Validate role-query inputs before conversion so diagnostics retain the
+  // query's source location instead of the conversion wrapper's module
+  // location.
   WalkResult validation = mod.walk([&](PipeNetPredicateOpInterface predicate) {
-    if (predicate.getReferencedRecords()) {
+    if (PipeNetRecordsAttr records = predicate.getReferencedRecords()) {
+      if (!records.getPipes().front().getDeviceTransfer()) {
+        FailureOr<std::pair<int64_t, int64_t>> launchGrid =
+            getLaunchGrid(predicate);
+        if (failed(launchGrid)) {
+          predicate->emitError()
+              << "local PipeNet role query requires a valid ttl.launch_grid "
+                 "with two positive integer extents; set the operation's "
+                 "launch grid to include its PipeNet endpoints";
+          return WalkResult::interrupt();
+        }
+        if (failed(validateLocalPipeNetParticipantPlanInputs(
+                records, predicate.getReferencedRole(), launchGrid->first,
+                launchGrid->second,
+                [&]() { return predicate->emitError(); }))) {
+          return WalkResult::interrupt();
+        }
+      }
       return WalkResult::advance();
     }
     int64_t pipeNetId = predicate.getReferencedPipeNetId();

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -4045,8 +4045,6 @@ lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
       .getResult();
 }
 
-// Lower a per-pipe-role predicate op to the OR of per-pipe matches in the
-// named PipeNet. `roleBuilder` produces the i1 match for one static pipe.
 template <typename Op>
 static LogicalResult lowerRolePredicate(
     Op op, ConversionPatternRewriter &rewriter,

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -4006,8 +4006,7 @@ lowerPlannedDeviceDestinationCount(Operation *op, PipeNetRecordsAttr records,
 // Local records permit one launch-node-indexed count-table lookup.
 static FailureOr<Value>
 lowerLocalRoleRecordCount(Operation *op, PipeNetRecordsAttr records,
-                          PipeRole role,
-                          ConversionPatternRewriter &rewriter) {
+                          PipeRole role, ConversionPatternRewriter &rewriter) {
   FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
   if (failed(launchGrid)) {
     return failure();
@@ -4034,16 +4033,15 @@ lowerLocalRoleRecordCount(Operation *op, PipeNetRecordsAttr records,
 
 static FailureOr<Value>
 lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
-                        PipeRole role,
-                        ConversionPatternRewriter &rewriter) {
+                        PipeRole role, ConversionPatternRewriter &rewriter) {
   FailureOr<Value> recordCount =
       lowerLocalRoleRecordCount(op, records, role, rewriter);
   if (failed(recordCount)) {
     return failure();
   }
   Value zero = arith::ConstantIndexOp::create(rewriter, op->getLoc(), 0);
-  return arith::CmpIOp::create(rewriter, op->getLoc(),
-                              arith::CmpIPredicate::ne, *recordCount, zero)
+  return arith::CmpIOp::create(rewriter, op->getLoc(), arith::CmpIPredicate::ne,
+                               *recordCount, zero)
       .getResult();
 }
 
@@ -4152,8 +4150,8 @@ struct PipeNetDestinationCountLowering
                   : lowerDeviceDestinationCountByRecord(op, records, rewriter));
       return success();
     }
-    FailureOr<Value> localCount = lowerLocalRoleRecordCount(
-        op, records, PipeRole::Destination, rewriter);
+    FailureOr<Value> localCount =
+        lowerLocalRoleRecordCount(op, records, PipeRole::Destination, rewriter);
     if (succeeded(localCount)) {
       rewriter.replaceOp(op, *localCount);
       return success();

--- a/lib/Dialect/TTL/Transforms/PipeLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeLowering.cpp
@@ -4003,17 +4003,27 @@ lowerPlannedDeviceDestinationCount(Operation *op, PipeNetRecordsAttr records,
       rewriter, loc, participantPlan->recordCountsByDevice, currentDevice);
 }
 
-// Local records permit one launch-node-indexed count-table lookup.
-static FailureOr<Value>
-lowerLocalRoleRecordCount(Operation *op, PipeNetRecordsAttr records,
-                          PipeRole role, ConversionPatternRewriter &rewriter) {
+// Emit an index value counting entries in `records` for which the current node
+// has `role` (source, destination, or either). Use the launch grid enclosing
+// `op`; fail before emitting IR if that grid or the local records are invalid.
+// If supplied, `emitError` reports the invalid input at the caller's location.
+static FailureOr<Value> lowerLocalRoleRecordCount(
+    Operation *op, PipeNetRecordsAttr records, PipeRole role,
+    ConversionPatternRewriter &rewriter,
+    llvm::function_ref<InFlightDiagnostic()> emitError = {}) {
   FailureOr<std::pair<int64_t, int64_t>> launchGrid = getLaunchGrid(op);
   if (failed(launchGrid)) {
+    if (emitError) {
+      emitError()
+          << "local PipeNet role query requires a valid ttl.launch_grid "
+             "with two positive integer extents; set the operation's "
+             "launch grid to include its PipeNet endpoints";
+    }
     return failure();
   }
   auto [gridX, gridY] = *launchGrid;
   FailureOr<LocalPipeNetParticipantPlan> participantPlan =
-      buildLocalPipeNetParticipantPlan(records, role, gridX, gridY);
+      buildLocalPipeNetParticipantPlan(records, role, gridX, gridY, emitError);
   if (failed(participantPlan)) {
     return failure();
   }
@@ -4031,12 +4041,14 @@ lowerLocalRoleRecordCount(Operation *op, PipeNetRecordsAttr records,
       rewriter, loc, participantPlan->recordCountsByNode, nodeIndex);
 }
 
-// Reuse the count query so duplicate records still produce one boolean match.
+// Emit an i1 that is true when the current node is a source, destination, or
+// either, as requested by `role`, in any entry of the local `records`.
+// Use the launch grid enclosing `op`; propagate failure without emitting IR.
 static FailureOr<Value>
 lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
                         PipeRole role, ConversionPatternRewriter &rewriter) {
-  FailureOr<Value> recordCount =
-      lowerLocalRoleRecordCount(op, records, role, rewriter);
+  FailureOr<Value> recordCount = lowerLocalRoleRecordCount(
+      op, records, role, rewriter, [&]() { return op->emitError(); });
   if (failed(recordCount)) {
     return failure();
   }
@@ -4046,8 +4058,9 @@ lowerLocalRolePredicate(Operation *op, PipeNetRecordsAttr records,
       .getResult();
 }
 
-// Record attributes define the exact queried endpoints; older recordless
-// operations instead query every pipe declaration with the referenced id.
+// Replace `op` with an i1 testing whether the current node/device has `role` in
+// its records. If `op` has no records, use `pipeNetIndex` to find its pipes and
+// `roleBuilder` to emit each pipe's coordinate test, then OR those results.
 template <typename Op>
 static LogicalResult lowerRolePredicate(
     Op op, ConversionPatternRewriter &rewriter,
@@ -4064,8 +4077,7 @@ static LogicalResult lowerRolePredicate(
     FailureOr<Value> localPredicate =
         lowerLocalRolePredicate(op, records, role, rewriter);
     if (failed(localPredicate)) {
-      return rewriter.notifyMatchFailure(
-          op, "cannot build a local PipeNet participant plan");
+      return failure();
     }
     rewriter.replaceOp(op, *localPredicate);
     return success();

--- a/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
@@ -37,7 +37,7 @@ static FailureOr<int64_t> getRepresentableDeviceCount(DeviceDomainAttr domain) {
   return static_cast<int64_t>(deviceCount);
 }
 
-FailureOr<LocalPipeNetParticipantPlan> buildLocalPipeNetParticipantPlan(
+LogicalResult validateLocalPipeNetParticipantPlanInputs(
     PipeNetRecordsAttr records, PipeRole role, int64_t gridX, int64_t gridY,
     llvm::function_ref<InFlightDiagnostic()> emitError) {
   if (gridX <= 0 || gridY <= 0) {
@@ -61,8 +61,6 @@ FailureOr<LocalPipeNetParticipantPlan> buildLocalPipeNetParticipantPlan(
     return failure();
   }
 
-  SmallVector<SmallVector<int64_t>> recordsByNode(
-      static_cast<std::size_t>(*maybeGridArea));
   for (auto [recordIndex, record] : llvm::enumerate(records.getPipes())) {
     if (record.getDeviceTransfer()) {
       if (emitError) {
@@ -73,7 +71,6 @@ FailureOr<LocalPipeNetParticipantPlan> buildLocalPipeNetParticipantPlan(
       }
       return failure();
     }
-    llvm::SmallDenseSet<int64_t, 4> participantIndices;
     for (const PipeRecordRoleFacts &facts :
          getPipeRecordRoleFacts(record, role)) {
       if (facts.device || facts.minX < 0 || facts.minY < 0 ||
@@ -90,6 +87,24 @@ FailureOr<LocalPipeNetParticipantPlan> buildLocalPipeNetParticipantPlan(
         }
         return failure();
       }
+    }
+  }
+  return success();
+}
+
+FailureOr<LocalPipeNetParticipantPlan>
+buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
+                                 int64_t gridX, int64_t gridY) {
+  if (failed(validateLocalPipeNetParticipantPlanInputs(records, role, gridX,
+                                                       gridY))) {
+    return failure();
+  }
+  SmallVector<SmallVector<int64_t>> recordsByNode(
+      static_cast<std::size_t>(gridX * gridY));
+  for (auto [recordIndex, record] : llvm::enumerate(records.getPipes())) {
+    llvm::SmallDenseSet<int64_t, 4> participantIndices;
+    for (const PipeRecordRoleFacts &facts :
+         getPipeRecordRoleFacts(record, role)) {
       for (int64_t nodeY = facts.minY; nodeY <= facts.maxY; ++nodeY) {
         for (int64_t nodeX = facts.minX; nodeX <= facts.maxX; ++nodeX) {
           participantIndices.insert(nodeY * gridX + nodeX);

--- a/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetParticipantPlan.cpp
@@ -37,16 +37,27 @@ static FailureOr<int64_t> getRepresentableDeviceCount(DeviceDomainAttr domain) {
   return static_cast<int64_t>(deviceCount);
 }
 
-FailureOr<LocalPipeNetParticipantPlan>
-buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
-                                 int64_t gridX, int64_t gridY) {
+FailureOr<LocalPipeNetParticipantPlan> buildLocalPipeNetParticipantPlan(
+    PipeNetRecordsAttr records, PipeRole role, int64_t gridX, int64_t gridY,
+    llvm::function_ref<InFlightDiagnostic()> emitError) {
   if (gridX <= 0 || gridY <= 0) {
+    if (emitError) {
+      emitError()
+          << "local PipeNet launch grid (" << gridX << ", " << gridY
+          << ") must have two positive extents; correct the launch grid";
+    }
     return failure();
   }
   std::optional<int64_t> maybeGridArea = llvm::checkedMul(gridX, gridY);
   if (!maybeGridArea ||
       records.getPipes().size() >
           static_cast<std::size_t>(std::numeric_limits<int64_t>::max())) {
+    if (emitError) {
+      emitError() << "local PipeNet table for launch grid (" << gridX << ", "
+                  << gridY << ") and " << records.getPipes().size()
+                  << " records exceeds the signed 64-bit indexing limit; "
+                     "reduce the launch grid or split the PipeNet";
+    }
     return failure();
   }
 
@@ -54,6 +65,12 @@ buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
       static_cast<std::size_t>(*maybeGridArea));
   for (auto [recordIndex, record] : llvm::enumerate(records.getPipes())) {
     if (record.getDeviceTransfer()) {
+      if (emitError) {
+        emitError()
+            << "PipeNet record " << recordIndex
+            << " specifies a logical-device transfer but local planning "
+               "was requested; use logical-device PipeNet lowering";
+      }
       return failure();
     }
     llvm::SmallDenseSet<int64_t, 4> participantIndices;
@@ -62,6 +79,15 @@ buildLocalPipeNetParticipantPlan(PipeNetRecordsAttr records, PipeRole role,
       if (facts.device || facts.minX < 0 || facts.minY < 0 ||
           facts.minX > facts.maxX || facts.minY > facts.maxY ||
           facts.maxX >= gridX || facts.maxY >= gridY) {
+        if (emitError) {
+          emitError() << "PipeNet record " << recordIndex
+                      << " has endpoint range core_x=" << facts.minX << ".."
+                      << facts.maxX << ", core_y=" << facts.minY << ".."
+                      << facts.maxY << " outside the local launch grid ("
+                      << gridX << ", " << gridY
+                      << "); increase the launch grid or correct the PipeNet "
+                         "endpoint coordinates";
+        }
         return failure();
       }
       for (int64_t nodeY = facts.minY; nodeY <= facts.maxY; ++nodeY) {

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -2430,16 +2430,14 @@ validatePipeEndpoints(ModuleOp module,
       return;
     }
 
-    PipeNetRecordsAttr records;
-    if (auto predicate = mlir::dyn_cast<PipeNetPredicateOpInterface>(op)) {
-      records = predicate.getReferencedRecords();
-    } else {
-      records = llvm::TypeSwitch<Operation *, PipeNetRecordsAttr>(op)
-                    .Case<PipeNetForeachSrcOp, PipeNetForeachDstOp,
-                          SelectPipeSrcOp, SelectPipeDstOp>(
-                        [](auto recordsOp) { return recordsOp.getRecords(); })
-                    .Default(PipeNetRecordsAttr());
-    }
+    auto records =
+        llvm::TypeSwitch<Operation *, PipeNetRecordsAttr>(op)
+            .Case<PipeNetPredicateOpInterface>(
+                [](auto query) { return query.getReferencedRecords(); })
+            .Case<PipeNetForeachSrcOp, PipeNetForeachDstOp, SelectPipeSrcOp,
+                  SelectPipeDstOp>(
+                [](auto recordsOp) { return recordsOp.getRecords(); })
+            .Default(PipeNetRecordsAttr());
     if (!records || !validatedRecordTables.insert(records).second) {
       return;
     }

--- a/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyPipeNetGuards.cpp
@@ -2430,12 +2430,16 @@ validatePipeEndpoints(ModuleOp module,
       return;
     }
 
-    PipeNetRecordsAttr records =
-        llvm::TypeSwitch<Operation *, PipeNetRecordsAttr>(op)
-            .Case<PipeNetForeachSrcOp, PipeNetForeachDstOp, SelectPipeSrcOp,
-                  SelectPipeDstOp>(
-                [](auto recordsOp) { return recordsOp.getRecords(); })
-            .Default(PipeNetRecordsAttr());
+    PipeNetRecordsAttr records;
+    if (auto predicate = mlir::dyn_cast<PipeNetPredicateOpInterface>(op)) {
+      records = predicate.getReferencedRecords();
+    } else {
+      records = llvm::TypeSwitch<Operation *, PipeNetRecordsAttr>(op)
+                    .Case<PipeNetForeachSrcOp, PipeNetForeachDstOp,
+                          SelectPipeSrcOp, SelectPipeDstOp>(
+                        [](auto recordsOp) { return recordsOp.getRecords(); })
+                    .Default(PipeNetRecordsAttr());
+    }
     if (!records || !validatedRecordTables.insert(records).second) {
       return;
     }

--- a/python/ttl/_src/ttl_ast.py
+++ b/python/ttl/_src/ttl_ast.py
@@ -1165,8 +1165,7 @@ class TTLGenericCompiler(TTCompilerBase):
                 IntegerType.get_signless(64, self.ctx), pipenet.pipe_net_id
             )
         }
-        if method == "destination_count" or pipenet.is_graph:
-            arguments["records"] = self._get_pipe_net_records_attr(pipenet)
+        arguments["records"] = self._get_pipe_net_records_attr(pipenet)
         return self._PIPENET_QUERY_OPS[method](**arguments)
 
     def _device_domain_call_receiver(self, node):

--- a/python/ttl/pipe.py
+++ b/python/ttl/pipe.py
@@ -383,19 +383,18 @@ class PipeNet:
         )
 
     def is_src(self) -> bool:
-        """Boolean predicate: current node is a source of any pipe in this net.
+        """Return whether the current node is a source of any pipe in this PipeNet.
 
-        Lowers to `ttl.is_src` and is recognized structurally by the
-        `ttl-verify-pipenet-guards` pass, so it can be used as the condition
-        of an `if` to gate pipe-coupled work."""
+        The compiler recognizes the result as a source-role condition when it
+        verifies guarded PipeNet traffic.
+        """
         raise RuntimeError(
             "PipeNet.is_src() should only be called inside a TTL kernel. "
             "The compiler handles this method specially."
         )
 
     def is_dst(self) -> bool:
-        """Boolean predicate: current node is a destination of any pipe in
-        this net. Lowers to `ttl.is_dst`."""
+        """Return whether the current node is in a destination range in this PipeNet."""
         raise RuntimeError(
             "PipeNet.is_dst() should only be called inside a TTL kernel. "
             "The compiler handles this method specially."
@@ -413,8 +412,7 @@ class PipeNet:
         )
 
     def is_active(self) -> bool:
-        """Boolean predicate: current node is either a source or a
-        destination of any pipe in this net. Lowers to `ttl.is_active`."""
+        """Return whether this node is a source or destination in this PipeNet."""
         raise RuntimeError(
             "PipeNet.is_active() should only be called inside a TTL kernel. "
             "The compiler handles this method specially."

--- a/test/python/pipe/test_pipenet_role_predicates.py
+++ b/test/python/pipe/test_pipenet_role_predicates.py
@@ -65,9 +65,7 @@ def test_local_role_predicates(device, dtype, to_device):
 
     expected = torch.zeros(3 * TILE, GRID_X * TILE, dtype=dtype)
     expected[0:TILE, 0 : 2 * TILE] = inp_torch[:, 0 : 2 * TILE]
-    expected[TILE : 2 * TILE, 2 * TILE : 4 * TILE] = inp_torch[
-        :, 2 * TILE : 4 * TILE
-    ]
+    expected[TILE : 2 * TILE, 2 * TILE : 4 * TILE] = inp_torch[:, 2 * TILE : 4 * TILE]
     expected[2 * TILE : 3 * TILE, 0 : 4 * TILE] = inp_torch[:, 0 : 4 * TILE]
 
     assert_allclose(expected.float(), ttnn.to_torch(out).float(), rtol=0.0, atol=0.0)

--- a/test/python/pipe/test_pipenet_role_predicates.py
+++ b/test/python/pipe/test_pipenet_role_predicates.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device coverage for table-planned local PipeNet role predicates."""
+
+import pytest
+import torch
+import ttl
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+from ttlang_test_utils import to_dram, to_l1
+from utils.correctness import assert_allclose
+
+pytestmark = pytest.mark.requires_device
+
+TILE = 32
+GRID_X = 5
+
+
+@ttl.operation(grid=(GRID_X, 1))
+def local_role_predicates(inp, out):
+    net = ttl.PipeNet(
+        [
+            ttl.Pipe(src=(0, 0), dst=(3, 0)),
+            ttl.Pipe(src=(0, 0), dst=(3, 0)),
+            ttl.Pipe(src=(1, 0), dst=(2, 0)),
+        ]
+    )
+    staging_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=1)
+
+    @ttl.compute()
+    def compute():
+        pass
+
+    @ttl.datamovement()
+    def dm():
+        node_x, _node_y = ttl.node(dims=2)
+        with staging_dfb.reserve() as staging_block:
+            ttl.copy(inp[0, node_x], staging_block).wait()
+        with staging_dfb.wait() as staging_block:
+            if net.is_src():
+                ttl.copy(staging_block, out[0, node_x]).wait()
+            if net.is_dst():
+                ttl.copy(staging_block, out[1, node_x]).wait()
+            if net.is_active():
+                ttl.copy(staging_block, out[2, node_x]).wait()
+
+    @ttl.datamovement()
+    def dm_brisc():
+        pass
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
+@pytest.mark.parametrize("to_device", [to_dram, to_l1], ids=["dram", "l1"])
+def test_local_role_predicates(device, dtype, to_device):
+    torch.manual_seed(0)
+    inp_torch = torch.randn(TILE, GRID_X * TILE, dtype=dtype)
+    inp = to_device(inp_torch, device)
+    out = to_device(torch.zeros(3 * TILE, GRID_X * TILE, dtype=dtype), device)
+
+    local_role_predicates(inp, out)
+    ttnn.synchronize_device(device)
+
+    expected = torch.zeros(3 * TILE, GRID_X * TILE, dtype=dtype)
+    expected[0:TILE, 0 : 2 * TILE] = inp_torch[:, 0 : 2 * TILE]
+    expected[TILE : 2 * TILE, 2 * TILE : 4 * TILE] = inp_torch[
+        :, 2 * TILE : 4 * TILE
+    ]
+    expected[2 * TILE : 3 * TILE, 0 : 4 * TILE] = inp_torch[:, 0 : 4 * TILE]
+
+    assert_allclose(expected.float(), ttnn.to_torch(out).float(), rtol=0.0, atol=0.0)

--- a/test/python/pipe/test_pipenet_role_predicates.py
+++ b/test/python/pipe/test_pipenet_role_predicates.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Device coverage for table-planned local PipeNet role predicates."""
+"""Verify local role queries select the correct nodes and exclude inactive nodes."""
 
 import pytest
 import torch

--- a/test/python/pipenet_predicate_emission.py
+++ b/test/python/pipenet_predicate_emission.py
@@ -21,9 +21,9 @@
 """Frontend-pipeline integration check for the PipeNet verifier.
 
 `net.is_active()` lowers to `ttl.is_active`, which the verifier
-recognizes structurally. After lowering the predicate becomes the
-same arith chain the runtime evaluates. A straight-line kernel
-without any PipeNet must not contain the predicate machinery.
+recognizes structurally. After lowering, the table-planned predicate remains
+the runtime guard. A straight-line kernel without any PipeNet must not contain
+the predicate machinery.
 """
 
 # Frontend emits the predicate op with the static PipeNet record table.
@@ -39,9 +39,9 @@ without any PipeNet must not contain the predicate machinery.
 # FINAL-NOT: emitc.logical_or
 # FINAL: emitc.if
 
-# A kernel without any PipeNet contains neither the emitc.if nor the
-# logical_or. There is no role predicate to evaluate.
-# NO-PIPENET-NOT: emitc.logical_or
+# A kernel without any PipeNet contains neither the table lookup nor its guard.
+# NO-PIPENET-NOT: experimental::constant_table_lookup
+# NO-PIPENET-NOT: emitc.if
 
 import os
 

--- a/test/python/pipenet_predicate_emission.py
+++ b/test/python/pipenet_predicate_emission.py
@@ -26,16 +26,17 @@ same arith chain the runtime evaluates. A straight-line kernel
 without any PipeNet must not contain the predicate machinery.
 """
 
-# Frontend emits the predicate op for `if net.is_active()`.
+# Frontend emits the predicate op with the static PipeNet record table.
 # INITIAL: ttl.is_active
+# INITIAL-SAME: records = #ttl.pipenet_records<
 
 # A unified PipeNet source callback receives the compiler-owned affinity.
 # LOGICAL: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<pipe_source>", role = "pipe_source">
 
 # After lowering, the user's guard survives as an emitc.if; the
-# predicate chain reduces to a logical_or over the per-pipe role
-# matches.
-# FINAL: emitc.logical_or
+# predicate becomes one launch-node-indexed table lookup.
+# FINAL: experimental::constant_table_lookup
+# FINAL-NOT: emitc.logical_or
 # FINAL: emitc.if
 
 # A kernel without any PipeNet contains neither the emitc.if nor the

--- a/test/python/pipenet_predicate_emission.py
+++ b/test/python/pipenet_predicate_emission.py
@@ -21,12 +21,12 @@
 """Frontend-pipeline integration check for the PipeNet verifier.
 
 `net.is_active()` lowers to `ttl.is_active`, which the verifier
-recognizes structurally. After lowering, the table-planned predicate remains
-the runtime guard. A straight-line kernel without any PipeNet must not contain
-the predicate machinery.
+recognizes structurally. Lowering tests whether the current node's record count
+is nonzero. A kernel without any PipeNet requires neither the lookup nor its
+conditional branch.
 """
 
-# Frontend emits the predicate op with the static PipeNet record table.
+# The role query includes the records used to determine active nodes.
 # INITIAL: ttl.is_active
 # INITIAL-SAME: records = #ttl.pipenet_records<
 
@@ -34,7 +34,7 @@ the predicate machinery.
 # LOGICAL: ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement, identity = "<pipe_source>", role = "pipe_source">
 
 # After lowering, the user's guard survives as an emitc.if; the
-# predicate becomes one launch-node-indexed table lookup.
+# role query becomes one launch-node-indexed table lookup.
 # FINAL: experimental::constant_table_lookup
 # FINAL-NOT: emitc.logical_or
 # FINAL: emitc.if

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_computed_address_schedule.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_computed_address_schedule.mlir
@@ -65,6 +65,96 @@ module attributes {ttl.launch_grid = array<i64: 3, 1>} {
 
 // -----
 
+// Local record predicates fully determine the launch-node branch domains. The
+// outer false branch must exclude sources so receiver reservation sequences do
+// not include an infeasible second post on loopback source nodes.
+
+// CHECK-LABEL: func.func @local_record_predicate_domains
+// CHECK-SAME: ttl.pipe_computed_address_dfb_indices = array<i32: 1>
+// CHECK-NOT: ttl.pipe_sram_scratch_bytes
+// CHECK-NOT: ttkernel.noc_inline_dw_write
+// CHECK: return
+#local_records = #ttl.pipenet_records<net 7 name "local_collective" pipes [
+  #ttl.pipe_record<
+      srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
+      dstEndX = 0, dstEndY = 0, isCollective = true>,
+  #ttl.pipe_record<
+      srcX = 0, srcY = 1, dstStartX = 0, dstStartY = 1,
+      dstEndX = 1, dstEndY = 1, isCollective = true>
+]>
+
+// Sharing a numeric PipeNet id does not make another table part of this
+// predicate's source domain.
+#unrelated_records = #ttl.pipenet_records<net 7 name "unrelated_table" pipes [
+  #ttl.pipe_record<
+      srcX = 1, srcY = 1, dstStartX = 1, dstStartY = 1,
+      dstEndX = 1, dstEndY = 1>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 2, 2>} {
+  func.func @local_record_predicate_domains()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %src = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+    %dst = ttl.bind_cb {cb_index = 1, block_count = 3} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 3>
+    %zero = arith.constant 0 : index
+    %three = arith.constant 3 : index
+    %one = arith.constant 1 : index
+    %unrelated_source = ttl.is_src {
+        pipe_net_id = 7 : i64, records = #unrelated_records}
+    scf.for %iteration = %zero to %three step %one {
+      %is_source = ttl.is_src {
+          pipe_net_id = 7 : i64, records = #local_records}
+      scf.if %is_source {
+        %reserved = ttl.cb_reserve %dst
+            : <[1, 1], !ttcore.tile<32x32, f32>, 3>
+            -> tensor<1x1x!ttcore.tile<32x32, f32>>
+        ttl.pipenet_foreach_dst attributes {records = #local_records} {
+        ^bb0(%receive_pipe: !ttl.selected_pipe_dst):
+          %post = ttl.copy %receive_pipe, %reserved
+              : (!ttl.selected_pipe_dst,
+                 tensor<1x1x!ttcore.tile<32x32, f32>>)
+              -> !ttl.receive_request
+          ttl.pipenet_foreach_src attributes {records = #local_records} {
+          ^bb0(%send_pipe: !ttl.selected_pipe_src):
+            %send = ttl.copy %src, %send_pipe
+                : (!ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+                   !ttl.selected_pipe_src)
+                -> !ttl.transfer_handle<write>
+            ttl.wait %send : !ttl.transfer_handle<write>
+            ttl.yield
+          }
+          ttl.wait %post : !ttl.receive_request
+          ttl.yield
+        }
+        ttl.cb_push %dst : <[1, 1], !ttcore.tile<32x32, f32>, 3>
+      } else {
+        %is_destination = ttl.is_dst {
+            pipe_net_id = 7 : i64, records = #local_records}
+        scf.if %is_destination {
+          %reserved = ttl.cb_reserve %dst
+              : <[1, 1], !ttcore.tile<32x32, f32>, 3>
+              -> tensor<1x1x!ttcore.tile<32x32, f32>>
+          ttl.pipenet_foreach_dst attributes {records = #local_records} {
+          ^bb0(%receive_pipe: !ttl.selected_pipe_dst):
+            %post = ttl.copy %receive_pipe, %reserved
+                : (!ttl.selected_pipe_dst,
+                   tensor<1x1x!ttcore.tile<32x32, f32>>)
+                -> !ttl.receive_request
+            ttl.wait %post : !ttl.receive_request
+            ttl.yield
+          }
+          ttl.cb_push %dst : <[1, 1], !ttcore.tile<32x32, f32>, 3>
+        }
+      }
+    }
+    func.return
+  }
+}
+
+// -----
+
 // Pipe A occurs once and uses slot 0 at every receiver. Receivers 1 and 2 also
 // reserve slot 1 for Pipe B, but that later reservation cannot change Pipe A's
 // one-element address sequence.

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_device_role_queries.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_device_role_queries.mlir
@@ -1,0 +1,69 @@
+// Verify that graph role queries retain device matching even when every
+// endpoint has the same launch-node coordinates.
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-verify-pipenet-guards,convert-ttl-to-ttkernel)' | FileCheck %s
+
+#domain = #ttl.device_domain<components = <name = "device", extent = [4]>>
+#records = #ttl.pipenet_records<net 1 name "device_roles" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 0, dstStartY = 0,
+   dstEndX = 0, dstEndY = 0,
+   deviceTransfer = <domain = #domain,
+     edge = <source = <coordinates = [0]>,
+             destination = <coordinates = [3]>>>>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 1, 1>} {
+  // Matching launch coordinates must not select device 3 as a source.
+  // CHECK-LABEL: func.func @device_source
+  // CHECK: %[[ARG:.*]] = ttkernel.get_common_arg_val
+  // CHECK-NEXT: %[[DEVICE:.*]] = arith.index_cast %[[ARG]] : i32 to index
+  // CHECK: %[[RESULT:.*]] = scf.for
+  // CHECK-COUNT-4: ttkernel.experimental.constant_table_lookup {{.*}}, [0]
+  // CHECK-NEXT: %[[ENDPOINT:.*]] = ttkernel.experimental.constant_table_lookup {{.*}}, [0]
+  // CHECK: %[[MATCH:.*]] = arith.cmpi eq, %[[DEVICE]], %[[ENDPOINT]] : index
+  // CHECK-NEXT: %[[SELECTED:.*]] = arith.andi %{{.*}}, %[[MATCH]] : i1
+  // CHECK-NEXT: %[[ACCUMULATED:.*]] = arith.ori %{{.*}}, %[[SELECTED]] : i1
+  // CHECK-NEXT: scf.yield %[[ACCUMULATED]] : i1
+  // CHECK: ttl.dprint "source={}"(%[[RESULT]])
+  func.func @device_source()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %is_source = ttl.is_src {pipe_net_id = 1 : i64, records = #records}
+    "ttl.dprint"(%is_source) {fmt = "source={}", mode = "scalar"} : (i1) -> ()
+    func.return
+  }
+
+  // Destination matching must use the destination device rather than source.
+  // CHECK-LABEL: func.func @device_destination
+  // CHECK: %[[ARG:.*]] = ttkernel.get_common_arg_val
+  // CHECK-NEXT: %[[DEVICE:.*]] = arith.index_cast %[[ARG]] : i32 to index
+  // CHECK: %[[RESULT:.*]] = scf.for
+  // CHECK: %[[ENDPOINT:.*]] = ttkernel.experimental.constant_table_lookup {{.*}}, [3]
+  // CHECK: %[[MATCH:.*]] = arith.cmpi eq, %[[DEVICE]], %[[ENDPOINT]] : index
+  // CHECK-NEXT: %[[SELECTED:.*]] = arith.andi %{{.*}}, %[[MATCH]] : i1
+  // CHECK-NEXT: %[[ACCUMULATED:.*]] = arith.ori %{{.*}}, %[[SELECTED]] : i1
+  // CHECK-NEXT: scf.yield %[[ACCUMULATED]] : i1
+  // CHECK: ttl.dprint "destination={}"(%[[RESULT]])
+  func.func @device_destination()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %is_destination = ttl.is_dst {pipe_net_id = 1 : i64, records = #records}
+    "ttl.dprint"(%is_destination) {fmt = "destination={}", mode = "scalar"} : (i1) -> ()
+    func.return
+  }
+
+  // Active queries select either endpoint device, leaving devices 1 and 2 idle.
+  // CHECK-LABEL: func.func @device_active
+  // CHECK: %[[ARG:.*]] = ttkernel.get_common_arg_val
+  // CHECK-NEXT: %[[DEVICE:.*]] = arith.index_cast %[[ARG]] : i32 to index
+  // CHECK: %[[RESULT:.*]] = scf.for
+  // CHECK: %[[ENDPOINT:.*]] = ttkernel.experimental.constant_table_lookup {{.*}}, [0, 3]
+  // CHECK: %[[MATCH:.*]] = arith.cmpi eq, %[[DEVICE]], %[[ENDPOINT]] : index
+  // CHECK-NEXT: %[[SELECTED:.*]] = arith.andi %{{.*}}, %[[MATCH]] : i1
+  // CHECK-NEXT: %[[ACCUMULATED:.*]] = arith.ori %{{.*}}, %[[SELECTED]] : i1
+  // CHECK-NEXT: scf.yield %[[ACCUMULATED]] : i1
+  // CHECK: ttl.dprint "active={}"(%[[RESULT]])
+  func.func @device_active()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %is_active = ttl.is_active {pipe_net_id = 1 : i64, records = #records}
+    "ttl.dprint"(%is_active) {fmt = "active={}", mode = "scalar"} : (i1) -> ()
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_lowering_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_lowering_invalid.mlir
@@ -1,0 +1,55 @@
+// RUN: ttlang-opt %s --convert-ttl-to-ttkernel --verify-diagnostics --split-input-file
+
+// Direct conversion reports invalid local role-query inputs before emitting IR.
+
+// A serialized role query without a launch grid needs a concrete correction.
+#records = #ttl.pipenet_records<net 0 pipes [
+  <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
+module {
+  func.func @missing_launch_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-error @below {{local PipeNet role query requires a valid ttl.launch_grid with two positive integer extents; set the operation's launch grid to include its PipeNet endpoints}}
+    // expected-error @below {{failed to legalize operation 'ttl.is_src'}}
+    %is_source = ttl.is_src {pipe_net_id = 0 : i64, records = #records}
+    "ttl.dprint"(%is_source) {fmt = "source={}", mode = "scalar"} : (i1) -> ()
+    func.return
+  }
+}
+
+// -----
+
+// Destination diagnostics include the invalid coordinates and actual grid.
+#records = #ttl.pipenet_records<net 0 pipes [
+  <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>
+]>
+module attributes {ttl.launch_grid = array<i64: 3, 2>} {
+  func.func @destination_outside_launch_grid()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-error @below {{PipeNet record 0 has endpoint range core_x=3..3, core_y=0..0 outside the local launch grid (3, 2); increase the launch grid or correct the PipeNet endpoint coordinates}}
+    // expected-error @below {{failed to legalize operation 'ttl.is_dst'}}
+    %is_destination = ttl.is_dst {pipe_net_id = 0 : i64, records = #records}
+    "ttl.dprint"(%is_destination) {fmt = "destination={}", mode = "scalar"} : (i1) -> ()
+    func.return
+  }
+}
+
+// -----
+
+// A grid whose area overflows an index must fail before allocating its table.
+#records = #ttl.pipenet_records<net 0 pipes [
+  <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
+module attributes {ttl.launch_grid = array<i64: 9223372036854775807, 2>} {
+  func.func @launch_grid_index_overflow()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-error @below {{local PipeNet table for launch grid (9223372036854775807, 2) and 1 records exceeds the signed 64-bit indexing limit; reduce the launch grid or split the PipeNet}}
+    // expected-error @below {{failed to legalize operation 'ttl.is_active'}}
+    %is_active = ttl.is_active {pipe_net_id = 0 : i64, records = #records}
+    "ttl.dprint"(%is_active) {fmt = "active={}", mode = "scalar"} : (i1) -> ()
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_lowering_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_lowering_invalid.mlir
@@ -11,7 +11,6 @@ module {
   func.func @missing_launch_grid()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-error @below {{local PipeNet role query requires a valid ttl.launch_grid with two positive integer extents; set the operation's launch grid to include its PipeNet endpoints}}
-    // expected-error @below {{failed to legalize operation 'ttl.is_src'}}
     %is_source = ttl.is_src {pipe_net_id = 0 : i64, records = #records}
     "ttl.dprint"(%is_source) {fmt = "source={}", mode = "scalar"} : (i1) -> ()
     func.return
@@ -29,7 +28,6 @@ module attributes {ttl.launch_grid = array<i64: 3, 2>} {
   func.func @destination_outside_launch_grid()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-error @below {{PipeNet record 0 has endpoint range core_x=3..3, core_y=0..0 outside the local launch grid (3, 2); increase the launch grid or correct the PipeNet endpoint coordinates}}
-    // expected-error @below {{failed to legalize operation 'ttl.is_dst'}}
     %is_destination = ttl.is_dst {pipe_net_id = 0 : i64, records = #records}
     "ttl.dprint"(%is_destination) {fmt = "destination={}", mode = "scalar"} : (i1) -> ()
     func.return
@@ -47,7 +45,6 @@ module attributes {ttl.launch_grid = array<i64: 9223372036854775807, 2>} {
   func.func @launch_grid_index_overflow()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     // expected-error @below {{local PipeNet table for launch grid (9223372036854775807, 2) and 1 records exceeds the signed 64-bit indexing limit; reduce the launch grid or split the PipeNet}}
-    // expected-error @below {{failed to legalize operation 'ttl.is_active'}}
     %is_active = ttl.is_active {pipe_net_id = 0 : i64, records = #records}
     "ttl.dprint"(%is_active) {fmt = "active={}", mode = "scalar"} : (i1) -> ()
     func.return

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
@@ -1,0 +1,45 @@
+// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+
+#records = #ttl.pipenet_records<net 0 name "local_roles" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
+  <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
+   dstEndX = 3, dstEndY = 0>,
+  <srcX = 1, srcY = 0, dstStartX = 2, dstStartY = 0,
+   dstEndX = 2, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+  // CHECK-LABEL: func.func @local_is_src
+  // CHECK-NOT: scf.for
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 0, 0]
+  // CHECK: arith.cmpi ne
+  func.func @local_is_src() -> i1
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %predicate = ttl.is_src {
+        pipe_net_id = 0 : i64, records = #records}
+    func.return %predicate : i1
+  }
+
+  // CHECK-LABEL: func.func @local_is_dst
+  // CHECK-NOT: scf.for
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 2]
+  // CHECK: arith.cmpi ne
+  func.func @local_is_dst() -> i1
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %predicate = ttl.is_dst {
+        pipe_net_id = 0 : i64, records = #records}
+    func.return %predicate : i1
+  }
+
+  // CHECK-LABEL: func.func @local_is_active
+  // CHECK-NOT: scf.for
+  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 1, 2]
+  // CHECK: arith.cmpi ne
+  func.func @local_is_active() -> i1
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %predicate = ttl.is_active {
+        pipe_net_id = 0 : i64, records = #records}
+    func.return %predicate : i1
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
@@ -1,57 +1,71 @@
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-verify-pipenet-guards,convert-ttl-to-ttkernel)' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-verify-pipenet-guards,convert-ttl-to-ttkernel)' | FileCheck %s --implicit-check-not=scf.for
 
-// Verify that each local PipeNet role predicate lowers to one participant-table
-// lookup without a per-record loop.
+// Verify row-major role-query lookup and result data flow for duplicate records,
+// rectangular receivers, a loopback endpoint, and an inactive launch node.
 
 #records = #ttl.pipenet_records<net 0 name "local_roles" pipes [
-  <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
-   dstEndX = 3, dstEndY = 0>,
-  <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
-   dstEndX = 3, dstEndY = 0>,
-  <srcX = 1, srcY = 0, dstStartX = 2, dstStartY = 0,
-   dstEndX = 2, dstEndY = 0>
+  <srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 0,
+   dstEndX = 2, dstEndY = 1, isCollective = true>,
+  <srcX = 0, srcY = 1, dstStartX = 1, dstStartY = 0,
+   dstEndX = 2, dstEndY = 1, isCollective = true>,
+  <srcX = 2, srcY = 0, dstStartX = 2, dstStartY = 0,
+   dstEndX = 2, dstEndY = 0, isCollective = true>
 ]>
 
-module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+module attributes {ttl.launch_grid = array<i64: 3, 2>} {
   // Duplicate records must not change boolean source membership.
   // CHECK-LABEL: func.func @local_is_src
   // CHECK-NOT: scf.for
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 0, 0]
-  // CHECK: arith.cmpi ne
+  // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[WIDTH:.*]] = arith.constant 3 : index
+  // CHECK: %[[X:.*]] = ttkernel.my_logical_x
+  // CHECK-NEXT: %[[Y:.*]] = ttkernel.my_logical_y
+  // CHECK-NEXT: %[[ROW:.*]] = arith.muli %[[Y]], %[[WIDTH]] : index
+  // CHECK-NEXT: %[[NODE:.*]] = arith.addi %[[ROW]], %[[X]] : index
+  // CHECK-NEXT: %[[COUNT:.*]] = ttkernel.experimental.constant_table_lookup %[[NODE]], [0, 0, 1, 2, 0, 0]
+  // CHECK-NEXT: %[[MATCH:.*]] = arith.cmpi ne, %[[COUNT]], %[[ZERO]] : index
+  // CHECK-NEXT: ttl.dprint "source={}"(%[[MATCH]])
   // CHECK-NOT: ttkernel.experimental.constant_table_lookup
   // CHECK-NOT: scf.for
-  func.func @local_is_src() -> i1
+  func.func @local_is_src()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %predicate = ttl.is_src {
         pipe_net_id = 0 : i64, records = #records}
-    func.return %predicate : i1
+    "ttl.dprint"(%predicate) {fmt = "source={}", mode = "scalar"} : (i1) -> ()
+    func.return
   }
 
   // Destination membership includes each node selected by a record range.
   // CHECK-LABEL: func.func @local_is_dst
   // CHECK-NOT: scf.for
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 2]
-  // CHECK: arith.cmpi ne
+  // CHECK: %[[ZERO:.*]] = arith.constant 0 : index
+  // CHECK: %[[COUNT:.*]] = ttkernel.experimental.constant_table_lookup {{.*}}, [0, 2, 3, 0, 2, 2]
+  // CHECK-NEXT: %[[MATCH:.*]] = arith.cmpi ne, %[[COUNT]], %[[ZERO]] : index
+  // CHECK-NEXT: ttl.dprint "destination={}"(%[[MATCH]])
   // CHECK-NOT: ttkernel.experimental.constant_table_lookup
   // CHECK-NOT: scf.for
-  func.func @local_is_dst() -> i1
+  func.func @local_is_dst()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %predicate = ttl.is_dst {
         pipe_net_id = 0 : i64, records = #records}
-    func.return %predicate : i1
+    "ttl.dprint"(%predicate) {fmt = "destination={}", mode = "scalar"} : (i1) -> ()
+    func.return
   }
 
-  // Active membership is the union of the source and destination sets.
+  // Active membership counts the loopback record once, despite both roles.
   // CHECK-LABEL: func.func @local_is_active
   // CHECK-NOT: scf.for
-  // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 1, 2]
-  // CHECK: arith.cmpi ne
+  // CHECK: %[[ZERO:.*]] = arith.constant 0 : index
+  // CHECK: %[[COUNT:.*]] = ttkernel.experimental.constant_table_lookup {{.*}}, [0, 2, 3, 2, 2, 2]
+  // CHECK-NEXT: %[[MATCH:.*]] = arith.cmpi ne, %[[COUNT]], %[[ZERO]] : index
+  // CHECK-NEXT: ttl.dprint "active={}"(%[[MATCH]])
   // CHECK-NOT: ttkernel.experimental.constant_table_lookup
   // CHECK-NOT: scf.for
-  func.func @local_is_active() -> i1
+  func.func @local_is_active()
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %predicate = ttl.is_active {
         pipe_net_id = 0 : i64, records = #records}
-    func.return %predicate : i1
+    "ttl.dprint"(%predicate) {fmt = "active={}", mode = "scalar"} : (i1) -> ()
+    func.return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
@@ -1,5 +1,8 @@
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-verify-pipenet-guards,convert-ttl-to-ttkernel)' | FileCheck %s
 
+// Verify that each local PipeNet role predicate lowers to one participant-table
+// lookup without a per-record loop.
+
 #records = #ttl.pipenet_records<net 0 name "local_roles" pipes [
   <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,
    dstEndX = 3, dstEndY = 0>,
@@ -10,6 +13,7 @@
 ]>
 
 module attributes {ttl.launch_grid = array<i64: 4, 1>} {
+  // Duplicate records must not change boolean source membership.
   // CHECK-LABEL: func.func @local_is_src
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 0, 0]
@@ -23,6 +27,7 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
     func.return %predicate : i1
   }
 
+  // Destination membership includes each node selected by a record range.
   // CHECK-LABEL: func.func @local_is_dst
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 2]
@@ -36,6 +41,7 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
     func.return %predicate : i1
   }
 
+  // Active membership is the union of the source and destination sets.
   // CHECK-LABEL: func.func @local_is_active
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 1, 2]

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
@@ -14,6 +14,8 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 0, 0]
   // CHECK: arith.cmpi ne
+  // CHECK-NOT: ttkernel.experimental.constant_table_lookup
+  // CHECK-NOT: scf.for
   func.func @local_is_src() -> i1
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %predicate = ttl.is_src {
@@ -25,6 +27,8 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [0, 0, 1, 2]
   // CHECK: arith.cmpi ne
+  // CHECK-NOT: ttkernel.experimental.constant_table_lookup
+  // CHECK-NOT: scf.for
   func.func @local_is_dst() -> i1
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %predicate = ttl.is_dst {
@@ -36,6 +40,8 @@ module attributes {ttl.launch_grid = array<i64: 4, 1>} {
   // CHECK-NOT: scf.for
   // CHECK: ttkernel.experimental.constant_table_lookup {{.*}}, [2, 1, 1, 2]
   // CHECK: arith.cmpi ne
+  // CHECK-NOT: ttkernel.experimental.constant_table_lookup
+  // CHECK-NOT: scf.for
   func.func @local_is_active() -> i1
       attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %predicate = ttl.is_active {

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_local_role_predicates.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s -convert-ttl-to-ttkernel | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttl-verify-pipenet-guards,convert-ttl-to-ttkernel)' | FileCheck %s
 
 #records = #ttl.pipenet_records<net 0 name "local_roles" pipes [
   <srcX = 0, srcY = 0, dstStartX = 3, dstStartY = 0,

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
@@ -1,0 +1,44 @@
+// RUN: ttlang-opt %s --verify-diagnostics --split-input-file
+
+#records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @mismatched_is_src() {
+    // expected-error @below {{PipeNet 7, but pipe_net_id is 3}}
+    %predicate = ttl.is_src {pipe_net_id = 3 : i64, records = #records}
+    func.return
+  }
+}
+
+// -----
+
+#records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @mismatched_is_dst() {
+    // expected-error @below {{PipeNet 7, but pipe_net_id is 3}}
+    %predicate = ttl.is_dst {pipe_net_id = 3 : i64, records = #records}
+    func.return
+  }
+}
+
+// -----
+
+#records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @mismatched_is_active() {
+    // expected-error @below {{PipeNet 7, but pipe_net_id is 3}}
+    %predicate = ttl.is_active {pipe_net_id = 3 : i64, records = #records}
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s --verify-diagnostics --split-input-file
+// RUN: ttlang-opt %s --verify-diagnostics --split-input-file -ttl-verify-pipenet-guards
 
 #records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
@@ -39,6 +39,21 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @mismatched_is_active() {
     // expected-error @below {{PipeNet 7, but pipe_net_id is 3}}
     %predicate = ttl.is_active {pipe_net_id = 3 : i64, records = #records}
+    func.return
+  }
+}
+
+// -----
+
+#records = #ttl.pipenet_records<net 7 name "outside_grid" pipes [
+  <srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0,
+   dstEndX = 2, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @outside_grid_is_dst() {
+    // expected-error @below {{declares destination range core_x=2..2, core_y=0..0 outside the module `ttl.launch_grid`}}
+    %predicate = ttl.is_dst {pipe_net_id = 7 : i64, records = #records}
     func.return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
@@ -1,8 +1,8 @@
 // RUN: ttlang-opt %s --verify-diagnostics --split-input-file -ttl-verify-pipenet-guards
 
-// Verify diagnostics for malformed PipeNet predicate record metadata.
+// Verify role-query record identity and both source and destination grid bounds.
 
-// A predicate and its record table must identify the same PipeNet.
+// A source query and its record table must identify the same PipeNet.
 
 #records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
@@ -19,7 +19,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// Destination predicates enforce the same PipeNet identity requirement.
+// Destination queries enforce the same PipeNet identity requirement.
 
 #records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
@@ -36,7 +36,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// Active predicates enforce the same PipeNet identity requirement.
+// Active queries enforce the same PipeNet identity requirement.
 
 #records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
@@ -53,7 +53,7 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// Predicate record endpoints must belong to the module launch grid.
+// Destination record endpoints must belong to the module launch grid.
 
 #records = #ttl.pipenet_records<net 7 name "outside_grid" pipes [
   <srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0,
@@ -64,6 +64,23 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
   func.func @outside_grid_is_dst() {
     // expected-error @below {{declares destination range core_x=2..2, core_y=0..0 outside the module `ttl.launch_grid`}}
     %predicate = ttl.is_dst {pipe_net_id = 7 : i64, records = #records}
+    func.return
+  }
+}
+
+// -----
+
+// A valid destination cannot hide a source outside the launch grid's Y extent.
+
+#records = #ttl.pipenet_records<net 7 name "source_outside_grid" pipes [
+  <srcX = 0, srcY = 2, dstStartX = 1, dstStartY = 0,
+   dstEndX = 1, dstEndY = 0>
+]>
+
+module attributes {ttl.launch_grid = array<i64: 3, 2>} {
+  func.func @outside_grid_is_src() {
+    // expected-error @below {{declares source core_x=0, core_y=2 outside the module `ttl.launch_grid`}}
+    %is_source = ttl.is_src {pipe_net_id = 7 : i64, records = #records}
     func.return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_role_predicates_invalid.mlir
@@ -1,5 +1,9 @@
 // RUN: ttlang-opt %s --verify-diagnostics --split-input-file -ttl-verify-pipenet-guards
 
+// Verify diagnostics for malformed PipeNet predicate record metadata.
+
+// A predicate and its record table must identify the same PipeNet.
+
 #records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
    dstEndX = 1, dstEndY = 0>
@@ -14,6 +18,8 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 }
 
 // -----
+
+// Destination predicates enforce the same PipeNet identity requirement.
 
 #records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
@@ -30,6 +36,8 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
+// Active predicates enforce the same PipeNet identity requirement.
+
 #records = #ttl.pipenet_records<net 7 name "mismatched" pipes [
   <srcX = 0, srcY = 0, dstStartX = 1, dstStartY = 0,
    dstEndX = 1, dstEndY = 0>
@@ -44,6 +52,8 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 }
 
 // -----
+
+// Predicate record endpoints must belong to the module launch grid.
 
 #records = #ttl.pipenet_records<net 7 name "outside_grid" pipes [
   <srcX = 0, srcY = 0, dstStartX = 2, dstStartY = 0,


### PR DESCRIPTION
### Problem description

For a local PipeNet, the compiler knows which launch coordinates are sources and destinations from the static transfer records. Calls such as `net.is_src()` nevertheless lower to a runtime coordinate comparison for every record, increasing kernel code and preventing later constant folding.

```python
if net.is_src():
    ttl.copy(send_block, output[0, node_x]).wait()
if net.is_dst():
    ttl.copy(receive_block, output[1, node_x]).wait()
```

### What's changed

~90 LOC implementation.

- Adds the local PipeNet's static transfer records to the `records` attribute on emitted `ttl.is_src`, `ttl.is_dst`, and `ttl.is_active` operations so lowering can use the same records that defined the role query.
- Computes the source or destination record count for every launch coordinate and lowers each role query to one coordinate-indexed lookup followed by a comparison with zero.
- Includes records referenced by these operations in launch-domain and endpoint validation so a lookup is accepted only for coordinates represented by those records.
- Preserves logical-device matching and compatibility with older TTL IR without `records`; that form resolves `pipe_net_id` to matching pipe declarations and emits coordinate comparisons for each distinct endpoint relation.

### Stack

Targets main.

### Checklist

- [x] New device tests cover source, destination, active, and inactive nodes with BF16/FP32 tensors in DRAM/L1.
- [x] Focused MLIR tests verify two-dimensional lookup indexing, rectangular receivers, duplicate and loopback records, and logical-device matching for all three roles.
- [x] New invalid tests reject mismatched PipeNet IDs and source/destination endpoints outside the launch grid.
