### PR TITLE
[ttl][ttkernel] Unroll static local PipeNet record loops [tree-reduce-6]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -129,15 +129,18 @@ ttkernel-insert-inits              (Module) Insert hardware init calls
   ... L1 accumulation, cleanup ...
 ttkernel-specialize-cores          (Module, optional) Clone coordinate-dependent kernels
 canonicalize, cse                  (Module, after specialization) Resolve coordinate-dependent control flow
+ttkernel-unroll-static-pipenet-record-loops
+                                    (FuncOp) Unroll static local record loops
+canonicalize, cse                  (Module) Fold selected record tables
 ttkernel-finalize-tensor-runtime-args (Module) Finalize tensor and DFB argument indices
 canonicalize                       (Module) Remove obsolete argument expressions
 ttkernel-annotate-dfb-use          (Module, specialized only) Record surviving physical DFB uses
 ```
 
-Tensor runtime-argument finalization runs with or without per-core
-specialization. Core specialization and DFB-use annotation are optional.
-Annotation follows canonicalization so an eliminated branch cannot keep an
-otherwise-unused DFB live on that clone's launch node.
+Core specialization and DFB-use annotation are optional. Record-loop unrolling,
+cleanup, and tensor runtime-argument finalization run in both modes. Finalization
+follows record-loop cleanup so eliminated uses cannot retain obsolete arguments;
+annotation then records only surviving DFB uses on each clone's launch node.
 
 `ttl-finalize-dfb-indices` must precede
 `ttl-set-compute-kernel-config` and `ttl-annotate-cb-associations`.

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -186,7 +186,8 @@ The pipeline runs these passes and subpasses in order:
 - `ttkernel-insert-l1-accumulation` -- insert `pack_reconfig_l1_acc` guards for `+=` and reduction loops
 - `ttkernel-combine-pack-tiles` -- combine consecutive `pack_tile` into `pack_tile_block` *(only if `combine-pack-tiles=true`)*
 - Canonicalization and CSE cleanup
-- `ttkernel-specialize-and-annotate-dfb-use` -- `ttkernel-specialize-cores`, `canonicalize`, `cse`, then `ttkernel-annotate-dfb-use` *(only if `specialize-cores=true`)*
+- `ttkernel-specialize-and-annotate-dfb-use` -- `ttkernel-specialize-cores`, `canonicalize`, `cse`, `ttkernel-unroll-static-pipenet-record-loops`, `canonicalize`, `cse`, then `ttkernel-annotate-dfb-use` *(only if `specialize-cores=true`)*
+- Without core specialization, `ttkernel-unroll-static-pipenet-record-loops`, canonicalization, and CSE still run to consume compiler-owned loop markers and optimize any already-static local record loops.
 - *(if `lower-to-emitc=true`)* `lower-affine`, `convert-ttkernel-to-emitc`, `emitc-form-expressions`
 
 ### Individual Pass Options
@@ -390,7 +391,8 @@ unspecialized with a warning so erasing the original does not leave dangling
 `SymbolRefAttr`s; unrelated functions in the module are still specialized.
 Each clone replaces coordinate reads with `arith.constant`s and is tagged with
 `ttl.core_coord` for runtime dispatch. Downstream `canonicalize` / `cse` fold
-the now-constant conditions and loop bounds.
+the now-constant conditions and loop bounds. Static local PipeNet record loops
+are then fully unrolled so record-table lookups can fold to constants.
 `ttkernel-annotate-dfb-use` then records surviving DFB compile-time arguments,
 synchronized resets, and external-call dependencies on each specialized
 function. Debug prints of a DFB remain only on cores that still have a
@@ -405,4 +407,19 @@ registered `ttkernel-specialize-and-annotate-dfb-use` sub-pipeline:
 ttlang-opt input.mlir -p 'ttl-to-ttkernel-pipeline{specialize-cores=true lower-to-emitc=true}'
 # Or stand-alone:
 ttlang-opt input.mlir -p 'builtin.module(ttkernel-specialize-and-annotate-dfb-use)'
+```
+
+#### `ttkernel-unroll-static-pipenet-record-loops`
+
+Fully unroll compiler-marked local PipeNet record loops after their bounds
+become constant. This exposes each selected record index to canonicalization,
+which replaces immutable record-table lookups with constants. Dynamic loop
+bounds remain unchanged, and their temporary compiler marker is removed.
+
+The full TTL-to-TTKernel pipeline runs this pass even when core specialization
+is disabled so the marker never reaches code generation. In that case, loops
+whose bounds still depend on runtime coordinates remain loops.
+
+```bash
+ttlang-opt input.mlir -p 'builtin.module(func.func(ttkernel-unroll-static-pipenet-record-loops),canonicalize)'
 ```

--- a/include/ttlang/Dialect/TTL/IR/TTL.h
+++ b/include/ttlang/Dialect/TTL/IR/TTL.h
@@ -128,6 +128,11 @@ constexpr llvm::StringLiteral
 /// linearization stride for this dimension.
 constexpr llvm::StringLiteral kTileLoopStrideAttrName("ttl.tile_loop_stride");
 
+/// Marks a compiler-generated loop over the local PipeNet records selected for
+/// one launch node.
+constexpr llvm::StringLiteral
+    kPipeNetLocalRecordLoopAttrName("ttl.pipenet_local_record_loop");
+
 /// Marks an scf.for loop as iterating over a reduction dimension.
 constexpr llvm::StringLiteral kReductionLoopAttrName("ttl.reduction_loop");
 

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -1472,6 +1472,27 @@ def TTKernelSpecializeCores
   ];
 }
 
