### PR TITLE
[ttl][dfb] Preserve descriptor use through lowering

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -145,11 +145,12 @@ requiring kernel specialization. An exact empty domain installs no descriptor;
 an unknown domain retains conservative whole-grid allocation.
 
 Per-core kernel specialization can remove different DFB operations on
-different launch nodes. Each final TTKernel function records the physical
-indices still referenced by its compile-time arguments in
-`ttl.used_dfb_indices`. Direct helper calls contribute their transitive uses.
-An unresolved call or missing annotation is conservative and keeps every DFB
-available on the affected function's launch nodes.
+different launch nodes. Each final TTKernel function records the physical DFB
+indices used by its remaining compile-time argument reads and external calls in
+`ttl.used_dfb_indices`. External-call metadata preserves dependencies that do
+not appear as C++ arguments. Direct helper calls contribute their transitive
+uses. An unresolved call or missing annotation is conservative and keeps every
+DFB available on the affected function's launch nodes.
 
 The runtime unions these sets for every kernel dispatched to a logical core,
 then intersects the result with the physical allocation domain and finalized

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -472,8 +472,12 @@ operand segments for template, dependency-only, and function-argument DFBs.
 Dependency occurrences, protocol effects, non-transactional accesses, and
 unknown access remain in TTL for analysis and verification. TTL to TTKernel
 conversion resolves DFB indices and materializes descriptor metadata before the
-DFB type loses its block geometry; it discards dependency-only operands and
-access-contract metadata because those facts do not alter the C++ call.
+DFB type loses its block geometry. It removes dependency operands and access
+contracts that do not alter the C++ call, but records their finalized physical
+indices in the TTKernel call's `dfb_descriptor_indices`. This metadata lets
+per-core specialization retain every descriptor the external call may use and
+does not add C++ arguments. Unknown external access records every user-managed
+DFB in the enclosing kernel; compiler-allocated temporary DFBs are excluded.
 TTKernel to EmitC resolves constants and descriptor types, and C++ emission
 inserts the required prelude and header during its existing operation scan.
 

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -387,11 +387,11 @@ the original does not leave dangling `SymbolRefAttr`s; unrelated functions in
 the module are still specialized. Each clone replaces coordinate reads with
 `arith.constant`s and is tagged with `ttl.core_coord` for runtime dispatch.
 Downstream `canonicalize` / `cse` fold the now-constant branches.
-`ttkernel-annotate-dfb-use` then records surviving DFB compile-time
-argument indices on each specialized function. Debug prints of a DFB
-remain only on cores that still have a non-print use of that DFB; a
-print whose DFB was folded away is dropped rather than keeping the
-descriptor alive for debugging.
+`ttkernel-annotate-dfb-use` then records surviving physical DFB indices from
+compile-time argument reads and external-call descriptor metadata on each
+specialized function. Debug prints of a DFB remain only on cores that still
+have a non-print use of that DFB; a print whose DFB was folded away is dropped
+rather than keeping the descriptor alive for debugging.
 
 This pass is off by default. Enable it through the pipeline option
 `specialize-cores` (Python: `--ttl-specialize-cores`), which runs the

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -388,6 +388,12 @@ they do not emit reserve, push, wait, or pop calls. Dependency-only operands,
 protocol effects, and non-transactional access metadata leave the generated
 C++ call signature unchanged.
 
+After physical DFB allocation, lowering records each dependency's finalized
+index as TTKernel call metadata. Per-core specialization uses this metadata to
+retain descriptors required by the external call, including dependencies that
+do not become C++ arguments. Unknown external access records every user-managed
+DFB in the enclosing kernel.
+
 The IR stores each effect as a generated enum and a typed attribute. Its
 dependency index identifies an element of the value sequence returned by the
 call's `getDFBDependencyOperands()` interface method. Operation adaptation may

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -5049,6 +5049,11 @@ def TTKernel_OpaqueCallOp : TTKernel_Op<"opaque_call",
       `unsigned_arg_indices` preserves unsigned address semantics when an
       earlier signless i32 value reaches the C++ call boundary.
 
