### PR TITLE
[ttl][ttkernel] Preserve DFB descriptor requirements

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -146,10 +146,12 @@ an unknown domain retains conservative whole-grid allocation.
 
 Per-core kernel specialization can remove different DFB operations on
 different launch nodes. Each final TTKernel function records the physical
-indices still referenced by its compile-time arguments in
-`ttl.used_dfb_indices`. Direct helper calls contribute their transitive uses.
-An unresolved call or missing annotation is conservative and keeps every DFB
-available on the affected function's launch nodes.
+indices still required by its compile-time arguments, synchronized resets, and
+external calls in `ttl.used_dfb_indices`. Lowered `ttkernel.opaque_call`
+operations retain these requirements in `dfb_resource_indices` until DFB-use
+annotation runs after specialization. Direct helper calls contribute their
+transitive uses. An unresolved call or missing annotation is conservative and
+keeps every DFB available on the affected function's launch nodes.
 
 The runtime unions these sets for every kernel dispatched to a logical core,
 then intersects the result with the physical allocation domain and finalized

--- a/docs/development/ExternalFuncInteropLowering.md
+++ b/docs/development/ExternalFuncInteropLowering.md
@@ -483,8 +483,11 @@ operand segments for template, dependency-only, and function-argument DFBs.
 Dependency occurrences, protocol effects, non-transactional accesses, and
 unknown access remain in TTL for analysis and verification. TTL to TTKernel
 conversion resolves DFB indices and materializes descriptor metadata before the
-DFB type loses its block geometry; it discards dependency-only operands and
-access-contract metadata because those facts do not alter the C++ call.
+DFB type loses its block geometry. It records the required physical descriptors
+in `dfb_resource_indices` on the resulting `ttkernel.opaque_call`. After core
+specialization, `ttkernel-annotate-dfb-use` includes requirements from
+surviving calls in `ttl.used_dfb_indices`. Dependency-only operands and access-
+contract metadata do not alter the C++ call and are not emitted.
 TTKernel to EmitC resolves constants and descriptor types, and C++ emission
 inserts the required prelude and header during its existing operation scan.
 

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -387,11 +387,11 @@ the original does not leave dangling `SymbolRefAttr`s; unrelated functions in
 the module are still specialized. Each clone replaces coordinate reads with
 `arith.constant`s and is tagged with `ttl.core_coord` for runtime dispatch.
 Downstream `canonicalize` / `cse` fold the now-constant branches.
-`ttkernel-annotate-dfb-use` then records surviving DFB compile-time
-argument indices on each specialized function. Debug prints of a DFB
-remain only on cores that still have a non-print use of that DFB; a
-print whose DFB was folded away is dropped rather than keeping the
-descriptor alive for debugging.
+`ttkernel-annotate-dfb-use` then records surviving DFB compile-time arguments,
+synchronized resets, and external-call dependencies on each specialized
+function. Debug prints of a DFB remain only on cores that still have a
+non-print use of that DFB; a print whose DFB was folded away is dropped rather
+than keeping the descriptor alive for debugging.
 
 This pass is off by default. Enable it through the pipeline option
 `specialize-cores` (Python: `--ttl-specialize-cores`), which runs the

--- a/docs/sphinx/reference/external-functions.md
+++ b/docs/sphinx/reference/external-functions.md
@@ -287,6 +287,11 @@ C++ function arguments. DFBs in `func_args` and DFB descriptors in
 must identify distinct source occurrences and must not repeat an automatic
 dependency source.
 
+Lowering preserves each dependency as DFB resource metadata on the generated
+external call until core specialization removes unreachable calls. Per-core
+descriptor annotations include the dependencies that remain. The generated C++
+call still receives only its declared template and function arguments.
+
 The Python frontend accepts one DFB in multiple automatic dependency positions
 when every occurrence remains opaque. An effect or access summary names a DFB
 expression, not a C++ argument position, so a summarized occurrence must be

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -5152,9 +5152,10 @@ def TTKernel_OpaqueCallOp : TTKernel_Op<"opaque_call",
       `unsigned_arg_indices` preserves unsigned address semantics when an
       earlier signless i32 value reaches the C++ call boundary.
 
-      `dfb_resource_indices` lists physical DFB descriptors that must be
-      available while the call executes. It adds no C++ arguments. The indices
-      are strictly increasing and contain no duplicates.
+      `dfb_resource_indices` lists finalized physical DFB indices whose
+      descriptors must remain available while the call executes. It adds no
+      C++ arguments. The indices are strictly increasing and contain no
+      duplicates.
 
       Example:
       ```

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -5152,6 +5152,10 @@ def TTKernel_OpaqueCallOp : TTKernel_Op<"opaque_call",
       `unsigned_arg_indices` preserves unsigned address semantics when an
       earlier signless i32 value reaches the C++ call boundary.
 
+      `dfb_resource_indices` lists physical DFB descriptors that must be
+      available while the call executes. It adds no C++ arguments. The indices
+      are strictly increasing and contain no duplicates.
+
       Example:
       ```
       ttkernel.opaque_call "my_func" template_args [1 : si32]
@@ -5163,7 +5167,8 @@ def TTKernel_OpaqueCallOp : TTKernel_Op<"opaque_call",
       StrAttr:$header,
       Variadic<AnyType>:$arg_operands,
       OptionalAttr<ArrayAttr>:$template_args,
