### PR TITLE
[ttl][compute] Publish row-prefix outputs as short tiles [tree-reduce-11]

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -321,9 +321,9 @@ def TTL_ComputeOp : TTL_Op<"compute", [
   let description = [{
     `ttl.compute` is a structured operation similar to `linalg.generic` but with
     tile-typed block arguments. It iterates over a grid of tiles and applies
-    the body computation to each tile position. Circular buffers are associated
-    to tensor operands/results via `ttl.attach_cb` (one CB per tensor SSA
-    value); `ttl.compute` itself only carries tensor operands.
+    the body computation to each tile position. `ttl.attach_cb` associates one
+    dataflow buffer (DFB) with each tensor SSA operand or result.
+    `ttl.compute` itself carries only tensor operands.
 
     The operation takes tensors of tiles as inputs and outputs. The block
     arguments are individual tiles (`!ttcore.tile<H, W, dtype>`) extracted from
@@ -333,23 +333,10 @@ def TTL_ComputeOp : TTL_Op<"compute", [
     iterator. The accumulator remains resident in DST across the corresponding
     reduction iterations.
 
-    In the pipeline, `ttl.compute` is lowered to `scf.for` loops by
-    `ttl-lower-to-loops` BEFORE bufferization. The `ttl.tile_*` ops in the
-    loop body are then converted to TTKernel ops after bufferization.
-
-    Example:
-    ```mlir
-    %result = ttl.compute
-        ins(%a, %b : tensor<4x4x!ttcore.tile<32x32, f32>>,
-                     tensor<4x4x!ttcore.tile<32x32, f32>>)
-        outs(%init : tensor<4x4x!ttcore.tile<32x32, f32>>) {
-      ^bb0(%a_tile: !ttcore.tile<32x32, f32>,
-           %b_tile: !ttcore.tile<32x32, f32>,
-           %out_tile: !ttcore.tile<32x32, f32>):
-        %sum = ttl.tile_add %a_tile, %b_tile : !ttcore.tile<32x32, f32>
-        ttl.yield
-    } -> tensor<4x4x!ttcore.tile<32x32, f32>>
-    ```
+    Every iteration dimension must occur in at least one operand indexing map
+    so its bound is defined. Tensor dimensions may use constant-zero map
+    results only when their extent is one. A zero-rank iteration domain
+    therefore represents one execution over unit-extent tensor operands.
   }];
 
   let arguments = (ins

--- a/include/ttlang/Dialect/TTL/IR/TTLOps.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOps.td
@@ -337,6 +337,61 @@ def TTL_ComputeOp : TTL_Op<"compute", [
     so its bound is defined. Tensor dimensions may use constant-zero map
     results only when their extent is one. A zero-rank iteration domain
     therefore represents one execution over unit-extent tensor operands.
+
+    Example:
+    ```mlir
+    #identity = affine_map<(dim0, dim1) -> (dim0, dim1)>
+
+    func.func @add(
+        %lhs: tensor<4x4x!ttcore.tile<32x32, f32>>,
+        %rhs: tensor<4x4x!ttcore.tile<32x32, f32>>,
+        %init: tensor<4x4x!ttcore.tile<32x32, f32>>)
+        -> tensor<4x4x!ttcore.tile<32x32, f32>> {
+      %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 2} :
+          !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+      %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 2} :
+          !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+      %out_dfb = ttl.bind_cb {cb_index = 2, block_count = 2} :
+          !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+      %lhs_attached = ttl.attach_cb %lhs, %lhs_dfb :
+          (tensor<4x4x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+          -> tensor<4x4x!ttcore.tile<32x32, f32>>
+      %rhs_attached = ttl.attach_cb %rhs, %rhs_dfb :
+          (tensor<4x4x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+          -> tensor<4x4x!ttcore.tile<32x32, f32>>
+      %init_attached = ttl.attach_cb %init, %out_dfb :
+          (tensor<4x4x!ttcore.tile<32x32, f32>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+          -> tensor<4x4x!ttcore.tile<32x32, f32>>
+      %out_view = ttl.cb_reserve %out_dfb :
+          <[1, 1], !ttcore.tile<32x32, f32>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, f32>>
+      %result = ttl.compute
+          ins(%lhs_attached, %rhs_attached :
+              tensor<4x4x!ttcore.tile<32x32, f32>>,
+              tensor<4x4x!ttcore.tile<32x32, f32>>)
+          outs(%init_attached : tensor<4x4x!ttcore.tile<32x32, f32>>)
+          {indexing_maps = [#identity, #identity, #identity],
+           iterator_types = ["parallel", "parallel"]} {
+        ^bb0(%lhs_tile: !ttcore.tile<32x32, f32>,
+             %rhs_tile: !ttcore.tile<32x32, f32>,
+             %out_tile: !ttcore.tile<32x32, f32>):
+          %row = ttl.iter_index 0 : index
+          %column = ttl.iter_index 1 : index
+          %dst = arith.constant 0 : index
+          %sum = ttl.tile_add %lhs_tile, %rhs_tile into dst[%dst] :
+              !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>
+              -> !ttcore.tile<32x32, f32>
+          ttl.tile_store %sum, %out_view[%row, %column] from dst[%dst] :
+              !ttcore.tile<32x32, f32>,
+              tensor<1x1x!ttcore.tile<32x32, f32>>
+          ttl.yield
+      } -> tensor<4x4x!ttcore.tile<32x32, f32>>
+      func.return %result : tensor<4x4x!ttcore.tile<32x32, f32>>
+    }
+    ```
   }];
 
   let arguments = (ins

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1588,6 +1588,13 @@ mlir::tt::ttl::ComputeOp::getTiledImplementation(
   // can compute the correct global DFB offset from the extract_slice.
   mlir::IRMapping mapping;
   mlir::WalkResult storeWalk = getBody().walk([&](TileStoreOp store) {
+    if (store.getRowPrefix()) {
+      // Row-prefix packing derives its byte count from the complete reserved
+      // view. Its zero output map already fixes the one bulk store at the
+      // reservation origin, so replacing that view with a unit slice would
+      // truncate the packed prefix.
+      return mlir::WalkResult::advance();
+    }
     mlir::Value view = store.getView();
     if (view.getParentRegion() == &getBody()) {
       return mlir::WalkResult::advance();

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1865,9 +1865,9 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
   // require the corresponding tensor dimension to be 1.
   // Examples of invalid maps: (d0, d1)->(d0 + d1), (d0, d1)->(1),
   // (d0, d1, d2)->(d0, d0), (d0)[s0]->(d0 + s0).
-  auto validateMapStructure =
-      [&](AffineMap map, RankedTensorType tensorTy, StringRef kind,
-          size_t idx) -> mlir::LogicalResult {
+  auto validateMapStructure = [&](AffineMap map, RankedTensorType tensorTy,
+                                  StringRef kind,
+                                  size_t idx) -> mlir::LogicalResult {
     if (map.getNumSymbols() != 0) {
       return emitOpError() << kind << " " << idx
                            << " indexing map must not contain symbols";
@@ -1884,9 +1884,8 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
       } else if (auto constantExpr =
                      mlir::dyn_cast<mlir::AffineConstantExpr>(expr)) {
         if (constantExpr.getValue() != 0) {
-          return emitOpError()
-                 << kind << " " << idx
-                 << " indexing map constants must be zero";
+          return emitOpError() << kind << " " << idx
+                               << " indexing map constants must be zero";
         }
         if (tensorTy.getDimSize(resIdx) != 1) {
           return emitOpError() << kind << " " << idx << " broadcast dim "

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1868,6 +1868,10 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
   auto validateMapStructure =
       [&](AffineMap map, RankedTensorType tensorTy, StringRef kind,
           size_t idx) -> mlir::LogicalResult {
+    if (map.getNumSymbols() != 0) {
+      return emitOpError() << kind << " " << idx
+                           << " indexing map must not contain symbols";
+    }
     llvm::SmallBitVector referencedDims(map.getNumDims(), false);
     for (auto [resIdx, expr] : llvm::enumerate(map.getResults())) {
       if (auto dimExpr = mlir::dyn_cast<mlir::AffineDimExpr>(expr)) {

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1343,9 +1343,11 @@ mlir::tt::ttl::TileTypecastOp::fold(FoldAdaptor /*adaptor*/) {
 
 void mlir::tt::ttl::ComputeOp::print(mlir::OpAsmPrinter &p) {
   p << " ins(";
-  p.printOperands(getInputs());
-  p << " : ";
-  llvm::interleaveComma(getInputs().getTypes(), p);
+  if (!getInputs().empty()) {
+    p.printOperands(getInputs());
+    p << " : ";
+    llvm::interleaveComma(getInputs().getTypes(), p);
+  }
   p << ")";
 
   p << " outs(";
@@ -1832,21 +1834,6 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
   auto iteratorCount = getIteratorTypes().size();
   auto maps = mapsAttr;
 
-  // The iteration domain (from iterator_types) must be at least as large as the
-  // maximum operand rank. Extra dimensions are reduction dims that do not
-  // appear in any operand's shape (e.g., the K dimension in matmul: rank-2
-  // operands with a 3D [M, N, K] iteration space).
-  int64_t maxTensorRank = 0;
-  for (Value operand : llvm::concat<Value>(getInputs(), getOutputs())) {
-    auto ty = cast<RankedTensorType>(operand.getType());
-    maxTensorRank = std::max(maxTensorRank, ty.getRank());
-  }
-  if (iteratorCount < static_cast<size_t>(maxTensorRank)) {
-    return emitOpError("iterator_types count (")
-           << iteratorCount << ") must be >= maximum tensor rank ("
-           << maxTensorRank << ")";
-  }
-
   auto verifyMapCommon = [&](AffineMap map,
                              size_t expectedResults) -> mlir::LogicalResult {
     if (map.getNumDims() != iteratorCount) {
@@ -1872,27 +1859,44 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
   // Examples of invalid maps: (d0, d1)->(d0 + d1), (d0, d1)->(1),
   // (d0, d1, d2)->(d0, d0), (d0)[s0]->(d0 + s0).
   auto validateMapStructure =
-      [&](AffineMap map, RankedTensorType tensorTy, StringRef kind, size_t idx,
-          SmallVectorImpl<bool> *dimsReferenced) -> mlir::LogicalResult {
-    if (!map.isProjectedPermutation(/*allowZeroInResults=*/true)) {
-      return emitOpError() << kind << " " << idx
-                           << " indexing map must be a projected permutation"
-                              " (unique dims or 0 constants)";
-    }
+      [&](AffineMap map, RankedTensorType tensorTy, StringRef kind,
+          size_t idx) -> mlir::LogicalResult {
+    llvm::SmallBitVector referencedDims(map.getNumDims(), false);
     for (auto [resIdx, expr] : llvm::enumerate(map.getResults())) {
       if (auto dimExpr = mlir::dyn_cast<mlir::AffineDimExpr>(expr)) {
-        if (dimsReferenced) {
-          (*dimsReferenced)[dimExpr.getPosition()] = true;
+        if (referencedDims.test(dimExpr.getPosition())) {
+          return emitOpError()
+                 << kind << " " << idx
+                 << " indexing map must not repeat an iterator dimension";
         }
-      } else if (auto cstExpr =
+        referencedDims.set(dimExpr.getPosition());
+      } else if (auto constantExpr =
                      mlir::dyn_cast<mlir::AffineConstantExpr>(expr)) {
+        if (constantExpr.getValue() != 0) {
+          return emitOpError()
+                 << kind << " " << idx
+                 << " indexing map constants must be zero";
+        }
         if (tensorTy.getDimSize(resIdx) != 1) {
           return emitOpError() << kind << " " << idx << " broadcast dim "
                                << resIdx << " must have size 1";
         }
+      } else {
+        return emitOpError()
+               << kind << " " << idx
+               << " indexing map results must be unique dimensions or zero "
+                  "constants";
       }
     }
     return success();
+  };
+  auto recordReferencedDims = [](AffineMap map,
+                                 SmallVectorImpl<bool> &dimsReferenced) {
+    for (AffineExpr expr : map.getResults()) {
+      if (auto dimExpr = mlir::dyn_cast<mlir::AffineDimExpr>(expr)) {
+        dimsReferenced[dimExpr.getPosition()] = true;
+      }
+    }
   };
 
   auto requireAttachedCB = [&](Value tensor, size_t idx,
@@ -1907,6 +1911,7 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
   };
 
   SmallVector<bool> dimsReferencedByInputs(iteratorCount, false);
+  SmallVector<bool> dimsReferencedByOperands(iteratorCount, false);
   for (size_t i = 0; i < numInputs; ++i) {
     auto tensorTy = mlir::cast<RankedTensorType>(getInputs()[i].getType());
     if (!tensorTy.hasStaticShape()) {
@@ -1919,10 +1924,11 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
     if (failed(verifyMapCommon(map, tensorTy.getRank()))) {
       return failure();
     }
-    if (failed(validateMapStructure(map, tensorTy, "input", i,
-                                    &dimsReferencedByInputs))) {
+    if (failed(validateMapStructure(map, tensorTy, "input", i))) {
       return failure();
     }
+    recordReferencedDims(map, dimsReferencedByInputs);
+    recordReferencedDims(map, dimsReferencedByOperands);
   }
 
   DenseSet<Value> outputDFBs;
@@ -1946,10 +1952,10 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
     if (failed(verifyMapCommon(map, tensorTy.getRank()))) {
       return failure();
     }
-    if (failed(validateMapStructure(map, tensorTy, "output", i,
-                                    /*dimsReferenced=*/nullptr))) {
+    if (failed(validateMapStructure(map, tensorTy, "output", i))) {
       return failure();
     }
+    recordReferencedDims(map, dimsReferencedByOperands);
 
     // Reduction dims must not appear in output maps. Like linalg.generic,
     // reduction dimensions are contracted: the body accumulates into the
@@ -1971,6 +1977,13 @@ mlir::LogicalResult mlir::tt::ttl::ComputeOp::verify() {
       return emitOpError()
              << "reduction dimension " << d
              << " must be referenced by at least one input indexing map";
+    }
+  }
+  for (size_t dimension = 0; dimension < iteratorCount; ++dimension) {
+    if (!dimsReferencedByOperands[dimension]) {
+      return emitOpError() << "iterator dimension " << dimension
+                           << " must be referenced by at least one indexing "
+                              "map";
     }
   }
 

--- a/lib/Dialect/TTL/IR/TTLOps.cpp
+++ b/lib/Dialect/TTL/IR/TTLOps.cpp
@@ -1588,13 +1588,6 @@ mlir::tt::ttl::ComputeOp::getTiledImplementation(
   // can compute the correct global DFB offset from the extract_slice.
   mlir::IRMapping mapping;
   mlir::WalkResult storeWalk = getBody().walk([&](TileStoreOp store) {
-    if (store.getRowPrefix()) {
-      // Row-prefix packing derives its byte count from the complete reserved
-      // view. Its zero output map already fixes the one bulk store at the
-      // reservation origin, so replacing that view with a unit slice would
-      // truncate the packed prefix.
-      return mlir::WalkResult::advance();
-    }
     mlir::Value view = store.getView();
     if (view.getParentRegion() == &getBody()) {
       return mlir::WalkResult::advance();

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -1906,6 +1906,8 @@ static FailureOr<WaitedDFBMutationPlan> buildWaitedDFBMutationPlan(
   return plan;
 }
 
+// Derive one immutable representation per output DFB. Changing the source
+// result type is safe only when output stores consume every result use.
 static FailureOr<SmallVector<ComputeOutputPlan>>
 buildComputeOutputPlans(ComputeOpCreationPlan &creation,
                         std::string &failureReason) {

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -125,13 +125,6 @@ static AffineMap buildZeroMap(MLIRContext *context, int64_t domainRank,
   return AffineMap::get(domainRank, 0, expressions, context);
 }
 
-static RankedTensorType
-buildSingleElementTensorType(RankedTensorType tensorType) {
-  SmallVector<int64_t> shape(tensorType.getRank(), 1);
-  return RankedTensorType::get(shape, tensorType.getElementType(),
-                               tensorType.getEncoding());
-}
-
 static AffineMap
 buildBroadcastAwareInputMap(MLIRContext *context, RankedTensorType inputType,
                             RankedTensorType outputType, int64_t iterationRank,
@@ -1936,11 +1929,9 @@ buildComputeOutputPlans(ComputeOpCreationPlan &creation,
     }
 
     ComputeOutputPlan plan;
-    plan.dfb = outputDFB;
     if (!usesRowPrefix) {
       onlyRowPrefixOutputs = false;
-      plan.attachmentType = creation.resultType;
-      plan.formalType = creation.resultType;
+      plan.tensorType = creation.resultType;
       plan.indexingMap = creation.iteration.outputMap;
     } else {
       if (creation.rowNormalization) {
@@ -1959,16 +1950,15 @@ buildComputeOutputPlans(ComputeOpCreationPlan &creation,
                         "destination tensor type";
         return failure();
       }
-      plan.attachmentType = destinationType;
-      plan.formalType = buildSingleElementTensorType(destinationType);
+      plan.tensorType = destinationType;
       plan.indexingMap = buildZeroMap(stores.front().getContext(),
                                       creation.iteration.iteratorTypes.size(),
                                       destinationType.getRank());
-      changesResultRepresentation |= plan.formalType != creation.resultType;
+      changesResultRepresentation |= plan.tensorType != creation.resultType;
     }
 
-    if (!plans.empty() && plans.front().formalType.getElementType() !=
-                              plan.formalType.getElementType()) {
+    if (!plans.empty() && plans.front().tensorType.getElementType() !=
+                              plan.tensorType.getElementType()) {
       failureReason = "one compute cannot publish output dataflow buffers with "
                       "different tile types";
       return failure();
@@ -1979,15 +1969,14 @@ buildComputeOutputPlans(ComputeOpCreationPlan &creation,
   if (creation.inputs.empty() && onlyRowPrefixOutputs) {
     assert(creation.resultType.getNumElements() == 1 &&
            "row-prefix source must contain one tile");
-    // No operand carries a nonconstant indexing map from which the tiling
-    // interface could recover loop bounds. Model the one-tile source as one
-    // zero-rank execution instead of retaining unused unit iterators.
+    // No operand defines a loop bound. Represent the one-tile source with a
+    // zero-dimensional iteration domain instead of unused unit iterators.
     creation.iteration.iteratorTypes.clear();
     creation.iteration.outputMap = buildZeroMap(
         creation.source->getContext(), 0, creation.resultType.getRank());
     for (ComputeOutputPlan &plan : plans) {
       plan.indexingMap = buildZeroMap(creation.source->getContext(), 0,
-                                      plan.formalType.getRank());
+                                      plan.tensorType.getRank());
     }
   }
 
@@ -2286,12 +2275,7 @@ static FailureOr<PassthroughStorePlan> buildPassthroughStorePlan(
   auto outputTensorType = cast<RankedTensorType>(store.getView().getType());
   auto outputTileType =
       cast<ttcore::TileType>(outputTensorType.getElementType());
-  if (store.getRowPrefix()) {
-    plan.computeOutputTensorType =
-        buildSingleElementTensorType(outputTensorType);
-  } else {
-    plan.computeOutputTensorType = outputTensorType;
-  }
+  plan.computeOutputTensorType = outputTensorType;
   plan.inputTileType = tileType;
   plan.outputTileType = outputTileType;
   AffineMap identity = AffineMap::getMultiDimIdentityMap(tensorType.getRank(),

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -1959,9 +1959,9 @@ buildComputeOutputPlans(ComputeOpCreationPlan &creation,
       }
       plan.attachmentType = destinationType;
       plan.formalType = buildSingleElementTensorType(destinationType);
-      plan.indexingMap = buildZeroMap(
-          stores.front().getContext(), creation.iteration.iteratorTypes.size(),
-          destinationType.getRank());
+      plan.indexingMap = buildZeroMap(stores.front().getContext(),
+                                      creation.iteration.iteratorTypes.size(),
+                                      destinationType.getRank());
       changesResultRepresentation |= plan.formalType != creation.resultType;
     }
 
@@ -2296,9 +2296,8 @@ static FailureOr<PassthroughStorePlan> buildPassthroughStorePlan(
                                                          store->getContext());
   plan.iteration.inputMaps = {identity};
   if (store.getRowPrefix()) {
-    plan.iteration.outputMap =
-        buildZeroMap(store.getContext(), tensorType.getRank(),
-                     outputTensorType.getRank());
+    plan.iteration.outputMap = buildZeroMap(
+        store.getContext(), tensorType.getRank(), outputTensorType.getRank());
   } else {
     plan.iteration.outputMap = identity;
   }

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.cpp
@@ -125,6 +125,13 @@ static AffineMap buildZeroMap(MLIRContext *context, int64_t domainRank,
   return AffineMap::get(domainRank, 0, expressions, context);
 }
 
+static RankedTensorType
+buildSingleElementTensorType(RankedTensorType tensorType) {
+  SmallVector<int64_t> shape(tensorType.getRank(), 1);
+  return RankedTensorType::get(shape, tensorType.getElementType(),
+                               tensorType.getEncoding());
+}
+
 static AffineMap
 buildBroadcastAwareInputMap(MLIRContext *context, RankedTensorType inputType,
                             RankedTensorType outputType, int64_t iterationRank,
@@ -1899,6 +1906,104 @@ static FailureOr<WaitedDFBMutationPlan> buildWaitedDFBMutationPlan(
   return plan;
 }
 
+static FailureOr<SmallVector<ComputeOutputPlan>>
+buildComputeOutputPlans(ComputeOpCreationPlan &creation,
+                        std::string &failureReason) {
+  SmallVector<ComputeOutputPlan> plans;
+  plans.reserve(creation.outputs.dfbs.size());
+  bool changesResultRepresentation = false;
+  bool onlyRowPrefixOutputs = true;
+
+  for (Value outputDFB : creation.outputs.dfbs) {
+    SmallVector<StoreOp> stores;
+    for (const OutputDFBTransaction &transaction :
+         creation.outputs.transactions) {
+      if (transaction.dfb == outputDFB) {
+        llvm::append_range(stores, transaction.stores);
+      }
+    }
+    assert(!stores.empty() && "every output DFB must have a store");
+
+    bool usesRowPrefix = static_cast<bool>(stores.front().getRowPrefix());
+    if (llvm::any_of(stores, [&](StoreOp store) {
+          return static_cast<bool>(store.getRowPrefix()) != usesRowPrefix;
+        })) {
+      failureReason =
+          "one dataflow buffer cannot mix row-prefix and regular stores";
+      return failure();
+    }
+
+    ComputeOutputPlan plan;
+    plan.dfb = outputDFB;
+    if (!usesRowPrefix) {
+      onlyRowPrefixOutputs = false;
+      plan.attachmentType = creation.resultType;
+      plan.formalType = creation.resultType;
+      plan.indexingMap = creation.iteration.outputMap;
+    } else {
+      if (creation.rowNormalization) {
+        failureReason =
+            "row-prefix output is unsupported for row-normalization block "
+            "creation";
+        return failure();
+      }
+
+      auto destinationType =
+          cast<RankedTensorType>(stores.front().getView().getType());
+      if (llvm::any_of(stores, [&](StoreOp store) {
+            return store.getView().getType() != destinationType;
+          })) {
+        failureReason = "row-prefix stores to one dataflow buffer require one "
+                        "destination tensor type";
+        return failure();
+      }
+      plan.attachmentType = destinationType;
+      plan.formalType = buildSingleElementTensorType(destinationType);
+      plan.indexingMap = buildZeroMap(
+          stores.front().getContext(), creation.iteration.iteratorTypes.size(),
+          destinationType.getRank());
+      changesResultRepresentation |= plan.formalType != creation.resultType;
+    }
+
+    if (!plans.empty() && plans.front().formalType.getElementType() !=
+                              plan.formalType.getElementType()) {
+      failureReason = "one compute cannot publish output dataflow buffers with "
+                      "different tile types";
+      return failure();
+    }
+    plans.push_back(std::move(plan));
+  }
+
+  if (creation.inputs.empty() && onlyRowPrefixOutputs) {
+    assert(creation.resultType.getNumElements() == 1 &&
+           "row-prefix source must contain one tile");
+    // No operand carries a nonconstant indexing map from which the tiling
+    // interface could recover loop bounds. Model the one-tile source as one
+    // zero-rank execution instead of retaining unused unit iterators.
+    creation.iteration.iteratorTypes.clear();
+    creation.iteration.outputMap = buildZeroMap(
+        creation.source->getContext(), 0, creation.resultType.getRank());
+    for (ComputeOutputPlan &plan : plans) {
+      plan.indexingMap = buildZeroMap(creation.source->getContext(), 0,
+                                      plan.formalType.getRank());
+    }
+  }
+
+  if (changesResultRepresentation &&
+      llvm::any_of(creation.source->getResult(0).getUses(),
+                   [&](OpOperand &use) {
+                     auto store = dyn_cast<StoreOp>(use.getOwner());
+                     return !store || &store.getTensorMutable() != &use ||
+                            !llvm::is_contained(creation.outputs.stores, store);
+                   })) {
+    failureReason =
+        "row-prefix output cannot preserve a non-store use of the full-tile "
+        "result";
+    return failure();
+  }
+  return plans;
+}
+
 static PlanningResult<ComputeOpCreationPlan, ComputeOpCreationRejection>
 buildComputeOpCreationPlan(Operation *source,
                            const DFBValueLifetimeAnalysis &lifetimes,
@@ -2016,6 +2121,15 @@ buildComputeOpCreationPlan(Operation *source,
         outputs.getRejection().message);
   }
   plan.outputs = std::move(outputs).takePlan();
+
+  FailureOr<SmallVector<ComputeOutputPlan>> outputPlans =
+      buildComputeOutputPlans(plan, failureReason);
+  if (failed(outputPlans)) {
+    return rejectComputeOpCreation(
+        source, ComputeOpCreationRejectionKind::UnsupportedOutputPublication,
+        std::move(failureReason));
+  }
+  plan.outputPlans = std::move(*outputPlans);
 
   for (const OutputDFBTransaction &transaction : plan.outputs.transactions) {
     if (!transaction.isWaitedMutation()) {
@@ -2170,20 +2284,21 @@ static FailureOr<PassthroughStorePlan> buildPassthroughStorePlan(
   auto outputTensorType = cast<RankedTensorType>(store.getView().getType());
   auto outputTileType =
       cast<ttcore::TileType>(outputTensorType.getElementType());
-  plan.computeOutputTensorType = outputTensorType;
+  if (store.getRowPrefix()) {
+    plan.computeOutputTensorType =
+        buildSingleElementTensorType(outputTensorType);
+  } else {
+    plan.computeOutputTensorType = outputTensorType;
+  }
   plan.inputTileType = tileType;
   plan.outputTileType = outputTileType;
   AffineMap identity = AffineMap::getMultiDimIdentityMap(tensorType.getRank(),
                                                          store->getContext());
   plan.iteration.inputMaps = {identity};
   if (store.getRowPrefix()) {
-    // Both tensors contain one tile, but their ranks may differ; every source
-    // coordinate therefore stores to the destination's sole tile.
-    SmallVector<AffineExpr> zeroResults(
-        outputTensorType.getRank(),
-        getAffineConstantExpr(0, store.getContext()));
-    plan.iteration.outputMap = AffineMap::get(tensorType.getRank(), 0,
-                                              zeroResults, store.getContext());
+    plan.iteration.outputMap =
+        buildZeroMap(store.getContext(), tensorType.getRank(),
+                     outputTensorType.getRank());
   } else {
     plan.iteration.outputMap = identity;
   }

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -371,6 +371,25 @@ struct OutputPublicationPlan {
   }
 };
 
+/// Formal tensor representation for one created `ComputeOp` output.
+///
+/// `formalType` and `indexingMap` define how one compute iteration addresses a
+/// DFB-backed view. These differ from the complete DFB attachment and source
+/// result for type-changing stores such as row-prefix packing.
+struct ComputeOutputPlan {
+  /// DFB represented by this formal output.
+  Value dfb;
+
+  /// Complete tensor type required when attaching `dfb`.
+  RankedTensorType attachmentType;
+
+  /// DFB-backed tensor view used as the formal compute output.
+  RankedTensorType formalType;
+
+  /// Map from compute iteration indices to this output's view coordinates.
+  AffineMap indexingMap;
+};
+
 /// Immutable proof for one straight-line replacement of a waited DFB block.
 ///
 /// The initial contract accepts one complete one-block consumer acquisition
@@ -612,6 +631,9 @@ struct ComputeOpCreationPlan {
 
   /// Reserve, store, and publication transactions affected by creation.
   OutputPublicationPlan outputs;
+
+  /// Formal output representations in `outputs.dfbs` order.
+  SmallVector<ComputeOutputPlan> outputPlans;
 
   /// Consumer-owned DFB replacements proved before IR mutation.
   SmallVector<WaitedDFBMutationPlan> waitedMutations;

--- a/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
+++ b/lib/Dialect/TTL/Transforms/ComputeOpCreationPlanning.h
@@ -371,20 +371,10 @@ struct OutputPublicationPlan {
   }
 };
 
-/// Formal tensor representation for one created `ComputeOp` output.
-///
-/// `formalType` and `indexingMap` define how one compute iteration addresses a
-/// DFB-backed view. These differ from the complete DFB attachment and source
-/// result for type-changing stores such as row-prefix packing.
+/// Tensor representation for one created `ComputeOp` output.
 struct ComputeOutputPlan {
-  /// DFB represented by this formal output.
-  Value dfb;
-
-  /// Complete tensor type required when attaching `dfb`.
-  RankedTensorType attachmentType;
-
-  /// DFB-backed tensor view used as the formal compute output.
-  RankedTensorType formalType;
+  /// Tensor type of the compute result attached to the associated DFB.
+  RankedTensorType tensorType;
 
   /// Map from compute iteration indices to this output's view coordinates.
   AffineMap indexingMap;
@@ -632,7 +622,7 @@ struct ComputeOpCreationPlan {
   /// Reserve, store, and publication transactions affected by creation.
   OutputPublicationPlan outputs;
 
-  /// Formal output representations in `outputs.dfbs` order.
+  /// Created output representations in `outputs.dfbs` order.
   SmallVector<ComputeOutputPlan> outputPlans;
 
   /// Consumer-owned DFB replacements proved before IR mutation.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -399,7 +399,17 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
 
     SmallVector<Range> iterDomain = getIterationDomain(rewriter, op);
     if (iterDomain.empty()) {
-      return failure();
+      auto dstSection = DstSectionOp::create(rewriter, loc);
+      Block &sectionBody = dstSection.getBody().front();
+      OpBuilder bodyBuilder(&sectionBody,
+                            Block::iterator(sectionBody.getTerminator()));
+      if (failed(generateTileProcessing(bodyBuilder, loc, op, indexingMaps,
+                                        ValueRange{}))) {
+        return rewriter.notifyMatchFailure(
+            op, "zero-rank tile index computation failed");
+      }
+      rewriter.replaceOp(op, op.getOutputs());
+      return success();
     }
 
     SmallVector<Value> lowerBounds, upperBounds, steps;

--- a/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLComputeToSCF.cpp
@@ -48,10 +48,9 @@ static SmallVector<Range> getIterationDomain(OpBuilder &b, ComputeOp op) {
 
 /// Generate side-effect-only loop body. Extracts tiles from inputs, clones
 /// compute body ops, and returns nothing (stores are explicit side effects).
-static LogicalResult generateTileProcessing(OpBuilder &b, Location loc,
-                                            ComputeOp op,
-                                            ArrayRef<AffineMap> indexingMaps,
-                                            ValueRange ivs) {
+static void generateTileProcessing(OpBuilder &b, Location loc, ComputeOp op,
+                                   ArrayRef<AffineMap> indexingMaps,
+                                   ValueRange ivs) {
   size_t numInputs = op.getInputs().size();
   auto extractedInputs =
       extractTilesAtIndices(b, loc, op.getInputs(), indexingMaps, ivs);
@@ -82,8 +81,6 @@ static LogicalResult generateTileProcessing(OpBuilder &b, Location loc,
 
     b.clone(bodyOp, mapping);
   }
-
-  return success();
 }
 
 static bool requiresDstAccumulation(ComputeOp op) {
@@ -403,11 +400,7 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
       Block &sectionBody = dstSection.getBody().front();
       OpBuilder bodyBuilder(&sectionBody,
                             Block::iterator(sectionBody.getTerminator()));
-      if (failed(generateTileProcessing(bodyBuilder, loc, op, indexingMaps,
-                                        ValueRange{}))) {
-        return rewriter.notifyMatchFailure(
-            op, "zero-rank tile index computation failed");
-      }
+      generateTileProcessing(bodyBuilder, loc, op, indexingMaps, ValueRange{});
       rewriter.replaceOp(op, op.getOutputs());
       return success();
     }
@@ -448,7 +441,6 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
 
     // Side-effect-only loops: no iter_args, no tensor.insert, no scf.yield
     // with tensor values. Stores are explicit side effects (tile_store).
-    bool processingFailed = false;
     bool usedDstAccumulation = false;
     scf::LoopNest loopNest = [&]() {
       if (isSubblocked) {
@@ -462,10 +454,7 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
             sectionBuilder, loc, lowerBounds, upperBounds, steps, ValueRange{},
             [&](OpBuilder &nested, Location nestedLoc, ValueRange ivs,
                 ValueRange) -> scf::ValueVector {
-              if (failed(generateTileProcessing(nested, nestedLoc, op,
-                                                indexingMaps, ivs))) {
-                processingFailed = true;
-              }
+              generateTileProcessing(nested, nestedLoc, op, indexingMaps, ivs);
               return {};
             });
       }
@@ -497,10 +486,8 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
             Block &sectionBody = dstSection.getBody().front();
             OpBuilder bodyBuilder(&sectionBody,
                                   Block::iterator(sectionBody.getTerminator()));
-            if (failed(generateTileProcessing(bodyBuilder, nestedLoc, op,
-                                              indexingMaps, ivs))) {
-              processingFailed = true;
-            }
+            generateTileProcessing(bodyBuilder, nestedLoc, op, indexingMaps,
+                                   ivs);
             return {};
           });
     }();
@@ -543,11 +530,6 @@ struct LowerComputeToLoops : OpRewritePattern<ComputeOp> {
     // keep their tile loops for per-tile sync.
     if (fullStridesAttr && !loopNest.loops.empty()) {
       loopsToUnroll.push_back(loopNest.loops.front());
-    }
-
-    if (processingFailed) {
-      return rewriter.notifyMatchFailure(
-          op, "copy_tile index computation failed (mismatched rank/IVs)");
     }
 
     rewriter.replaceOp(op, op.getOutputs());

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -189,6 +189,8 @@ static void appendOutputIndexingMaps(const ComputeOpCreationPlan &creation,
   }
 }
 
+// Attach the complete DFB view before selecting its formal compute result;
+// allocation geometry remains complete when publication uses a compact view.
 static Value buildFormalOutput(PatternRewriter &rewriter, Location loc,
                                RankedTensorType attachmentType,
                                RankedTensorType formalType, Value outputDFB,
@@ -242,6 +244,8 @@ addFormalOutputBlockArguments(Block *body, Location loc,
   }
 }
 
+// Type-changing publication absorbs every original result use, so no
+// type-compatible replacement exists or remains necessary.
 static void replaceComputeSource(PatternRewriter &rewriter, Operation *source,
                                  Value computeResult) {
   assert(source->getNumResults() == 1 &&

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -171,6 +171,92 @@ static Value buildInitTensor(OpBuilder &b, Location loc, RankedTensorType type,
                                  dynDims);
 }
 
+static void verifyOutputPlans(const ComputeOpCreationPlan &creation,
+                              const OutputPublicationPlan &outputs) {
+  assert(creation.outputPlans.size() == outputs.dfbs.size() &&
+         "each resolved output requires a formal output plan");
+  for (auto [outputPlan, outputDFB] :
+       llvm::zip_equal(creation.outputPlans, outputs.dfbs)) {
+    assert(outputPlan.dfb == outputDFB &&
+           "resolved output order changed after creation planning");
+  }
+}
+
+static void appendOutputIndexingMaps(
+    const ComputeOpCreationPlan &creation,
+    SmallVectorImpl<Attribute> &indexingMaps) {
+  for (const ComputeOutputPlan &outputPlan : creation.outputPlans) {
+    indexingMaps.push_back(AffineMapAttr::get(outputPlan.indexingMap));
+  }
+}
+
+static Value buildFormalOutput(PatternRewriter &rewriter, Location loc,
+                               RankedTensorType attachmentType,
+                               RankedTensorType formalType,
+                               Value outputDFB,
+                               std::optional<Value> dynamicDimensionExemplar) {
+  Value init = dynamicDimensionExemplar
+                   ? buildInitTensor(rewriter, loc, attachmentType,
+                                     *dynamicDimensionExemplar)
+                   : tensor::EmptyOp::create(rewriter, loc,
+                                             attachmentType.getShape(),
+                                             attachmentType.getElementType());
+  Value attached = AttachCBOp::create(rewriter, loc, attachmentType, init,
+                                      outputDFB);
+  if (formalType == attachmentType) {
+    return attached;
+  }
+
+  SmallVector<OpFoldResult> offsets(formalType.getRank(),
+                                    rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> sizes;
+  sizes.reserve(formalType.getRank());
+  for (int64_t extent : formalType.getShape()) {
+    sizes.push_back(rewriter.getIndexAttr(extent));
+  }
+  SmallVector<OpFoldResult> strides(formalType.getRank(),
+                                    rewriter.getIndexAttr(1));
+  return tensor::ExtractSliceOp::create(rewriter, loc, formalType,
+                                        attached, offsets, sizes, strides);
+}
+
+static void buildFormalOutputs(
+    PatternRewriter &rewriter, Location loc,
+    const ComputeOpCreationPlan &creation,
+    const OutputPublicationPlan &outputs,
+    std::optional<Value> dynamicDimensionExemplar,
+    SmallVectorImpl<Value> &attachedOutputs,
+    SmallVectorImpl<Type> &resultTypes) {
+  verifyOutputPlans(creation, outputs);
+  for (auto [outputPlan, outputDFB] :
+       llvm::zip_equal(creation.outputPlans, outputs.dfbs)) {
+    attachedOutputs.push_back(buildFormalOutput(
+        rewriter, loc, outputPlan.attachmentType, outputPlan.formalType,
+        outputDFB, dynamicDimensionExemplar));
+    resultTypes.push_back(outputPlan.formalType);
+  }
+}
+
+static void addFormalOutputBlockArguments(
+    Block *body, Location loc, const ComputeOpCreationPlan &creation) {
+  for (const ComputeOutputPlan &outputPlan : creation.outputPlans) {
+    body->addArgument(outputPlan.formalType.getElementType(), loc);
+  }
+}
+
+static void replaceComputeSource(PatternRewriter &rewriter, Operation *source,
+                                 Value computeResult) {
+  assert(source->getNumResults() == 1 &&
+         "compute creation requires one source result");
+  if (source->getResult(0).getType() == computeResult.getType()) {
+    rewriter.replaceOp(source, computeResult);
+    return;
+  }
+  assert(source->getResult(0).use_empty() &&
+         "type-changing output publication requires no surviving source use");
+  rewriter.eraseOp(source);
+}
+
 /// Selects the insertion position proven by output-publication planning.
 static void insertAtCreationAnchor(PatternRewriter &rewriter,
                                    const OutputPublicationPlan &outputs) {
@@ -415,7 +501,6 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   assert(creation.recipe == ComputeOpCreationRecipe::Fused &&
          "fused builder requires a fused creation recipe");
   const FusionTraceResult &trace = creation.trace;
-  RankedTensorType type = creation.resultType;
 
   // Verify every recorded dependency before creating IR. This prevents plan
   // invalidation by an earlier rewrite from leaving a partially built compute.
@@ -454,10 +539,7 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   for (AffineMap inputMap : creation.iteration.inputMaps) {
     maps.push_back(AffineMapAttr::get(inputMap));
   }
-  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
-       ++outputIndex) {
-    maps.push_back(AffineMapAttr::get(creation.iteration.outputMap));
-  }
+  appendOutputIndexingMaps(creation, maps);
   SmallVector<Attribute> iteratorTypes =
       buildIteratorTypeAttributes(rewriter, creation.iteration.iteratorTypes);
 
@@ -469,17 +551,11 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   // chains with no root inputs, use tensor.empty directly (static shapes).
   SmallVector<Value> allInitAttached;
   SmallVector<Type> resultTypes;
-  for (Value outputDFB : outputs.dfbs) {
-    Value init = creation.inputs.empty()
-                     ? tensor::EmptyOp::create(rewriter, loc, type.getShape(),
-                                               type.getElementType())
-                           .getResult()
-                     : buildInitTensor(rewriter, loc, type, creation.inputs[0]);
-    Value initAttached =
-        AttachCBOp::create(rewriter, loc, init.getType(), init, outputDFB);
-    allInitAttached.push_back(initAttached);
-    resultTypes.push_back(type);
-  }
+  buildFormalOutputs(rewriter, loc, creation, outputs,
+                     creation.inputs.empty()
+                         ? std::nullopt
+                         : std::optional<Value>(creation.inputs[0]),
+                     allInitAttached, resultTypes);
 
   // Create ttl.compute op
   auto computeOp = ComputeOp::create(
@@ -493,9 +569,7 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   for (ttcore::TileType inputTileType : creation.inputTileTypes) {
     body->addArgument(inputTileType, loc);
   }
-  for (size_t i = 0; i < outputs.dfbs.size(); ++i) {
-    body->addArgument(creation.resultTileType, loc);
-  }
+  addFormalOutputBlockArguments(body, loc, creation);
 
   rewriter.setInsertionPointToStart(body);
 
@@ -585,7 +659,7 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   replaceOutputPushesBeforeCompute(rewriter, computeOp, outputs,
                                    replacedPushes);
   eraseAbsorbedOutputOps(rewriter, outputs, computeOp, replacedPushes);
-  rewriter.replaceOp(sinkOp, computeOp.getResult(0));
+  replaceComputeSource(rewriter, sinkOp, computeOp.getResult(0));
 
   // Erase the fused ops in reverse topological order (sink to roots).
   // This ensures each op's users are erased before the op itself.
@@ -626,26 +700,19 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
         sinkOp, "row-normalization expression changed after planning");
   }
   Location loc = sinkOp->getLoc();
-  RankedTensorType outputType = creation.resultType;
   SmallVector<Attribute> maps;
   for (AffineMap inputMap : creation.iteration.inputMaps) {
     maps.push_back(AffineMapAttr::get(inputMap));
   }
-  maps.append(outputs.dfbs.size(),
-              AffineMapAttr::get(creation.iteration.outputMap));
+  appendOutputIndexingMaps(creation, maps);
   SmallVector<Attribute> iteratorTypes =
       buildIteratorTypeAttributes(rewriter, creation.iteration.iteratorTypes);
 
   insertAtCreationAnchor(rewriter, outputs);
   SmallVector<Value> outputViews;
   SmallVector<Type> resultTypes;
-  for (Value outputDFB : outputs.dfbs) {
-    Value init =
-        buildInitTensor(rewriter, loc, outputType, creation.inputs.front());
-    outputViews.push_back(
-        AttachCBOp::create(rewriter, loc, init.getType(), init, outputDFB));
-    resultTypes.push_back(outputType);
-  }
+  buildFormalOutputs(rewriter, loc, creation, outputs, creation.inputs.front(),
+                     outputViews, resultTypes);
 
   auto computeOp = ComputeOp::create(
       rewriter, loc, TypeRange(resultTypes), ValueRange(creation.inputs),
@@ -655,10 +722,7 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   for (ttcore::TileType inputTileType : creation.inputTileTypes) {
     body->addArgument(inputTileType, loc);
   }
-  Type outputTileType = creation.resultTileType;
-  SmallVector<Type> outputTileTypes(outputs.dfbs.size(), outputTileType);
-  SmallVector<Location> outputLocations(outputs.dfbs.size(), loc);
-  body->addArguments(outputTileTypes, outputLocations);
+  addFormalOutputBlockArguments(body, loc, creation);
 
   rewriter.setInsertionPointToStart(body);
   Value inputTile = body->getArgument(0);
@@ -667,8 +731,9 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   Value outputTile = body->getArgument(creation.inputs.size());
   Value result =
       createTileOpWithPlaceholderDstIndex<TileRowNormalizationBlockOp>(
-          rewriter, loc, outputTileType, inputTile, gammaTile, outputTile,
-          schedule.scale, schedule.epsilon, rewriter.getBoolAttr(hasGamma),
+          rewriter, loc, creation.resultTileType, inputTile, gammaTile,
+          outputTile, schedule.scale, schedule.epsilon,
+          rewriter.getBoolAttr(hasGamma),
           rewriter.getI64IntegerAttr(schedule.numTiles));
 
   for (StoreOp store : outputs.stores) {
@@ -680,7 +745,7 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   replaceOutputPushesBeforeCompute(rewriter, computeOp, outputs,
                                    replacedPushes);
   eraseAbsorbedOutputOps(rewriter, outputs, computeOp, replacedPushes);
-  rewriter.replaceOp(sinkOp, computeOp.getResult(0));
+  replaceComputeSource(rewriter, sinkOp, computeOp.getResult(0));
   for (Operation *operation : llvm::reverse(creation.trace.opsInOrder)) {
     if (operation != sinkOp && operation->use_empty()) {
       rewriter.eraseOp(operation);
@@ -719,16 +784,12 @@ static LogicalResult buildComputeFromInputs(
 
   Location loc = op->getLoc();
   ValueRange inputs(creation->inputs);
-  RankedTensorType outputType = creation->resultType;
 
   SmallVector<Attribute> maps;
   for (AffineMap inputMap : creation->iteration.inputMaps) {
     maps.push_back(AffineMapAttr::get(inputMap));
   }
-  for (size_t outputIndex = 0; outputIndex < outputs.dfbs.size();
-       ++outputIndex) {
-    maps.push_back(AffineMapAttr::get(creation->iteration.outputMap));
-  }
+  appendOutputIndexingMaps(*creation, maps);
   SmallVector<Attribute> iteratorTypes =
       buildIteratorTypeAttributes(rewriter, creation->iteration.iteratorTypes);
 
@@ -736,18 +797,10 @@ static LogicalResult buildComputeFromInputs(
 
   SmallVector<Value> allInitAttached;
   SmallVector<Type> resultTypes;
-  for (Value outputDFB : outputs.dfbs) {
-    Value init =
-        inputs.empty()
-            ? tensor::EmptyOp::create(rewriter, loc, outputType.getShape(),
-                                      outputType.getElementType())
-                  .getResult()
-            : buildInitTensor(rewriter, loc, outputType, inputs[0]);
-    Value initAttached =
-        AttachCBOp::create(rewriter, loc, init.getType(), init, outputDFB);
-    allInitAttached.push_back(initAttached);
-    resultTypes.push_back(outputType);
-  }
+  buildFormalOutputs(rewriter, loc, *creation, outputs,
+                     inputs.empty() ? std::nullopt
+                                    : std::optional<Value>(inputs.front()),
+                     allInitAttached, resultTypes);
 
   auto computeOp = ComputeOp::create(rewriter, loc, TypeRange(resultTypes),
                                      inputs, ValueRange(allInitAttached),
@@ -758,9 +811,7 @@ static LogicalResult buildComputeFromInputs(
   for (ttcore::TileType inputTileType : creation->inputTileTypes) {
     body->addArgument(inputTileType, loc);
   }
-  for (size_t i = 0; i < outputs.dfbs.size(); ++i) {
-    body->addArgument(creation->resultTileType, loc);
-  }
+  addFormalOutputBlockArguments(body, loc, *creation);
 
   rewriter.setInsertionPointToStart(body);
   ComputeInstrumentationEmitter instrumentationEmitter(
@@ -781,7 +832,7 @@ static LogicalResult buildComputeFromInputs(
   replaceOutputPushesBeforeCompute(rewriter, computeOp, outputs,
                                    replacedPushes);
   eraseAbsorbedOutputOps(rewriter, outputs, computeOp, replacedPushes);
-  rewriter.replaceOp(op, computeOp.getResult(0));
+  replaceComputeSource(rewriter, op, computeOp.getResult(0));
   for (const ComputeInstrumentationPlacement &placement :
        creation->instrumentation) {
     rewriter.eraseOp(placement.operation);
@@ -1159,9 +1210,11 @@ struct LowerStoreToCompute : OpRewritePattern<StoreOp> {
     SmallVector<Attribute> iteratorTypes =
         buildIteratorTypeAttributes(rewriter, plan.iteration.iteratorTypes);
 
-    Value init = buildInitTensor(rewriter, loc, outputType, plan.outputView);
-    Value initAttached =
-        AttachCBOp::create(rewriter, loc, init.getType(), init, plan.outputDFB);
+    auto attachmentType =
+        cast<RankedTensorType>(plan.outputView.getType());
+    Value initAttached = buildFormalOutput(
+        rewriter, loc, attachmentType, outputType, plan.outputDFB,
+        plan.outputView);
 
     auto computeOp = ComputeOp::create(
         rewriter, loc, TypeRange{outputType}, ValueRange{input},

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -182,9 +182,8 @@ static void verifyOutputPlans(const ComputeOpCreationPlan &creation,
   }
 }
 
-static void appendOutputIndexingMaps(
-    const ComputeOpCreationPlan &creation,
-    SmallVectorImpl<Attribute> &indexingMaps) {
+static void appendOutputIndexingMaps(const ComputeOpCreationPlan &creation,
+                                     SmallVectorImpl<Attribute> &indexingMaps) {
   for (const ComputeOutputPlan &outputPlan : creation.outputPlans) {
     indexingMaps.push_back(AffineMapAttr::get(outputPlan.indexingMap));
   }
@@ -192,17 +191,16 @@ static void appendOutputIndexingMaps(
 
 static Value buildFormalOutput(PatternRewriter &rewriter, Location loc,
                                RankedTensorType attachmentType,
-                               RankedTensorType formalType,
-                               Value outputDFB,
+                               RankedTensorType formalType, Value outputDFB,
                                std::optional<Value> dynamicDimensionExemplar) {
-  Value init = dynamicDimensionExemplar
-                   ? buildInitTensor(rewriter, loc, attachmentType,
-                                     *dynamicDimensionExemplar)
-                   : tensor::EmptyOp::create(rewriter, loc,
-                                             attachmentType.getShape(),
-                                             attachmentType.getElementType());
-  Value attached = AttachCBOp::create(rewriter, loc, attachmentType, init,
-                                      outputDFB);
+  Value init =
+      dynamicDimensionExemplar
+          ? buildInitTensor(rewriter, loc, attachmentType,
+                            *dynamicDimensionExemplar)
+          : tensor::EmptyOp::create(rewriter, loc, attachmentType.getShape(),
+                                    attachmentType.getElementType());
+  Value attached =
+      AttachCBOp::create(rewriter, loc, attachmentType, init, outputDFB);
   if (formalType == attachmentType) {
     return attached;
   }
@@ -216,17 +214,16 @@ static Value buildFormalOutput(PatternRewriter &rewriter, Location loc,
   }
   SmallVector<OpFoldResult> strides(formalType.getRank(),
                                     rewriter.getIndexAttr(1));
-  return tensor::ExtractSliceOp::create(rewriter, loc, formalType,
-                                        attached, offsets, sizes, strides);
+  return tensor::ExtractSliceOp::create(rewriter, loc, formalType, attached,
+                                        offsets, sizes, strides);
 }
 
-static void buildFormalOutputs(
-    PatternRewriter &rewriter, Location loc,
-    const ComputeOpCreationPlan &creation,
-    const OutputPublicationPlan &outputs,
-    std::optional<Value> dynamicDimensionExemplar,
-    SmallVectorImpl<Value> &attachedOutputs,
-    SmallVectorImpl<Type> &resultTypes) {
+static void buildFormalOutputs(PatternRewriter &rewriter, Location loc,
+                               const ComputeOpCreationPlan &creation,
+                               const OutputPublicationPlan &outputs,
+                               std::optional<Value> dynamicDimensionExemplar,
+                               SmallVectorImpl<Value> &attachedOutputs,
+                               SmallVectorImpl<Type> &resultTypes) {
   verifyOutputPlans(creation, outputs);
   for (auto [outputPlan, outputDFB] :
        llvm::zip_equal(creation.outputPlans, outputs.dfbs)) {
@@ -237,8 +234,9 @@ static void buildFormalOutputs(
   }
 }
 
-static void addFormalOutputBlockArguments(
-    Block *body, Location loc, const ComputeOpCreationPlan &creation) {
+static void
+addFormalOutputBlockArguments(Block *body, Location loc,
+                              const ComputeOpCreationPlan &creation) {
   for (const ComputeOutputPlan &outputPlan : creation.outputPlans) {
     body->addArgument(outputPlan.formalType.getElementType(), loc);
   }
@@ -1210,11 +1208,10 @@ struct LowerStoreToCompute : OpRewritePattern<StoreOp> {
     SmallVector<Attribute> iteratorTypes =
         buildIteratorTypeAttributes(rewriter, plan.iteration.iteratorTypes);
 
-    auto attachmentType =
-        cast<RankedTensorType>(plan.outputView.getType());
-    Value initAttached = buildFormalOutput(
-        rewriter, loc, attachmentType, outputType, plan.outputDFB,
-        plan.outputView);
+    auto attachmentType = cast<RankedTensorType>(plan.outputView.getType());
+    Value initAttached =
+        buildFormalOutput(rewriter, loc, attachmentType, outputType,
+                          plan.outputDFB, plan.outputView);
 
     auto computeOp = ComputeOp::create(
         rewriter, loc, TypeRange{outputType}, ValueRange{input},

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -171,17 +171,6 @@ static Value buildInitTensor(OpBuilder &b, Location loc, RankedTensorType type,
                                  dynDims);
 }
 
-static void verifyOutputPlans(const ComputeOpCreationPlan &creation,
-                              const OutputPublicationPlan &outputs) {
-  assert(creation.outputPlans.size() == outputs.dfbs.size() &&
-         "each resolved output requires a formal output plan");
-  for (auto [outputPlan, outputDFB] :
-       llvm::zip_equal(creation.outputPlans, outputs.dfbs)) {
-    assert(outputPlan.dfb == outputDFB &&
-           "resolved output order changed after creation planning");
-  }
-}
-
 static void appendOutputIndexingMaps(const ComputeOpCreationPlan &creation,
                                      SmallVectorImpl<Attribute> &indexingMaps) {
   for (const ComputeOutputPlan &outputPlan : creation.outputPlans) {
@@ -189,63 +178,44 @@ static void appendOutputIndexingMaps(const ComputeOpCreationPlan &creation,
   }
 }
 
-// Attach the complete DFB view before selecting its formal compute result;
-// allocation geometry remains complete when publication uses a compact view.
-static Value buildFormalOutput(PatternRewriter &rewriter, Location loc,
-                               RankedTensorType attachmentType,
-                               RankedTensorType formalType, Value outputDFB,
-                               std::optional<Value> dynamicDimensionExemplar) {
+static Value buildComputeOutput(PatternRewriter &rewriter, Location loc,
+                                RankedTensorType outputType, Value outputDFB,
+                                std::optional<Value> dynamicDimensionExemplar) {
   Value init =
       dynamicDimensionExemplar
-          ? buildInitTensor(rewriter, loc, attachmentType,
+          ? buildInitTensor(rewriter, loc, outputType,
                             *dynamicDimensionExemplar)
-          : tensor::EmptyOp::create(rewriter, loc, attachmentType.getShape(),
-                                    attachmentType.getElementType());
-  Value attached =
-      AttachCBOp::create(rewriter, loc, attachmentType, init, outputDFB);
-  if (formalType == attachmentType) {
-    return attached;
-  }
-
-  SmallVector<OpFoldResult> offsets(formalType.getRank(),
-                                    rewriter.getIndexAttr(0));
-  SmallVector<OpFoldResult> sizes;
-  sizes.reserve(formalType.getRank());
-  for (int64_t extent : formalType.getShape()) {
-    sizes.push_back(rewriter.getIndexAttr(extent));
-  }
-  SmallVector<OpFoldResult> strides(formalType.getRank(),
-                                    rewriter.getIndexAttr(1));
-  return tensor::ExtractSliceOp::create(rewriter, loc, formalType, attached,
-                                        offsets, sizes, strides);
+          : tensor::EmptyOp::create(rewriter, loc, outputType.getShape(),
+                                    outputType.getElementType());
+  return AttachCBOp::create(rewriter, loc, outputType, init, outputDFB);
 }
 
-static void buildFormalOutputs(PatternRewriter &rewriter, Location loc,
-                               const ComputeOpCreationPlan &creation,
-                               const OutputPublicationPlan &outputs,
-                               std::optional<Value> dynamicDimensionExemplar,
-                               SmallVectorImpl<Value> &attachedOutputs,
-                               SmallVectorImpl<Type> &resultTypes) {
-  verifyOutputPlans(creation, outputs);
+static void buildComputeOutputs(PatternRewriter &rewriter, Location loc,
+                                const ComputeOpCreationPlan &creation,
+                                const OutputPublicationPlan &outputs,
+                                std::optional<Value> dynamicDimensionExemplar,
+                                SmallVectorImpl<Value> &attachedOutputs,
+                                SmallVectorImpl<Type> &resultTypes) {
+  assert(creation.outputPlans.size() == outputs.dfbs.size() &&
+         "each resolved output requires an output plan");
   for (auto [outputPlan, outputDFB] :
        llvm::zip_equal(creation.outputPlans, outputs.dfbs)) {
-    attachedOutputs.push_back(buildFormalOutput(
-        rewriter, loc, outputPlan.attachmentType, outputPlan.formalType,
-        outputDFB, dynamicDimensionExemplar));
-    resultTypes.push_back(outputPlan.formalType);
+    attachedOutputs.push_back(
+        buildComputeOutput(rewriter, loc, outputPlan.tensorType, outputDFB,
+                           dynamicDimensionExemplar));
+    resultTypes.push_back(outputPlan.tensorType);
   }
 }
 
-static void
-addFormalOutputBlockArguments(Block *body, Location loc,
-                              const ComputeOpCreationPlan &creation) {
+static void addOutputBlockArguments(Block *body, Location loc,
+                                    const ComputeOpCreationPlan &creation) {
   for (const ComputeOutputPlan &outputPlan : creation.outputPlans) {
-    body->addArgument(outputPlan.formalType.getElementType(), loc);
+    body->addArgument(outputPlan.tensorType.getElementType(), loc);
   }
 }
 
-// Type-changing publication absorbs every original result use, so no
-// type-compatible replacement exists or remains necessary.
+// Planning permits a type-changing result only when its stores are the source
+// result's only uses, so erasing the source cannot invalidate another user.
 static void replaceComputeSource(PatternRewriter &rewriter, Operation *source,
                                  Value computeResult) {
   assert(source->getNumResults() == 1 &&
@@ -553,11 +523,11 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   // chains with no root inputs, use tensor.empty directly (static shapes).
   SmallVector<Value> allInitAttached;
   SmallVector<Type> resultTypes;
-  buildFormalOutputs(rewriter, loc, creation, outputs,
-                     creation.inputs.empty()
-                         ? std::nullopt
-                         : std::optional<Value>(creation.inputs[0]),
-                     allInitAttached, resultTypes);
+  buildComputeOutputs(rewriter, loc, creation, outputs,
+                      creation.inputs.empty()
+                          ? std::nullopt
+                          : std::optional<Value>(creation.inputs[0]),
+                      allInitAttached, resultTypes);
 
   // Create ttl.compute op
   auto computeOp = ComputeOp::create(
@@ -571,7 +541,7 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
   for (ttcore::TileType inputTileType : creation.inputTileTypes) {
     body->addArgument(inputTileType, loc);
   }
-  addFormalOutputBlockArguments(body, loc, creation);
+  addOutputBlockArguments(body, loc, creation);
 
   rewriter.setInsertionPointToStart(body);
 
@@ -713,8 +683,8 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   insertAtCreationAnchor(rewriter, outputs);
   SmallVector<Value> outputViews;
   SmallVector<Type> resultTypes;
-  buildFormalOutputs(rewriter, loc, creation, outputs, creation.inputs.front(),
-                     outputViews, resultTypes);
+  buildComputeOutputs(rewriter, loc, creation, outputs, creation.inputs.front(),
+                      outputViews, resultTypes);
 
   auto computeOp = ComputeOp::create(
       rewriter, loc, TypeRange(resultTypes), ValueRange(creation.inputs),
@@ -724,7 +694,7 @@ buildRowNormalizationCompute(Operation *sinkOp, PatternRewriter &rewriter,
   for (ttcore::TileType inputTileType : creation.inputTileTypes) {
     body->addArgument(inputTileType, loc);
   }
-  addFormalOutputBlockArguments(body, loc, creation);
+  addOutputBlockArguments(body, loc, creation);
 
   rewriter.setInsertionPointToStart(body);
   Value inputTile = body->getArgument(0);
@@ -799,10 +769,10 @@ static LogicalResult buildComputeFromInputs(
 
   SmallVector<Value> allInitAttached;
   SmallVector<Type> resultTypes;
-  buildFormalOutputs(rewriter, loc, *creation, outputs,
-                     inputs.empty() ? std::nullopt
-                                    : std::optional<Value>(inputs.front()),
-                     allInitAttached, resultTypes);
+  buildComputeOutputs(rewriter, loc, *creation, outputs,
+                      inputs.empty() ? std::nullopt
+                                     : std::optional<Value>(inputs.front()),
+                      allInitAttached, resultTypes);
 
   auto computeOp = ComputeOp::create(rewriter, loc, TypeRange(resultTypes),
                                      inputs, ValueRange(allInitAttached),
@@ -813,7 +783,7 @@ static LogicalResult buildComputeFromInputs(
   for (ttcore::TileType inputTileType : creation->inputTileTypes) {
     body->addArgument(inputTileType, loc);
   }
-  addFormalOutputBlockArguments(body, loc, *creation);
+  addOutputBlockArguments(body, loc, *creation);
 
   rewriter.setInsertionPointToStart(body);
   ComputeInstrumentationEmitter instrumentationEmitter(
@@ -1212,10 +1182,8 @@ struct LowerStoreToCompute : OpRewritePattern<StoreOp> {
     SmallVector<Attribute> iteratorTypes =
         buildIteratorTypeAttributes(rewriter, plan.iteration.iteratorTypes);
 
-    auto attachmentType = cast<RankedTensorType>(plan.outputView.getType());
-    Value initAttached =
-        buildFormalOutput(rewriter, loc, attachmentType, outputType,
-                          plan.outputDFB, plan.outputView);
+    Value initAttached = buildComputeOutput(rewriter, loc, outputType,
+                                            plan.outputDFB, plan.outputView);
 
     auto computeOp = ComputeOp::create(
         rewriter, loc, TypeRange{outputType}, ValueRange{input},

--- a/test/ttlang/Conversion/TTLToCompute/row_prefix_store.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/row_prefix_store.mlir
@@ -5,9 +5,13 @@
 // RUN:   --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,canonicalize,cse)' \
 // RUN:   | FileCheck %s --check-prefix=TTKERNEL
 
+// Summary: Verifies row-prefix outputs retain complete DFB attachments while
+// compute uses compact formal output views.
+
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (0, 0)>
 
+// A direct elementwise compute publishes a compact bf16 output.
 // CHECK-LABEL: func.func @direct_bf16
 // CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x14x!ttcore.tile<1x32, bf16>>
 // CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
@@ -54,6 +58,7 @@ func.func @direct_bf16(
 
 // -----
 
+// A fused expression publishes a compact f32 output.
 // CHECK-LABEL: func.func @fused_f32
 // CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x7x!ttcore.tile<2x32, f32>>
 // CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
@@ -103,6 +108,7 @@ func.func @fused_f32(
 
 // -----
 
+// A DFB-backed input can publish directly through a compact output.
 // CHECK-LABEL: func.func @passthrough_bf16
 // CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x4x!ttcore.tile<4x32, bf16>>
 // CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
@@ -137,6 +143,7 @@ func.func @passthrough_bf16(
 
 // -----
 
+// A zero-input compute publishes the same tile to multiple compact outputs.
 // CHECK-LABEL: func.func @multiple_compact_outputs
 // CHECK-DAG:   tensor.empty() : tensor<1x8x!ttcore.tile<2x32, bf16>>
 // CHECK-DAG:   tensor.empty() : tensor<1x8x!ttcore.tile<2x32, bf16>>

--- a/test/ttlang/Conversion/TTLToCompute/row_prefix_store.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/row_prefix_store.mlir
@@ -1,0 +1,172 @@
+// RUN: ttlang-opt %s --split-input-file \
+// RUN:   --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),canonicalize)' \
+// RUN:   | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file \
+// RUN:   --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,canonicalize,cse)' \
+// RUN:   | FileCheck %s --check-prefix=TTKERNEL
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (0, 0)>
+
+// CHECK-LABEL: func.func @direct_bf16
+// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x14x!ttcore.tile<1x32, bf16>>
+// CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
+// CHECK:       %[[OUTPUT:.*]] = tensor.extract_slice %[[ATTACHED]][0, 0] [1, 1] [1, 1]
+// CHECK:       ttl.compute
+// CHECK-SAME:  ins(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>)
+// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<1x32, bf16>>)
+// CHECK-SAME:  indexing_maps = [#map, #map, #map1]
+// CHECK:       ^bb0({{.*}}!ttcore.tile<32x32, bf16>{{.*}}!ttcore.tile<32x32, bf16>{{.*}}!ttcore.tile<1x32, bf16>):
+// CHECK:         %[[SUM:.*]] = ttl.tile_add
+// CHECK:         ttl.tile_store %[[SUM]], %{{.*}}[%{{.*}}, %{{.*}}] from dst[%{{.*}}] {row_prefix{{.*}}}
+// CHECK:       } -> tensor<1x1x!ttcore.tile<1x32, bf16>>
+// TTKERNEL-LABEL: func.func @direct_bf16
+// TTKERNEL:       ttkernel.pack_rows({{.*}}) {row_count = 28 : i64}
+func.func @direct_bf16(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+  %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %attached_rhs = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
+        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+  %sum = ttl.add %attached_lhs, %attached_rhs
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %sum, %output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x14x!ttcore.tile<1x32, bf16>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @fused_f32
+// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x7x!ttcore.tile<2x32, f32>>
+// CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
+// CHECK:       %[[OUTPUT:.*]] = tensor.extract_slice %[[ATTACHED]][0, 0] [1, 1] [1, 1]
+// CHECK:       ttl.compute
+// CHECK-SAME:  ins(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>)
+// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<2x32, f32>>)
+// CHECK-SAME:  indexing_maps = [#map, #map, #map1]
+// CHECK:         %[[EXP:.*]] = ttl.tile_exp
+// CHECK:         %[[SUM:.*]] = ttl.tile_add %[[EXP]],
+// CHECK:         ttl.tile_store %[[SUM]], %{{.*}}[%{{.*}}, %{{.*}}] from dst[%{{.*}}] {row_prefix{{.*}}}
+// CHECK:       } -> tensor<1x1x!ttcore.tile<2x32, f32>>
+// TTKERNEL-LABEL: func.func @fused_f32
+// TTKERNEL:       ttkernel.pack_rows({{.*}}) {row_count = 28 : i64}
+func.func @fused_f32(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>) {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 7], !ttcore.tile<2x32, f32>, 1>
+  %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %attached_rhs = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 7], !ttcore.tile<2x32, f32>, 1>
+        -> tensor<1x7x!ttcore.tile<2x32, f32>>
+  %exp = ttl.exp %attached_lhs
+      : tensor<1x1x!ttcore.tile<32x32, f32>>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %sum = ttl.add %exp, %attached_rhs
+      : tensor<1x1x!ttcore.tile<32x32, f32>>,
+        tensor<1x1x!ttcore.tile<32x32, f32>>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  ttl.store %sum, %output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, f32>>,
+        tensor<1x7x!ttcore.tile<2x32, f32>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @passthrough_bf16
+// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x4x!ttcore.tile<4x32, bf16>>
+// CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
+// CHECK:       %[[OUTPUT:.*]] = tensor.extract_slice %[[ATTACHED]][0, 0] [1, 1] [1, 1]
+// CHECK:       ttl.compute
+// CHECK-SAME:  ins(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>)
+// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<4x32, bf16>>)
+// CHECK-SAME:  indexing_maps = [#map, #map1]
+// CHECK:       ^bb0(%[[INPUT:.*]]: !ttcore.tile<32x32, bf16>, %{{.*}}: !ttcore.tile<4x32, bf16>):
+// CHECK:         ttl.tile_store %[[INPUT]], %{{.*}}[%{{.*}}, %{{.*}}] from dst[%{{.*}}] {row_prefix{{.*}}}
+// CHECK:       } -> tensor<1x1x!ttcore.tile<4x32, bf16>>
+// TTKERNEL-LABEL: func.func @passthrough_bf16
+// TTKERNEL:       ttkernel.pack_rows({{.*}}) {row_count = 32 : i64}
+func.func @passthrough_bf16(
+    %input: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 4], !ttcore.tile<4x32, bf16>, 1>
+  %attached_input = ttl.attach_cb %input, %input_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 4], !ttcore.tile<4x32, bf16>, 1>
+        -> tensor<1x4x!ttcore.tile<4x32, bf16>>
+  ttl.store %attached_input, %output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x4x!ttcore.tile<4x32, bf16>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @multiple_compact_outputs
+// CHECK-DAG:   tensor.empty() : tensor<1x8x!ttcore.tile<2x32, bf16>>
+// CHECK-DAG:   tensor.empty() : tensor<1x8x!ttcore.tile<2x32, bf16>>
+// CHECK-DAG:   tensor.extract_slice {{.*}}[0, 0] [1, 1] [1, 1]
+// CHECK-DAG:   tensor.extract_slice {{.*}}[0, 0] [1, 1] [1, 1]
+// CHECK:       ttl.compute ins() outs(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<2x32, bf16>>, tensor<1x1x!ttcore.tile<2x32, bf16>>)
+// CHECK-SAME:  indexing_maps = [#map, #map]
+// CHECK:         %[[FILL:.*]] = ttl.tile_fill
+// CHECK-COUNT-2: ttl.tile_store %[[FILL]], {{.*}} {row_prefix{{.*}}}
+// CHECK:       } -> (tensor<1x1x!ttcore.tile<2x32, bf16>>, tensor<1x1x!ttcore.tile<2x32, bf16>>)
+// TTKERNEL-LABEL: func.func @multiple_compact_outputs
+// TTKERNEL-COUNT-2: ttkernel.pack_rows({{.*}}) {row_count = 32 : i64}
+func.func @multiple_compact_outputs() {
+  %first_output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 8], !ttcore.tile<2x32, bf16>, 1>
+  %second_output_dfb = ttl.bind_cb {cb_index = 17, block_count = 1}
+      : !ttl.cb<[1, 8], !ttcore.tile<2x32, bf16>, 1>
+  %first_output = ttl.cb_reserve %first_output_dfb
+      : <[1, 8], !ttcore.tile<2x32, bf16>, 1>
+        -> tensor<1x8x!ttcore.tile<2x32, bf16>>
+  %second_output = ttl.cb_reserve %second_output_dfb
+      : <[1, 8], !ttcore.tile<2x32, bf16>, 1>
+        -> tensor<1x8x!ttcore.tile<2x32, bf16>>
+  %filled = ttl.fill 0.000000e+00
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %filled, %first_output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x8x!ttcore.tile<2x32, bf16>>
+  ttl.store %filled, %second_output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x8x!ttcore.tile<2x32, bf16>>
+  return
+}

--- a/test/ttlang/Conversion/TTLToCompute/row_prefix_store.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/row_prefix_store.mlir
@@ -5,27 +5,26 @@
 // RUN:   --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations),convert-ttl-to-ttkernel,ttkernel-insert-inits,canonicalize,cse)' \
 // RUN:   | FileCheck %s --check-prefix=TTKERNEL
 
-// Summary: Verifies row-prefix outputs retain complete DFB attachments while
-// compute uses compact formal output views.
+// Summary: Verifies compute creation publishes one short-height output tile
+// directly with the standard tile pack operation.
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (0, 0)>
 
-// A direct elementwise compute publishes a compact bf16 output.
+// A direct elementwise compute publishes a short-height bf16 output.
 // CHECK-LABEL: func.func @direct_bf16
-// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x14x!ttcore.tile<1x32, bf16>>
-// CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
-// CHECK:       %[[OUTPUT:.*]] = tensor.extract_slice %[[ATTACHED]][0, 0] [1, 1] [1, 1]
+// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x1x!ttcore.tile<16x32, bf16>>
+// CHECK:       %[[OUTPUT:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
 // CHECK:       ttl.compute
 // CHECK-SAME:  ins(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x!ttcore.tile<32x32, bf16>>)
-// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<1x32, bf16>>)
+// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<16x32, bf16>>)
 // CHECK-SAME:  indexing_maps = [#map, #map, #map1]
-// CHECK:       ^bb0({{.*}}!ttcore.tile<32x32, bf16>{{.*}}!ttcore.tile<32x32, bf16>{{.*}}!ttcore.tile<1x32, bf16>):
+// CHECK:       ^bb0({{.*}}!ttcore.tile<32x32, bf16>{{.*}}!ttcore.tile<32x32, bf16>{{.*}}!ttcore.tile<16x32, bf16>):
 // CHECK:         %[[SUM:.*]] = ttl.tile_add
 // CHECK:         ttl.tile_store %[[SUM]], %{{.*}}[%{{.*}}, %{{.*}}] from dst[%{{.*}}] {row_prefix{{.*}}}
-// CHECK:       } -> tensor<1x1x!ttcore.tile<1x32, bf16>>
+// CHECK:       } -> tensor<1x1x!ttcore.tile<16x32, bf16>>
 // TTKERNEL-LABEL: func.func @direct_bf16
-// TTKERNEL:       ttkernel.pack_rows({{.*}}) {row_count = 28 : i64}
+// TTKERNEL:       ttkernel.pack_tile(
 func.func @direct_bf16(
     %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
     %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
@@ -34,7 +33,7 @@ func.func @direct_bf16(
   %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
-      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 1>
   %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
       : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
@@ -44,35 +43,34 @@ func.func @direct_bf16(
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %output = ttl.cb_reserve %output_dfb
-      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
-        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
   %sum = ttl.add %attached_lhs, %attached_rhs
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
         tensor<1x1x!ttcore.tile<32x32, bf16>>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.store %sum, %output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x14x!ttcore.tile<1x32, bf16>>
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
   return
 }
 
 // -----
 
-// A fused expression publishes a compact f32 output.
+// A fused expression publishes a short-height f32 output.
 // CHECK-LABEL: func.func @fused_f32
-// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x7x!ttcore.tile<2x32, f32>>
-// CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
-// CHECK:       %[[OUTPUT:.*]] = tensor.extract_slice %[[ATTACHED]][0, 0] [1, 1] [1, 1]
+// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x1x!ttcore.tile<16x32, f32>>
+// CHECK:       %[[OUTPUT:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
 // CHECK:       ttl.compute
 // CHECK-SAME:  ins(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>)
-// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<2x32, f32>>)
+// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<16x32, f32>>)
 // CHECK-SAME:  indexing_maps = [#map, #map, #map1]
 // CHECK:         %[[EXP:.*]] = ttl.tile_exp
 // CHECK:         %[[SUM:.*]] = ttl.tile_add %[[EXP]],
 // CHECK:         ttl.tile_store %[[SUM]], %{{.*}}[%{{.*}}, %{{.*}}] from dst[%{{.*}}] {row_prefix{{.*}}}
-// CHECK:       } -> tensor<1x1x!ttcore.tile<2x32, f32>>
+// CHECK:       } -> tensor<1x1x!ttcore.tile<16x32, f32>>
 // TTKERNEL-LABEL: func.func @fused_f32
-// TTKERNEL:       ttkernel.pack_rows({{.*}}) {row_count = 28 : i64}
+// TTKERNEL:       ttkernel.pack_tile(
 func.func @fused_f32(
     %lhs: tensor<1x1x!ttcore.tile<32x32, f32>>,
     %rhs: tensor<1x1x!ttcore.tile<32x32, f32>>) {
@@ -81,7 +79,7 @@ func.func @fused_f32(
   %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
   %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
-      : !ttl.cb<[1, 7], !ttcore.tile<2x32, f32>, 1>
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, f32>, 1>
   %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
       : (tensor<1x1x!ttcore.tile<32x32, f32>>,
          !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>)
@@ -91,8 +89,8 @@ func.func @fused_f32(
          !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>)
         -> tensor<1x1x!ttcore.tile<32x32, f32>>
   %output = ttl.cb_reserve %output_dfb
-      : <[1, 7], !ttcore.tile<2x32, f32>, 1>
-        -> tensor<1x7x!ttcore.tile<2x32, f32>>
+      : <[1, 1], !ttcore.tile<16x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, f32>>
   %exp = ttl.exp %attached_lhs
       : tensor<1x1x!ttcore.tile<32x32, f32>>
         -> tensor<1x1x!ttcore.tile<32x32, f32>>
@@ -102,78 +100,75 @@ func.func @fused_f32(
         -> tensor<1x1x!ttcore.tile<32x32, f32>>
   ttl.store %sum, %output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, f32>>,
-        tensor<1x7x!ttcore.tile<2x32, f32>>
+        tensor<1x1x!ttcore.tile<16x32, f32>>
   return
 }
 
 // -----
 
-// A DFB-backed input can publish directly through a compact output.
+// A DFB-backed input can publish directly through a short-height output DFB.
 // CHECK-LABEL: func.func @passthrough_bf16
-// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x4x!ttcore.tile<4x32, bf16>>
-// CHECK:       %[[ATTACHED:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
-// CHECK:       %[[OUTPUT:.*]] = tensor.extract_slice %[[ATTACHED]][0, 0] [1, 1] [1, 1]
+// CHECK:       %[[EMPTY:.*]] = tensor.empty() : tensor<1x1x!ttcore.tile<16x32, bf16>>
+// CHECK:       %[[OUTPUT:.*]] = ttl.attach_cb %[[EMPTY]], %{{.*}}
 // CHECK:       ttl.compute
 // CHECK-SAME:  ins(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, bf16>>)
-// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<4x32, bf16>>)
+// CHECK-SAME:  outs(%[[OUTPUT]] : tensor<1x1x!ttcore.tile<16x32, bf16>>)
 // CHECK-SAME:  indexing_maps = [#map, #map1]
-// CHECK:       ^bb0(%[[INPUT:.*]]: !ttcore.tile<32x32, bf16>, %{{.*}}: !ttcore.tile<4x32, bf16>):
+// CHECK:       ^bb0(%[[INPUT:.*]]: !ttcore.tile<32x32, bf16>, %{{.*}}: !ttcore.tile<16x32, bf16>):
 // CHECK:         ttl.tile_store %[[INPUT]], %{{.*}}[%{{.*}}, %{{.*}}] from dst[%{{.*}}] {row_prefix{{.*}}}
-// CHECK:       } -> tensor<1x1x!ttcore.tile<4x32, bf16>>
+// CHECK:       } -> tensor<1x1x!ttcore.tile<16x32, bf16>>
 // TTKERNEL-LABEL: func.func @passthrough_bf16
-// TTKERNEL:       ttkernel.pack_rows({{.*}}) {row_count = 32 : i64}
+// TTKERNEL:       ttkernel.pack_tile(
 func.func @passthrough_bf16(
     %input: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
   %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
-      : !ttl.cb<[1, 4], !ttcore.tile<4x32, bf16>, 1>
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 1>
   %attached_input = ttl.attach_cb %input, %input_dfb
       : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %output = ttl.cb_reserve %output_dfb
-      : <[1, 4], !ttcore.tile<4x32, bf16>, 1>
-        -> tensor<1x4x!ttcore.tile<4x32, bf16>>
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
   ttl.store %attached_input, %output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x4x!ttcore.tile<4x32, bf16>>
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
   return
 }
 
 // -----
 
-// A zero-input compute publishes the same tile to multiple compact outputs.
-// CHECK-LABEL: func.func @multiple_compact_outputs
-// CHECK-DAG:   tensor.empty() : tensor<1x8x!ttcore.tile<2x32, bf16>>
-// CHECK-DAG:   tensor.empty() : tensor<1x8x!ttcore.tile<2x32, bf16>>
-// CHECK-DAG:   tensor.extract_slice {{.*}}[0, 0] [1, 1] [1, 1]
-// CHECK-DAG:   tensor.extract_slice {{.*}}[0, 0] [1, 1] [1, 1]
-// CHECK:       ttl.compute ins() outs(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<2x32, bf16>>, tensor<1x1x!ttcore.tile<2x32, bf16>>)
+// A zero-input compute publishes the same tile to multiple short-height outputs.
+// CHECK-LABEL: func.func @multiple_short_height_outputs
+// CHECK-DAG:   tensor.empty() : tensor<1x1x!ttcore.tile<16x32, bf16>>
+// CHECK-DAG:   tensor.empty() : tensor<1x1x!ttcore.tile<16x32, bf16>>
+// CHECK:       ttl.compute ins() outs(%{{.*}}, %{{.*}} : tensor<1x1x!ttcore.tile<16x32, bf16>>, tensor<1x1x!ttcore.tile<16x32, bf16>>)
 // CHECK-SAME:  indexing_maps = [#map, #map]
 // CHECK:         %[[FILL:.*]] = ttl.tile_fill
 // CHECK-COUNT-2: ttl.tile_store %[[FILL]], {{.*}} {row_prefix{{.*}}}
-// CHECK:       } -> (tensor<1x1x!ttcore.tile<2x32, bf16>>, tensor<1x1x!ttcore.tile<2x32, bf16>>)
-// TTKERNEL-LABEL: func.func @multiple_compact_outputs
-// TTKERNEL-COUNT-2: ttkernel.pack_rows({{.*}}) {row_count = 32 : i64}
-func.func @multiple_compact_outputs() {
+// CHECK:       } -> (tensor<1x1x!ttcore.tile<16x32, bf16>>, tensor<1x1x!ttcore.tile<16x32, bf16>>)
+// TTKERNEL-LABEL: func.func @multiple_short_height_outputs
+// TTKERNEL-COUNT-2: ttkernel.pack_tile(
+func.func @multiple_short_height_outputs() {
   %first_output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
-      : !ttl.cb<[1, 8], !ttcore.tile<2x32, bf16>, 1>
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 1>
   %second_output_dfb = ttl.bind_cb {cb_index = 17, block_count = 1}
-      : !ttl.cb<[1, 8], !ttcore.tile<2x32, bf16>, 1>
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 1>
   %first_output = ttl.cb_reserve %first_output_dfb
-      : <[1, 8], !ttcore.tile<2x32, bf16>, 1>
-        -> tensor<1x8x!ttcore.tile<2x32, bf16>>
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
   %second_output = ttl.cb_reserve %second_output_dfb
-      : <[1, 8], !ttcore.tile<2x32, bf16>, 1>
-        -> tensor<1x8x!ttcore.tile<2x32, bf16>>
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
   %filled = ttl.fill 0.000000e+00
       : tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.store %filled, %first_output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x8x!ttcore.tile<2x32, bf16>>
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
   ttl.store %filled, %second_output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x8x!ttcore.tile<2x32, bf16>>
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
   return
 }

--- a/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
@@ -107,7 +107,7 @@ func.func @compute_invalid_map_expr(
   %init_att = ttl.attach_cb %init, %cbout
       : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
         -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  // expected-error @below {{input 0 indexing map must be a projected permutation (unique dims or 0 constants)}}
+  // expected-error @below {{input 0 indexing map results must be unique dimensions or zero constants}}
   %0 = ttl.compute
       ins(%a_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
       outs(%init_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
@@ -118,6 +118,64 @@ func.func @compute_invalid_map_expr(
     ttl.yield
   } -> tensor<2x2x!ttcore.tile<32x32, f32>>
   func.return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Test: One iterator dimension occurs more than once in an indexing map.
+func.func @compute_repeated_map_dimension(
+    %output_dfb: !ttl.cb<[2, 2, 2], !ttcore.tile<32x32, f32>, 1>) {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<2x2x2x!ttcore.tile<32x32, f32>>
+  %attached_init = ttl.attach_cb %init, %output_dfb
+      : (tensor<2x2x2x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[2, 2, 2], !ttcore.tile<32x32, f32>, 1>)
+        -> tensor<2x2x2x!ttcore.tile<32x32, f32>>
+  %view = ttl.cb_reserve %output_dfb
+      : <[2, 2, 2], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<2x2x2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{output 0 indexing map must not repeat an iterator dimension}}
+  %result = ttl.compute
+      ins()
+      outs(%attached_init : tensor<2x2x2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%output_tile: !ttcore.tile<32x32, f32>):
+    ttl.tile_store %output_tile, %view[%c0, %c0, %c0] from dst[%c0]
+        : !ttcore.tile<32x32, f32>,
+          tensor<2x2x2x!ttcore.tile<32x32, f32>>
+    ttl.yield
+  } -> tensor<2x2x2x!ttcore.tile<32x32, f32>>
+  return
+}
+
+// -----
+
+// Test: Indexing-map constants other than zero are unsupported.
+func.func @compute_nonzero_map_constant(
+    %output_dfb: !ttl.cb<[2, 1, 2], !ttcore.tile<32x32, f32>, 1>) {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<2x1x2x!ttcore.tile<32x32, f32>>
+  %attached_init = ttl.attach_cb %init, %output_dfb
+      : (tensor<2x1x2x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[2, 1, 2], !ttcore.tile<32x32, f32>, 1>)
+        -> tensor<2x1x2x!ttcore.tile<32x32, f32>>
+  %view = ttl.cb_reserve %output_dfb
+      : <[2, 1, 2], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<2x1x2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{output 0 indexing map constants must be zero}}
+  %result = ttl.compute
+      ins()
+      outs(%attached_init : tensor<2x1x2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, 1, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+  ^bb0(%output_tile: !ttcore.tile<32x32, f32>):
+    ttl.tile_store %output_tile, %view[%c0, %c0, %c0] from dst[%c0]
+        : !ttcore.tile<32x32, f32>,
+          tensor<2x1x2x!ttcore.tile<32x32, f32>>
+    ttl.yield
+  } -> tensor<2x1x2x!ttcore.tile<32x32, f32>>
+  return
 }
 
 // -----
@@ -485,32 +543,36 @@ func.func @compute_dynamic_output(
 
 // -----
 
-// Test: More iterator dimensions than any tensor rank (catches malformed IR
-// where iteration domain doesn't correspond to any actual tensor).
-// Iterator count below max tensor rank (1 < 2).
-func.func @compute_iterator_below_tensor_rank(
-    %a: tensor<2x2x!ttcore.tile<32x32, f32>>,
+// Test: Iterator dimension absent from every indexing map.
+func.func @compute_unreferenced_iterator(
+    %a: tensor<1x1x!ttcore.tile<32x32, f32>>,
     %cba: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
     %cbout: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
-  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
   %a_att = ttl.attach_cb %a, %cba
-      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
   %init_att = ttl.attach_cb %init, %cbout
-      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
-        -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  // expected-error @below {{iterator_types count (1) must be >= maximum tensor rank (2)}}
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %view = ttl.cb_reserve %cbout
+      : <[1, 1], !ttcore.tile<32x32, f32>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{iterator dimension 0 must be referenced by at least one indexing map}}
   %0 = ttl.compute
-      ins(%a_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
-      outs(%init_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
-      {indexing_maps = [affine_map<(d0) -> (d0, d0)>,
-                        affine_map<(d0) -> (d0, d0)>],
+      ins(%a_att : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      outs(%init_att : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0) -> (0, 0)>,
+                        affine_map<(d0) -> (0, 0)>],
        iterator_types = ["parallel"]} {
     ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>):
+      ttl.tile_store %arg0, %view[%c0, %c0] from dst[%c0]
+          : !ttcore.tile<32x32, f32>, tensor<1x1x!ttcore.tile<32x32, f32>>
       ttl.yield
-  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
-  func.return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<1x1x!ttcore.tile<32x32, f32>>
 }
 
 // -----

--- a/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
@@ -180,6 +180,34 @@ func.func @compute_nonzero_map_constant(
 
 // -----
 
+// Test: Indexing maps cannot contain affine symbols.
+func.func @compute_map_symbol(
+    %output_dfb: !ttl.cb<[2], !ttcore.tile<32x32, f32>, 1>) {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<2x!ttcore.tile<32x32, f32>>
+  %attached_init = ttl.attach_cb %init, %output_dfb
+      : (tensor<2x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[2], !ttcore.tile<32x32, f32>, 1>)
+        -> tensor<2x!ttcore.tile<32x32, f32>>
+  %view = ttl.cb_reserve %output_dfb
+      : <[2], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{output 0 indexing map must not contain symbols}}
+  %result = ttl.compute
+      ins()
+      outs(%attached_init : tensor<2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0)[s0] -> (d0)>],
+       iterator_types = ["parallel"]} {
+  ^bb0(%output_tile: !ttcore.tile<32x32, f32>):
+    ttl.tile_store %output_tile, %view[%c0] from dst[%c0]
+        : !ttcore.tile<32x32, f32>, tensor<2x!ttcore.tile<32x32, f32>>
+    ttl.yield
+  } -> tensor<2x!ttcore.tile<32x32, f32>>
+  return
+}
+
+// -----
+
 // Test: Broadcast constant on non-1 dimension
 func.func @compute_broadcast_dim_not_one(
     %a: tensor<2x2x!ttcore.tile<32x32, f32>>,

--- a/test/ttlang/Dialect/TTL/IR/compute_with_cbs.mlir
+++ b/test/ttlang/Dialect/TTL/IR/compute_with_cbs.mlir
@@ -177,3 +177,37 @@ func.func @compute_with_nested_matmul_subtile(
   } -> tensor<1x1x!ttcore.tile<1x32, bf16>>
   func.return %result : tensor<1x1x!ttcore.tile<1x32, bf16>>
 }
+
+// -----
+
+// A zero-rank iteration domain executes once over unit-extent outputs.
+// CHECK-LABEL: func.func @compute_zero_rank_iteration
+// CHECK:       ttl.compute ins() outs(%{{.*}} : tensor<1x1x!ttcore.tile<32x32, f32>>)
+// CHECK-SAME:  indexing_maps = [#map{{[0-9]*}}]
+// CHECK-SAME:  iterator_types = []
+func.func @compute_zero_rank_iteration(
+    %output_dfb: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %attached_init = ttl.attach_cb %init, %output_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, f32>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, f32>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %result = ttl.compute
+      ins()
+      outs(%attached_init : tensor<1x1x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<() -> (0, 0)>], iterator_types = []} {
+  ^bb0(%output_tile: !ttcore.tile<32x32, f32>):
+    %filled = ttl.tile_fill 0.000000e+00 into dst[%c0]
+        : !ttcore.tile<32x32, f32>
+    ttl.tile_store %filled, %output[%c0, %c0] from dst[%c0]
+        : !ttcore.tile<32x32, f32>,
+          tensor<1x1x!ttcore.tile<32x32, f32>>
+    ttl.yield
+  } -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %result : tensor<1x1x!ttcore.tile<32x32, f32>>
+}

--- a/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
@@ -119,6 +119,47 @@ func.func @mixed_store_kinds(
 
 // -----
 
+// CHECK-LABEL: ComputeOp creation plan @different_destination_types
+// CHECK:       rejected-source {{.*}} ttl.add
+// CHECK-SAME:  reason=row-prefix stores to one dataflow buffer require one destination tensor type
+func.func @different_destination_types(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+  %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %attached_rhs = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
+        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+  %short_output = tensor.extract_slice %output[0, 0] [1, 13] [1, 1]
+      : tensor<1x14x!ttcore.tile<1x32, bf16>>
+        to tensor<1x13x!ttcore.tile<1x32, bf16>>
+  %sum = ttl.add %attached_lhs, %attached_rhs
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %sum, %output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x14x!ttcore.tile<1x32, bf16>>
+  ttl.store %sum, %short_output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x13x!ttcore.tile<1x32, bf16>>
+  return
+}
+
+// -----
+
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_output
 // CHECK:       rejected-source {{.*}} ttl.mul
 // CHECK-SAME:  reason=row-prefix output is unsupported for row-normalization block creation

--- a/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
@@ -2,6 +2,10 @@
 // RUN:   -pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' \
 // RUN:   -o /dev/null 2>&1 | FileCheck %s
 
+// Summary: Verifies row-prefix output planning rejects publication contracts
+// that cannot preserve one valid compute output representation.
+
+// A compact formal result cannot replace an observable full-tile result.
 // CHECK-LABEL: ComputeOp creation plan @non_store_result_use
 // CHECK:       rejected-source {{.*}} ttl.add
 // CHECK-SAME:  reason=row-prefix output cannot preserve a non-store use of the full-tile result
@@ -39,6 +43,7 @@ func.func @non_store_result_use(
 
 // -----
 
+// One compute cannot publish formal outputs with different tile types.
 // CHECK-LABEL: ComputeOp creation plan @different_output_tile_types
 // CHECK:       rejected-source {{.*}} ttl.add
 // CHECK-SAME:  reason=one compute cannot publish output dataflow buffers with different tile types
@@ -82,6 +87,7 @@ func.func @different_output_tile_types(
 
 // -----
 
+// Stores sharing one DFB must use one publication strategy.
 // CHECK-LABEL: ComputeOp creation plan @mixed_store_kinds
 // CHECK:       rejected-source {{.*}} ttl.add reason=one dataflow buffer cannot mix row-prefix and regular stores
 func.func @mixed_store_kinds(
@@ -119,6 +125,7 @@ func.func @mixed_store_kinds(
 
 // -----
 
+// Row-prefix stores sharing one DFB must agree on its complete view type.
 // CHECK-LABEL: ComputeOp creation plan @different_destination_types
 // CHECK:       rejected-source {{.*}} ttl.add
 // CHECK-SAME:  reason=row-prefix stores to one dataflow buffer require one destination tensor type
@@ -160,6 +167,7 @@ func.func @different_destination_types(
 
 // -----
 
+// Row-normalization creation does not support compact output publication.
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_output
 // CHECK:       rejected-source {{.*}} ttl.mul
 // CHECK-SAME:  reason=row-prefix output is unsupported for row-normalization block creation

--- a/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
@@ -116,3 +116,61 @@ func.func @mixed_store_kinds(
         tensor<1x1x!ttcore.tile<32x32, bf16>>
   return
 }
+
+// -----
+
+// CHECK-LABEL: ComputeOp creation plan @row_normalization_output
+// CHECK:       rejected-source {{.*}} ttl.mul
+// CHECK-SAME:  reason=row-prefix output is unsupported for row-normalization block creation
+module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
+  func.func @row_normalization_output()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 2>
+    %input_wait = ttl.cb_wait %input_dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %input = ttl.attach_cb %input_wait, %input_dfb
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %square = ttl.mul %input, %input
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scaler = ttl.fill 1.000000e+00
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %reduced = ttl.reduce %square, %scaler 0 : i32 [0, 1]
+        : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+           tensor<1x1x!ttcore.tile<32x32, bf16>>)
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %mean_square = ttl.mul_unary_const %reduced, 9.765625e-04
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %epsilon = ttl.fill 1.000000e-05
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %biased = ttl.add %epsilon, %mean_square
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %inverse_rms = ttl.rsqrt %biased
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %scalar = ttl.block.broadcast %inverse_rms dims = [0, 1], shape = [1, 1]
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %result = ttl.mul %scalar, %input
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x1x!ttcore.tile<32x32, bf16>>
+          -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    %output = ttl.cb_reserve %output_dfb
+        : <[1, 14], !ttcore.tile<1x32, bf16>, 2>
+          -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+    ttl.store %result, %output {row_prefix}
+        : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+          tensor<1x14x!ttcore.tile<1x32, bf16>>
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
@@ -1,0 +1,118 @@
+// RUN: ttlang-opt %s --split-input-file \
+// RUN:   -pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' \
+// RUN:   -o /dev/null 2>&1 | FileCheck %s
+
+// CHECK-LABEL: ComputeOp creation plan @non_store_result_use
+// CHECK:       rejected-source {{.*}} ttl.add
+// CHECK-SAME:  reason=row-prefix output cannot preserve a non-store use of the full-tile result
+// CHECK:       unassigned-store {{.*}} reason=row-prefix output cannot preserve a non-store use of the full-tile result
+func.func @non_store_result_use(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>)
+    -> tensor<1x1x!ttcore.tile<32x32, bf16>> {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+  %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %attached_rhs = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
+        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+  %sum = ttl.add %attached_lhs, %attached_rhs
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %sum, %output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x14x!ttcore.tile<1x32, bf16>>
+  return %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
+}
+
+// -----
+
+// CHECK-LABEL: ComputeOp creation plan @different_output_tile_types
+// CHECK:       rejected-source {{.*}} ttl.add
+// CHECK-SAME:  reason=one compute cannot publish output dataflow buffers with different tile types
+func.func @different_output_tile_types(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %full_output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %compact_output_dfb = ttl.bind_cb {cb_index = 17, block_count = 1}
+      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+  %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %attached_rhs = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %full_output = ttl.cb_reserve %full_output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %compact_output = ttl.cb_reserve %compact_output_dfb
+      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
+        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+  %sum = ttl.add %attached_lhs, %attached_rhs
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %sum, %full_output
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %sum, %compact_output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x14x!ttcore.tile<1x32, bf16>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: ComputeOp creation plan @mixed_store_kinds
+// CHECK:       rejected-source {{.*}} ttl.add reason=one dataflow buffer cannot mix row-prefix and regular stores
+func.func @mixed_store_kinds(
+    %lhs: tensor<1x1x!ttcore.tile<32x32, bf16>>,
+    %rhs: tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+  %lhs_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
+  %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %attached_rhs = ttl.attach_cb %rhs, %rhs_dfb
+      : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
+         !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %output = ttl.cb_reserve %output_dfb
+      : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  %sum = ttl.add %attached_lhs, %attached_rhs
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %sum, %output
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  ttl.store %sum, %output {row_prefix}
+      : tensor<1x1x!ttcore.tile<32x32, bf16>>,
+        tensor<1x1x!ttcore.tile<32x32, bf16>>
+  return
+}

--- a/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/row_prefix_output_planning.mlir
@@ -5,7 +5,7 @@
 // Summary: Verifies row-prefix output planning rejects publication contracts
 // that cannot preserve one valid compute output representation.
 
-// A compact formal result cannot replace an observable full-tile result.
+// A short-height compute result cannot replace an observable full-tile result.
 // CHECK-LABEL: ComputeOp creation plan @non_store_result_use
 // CHECK:       rejected-source {{.*}} ttl.add
 // CHECK-SAME:  reason=row-prefix output cannot preserve a non-store use of the full-tile result
@@ -19,7 +19,7 @@ func.func @non_store_result_use(
   %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
-      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 1>
   %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
       : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
@@ -29,21 +29,21 @@ func.func @non_store_result_use(
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %output = ttl.cb_reserve %output_dfb
-      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
-        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
   %sum = ttl.add %attached_lhs, %attached_rhs
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
         tensor<1x1x!ttcore.tile<32x32, bf16>>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.store %sum, %output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x14x!ttcore.tile<1x32, bf16>>
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
   return %sum : tensor<1x1x!ttcore.tile<32x32, bf16>>
 }
 
 // -----
 
-// One compute cannot publish formal outputs with different tile types.
+// One compute cannot configure output DFBs with different tile formats.
 // CHECK-LABEL: ComputeOp creation plan @different_output_tile_types
 // CHECK:       rejected-source {{.*}} ttl.add
 // CHECK-SAME:  reason=one compute cannot publish output dataflow buffers with different tile types
@@ -56,8 +56,8 @@ func.func @different_output_tile_types(
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %full_output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
-  %compact_output_dfb = ttl.bind_cb {cb_index = 17, block_count = 1}
-      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+  %short_output_dfb = ttl.bind_cb {cb_index = 17, block_count = 1}
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 1>
   %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
       : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
@@ -69,9 +69,9 @@ func.func @different_output_tile_types(
   %full_output = ttl.cb_reserve %full_output_dfb
       : <[1, 1], !ttcore.tile<32x32, bf16>, 1>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
-  %compact_output = ttl.cb_reserve %compact_output_dfb
-      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
-        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+  %short_output = ttl.cb_reserve %short_output_dfb
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
   %sum = ttl.add %attached_lhs, %attached_rhs
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
         tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -79,9 +79,9 @@ func.func @different_output_tile_types(
   ttl.store %sum, %full_output
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
         tensor<1x1x!ttcore.tile<32x32, bf16>>
-  ttl.store %sum, %compact_output {row_prefix}
+  ttl.store %sum, %short_output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x14x!ttcore.tile<1x32, bf16>>
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
   return
 }
 
@@ -137,7 +137,7 @@ func.func @different_destination_types(
   %rhs_dfb = ttl.bind_cb {cb_index = 1, block_count = 1}
       : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>
   %output_dfb = ttl.bind_cb {cb_index = 16, block_count = 1}
-      : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 1>
+      : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 1>
   %attached_lhs = ttl.attach_cb %lhs, %lhs_dfb
       : (tensor<1x1x!ttcore.tile<32x32, bf16>>,
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
@@ -147,27 +147,27 @@ func.func @different_destination_types(
          !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 1>)
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   %output = ttl.cb_reserve %output_dfb
-      : <[1, 14], !ttcore.tile<1x32, bf16>, 1>
-        -> tensor<1x14x!ttcore.tile<1x32, bf16>>
-  %short_output = tensor.extract_slice %output[0, 0] [1, 13] [1, 1]
-      : tensor<1x14x!ttcore.tile<1x32, bf16>>
-        to tensor<1x13x!ttcore.tile<1x32, bf16>>
+      : <[1, 1], !ttcore.tile<16x32, bf16>, 1>
+        -> tensor<1x1x!ttcore.tile<16x32, bf16>>
+  %rank_reduced_output = tensor.extract_slice %output[0, 0] [1, 1] [1, 1]
+      : tensor<1x1x!ttcore.tile<16x32, bf16>>
+        to tensor<1x!ttcore.tile<16x32, bf16>>
   %sum = ttl.add %attached_lhs, %attached_rhs
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
         tensor<1x1x!ttcore.tile<32x32, bf16>>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
   ttl.store %sum, %output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x14x!ttcore.tile<1x32, bf16>>
-  ttl.store %sum, %short_output {row_prefix}
+        tensor<1x1x!ttcore.tile<16x32, bf16>>
+  ttl.store %sum, %rank_reduced_output {row_prefix}
       : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-        tensor<1x13x!ttcore.tile<1x32, bf16>>
+        tensor<1x!ttcore.tile<16x32, bf16>>
   return
 }
 
 // -----
 
-// Row-normalization creation does not support compact output publication.
+// Row-normalization creation does not support short-height output publication.
 // CHECK-LABEL: ComputeOp creation plan @row_normalization_output
 // CHECK:       rejected-source {{.*}} ttl.mul
 // CHECK-SAME:  reason=row-prefix output is unsupported for row-normalization block creation
@@ -177,7 +177,7 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
     %input_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %output_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
-        : !ttl.cb<[1, 14], !ttcore.tile<1x32, bf16>, 2>
+        : !ttl.cb<[1, 1], !ttcore.tile<16x32, bf16>, 2>
     %input_wait = ttl.cb_wait %input_dfb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
           -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -215,11 +215,11 @@ module attributes {ttl.target_arch = #ttcore.arch<blackhole>} {
           tensor<1x1x!ttcore.tile<32x32, bf16>>
           -> tensor<1x1x!ttcore.tile<32x32, bf16>>
     %output = ttl.cb_reserve %output_dfb
-        : <[1, 14], !ttcore.tile<1x32, bf16>, 2>
-          -> tensor<1x14x!ttcore.tile<1x32, bf16>>
+        : <[1, 1], !ttcore.tile<16x32, bf16>, 2>
+          -> tensor<1x1x!ttcore.tile<16x32, bf16>>
     ttl.store %result, %output {row_prefix}
         : tensor<1x1x!ttcore.tile<32x32, bf16>>,
-          tensor<1x14x!ttcore.tile<1x32, bf16>>
+          tensor<1x1x!ttcore.tile<16x32, bf16>>
     return
   }
 }


### PR DESCRIPTION
### Problem description

A row-prefix store writes the valid leading rows of a full DST tile into a native short-height output DFB. When compute creation absorbs that store, it currently assigns the full source type to every `ttl.compute` output. That type cannot attach to the short-height DFB, so a tree reduction cannot publish a logical 14x32 result directly as one `tile<16x32>`.

```mlir
%sum = ttl.add %lhs, %rhs
ttl.store %sum, %output {row_prefix}
    : tensor<1x1x!ttcore.tile<32x32, bf16>>,
      tensor<1x1x!ttcore.tile<16x32, bf16>>
```

### What's changed

~320 LOC implementation.

- Plans the output tensor type and indexing map for each output DFB before rewriting.
- Uses the row-prefix destination's native short-height tile type as the `ttl.compute` result and lowers publication through the existing `ttkernel.pack_tile`.
- Uses a constant-zero output map because one full DST tile produces one short-height destination tile.
- Supports the zero-dimensional iteration domain required by input-free one-tile producers and rejects unreferenced, symbolic, repeated, and nonzero indexing-map dimensions.
- Rejects output tile-type mixtures that the compute kernel's shared packer initialization cannot represent.

### Stack

main -> [#982](https://github.com/tenstorrent/tt-lang/pull/982) -> [#986](https://github.com/tenstorrent/tt-lang/pull/986) -> [#987](https://github.com/tenstorrent/tt-lang/pull/987) -> [#988](https://github.com/tenstorrent/tt-lang/pull/988) -> [#989](https://github.com/tenstorrent/tt-lang/pull/989) -> [#990](https://github.com/tenstorrent/tt-lang/pull/990) -> [#991](https://github.com/tenstorrent/tt-lang/pull/991) -> **[#992](https://github.com/tenstorrent/tt-lang/pull/992)**

### Checklist

- [x] New MLIR tests cover direct, fused, passthrough, input-free, and multiple short-height outputs.
- [x] New invalid MLIR tests cover incompatible output plans and malformed indexing maps.
- [x] New frontend compile tests cover BF16 and FP32 row-prefix API contracts.