+      `dfb_descriptor_indices` records the finalized physical indices of the
+      DFB descriptors required by the call. It preserves requirements whose TTL
+      operands become static C++ metadata or are not passed to the callee. It
+      does not add C++ function arguments.
+
       Example:
       ```
       ttkernel.opaque_call "my_func" template_args [1 : si32]
@@ -5060,7 +5065,8 @@ def TTKernel_OpaqueCallOp : TTKernel_Op<"opaque_call",
       StrAttr:$header,
       Variadic<AnyType>:$arg_operands,
       OptionalAttr<ArrayAttr>:$template_args,
-      OptionalAttr<DenseI32ArrayAttr>:$unsigned_arg_indices
+      OptionalAttr<DenseI32ArrayAttr>:$unsigned_arg_indices,
+      OptionalAttr<DenseI32ArrayAttr>:$dfb_descriptor_indices
     );
     let results = (outs Variadic<AnyType>);
     let assemblyFormat = [{

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1482,14 +1482,18 @@ def TTKernelAnnotateDFBUse
   let summary = "Record physical DFB indices used by each TTKernel function";
   let description = [{
     Runs after per-core specialization and canonicalization.
-    For each `ttkernel.thread` function, records the
-    sorted physical DFB indices reached through surviving
-    `ttkernel.get_compile_time_arg_val` operations below
-    `ttl.base_cta_index` in `ttl.used_dfb_indices`. Helpers stay in the
+    For each `ttkernel.thread` function, records the sorted physical DFB
+    indices reached through surviving `ttkernel.get_compile_time_arg_val`
+    operations below `ttl.base_cta_index` or listed in a surviving
+    `ttkernel.opaque_call`'s `dfb_descriptor_indices`. Helpers stay in the
     call-graph analysis so their uses propagate to kernel entries.
     Declarations are not annotated. The compile-time ABI places
     every DFB before tensor-accessor arguments, including DFB ids passed to
     opaque externs as scalar values.
+
+    Opaque-call descriptor metadata preserves DFB requirements whose TTL
+    operands became static C++ metadata or were removed during lowering. The
+    metadata does not add a C++ function argument.
 
     Calls are resolved through the MLIR call graph. Uses are propagated from
     callees to callers in SCC order, including recursive calls. An unknown or

--- a/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
+++ b/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
@@ -9,13 +9,20 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <optional>
 
 namespace mlir::tt::utils {
+
+inline bool areIndicesStrictlyIncreasing(ArrayRef<int32_t> indices) {
+  return llvm::adjacent_find(indices, std::greater_equal<int32_t>()) ==
+         indices.end();
+}
 
 /// Verifies the attributes shared by `ttl.opaque_call` and
 /// `ttkernel.opaque_call`.
@@ -40,16 +47,11 @@ verifyOpaqueCallUnsignedArgIndices(Operation *op,
     return success();
   }
 
-  int32_t previousIndex = -1;
   for (int32_t index : *indices) {
     if (index < 0 || static_cast<size_t>(index) >= arguments.size()) {
       return op->emitOpError("unsigned function argument index ")
              << index << " is out of range for " << arguments.size()
              << " arguments";
-    }
-    if (index <= previousIndex) {
-      return op->emitOpError(
-          "unsigned function argument indices must be strictly increasing");
     }
     auto integerType = dyn_cast<IntegerType>(arguments[index].getType());
     if (!integerType || integerType.getWidth() != 32) {
@@ -57,7 +59,29 @@ verifyOpaqueCallUnsignedArgIndices(Operation *op,
              << index << " must reference a 32-bit integer operand, got "
              << arguments[index].getType();
     }
-    previousIndex = index;
+  }
+  if (!areIndicesStrictlyIncreasing(*indices)) {
+    return op->emitOpError(
+        "unsigned function argument indices must be strictly increasing");
+  }
+  return success();
+}
+
+inline LogicalResult verifyOpaqueCallDFBDescriptorIndices(
+    Operation *op, std::optional<ArrayRef<int32_t>> indices) {
+  if (!indices) {
+    return success();
+  }
+  auto negativeIndex = llvm::find_if(*indices, [](int32_t index) {
+    return index < 0;
+  });
+  if (negativeIndex != indices->end()) {
+    return op->emitOpError("DFB descriptor index must be nonnegative, got ")
+           << *negativeIndex;
+  }
+  if (!areIndicesStrictlyIncreasing(*indices)) {
+    return op->emitOpError(
+        "DFB descriptor indices must be strictly increasing");
   }
   return success();
 }

--- a/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
+++ b/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
@@ -67,14 +67,14 @@ verifyOpaqueCallUnsignedArgIndices(Operation *op,
   return success();
 }
 
-inline LogicalResult verifyOpaqueCallDFBDescriptorIndices(
-    Operation *op, std::optional<ArrayRef<int32_t>> indices) {
+inline LogicalResult
+verifyOpaqueCallDFBDescriptorIndices(Operation *op,
+                                     std::optional<ArrayRef<int32_t>> indices) {
   if (!indices) {
     return success();
   }
-  auto negativeIndex = llvm::find_if(*indices, [](int32_t index) {
-    return index < 0;
-  });
+  auto negativeIndex =
+      llvm::find_if(*indices, [](int32_t index) { return index < 0; });
   if (negativeIndex != indices->end()) {
     return op->emitOpError("DFB descriptor index must be nonnegative, got ")
            << *negativeIndex;

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -727,6 +727,10 @@ void UnpackStallOnPackOp::getCanonicalizationPatterns(
           getOperation(), getUnsignedArgIndices(), getArgOperands()))) {
     return failure();
   }
+  if (failed(mlir::tt::utils::verifyOpaqueCallDFBDescriptorIndices(
+          getOperation(), getDfbDescriptorIndices()))) {
+    return failure();
+  }
   std::optional<ArrayAttr> templateArgs = getTemplateArgs();
   if (!templateArgs) {
     return success();

--- a/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
@@ -131,17 +131,35 @@ static func::FuncOp getCallableFunc(CallGraphNode *node) {
   return dyn_cast<func::FuncOp>(node->getCallableRegion()->getParentOp());
 }
 
-static void collectDirectDFBUses(func::FuncOp func, int64_t dfbCount,
-                                 DFBSet &used) {
-  func.walk([&](ttk::GetCompileArgValOp op) {
-    if (isPrintOnly(op)) {
+static LogicalResult collectDirectDFBUses(func::FuncOp func, int64_t dfbCount,
+                                          DFBSet &used) {
+  func.walk([&](ttk::GetCompileArgValOp getArg) {
+    if (isPrintOnly(getArg)) {
       return;
     }
-    int64_t index = static_cast<int64_t>(op.getArgIndex());
+    int64_t index = static_cast<int64_t>(getArg.getArgIndex());
     if (index >= 0 && index < dfbCount) {
       used.insert(static_cast<int32_t>(index));
     }
   });
+
+  WalkResult result = func.walk([&](ttk::OpaqueCallOp call) -> WalkResult {
+    std::optional<ArrayRef<int32_t>> indices = call.getDfbDescriptorIndices();
+    if (!indices) {
+      return WalkResult::advance();
+    }
+    for (int32_t index : *indices) {
+      if (index < 0 || index >= dfbCount) {
+        call.emitOpError("DFB descriptor index ")
+            << index << " is outside [0, " << dfbCount - 1
+            << "] for the enclosing function";
+        return WalkResult::interrupt();
+      }
+      used.insert(index);
+    }
+    return WalkResult::advance();
+  });
+  return result.wasInterrupted() ? failure() : success();
 }
 
 static void recordAllDFBs(func::FuncOp func, int64_t maxDFBCount,
@@ -228,7 +246,11 @@ struct TTKernelAnnotateDFBUsePass
 
     for (func::FuncOp func : module.getOps<func::FuncOp>()) {
       int64_t dfbCount = getFuncDFBCount(func, maxDFBCount);
-      collectDirectDFBUses(func, dfbCount, usedDFBs[func.getOperation()]);
+      if (failed(collectDirectDFBUses(func, dfbCount,
+                                      usedDFBs[func.getOperation()]))) {
+        signalPassFailure();
+        return;
+      }
     }
 
     CallGraph callgraph(module);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -241,6 +241,50 @@ static FailureOr<int32_t> getValidatedDFBIndex(Value dfb, Operation *op) {
   return static_cast<int32_t>(*dfbIndex);
 }
 
+static void
+sortAndDeduplicateDFBIndices(SmallVectorImpl<int32_t> &dfbIndices) {
+  llvm::sort(dfbIndices);
+  dfbIndices.erase(llvm::unique(dfbIndices), dfbIndices.end());
+}
+
+static FailureOr<SmallVector<int32_t>>
+getValidatedDFBDescriptorIndices(ValueRange dfbs, Operation *op) {
+  SmallVector<int32_t> indices;
+  indices.reserve(dfbs.size());
+  for (Value dfb : dfbs) {
+    FailureOr<int32_t> dfbIndex = getValidatedDFBIndex(dfb, op);
+    if (failed(dfbIndex)) {
+      return failure();
+    }
+    indices.push_back(*dfbIndex);
+  }
+  sortAndDeduplicateDFBIndices(indices);
+  return indices;
+}
+
+static FailureOr<SmallVector<int32_t>>
+collectValidatedUserManagedDFBIndices(ModuleOp module) {
+  SmallVector<int32_t> indices;
+  WalkResult walkResult = module.walk([&](BindCBOp bind) -> WalkResult {
+    if (bind->hasAttr(kCompilerAllocatedAttrName)) {
+      return WalkResult::advance();
+    }
+    FailureOr<int32_t> dfbIndex =
+        getValidatedDFBIndex(bind.getResult(), bind);
+    if (failed(dfbIndex)) {
+      return WalkResult::interrupt();
+    }
+    indices.push_back(*dfbIndex);
+    return WalkResult::advance();
+  });
+  if (walkResult.wasInterrupted()) {
+    return failure();
+  }
+
+  sortAndDeduplicateDFBIndices(indices);
+  return indices;
+}
+
 /// Read one L1 address from the function's common runtime arguments.
 static Value getCommonRuntimeArg(unsigned argIdx, Location loc,
                                  ConversionPatternRewriter &rewriter) {
@@ -1689,12 +1733,19 @@ static LogicalResult lowerDFBReset(Operation *operation,
       rewriter, location, static_cast<uint32_t>(dfbMask), 32);
   Value highMask = arith::ConstantIntOp::create(
       rewriter, location, static_cast<uint32_t>(dfbMask >> 32), 32);
+  SmallVector<int32_t> dfbDescriptorIndices;
+  for (unsigned dfbIndex = 0; dfbIndex < 64; ++dfbIndex) {
+    if ((dfbMask & (uint64_t{1} << dfbIndex)) != 0) {
+      dfbDescriptorIndices.push_back(static_cast<int32_t>(dfbIndex));
+    }
+  }
   ttk::OpaqueCallOp::create(
       rewriter, location, TypeRange{},
       rewriter.getStringAttr("experimental::reset_dfb_interfaces"),
       rewriter.getStringAttr("<cstdint>"),
       ValueRange{synchronizationAddress, lowMask, highMask}, ArrayAttr(),
-      rewriter.getDenseI32ArrayAttr({0, 1, 2}));
+      rewriter.getDenseI32ArrayAttr({0, 1, 2}),
+      rewriter.getDenseI32ArrayAttr(dfbDescriptorIndices));
   rewriter.eraseOp(operation);
   return success();
 }
@@ -1791,7 +1842,7 @@ struct DFBReconfigurationLowering : OpConversionPattern<DFBReconfigurationOp> {
         rewriter, op.getLoc(), TypeRange{},
         rewriter.getStringAttr("experimental::reconfigure_dfb_interfaces"),
         rewriter.getStringAttr("<cstdint>"), ValueRange{configurationAddress},
-        ArrayAttr(), rewriter.getDenseI32ArrayAttr({0}));
+        ArrayAttr(), rewriter.getDenseI32ArrayAttr({0}), DenseI32ArrayAttr());
     rewriter.eraseOp(op);
     return success();
   }
@@ -1818,12 +1869,25 @@ using OpaqueArgumentPlan =
     std::variant<OpaqueScalarArgument, OpaqueDFBArgument, OpaqueTensorArgument>;
 
 struct OpaqueCallLowering : OpConversionPattern<OpaqueCallOp> {
-  using OpConversionPattern::OpConversionPattern;
+  OpaqueCallLowering(TypeConverter &typeConverter, MLIRContext *context,
+                     ArrayRef<int32_t> userManagedDFBIndices)
+      : OpConversionPattern(typeConverter, context),
+        userManagedDFBIndices(userManagedDFBIndices) {}
 
   LogicalResult
   matchAndRewrite(OpaqueCallOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location location = op.getLoc();
+
+    FailureOr<SmallVector<int32_t>> dfbDescriptorIndices =
+        getValidatedDFBDescriptorIndices(op.getDFBDependencyOperands(), op);
+    if (failed(dfbDescriptorIndices)) {
+      return failure();
+    }
+    if (op.hasUnknownDFBAccess()) {
+      llvm::append_range(*dfbDescriptorIndices, userManagedDFBIndices);
+      sortAndDeduplicateDFBIndices(*dfbDescriptorIndices);
+    }
 
     SmallVector<Attribute> templateArgs;
     if (std::optional<ArrayAttr> sourceTemplateArgs = op.getTemplateArgs()) {
@@ -1905,14 +1969,22 @@ struct OpaqueCallLowering : OpConversionPattern<OpaqueCallOp> {
     if (!templateArgs.empty()) {
       templateArgsAttr = rewriter.getArrayAttr(templateArgs);
     }
+    DenseI32ArrayAttr dfbDescriptorIndicesAttr;
+    if (!dfbDescriptorIndices->empty()) {
+      dfbDescriptorIndicesAttr =
+          rewriter.getDenseI32ArrayAttr(*dfbDescriptorIndices);
+    }
     auto newOp = ttk::OpaqueCallOp::create(
         rewriter, location, resultTypes, op.getCalleeAttr(), op.getHeaderAttr(),
-        convertedArgs, templateArgsAttr, op.getUnsignedArgIndicesAttr());
+        convertedArgs, templateArgsAttr, op.getUnsignedArgIndicesAttr(),
+        dfbDescriptorIndicesAttr);
     rewriter.replaceOp(op, newOp->getResults());
     return success();
   }
 
 private:
+  SmallVector<int32_t> userManagedDFBIndices;
+
   /// Resolve DFB metadata before type conversion discards block geometry.
   static FailureOr<Attribute>
   convertTemplateArg(ExternalTemplateArgAttr templateArg,
@@ -2465,6 +2537,11 @@ static LogicalResult lowerTTLOpsToTTKernel(
   if (failed(resetLoweringPlan)) {
     return failure();
   }
+  FailureOr<SmallVector<int32_t>> userManagedDFBIndices =
+      collectValidatedUserManagedDFBIndices(mod);
+  if (failed(userManagedDFBIndices)) {
+    return failure();
+  }
   pipePlanningOptions.enableComputedAddresses = pipeComputedAddresses;
   pipePlanningOptions.enableCapacitySynchronization = pipeCapacitySync;
   pipePlanningOptions.counterAllocationPolicy =
@@ -2557,8 +2634,9 @@ static LogicalResult lowerTTLOpsToTTKernel(
       .add<BindCBLowering, TensorSliceLowering, TileStoreLowering,
            StoreLowering, CoreXLowering, CoreYLowering, RawElementReadLowering,
            ReadIndexLowering, RawElementWriteLowering, RawAddrLowering,
-           DFBReconfigurationLowering, OpaqueCallLowering, GetDfbIdLowering>(
-          typeConverter, &ctx);
+           DFBReconfigurationLowering, GetDfbIdLowering>(typeConverter, &ctx);
+  patterns.add<OpaqueCallLowering>(typeConverter, &ctx,
+                                   *userManagedDFBIndices);
   patterns.add<CBPopLowering>(typeConverter, &ctx, pipeCapacityPlan,
                               pipeTransportPlan, transportSlotCounters,
                               pipeResourcePlan);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -241,8 +241,7 @@ static FailureOr<int32_t> getValidatedDFBIndex(Value dfb, Operation *op) {
   return static_cast<int32_t>(*dfbIndex);
 }
 
-static void
-sortAndDeduplicateDFBIndices(SmallVectorImpl<int32_t> &dfbIndices) {
+static void sortAndDeduplicateDFBIndices(SmallVectorImpl<int32_t> &dfbIndices) {
   llvm::sort(dfbIndices);
   dfbIndices.erase(llvm::unique(dfbIndices), dfbIndices.end());
 }
@@ -269,8 +268,7 @@ collectValidatedUserManagedDFBIndices(ModuleOp module) {
     if (bind->hasAttr(kCompilerAllocatedAttrName)) {
       return WalkResult::advance();
     }
-    FailureOr<int32_t> dfbIndex =
-        getValidatedDFBIndex(bind.getResult(), bind);
+    FailureOr<int32_t> dfbIndex = getValidatedDFBIndex(bind.getResult(), bind);
     if (failed(dfbIndex)) {
       return WalkResult::interrupt();
     }
@@ -2635,8 +2633,7 @@ static LogicalResult lowerTTLOpsToTTKernel(
            StoreLowering, CoreXLowering, CoreYLowering, RawElementReadLowering,
            ReadIndexLowering, RawElementWriteLowering, RawAddrLowering,
            DFBReconfigurationLowering, GetDfbIdLowering>(typeConverter, &ctx);
-  patterns.add<OpaqueCallLowering>(typeConverter, &ctx,
-                                   *userManagedDFBIndices);
+  patterns.add<OpaqueCallLowering>(typeConverter, &ctx, *userManagedDFBIndices);
   patterns.add<CBPopLowering>(typeConverter, &ctx, pipeCapacityPlan,
                               pipeTransportPlan, transportSlotCounters,
                               pipeResourcePlan);

--- a/test/python/include/repeated_dfb_transactions.hpp
+++ b/test/python/include/repeated_dfb_transactions.hpp
@@ -45,17 +45,17 @@ inline void read_high_water_dfb_logical_dm(SourceAccessor source) {
   constexpr uint32_t highWaterTiles = 2 * Destination::pages_per_block;
 
   CircularBuffer destination(get_compile_time_arg_val(Destination::index));
-  Noc noc0(0);
+  Noc noc;
   destination.reserve_back(highWaterTiles);
   for (uint32_t transaction = 0; transaction < transactionCount;
        ++transaction) {
     for (uint32_t tile = 0; tile < transactionTiles; ++tile) {
       uint32_t pageId = transaction * transactionTiles + tile;
-      noc0.async_read(source, destination, Destination::page_size_bytes,
-                      {.page_id = pageId},
-                      {.offset_bytes = tile * Destination::page_size_bytes});
+      noc.async_read(source, destination, Destination::page_size_bytes,
+                     {.page_id = pageId},
+                     {.offset_bytes = tile * Destination::page_size_bytes});
     }
-    noc0.async_read_barrier();
+    noc.async_read_barrier();
     destination.push_back(transactionTiles);
     if (transaction + 1 < transactionCount) {
       destination.reserve_back(highWaterTiles);
@@ -72,17 +72,17 @@ inline void write_high_water_dfb_logical_dm(DestinationAccessor destination) {
   constexpr uint32_t transactionCount = 4;
   constexpr uint32_t transactionTiles = Source::pages_per_block;
   CircularBuffer source(get_compile_time_arg_val(Source::index));
-  Noc noc0(0);
+  Noc noc;
   for (uint32_t transaction = 0; transaction < transactionCount;
        ++transaction) {
     source.wait_front(transactionTiles);
     for (uint32_t tile = 0; tile < transactionTiles; ++tile) {
       uint32_t pageId = transaction * transactionTiles + tile;
-      noc0.async_write(source, destination, Source::page_size_bytes,
-                       {.offset_bytes = tile * Source::page_size_bytes},
-                       {.page_id = pageId});
+      noc.async_write(source, destination, Source::page_size_bytes,
+                      {.offset_bytes = tile * Source::page_size_bytes},
+                      {.page_id = pageId});
     }
-    noc0.async_write_barrier();
+    noc.async_write_barrier();
     source.pop_front(transactionTiles);
   }
 #endif

--- a/test/python/test_external_descriptor_reset.py
+++ b/test/python/test_external_descriptor_reset.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device regression for physical DFB descriptor dependencies."""
+
+import os
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+from ttl import ttl_api  # noqa: E402
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+TILE = 32
+REPEATED_DFB_TRANSACTIONS_HEADER = os.path.join(
+    os.path.dirname(__file__), "include", "repeated_dfb_transactions.hpp"
+)
+
+
+def _make_external_descriptor_reset_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    reset = ttl.DFBReset(
+        participants=(compute_kernel, reader_kernel, writer_kernel),
+    )
+
+    @ttl.operation(grid=(1, 1))
+    def external_descriptor_reset_kernel(input_tensor, output_tensor):
+        external_stream = ttl.make_dfb(
+            data_format,
+            shape=(1, 4),
+            block_count=3,
+        )
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            ttl.reset_dfbs(reset, dfbs=[external_stream])
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            ttl.call_extern_func(
+                REPEATED_DFB_TRANSACTIONS_HEADER,
+                "read_high_water_dfb_logical_dm",
+                template_args=[ttl.dfb_descriptor(external_stream)],
+                func_args=[input_tensor],
+                dfb_effects=[
+                    ttl.DFBEffect.reserve(external_stream, tiles=8),
+                    ttl.DFBEffect.push(external_stream, tiles=4),
+                    ttl.DFBEffect.reserve(external_stream, tiles=8),
+                    ttl.DFBEffect.push(external_stream, tiles=4),
+                    ttl.DFBEffect.reserve(external_stream, tiles=8),
+                    ttl.DFBEffect.push(external_stream, tiles=4),
+                    ttl.DFBEffect.reserve(external_stream, tiles=8),
+                    ttl.DFBEffect.push(external_stream, tiles=4),
+                ],
+            )
+            ttl.reset_dfbs(reset, dfbs=[external_stream])
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            ttl.call_extern_func(
+                REPEATED_DFB_TRANSACTIONS_HEADER,
+                "write_high_water_dfb_logical_dm",
+                template_args=[ttl.dfb_descriptor(external_stream)],
+                func_args=[output_tensor],
+                dfb_effects=[
+                    ttl.DFBEffect.wait(external_stream, tiles=4),
+                    ttl.DFBEffect.pop(external_stream, tiles=4),
+                    ttl.DFBEffect.wait(external_stream, tiles=4),
+                    ttl.DFBEffect.pop(external_stream, tiles=4),
+                    ttl.DFBEffect.wait(external_stream, tiles=4),
+                    ttl.DFBEffect.pop(external_stream, tiles=4),
+                    ttl.DFBEffect.wait(external_stream, tiles=4),
+                    ttl.DFBEffect.pop(external_stream, tiles=4),
+                ],
+            )
+            ttl.reset_dfbs(reset, dfbs=[external_stream])
+
+    return external_descriptor_reset_kernel
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    "to_device",
+    [to_dram, to_l1],
+    ids=["dram", "l1"],
+)
+def test_external_descriptor_survives_synchronized_reset(
+    device,
+    dtype,
+    to_device,
+    monkeypatch,
+    tmp_path,
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    data_format = "bf16" if dtype == torch.bfloat16 else "float32"
+    operation = _make_external_descriptor_reset_kernel(data_format)
+    final_mlir_path = tmp_path / "external_descriptor_reset.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+
+    element_indices = torch.arange(TILE * 16 * TILE, dtype=torch.float32).reshape(
+        TILE, 16 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+    assert final_mlir_path.read_text().count("dfb_index =") == 1

--- a/test/python/test_external_descriptor_reset.py
+++ b/test/python/test_external_descriptor_reset.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Device regression for physical DFB descriptor dependencies."""
+"""Device regression for core-specialized physical DFB descriptor dependencies."""
 
 import os
 
@@ -32,7 +32,7 @@ def _make_external_descriptor_reset_kernel(data_format):
         participants=(compute_kernel, reader_kernel, writer_kernel),
     )
 
-    @ttl.operation(grid=(1, 1))
+    @ttl.operation(grid=(2, 1))
     def external_descriptor_reset_kernel(input_tensor, output_tensor):
         external_stream = ttl.make_dfb(
             data_format,
@@ -42,47 +42,53 @@ def _make_external_descriptor_reset_kernel(data_format):
 
         @ttl.compute(kernel=compute_kernel)
         def compute():
-            ttl.reset_dfbs(reset, dfbs=[external_stream])
+            core_x, _core_y = ttl.node(dims=2)
+            if core_x == 0:
+                ttl.reset_dfbs(reset, dfbs=[external_stream])
 
         @ttl.datamovement(kernel=reader_kernel)
         def read():
-            ttl.call_extern_func(
-                REPEATED_DFB_TRANSACTIONS_HEADER,
-                "read_high_water_dfb_logical_dm",
-                template_args=[ttl.dfb_descriptor(external_stream)],
-                func_args=[input_tensor],
-                dfb_effects=[
-                    ttl.DFBEffect.reserve(external_stream, tiles=8),
-                    ttl.DFBEffect.push(external_stream, tiles=4),
-                    ttl.DFBEffect.reserve(external_stream, tiles=8),
-                    ttl.DFBEffect.push(external_stream, tiles=4),
-                    ttl.DFBEffect.reserve(external_stream, tiles=8),
-                    ttl.DFBEffect.push(external_stream, tiles=4),
-                    ttl.DFBEffect.reserve(external_stream, tiles=8),
-                    ttl.DFBEffect.push(external_stream, tiles=4),
-                ],
-            )
-            ttl.reset_dfbs(reset, dfbs=[external_stream])
+            core_x, _core_y = ttl.node(dims=2)
+            if core_x == 0:
+                ttl.call_extern_func(
+                    REPEATED_DFB_TRANSACTIONS_HEADER,
+                    "read_high_water_dfb_logical_dm",
+                    template_args=[ttl.dfb_descriptor(external_stream)],
+                    func_args=[input_tensor],
+                    dfb_effects=[
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                    ],
+                )
+                ttl.reset_dfbs(reset, dfbs=[external_stream])
 
         @ttl.datamovement(kernel=writer_kernel)
         def write():
-            ttl.call_extern_func(
-                REPEATED_DFB_TRANSACTIONS_HEADER,
-                "write_high_water_dfb_logical_dm",
-                template_args=[ttl.dfb_descriptor(external_stream)],
-                func_args=[output_tensor],
-                dfb_effects=[
-                    ttl.DFBEffect.wait(external_stream, tiles=4),
-                    ttl.DFBEffect.pop(external_stream, tiles=4),
-                    ttl.DFBEffect.wait(external_stream, tiles=4),
-                    ttl.DFBEffect.pop(external_stream, tiles=4),
-                    ttl.DFBEffect.wait(external_stream, tiles=4),
-                    ttl.DFBEffect.pop(external_stream, tiles=4),
-                    ttl.DFBEffect.wait(external_stream, tiles=4),
-                    ttl.DFBEffect.pop(external_stream, tiles=4),
-                ],
-            )
-            ttl.reset_dfbs(reset, dfbs=[external_stream])
+            core_x, _core_y = ttl.node(dims=2)
+            if core_x == 0:
+                ttl.call_extern_func(
+                    REPEATED_DFB_TRANSACTIONS_HEADER,
+                    "write_high_water_dfb_logical_dm",
+                    template_args=[ttl.dfb_descriptor(external_stream)],
+                    func_args=[output_tensor],
+                    dfb_effects=[
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                    ],
+                )
+                ttl.reset_dfbs(reset, dfbs=[external_stream])
 
     return external_descriptor_reset_kernel
 
@@ -93,7 +99,7 @@ def _make_external_descriptor_reset_kernel(data_format):
     [to_dram, to_l1],
     ids=["dram", "l1"],
 )
-def test_external_descriptor_survives_synchronized_reset(
+def test_external_descriptor_survives_specialization_and_synchronized_reset(
     device,
     dtype,
     to_device,
@@ -115,7 +121,11 @@ def test_external_descriptor_survives_synchronized_reset(
     input_tensor = to_device(input_host, device)
     output_tensor = to_device(torch.zeros_like(input_host), device)
 
-    operation(input_tensor, output_tensor, options="--ttl-reuse-user-dfbs")
+    operation(
+        input_tensor,
+        output_tensor,
+        options="--ttl-reuse-user-dfbs --ttl-specialize-cores",
+    )
 
     actual = ttnn.to_torch(output_tensor).float()
     expected = input_host.float()
@@ -124,4 +134,8 @@ def test_external_descriptor_survives_synchronized_reset(
     else:
         assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
-    assert final_mlir_path.read_text().count("dfb_index =") == 1
+    final_mlir = final_mlir_path.read_text()
+    assert final_mlir.count("dfb_index =") == 1
+    assert final_mlir.count("ttl.core_coord") == 6
+    assert final_mlir.count("ttl.used_dfb_indices = array<i32: 0>") == 3
+    assert final_mlir.count("ttl.used_dfb_indices = array<i32>") == 3

--- a/test/ttlang/Conversion/TTLToTTKernel/dfb_reset.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/dfb_reset.mlir
@@ -11,10 +11,10 @@
 // CHECK-DAG: %[[SECOND_OFFSET:.*]] = arith.constant 16 : i32
 // CHECK-DAG: %[[ALL_LOW:.*]] = arith.constant 4 : i32
 // CHECK: %[[SCRATCH_BASE:.*]] = ttkernel.get_common_arg_val
-// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SCRATCH_BASE]], %[[SELECTED_LOW]], %[[SELECTED_HIGH]])
+// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SCRATCH_BASE]], %[[SELECTED_LOW]], %[[SELECTED_HIGH]]) {dfb_descriptor_indices = array<i32: 33>,
 // CHECK: %[[SECOND_BASE:.*]] = ttkernel.get_common_arg_val
 // CHECK: %[[SECOND_STATE:.*]] = arith.addi %[[SECOND_BASE]], %[[SECOND_OFFSET]] : i32
-// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SECOND_STATE]], %[[ALL_LOW]], %[[SELECTED_HIGH]])
+// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SECOND_STATE]], %[[ALL_LOW]], %[[SELECTED_HIGH]]) {dfb_descriptor_indices = array<i32: 2, 33>,
 
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @reset_masks()
@@ -38,7 +38,7 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
 // CHECK-LABEL: func.func @pipe_and_reset
 // CHECK: %[[RESET_OFFSET:.*]] = arith.constant 32 : i32
 // CHECK: %[[RESET_STATE:.*]] = arith.addi {{.*}}, %[[RESET_OFFSET]] : i32
-// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[RESET_STATE]],
+// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[RESET_STATE]],{{.*}}) {dfb_descriptor_indices = array<i32: 0>,
 module attributes {
   ttl.launch_grid = array<i64: 2, 2>,
   ttl.target_arch = #ttcore.arch<blackhole>

--- a/test/ttlang/Conversion/TTLToTTKernel/dfb_reset_invalid.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/dfb_reset_invalid.mlir
@@ -28,7 +28,7 @@ module attributes {ttl.target_arch = #ttcore.arch<wormhole_b0>} {
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @out_of_range_index()
       attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
-    // expected-error @below {{'ttl.bind_cb' op finalized DFB index 64 is outside [0, 63] for the 64-DFB-index Blackhole target capacity}}
+    // expected-error @below {{finalized DFB index 64 is outside [0, 63] for the 64-DFB-index Blackhole target capacity}}
     %dfb = ttl.bind_cb {cb_index = 64, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
     ttl.reset_dfbs <0, participants[<kind = compute, identity = "compute", operation = "reset_test">, <kind = data_movement, identity = "reader", operation = "reset_test">, <kind = data_movement, identity = "writer", operation = "reset_test">]>(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
     return

--- a/test/ttlang/Conversion/TTLToTTKernel/opaque_call.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/opaque_call.mlir
@@ -1,7 +1,7 @@
 // Verify opaque_call lowering from TTL to TTKernel.
 // Checks template arg forwarding, DFB-to-CB conversion for func_args,
 // get_dfb_id lowering, tensor func-arg TensorAccessor materialization,
-// and ttl.raw_addr lowering.
+// ttl.raw_addr lowering, and preservation of external DFB dependencies.
 // RUN: ttlang-opt --convert-ttl-to-ttkernel --split-input-file %s | FileCheck %s
 
 // Void call with no args lowers directly.
@@ -27,7 +27,7 @@ func.func @call_with_template_args() attributes {ttl.kernel_thread = #ttkernel.t
 // A finalized DFB index becomes an unsigned static argument.
 // CHECK-LABEL: func.func @call_with_dfb_template_arg
 // CHECK-NOT: ttkernel.get_dfb_id
-// CHECK: ttkernel.opaque_call "drain" template_args [2 : ui32]() {header = "drain.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "drain" template_args [2 : ui32]() {dfb_descriptor_indices = array<i32: 2>, header = "drain.hpp"} : () -> ()
 func.func @call_with_dfb_template_arg() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   ttl.opaque_call "drain" template_args [#ttl.external_template_arg<dfb_index, 0>] template_dfbs(%cb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>) dfb_dependencies(%cb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>) () {header = "drain.hpp"} : () -> ()
@@ -38,7 +38,7 @@ func.func @call_with_dfb_template_arg() attributes {ttl.kernel_thread = #ttkerne
 
 // A DFB template operand preserves its finalized index and allocation geometry.
 // CHECK-LABEL: func.func @call_with_dfb_descriptor
-// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4096>]() {header = "describe.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4096>]() {dfb_descriptor_indices = array<i32: 2>, header = "describe.hpp"} : () -> ()
 func.func @call_with_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 4} : !ttl.cb<[2, 3], !ttcore.tile<32x32, f32>, 4>
   ttl.opaque_call "describe" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%cb : !ttl.cb<[2, 3], !ttcore.tile<32x32, f32>, 4>) () {header = "describe.hpp"} : () -> ()
@@ -49,7 +49,7 @@ func.func @call_with_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.
 
 // Subtile dimensions change bytes per page, not the number of pages in a block.
 // CHECK-LABEL: func.func @call_with_subtile_dfb_descriptor
-// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 32>]() {header = "describe.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 32>]() {dfb_descriptor_indices = array<i32: 2>, header = "describe.hpp"} : () -> ()
 func.func @call_with_subtile_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 4} : !ttl.cb<[2, 3], !ttcore.tile<1x16, bf16>, 4>
   ttl.opaque_call "describe" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%cb : !ttl.cb<[2, 3], !ttcore.tile<1x16, bf16>, 4>) () {header = "describe.hpp"} : () -> ()
@@ -60,7 +60,7 @@ func.func @call_with_subtile_dfb_descriptor() attributes {ttl.kernel_thread = #t
 
 // Scalar DFBs use one scalar element per page rather than tile storage size.
 // CHECK-LABEL: func.func @call_with_scalar_dfb_descriptor
-// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4>]() {header = "describe.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4>]() {dfb_descriptor_indices = array<i32: 2>, header = "describe.hpp"} : () -> ()
 func.func @call_with_scalar_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 4} : !ttl.cb<[2, 3], f32, 4>
   ttl.opaque_call "describe" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%cb : !ttl.cb<[2, 3], f32, 4>) () {header = "describe.hpp"} : () -> ()
@@ -72,7 +72,7 @@ func.func @call_with_scalar_dfb_descriptor() attributes {ttl.kernel_thread = #tt
 // DFB func_arg is lowered to an unsigned physical index.
 // CHECK-LABEL: func.func @call_with_dfb_func_arg
 // CHECK: %[[CB_IDX:.*]] = ttkernel.get_compile_time_arg_val(1) : () -> ui32
-// CHECK-NEXT: ttkernel.opaque_call "use_cb"(%[[CB_IDX]]) {header = "use_cb.hpp"} : (ui32) -> ()
+// CHECK-NEXT: ttkernel.opaque_call "use_cb"(%[[CB_IDX]]) {dfb_descriptor_indices = array<i32: 1>, header = "use_cb.hpp"} : (ui32) -> ()
 func.func @call_with_dfb_func_arg() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.opaque_call "use_cb" (%cb) {header = "use_cb.hpp"} : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
@@ -134,10 +134,11 @@ func.func @call_with_compute_raw_addr_func_arg(%arg0: tensor<1x1x!ttcore.tile<32
 // TTKernel call arguments or protocol operations.
 // CHECK-LABEL: func.func @dfb_protocol_metadata
 // CHECK-NOT: ttkernel.cb_
-// CHECK: ttkernel.opaque_call "hidden_protocol"() {header = "hidden_protocol.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "hidden_protocol"() {dfb_descriptor_indices = array<i32: 3>, header = "hidden_protocol.hpp"} : () -> ()
 // CHECK-NOT: ttkernel.cb_
 func.func @dfb_protocol_metadata() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
   %dfb = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+  %temporary = ttl.bind_cb {cb_index = 4, block_count = 2} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.opaque_call "hidden_protocol" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "hidden_protocol.hpp", unknown_dfb_access} : () -> ()
   return
 }

--- a/test/ttlang/Dialect/TTKernel/IR/opaque_call.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/opaque_call.mlir
@@ -28,3 +28,13 @@ func.func @unsigned_func_arg(%arg0: i32) {
   ttkernel.opaque_call "use_address" (%arg0) {header = "address.hpp", unsigned_arg_indices = array<i32: 0>} : (i32) -> ()
   return
 }
+
+// -----
+
+// DFB metadata round trips without adding C++ operands.
+// CHECK-LABEL: func.func @descriptor_metadata
+// CHECK: ttkernel.opaque_call "reset"() {dfb_descriptor_indices = array<i32: 1, 3>, header = "reset.hpp"} : () -> ()
+func.func @descriptor_metadata() {
+  ttkernel.opaque_call "reset" () {dfb_descriptor_indices = array<i32: 1, 3>, header = "reset.hpp"} : () -> ()
+  return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/opaque_call_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/opaque_call_invalid.mlir
@@ -88,3 +88,21 @@ func.func @unsigned_arg_not_integer(%arg0: f32) {
   ttkernel.opaque_call "foo" (%arg0) {header = "h.hpp", unsigned_arg_indices = array<i32: 0>} : (f32) -> ()
   return
 }
+
+// -----
+
+// Physical DFB indices are nonnegative.
+func.func @negative_dfb_descriptor_index() {
+  // expected-error @below {{'ttkernel.opaque_call' op DFB descriptor index must be nonnegative, got -1}}
+  ttkernel.opaque_call "foo" () {dfb_descriptor_indices = array<i32: -1>, header = "h.hpp"} : () -> ()
+  return
+}
+
+// -----
+
+// DFB descriptor indices have one canonical order without duplicates.
+func.func @dfb_descriptor_indices_not_increasing() {
+  // expected-error @below {{'ttkernel.opaque_call' op DFB descriptor indices must be strictly increasing}}
+  ttkernel.opaque_call "foo" () {dfb_descriptor_indices = array<i32: 1, 1>, header = "h.hpp"} : () -> ()
+  return
+}

--- a/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use.mlir
@@ -23,6 +23,9 @@
 // CHECK-LABEL: func.func @cycle_b()
 // CHECK-SAME: ttl.used_dfb_indices = array<i32: 0, 1>
 
+// CHECK-LABEL: func.func @opaque_only()
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 1, 3>
+
 module {
   func.func private @unknown()
 
@@ -74,6 +77,13 @@ module {
       ttkernel.thread = #ttkernel.thread<compute>} {
     %0 = ttkernel.get_compile_time_arg_val(1) : () -> i32
     func.call @cycle_a() : () -> ()
+    return
+  }
+
+  func.func @opaque_only() attributes {
+      ttl.base_cta_index = 4 : i32,
+      ttkernel.thread = #ttkernel.thread<compute>} {
+    ttkernel.opaque_call "describe" () {dfb_descriptor_indices = array<i32: 1, 3>, header = "describe.hpp"} : () -> ()
     return
   }
 }

--- a/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use_invalid.mlir
@@ -1,0 +1,11 @@
+// RUN: ttlang-opt %s -ttkernel-annotate-dfb-use --verify-diagnostics
+
+// An opaque call cannot reference a DFB outside the enclosing kernel's
+// compile-time DFB argument range.
+func.func @out_of_range_opaque_dfb() attributes {
+    ttl.base_cta_index = 2 : i32,
+    ttkernel.thread = #ttkernel.thread<compute>} {
+  // expected-error @below {{'ttkernel.opaque_call' op DFB descriptor index 2 is outside [0, 1] for the enclosing function}}
+  ttkernel.opaque_call "describe" () {dfb_descriptor_indices = array<i32: 2>, header = "describe.hpp"} : () -> ()
+  return
+}


### PR DESCRIPTION
### Problem description

TTL lowering removes DFB operands after converting external calls and synchronized resets to TTKernel metadata. The generated C++ can still reference those physical descriptors, but DFB-use annotation previously inspected only surviving compile-time argument reads. Core specialization could therefore omit a required descriptor.

### What's changed

- Finalize and preserve physical DFB descriptor indices before TTL operands are removed.
- Record the sorted indices as non-emitting opaque-call metadata.
- Union preserved indices with direct compile-time argument uses through the existing call-graph analysis.
- Retain conservative unknown external access to user-managed DFBs.

### Stack

This draft is based on main. PR #985 supersedes its opaque-call-specific representation with the general TTKernel resource-use mechanism stacked on #984.

### Performance

No standalone performance result is claimed. The change restores required per-kernel descriptor metadata and does not add generated C++ operations.

### Checklist

- [x] New/Existing tests provide coverage for changes