+def TTKernelUnrollStaticPipeNetRecordLoops
+    : Pass<"ttkernel-unroll-static-pipenet-record-loops",
+           "::mlir::func::FuncOp"> {
+  let summary = "Unroll static local PipeNet record loops";
+  let description = [{
+    Fully unrolls compiler-marked local PipeNet record loops whose bounds are
+    constant. Per-core specialization makes those bounds constant when they
+    depend on a launch coordinate. Unrolling exposes the selected record index
+    to canonicalization, which can replace immutable record-table lookups with
+    constants.
+
+    A loop with dynamic bounds remains structurally unchanged. Its temporary
+    compiler marker is removed because no later pass consumes it.
+  }];
+
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::scf::SCFDialect"
+  ];
+}
+
 def TTKernelAnnotateDFBUse
     : Pass<"ttkernel-annotate-dfb-use", "::mlir::ModuleOp"> {
   let summary = "Record physical DFB indices used by each TTKernel function";

--- a/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(TTLangTTKernelTransforms
   TTKernelLowerScalarFpTypes.cpp
   TTKernelAnnotateDFBUse.cpp
   TTKernelSpecializeCores.cpp
+  TTKernelUnrollStaticPipeNetRecordLoops.cpp
 
   DEPENDS
   TTLangTTLTransformsIncGen

--- a/lib/Dialect/TTKernel/Transforms/TTKernelUnrollStaticPipeNetRecordLoops.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelUnrollStaticPipeNetRecordLoops.cpp
@@ -7,7 +7,11 @@
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallVector.h"
+
+#include <cassert>
+#include <optional>
 
 namespace mlir::tt::ttl {
 
@@ -28,8 +32,16 @@ struct TTKernelUnrollStaticPipeNetRecordLoopsPass
     });
 
     for (scf::ForOp recordLoop : recordLoops) {
-      if (!recordLoop.getStaticTripCount()) {
+      assert(recordLoop.getInitArgs().empty() &&
+             recordLoop.getNumResults() == 0 &&
+             "local PipeNet record loops cannot carry values");
+      std::optional<APInt> tripCount = recordLoop.getStaticTripCount();
+      if (!tripCount) {
         recordLoop->removeAttr(kPipeNetLocalRecordLoopAttrName);
+        continue;
+      }
+      if (tripCount->isZero()) {
+        recordLoop.erase();
         continue;
       }
       if (failed(loopUnrollFull(recordLoop))) {

--- a/lib/Dialect/TTKernel/Transforms/TTKernelUnrollStaticPipeNetRecordLoops.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelUnrollStaticPipeNetRecordLoops.cpp
@@ -25,6 +25,8 @@ struct TTKernelUnrollStaticPipeNetRecordLoopsPass
           TTKernelUnrollStaticPipeNetRecordLoopsPass> {
   void runOnOperation() override {
     SmallVector<scf::ForOp> recordLoops;
+    // Unroll inner loops first because unrolling a parent invalidates its
+    // nested operation handles and clones any unprocessed loop markers.
     getOperation().walk<WalkOrder::PostOrder>([&](scf::ForOp loop) {
       if (loop->hasAttr(kPipeNetLocalRecordLoopAttrName)) {
         recordLoops.push_back(loop);

--- a/lib/Dialect/TTKernel/Transforms/TTKernelUnrollStaticPipeNetRecordLoops.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelUnrollStaticPipeNetRecordLoops.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttlang/Dialect/TTL/IR/TTL.h"
+#include "ttlang/Dialect/TTL/Passes.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttl {
+
+#define GEN_PASS_DEF_TTKERNELUNROLLSTATICPIPENETRECORDLOOPS
+#include "ttlang/Dialect/TTL/Passes.h.inc"
+
+namespace {
+
+struct TTKernelUnrollStaticPipeNetRecordLoopsPass
+    : impl::TTKernelUnrollStaticPipeNetRecordLoopsBase<
+          TTKernelUnrollStaticPipeNetRecordLoopsPass> {
+  void runOnOperation() override {
+    SmallVector<scf::ForOp> recordLoops;
+    getOperation().walk<WalkOrder::PostOrder>([&](scf::ForOp loop) {
+      if (loop->hasAttr(kPipeNetLocalRecordLoopAttrName)) {
+        recordLoops.push_back(loop);
+      }
+    });
+
+    for (scf::ForOp recordLoop : recordLoops) {
+      if (!recordLoop.getStaticTripCount()) {
+        recordLoop->removeAttr(kPipeNetLocalRecordLoopAttrName);
+        continue;
+      }
+      if (failed(loopUnrollFull(recordLoop))) {
+        recordLoop.emitOpError(
+            "failed to fully unroll local PipeNet record loop");
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::ttl

--- a/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
+++ b/lib/Dialect/TTL/Pipelines/TTLPipelines.cpp
@@ -126,6 +126,10 @@ void createTTLToTTKernelPipeline(OpPassManager &pm,
   if (options.specializeCores) {
     buildTTKernelSpecializationPipeline(pm);
   } else {
+    pm.addNestedPass<func::FuncOp>(
+        createTTKernelUnrollStaticPipeNetRecordLoops());
+    pm.addPass(createCanonicalizerPass());
+    pm.addPass(createCSEPass());
     pm.addPass(createTTKernelFinalizeTensorRuntimeArgs());
     pm.addPass(createCanonicalizerPass());
   }
@@ -149,6 +153,10 @@ void buildTTLAutoSyncPipeline(OpPassManager &pm) {
 
 void buildTTKernelSpecializationPipeline(OpPassManager &pm) {
   pm.addPass(createTTKernelSpecializeCores());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+  pm.addNestedPass<func::FuncOp>(
+      createTTKernelUnrollStaticPipeNetRecordLoops());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
   pm.addPass(createTTKernelFinalizeTensorRuntimeArgs());

--- a/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
@@ -206,6 +206,7 @@ tryLowerLocalPipeNetForeach(ForeachOp op, RewriterBase &rewriter,
   Value upper = arith::AddIOp::create(rewriter, loc, lower, recordCount);
   Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
   auto forOp = scf::ForOp::create(rewriter, loc, lower, upper, one);
+  forOp->setAttr(kPipeNetLocalRecordLoopAttrName, rewriter.getUnitAttr());
   foreachLoweringInfo.controlOps.push_back(forOp);
   foreachLoweringInfo.recordLoops[forOp] = {
       records, recordSelection,

--- a/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
+++ b/lib/Dialect/TTL/Transforms/PipeNetForeachLowering.cpp
@@ -384,6 +384,8 @@ static void lowerPipeNetForeach(ForeachOp op, RewriterBase &rewriter,
   Value upper =
       arith::ConstantIndexOp::create(rewriter, loc, records.getPipes().size());
   Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
+  // Keep the fallback loop rolled because it scans the complete PipeNet table;
+  // only the bounded per-node table is suitable for unconditional unrolling.
   auto forOp = scf::ForOp::create(rewriter, loc, lower, upper, step);
   foreachLoweringInfo.recordLoops[forOp] = {records, recordSelection, {}};
 

--- a/python/ttl/ttl_api.py
+++ b/python/ttl/ttl_api.py
@@ -2891,6 +2891,12 @@ def _lower_program_to_kernel(
         ]
         if compiler_options.specialize_cores:
             pipeline_passes.append("ttkernel-specialize-and-annotate-dfb-use")
+        else:
+            pipeline_passes += [
+                "func.func(ttkernel-unroll-static-pipenet-record-loops)",
+                "canonicalize",
+                "cse",
+            ]
         pipeline_passes += [
             "convert-ttkernel-to-emitc",
             "symbol-dce",

--- a/test/bindings/python/ttl_passes.py
+++ b/test/bindings/python/ttl_passes.py
@@ -26,6 +26,7 @@ def test_ttl_passes_registered():
         "ttl-assign-dst",
         "ttl-lower-to-loops",
         "ttl-annotate-cb-associations",
+        "ttkernel-unroll-static-pipenet-record-loops",
     ]
 
     for pass_name in func_passes:
@@ -39,6 +40,7 @@ def test_ttl_passes_registered():
         # CHECK: ttl-assign-dst pass registered
         # CHECK: ttl-lower-to-loops pass registered
         # CHECK: ttl-annotate-cb-associations pass registered
+        # CHECK: ttkernel-unroll-static-pipenet-record-loops pass registered
 
     # Module-level passes.
     module_passes = [

--- a/test/python/auto_profile_bcast_multitile.py
+++ b/test/python/auto_profile_bcast_multitile.py
@@ -154,10 +154,9 @@ def bcast_multitile_kernel(
 # CHECK-NEXT:             add_binary_tile([[V6]], [[V5]], [[V6]]);
 # CHECK-NEXT:             tile_regs_commit();
 # CHECK-NEXT:             tile_regs_wait();
-# CHECK-NEXT:             size_t [[V12:.*]] = 4;
-# CHECK-NEXT:             size_t [[V13:.*]] = [[K]] * [[V12]];
-# CHECK-NEXT:             size_t [[V14:.*]] = [[V13]] + [[L]];
-# CHECK-NEXT:             pack_tile<true>([[V6]], get_compile_time_arg_val(3), [[V14]]);
+# CHECK-NEXT:             size_t [[V12:.*]] = [[K]] * [[V4]];
+# CHECK-NEXT:             size_t [[V13:.*]] = [[V12]] + [[L]];
+# CHECK-NEXT:             pack_tile<true>([[V6]], get_compile_time_arg_val(3), [[V13]]);
 # CHECK-NEXT:             tile_regs_release();
 # CHECK-NEXT:           }
 # CHECK-NEXT:         }

--- a/test/python/pipe/test_pipenet_collectives.py
+++ b/test/python/pipe/test_pipenet_collectives.py
@@ -11,7 +11,9 @@ extent equal to work extent. The cases here cover regimes the
 `ttl-verify-pipenet-guards` verifier exercises under `grid="full"`:
 
 * Table-driven single-receiver collectives: five loopback-only collective
-  records verify that one-node ranges use unicast transport.
+  records verify that one-node ranges use unicast transport. Specialized
+  coverage also verifies local record loops and table lookups leave no runtime
+  code.
 * Scatter on a subgrid (`grid="full"`, work = 4 nodes in row 0):
   single PipeNet, single multicast pipe, dst rectangle smaller than the
   launch grid.
@@ -27,6 +29,9 @@ issue #505 (within-PipeNet multicast destination overlap). The
 per-source PipeNet workaround is sketched in TODO comments.
 """
 
+import runpy
+from pathlib import Path
+
 import pytest
 import torch
 import ttl
@@ -34,6 +39,7 @@ import ttl
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 from ttlang_test_utils import assert_pcc, to_dram
+from utils.correctness import assert_allclose
 
 TILE = 32
 
@@ -44,48 +50,59 @@ TILE = 32
 TABLE_DRIVEN_COLLECTIVE_RECORDS = 5
 
 
-@ttl.operation(grid=(1, TABLE_DRIVEN_COLLECTIVE_RECORDS))
-def table_driven_single_receiver_collective_kernel(inp, out):
-    net = ttl.PipeNet(
-        [
-            ttl.Pipe(src=(0, row_idx), dst=(slice(0, 1), row_idx))
-            for row_idx in range(TABLE_DRIVEN_COLLECTIVE_RECORDS)
-        ]
-    )
+def _make_table_driven_single_receiver_collective():
+    @ttl.operation(grid=(1, TABLE_DRIVEN_COLLECTIVE_RECORDS))
+    def table_driven_single_receiver_collective(inp, out):
+        net = ttl.PipeNet(
+            [
+                ttl.Pipe(src=(0, row_idx), dst=(slice(0, 1), row_idx))
+                for row_idx in range(TABLE_DRIVEN_COLLECTIVE_RECORDS)
+            ]
+        )
 
-    recv_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
-    send_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
-    out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
+        recv_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+        send_dfb = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+        out_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, 1), block_count=2)
 
-    @ttl.compute()
-    def compute():
-        with recv_dfb.wait() as recv_blk, out_dfb.reserve() as out_blk:
-            out_blk.store(recv_blk)
+        @ttl.compute()
+        def compute():
+            with recv_dfb.wait() as recv_blk, out_dfb.reserve() as out_blk:
+                out_blk.store(recv_blk)
 
-    @ttl.datamovement()
-    def post_and_send():
-        _, node_y = ttl.node(dims=2)
-        with send_dfb.reserve() as send_blk:
-            ttl.copy(inp[node_y : node_y + 1, 0:1], send_blk).wait()
+        @ttl.datamovement()
+        def post_and_send():
+            _, node_y = ttl.node(dims=2)
+            with send_dfb.reserve() as send_blk:
+                ttl.copy(inp[node_y : node_y + 1, 0:1], send_blk).wait()
 
-        with send_dfb.wait() as send_blk, recv_dfb.reserve() as recv_blk:
+            with send_dfb.wait() as send_blk, recv_dfb.reserve() as recv_blk:
 
-            def receive_then_send(recv_pipe):
-                recv_tx = ttl.copy(recv_pipe, recv_blk)
+                def receive_then_send(recv_pipe):
+                    recv_tx = ttl.copy(recv_pipe, recv_blk)
 
-                def send(send_pipe):
-                    ttl.copy(send_blk, send_pipe).wait()
+                    def send(send_pipe):
+                        ttl.copy(send_blk, send_pipe).wait()
 
-                net.if_src(send)
-                recv_tx.wait()
+                    net.if_src(send)
+                    recv_tx.wait()
 
-            net.if_dst(receive_then_send)
+                net.if_dst(receive_then_send)
 
-    @ttl.datamovement()
-    def write_output():
-        _, node_y = ttl.node(dims=2)
-        with out_dfb.wait() as out_blk:
-            ttl.copy(out_blk, out[node_y : node_y + 1, 0:1]).wait()
+        @ttl.datamovement()
+        def write_output():
+            _, node_y = ttl.node(dims=2)
+            with out_dfb.wait() as out_blk:
+                ttl.copy(out_blk, out[node_y : node_y + 1, 0:1]).wait()
+
+    return table_driven_single_receiver_collective
+
+
+table_driven_single_receiver_collective_default = (
+    _make_table_driven_single_receiver_collective()
+)
+table_driven_single_receiver_collective_specialized = (
+    _make_table_driven_single_receiver_collective()
+)
 
 
 @pytest.mark.parametrize(
@@ -98,10 +115,43 @@ def test_table_driven_single_receiver_collective(device, torch_dtype):
     input_tensor = to_dram(input_torch, device)
     output_tensor = to_dram(torch.zeros_like(input_torch), device)
 
-    table_driven_single_receiver_collective_kernel(input_tensor, output_tensor)
+    table_driven_single_receiver_collective_default(input_tensor, output_tensor)
 
     result = ttnn.to_torch(output_tensor).float()
     assert_pcc(input_torch.float(), result)
+
+
+@pytest.mark.parametrize(
+    "torch_dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"]
+)
+def test_specialized_collective_unrolls_local_record_loop(
+    device, torch_dtype, monkeypatch, tmp_path
+):
+    runner_path = tmp_path / f"specialized_collective_{torch_dtype}_runner.py"
+    monkeypatch.setenv("TTLANG_EMIT_RUNNER", str(runner_path))
+    input_torch = torch.randn(
+        TABLE_DRIVEN_COLLECTIVE_RECORDS * TILE, TILE, dtype=torch_dtype
+    )
+    input_tensor = to_dram(input_torch, device)
+    output_tensor = to_dram(torch.zeros_like(input_torch), device)
+
+    table_driven_single_receiver_collective_specialized(
+        input_tensor, output_tensor, options="--ttl-specialize-cores"
+    )
+
+    actual = ttnn.to_torch(output_tensor).float()
+    assert_allclose(actual, input_torch.float(), rtol=0.0, atol=0.0)
+
+    runner = runpy.run_path(str(runner_path))
+    specialized_sources = [
+        Path(kernel_path).read_text()
+        for kernel_path, _thread_type in runner["KERNEL_PATHS"]
+        if "post_and_send_c" in Path(kernel_path).name
+    ]
+    assert len(specialized_sources) == TABLE_DRIVEN_COLLECTIVE_RECORDS
+    for kernel_source in specialized_sources:
+        assert "for (" not in kernel_source
+        assert "experimental::constant_table_lookup" not in kernel_source
 
 
 # ---------------------------------------------------------------------------

--- a/test/python/signpost_scopes.py
+++ b/test/python/signpost_scopes.py
@@ -143,10 +143,9 @@ def bcast_multitile_kernel(
 # CHECK-NEXT:     DeviceZoneScopedN("ttl_store");
 # CHECK-NEXT:     tile_regs_commit();
 # CHECK-NEXT:     tile_regs_wait();
-# CHECK-NEXT:     size_t [[V12:.*]] = 4;
-# CHECK-NEXT:     size_t [[V13:.*]] = [[K]] * [[V12]];
-# CHECK-NEXT:     size_t [[V14:.*]] = [[V13]] + [[L]];
-# CHECK-NEXT:     pack_tile<true>([[V6]], get_compile_time_arg_val(3), [[V14]]);
+# CHECK-NEXT:     size_t [[V12:.*]] = [[K]] * [[V4]];
+# CHECK-NEXT:     size_t [[V13:.*]] = [[V12]] + [[L]];
+# CHECK-NEXT:     pack_tile<true>([[V6]], get_compile_time_arg_val(3), [[V13]]);
 # CHECK-NEXT:     }
 # CHECK-NEXT:     }
 # CHECK-NEXT:     }

--- a/test/python/simple_add_multitile.py
+++ b/test/python/simple_add_multitile.py
@@ -136,9 +136,8 @@ def add_multitile_kernel(lhs, rhs, out):
 # CHECK-CPP: for (size_t [[I:i[0-9]+]] = {{.*}}; [[I]] < [[BOUND]]; [[I]] += {{.*}}) {
 # CHECK-CPP: for (size_t [[J:j[0-9]+]] = {{.*}}; [[J]] < [[BOUND]]; [[J]] += {{.*}}) {
 
-# Linearized index calculation: i * 2 + j
-# CHECK-CPP: size_t [[COLS:v[0-9]+]] = 2;
-# CHECK-CPP: size_t [[ROW_OFF:v[0-9]+]] = [[I]] * [[COLS]];
+# The square tile grid's loop bound is also its row stride: i * 2 + j.
+# CHECK-CPP: size_t [[ROW_OFF:v[0-9]+]] = [[I]] * [[BOUND]];
 # CHECK-CPP: size_t [[LIN_IDX:v[0-9]+]] = [[ROW_OFF]] + [[J]];
 
 # Copy tiles using linearized index (at first use: CB0 then CB1)

--- a/test/ttlang/Dialect/TTKernel/Transforms/unroll_static_pipenet_record_loops.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/unroll_static_pipenet_record_loops.mlir
@@ -1,3 +1,4 @@
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttkernel-unroll-static-pipenet-record-loops))' | FileCheck %s --check-prefix=PASS --implicit-check-not=ttl.pipenet_local_record_loop
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttkernel-unroll-static-pipenet-record-loops),canonicalize)' | FileCheck %s
 
 // Summary: Verifies static local PipeNet record loops are fully unrolled and
@@ -5,6 +6,9 @@
 
 func.func private @consume(index)
 
+// PASS-LABEL: func.func @unroll_static
+// PASS-NOT:     scf.for
+// PASS:         return
 // CHECK-LABEL: func.func @unroll_static
 // CHECK-NOT:     scf.for
 // CHECK-NOT:     ttkernel.experimental.constant_table_lookup
@@ -26,6 +30,9 @@ func.func @unroll_static() {
   return
 }
 
+// PASS-LABEL: func.func @inline_single_iteration
+// PASS-NOT:     scf.for
+// PASS:         return
 // CHECK-LABEL: func.func @inline_single_iteration
 // CHECK-NOT:     scf.for
 // CHECK:         %[[THIRTEEN:.*]] = arith.constant 13 : index
@@ -42,6 +49,10 @@ func.func @inline_single_iteration() {
   return
 }
 
+// PASS-LABEL: func.func @erase_zero_iterations
+// PASS-NOT:     scf.for
+// PASS-NOT:     call @consume
+// PASS:         return
 // CHECK-LABEL: func.func @erase_zero_iterations
 // CHECK-NOT:     scf.for
 // CHECK-NOT:     call @consume
@@ -55,6 +66,10 @@ func.func @erase_zero_iterations() {
   return
 }
 
+// PASS-LABEL: func.func @retain_dynamic
+// PASS:         scf.for
+// PASS:         call @consume
+// PASS:         return
 // CHECK-LABEL: func.func @retain_dynamic
 // CHECK:         scf.for
 // CHECK-NOT:     ttl.pipenet_local_record_loop
@@ -69,6 +84,10 @@ func.func @retain_dynamic(%upper : index) {
   return
 }
 
+// PASS-LABEL: func.func @retain_unmarked
+// PASS:         scf.for
+// PASS:         call @consume
+// PASS:         return
 // CHECK-LABEL: func.func @retain_unmarked
 // CHECK:         scf.for
 // CHECK-NOT:     ttl.pipenet_local_record_loop
@@ -86,6 +105,9 @@ func.func @retain_unmarked() {
 
 // Nested callbacks can produce nested record loops. Post-order unrolling must
 // fully expand both loops without invalidating the outer loop handle.
+// PASS-LABEL: func.func @unroll_nested
+// PASS-NOT:     scf.for
+// PASS:         return
 // CHECK-LABEL: func.func @unroll_nested
 // CHECK-NOT:     scf.for
 // CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0 : index

--- a/test/ttlang/Dialect/TTKernel/Transforms/unroll_static_pipenet_record_loops.mlir
+++ b/test/ttlang/Dialect/TTKernel/Transforms/unroll_static_pipenet_record_loops.mlir
@@ -1,0 +1,110 @@
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(ttkernel-unroll-static-pipenet-record-loops),canonicalize)' | FileCheck %s
+
+// Summary: Verifies static local PipeNet record loops are fully unrolled and
+// their temporary compiler marker does not remain on dynamic loops.
+
+func.func private @consume(index)
+
+// CHECK-LABEL: func.func @unroll_static
+// CHECK-NOT:     scf.for
+// CHECK-NOT:     ttkernel.experimental.constant_table_lookup
+// CHECK-DAG:     %[[THREE:.*]] = arith.constant 3 : index
+// CHECK-DAG:     %[[FIVE:.*]] = arith.constant 5 : index
+// CHECK-DAG:     %[[EIGHT:.*]] = arith.constant 8 : index
+// CHECK:         call @consume(%[[THREE]]) : (index) -> ()
+// CHECK:         call @consume(%[[FIVE]]) : (index) -> ()
+// CHECK:         call @consume(%[[EIGHT]]) : (index) -> ()
+// CHECK:         return
+func.func @unroll_static() {
+  %lower = arith.constant 0 : index
+  %upper = arith.constant 3 : index
+  %step = arith.constant 1 : index
+  scf.for %record = %lower to %upper step %step {
+    %value = ttkernel.experimental.constant_table_lookup %record, [3, 5, 8] : index
+    func.call @consume(%value) : (index) -> ()
+  } {ttl.pipenet_local_record_loop}
+  return
+}
+
+// CHECK-LABEL: func.func @inline_single_iteration
+// CHECK-NOT:     scf.for
+// CHECK:         %[[THIRTEEN:.*]] = arith.constant 13 : index
+// CHECK:         call @consume(%[[THIRTEEN]]) : (index) -> ()
+// CHECK:         return
+func.func @inline_single_iteration() {
+  %lower = arith.constant 1 : index
+  %upper = arith.constant 2 : index
+  %step = arith.constant 1 : index
+  scf.for %record = %lower to %upper step %step {
+    %value = ttkernel.experimental.constant_table_lookup %record, [11, 13] : index
+    func.call @consume(%value) : (index) -> ()
+  } {ttl.pipenet_local_record_loop}
+  return
+}
+
+// CHECK-LABEL: func.func @erase_zero_iterations
+// CHECK-NOT:     scf.for
+// CHECK-NOT:     call @consume
+// CHECK:         return
+func.func @erase_zero_iterations() {
+  %bound = arith.constant 2 : index
+  %step = arith.constant 1 : index
+  scf.for %record = %bound to %bound step %step {
+    func.call @consume(%record) : (index) -> ()
+  } {ttl.pipenet_local_record_loop}
+  return
+}
+
+// CHECK-LABEL: func.func @retain_dynamic
+// CHECK:         scf.for
+// CHECK-NOT:     ttl.pipenet_local_record_loop
+// CHECK:         call @consume
+// CHECK:         return
+func.func @retain_dynamic(%upper : index) {
+  %lower = arith.constant 0 : index
+  %step = arith.constant 1 : index
+  scf.for %record = %lower to %upper step %step {
+    func.call @consume(%record) : (index) -> ()
+  } {ttl.pipenet_local_record_loop}
+  return
+}
+
+// CHECK-LABEL: func.func @retain_unmarked
+// CHECK:         scf.for
+// CHECK-NOT:     ttl.pipenet_local_record_loop
+// CHECK:         call @consume
+// CHECK:         return
+func.func @retain_unmarked() {
+  %lower = arith.constant 0 : index
+  %upper = arith.constant 3 : index
+  %step = arith.constant 1 : index
+  scf.for %record = %lower to %upper step %step {
+    func.call @consume(%record) : (index) -> ()
+  }
+  return
+}
+
+// Nested callbacks can produce nested record loops. Post-order unrolling must
+// fully expand both loops without invalidating the outer loop handle.
+// CHECK-LABEL: func.func @unroll_nested
+// CHECK-NOT:     scf.for
+// CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[ONE:.*]] = arith.constant 1 : index
+// CHECK-DAG:     %[[TWO:.*]] = arith.constant 2 : index
+// CHECK:         call @consume(%[[ZERO]]) : (index) -> ()
+// CHECK:         call @consume(%[[ONE]]) : (index) -> ()
+// CHECK:         call @consume(%[[ONE]]) : (index) -> ()
+// CHECK:         call @consume(%[[TWO]]) : (index) -> ()
+// CHECK:         return
+func.func @unroll_nested() {
+  %lower = arith.constant 0 : index
+  %upper = arith.constant 2 : index
+  %step = arith.constant 1 : index
+  scf.for %outer = %lower to %upper step %step {
+    scf.for %inner = %lower to %upper step %step {
+      %record = arith.addi %outer, %inner : index
+      func.call @consume(%record) : (index) -> ()
+    } {ttl.pipenet_local_record_loop}
+  } {ttl.pipenet_local_record_loop}
+  return
+}

--- a/test/ttlang/Dialect/TTL/Pipelines/specialize_cores_pipeline.mlir
+++ b/test/ttlang/Dialect/TTL/Pipelines/specialize_cores_pipeline.mlir
@@ -4,7 +4,7 @@
 // unrolling and argument finalization without specialization.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-and-annotate-dfb-use)' --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=SUBPIPELINE
 // RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline='specialize-cores=true' --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=ENABLED
-// RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=DISABLED
+// RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=DISABLED --implicit-check-not=ttkernel-specialize-cores --implicit-check-not=ttkernel-annotate-dfb-use
 
 // SUBPIPELINE-LABEL: Pass Manager with
 // SUBPIPELINE-NEXT: builtin.module(
@@ -38,9 +38,12 @@
 // ENABLED-NEXT: ttkernel-annotate-dfb-use
 
 // DISABLED: ttkernel-insert-l1-accumulation
-// DISABLED-NOT: ttkernel-specialize-cores
-// DISABLED-NOT: ttkernel-annotate-dfb-use
 // DISABLED: func.func(
+// DISABLED-NEXT: ttkernel-combine-pack-tiles
+// DISABLED-NEXT: ),
+// DISABLED-NEXT: canonicalize{{.*}},
+// DISABLED-NEXT: cse,
+// DISABLED-NEXT: func.func(
 // DISABLED-NEXT: ttkernel-unroll-static-pipenet-record-loops
 // DISABLED-NEXT: ),
 // DISABLED-NEXT: canonicalize{{.*}},

--- a/test/ttlang/Dialect/TTL/Pipelines/specialize_cores_pipeline.mlir
+++ b/test/ttlang/Dialect/TTL/Pipelines/specialize_cores_pipeline.mlir
@@ -1,5 +1,7 @@
-// Summary: The specialize-and-annotate-dfb-use subpipeline owns per-core
-// cloning, folding, tensor-argument finalization, and DFB-use annotation.
+// Summary: The specialize-and-annotate-dfb-use subpipeline owns the
+// per-core clone, fold, local record-loop unroll, tensor-argument finalization,
+// and DFB-use annotation sequence. The full pipeline also runs record-loop
+// unrolling and argument finalization without specialization.
 // RUN: ttlang-opt %s -pass-pipeline='builtin.module(ttkernel-specialize-and-annotate-dfb-use)' --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=SUBPIPELINE
 // RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline='specialize-cores=true' --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=ENABLED
 // RUN: ttlang-opt %s --ttl-to-ttkernel-pipeline --dump-pass-pipeline -o /dev/null 2>&1 | FileCheck %s --check-prefix=DISABLED
@@ -7,6 +9,11 @@
 // SUBPIPELINE-LABEL: Pass Manager with
 // SUBPIPELINE-NEXT: builtin.module(
 // SUBPIPELINE-NEXT: ttkernel-specialize-cores,
+// SUBPIPELINE-NEXT: canonicalize{{.*}},
+// SUBPIPELINE-NEXT: cse,
+// SUBPIPELINE-NEXT: func.func(
+// SUBPIPELINE-NEXT:   ttkernel-unroll-static-pipenet-record-loops
+// SUBPIPELINE-NEXT: ),
 // SUBPIPELINE-NEXT: canonicalize{{.*}},
 // SUBPIPELINE-NEXT: cse,
 // SUBPIPELINE-NEXT: ttkernel-finalize-tensor-runtime-args,
@@ -21,13 +28,24 @@
 // ENABLED-NEXT: ttkernel-specialize-cores,
 // ENABLED-NEXT: canonicalize{{.*}},
 // ENABLED-NEXT: cse,
+// ENABLED-NEXT: func.func(
+// ENABLED-NEXT:   ttkernel-unroll-static-pipenet-record-loops
+// ENABLED-NEXT: ),
+// ENABLED-NEXT: canonicalize{{.*}},
+// ENABLED-NEXT: cse,
 // ENABLED-NEXT: ttkernel-finalize-tensor-runtime-args,
 // ENABLED-NEXT: canonicalize{{.*}},
 // ENABLED-NEXT: ttkernel-annotate-dfb-use
 
 // DISABLED: ttkernel-insert-l1-accumulation
-// DISABLED: ttkernel-finalize-tensor-runtime-args
 // DISABLED-NOT: ttkernel-specialize-cores
 // DISABLED-NOT: ttkernel-annotate-dfb-use
+// DISABLED: func.func(
+// DISABLED-NEXT: ttkernel-unroll-static-pipenet-record-loops
+// DISABLED-NEXT: ),
+// DISABLED-NEXT: canonicalize{{.*}},
+// DISABLED-NEXT: cse
+// DISABLED-NEXT: ttkernel-finalize-tensor-runtime-args
+// DISABLED-NEXT: canonicalize{{.*}}
 
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {}

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_grid_major_record_index.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_grid_major_record_index.mlir
@@ -18,12 +18,12 @@
 // CHECK-NEXT: %[[LOWER:.*]] = ttkernel.experimental.constant_table_lookup %[[DEVICE]], [0, 1, 2] : index
 // CHECK-NEXT: %[[UPPER:.*]] = ttkernel.experimental.constant_table_lookup %[[NEXT_DEVICE]], [0, 1, 2] : index
 // CHECK: scf.for %[[EDGE_POSITION:.*]] = %[[LOWER]] to %[[UPPER]] step
-// CHECK-NOT: ttl.pipenet_local_record_loop
 // CHECK-NEXT: %[[EDGE_BLOCK:.*]] = ttkernel.experimental.constant_table_lookup %[[EDGE_POSITION]], [0, 1] : index
 // CHECK-NEXT: %[[EDGE_OFFSET:.*]] = arith.muli %[[EDGE_BLOCK]], %{{.*}} : index
 // CHECK-NEXT: %[[RECORD:.*]] = arith.addi %[[EDGE_OFFSET]], %[[NODE_INDEX]] : index
 // CHECK-NOT: arith.cmpi
 // CHECK: ttkernel.routing_plane.fused_write_atomic_inc
+// CHECK-NOT: ttl.pipenet_local_record_loop
 
 // Each device is also the destination of one reverse edge. Destination
 // lowering uses the same compact range and row-major record calculation.
@@ -38,12 +38,12 @@
 // CHECK-NEXT: %[[DST_LOWER:.*]] = ttkernel.experimental.constant_table_lookup %[[DST_DEVICE]], [0, 1, 2] : index
 // CHECK-NEXT: %[[DST_UPPER:.*]] = ttkernel.experimental.constant_table_lookup %[[DST_NEXT_DEVICE]], [0, 1, 2] : index
 // CHECK: scf.for %[[DST_EDGE_POSITION:.*]] = %[[DST_LOWER]] to %[[DST_UPPER]] step
-// CHECK-NOT: ttl.pipenet_local_record_loop
 // CHECK-NEXT: %[[DST_EDGE_BLOCK:.*]] = ttkernel.experimental.constant_table_lookup %[[DST_EDGE_POSITION]], [1, 0] : index
 // CHECK-NEXT: %[[DST_EDGE_OFFSET:.*]] = arith.muli %[[DST_EDGE_BLOCK]], %{{.*}} : index
 // CHECK-NEXT: %[[DST_RECORD:.*]] = arith.addi %[[DST_EDGE_OFFSET]], %[[DST_NODE_INDEX]] : index
 // CHECK-NOT: arith.cmpi
 // CHECK: ttkernel.routing_plane.atomic_inc
+// CHECK-NOT: ttl.pipenet_local_record_loop
 
 #domain = #ttl.device_domain<components = <name = "device", extent = [2]>>
 #records = #ttl.pipenet_records<net 0 name "grid_major" pipes [

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_grid_major_record_index.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_grid_major_record_index.mlir
@@ -18,6 +18,7 @@
 // CHECK-NEXT: %[[LOWER:.*]] = ttkernel.experimental.constant_table_lookup %[[DEVICE]], [0, 1, 2] : index
 // CHECK-NEXT: %[[UPPER:.*]] = ttkernel.experimental.constant_table_lookup %[[NEXT_DEVICE]], [0, 1, 2] : index
 // CHECK: scf.for %[[EDGE_POSITION:.*]] = %[[LOWER]] to %[[UPPER]] step
+// CHECK-NOT: ttl.pipenet_local_record_loop
 // CHECK-NEXT: %[[EDGE_BLOCK:.*]] = ttkernel.experimental.constant_table_lookup %[[EDGE_POSITION]], [0, 1] : index
 // CHECK-NEXT: %[[EDGE_OFFSET:.*]] = arith.muli %[[EDGE_BLOCK]], %{{.*}} : index
 // CHECK-NEXT: %[[RECORD:.*]] = arith.addi %[[EDGE_OFFSET]], %[[NODE_INDEX]] : index
@@ -37,6 +38,7 @@
 // CHECK-NEXT: %[[DST_LOWER:.*]] = ttkernel.experimental.constant_table_lookup %[[DST_DEVICE]], [0, 1, 2] : index
 // CHECK-NEXT: %[[DST_UPPER:.*]] = ttkernel.experimental.constant_table_lookup %[[DST_NEXT_DEVICE]], [0, 1, 2] : index
 // CHECK: scf.for %[[DST_EDGE_POSITION:.*]] = %[[DST_LOWER]] to %[[DST_UPPER]] step
+// CHECK-NOT: ttl.pipenet_local_record_loop
 // CHECK-NEXT: %[[DST_EDGE_BLOCK:.*]] = ttkernel.experimental.constant_table_lookup %[[DST_EDGE_POSITION]], [1, 0] : index
 // CHECK-NEXT: %[[DST_EDGE_OFFSET:.*]] = arith.muli %[[DST_EDGE_BLOCK]], %{{.*}} : index
 // CHECK-NEXT: %[[DST_RECORD:.*]] = arith.addi %[[DST_EDGE_OFFSET]], %[[DST_NODE_INDEX]] : index

--- a/test/ttlang/Dialect/TTL/Transforms/pipenet_participant_plan.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipenet_participant_plan.mlir
@@ -16,6 +16,7 @@ module attributes {ttl.launch_grid = array<i64: 3, 2>} {
 // CHECK: scf.for %[[PARTICIPANT_INDEX:.*]] = %[[RECORD_OFFSET]] to %[[RECORD_END]]
 // CHECK: %[[RECORD_INDEX:.*]] = ttkernel.experimental.constant_table_lookup %[[PARTICIPANT_INDEX]], [0, 2, 4, 3, 1] : index
 // CHECK-NOT: scf.if
+// CHECK: ttl.pipenet_local_record_loop
 // CHECK: return
 func.func @participant_sender()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
@@ -50,6 +51,7 @@ func.func @participant_sender()
 // CHECK: scf.for %[[PARTICIPANT_INDEX:.*]] = %[[RECORD_OFFSET]] to %[[RECORD_END]]
 // CHECK: %[[RECORD_INDEX:.*]] = ttkernel.experimental.constant_table_lookup %[[PARTICIPANT_INDEX]], [1, 0, 4, 0, 3, 1, 2, 2, 2, 3] : index
 // CHECK-NOT: scf.if
+// CHECK: ttl.pipenet_local_record_loop
 // CHECK: return
 func.func @participant_receiver()
     attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {


### PR DESCRIPTION
### Problem description

PR #986 converts each core's selected PipeNet record count into a constant, but the generated `scf.for` still indexes the record table at runtime. That leaves loop control and table lookups in kernels whose exact transfer sequence is already known.

```mlir
scf.for %record = %zero to %three step %one {
  %value = ttkernel.experimental.constant_table_lookup %record, [3, 5, 8] : index
  func.call @consume(%value) : (index) -> ()
} {ttl.pipenet_local_record_loop}
```

The compiler should emit the known operations directly:

```mlir
%three = arith.constant 3 : index
%five = arith.constant 5 : index
%eight = arith.constant 8 : index
func.call @consume(%three) : (index) -> ()
func.call @consume(%five) : (index) -> ()
func.call @consume(%eight) : (index) -> ()
```

### What's changed

~100 LOC implementation.

The PipeNet lowering marks only compiler-generated local record loops. A TTKernel pass runs after per-core specialization and canonicalization, fully unrolls marked loops with static bounds, and removes zero-iteration loops. This exposes constant record coordinates and transfer fields to the existing canonicalizer.

Dynamic marked loops remain rolled but lose the temporary marker before code generation. Unmarked user loops and the complete-table fallback loop remain unchanged; unconditionally unrolling those loops would duplicate potentially large transfer tables.

### Stack

main -> [#982](https://github.com/tenstorrent/tt-lang/pull/982) -> [#986](https://github.com/tenstorrent/tt-lang/pull/986) -> **[#987](https://github.com/tenstorrent/tt-lang/pull/987)** -> [#988](https://github.com/tenstorrent/tt-lang/pull/988) -> [#989](https://github.com/tenstorrent/tt-lang/pull/989) -> [#990](https://github.com/tenstorrent/tt-lang/pull/990) -> [#991](https://github.com/tenstorrent/tt-lang/pull/991) -> [#992](https://github.com/tenstorrent/tt-lang/pull/992)

### Checklist

- [x] New MLIR tests cover static, single-iteration, zero-iteration, dynamic, unmarked, and nested record loops, plus enabled and disabled specialization pipelines.
- [x] New PipeNet collective tests cover table-driven record loops on device.