-      OptionalAttr<DenseI32ArrayAttr>:$unsigned_arg_indices
+      OptionalAttr<DenseI32ArrayAttr>:$unsigned_arg_indices,
+      OptionalAttr<DenseI32ArrayAttr>:$dfb_resource_indices
     );
     let results = (outs Variadic<AnyType>);
     let assemblyFormat = [{

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1521,11 +1521,17 @@ def TTKernelAnnotateDFBUse
     For each `ttkernel.thread` function, records the
     sorted physical DFB indices reached through surviving
     `ttkernel.get_compile_time_arg_val` operations below
-    `ttl.base_cta_index` in `ttl.used_dfb_indices`. Helpers stay in the
-    call-graph analysis so their uses propagate to kernel entries.
+    `ttl.base_cta_index` and `dfb_resource_indices` metadata on surviving
+    `ttkernel.opaque_call` operations in `ttl.used_dfb_indices`. The metadata
+    preserves resource requirements after lowering replaces DFB operands with
+    static values. Helpers stay in the call-graph analysis so their uses
+    propagate to kernel entries.
     Declarations are not annotated. The compile-time ABI places
     every DFB before tensor-accessor arguments, including DFB ids passed to
     opaque externs as scalar values.
+
+    Resource indices must be within the enclosing function's DFB compile-time
+    argument range.
 
     Calls are resolved through the MLIR call graph. Uses are propagated from
     callees to callers in SCC order, including recursive calls. An unknown or

--- a/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
+++ b/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
@@ -19,11 +19,15 @@
 
 namespace mlir::tt::utils {
 
+/// Returns whether `nextIndex` follows `previousIndex` in canonical index
+/// order.
 inline bool isNextIndexStrictlyIncreasing(int32_t previousIndex,
                                           int32_t nextIndex) {
   return previousIndex < nextIndex;
 }
 
+/// Returns whether the indices are sorted in ascending order without
+/// duplicates.
 inline bool areIndicesStrictlyIncreasing(ArrayRef<int32_t> indices) {
   return std::adjacent_find(indices.begin(), indices.end(),
                             [](int32_t previousIndex, int32_t nextIndex) {

--- a/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
+++ b/include/ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h
@@ -9,13 +9,28 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 
 namespace mlir::tt::utils {
+
+inline bool isNextIndexStrictlyIncreasing(int32_t previousIndex,
+                                          int32_t nextIndex) {
+  return previousIndex < nextIndex;
+}
+
+inline bool areIndicesStrictlyIncreasing(ArrayRef<int32_t> indices) {
+  return std::adjacent_find(indices.begin(), indices.end(),
+                            [](int32_t previousIndex, int32_t nextIndex) {
+                              return !isNextIndexStrictlyIncreasing(
+                                  previousIndex, nextIndex);
+                            }) == indices.end();
+}
 
 /// Verifies the attributes shared by `ttl.opaque_call` and
 /// `ttkernel.opaque_call`.
@@ -47,7 +62,7 @@ verifyOpaqueCallUnsignedArgIndices(Operation *op,
              << index << " is out of range for " << arguments.size()
              << " arguments";
     }
-    if (index <= previousIndex) {
+    if (!isNextIndexStrictlyIncreasing(previousIndex, index)) {
       return op->emitOpError(
           "unsigned function argument indices must be strictly increasing");
     }

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -727,6 +727,8 @@ void UnpackStallOnPackOp::getCanonicalizationPatterns(
           getOperation(), getUnsignedArgIndices(), getArgOperands()))) {
     return failure();
   }
+  // Absence represents no descriptor requirement. A canonical nonnegative set
+  // lets downstream annotation merge physical DFB indices without normalizing.
   if (std::optional<ArrayRef<int32_t>> requiredPhysicalDFBIndices =
           getDfbResourceIndices()) {
     if (requiredPhysicalDFBIndices->empty()) {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -16,7 +16,9 @@
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "llvm/ADT/STLExtras.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <optional>
 
@@ -726,6 +728,22 @@ void UnpackStallOnPackOp::getCanonicalizationPatterns(
   if (failed(mlir::tt::utils::verifyOpaqueCallUnsignedArgIndices(
           getOperation(), getUnsignedArgIndices(), getArgOperands()))) {
     return failure();
+  }
+  if (std::optional<ArrayRef<int32_t>> resourceIndices =
+          getDfbResourceIndices()) {
+    if (resourceIndices->empty()) {
+      return emitOpError("DFB resource indices must not be empty");
+    }
+    if (!llvm::all_of(*resourceIndices,
+                      [](int32_t index) { return index >= 0; })) {
+      return emitOpError("DFB resource indices must be nonnegative");
+    }
+    if (std::adjacent_find(resourceIndices->begin(), resourceIndices->end(),
+                           std::greater_equal<>()) != resourceIndices->end()) {
+      return emitOpError(
+          "DFB resource indices must be strictly increasing without "
+          "duplicates");
+    }
   }
   std::optional<ArrayAttr> templateArgs = getTemplateArgs();
   if (!templateArgs) {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -727,16 +727,17 @@ void UnpackStallOnPackOp::getCanonicalizationPatterns(
           getOperation(), getUnsignedArgIndices(), getArgOperands()))) {
     return failure();
   }
-  if (std::optional<ArrayRef<int32_t>> resourceIndices =
+  if (std::optional<ArrayRef<int32_t>> requiredPhysicalDFBIndices =
           getDfbResourceIndices()) {
-    if (resourceIndices->empty()) {
+    if (requiredPhysicalDFBIndices->empty()) {
       return emitOpError("DFB resource indices must not be empty");
     }
-    if (!llvm::all_of(*resourceIndices,
+    if (!llvm::all_of(*requiredPhysicalDFBIndices,
                       [](int32_t index) { return index >= 0; })) {
       return emitOpError("DFB resource indices must be nonnegative");
     }
-    if (!mlir::tt::utils::areIndicesStrictlyIncreasing(*resourceIndices)) {
+    if (!mlir::tt::utils::areIndicesStrictlyIncreasing(
+            *requiredPhysicalDFBIndices)) {
       return emitOpError(
           "DFB resource indices must be strictly increasing without "
           "duplicates");

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -16,9 +16,7 @@
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "llvm/ADT/STLExtras.h"
 
-#include <algorithm>
 #include <cstdint>
-#include <functional>
 #include <limits>
 #include <optional>
 
@@ -738,8 +736,7 @@ void UnpackStallOnPackOp::getCanonicalizationPatterns(
                       [](int32_t index) { return index >= 0; })) {
       return emitOpError("DFB resource indices must be nonnegative");
     }
-    if (std::adjacent_find(resourceIndices->begin(), resourceIndices->end(),
-                           std::greater_equal<>()) != resourceIndices->end()) {
+    if (!mlir::tt::utils::areIndicesStrictlyIncreasing(*resourceIndices)) {
       return emitOpError(
           "DFB resource indices must be strictly increasing without "
           "duplicates");

--- a/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
@@ -131,8 +131,8 @@ static func::FuncOp getCallableFunc(CallGraphNode *node) {
   return dyn_cast<func::FuncOp>(node->getCallableRegion()->getParentOp());
 }
 
-static void collectDirectDFBUses(func::FuncOp func, int64_t dfbCount,
-                                 DFBSet &used) {
+static LogicalResult collectDirectDFBUses(func::FuncOp func, int64_t dfbCount,
+                                          DFBSet &used) {
   func.walk([&](ttk::GetCompileArgValOp op) {
     if (isPrintOnly(op)) {
       return;
@@ -142,6 +142,25 @@ static void collectDirectDFBUses(func::FuncOp func, int64_t dfbCount,
       used.insert(static_cast<int32_t>(index));
     }
   });
+
+  WalkResult result = func.walk([&](ttk::OpaqueCallOp call) -> WalkResult {
+    std::optional<ArrayRef<int32_t>> resourceIndices =
+        call.getDfbResourceIndices();
+    if (!resourceIndices) {
+      return WalkResult::advance();
+    }
+    for (int32_t index : *resourceIndices) {
+      if (index >= dfbCount) {
+        call.emitOpError("DFB resource index ")
+            << index << " is outside the enclosing function's DFB range [0, "
+            << dfbCount << ")";
+        return WalkResult::interrupt();
+      }
+      used.insert(index);
+    }
+    return WalkResult::advance();
+  });
+  return result.wasInterrupted() ? failure() : success();
 }
 
 static void recordAllDFBs(func::FuncOp func, int64_t maxDFBCount,
@@ -217,7 +236,7 @@ struct TTKernelAnnotateDFBUsePass
     ModuleOp module = getOperation();
     llvm::DenseMap<Operation *, DFBSet> usedDFBs;
     llvm::SmallDenseSet<Operation *> conservative;
-    // Maximum DFB index in the module.
+    // Largest per-function DFB count in the module.
     int64_t maxDFBCount = 0;
 
     for (func::FuncOp func : module.getOps<func::FuncOp>()) {
@@ -228,7 +247,11 @@ struct TTKernelAnnotateDFBUsePass
 
     for (func::FuncOp func : module.getOps<func::FuncOp>()) {
       int64_t dfbCount = getFuncDFBCount(func, maxDFBCount);
-      collectDirectDFBUses(func, dfbCount, usedDFBs[func.getOperation()]);
+      if (failed(collectDirectDFBUses(func, dfbCount,
+                                      usedDFBs[func.getOperation()]))) {
+        signalPassFailure();
+        return;
+      }
     }
 
     CallGraph callgraph(module);

--- a/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
@@ -131,6 +131,8 @@ static func::FuncOp getCallableFunc(CallGraphNode *node) {
   return dyn_cast<func::FuncOp>(node->getCallableRegion()->getParentOp());
 }
 
+// Collects descriptor requirements encoded directly in a function and rejects
+// physical indices outside its descriptor table.
 static LogicalResult collectDirectDFBUses(func::FuncOp func, int64_t dfbCount,
                                           DFBSet &used) {
   func.walk([&](ttk::GetCompileArgValOp op) {
@@ -143,13 +145,17 @@ static LogicalResult collectDirectDFBUses(func::FuncOp func, int64_t dfbCount,
     }
   });
 
+  // TTL lowering removes DFB operands, so each opaque call carries finalized
+  // physical DFB indices whose descriptors must survive core specialization.
+  // The op verifier checks index form; this pass checks each index against the
+  // enclosing function's DFB count.
   WalkResult result = func.walk([&](ttk::OpaqueCallOp call) -> WalkResult {
-    std::optional<ArrayRef<int32_t>> resourceIndices =
+    std::optional<ArrayRef<int32_t>> requiredPhysicalDFBIndices =
         call.getDfbResourceIndices();
-    if (!resourceIndices) {
+    if (!requiredPhysicalDFBIndices) {
       return WalkResult::advance();
     }
-    for (int32_t index : *resourceIndices) {
+    for (int32_t index : *requiredPhysicalDFBIndices) {
       if (index >= dfbCount) {
         call.emitOpError("DFB resource index ")
             << index << " is outside the enclosing function's DFB range [0, "

--- a/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelAnnotateDFBUse.cpp
@@ -236,7 +236,6 @@ struct TTKernelAnnotateDFBUsePass
     ModuleOp module = getOperation();
     llvm::DenseMap<Operation *, DFBSet> usedDFBs;
     llvm::SmallDenseSet<Operation *> conservative;
-    // Largest per-function DFB count in the module.
     int64_t maxDFBCount = 0;
 
     for (func::FuncOp func : module.getOps<func::FuncOp>()) {

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -436,6 +436,55 @@ static FailureOr<int32_t> getValidatedDFBIndex(Value dfb, Operation *op) {
   return static_cast<int32_t>(*dfbIndex);
 }
 
+static void sortAndDeduplicateDFBIndices(SmallVectorImpl<int32_t> &indices) {
+  llvm::sort(indices);
+  indices.erase(llvm::unique(indices), indices.end());
+}
+
+static FailureOr<SmallVector<int32_t>>
+getValidatedDFBResourceIndices(ValueRange dfbs, Operation *op) {
+  SmallVector<int32_t> indices;
+  indices.reserve(dfbs.size());
+  for (Value dfb : dfbs) {
+    FailureOr<int32_t> index = getValidatedDFBIndex(dfb, op);
+    if (failed(index)) {
+      return failure();
+    }
+    indices.push_back(*index);
+  }
+  sortAndDeduplicateDFBIndices(indices);
+  return indices;
+}
+
+static FailureOr<SmallVector<int32_t>>
+collectUserManagedDFBResourceIndices(ModuleOp module) {
+  SmallVector<int32_t> indices;
+  WalkResult result = module.walk([&](BindCBOp bind) -> WalkResult {
+    if (bind->hasAttr(kCompilerAllocatedAttrName)) {
+      return WalkResult::advance();
+    }
+    FailureOr<int32_t> index = getValidatedDFBIndex(bind.getResult(), bind);
+    if (failed(index)) {
+      return WalkResult::interrupt();
+    }
+    indices.push_back(*index);
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted()) {
+    return failure();
+  }
+  sortAndDeduplicateDFBIndices(indices);
+  return indices;
+}
+
+static DenseI32ArrayAttr getDFBResourceIndicesAttr(ArrayRef<int32_t> indices,
+                                                   RewriterBase &rewriter) {
+  if (indices.empty()) {
+    return {};
+  }
+  return rewriter.getDenseI32ArrayAttr(indices);
+}
+
 /// Read one L1 address from the function's common runtime arguments.
 static Value getCommonRuntimeArg(unsigned argIdx, Location loc,
                                  ConversionPatternRewriter &rewriter) {
@@ -1579,12 +1628,19 @@ static LogicalResult lowerDFBReset(Operation *operation,
       rewriter, location, static_cast<uint32_t>(dfbMask), 32);
   Value highMask = arith::ConstantIntOp::create(
       rewriter, location, static_cast<uint32_t>(dfbMask >> 32), 32);
+  SmallVector<int32_t> resourceIndices;
+  for (unsigned index = 0; index < 64; ++index) {
+    if ((dfbMask & (uint64_t{1} << index)) != 0) {
+      resourceIndices.push_back(static_cast<int32_t>(index));
+    }
+  }
   ttk::OpaqueCallOp::create(
       rewriter, location, TypeRange{},
       rewriter.getStringAttr("experimental::reset_dfb_interfaces"),
       rewriter.getStringAttr("<cstdint>"),
       ValueRange{synchronizationAddress, lowMask, highMask}, ArrayAttr(),
-      rewriter.getDenseI32ArrayAttr({0, 1, 2}));
+      rewriter.getDenseI32ArrayAttr({0, 1, 2}),
+      getDFBResourceIndicesAttr(resourceIndices, rewriter));
   rewriter.eraseOp(operation);
   return success();
 }
@@ -1681,7 +1737,7 @@ struct DFBReconfigurationLowering : OpConversionPattern<DFBReconfigurationOp> {
         rewriter, op.getLoc(), TypeRange{},
         rewriter.getStringAttr("experimental::reconfigure_dfb_interfaces"),
         rewriter.getStringAttr("<cstdint>"), ValueRange{configurationAddress},
-        ArrayAttr(), rewriter.getDenseI32ArrayAttr({0}));
+        ArrayAttr(), rewriter.getDenseI32ArrayAttr({0}), DenseI32ArrayAttr());
     rewriter.eraseOp(op);
     return success();
   }
@@ -1709,12 +1765,25 @@ using OpaqueArgumentPlan =
     std::variant<OpaqueScalarArgument, OpaqueDFBArgument, OpaqueTensorArgument>;
 
 struct OpaqueCallLowering : OpConversionPattern<OpaqueCallOp> {
-  using OpConversionPattern::OpConversionPattern;
+  OpaqueCallLowering(TypeConverter &typeConverter, MLIRContext *context,
+                     ArrayRef<int32_t> userManagedDFBResourceIndices)
+      : OpConversionPattern(typeConverter, context),
+        userManagedDFBResourceIndices(userManagedDFBResourceIndices) {}
 
   LogicalResult
   matchAndRewrite(OpaqueCallOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location location = op.getLoc();
+
+    FailureOr<SmallVector<int32_t>> resourceIndices =
+        getValidatedDFBResourceIndices(op.getDFBDependencyOperands(), op);
+    if (failed(resourceIndices)) {
+      return failure();
+    }
+    if (op.hasUnknownDFBAccess()) {
+      llvm::append_range(*resourceIndices, userManagedDFBResourceIndices);
+      sortAndDeduplicateDFBIndices(*resourceIndices);
+    }
 
     SmallVector<Attribute> templateArgs;
     if (std::optional<ArrayAttr> sourceTemplateArgs = op.getTemplateArgs()) {
@@ -1833,12 +1902,15 @@ struct OpaqueCallLowering : OpConversionPattern<OpaqueCallOp> {
     }
     auto newOp = ttk::OpaqueCallOp::create(
         rewriter, location, resultTypes, op.getCalleeAttr(), op.getHeaderAttr(),
-        convertedArgs, templateArgsAttr, op.getUnsignedArgIndicesAttr());
+        convertedArgs, templateArgsAttr, op.getUnsignedArgIndicesAttr(),
+        getDFBResourceIndicesAttr(*resourceIndices, rewriter));
     rewriter.replaceOp(op, newOp->getResults());
     return success();
   }
 
 private:
+  SmallVector<int32_t> userManagedDFBResourceIndices;
+
   /// Resolve DFB metadata before type conversion discards block geometry.
   static FailureOr<Attribute>
   convertTemplateArg(ExternalTemplateArgAttr templateArg,
@@ -2414,6 +2486,12 @@ static LogicalResult lowerTTLOpsToTTKernel(
   if (failed(resetLoweringPlan)) {
     return failure();
   }
+
+  FailureOr<SmallVector<int32_t>> userManagedDFBResourceIndices =
+      collectUserManagedDFBResourceIndices(mod);
+  if (failed(userManagedDFBResourceIndices)) {
+    return failure();
+  }
   pipePlanningOptions.enableComputedAddresses = pipeComputedAddresses;
   pipePlanningOptions.enableCapacitySynchronization = pipeCapacitySync;
   pipePlanningOptions.counterAllocationPolicy =
@@ -2512,16 +2590,17 @@ static LogicalResult lowerTTLOpsToTTKernel(
       typeConverter, &ctx, pipeTransportPlan);
   patterns.add<ResetDFBsLowering, ResetAllDFBsLowering>(typeConverter, &ctx,
                                                         *resetLoweringPlan);
-  patterns
-      .add<BindCBLowering, TensorSliceLowering, TileStoreLowering,
-           StoreLowering, CoreXLowering, CoreYLowering, RawElementReadLowering,
-           ReadIndexLowering, RawElementWriteLowering, RawAddrLowering,
-           DFBReconfigurationLowering, OpaqueCallLowering, GetDfbIdLowering,
-           IsDeviceLowering, CurrentDeviceIndexLowering,
-           IsDeviceInRangeLowering, SelectedPipeSourceDeviceIndexLowering,
-           SelectedPipeDestinationDeviceIndexLowering,
-           SelectedPipeSourceCoordinatesLowering,
-           SelectedPipeDestinationCoordinatesLowering>(typeConverter, &ctx);
+  patterns.add<
+      BindCBLowering, TensorSliceLowering, TileStoreLowering, StoreLowering,
+      CoreXLowering, CoreYLowering, RawElementReadLowering, ReadIndexLowering,
+      RawElementWriteLowering, RawAddrLowering, DFBReconfigurationLowering,
+      GetDfbIdLowering, IsDeviceLowering, CurrentDeviceIndexLowering,
+      IsDeviceInRangeLowering, SelectedPipeSourceDeviceIndexLowering,
+      SelectedPipeDestinationDeviceIndexLowering,
+      SelectedPipeSourceCoordinatesLowering,
+      SelectedPipeDestinationCoordinatesLowering>(typeConverter, &ctx);
+  patterns.add<OpaqueCallLowering>(typeConverter, &ctx,
+                                   *userManagedDFBResourceIndices);
   patterns.add<CBPopLowering>(typeConverter, &ctx, pipeCapacityPlan,
                               pipeTransportPlan, transportSlotCounters,
                               pipeResourcePlan);

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToTTKernel.cpp
@@ -422,6 +422,7 @@ static FailureOr<unsigned> getTensorFuncArgIndex(Value tensor) {
   return blockArg.getArgNumber();
 }
 
+// Resolves a TTL DFB SSA value to its finalized physical descriptor index.
 static FailureOr<int32_t> getValidatedDFBIndex(Value dfb, Operation *op) {
   std::optional<int64_t> dfbIndex = getCBIndex(dfb);
   if (!dfbIndex) {
@@ -436,13 +437,15 @@ static FailureOr<int32_t> getValidatedDFBIndex(Value dfb, Operation *op) {
   return static_cast<int32_t>(*dfbIndex);
 }
 
+// Canonicalizes index sets for TTKernel's strict attribute-ordering invariant.
 static void sortAndDeduplicateDFBIndices(SmallVectorImpl<int32_t> &indices) {
   llvm::sort(indices);
   indices.erase(llvm::unique(indices), indices.end());
 }
 
+// Converts DFB operands into a canonical set of finalized physical indices.
 static FailureOr<SmallVector<int32_t>>
-getValidatedDFBResourceIndices(ValueRange dfbs, Operation *op) {
+getValidatedPhysicalDFBIndices(ValueRange dfbs, Operation *op) {
   SmallVector<int32_t> indices;
   indices.reserve(dfbs.size());
   for (Value dfb : dfbs) {
@@ -456,8 +459,10 @@ getValidatedDFBResourceIndices(ValueRange dfbs, Operation *op) {
   return indices;
 }
 
+// Unknown external calls can name user-managed DFBs by physical index without
+// explicit operands, so collect every such index in the module.
 static FailureOr<SmallVector<int32_t>>
-collectUserManagedDFBResourceIndices(ModuleOp module) {
+collectUserManagedPhysicalDFBIndices(ModuleOp module) {
   SmallVector<int32_t> indices;
   WalkResult result = module.walk([&](BindCBOp bind) -> WalkResult {
     if (bind->hasAttr(kCompilerAllocatedAttrName)) {
@@ -477,7 +482,8 @@ collectUserManagedDFBResourceIndices(ModuleOp module) {
   return indices;
 }
 
-static DenseI32ArrayAttr getDFBResourceIndicesAttr(ArrayRef<int32_t> indices,
+// Absence denotes no descriptor requirement; an explicit empty list is invalid.
+static DenseI32ArrayAttr getRequiredDFBIndicesAttr(ArrayRef<int32_t> indices,
                                                    RewriterBase &rewriter) {
   if (indices.empty()) {
     return {};
@@ -1628,10 +1634,12 @@ static LogicalResult lowerDFBReset(Operation *operation,
       rewriter, location, static_cast<uint32_t>(dfbMask), 32);
   Value highMask = arith::ConstantIntOp::create(
       rewriter, location, static_cast<uint32_t>(dfbMask >> 32), 32);
-  SmallVector<int32_t> resourceIndices;
+  // Lowering removes the reset's DFB operands, so retain every selected index
+  // as a descriptor requirement.
+  SmallVector<int32_t> requiredPhysicalDFBIndices;
   for (unsigned index = 0; index < 64; ++index) {
     if ((dfbMask & (uint64_t{1} << index)) != 0) {
-      resourceIndices.push_back(static_cast<int32_t>(index));
+      requiredPhysicalDFBIndices.push_back(static_cast<int32_t>(index));
     }
   }
   ttk::OpaqueCallOp::create(
@@ -1640,7 +1648,7 @@ static LogicalResult lowerDFBReset(Operation *operation,
       rewriter.getStringAttr("<cstdint>"),
       ValueRange{synchronizationAddress, lowMask, highMask}, ArrayAttr(),
       rewriter.getDenseI32ArrayAttr({0, 1, 2}),
-      getDFBResourceIndicesAttr(resourceIndices, rewriter));
+      getRequiredDFBIndicesAttr(requiredPhysicalDFBIndices, rewriter));
   rewriter.eraseOp(operation);
   return success();
 }
@@ -1766,23 +1774,28 @@ using OpaqueArgumentPlan =
 
 struct OpaqueCallLowering : OpConversionPattern<OpaqueCallOp> {
   OpaqueCallLowering(TypeConverter &typeConverter, MLIRContext *context,
-                     ArrayRef<int32_t> userManagedDFBResourceIndices)
+                     ArrayRef<int32_t> userManagedPhysicalDFBIndices)
       : OpConversionPattern(typeConverter, context),
-        userManagedDFBResourceIndices(userManagedDFBResourceIndices) {}
+        userManagedPhysicalDFBIndices(userManagedPhysicalDFBIndices) {}
 
   LogicalResult
   matchAndRewrite(OpaqueCallOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location location = op.getLoc();
 
-    FailureOr<SmallVector<int32_t>> resourceIndices =
-        getValidatedDFBResourceIndices(op.getDFBDependencyOperands(), op);
-    if (failed(resourceIndices)) {
+    // Dependency operands name every descriptor required by a typed external
+    // call, including operands that are absent from the emitted C++ call.
+    FailureOr<SmallVector<int32_t>> requiredPhysicalDFBIndices =
+        getValidatedPhysicalDFBIndices(op.getDFBDependencyOperands(), op);
+    if (failed(requiredPhysicalDFBIndices)) {
       return failure();
     }
     if (op.hasUnknownDFBAccess()) {
-      llvm::append_range(*resourceIndices, userManagedDFBResourceIndices);
-      sortAndDeduplicateDFBIndices(*resourceIndices);
+      // An untyped external call may refer to any user-managed physical DFB
+      // index without listing it as an operand.
+      llvm::append_range(*requiredPhysicalDFBIndices,
+                         userManagedPhysicalDFBIndices);
+      sortAndDeduplicateDFBIndices(*requiredPhysicalDFBIndices);
     }
 
     SmallVector<Attribute> templateArgs;
@@ -1903,13 +1916,13 @@ struct OpaqueCallLowering : OpConversionPattern<OpaqueCallOp> {
     auto newOp = ttk::OpaqueCallOp::create(
         rewriter, location, resultTypes, op.getCalleeAttr(), op.getHeaderAttr(),
         convertedArgs, templateArgsAttr, op.getUnsignedArgIndicesAttr(),
-        getDFBResourceIndicesAttr(*resourceIndices, rewriter));
+        getRequiredDFBIndicesAttr(*requiredPhysicalDFBIndices, rewriter));
     rewriter.replaceOp(op, newOp->getResults());
     return success();
   }
 
 private:
-  SmallVector<int32_t> userManagedDFBResourceIndices;
+  SmallVector<int32_t> userManagedPhysicalDFBIndices;
 
   /// Resolve DFB metadata before type conversion discards block geometry.
   static FailureOr<Attribute>
@@ -2487,9 +2500,9 @@ static LogicalResult lowerTTLOpsToTTKernel(
     return failure();
   }
 
-  FailureOr<SmallVector<int32_t>> userManagedDFBResourceIndices =
-      collectUserManagedDFBResourceIndices(mod);
-  if (failed(userManagedDFBResourceIndices)) {
+  FailureOr<SmallVector<int32_t>> userManagedPhysicalDFBIndices =
+      collectUserManagedPhysicalDFBIndices(mod);
+  if (failed(userManagedPhysicalDFBIndices)) {
     return failure();
   }
   pipePlanningOptions.enableComputedAddresses = pipeComputedAddresses;
@@ -2600,7 +2613,7 @@ static LogicalResult lowerTTLOpsToTTKernel(
       SelectedPipeSourceCoordinatesLowering,
       SelectedPipeDestinationCoordinatesLowering>(typeConverter, &ctx);
   patterns.add<OpaqueCallLowering>(typeConverter, &ctx,
-                                   *userManagedDFBResourceIndices);
+                                   *userManagedPhysicalDFBIndices);
   patterns.add<CBPopLowering>(typeConverter, &ctx, pipeCapacityPlan,
                               pipeTransportPlan, transportSlotCounters,
                               pipeResourcePlan);

--- a/test/python/include/repeated_dfb_transactions.hpp
+++ b/test/python/include/repeated_dfb_transactions.hpp
@@ -45,17 +45,17 @@ inline void read_high_water_dfb_logical_dm(SourceAccessor source) {
   constexpr uint32_t highWaterTiles = 2 * Destination::pages_per_block;
 
   CircularBuffer destination(get_compile_time_arg_val(Destination::index));
-  Noc noc0(0);
+  Noc noc;
   destination.reserve_back(highWaterTiles);
   for (uint32_t transaction = 0; transaction < transactionCount;
        ++transaction) {
     for (uint32_t tile = 0; tile < transactionTiles; ++tile) {
       uint32_t pageId = transaction * transactionTiles + tile;
-      noc0.async_read(source, destination, Destination::page_size_bytes,
-                      {.page_id = pageId},
-                      {.offset_bytes = tile * Destination::page_size_bytes});
+      noc.async_read(source, destination, Destination::page_size_bytes,
+                     {.page_id = pageId},
+                     {.offset_bytes = tile * Destination::page_size_bytes});
     }
-    noc0.async_read_barrier();
+    noc.async_read_barrier();
     destination.push_back(transactionTiles);
     if (transaction + 1 < transactionCount) {
       destination.reserve_back(highWaterTiles);
@@ -72,17 +72,17 @@ inline void write_high_water_dfb_logical_dm(DestinationAccessor destination) {
   constexpr uint32_t transactionCount = 4;
   constexpr uint32_t transactionTiles = Source::pages_per_block;
   CircularBuffer source(get_compile_time_arg_val(Source::index));
-  Noc noc0(0);
+  Noc noc;
   for (uint32_t transaction = 0; transaction < transactionCount;
        ++transaction) {
     source.wait_front(transactionTiles);
     for (uint32_t tile = 0; tile < transactionTiles; ++tile) {
       uint32_t pageId = transaction * transactionTiles + tile;
-      noc0.async_write(source, destination, Source::page_size_bytes,
-                       {.offset_bytes = tile * Source::page_size_bytes},
-                       {.page_id = pageId});
+      noc.async_write(source, destination, Source::page_size_bytes,
+                      {.offset_bytes = tile * Source::page_size_bytes},
+                      {.page_id = pageId});
     }
-    noc0.async_write_barrier();
+    noc.async_write_barrier();
     source.pop_front(transactionTiles);
   }
 #endif

--- a/test/python/include/repeated_dfb_transactions.hpp
+++ b/test/python/include/repeated_dfb_transactions.hpp
@@ -45,17 +45,17 @@ inline void read_high_water_dfb_logical_dm(SourceAccessor source) {
   constexpr uint32_t highWaterTiles = 2 * Destination::pages_per_block;
 
   CircularBuffer destination(get_compile_time_arg_val(Destination::index));
-  Noc noc;
+  Noc noc0(0);
   destination.reserve_back(highWaterTiles);
   for (uint32_t transaction = 0; transaction < transactionCount;
        ++transaction) {
     for (uint32_t tile = 0; tile < transactionTiles; ++tile) {
       uint32_t pageId = transaction * transactionTiles + tile;
-      noc.async_read(source, destination, Destination::page_size_bytes,
-                     {.page_id = pageId},
-                     {.offset_bytes = tile * Destination::page_size_bytes});
+      noc0.async_read(source, destination, Destination::page_size_bytes,
+                      {.page_id = pageId},
+                      {.offset_bytes = tile * Destination::page_size_bytes});
     }
-    noc.async_read_barrier();
+    noc0.async_read_barrier();
     destination.push_back(transactionTiles);
     if (transaction + 1 < transactionCount) {
       destination.reserve_back(highWaterTiles);
@@ -72,17 +72,17 @@ inline void write_high_water_dfb_logical_dm(DestinationAccessor destination) {
   constexpr uint32_t transactionCount = 4;
   constexpr uint32_t transactionTiles = Source::pages_per_block;
   CircularBuffer source(get_compile_time_arg_val(Source::index));
-  Noc noc;
+  Noc noc0(0);
   for (uint32_t transaction = 0; transaction < transactionCount;
        ++transaction) {
     source.wait_front(transactionTiles);
     for (uint32_t tile = 0; tile < transactionTiles; ++tile) {
       uint32_t pageId = transaction * transactionTiles + tile;
-      noc.async_write(source, destination, Source::page_size_bytes,
-                      {.offset_bytes = tile * Source::page_size_bytes},
-                      {.page_id = pageId});
+      noc0.async_write(source, destination, Source::page_size_bytes,
+                       {.offset_bytes = tile * Source::page_size_bytes},
+                       {.page_id = pageId});
     }
-    noc.async_write_barrier();
+    noc0.async_write_barrier();
     source.pop_front(transactionTiles);
   }
 #endif

--- a/test/python/test_external_descriptor_reset.py
+++ b/test/python/test_external_descriptor_reset.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device regression for core-specialized physical DFB descriptor dependencies."""
+
+import os
+
+import pytest
+import torch
+
+ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
+
+import ttl  # noqa: E402
+from ttl import ttl_api  # noqa: E402
+from ttlang_test_utils import to_dram, to_l1  # noqa: E402
+from utils.correctness import assert_allclose  # noqa: E402
+
+pytestmark = pytest.mark.requires_device
+
+TILE = 32
+REPEATED_DFB_TRANSACTIONS_HEADER = os.path.join(
+    os.path.dirname(__file__), "include", "repeated_dfb_transactions.hpp"
+)
+
+
+def _make_external_descriptor_reset_kernel(data_format):
+    compute_kernel = ttl.Kernel(ttl.KernelKind.COMPUTE)
+    reader_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    writer_kernel = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+    reset = ttl.DFBReset(
+        participants=(compute_kernel, reader_kernel, writer_kernel),
+    )
+
+    @ttl.operation(grid=(2, 1))
+    def external_descriptor_reset_kernel(input_tensor, output_tensor):
+        external_stream = ttl.make_dfb(
+            data_format,
+            shape=(1, 4),
+            block_count=3,
+        )
+
+        @ttl.compute(kernel=compute_kernel)
+        def compute():
+            core_x, _core_y = ttl.node(dims=2)
+            if core_x == 1:
+                ttl.reset_dfbs(reset, dfbs=[external_stream])
+
+        @ttl.datamovement(kernel=reader_kernel)
+        def read():
+            core_x, _core_y = ttl.node(dims=2)
+            if core_x == 1:
+                ttl.call_extern_func(
+                    REPEATED_DFB_TRANSACTIONS_HEADER,
+                    "read_high_water_dfb_logical_dm",
+                    template_args=[ttl.dfb_descriptor(external_stream)],
+                    func_args=[input_tensor],
+                    dfb_effects=[
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                        ttl.DFBEffect.reserve(external_stream, tiles=8),
+                        ttl.DFBEffect.push(external_stream, tiles=4),
+                    ],
+                )
+                ttl.reset_dfbs(reset, dfbs=[external_stream])
+
+        @ttl.datamovement(kernel=writer_kernel)
+        def write():
+            core_x, _core_y = ttl.node(dims=2)
+            if core_x == 1:
+                ttl.call_extern_func(
+                    REPEATED_DFB_TRANSACTIONS_HEADER,
+                    "write_high_water_dfb_logical_dm",
+                    template_args=[ttl.dfb_descriptor(external_stream)],
+                    func_args=[output_tensor],
+                    dfb_effects=[
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                        ttl.DFBEffect.wait(external_stream, tiles=4),
+                        ttl.DFBEffect.pop(external_stream, tiles=4),
+                    ],
+                )
+                ttl.reset_dfbs(reset, dfbs=[external_stream])
+
+    return external_descriptor_reset_kernel
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    "to_device",
+    [to_dram, to_l1],
+    ids=["dram", "l1"],
+)
+def test_external_descriptor_survives_specialization_and_synchronized_reset(
+    device,
+    dtype,
+    to_device,
+    monkeypatch,
+    tmp_path,
+):
+    if ttl_api._detect_device_arch(device) != "blackhole":
+        pytest.skip("requires Blackhole DFB reset support")
+
+    data_format = "bf16" if dtype == torch.bfloat16 else "float32"
+    operation = _make_external_descriptor_reset_kernel(data_format)
+    final_mlir_path = tmp_path / "external_descriptor_reset.mlir"
+    monkeypatch.setenv("TTLANG_FINAL_MLIR", str(final_mlir_path))
+
+    element_indices = torch.arange(TILE * 16 * TILE, dtype=torch.float32).reshape(
+        TILE, 16 * TILE
+    )
+    input_host = ((element_indices.remainder(257) - 128) / 64).to(dtype)
+    input_tensor = to_device(input_host, device)
+    output_tensor = to_device(torch.zeros_like(input_host), device)
+
+    operation(
+        input_tensor,
+        output_tensor,
+        options="--ttl-reuse-user-dfbs --ttl-specialize-cores",
+    )
+
+    actual = ttnn.to_torch(output_tensor).float()
+    expected = input_host.float()
+    if dtype == torch.bfloat16:
+        assert_allclose(actual, expected, rtol=0.05, atol=1.0)
+    else:
+        assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+    final_mlir = final_mlir_path.read_text()
+    assert final_mlir.count("dfb_index =") == 1
+    assert final_mlir.count("ttl.core_coord") == 6
+    assert final_mlir.count("ttl.used_dfb_indices = array<i32: 0>") == 3
+    assert final_mlir.count("ttl.used_dfb_indices = array<i32>") == 3

--- a/test/ttlang/Conversion/TTKernelToEmitC/opaque_call_template_args.mlir
+++ b/test/ttlang/Conversion/TTKernelToEmitC/opaque_call_template_args.mlir
@@ -31,7 +31,7 @@ func.func @typed_literals_to_emitc() attributes {ttkernel.thread = #ttkernel.thr
 // CPP: #include "describe.hpp"
 // CPP: describe<11, ttlang::DFBDescriptor<3, 2, 4, 4096>>();
 func.func @dfb_descriptor_template_to_emitc() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
-  ttkernel.opaque_call "describe" template_args [11 : si32, #ttkernel.dfb_descriptor<3, 2, 4, 4096>] () {header = "describe.hpp"} : () -> ()
+  ttkernel.opaque_call "describe" template_args [11 : si32, #ttkernel.dfb_descriptor<3, 2, 4, 4096>] () {dfb_resource_indices = array<i32: 3>, header = "describe.hpp"} : () -> ()
   return
 }
 

--- a/test/ttlang/Conversion/TTLToTTKernel/dfb_reset.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/dfb_reset.mlir
@@ -11,10 +11,10 @@
 // CHECK-DAG: %[[SECOND_OFFSET:.*]] = arith.constant 16 : i32
 // CHECK-DAG: %[[ALL_LOW:.*]] = arith.constant 4 : i32
 // CHECK: %[[SCRATCH_BASE:.*]] = ttkernel.get_common_arg_val
-// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SCRATCH_BASE]], %[[SELECTED_LOW]], %[[SELECTED_HIGH]])
+// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SCRATCH_BASE]], %[[SELECTED_LOW]], %[[SELECTED_HIGH]]) {dfb_resource_indices = array<i32: 33>,
 // CHECK: %[[SECOND_BASE:.*]] = ttkernel.get_common_arg_val
 // CHECK: %[[SECOND_STATE:.*]] = arith.addi %[[SECOND_BASE]], %[[SECOND_OFFSET]] : i32
-// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SECOND_STATE]], %[[ALL_LOW]], %[[SELECTED_HIGH]])
+// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[SECOND_STATE]], %[[ALL_LOW]], %[[SELECTED_HIGH]]) {dfb_resource_indices = array<i32: 2, 33>,
 
 module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
   func.func @reset_masks()
@@ -38,7 +38,7 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
 // CHECK-LABEL: func.func @pipe_and_reset
 // CHECK: %[[RESET_OFFSET:.*]] = arith.constant 32 : i32
 // CHECK: %[[RESET_STATE:.*]] = arith.addi {{.*}}, %[[RESET_OFFSET]] : i32
-// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[RESET_STATE]],
+// CHECK: ttkernel.opaque_call "experimental::reset_dfb_interfaces"(%[[RESET_STATE]], {{.*}}) {dfb_resource_indices = array<i32: 0>,
 module attributes {
   ttl.launch_grid = array<i64: 2, 2>,
   ttl.target_arch = #ttcore.arch<blackhole>

--- a/test/ttlang/Conversion/TTLToTTKernel/opaque_call.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/opaque_call.mlir
@@ -1,7 +1,7 @@
 // Verify opaque_call lowering from TTL to TTKernel.
 // Checks template arg forwarding, DFB-to-CB conversion for func_args,
 // get_dfb_id lowering, tensor func-arg TensorAccessor materialization,
-// and ttl.raw_addr lowering.
+// DFB resource preservation, and ttl.raw_addr lowering.
 // RUN: ttlang-opt --convert-ttl-to-ttkernel --split-input-file %s | FileCheck %s
 
 // Void call with no args lowers directly.
@@ -27,7 +27,7 @@ func.func @call_with_template_args() attributes {ttl.kernel_thread = #ttkernel.t
 // A finalized DFB index becomes an unsigned static argument.
 // CHECK-LABEL: func.func @call_with_dfb_template_arg
 // CHECK-NOT: ttkernel.get_dfb_id
-// CHECK: ttkernel.opaque_call "drain" template_args [2 : ui32]() {header = "drain.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "drain" template_args [2 : ui32]() {dfb_resource_indices = array<i32: 2>, header = "drain.hpp"} : () -> ()
 func.func @call_with_dfb_template_arg() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   ttl.opaque_call "drain" template_args [#ttl.external_template_arg<dfb_index, 0>] template_dfbs(%cb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>) dfb_dependencies(%cb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>) () {header = "drain.hpp"} : () -> ()
@@ -36,9 +36,21 @@ func.func @call_with_dfb_template_arg() attributes {ttl.kernel_thread = #ttkerne
 
 // -----
 
+// A DFB index does not declare DFB storage access by itself.
+// CHECK-LABEL: func.func @call_with_index_only_dfb_template_arg
+// CHECK-NOT: dfb_resource_indices
+// CHECK: ttkernel.opaque_call "select" template_args [4 : ui32]() {header = "select.hpp"} : () -> ()
+func.func @call_with_index_only_dfb_template_arg() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+  %cb = ttl.bind_cb {cb_index = 4, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  ttl.opaque_call "select" template_args [#ttl.external_template_arg<dfb_index, 0>] template_dfbs(%cb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>) () {header = "select.hpp"} : () -> ()
+  return
+}
+
+// -----
+
 // A DFB template operand preserves its finalized index and allocation geometry.
 // CHECK-LABEL: func.func @call_with_dfb_descriptor
-// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4096>]() {header = "describe.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4096>]() {dfb_resource_indices = array<i32: 2>, header = "describe.hpp"} : () -> ()
 func.func @call_with_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 4} : !ttl.cb<[2, 3], !ttcore.tile<32x32, f32>, 4>
   ttl.opaque_call "describe" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%cb : !ttl.cb<[2, 3], !ttcore.tile<32x32, f32>, 4>) () {header = "describe.hpp"} : () -> ()
@@ -49,7 +61,7 @@ func.func @call_with_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.
 
 // Subtile dimensions change bytes per page, not the number of pages in a block.
 // CHECK-LABEL: func.func @call_with_subtile_dfb_descriptor
-// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 32>]() {header = "describe.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 32>]() {dfb_resource_indices = array<i32: 2>, header = "describe.hpp"} : () -> ()
 func.func @call_with_subtile_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 4} : !ttl.cb<[2, 3], !ttcore.tile<1x16, bf16>, 4>
   ttl.opaque_call "describe" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%cb : !ttl.cb<[2, 3], !ttcore.tile<1x16, bf16>, 4>) () {header = "describe.hpp"} : () -> ()
@@ -60,7 +72,7 @@ func.func @call_with_subtile_dfb_descriptor() attributes {ttl.kernel_thread = #t
 
 // Scalar DFBs use one scalar element per page rather than tile storage size.
 // CHECK-LABEL: func.func @call_with_scalar_dfb_descriptor
-// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4>]() {header = "describe.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "describe" template_args [#ttkernel.dfb_descriptor<2, 6, 4, 4>]() {dfb_resource_indices = array<i32: 2>, header = "describe.hpp"} : () -> ()
 func.func @call_with_scalar_dfb_descriptor() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 2, block_count = 4} : !ttl.cb<[2, 3], f32, 4>
   ttl.opaque_call "describe" template_args [#ttl.external_template_arg<dfb_descriptor, 0>] template_dfbs(%cb : !ttl.cb<[2, 3], f32, 4>) () {header = "describe.hpp"} : () -> ()
@@ -72,7 +84,7 @@ func.func @call_with_scalar_dfb_descriptor() attributes {ttl.kernel_thread = #tt
 // DFB func_arg is lowered to an unsigned physical index.
 // CHECK-LABEL: func.func @call_with_dfb_func_arg
 // CHECK: %[[CB_IDX:.*]] = ttkernel.get_compile_time_arg_val(1) : () -> ui32
-// CHECK-NEXT: ttkernel.opaque_call "use_cb"(%[[CB_IDX]]) {header = "use_cb.hpp"} : (ui32) -> ()
+// CHECK-NEXT: ttkernel.opaque_call "use_cb"(%[[CB_IDX]]) {dfb_resource_indices = array<i32: 1>, header = "use_cb.hpp"} : (ui32) -> ()
 func.func @call_with_dfb_func_arg() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
   %cb = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.opaque_call "use_cb" (%cb) {header = "use_cb.hpp"} : (!ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) -> ()
@@ -279,9 +291,11 @@ func.func @call_with_row_major_tensor(
 // TTKernel call arguments or protocol operations.
 // CHECK-LABEL: func.func @dfb_protocol_metadata
 // CHECK-NOT: ttkernel.cb_
-// CHECK: ttkernel.opaque_call "hidden_protocol"() {header = "hidden_protocol.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "hidden_protocol"() {dfb_resource_indices = array<i32: 1, 3>, header = "hidden_protocol.hpp"} : () -> ()
 // CHECK-NOT: ttkernel.cb_
 func.func @dfb_protocol_metadata() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %unlisted = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %compiler = ttl.bind_cb {cb_index = 2, block_count = 1} {ttl.compiler_allocated} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %dfb = ttl.bind_cb {cb_index = 3, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
   ttl.opaque_call "hidden_protocol" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "hidden_protocol.hpp", unknown_dfb_access} : () -> ()
   return

--- a/test/ttlang/Dialect/TTKernel/IR/opaque_call.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/opaque_call.mlir
@@ -1,4 +1,5 @@
-// Verify ttkernel.opaque_call round trips ordered static template arguments.
+// Verify ttkernel.opaque_call round trips ordered static arguments and DFB
+// resource requirements.
 // RUN: ttlang-opt %s --split-input-file | FileCheck %s
 
 // A void call omits the optional template argument list.
@@ -13,9 +14,9 @@ func.func @void_no_template_args() {
 
 // Static argument kinds and source order remain explicit in TTKernel IR.
 // CHECK-LABEL: func.func @typed_template_args
-// CHECK: ttkernel.opaque_call "describe" template_args [-5 : si32, true, 4294967295 : ui32, #ttkernel.dfb_descriptor<3, 2, 4, 4096>]() {header = "describe.hpp"} : () -> ()
+// CHECK: ttkernel.opaque_call "describe" template_args [-5 : si32, true, 4294967295 : ui32, #ttkernel.dfb_descriptor<3, 2, 4, 4096>]() {dfb_resource_indices = array<i32: 3>, header = "describe.hpp"} : () -> ()
 func.func @typed_template_args() {
-  ttkernel.opaque_call "describe" template_args [-5 : si32, true, 4294967295 : ui32, #ttkernel.dfb_descriptor<3, 2, 4, 4096>] () {header = "describe.hpp"} : () -> ()
+  ttkernel.opaque_call "describe" template_args [-5 : si32, true, 4294967295 : ui32, #ttkernel.dfb_descriptor<3, 2, 4, 4096>] () {dfb_resource_indices = array<i32: 3>, header = "describe.hpp"} : () -> ()
   return
 }
 

--- a/test/ttlang/Dialect/TTKernel/IR/opaque_call_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/opaque_call_invalid.mlir
@@ -88,3 +88,35 @@ func.func @unsigned_arg_not_integer(%arg0: f32) {
   ttkernel.opaque_call "foo" (%arg0) {header = "h.hpp", unsigned_arg_indices = array<i32: 0>} : (f32) -> ()
   return
 }
+
+// -----
+
+func.func @empty_dfb_resource_indices() {
+  // expected-error @below {{'ttkernel.opaque_call' op DFB resource indices must not be empty}}
+  ttkernel.opaque_call "foo" () {dfb_resource_indices = array<i32>, header = "h.hpp"} : () -> ()
+  return
+}
+
+// -----
+
+func.func @negative_dfb_resource_index() {
+  // expected-error @below {{'ttkernel.opaque_call' op DFB resource indices must be nonnegative}}
+  ttkernel.opaque_call "foo" () {dfb_resource_indices = array<i32: -1>, header = "h.hpp"} : () -> ()
+  return
+}
+
+// -----
+
+func.func @duplicate_dfb_resource_index() {
+  // expected-error @below {{'ttkernel.opaque_call' op DFB resource indices must be strictly increasing without duplicates}}
+  ttkernel.opaque_call "foo" () {dfb_resource_indices = array<i32: 1, 1>, header = "h.hpp"} : () -> ()
+  return
+}
+
+// -----
+
+func.func @unordered_dfb_resource_indices() {
+  // expected-error @below {{'ttkernel.opaque_call' op DFB resource indices must be strictly increasing without duplicates}}
+  ttkernel.opaque_call "foo" () {dfb_resource_indices = array<i32: 2, 1>, header = "h.hpp"} : () -> ()
+  return
+}

--- a/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use.mlir
@@ -9,7 +9,7 @@
 // CHECK-NEXT: func.func @helper() attributes {ttl.base_cta_index = 3 : i32} {
 
 // CHECK-LABEL: func.func @calls_helper()
-// CHECK-SAME: ttl.used_dfb_indices = array<i32: 1, 2>
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 0, 1, 2>
 
 // CHECK-LABEL: func.func @calls_unknown()
 // CHECK-SAME: ttl.used_dfb_indices = array<i32: 0, 1>
@@ -34,6 +34,7 @@ module {
     %effective_pages = arith.addi %scalar_dfb_id, %pages : i32
     ttkernel.cb_wait_front(%dfb, %effective_pages)
         : (!ttkernel.cb<3, !ttcore.tile<32x32, bf16>>, i32) -> ()
+    ttkernel.opaque_call "inspect"() {dfb_resource_indices = array<i32: 0>, header = "inspect.hpp"} : () -> ()
     return
   }
 

--- a/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use_invalid.mlir
@@ -1,4 +1,6 @@
-// RUN: ttlang-opt %s -ttkernel-annotate-dfb-use --verify-diagnostics
+// Verify that DFB resource metadata cannot reference descriptors outside the
+// enclosing function's compile-time DFB argument range.
+// RUN: ttlang-opt %s -ttkernel-annotate-dfb-use --verify-diagnostics --split-input-file
 
 module {
   func.func @invalid_resource_index() attributes {

--- a/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/annotate_dfb_use_invalid.mlir
@@ -1,0 +1,11 @@
+// RUN: ttlang-opt %s -ttkernel-annotate-dfb-use --verify-diagnostics
+
+module {
+  func.func @invalid_resource_index() attributes {
+      ttl.base_cta_index = 2 : i32,
+      ttkernel.thread = #ttkernel.thread<noc>} {
+    // expected-error @below {{'ttkernel.opaque_call' op DFB resource index 2 is outside the enclosing function's DFB range [0, 2)}}
+    ttkernel.opaque_call "inspect"() {dfb_resource_indices = array<i32: 2>, header = "inspect.hpp"} : () -> ()
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_dfb_use_elision.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_dfb_use_elision.mlir
@@ -1,38 +1,42 @@
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-and-annotate-dfb-use)' | FileCheck %s
 
-// This characterizes the kernel half of per-core specialization. Core (0, 0)
-// retains its DFB use while core (0, 1) has the complete DFB-dependent branch
-// folded away. Python runtime tests verify that these attributes scope the
-// corresponding host DFB descriptors to the surviving core set.
+// This characterizes the kernel half of per-core specialization. Core (0, 1)
+// retains its direct and opaque-call DFB uses while core (0, 0) has the
+// complete DFB-dependent branch folded away. Python runtime tests verify that
+// these attributes scope the corresponding host DFB descriptors to the
+// surviving core set.
 
 // CHECK-NOT: func.func @conditional_dfb_user()
 // CHECK-LABEL: func.func @conditional_dfb_user_c0_0
 // CHECK-SAME: ttl.core_coord = {{\[\[}}[[$X:[0-9]+]], [[Y0:[0-9]+]]]]
-// CHECK-SAME: ttl.used_dfb_indices = array<i32: [[DFB:[0-9]+]]>
-// CHECK: ttkernel.get_compile_time_arg_val([[DFB]])
-// CHECK: ttkernel.cb_wait_front
-// CHECK-NOT: scf.if
-// CHECK-LABEL: func.func @conditional_dfb_user_c0_1
-// CHECK-SAME: ttl.core_coord = {{\[\[}}[[$X]], [[Y1:[0-9]+]]]]
 // CHECK-SAME: ttl.used_dfb_indices = array<i32>
 // CHECK-NOT: ttkernel.get_compile_time_arg_val
 // CHECK-NOT: ttkernel.cb_wait_front
+// CHECK-NOT: ttkernel.opaque_call
+// CHECK-NOT: scf.if
+// CHECK-LABEL: func.func @conditional_dfb_user_c0_1
+// CHECK-SAME: ttl.core_coord = {{\[\[}}[[$X]], [[Y1:[0-9]+]]]]
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 0, 1>
+// CHECK: ttkernel.get_compile_time_arg_val(0)
+// CHECK: ttkernel.cb_wait_front
+// CHECK: ttkernel.opaque_call "inspect"() {dfb_resource_indices = array<i32: 1>, header = "inspect.hpp"} : () -> ()
 // CHECK-NOT: scf.if
 // CHECK: return
 
 module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
   func.func @conditional_dfb_user() attributes {
-      ttl.base_cta_index = 1 : i32,
+      ttl.base_cta_index = 2 : i32,
       ttkernel.thread = #ttkernel.thread<noc>} {
-    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
     %pages = arith.constant 3 : i32
     %y = "ttkernel.my_logical_y_"() : () -> index
-    %is_active = arith.cmpi eq, %y, %c0 : index
+    %is_active = arith.cmpi eq, %y, %c1 : index
     scf.if %is_active {
       %dfb = ttkernel.get_compile_time_arg_val(0)
           : () -> !ttkernel.cb<3, !ttcore.tile<32x32, bf16>>
       ttkernel.cb_wait_front(%dfb, %pages)
           : (!ttkernel.cb<3, !ttcore.tile<32x32, bf16>>, i32) -> ()
+      ttkernel.opaque_call "inspect"() {dfb_resource_indices = array<i32: 1>, header = "inspect.hpp"} : () -> ()
     }
     return
   }

--- a/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_dfb_use_elision.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/specialize_cores_dfb_use_elision.mlir
@@ -1,4 +1,4 @@
-// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-and-annotate-dfb-use)' | FileCheck %s
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-and-annotate-dfb-use)' --split-input-file | FileCheck %s
 
 // This characterizes the kernel half of per-core specialization. Core (0, 1)
 // retains its direct and opaque-call DFB uses while core (0, 0) has the
@@ -38,6 +38,24 @@ module attributes {ttl.launch_grid = [1 : i64, 2 : i64]} {
           : (!ttkernel.cb<3, !ttcore.tile<32x32, bf16>>, i32) -> ()
       ttkernel.opaque_call "inspect"() {dfb_resource_indices = array<i32: 1>, header = "inspect.hpp"} : () -> ()
     }
+    return
+  }
+}
+
+// -----
+
+// A single-node launch still records a lowered opaque dependency with no
+// protocol effects even though core specialization performs no cloning.
+// CHECK-LABEL: func.func @single_node_opaque_dependency
+// CHECK-SAME: ttl.used_dfb_indices = array<i32: 0>
+// CHECK: ttkernel.opaque_call "inspect"() {dfb_resource_indices = array<i32: 0>, header = "inspect.hpp"} : () -> ()
+// CHECK-NOT: func.func @single_node_opaque_dependency_c
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @single_node_opaque_dependency() attributes {
+      ttl.base_cta_index = 1 : i32,
+      ttkernel.thread = #ttkernel.thread<noc>} {
+    ttkernel.opaque_call "inspect"() {dfb_resource_indices = array<i32: 0>, header = "inspect.hpp"} : () -> ()
     return
   }
 }


### PR DESCRIPTION
### Problem description

Each core must receive a descriptor for every DFB its kernel accesses. After external calls and synchronized resets are lowered, their DFB references are encoded as physical indices, descriptor attributes, or reset masks rather than SSA operands. The existing DFB-use analysis can therefore miss those references and launch a core without a required descriptor.

### What's changed

~190 LOC implementation.

- Preserve finalized physical DFB requirements on each lowered `ttkernel.opaque_call` until specialization removes unreachable calls.
- Validate that resource metadata is nonempty, nonnegative, sorted, unique, and within the enclosing function's DFB count.
- Propagate direct and transitive helper-call requirements into `ttl.used_dfb_indices`.
- Retain user-managed DFBs conservatively for unknown external access without exposing compiler-managed intermediates or changing the runtime-argument ABI.

Fixes #1011.

### Checklist

- [x] New tests cover external descriptor access, explicit dependencies, unknown external access, synchronized reset, helper calls, specialization elision, single-node execution, and BF16/FP32 device execution through DRAM and L1.
