### PR TITLE
[ttl][ttkernel] Add posted NoC write operations [tree-reduce-7]

### DIFF
--- a/include/ttlang/Dialect/TTKernel/IR/TTKernel.h
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernel.h
@@ -17,6 +17,12 @@ namespace mlir::tt::ttkernel {
 constexpr llvm::StringLiteral
     kExecutionCoreRangesAttrName("ttkernel.execution_core_ranges");
 
+/// Return whether enclosing `ttkernel.execution_core_ranges` attributes prove
+/// that two operations execute on disjoint worker cores. A nonnull `limit`
+/// must be a common ancestor and is excluded from the inspected metadata.
+bool haveDisjointExecutionCoreRanges(Operation *lhs, Operation *rhs,
+                                     Operation *limit = nullptr);
+
 } // namespace mlir::tt::ttkernel
 
 #endif

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4059,15 +4059,14 @@ def TTKernel_RemoteSramWriteU32Op
 
 def TTKernel_NocInlineDwWriteOp
     : TTKernel_NocWriteCommandOp<
-          "noc_inline_dw_write",
-          [TTKernel_NocCommandStatePreservingOpTrait]> {
+          "noc_inline_dw_write"> {
     let summary = "NocInlineDwWrite";
     let description = [{
       Initiates an inline 32-bit NOC write to a remote L1 address. The value is
-      provided as an SSA value, so the operation does not require a local SRAM
-      staging word. The operation uses the dedicated write-at command and does
-      not change resident asynchronous-write state. When `posted` is true, the
-      write does not request a remote acknowledgement.
+      provided as an SSA value, so callers do not provide a local SRAM staging
+      word. Resident asynchronous-write command state is unspecified after
+      this operation. When `posted` is true, the write does not request a
+      remote acknowledgement.
     }];
 
     let arguments = (ins IndexLike:$dstNocX,

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3728,7 +3728,10 @@ def TTKernel_NocAsyncWriteOp
                                  [AttrSizedOperandSegments]> {
     let summary = "NocAsyncWrite";
     let description = [{
-      NocAsyncWrite to either an L1 core coordinate or a DRAM bank.
+      Initiates an asynchronous write from local L1 to either a remote core or
+      a DRAM bank. When `posted` is true, the write does not request a remote
+      acknowledgement. Receiver-visible completion must be established by a
+      separate synchronization operation.
     }];
 
     let arguments = (ins I32:$srcLocalL1Addr,
@@ -3736,11 +3739,22 @@ def TTKernel_NocAsyncWriteOp
                          Variadic<I32>:$dstBankId,
                          I32:$dstAddress,
                          I32:$size,
-                         Optional<I8>:$noc);
+                         Optional<I8>:$noc,
+                         OptionalAttr<BoolAttr>:$posted);
 
     let assemblyFormat = [{
-      $srcLocalL1Addr `,` (`core` `[` $dstCoreXY^ `]`)? (`bank` `[` $dstBankId^ `]`)? `,` $dstAddress `,` $size (`,` `noc` $noc^)? attr-dict `:` functional-type(operands, results)
+      $srcLocalL1Addr `,` (`core` `[` $dstCoreXY^ `]`)? (`bank` `[` $dstBankId^ `]`)? `,` $dstAddress `,` $size (`,` `noc` $noc^)? (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins "Value":$srcLocalL1Addr,
+                     "::mlir::ValueRange":$dstCoreXY,
+                     "::mlir::ValueRange":$dstBankId,
+                     "Value":$dstAddress, "Value":$size, "Value":$noc), [{
+        build($_builder, $_state, srcLocalL1Addr, dstCoreXY, dstBankId,
+              dstAddress, size, noc, /*posted=*/BoolAttr{});
+      }]>,
+    ];
 
     let hasVerifier = 1;
 }
@@ -3803,16 +3817,26 @@ def TTKernel_NocAsyncWriteOnePacketSetStateOp
 
       The destination operand is a full NoC address. The companion
       `noc_async_write_one_packet_with_state` operation supplies the source L1
-      address and destination local L1 address that vary per transfer.
+      address and destination local L1 address that vary per transfer. The
+      `posted` setting is part of the command state and must match every
+      companion operation that uses it.
     }];
 
     let arguments = (ins TTKernel_NocAddr:$dstNocAddr,
                          I32:$size,
-                         Optional<I8>:$noc);
+                         Optional<I8>:$noc,
+                         OptionalAttr<BoolAttr>:$posted);
 
     let assemblyFormat = [{
-      `(` $dstNocAddr `,` $size (`,` `noc` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` $dstNocAddr `,` $size (`,` `noc` $noc^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins "Value":$dstNocAddr, "Value":$size, "Value":$noc), [{
+        build($_builder, $_state, dstNocAddr, size, noc,
+              /*posted=*/BoolAttr{});
+      }]>,
+    ];
 }
 
 def TTKernel_NocAsyncWriteOnePacketWithStateOp
@@ -3827,16 +3851,26 @@ def TTKernel_NocAsyncWriteOnePacketWithStateOp
 
       The destination local L1 address must refer to the same destination node
       that was used to set the command state. The transfer size is the size
-      programmed by the set-state operation.
+      programmed by the set-state operation. Its `posted` setting must match
+      the set-state operation.
     }];
 
     let arguments = (ins I32:$srcLocalL1Addr,
                          I32:$dstLocalL1Addr,
-                         Optional<I8>:$noc);
+                         Optional<I8>:$noc,
+                         OptionalAttr<BoolAttr>:$posted);
 
     let assemblyFormat = [{
-      `(` $srcLocalL1Addr `,` $dstLocalL1Addr (`,` `noc` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` $srcLocalL1Addr `,` $dstLocalL1Addr (`,` `noc` $noc^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins "Value":$srcLocalL1Addr, "Value":$dstLocalL1Addr,
+                     "Value":$noc), [{
+        build($_builder, $_state, srcLocalL1Addr, dstLocalL1Addr, noc,
+              /*posted=*/BoolAttr{});
+      }]>,
+    ];
 }
 
 def TTKernel_NocAsyncWriteBarrierOp
@@ -3862,6 +3896,36 @@ def TTKernel_NocAsyncWriteBarrierOp
     ];
 
     let hasCanonicalizer = 1;
+}
+
+def TTKernel_NocAsyncWritesFlushedOp
+    : TTKernel_NocWriteCommandOp<
+          "noc_async_writes_flushed",
+          [TTKernel_NocCommandStatePreservingOpTrait,
+           TTKernel_DeviceZoneOpTrait]> {
+    let summary = "NocAsyncWritesFlushed";
+    let description = [{
+      Blocks until outstanding writes of the selected response mode have
+      departed the current core on the selected NoC. This operation does not
+      wait for remote completion. When `posted` is true it observes posted
+      writes; otherwise it observes non-posted writes.
+    }];
+
+    let arguments = (ins Optional<I8>:$noc,
+                         OptionalAttr<BoolAttr>:$posted);
+
+    let assemblyFormat = [{
+      `(` ($noc^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
+    }];
+
+    let builders = [
+      OpBuilder<(ins), [{
+        build($_builder, $_state, /*noc=*/Value{}, /*posted=*/BoolAttr{});
+      }]>,
+      OpBuilder<(ins "Value":$noc), [{
+        build($_builder, $_state, noc, /*posted=*/BoolAttr{});
+      }]>,
+    ];
 }
 
 def TTKernel_NocAsyncAtomicBarrierOp
@@ -4002,19 +4066,31 @@ def TTKernel_NocInlineDwWriteOp
       Initiates an inline 32-bit NOC write to a remote L1 address. The value is
       provided as an SSA value, so the operation does not require a local SRAM
       staging word. The operation uses the dedicated write-at command and does
-      not change resident asynchronous-write state.
+      not change resident asynchronous-write state. When `posted` is true, the
+      write does not request a remote acknowledgement.
     }];
 
     let arguments = (ins IndexLike:$dstNocX,
                          IndexLike:$dstNocY,
-                         I32:$dstAddress,
+                         AnyTypeOf<[I32, TTKernel_L1Addr,
+                                    TTKernel_LocalSemaphore]>:$dstAddress,
                          I32:$val,
                          I8:$byte_enable,
-                         Optional<I8>:$noc);
+                         Optional<I8>:$noc,
+                         OptionalAttr<BoolAttr>:$posted);
 
     let assemblyFormat = [{
-      `(` `core` `[` $dstNocX `,` $dstNocY `]` `,` $dstAddress `,` $val `,` $byte_enable (`,` `noc` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` `core` `[` $dstNocX `,` $dstNocY `]` `,` $dstAddress `,` $val `,` $byte_enable (`,` `noc` $noc^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins "Value":$dstNocX, "Value":$dstNocY,
+                     "Value":$dstAddress, "Value":$val,
+                     "Value":$byte_enable, "Value":$noc), [{
+        build($_builder, $_state, dstNocX, dstNocY, dstAddress, val,
+              byte_enable, noc, /*posted=*/BoolAttr{});
+      }]>,
+    ];
 }
 
 def TTKernel_SemaphoreWaitOp : TTKernel_Op<"experimental.semaphore_wait"> {

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3880,7 +3880,9 @@ def TTKernel_NocAsyncWriteBarrierOp
            TTKernel_DeviceZoneOpTrait]> {
     let summary = "NocAsyncWriteBarrier";
     let description = [{
-      Waits for all outstanding write transactions on the given NOC.
+      Waits for remote completion of all outstanding non-posted write
+      transactions on the selected NoC. Posted writes are not observed because
+      they do not request remote acknowledgements.
     }];
 
     let arguments = (ins Optional<I8>:$noc);

--- a/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttlang/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3871,6 +3871,8 @@ def TTKernel_NocAsyncWriteOnePacketWithStateOp
               /*posted=*/BoolAttr{});
       }]>,
     ];
+
+    let hasVerifier = 1;
 }
 
 def TTKernel_NocAsyncWriteBarrierOp

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -835,6 +835,7 @@ public:
 } // namespace
 
 namespace {
+// Return whether an optional response-mode attribute selects posted writes.
 template <typename SourceOp>
 static bool usesPostedWriteMode(SourceOp op) {
   auto posted = op.getPosted();

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -835,6 +835,12 @@ public:
 } // namespace
 
 namespace {
+template <typename SourceOp>
+static bool usesPostedWriteMode(SourceOp op) {
+  auto posted = op.getPosted();
+  return posted && *posted;
+}
+
 template <typename SourceOp, typename Adaptor = typename SourceOp::Adaptor>
 class TTKernelToEmitCOpaqueRewriter : public OpConversionPattern<SourceOp> {
 public:
@@ -921,14 +927,13 @@ public:
       return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp, ttkernel::ReduceUninitOp>) {
       return ArrayAttr();
-    } else if constexpr (std::is_same_v<SourceOp,
-                                        ttkernel::NocSemaphoreIncOp> ||
-                         std::is_same_v<SourceOp,
-                                        ttkernel::NocSemaphoreIncMulticastOp>) {
-      // The metal C signature defaults `posted` to false, so emit a template
-      // arg only when the producer explicitly opts into posted semantics.
-      auto posted = op.getPosted();
-      if (!posted || !*posted) {
+    } else if constexpr (
+        std::is_same_v<SourceOp, ttkernel::NocSemaphoreIncOp> ||
+        std::is_same_v<SourceOp, ttkernel::NocSemaphoreIncMulticastOp> ||
+        std::is_same_v<SourceOp, ttkernel::NocAsyncWriteOnePacketSetStateOp> ||
+        std::is_same_v<SourceOp, ttkernel::NocAsyncWriteOnePacketWithStateOp>) {
+      // The low-level APIs default to non-posted writes.
+      if (!usesPostedWriteMode(op)) {
         return ArrayAttr();
       }
       SmallVector<Attribute, 1> template_args;
@@ -1690,6 +1695,40 @@ private:
   std::reference_wrapper<TTKernelToEmitCConversionState> state;
 };
 
+class TTKernelToEmitCNocWritesFlushedRewriter
+    : public OpConversionPattern<ttkernel::NocAsyncWritesFlushedOp> {
+public:
+  TTKernelToEmitCNocWritesFlushedRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx,
+      TTKernelToEmitCConversionState &state)
+      : OpConversionPattern<ttkernel::NocAsyncWritesFlushedOp>(typeConverter,
+                                                               ctx),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(ttkernel::NocAsyncWritesFlushedOp op,
+                  ttkernel::NocAsyncWritesFlushedOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    SmallVector<Value, 1> operands;
+    FailureOr<std::string> nocName = ensureNocDeclaration(
+        op.getOperation(), rewriter, state, operands, adaptor.getNoc());
+    if (failed(nocName)) {
+      return failure();
+    }
+    std::string templateArgument =
+        usesPostedWriteMode(op) ? "<NocOptions::POSTED>" : "";
+    std::string callStr =
+        *nocName + ".async_writes_flushed" + templateArgument + "();";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  std::reference_wrapper<TTKernelToEmitCConversionState> state;
+};
+
 template <typename SourceOp>
 class TTKernelToEmitCNocFullBarrierRewriter
     : public OpConversionPattern<SourceOp> {
@@ -1802,8 +1841,11 @@ public:
                 ", CoreLocalMem<uint32_t>({}), {}, " + endpoint.args +
                 ", {{});";
     } else {
-      callStr = *nocName + ".async_write(CoreLocalMem<uint32_t>({}), " +
-                endpoint.endpointName + ", {}, {{} , " + endpoint.args + ");";
+      std::string templateArgument =
+          usesPostedWriteMode(op) ? "<NocOptions::POSTED>" : "";
+      callStr = *nocName + ".async_write" + templateArgument +
+                "(CoreLocalMem<uint32_t>({}), " + endpoint.endpointName +
+                ", {}, {{} , " + endpoint.args + ");";
     }
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
@@ -1955,10 +1997,13 @@ public:
     SmallVector<Value, 5> operands{
         adaptor.getVal(), adaptor.getDstNocX(), adaptor.getDstNocY(),
         adaptor.getDstAddress(), adaptor.getByteEnable()};
-    std::string callStr =
-        *nocName + ".inline_dw_write<NocOptions::INLINE_L1>(" + endpoint +
-        ", {}, {{.noc_x = {}, .noc_y = {}, "
-        ".addr = static_cast<uint32_t>({})}, {});";
+    std::string options = usesPostedWriteMode(op)
+                              ? "NocOptions::INLINE_L1 | NocOptions::POSTED"
+                              : "NocOptions::INLINE_L1";
+    std::string callStr = *nocName + ".inline_dw_write<" + options + ">(" +
+                          endpoint +
+                          ", {}, {{.noc_x = {}, .noc_y = {}, "
+                          ".addr = static_cast<uint32_t>({})}, {});";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);
@@ -3443,6 +3488,7 @@ public:
     patterns
         .add<TTKernelToEmitCGetNocAddrRewriter,
              TTKernelToEmitCNocAtomicBarrierRewriter,
+             TTKernelToEmitCNocWritesFlushedRewriter,
              TTKernelToEmitCNocAsyncTileRewriter<ttkernel::NocAsyncReadTileOp>,
              TTKernelToEmitCNocAsyncTileRewriter<ttkernel::NocAsyncWriteTileOp>,
              TTKernelToEmitCNocAsyncReadOnePacketSetStateRewriter,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1721,7 +1721,7 @@ public:
     std::string callStr =
         *nocName + ".async_writes_flushed" + templateArgument + "();";
 
-    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr, operands);
+    emitc::VerbatimOp::create(rewriter, op.getLoc(), callStr, operands);
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Dialect/TTKernel/IR/TTKernelDialect.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelDialect.cpp
@@ -13,6 +13,7 @@
 #include "ttlang/Dialect/TTCore/IR/TTCore.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
@@ -22,6 +23,56 @@ using namespace mlir::tt::ttkernel;
 
 #define GET_ATTRDEF_CLASSES
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOpsAttrDefs.cpp.inc"
+
+namespace {
+
+SmallVector<ArrayAttr> getEnclosingExecutionCoreRanges(Operation *op,
+                                                       Operation *limit) {
+  SmallVector<ArrayAttr> domains;
+  for (Operation *ancestor = op->getParentOp(); ancestor && ancestor != limit;
+       ancestor = ancestor->getParentOp()) {
+    if (auto ranges =
+            ancestor->getAttrOfType<ArrayAttr>(kExecutionCoreRangesAttrName)) {
+      domains.push_back(ranges);
+    }
+  }
+  return domains;
+}
+
+bool haveDisjointCoreRanges(ArrayAttr lhs, ArrayAttr rhs) {
+  if (lhs.empty() || rhs.empty()) {
+    return false;
+  }
+  for (Attribute lhsAttr : lhs) {
+    auto lhsRange = dyn_cast<tt::ttcore::CoreRangeAttr>(lhsAttr);
+    if (!lhsRange) {
+      return false;
+    }
+    for (Attribute rhsAttr : rhs) {
+      auto rhsRange = dyn_cast<tt::ttcore::CoreRangeAttr>(rhsAttr);
+      if (!rhsRange || lhsRange.intersects(rhsRange)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+bool mlir::tt::ttkernel::haveDisjointExecutionCoreRanges(Operation *lhs,
+                                                         Operation *rhs,
+                                                         Operation *limit) {
+  SmallVector<ArrayAttr> lhsDomains =
+      getEnclosingExecutionCoreRanges(lhs, limit);
+  SmallVector<ArrayAttr> rhsDomains =
+      getEnclosingExecutionCoreRanges(rhs, limit);
+  return llvm::any_of(lhsDomains, [&](ArrayAttr lhsDomain) {
+    return llvm::any_of(rhsDomains, [&](ArrayAttr rhsDomain) {
+      return haveDisjointCoreRanges(lhsDomain, rhsDomain);
+    });
+  });
+}
 
 //===----------------------------------------------------------------------===//
 // TTKernel dialect.

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -10,15 +10,18 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "llvm/ADT/STLExtras.h"
 
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <utility>
 
 #define GET_OP_CLASSES
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.cpp.inc"
@@ -442,6 +445,181 @@ static ::mlir::LogicalResult verifyNocAsyncAddressMode(Operation *op,
 ::mlir::LogicalResult NocAsyncWriteOnePacketWithTridOp::verify() {
   return verifyNocAsyncAddressMode(getOperation(), getDstCoreXY(),
                                    getDstBankId());
+}
+
+using ConditionAssignment = std::pair<Value, bool>;
+
+/// Return the branch conditions that must hold for `operation` to execute.
+static SmallVector<ConditionAssignment>
+getEnclosingConditions(Operation *operation) {
+  SmallVector<ConditionAssignment> conditions;
+  for (Operation *ancestor = operation->getParentOp(); ancestor;
+       ancestor = ancestor->getParentOp()) {
+    auto ifOp = dyn_cast<scf::IfOp>(ancestor);
+    if (!ifOp) {
+      continue;
+    }
+    Region *operationRegion = operation->getParentRegion();
+    bool executesInThenRegion =
+        ifOp.getThenRegion().isAncestor(operationRegion);
+    bool executesInElseRegion =
+        ifOp.getElseRegion().isAncestor(operationRegion);
+    assert(executesInThenRegion != executesInElseRegion &&
+           "operation nested in scf.if must belong to exactly one branch");
+    conditions.emplace_back(ifOp.getCondition(), executesInThenRegion);
+  }
+  return conditions;
+}
+
+/// Return whether every execution of `use` also executes `setup`'s guards.
+static bool useExecutionImpliesSetupExecution(Operation *setup,
+                                              Operation *use) {
+  SmallVector<ConditionAssignment> setupConditions =
+      getEnclosingConditions(setup);
+  SmallVector<ConditionAssignment> useConditions = getEnclosingConditions(use);
+  return llvm::all_of(setupConditions, [&](ConditionAssignment setupCondition) {
+    return llvm::is_contained(useConditions, setupCondition);
+  });
+}
+
+static bool executionsMayOverlap(Operation *lhs, Operation *rhs) {
+  SmallVector<ConditionAssignment> lhsConditions =
+      getEnclosingConditions(lhs);
+  SmallVector<ConditionAssignment> rhsConditions =
+      getEnclosingConditions(rhs);
+  return llvm::none_of(lhsConditions, [&](ConditionAssignment lhsCondition) {
+    return llvm::is_contained(
+        rhsConditions,
+        ConditionAssignment{lhsCondition.first, !lhsCondition.second});
+  });
+}
+
+/// Exclude setup operations in loops that do not also contain the state use.
+static bool setupLoopExecutionsReachUse(Operation *setup, Operation *use) {
+  for (Operation *ancestor = setup->getParentOp(); ancestor;
+       ancestor = ancestor->getParentOp()) {
+    if (isa<LoopLikeOpInterface>(ancestor) && !ancestor->isAncestor(use)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Compare execution order after projecting nested operations into a common
+/// enclosing block.
+static bool structurallyPrecedes(Operation *before, Operation *after) {
+  for (Operation *ancestor = before; ancestor;
+       ancestor = ancestor->getParentOp()) {
+    if (ancestor->isProperAncestor(after)) {
+      return false;
+    }
+    if (Operation *projectedAfter =
+            ancestor->getBlock()->findAncestorOpInBlock(*after)) {
+      return ancestor->isBeforeInBlock(projectedAfter);
+    }
+  }
+  return false;
+}
+
+static bool haveSameNocSelector(Value lhs, Value rhs) {
+  if (!lhs || !rhs) {
+    return !lhs && !rhs;
+  }
+  if (lhs == rhs) {
+    return true;
+  }
+  std::optional<int64_t> lhsConstant = getConstantIntValue(lhs);
+  std::optional<int64_t> rhsConstant = getConstantIntValue(rhs);
+  return lhsConstant && rhsConstant && *lhsConstant == *rhsConstant;
+}
+
+/// Find the last state setup proven to execute before every execution of
+/// `use` on the same NoC.
+static NocAsyncWriteOnePacketSetStateOp
+findReachingWriteStateSetup(NocAsyncWriteOnePacketWithStateOp use) {
+  func::FuncOp function = use->getParentOfType<func::FuncOp>();
+  if (!function) {
+    return {};
+  }
+
+  NocAsyncWriteOnePacketSetStateOp reachingSetup;
+  function.walk([&](NocAsyncWriteOnePacketSetStateOp setup) {
+    if (!haveSameNocSelector(setup.getNoc(), use.getNoc()) ||
+        !setupLoopExecutionsReachUse(setup, use) ||
+        !useExecutionImpliesSetupExecution(setup, use) ||
+        !structurallyPrecedes(setup, use)) {
+      return;
+    }
+    if (!reachingSetup || structurallyPrecedes(reachingSetup, setup)) {
+      reachingSetup = setup;
+    }
+  });
+  return reachingSetup;
+}
+
+/// Return a state setup that may replace `reachingSetup` on only a subset of
+/// the executions that reach `use`.
+static NocAsyncWriteOnePacketSetStateOp findInterveningWriteStateSetup(
+    NocAsyncWriteOnePacketSetStateOp reachingSetup,
+    NocAsyncWriteOnePacketWithStateOp use) {
+  func::FuncOp function = use->getParentOfType<func::FuncOp>();
+  NocAsyncWriteOnePacketSetStateOp interveningSetup;
+  function.walk([&](NocAsyncWriteOnePacketSetStateOp setup) {
+    if (setup == reachingSetup ||
+        !haveSameNocSelector(setup.getNoc(), use.getNoc()) ||
+        !executionsMayOverlap(setup, use)) {
+      return;
+    }
+
+    bool precedesUse = structurallyPrecedes(setup, use);
+    bool followsReachingSetup = structurallyPrecedes(reachingSetup, setup);
+    if (precedesUse && followsReachingSetup) {
+      interveningSetup = setup;
+      return;
+    }
+
+    // A setup after the use becomes the reaching state on the next iteration
+    // unless that loop also contains the selected setup.
+    if (!structurallyPrecedes(use, setup)) {
+      return;
+    }
+    for (Operation *ancestor = use->getParentOp(); ancestor;
+         ancestor = ancestor->getParentOp()) {
+      if (!isa<LoopLikeOpInterface>(ancestor) ||
+          ancestor->isAncestor(reachingSetup)) {
+        continue;
+      }
+      if (ancestor->isAncestor(setup)) {
+        interveningSetup = setup;
+        return;
+      }
+    }
+  });
+  return interveningSetup;
+}
+
+::mlir::LogicalResult NocAsyncWriteOnePacketWithStateOp::verify() {
+  NocAsyncWriteOnePacketSetStateOp setup = findReachingWriteStateSetup(*this);
+  if (!setup) {
+    return emitOpError(
+        "requires a preceding one-packet write state setup on the same NoC "
+        "whose execution conditions cover this operation");
+  }
+  if (NocAsyncWriteOnePacketSetStateOp interveningSetup =
+          findInterveningWriteStateSetup(setup, *this)) {
+    InFlightDiagnostic diagnostic = emitOpError(
+        "cannot identify one preceding write state setup for every execution");
+    diagnostic.attachNote(interveningSetup.getLoc())
+        << "this setup may replace the selected state before a later issue";
+    return failure();
+  }
+  bool setupIsPosted = setup.getPosted().value_or(false);
+  bool useIsPosted = getPosted().value_or(false);
+  if (setupIsPosted != useIsPosted) {
+    return emitOpError(
+        "posted mode must match the preceding one-packet write state setup");
+  }
+  return success();
 }
 
 ::mlir::LogicalResult TensorAccessorArgsOp::verify() {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -521,7 +521,7 @@ static bool structurallyPrecedes(Operation *before, Operation *after) {
   return false;
 }
 
-static bool haveSameNocSelector(Value lhs, Value rhs) {
+static bool haveProvablySameNocSelector(Value lhs, Value rhs) {
   if (!lhs || !rhs) {
     return !lhs && !rhs;
   }
@@ -531,6 +531,19 @@ static bool haveSameNocSelector(Value lhs, Value rhs) {
   std::optional<int64_t> lhsConstant = getConstantIntValue(lhs);
   std::optional<int64_t> rhsConstant = getConstantIntValue(rhs);
   return lhsConstant && rhsConstant && *lhsConstant == *rhsConstant;
+}
+
+/// Return false only when two explicit constant selectors are distinct.
+static bool nocSelectorsMayAlias(Value lhs, Value rhs) {
+  if (lhs == rhs) {
+    return true;
+  }
+  if (!lhs || !rhs) {
+    return true;
+  }
+  std::optional<int64_t> lhsConstant = getConstantIntValue(lhs);
+  std::optional<int64_t> rhsConstant = getConstantIntValue(rhs);
+  return !lhsConstant || !rhsConstant || *lhsConstant == *rhsConstant;
 }
 
 /// Find the last state setup proven to execute before every execution of
@@ -544,7 +557,7 @@ findReachingWriteStateSetup(NocAsyncWriteOnePacketWithStateOp use) {
 
   NocAsyncWriteOnePacketSetStateOp reachingSetup;
   function.walk([&](NocAsyncWriteOnePacketSetStateOp setup) {
-    if (!haveSameNocSelector(setup.getNoc(), use.getNoc()) ||
+    if (!haveProvablySameNocSelector(setup.getNoc(), use.getNoc()) ||
         !setupLoopExecutionsReachUse(setup, use) ||
         !useExecutionImpliesSetupExecution(setup, use) ||
         !structurallyPrecedes(setup, use)) {
@@ -566,7 +579,7 @@ static NocAsyncWriteOnePacketSetStateOp findInterveningWriteStateSetup(
   NocAsyncWriteOnePacketSetStateOp interveningSetup;
   function.walk([&](NocAsyncWriteOnePacketSetStateOp setup) {
     if (setup == reachingSetup ||
-        !haveSameNocSelector(setup.getNoc(), use.getNoc()) ||
+        !nocSelectorsMayAlias(setup.getNoc(), use.getNoc()) ||
         !executionsMayOverlap(setup, use)) {
       return;
     }

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -483,10 +483,8 @@ static bool useExecutionImpliesSetupExecution(Operation *setup,
 }
 
 static bool executionsMayOverlap(Operation *lhs, Operation *rhs) {
-  SmallVector<ConditionAssignment> lhsConditions =
-      getEnclosingConditions(lhs);
-  SmallVector<ConditionAssignment> rhsConditions =
-      getEnclosingConditions(rhs);
+  SmallVector<ConditionAssignment> lhsConditions = getEnclosingConditions(lhs);
+  SmallVector<ConditionAssignment> rhsConditions = getEnclosingConditions(rhs);
   return llvm::none_of(lhsConditions, [&](ConditionAssignment lhsCondition) {
     return llvm::is_contained(
         rhsConditions,
@@ -572,9 +570,9 @@ findReachingWriteStateSetup(NocAsyncWriteOnePacketWithStateOp use) {
 
 /// Return a state setup that may replace `reachingSetup` on only a subset of
 /// the executions that reach `use`.
-static NocAsyncWriteOnePacketSetStateOp findInterveningWriteStateSetup(
-    NocAsyncWriteOnePacketSetStateOp reachingSetup,
-    NocAsyncWriteOnePacketWithStateOp use) {
+static NocAsyncWriteOnePacketSetStateOp
+findInterveningWriteStateSetup(NocAsyncWriteOnePacketSetStateOp reachingSetup,
+                               NocAsyncWriteOnePacketWithStateOp use) {
   func::FuncOp function = use->getParentOfType<func::FuncOp>();
   NocAsyncWriteOnePacketSetStateOp interveningSetup;
   function.walk([&](NocAsyncWriteOnePacketSetStateOp setup) {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -449,7 +449,7 @@ static ::mlir::LogicalResult verifyNocAsyncAddressMode(Operation *op,
 
 using ConditionAssignment = std::pair<Value, bool>;
 
-/// Return the branch conditions that must hold for `operation` to execute.
+// Return the branch conditions that must hold for `operation` to execute.
 static SmallVector<ConditionAssignment>
 getEnclosingConditions(Operation *operation) {
   SmallVector<ConditionAssignment> conditions;
@@ -471,7 +471,7 @@ getEnclosingConditions(Operation *operation) {
   return conditions;
 }
 
-/// Return whether every execution of `use` also executes `setup`'s guards.
+// Return whether every execution of `use` also executes `setup`'s guards.
 static bool useExecutionImpliesSetupExecution(Operation *setup,
                                               Operation *use) {
   SmallVector<ConditionAssignment> setupConditions =
@@ -482,6 +482,7 @@ static bool useExecutionImpliesSetupExecution(Operation *setup,
   });
 }
 
+// Return false only when a shared branch condition proves mutual exclusion.
 static bool executionsMayOverlap(Operation *lhs, Operation *rhs) {
   SmallVector<ConditionAssignment> lhsConditions = getEnclosingConditions(lhs);
   SmallVector<ConditionAssignment> rhsConditions = getEnclosingConditions(rhs);
@@ -492,7 +493,7 @@ static bool executionsMayOverlap(Operation *lhs, Operation *rhs) {
   });
 }
 
-/// Exclude setup operations in loops that do not also contain the state use.
+// Exclude setup operations in loops that do not also contain the state use.
 static bool setupLoopExecutionsReachUse(Operation *setup, Operation *use) {
   for (Operation *ancestor = setup->getParentOp(); ancestor;
        ancestor = ancestor->getParentOp()) {
@@ -503,8 +504,8 @@ static bool setupLoopExecutionsReachUse(Operation *setup, Operation *use) {
   return true;
 }
 
-/// Compare execution order after projecting nested operations into a common
-/// enclosing block.
+// Compare execution order after projecting nested operations into a common
+// enclosing block.
 static bool structurallyPrecedes(Operation *before, Operation *after) {
   for (Operation *ancestor = before; ancestor;
        ancestor = ancestor->getParentOp()) {
@@ -519,6 +520,8 @@ static bool structurallyPrecedes(Operation *before, Operation *after) {
   return false;
 }
 
+// Prove selector equality from SSA identity, equal constants, or two omitted
+// selectors that both select the default NoC.
 static bool haveProvablySameNocSelector(Value lhs, Value rhs) {
   if (!lhs || !rhs) {
     return !lhs && !rhs;
@@ -531,7 +534,7 @@ static bool haveProvablySameNocSelector(Value lhs, Value rhs) {
   return lhsConstant && rhsConstant && *lhsConstant == *rhsConstant;
 }
 
-/// Return false only when two explicit constant selectors are distinct.
+// Return false only when two explicit constant selectors are distinct.
 static bool nocSelectorsMayAlias(Value lhs, Value rhs) {
   if (lhs == rhs) {
     return true;
@@ -544,8 +547,8 @@ static bool nocSelectorsMayAlias(Value lhs, Value rhs) {
   return !lhsConstant || !rhsConstant || *lhsConstant == *rhsConstant;
 }
 
-/// Find the last state setup proven to execute before every execution of
-/// `use` on the same NoC.
+// Find the last state setup proven to execute before every execution of `use`
+// on the same NoC.
 static NocAsyncWriteOnePacketSetStateOp
 findReachingWriteStateSetup(NocAsyncWriteOnePacketWithStateOp use) {
   func::FuncOp function = use->getParentOfType<func::FuncOp>();
@@ -568,8 +571,8 @@ findReachingWriteStateSetup(NocAsyncWriteOnePacketWithStateOp use) {
   return reachingSetup;
 }
 
-/// Return a state setup that may replace `reachingSetup` on only a subset of
-/// the executions that reach `use`.
+// Return a state setup that may replace `reachingSetup` on only a subset of the
+// executions that reach `use`.
 static NocAsyncWriteOnePacketSetStateOp
 findInterveningWriteStateSetup(NocAsyncWriteOnePacketSetStateOp reachingSetup,
                                NocAsyncWriteOnePacketWithStateOp use) {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -721,12 +721,10 @@ void NocAsyncWriteBarrierOp::getCanonicalizationPatterns(
           return success();
         }
       }
-      if (mlir::isa<NocAsyncWriteOp, NocAsyncWriteTileOp,
-                    NocAsyncWriteOnePacketWithTridOp, NocAsyncWriteMulticastOp,
-                    NocAsyncWriteMulticastOnePacketOp,
-                    NocAsyncWriteMulticastLoopbackSrcOp, NocInlineDwWriteOp>(
-              it) ||
-          it->getNumRegions() > 0) {
+      bool issuesOrConfiguresWrite =
+          accessesNocCommand(it, NocCommandClass::Write) &&
+          !mlir::isa<NocAsyncWriteBarrierOp, NocAsyncWritesFlushedOp>(it);
+      if (issuesOrConfiguresWrite || it->getNumRegions() > 0) {
         break;
       }
     }

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -5,6 +5,7 @@
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
 
 #include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttlang/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttlang/Dialect/Utils/OpaqueCallVerifyUtils.h"
 
@@ -14,6 +15,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "llvm/ADT/STLExtras.h"
@@ -482,15 +484,11 @@ static bool useExecutionImpliesSetupExecution(Operation *setup,
   });
 }
 
-// Return false only when a shared branch condition proves mutual exclusion.
+// Return false when branch conditions or execution-core metadata prove that
+// the operations cannot execute on the same worker core.
 static bool executionsMayOverlap(Operation *lhs, Operation *rhs) {
-  SmallVector<ConditionAssignment> lhsConditions = getEnclosingConditions(lhs);
-  SmallVector<ConditionAssignment> rhsConditions = getEnclosingConditions(rhs);
-  return llvm::none_of(lhsConditions, [&](ConditionAssignment lhsCondition) {
-    return llvm::is_contained(
-        rhsConditions,
-        ConditionAssignment{lhsCondition.first, !lhsCondition.second});
-  });
+  return !insideMutuallyExclusiveRegions(lhs, rhs) &&
+         !haveDisjointExecutionCoreRanges(lhs, rhs);
 }
 
 // Exclude setup operations in loops that do not also contain the state use.

--- a/lib/Dialect/TTKernel/Transforms/TTKernelCleanupPatterns.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelCleanupPatterns.cpp
@@ -364,11 +364,13 @@ struct UseStatefulNocWriteInLoop : OpRewritePattern<NocAsyncWriteOp> {
       rewriter.setInsertionPointToStart(&setupIf.getThenRegion().front());
     }
     NocAsyncWriteOnePacketSetStateOp::create(
-        rewriter, loc, destinationNocAddress, op.getSize(), op.getNoc());
+        rewriter, loc, destinationNocAddress, op.getSize(), op.getNoc(),
+        op.getPostedAttr());
 
     rewriter.setInsertionPoint(op);
     NocAsyncWriteOnePacketWithStateOp::create(
-        rewriter, loc, op.getSrcLocalL1Addr(), op.getDstAddress(), op.getNoc());
+        rewriter, loc, op.getSrcLocalL1Addr(), op.getDstAddress(), op.getNoc(),
+        op.getPostedAttr());
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Dialect/TTKernel/Transforms/TTKernelCleanupPatterns.cpp
+++ b/lib/Dialect/TTKernel/Transforms/TTKernelCleanupPatterns.cpp
@@ -4,7 +4,6 @@
 
 #include "ttlang/Dialect/TTKernel/Transforms/TTKernelCleanupPatterns.h"
 
-#include "ttlang/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttlang/Target/TargetInfo.h"
@@ -44,56 +43,13 @@ static bool isDefinedOutsideRegion(Value value, Region *region) {
   return !region->isAncestor(definingOp->getParentRegion());
 }
 
-/// Return execution-domain constraints between `op` and `limit`.
-static SmallVector<ArrayAttr>
-getEnclosingExecutionCoreRanges(Operation *op, Operation *limit) {
-  SmallVector<ArrayAttr> domains;
-  for (Operation *ancestor = op->getParentOp(); ancestor && ancestor != limit;
-       ancestor = ancestor->getParentOp()) {
-    if (auto ranges =
-            ancestor->getAttrOfType<ArrayAttr>(kExecutionCoreRangesAttrName)) {
-      domains.push_back(ranges);
-    }
-  }
-  return domains;
-}
-
-/// Return whether two core-range arrays have an empty intersection.
-static bool haveDisjointCoreRanges(ArrayAttr lhs, ArrayAttr rhs) {
-  if (lhs.empty() || rhs.empty()) {
-    return false;
-  }
-  for (Attribute lhsAttr : lhs) {
-    auto lhsRange = dyn_cast<ttcore::CoreRangeAttr>(lhsAttr);
-    if (!lhsRange) {
-      return false;
-    }
-    for (Attribute rhsAttr : rhs) {
-      auto rhsRange = dyn_cast<ttcore::CoreRangeAttr>(rhsAttr);
-      if (!rhsRange || lhsRange.intersects(rhsRange)) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 /// Return whether two operations cannot execute on the same loop iteration.
 static bool haveMutuallyExclusiveExecution(Operation *lhs, Operation *rhs,
                                            Operation *loop) {
   if (insideMutuallyExclusiveRegions(lhs, rhs)) {
     return true;
   }
-
-  SmallVector<ArrayAttr> lhsDomains =
-      getEnclosingExecutionCoreRanges(lhs, loop);
-  SmallVector<ArrayAttr> rhsDomains =
-      getEnclosingExecutionCoreRanges(rhs, loop);
-  return llvm::any_of(lhsDomains, [&](ArrayAttr lhsDomain) {
-    return llvm::any_of(rhsDomains, [&](ArrayAttr rhsDomain) {
-      return haveDisjointCoreRanges(lhsDomain, rhsDomain);
-    });
-  });
+  return haveDisjointExecutionCoreRanges(lhs, rhs, loop);
 }
 
 /// Deduplicate consecutive barriers of the same type and NoC. Barriers only

--- a/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write.mlir
@@ -1,0 +1,21 @@
+// Summary: Verifies valid stateful one-packet write setup and issue contracts.
+// RUN: ttlang-opt %s -verify-each -o /dev/null
+
+// Proven-distinct constant NoC selectors do not interfere with resident state.
+func.func @distinct_constant_noc_does_not_interfere(
+    %initial_state_address: !ttkernel.noc_addr,
+    %intervening_state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32) {
+  %noc0 = arith.constant 0 : i8
+  %noc1 = arith.constant 1 : i8
+  ttkernel.noc_async_write_one_packet_set_state(
+      %initial_state_address, %size, noc %noc0)
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  ttkernel.noc_async_write_one_packet_set_state(
+      %intervening_state_address, %size, noc %noc1) posted true
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %noc0)
+      : (i32, i32, i8) -> ()
+  func.return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write.mlir
@@ -19,3 +19,26 @@ func.func @distinct_constant_noc_does_not_interfere(
       : (i32, i32, i8) -> ()
   func.return
 }
+
+// A setup at the start of each iteration restores state changed after the
+// preceding issue.
+func.func @loop_setup_restores_state_before_each_issue(
+    %initial_state_address: !ttkernel.noc_addr,
+    %later_state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32, %noc: i8) {
+  %lower = arith.constant 0 : index
+  %upper = arith.constant 2 : index
+  %step = arith.constant 1 : index
+  scf.for %iteration = %lower to %upper step %step {
+    ttkernel.noc_async_write_one_packet_set_state(
+        %initial_state_address, %size, noc %noc)
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+    ttkernel.noc_async_write_one_packet_with_state(
+        %source_address, %destination_address, noc %noc)
+        : (i32, i32, i8) -> ()
+    ttkernel.noc_async_write_one_packet_set_state(
+        %later_state_address, %size, noc %noc) posted true
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  }
+  func.return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write.mlir
@@ -42,3 +42,27 @@ func.func @loop_setup_restores_state_before_each_issue(
   }
   func.return
 }
+
+// Setups for disjoint worker cores cannot replace each other's resident state.
+func.func @disjoint_core_setups_do_not_interfere(
+    %core_zero: i1, %core_one: i1,
+    %core_zero_state_address: !ttkernel.noc_addr,
+    %core_one_state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32, %noc: i8) {
+  scf.if %core_one {
+    ttkernel.noc_async_write_one_packet_set_state(
+        %core_one_state_address, %size, noc %noc)
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  } {ttkernel.execution_core_ranges = [#ttcore.core_range<(1, 0), (1, 0)>]}
+  scf.if %core_zero {
+    ttkernel.noc_async_write_one_packet_set_state(
+        %core_zero_state_address, %size, noc %noc)
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  } {ttkernel.execution_core_ranges = [#ttcore.core_range<(0, 0), (0, 0)>]}
+  scf.if %core_one {
+    ttkernel.noc_async_write_one_packet_with_state(
+        %source_address, %destination_address, noc %noc)
+        : (i32, i32, i8) -> ()
+  } {ttkernel.execution_core_ranges = [#ttcore.core_range<(1, 0), (1, 0)>]}
+  func.return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
@@ -96,3 +96,30 @@ func.func @dynamic_intervening_noc_may_alias(
       : (i32, i32, i8) -> ()
   func.return
 }
+
+// -----
+
+// State changed after an issue remains changed when the next loop iteration
+// reaches that issue without restoring the selected setup.
+func.func @later_iteration_uses_intervening_state(
+    %initial_state_address: !ttkernel.noc_addr,
+    %later_state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32, %noc: i8) {
+  %lower = arith.constant 0 : index
+  %upper = arith.constant 2 : index
+  %step = arith.constant 1 : index
+  ttkernel.noc_async_write_one_packet_set_state(
+      %initial_state_address, %size, noc %noc)
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  scf.for %iteration = %lower to %upper step %step {
+    // expected-error @below {{'ttkernel.noc_async_write_one_packet_with_state' op cannot identify one preceding write state setup for every execution}}
+    ttkernel.noc_async_write_one_packet_with_state(
+        %source_address, %destination_address, noc %noc)
+        : (i32, i32, i8) -> ()
+    // expected-note @below {{this setup may replace the selected state before a later issue}}
+    ttkernel.noc_async_write_one_packet_set_state(
+        %later_state_address, %size, noc %noc) posted true
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  }
+  func.return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
@@ -74,3 +74,25 @@ func.func @conditional_intervening_setup(
       : (i32, i32, i8) -> ()
   func.return
 }
+
+// -----
+
+// Distinct dynamic selectors may identify the same NoC at runtime.
+func.func @dynamic_intervening_noc_may_alias(
+    %initial_noc: i8, %intervening_noc: i8,
+    %initial_state_address: !ttkernel.noc_addr,
+    %intervening_state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32) {
+  ttkernel.noc_async_write_one_packet_set_state(
+      %initial_state_address, %size, noc %initial_noc)
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  // expected-note @below {{this setup may replace the selected state before a later issue}}
+  ttkernel.noc_async_write_one_packet_set_state(
+      %intervening_state_address, %size, noc %intervening_noc) posted true
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  // expected-error @below {{'ttkernel.noc_async_write_one_packet_with_state' op cannot identify one preceding write state setup for every execution}}
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %initial_noc)
+      : (i32, i32, i8) -> ()
+  func.return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
@@ -1,0 +1,76 @@
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics
+
+// Summary: Verifies stateful one-packet write setup and issue contracts.
+
+// The issue operation must use the response mode programmed in the resident
+// write command.
+func.func @posted_mode_mismatch(
+    %state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32, %noc: i8) {
+  ttkernel.noc_async_write_one_packet_set_state(
+      %state_address, %size, noc %noc) posted true
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  // expected-error @below {{'ttkernel.noc_async_write_one_packet_with_state' op posted mode must match the preceding one-packet write state setup}}
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %noc)
+      : (i32, i32, i8) -> ()
+  func.return
+}
+
+// -----
+
+// A conditional setup cannot initialize state for an unconditional issue.
+func.func @conditional_setup(
+    %condition: i1, %state_address: !ttkernel.noc_addr,
+    %source_address: i32, %destination_address: i32, %size: i32, %noc: i8) {
+  scf.if %condition {
+    ttkernel.noc_async_write_one_packet_set_state(
+        %state_address, %size, noc %noc)
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  }
+  // expected-error @below {{'ttkernel.noc_async_write_one_packet_with_state' op requires a preceding one-packet write state setup on the same NoC whose execution conditions cover this operation}}
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %noc)
+      : (i32, i32, i8) -> ()
+  func.return
+}
+
+// -----
+
+// State programmed on another NoC does not configure this issue operation.
+func.func @different_noc(
+    %state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32, %setup_noc: i8, %use_noc: i8) {
+  ttkernel.noc_async_write_one_packet_set_state(
+      %state_address, %size, noc %setup_noc)
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  // expected-error @below {{'ttkernel.noc_async_write_one_packet_with_state' op requires a preceding one-packet write state setup on the same NoC whose execution conditions cover this operation}}
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %use_noc)
+      : (i32, i32, i8) -> ()
+  func.return
+}
+
+// -----
+
+// A setup that executes conditionally between the common setup and issue can
+// change the resident destination, size, and response mode for some issues.
+func.func @conditional_intervening_setup(
+    %condition: i1, %initial_state_address: !ttkernel.noc_addr,
+    %conditional_state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32, %noc: i8) {
+  ttkernel.noc_async_write_one_packet_set_state(
+      %initial_state_address, %size, noc %noc)
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  scf.if %condition {
+    // expected-note @below {{this setup may replace the selected state before a later issue}}
+    ttkernel.noc_async_write_one_packet_set_state(
+        %conditional_state_address, %size, noc %noc) posted true
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  }
+  // expected-error @below {{'ttkernel.noc_async_write_one_packet_with_state' op cannot identify one preceding write state setup for every execution}}
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %noc)
+      : (i32, i32, i8) -> ()
+  func.return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_stateful_write_invalid.mlir
@@ -77,6 +77,35 @@ func.func @conditional_intervening_setup(
 
 // -----
 
+// Overlapping execution-core ranges do not prove that conditional setups are
+// mutually exclusive.
+func.func @overlapping_core_setups_may_interfere(
+    %first_condition: i1, %second_condition: i1,
+    %first_state_address: !ttkernel.noc_addr,
+    %second_state_address: !ttkernel.noc_addr, %source_address: i32,
+    %destination_address: i32, %size: i32, %noc: i8) {
+  scf.if %first_condition {
+    ttkernel.noc_async_write_one_packet_set_state(
+        %first_state_address, %size, noc %noc)
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  } {ttkernel.execution_core_ranges = [#ttcore.core_range<(0, 0), (1, 0)>]}
+  scf.if %second_condition {
+    // expected-note @below {{this setup may replace the selected state before a later issue}}
+    ttkernel.noc_async_write_one_packet_set_state(
+        %second_state_address, %size, noc %noc)
+        : (!ttkernel.noc_addr, i32, i8) -> ()
+  } {ttkernel.execution_core_ranges = [#ttcore.core_range<(1, 0), (2, 0)>]}
+  scf.if %first_condition {
+    // expected-error @below {{'ttkernel.noc_async_write_one_packet_with_state' op cannot identify one preceding write state setup for every execution}}
+    ttkernel.noc_async_write_one_packet_with_state(
+        %source_address, %destination_address, noc %noc)
+        : (i32, i32, i8) -> ()
+  } {ttkernel.execution_core_ranges = [#ttcore.core_range<(0, 0), (1, 0)>]}
+  func.return
+}
+
+// -----
+
 // Distinct dynamic selectors may identify the same NoC at runtime.
 func.func @dynamic_intervening_noc_may_alias(
     %initial_noc: i8, %intervening_noc: i8,

--- a/test/ttlang/Dialect/TTKernel/IR/noc_write_barrier.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_write_barrier.mlir
@@ -1,0 +1,40 @@
+// RUN: ttlang-opt %s --canonicalize | FileCheck %s
+
+// Summary: Verifies a stateful write prevents removal of a subsequent write
+// barrier, while redundant barriers without an intervening write are removed.
+
+// CHECK-LABEL: func.func @preserve_after_stateful_write
+// CHECK: ttkernel.noc_async_write_barrier
+// CHECK: ttkernel.noc_async_write_one_packet_with_state
+// CHECK: ttkernel.noc_async_write_barrier
+func.func @preserve_after_stateful_write() {
+  %coordinate = arith.constant 0 : index
+  %noc = arith.constant 0 : i8
+  %destination_address = arith.constant 4096 : i32
+  %source_address = arith.constant 8192 : i32
+  %size = arith.constant 896 : i32
+  %destination_noc_address = ttkernel.get_noc_addr(
+      %coordinate, %coordinate, %destination_address, %noc)
+      : (index, index, i32, i8) -> !ttkernel.noc_addr
+  ttkernel.noc_async_write_one_packet_set_state(
+      %destination_noc_address, %size, noc %noc)
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %noc)
+      : (i32, i32, i8) -> ()
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %noc)
+      : (i32, i32, i8) -> ()
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  func.return
+}
+
+// CHECK-LABEL: func.func @remove_redundant_barrier
+// CHECK-COUNT-1: ttkernel.noc_async_write_barrier
+func.func @remove_redundant_barrier() {
+  %noc = arith.constant 0 : i8
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  func.return
+}

--- a/test/ttlang/Dialect/TTKernel/IR/noc_write_barrier.mlir
+++ b/test/ttlang/Dialect/TTKernel/IR/noc_write_barrier.mlir
@@ -38,3 +38,14 @@ func.func @remove_redundant_barrier() {
   ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
   func.return
 }
+
+// CHECK-LABEL: func.func @departure_wait_does_not_issue_write
+// CHECK-COUNT-1: ttkernel.noc_async_write_barrier
+// CHECK: ttkernel.noc_async_writes_flushed
+func.func @departure_wait_does_not_issue_write() {
+  %noc = arith.constant 0 : i8
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  ttkernel.noc_async_writes_flushed(%noc) : (i8) -> ()
+  ttkernel.noc_async_write_barrier(%noc) : (i8) -> ()
+  func.return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_stateful_one_packet_write.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_stateful_one_packet_write.mlir
@@ -104,6 +104,30 @@ func.func @inline_word_write_invalidates_async_write_state(
 
 // -----
 
+// Stateful lowering must preserve posted response mode on both operations;
+// mixing response modes would program and issue different command semantics.
+// CHECK-LABEL: func.func @posted_write_preserves_response_mode
+// CHECK: ttkernel.noc_async_write_one_packet_set_state({{.*}}) posted true
+// CHECK: scf.for
+// CHECK: ttkernel.noc_async_write_one_packet_with_state({{.*}}) posted true
+// CHECK-NOT: ttkernel.noc_async_write{{[ (]}}
+func.func @posted_write_preserves_response_mode(
+    %src_addr: i32, %dst_addr: i32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %noc = arith.constant 0 : i8
+  %size = arith.constant 896 : i32
+  scf.for %iteration = %c0 to %c4 step %c1 {
+    ttkernel.noc_async_write
+        %src_addr, core[%c1, %c0], %dst_addr, %size, noc %noc posted true
+        : (i32, index, index, i32, i32, i8) -> ()
+  }
+  func.return
+}
+
+// -----
+
 // A call in the loop may execute another NoC write and must prevent resident
 // write-command reuse across iterations.
 // CHECK-LABEL: func.func private @reprogram_write

--- a/test/ttlang/Dialect/TTL/Transforms/pipe_stateful_one_packet_write.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/pipe_stateful_one_packet_write.mlir
@@ -74,15 +74,15 @@ module attributes {ttl.launch_grid = array<i64: 2, 1>} {
 
 // -----
 
-// An inline word write uses a separate NoC command buffer, so it does not
-// prevent reuse of the resident asynchronous-write command on the same core.
-// CHECK-LABEL: func.func @inline_word_write_preserves_async_write_state
-// CHECK: ttkernel.noc_async_write_one_packet_set_state
+// An inline L1 write may use the ordinary asynchronous-write command, so the
+// loop cannot reuse resident write state across iterations.
+// CHECK-LABEL: func.func @inline_word_write_invalidates_async_write_state
+// CHECK-NOT: ttkernel.noc_async_write_one_packet_set_state
 // CHECK: scf.for
 // CHECK: ttkernel.noc_inline_dw_write
-// CHECK: ttkernel.noc_async_write_one_packet_with_state
-// CHECK-NOT: ttkernel.noc_async_write{{[ (]}}
-func.func @inline_word_write_preserves_async_write_state(
+// CHECK: ttkernel.noc_async_write{{[ (]}}
+// CHECK-NOT: ttkernel.noc_async_write_one_packet_with_state
+func.func @inline_word_write_invalidates_async_write_state(
     %src_addr: i32, %dst_addr: i32) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index

--- a/test/ttlang/Translate/TTLToCpp/posted_noc_writes.mlir
+++ b/test/ttlang/Translate/TTLToCpp/posted_noc_writes.mlir
@@ -1,0 +1,60 @@
+// RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %s -o %t.emitc.mlir
+// RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
+// RUN: FileCheck %s --input-file=%t.cpp --check-prefix=CPP
+
+// Summary: Verifies posted and non-posted payload, stateful one-packet,
+// inline, and departure-wait operations lower to the corresponding NoC APIs.
+
+func.func @posted_noc_writes() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+  %coordinate = arith.constant 0 : index
+  %noc = arith.constant 0 : i8
+  %bank = arith.constant 1 : i32
+  %destination_address = arith.constant 4096 : i32
+  %source_address = arith.constant 8192 : i32
+  %size = arith.constant 896 : i32
+  %value = arith.constant 1 : i32
+  %byte_enable = arith.constant 15 : i8
+  %local_semaphore = ttkernel.get_semaphore(%coordinate)
+      : (index) -> !ttkernel.local_semaphore
+  %typed_address = ttkernel.cast_to_l1_addr %local_semaphore
+      : !ttkernel.local_semaphore to !ttkernel.l1_addr
+  %destination_noc_address = ttkernel.get_noc_addr(
+      %coordinate, %coordinate, %destination_address, %noc)
+      : (index, index, i32, i8) -> !ttkernel.noc_addr
+
+  ttkernel.noc_async_write %source_address,
+      core[%coordinate, %coordinate], %destination_address, %size, noc %noc
+      posted true : (i32, index, index, i32, i32, i8) -> ()
+  ttkernel.noc_async_write %source_address, bank[%bank],
+      %destination_address, %size, noc %noc posted true
+      : (i32, i32, i32, i32, i8) -> ()
+  ttkernel.noc_async_write_one_packet_set_state(
+      %destination_noc_address, %size, noc %noc) posted true
+      : (!ttkernel.noc_addr, i32, i8) -> ()
+  ttkernel.noc_async_write_one_packet_with_state(
+      %source_address, %destination_address, noc %noc) posted true
+      : (i32, i32, i8) -> ()
+  ttkernel.noc_inline_dw_write(
+      core[%coordinate, %coordinate], %destination_address, %value,
+      %byte_enable, noc %noc) posted true
+      : (index, index, i32, i32, i8, i8) -> ()
+  ttkernel.noc_inline_dw_write(
+      core[%coordinate, %coordinate], %local_semaphore, %value,
+      %byte_enable, noc %noc) posted true
+      : (index, index, !ttkernel.local_semaphore, i32, i8, i8) -> ()
+  ttkernel.noc_inline_dw_write(
+      core[%coordinate, %coordinate], %typed_address, %value,
+      %byte_enable, noc %noc) posted true
+      : (index, index, !ttkernel.l1_addr, i32, i8, i8) -> ()
+  ttkernel.noc_async_writes_flushed(%noc) posted true : (i8) -> ()
+  ttkernel.noc_async_writes_flushed(%noc) : (i8) -> ()
+  func.return
+}
+
+// CPP-LABEL: void kernel_main() {
+// CPP-COUNT-2: .async_write<NocOptions::POSTED>
+// CPP: noc_async_write_one_packet_set_state<true>
+// CPP-NEXT: noc_async_write_one_packet_with_state<true>
+// CPP-COUNT-3: .inline_dw_write<NocOptions::INLINE_L1 | NocOptions::POSTED>
+// CPP-NEXT: noc0.async_writes_flushed<NocOptions::POSTED>();
+// CPP-NEXT: noc0.async_writes_flushed();


### PR DESCRIPTION
### Problem description

One-shot PipeNet transfers track remote completion with a separate completion word. The payload and completion writes therefore use posted NoC commands, and the sender reuses its source only after those commands leave the local command queue. Existing TTKernel IR represented acknowledged writes and remote-completion barriers only, so it could not distinguish local command departure from remote completion.

The required IR is explicit about both the posted write mode and the wait condition:

```mlir
ttkernel.noc_async_write %src, core[%x, %y], %dst, %size, noc %noc posted true
ttkernel.noc_inline_dw_write core[%x, %y], %semaphore, %value, %mask, noc %noc posted true
ttkernel.noc_async_writes_flushed(%noc) posted true
```

### What's changed

~415 LOC implementation.

Asynchronous, stateful one-packet, and inline-word NoC write operations now represent posted and non-posted response modes. Existing builders and write barriers remain non-posted by default, preserving current acknowledged-write behavior.

`ttkernel.noc_async_writes_flushed` with `posted true` waits for posted commands to leave the source command queue without asserting remote completion. This supplies the source-reuse condition needed by one-shot PipeNet signaling while the receiver continues to determine completion from its completion word.

Stateful one-packet writes verify that each issue uses the response mode established by one unambiguous preceding setup. Setups on statically disjoint worker cores are independent; unknown or overlapping core ranges remain conservative.

Canonicalization does not reuse resident NoC command state across operations that may replace or consume it.

### Stack

main -> [#982](https://github.com/tenstorrent/tt-lang/pull/982) -> [#986](https://github.com/tenstorrent/tt-lang/pull/986) -> [#987](https://github.com/tenstorrent/tt-lang/pull/987) -> **[#988](https://github.com/tenstorrent/tt-lang/pull/988)** -> [#989](https://github.com/tenstorrent/tt-lang/pull/989) -> [#990](https://github.com/tenstorrent/tt-lang/pull/990) -> [#991](https://github.com/tenstorrent/tt-lang/pull/991) -> [#992](https://github.com/tenstorrent/tt-lang/pull/992)

### Checklist

- [x] New MLIR tests cover posted and non-posted C++ lowering, stateful command preservation, loop-carried state replacement, disjoint-core setup independence, and barrier canonicalization.
