### PR TITLE
[ttl.exp][test] Add exp scaling tests

### DIFF
--- a/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsEnums.td
@@ -151,8 +151,7 @@ def TTL_AccumulationInitialMode : I32EnumAttr<"AccumulationInitialMode",
 //===----------------------------------------------------------------------===//
 
 // Controls whether the (approximate) exp clamps very negative inputs before
-// the SFPU evaluation. Underlying values match tt-metal's ckernel::InputClamping
-// and the TTKernel InputClamping enum so the lowering can forward by value:
+// the SFPU evaluation:
 //   None (0): no clamp -- faster, but inputs below ~-88.5 produce incorrect
 //             outputs (guaranteed negative; consider packer ReLU).
 //   ClampToNegative (1): clamp very negative inputs -- safer, slightly slower.

--- a/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLTileOpsToTTKernel.cpp
@@ -312,7 +312,6 @@ struct TTLTileTypecastToTTKernel : OpConversionPattern<TileTypecastOp> {
 ///   ttkernel.exp_tile : (tile_index, approx?, input_clamping?, iterations?,
 ///                        scale?)
 ///   ttkernel.exp_tile_init : (approx?, scale?, input_clamping?)
-/// where InputClamping shares the underlying values of ttl::InputClamping.
 struct TTLTileExpToTTKernel : OpConversionPattern<ExpTileOp> {
   using OpConversionPattern<ExpTileOp>::OpConversionPattern;
 
@@ -327,10 +326,13 @@ struct TTLTileExpToTTKernel : OpConversionPattern<ExpTileOp> {
       approxAttr = rewriter.getBoolAttr(true);
     }
     ttk::InputClampingAttr inputClampingAttr;
-    if (op.getInputClamping() != ttl::InputClamping::ClampToNegative) {
-      inputClampingAttr = ttk::InputClampingAttr::get(
-          rewriter.getContext(),
-          static_cast<ttk::InputClamping>(op.getInputClamping()));
+    switch (op.getInputClamping()) {
+    case ttl::InputClamping::None:
+      inputClampingAttr = ttk::InputClampingAttr::get(rewriter.getContext(),
+                                                      ttk::InputClamping::None);
+      break;
+    case ttl::InputClamping::ClampToNegative:
+      break;
     }
     IntegerAttr iterationsAttr;
     if (op.getIterations() != defaultExpIterations) {

--- a/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
+++ b/lib/Dialect/TTL/Transforms/ConvertTTLToCompute.cpp
@@ -551,7 +551,8 @@ static LogicalResult buildFusedCompute(Operation *sinkOp,
              "instrumented matmul must not be folded into its user");
       continue;
     case FusedOperationRecipe::DeferredExpScale:
-      instrumentationEmitter.emitAfter(op);
+      assert(!instrumentationEmitter.hasAfter(op) &&
+             "instrumented exp scale must not be folded into exp");
       continue;
     case FusedOperationRecipe::MatmulAccumulator: {
       assert(operationPlan.foldedMatmul && operationPlan.accumulator &&

--- a/test/python/test_exp_flags.py
+++ b/test/python/test_exp_flags.py
@@ -2,10 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# REQUIRES: ttnn
-# UNSUPPORTED: system-darwin
-# RUN: %python -m pytest %s -v
-
 """End-to-end coverage for the ttl.math.exp hardware flags.
 
 Flags must be passed as literal keyword arguments in the ``ttl.math.exp`` call
@@ -20,9 +16,28 @@ import ttl
 
 ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
-from ttlang_test_utils import assert_allclose, to_l1
+from ttlang_test_utils import assert_allclose, to_dram
 
 EXP_SCALE = 2.0
+TILE = 32
+ACCURATE_TOLERANCES = {
+    torch.bfloat16: {"rtol": 2e-2, "atol": 2e-2},
+    torch.float32: {"rtol": 1e-3, "atol": 1e-3},
+}
+APPROX_TOLERANCES = {
+    torch.bfloat16: {"rtol": 5e-2, "atol": 5e-2},
+    torch.float32: {"rtol": 4e-2, "atol": 5e-3},
+}
+MEMORY_CONFIGS = [
+    pytest.param(ttnn.DRAM_MEMORY_CONFIG, id="dram"),
+    pytest.param(ttnn.L1_MEMORY_CONFIG, id="l1"),
+]
+EXP_CONFIGS = [
+    pytest.param(torch.bfloat16, ttnn.DRAM_MEMORY_CONFIG, id="bf16-dram"),
+    pytest.param(torch.bfloat16, ttnn.L1_MEMORY_CONFIG, id="bf16-l1"),
+    pytest.param(torch.float32, ttnn.DRAM_MEMORY_CONFIG, id="f32-dram"),
+    pytest.param(torch.float32, ttnn.L1_MEMORY_CONFIG, id="f32-l1"),
+]
 
 
 @ttl.operation(grid=(1, 1))
@@ -63,6 +78,60 @@ def exp_approx_kernel(in_t, out_t):
     @ttl.datamovement()
     def dm_write():
         ttl.copy(out_cb.wait(), out_t[0, 0])
+
+
+@ttl.operation(grid=(1, 1))
+def exp_approx_scale_keyword_kernel(in_t, out_t):
+    tile_rows = in_t.shape[0] // TILE
+    tile_cols = in_t.shape[1] // TILE
+    a_cb = ttl.make_dataflow_buffer_like(
+        in_t, shape=(tile_rows, tile_cols), block_count=2
+    )
+    out_cb = ttl.make_dataflow_buffer_like(
+        out_t, shape=(tile_rows, tile_cols), block_count=2
+    )
+
+    @ttl.compute()
+    def compute_fn():
+        with a_cb.wait() as x, out_cb.reserve() as r:
+            r.store(ttl.math.exp(x, approx=True, scale=EXP_SCALE))
+
+    @ttl.datamovement()
+    def dm_read():
+        with a_cb.reserve() as block:
+            ttl.copy(in_t[0:tile_rows, 0:tile_cols], block).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with out_cb.wait() as block:
+            ttl.copy(block, out_t[0:tile_rows, 0:tile_cols]).wait()
+
+
+@ttl.operation(grid=(1, 1))
+def exp_approx_scale_mul_kernel(in_t, out_t):
+    tile_rows = in_t.shape[0] // TILE
+    tile_cols = in_t.shape[1] // TILE
+    a_cb = ttl.make_dataflow_buffer_like(
+        in_t, shape=(tile_rows, tile_cols), block_count=2
+    )
+    out_cb = ttl.make_dataflow_buffer_like(
+        out_t, shape=(tile_rows, tile_cols), block_count=2
+    )
+
+    @ttl.compute()
+    def compute_fn():
+        with a_cb.wait() as x, out_cb.reserve() as r:
+            r.store(ttl.math.exp(x * EXP_SCALE, approx=True))
+
+    @ttl.datamovement()
+    def dm_read():
+        with a_cb.reserve() as block:
+            ttl.copy(in_t[0:tile_rows, 0:tile_cols], block).wait()
+
+    @ttl.datamovement()
+    def dm_write():
+        with out_cb.wait() as block:
+            ttl.copy(block, out_t[0:tile_rows, 0:tile_cols]).wait()
 
 
 @ttl.operation(grid=(1, 1))
@@ -145,62 +214,79 @@ def exp_scale_keyword_kernel(in_t, out_t):
         ttl.copy(out_cb.wait(), out_t[0, 0])
 
 
-def _run(kernel, inp_t, device):
-    tile = ttnn.TILE_SIZE
-    in_t = to_l1(inp_t, device)
-    out_t = to_l1(torch.zeros(tile, tile, dtype=torch.bfloat16), device)
+def _run(kernel, inp_t, device, memory_config=ttnn.DRAM_MEMORY_CONFIG):
+    in_t = to_dram(inp_t, device)
+    out_t = to_dram(torch.zeros_like(inp_t), device)
+    if memory_config == ttnn.L1_MEMORY_CONFIG:
+        in_t = ttnn.to_memory_config(in_t, memory_config=memory_config)
+        out_t = ttnn.to_memory_config(out_t, memory_config=memory_config)
     kernel(in_t, out_t)
-    return ttnn.to_torch(out_t).reshape(tile, tile).to(torch.bfloat16)
+    return ttnn.to_torch(out_t).reshape(inp_t.shape).to(inp_t.dtype)
 
 
-def _rand_tile():
-    tile = ttnn.TILE_SIZE
-    return (torch.randn(tile, tile, dtype=torch.bfloat16) * 0.5).clamp(-1.0, 1.0)
+def _rand_input(shape, dtype):
+    return (torch.randn(shape, dtype=dtype) * 0.5).clamp(-1.0, 1.0)
 
 
-def test_exp_default(device):
-    inp_t = _rand_tile()
-    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
-    got = _run(exp_default_kernel, inp_t, device)
-    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+@pytest.mark.parametrize("dtype,memory_config", EXP_CONFIGS)
+def test_exp_default(device, dtype, memory_config):
+    inp_t = _rand_input((TILE, TILE), dtype)
+    expected = torch.exp(inp_t.float()).to(dtype)
+    got = _run(exp_default_kernel, inp_t, device, memory_config)
+    assert_allclose(got.float(), expected.float(), **ACCURATE_TOLERANCES[dtype])
 
 
-def test_exp_approx(device):
-    inp_t = _rand_tile()
-    expected = torch.exp(inp_t.float()).to(torch.bfloat16)
-    got = _run(exp_approx_kernel, inp_t, device)
-    # Approximate mode: relax tolerance.
-    assert_allclose(got, expected, rtol=5e-2, atol=5e-2)
+@pytest.mark.parametrize("dtype,memory_config", EXP_CONFIGS)
+def test_exp_approx(device, dtype, memory_config):
+    inp_t = _rand_input((TILE, TILE), dtype)
+    expected = torch.exp(inp_t.float()).to(dtype)
+    got = _run(exp_approx_kernel, inp_t, device, memory_config)
+    assert_allclose(got.float(), expected.float(), **APPROX_TOLERANCES[dtype])
 
 
 def test_exp_approx_skip_clamp(device):
-    # approx + skip_clamp_check (InputClamping::None) is a speed-over-accuracy
-    # mode: it skips the clamp the approximate SFPU exp normally relies on, so
-    # the result is not close to the exact exp (it saturates). We only verify
-    # the flags plumb through, compile, and run, producing finite positive
-    # outputs (exp is always > 0) rather than asserting close numerics.
-    inp_t = _rand_tile()
-    got = _run(exp_approx_skip_clamp_kernel, inp_t, device)
-    assert torch.isfinite(got).all()
-    assert (got > 0).all()
+    inp_t = torch.full((TILE, TILE), -100.0, dtype=torch.bfloat16)
+    clamped = _run(exp_approx_kernel, inp_t, device)
+    unclamped = _run(exp_approx_skip_clamp_kernel, inp_t, device)
+    assert torch.isfinite(clamped).all()
+    assert (clamped >= 0).all()
+    assert (unclamped < 0).any()
 
 
-def test_exp_scaled_by_literal_mul(device):
-    inp_t = _rand_tile()
-    expected = torch.exp(2.0 * inp_t.float()).to(torch.bfloat16)
-    got = _run(exp_scale_literal_mul_kernel, inp_t, device)
-    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+@pytest.mark.parametrize("dtype,memory_config", EXP_CONFIGS)
+def test_exp_scaled_by_literal_mul(device, dtype, memory_config):
+    inp_t = _rand_input((TILE, TILE), dtype)
+    expected = torch.exp(2.0 * inp_t.float()).to(dtype)
+    got = _run(exp_scale_literal_mul_kernel, inp_t, device, memory_config)
+    assert_allclose(got.float(), expected.float(), **ACCURATE_TOLERANCES[dtype])
 
 
-def test_exp_scaled_by_variable_mul(device):
-    inp_t = _rand_tile()
-    expected = torch.exp(EXP_SCALE * inp_t.float()).to(torch.bfloat16)
-    got = _run(exp_scale_variable_mul_kernel, inp_t, device)
-    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+@pytest.mark.parametrize("dtype,memory_config", EXP_CONFIGS)
+def test_exp_scaled_by_variable_mul(device, dtype, memory_config):
+    inp_t = _rand_input((TILE, TILE), dtype)
+    expected = torch.exp(EXP_SCALE * inp_t.float()).to(dtype)
+    got = _run(exp_scale_variable_mul_kernel, inp_t, device, memory_config)
+    assert_allclose(got.float(), expected.float(), **ACCURATE_TOLERANCES[dtype])
 
 
-def test_exp_scaled_by_keyword(device):
-    inp_t = _rand_tile()
-    expected = torch.exp(EXP_SCALE * inp_t.float()).to(torch.bfloat16)
-    got = _run(exp_scale_keyword_kernel, inp_t, device)
-    assert_allclose(got, expected, rtol=2e-2, atol=2e-2)
+@pytest.mark.parametrize("dtype,memory_config", EXP_CONFIGS)
+def test_exp_scaled_by_keyword(device, dtype, memory_config):
+    inp_t = _rand_input((TILE, TILE), dtype)
+    expected = torch.exp(EXP_SCALE * inp_t.float()).to(dtype)
+    got = _run(exp_scale_keyword_kernel, inp_t, device, memory_config)
+    assert_allclose(got.float(), expected.float(), **ACCURATE_TOLERANCES[dtype])
+
+
+@pytest.mark.parametrize("shape", [(TILE, TILE), (2 * TILE, 2 * TILE)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize("memory_config", MEMORY_CONFIGS)
+@pytest.mark.parametrize(
+    "kernel",
+    [exp_approx_scale_keyword_kernel, exp_approx_scale_mul_kernel],
+    ids=["keyword", "multiply"],
+)
+def test_exp_approx_scaled(device, shape, dtype, memory_config, kernel):
+    inp_t = _rand_input(shape, dtype)
+    expected = torch.exp(EXP_SCALE * inp_t.float()).to(dtype)
+    got = _run(kernel, inp_t, device, memory_config)
+    assert_allclose(got.float(), expected.float(), **APPROX_TOLERANCES[dtype])

--- a/test/ttlang/Conversion/TTLToCompute/exp_flags.mlir
+++ b/test/ttlang/Conversion/TTLToCompute/exp_flags.mlir
@@ -1,22 +1,43 @@
 // RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(convert-ttl-to-compute))' | FileCheck %s
+// RUN: ttlang-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(ttl-print-compute-op-creation-plans))' -o /dev/null 2>&1 | FileCheck %s --check-prefix=PLAN
 
-// The exp hardware flags (approx / scale / input_clamping / iterations) on the
+// The exp hardware flags (approx / scale / input_clamping) on the
 // tensor-level ttl.exp are forwarded unchanged to the ttl.tile_exp op created
 // inside the ttl.compute body.
 
 // CHECK-LABEL: func.func @exp_flags_forwarded
 func.func @exp_flags_forwarded(%arg0: tensor<4x4x!ttcore.tile<32x32, f32>>) -> tensor<4x4x!ttcore.tile<32x32, f32>> {
   // CHECK: ttl.compute
-  // CHECK: %[[EXP:.*]] = ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}iterations = 4 : i32{{.*}}scale = 5.000000e-01 : f32{{.*[}]}}
+  // CHECK-NOT: ttl.tile_mul_unary_const
+  // CHECK: %[[EXP:.*]] = ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}input_clamping = 0 : i32{{.*}}scale = 5.000000e-01 : f32{{.*[}]}}
   %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>
   %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>
   %a = ttl.attach_cb %arg0, %cb0 : (tensor<4x4x!ttcore.tile<32x32, f32>>, !ttl.cb<[4, 4], !ttcore.tile<32x32, f32>, 2>) -> tensor<4x4x!ttcore.tile<32x32, f32>>
   %reserve = ttl.cb_reserve %cb1 : <[4, 4], !ttcore.tile<32x32, f32>, 2> -> tensor<4x4x!ttcore.tile<32x32, f32>>
   %0 = ttl.exp %a {approx = true, scale = 5.000000e-01 : f32,
-                   input_clamping = 0 : i32, iterations = 4 : i32}
+                   input_clamping = 0 : i32}
       : tensor<4x4x!ttcore.tile<32x32, f32>> -> tensor<4x4x!ttcore.tile<32x32, f32>>
   ttl.store %0, %reserve : tensor<4x4x!ttcore.tile<32x32, f32>>, tensor<4x4x!ttcore.tile<32x32, f32>>
   func.return %0 : tensor<4x4x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Approximate exp folds a preceding constant multiply into the hardware scale.
+
+// CHECK-LABEL: func.func @exp_approx_scale_folded
+// CHECK: ttl.compute
+// CHECK-NOT: ttl.tile_mul_unary_const
+// CHECK: ttl.tile_exp %{{.*}} into dst[%{{.*}}] {{[{].*}}approx = true{{.*}}scale = 2.000000e+00 : f32{{.*[}]}}
+func.func @exp_approx_scale_folded(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>>) -> tensor<1x1x!ttcore.tile<32x32, f32>> {
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 2} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>
+  %a = ttl.attach_cb %arg0, %cb0 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %reserve = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, f32>, 2> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %scaled = ttl.mul_unary_const %a, 2.000000e+00 : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %exp = ttl.exp %scaled {approx = true} : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  ttl.store %exp, %reserve : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %exp : tensor<1x1x!ttcore.tile<32x32, f32>>
 }
 
 // -----
@@ -25,6 +46,9 @@ func.func @exp_flags_forwarded(%arg0: tensor<4x4x!ttcore.tile<32x32, f32>>) -> t
 // current accurate BF16 LLK scale path requires an immediate but accepts scale
 // as a runtime argument.
 
+// PLAN-LABEL: ComputeOp creation plan @exp_accurate_scale_materialized
+// PLAN:       ttl.exp kind=fused recipe=fused legal=true
+// PLAN:       fused {{.*}} deferred-exp-scale operands=0
 // CHECK-LABEL: func.func @exp_accurate_scale_materialized
 func.func @exp_accurate_scale_materialized(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>>) -> tensor<1x1x!ttcore.tile<32x32, f32>> {
   // CHECK: ttl.compute

--- a/test/ttlang/Conversion/TTLToTTKernel/exp_flags.mlir
+++ b/test/ttlang/Conversion/TTLToTTKernel/exp_flags.mlir
@@ -10,14 +10,13 @@
 // CHECK-LABEL: func.func @tile_exp_flags
 // CHECK: ttkernel.tile_regs_acquire
 // CHECK: ttkernel.exp_tile_init() {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}scale = 1073741824 : i32{{.*[}]}}
-// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}iterations = 4 : i32{{.*}}scale = 1073741824 : i32{{.*[}]}}
+// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}input_clamping = #ttkernel.input_clamping<none>{{.*}}scale = 1073741824 : i32{{.*[}]}}
 // CHECK: ttkernel.tile_regs_release
 func.func @tile_exp_flags(%a: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   ttkernel.tile_regs_acquire() : () -> ()
   %exp = ttl.tile_exp %a into dst[%c0] {approx = true, scale = 2.000000e+00 : f32,
-                                        input_clamping = 0 : i32,
-                                        iterations = 4 : i32}
+                                        input_clamping = 0 : i32}
       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %exp : !ttcore.tile<32x32, f32>
@@ -25,25 +24,25 @@ func.func @tile_exp_flags(%a: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f
 
 // -----
 
-// Two exps with identical flags share a single init; a third with different
-// flags forces a fresh init.
+// Two approximate exps with the same scale share an init; changing the scale
+// forces a fresh init and updates the runtime scale argument.
 // CHECK-LABEL: func.func @tile_exp_flag_change
-// CHECK: ttkernel.exp_tile_init
-// CHECK: ttkernel.exp_tile
+// CHECK: ttkernel.exp_tile_init() {{[{].*}}approx = true{{.*}}scale = 1073741824 : i32{{.*[}]}}
+// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}scale = 1073741824 : i32{{.*[}]}}
 // CHECK-NOT: ttkernel.exp_tile_init
-// CHECK: ttkernel.exp_tile
-// CHECK: ttkernel.exp_tile_init
-// CHECK: ttkernel.exp_tile
+// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}scale = 1073741824 : i32{{.*[}]}}
+// CHECK: ttkernel.exp_tile_init() {{[{].*}}approx = true{{.*}}scale = 1077936128 : i32{{.*[}]}}
+// CHECK: ttkernel.exp_tile({{.*}}) {{[{].*}}approx = true{{.*}}scale = 1077936128 : i32{{.*[}]}}
 func.func @tile_exp_flag_change(%a: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   ttkernel.tile_regs_acquire() : () -> ()
-  %e0 = ttl.tile_exp %a into dst[%c0] {approx = true}
+  %e0 = ttl.tile_exp %a into dst[%c0] {approx = true, scale = 2.000000e+00 : f32}
       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %e1 = ttl.tile_exp %a into dst[%c1] {approx = true}
+  %e1 = ttl.tile_exp %a into dst[%c1] {approx = true, scale = 2.000000e+00 : f32}
       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
-  %e2 = ttl.tile_exp %a into dst[%c2] {approx = false}
+  %e2 = ttl.tile_exp %a into dst[%c2] {approx = true, scale = 3.000000e+00 : f32}
       : !ttcore.tile<32x32, f32> -> !ttcore.tile<32x32, f32>
   ttkernel.tile_regs_release() : () -> ()
   func.return %e2 : !ttcore.tile<32x32, f32>

--- a/test/ttlang/Translate/TTLToCpp/exp_approx_scales_to_cpp.mlir
+++ b/test/ttlang/Translate/TTLToCpp/exp_approx_scales_to_cpp.mlir
@@ -1,0 +1,29 @@
+// RUN: ttlang-opt %s -pass-pipeline='builtin.module(func.func(convert-ttl-to-compute),ttl-set-compute-kernel-config{enable-fpu-binary-ops=0 matmul-full-fp32=0 reduce-full-fp32=0},func.func(ttl-assign-dst,ttl-lower-to-loops,ttl-annotate-cb-associations), convert-ttl-to-ttkernel, ttkernel-insert-inits, canonicalize, cse, lower-affine)' -o %t.ttkernel.mlir
+// RUN: ttlang-opt --allow-unregistered-dialect --convert-ttkernel-to-emitc %t.ttkernel.mlir -o %t.emitc.mlir
+// RUN: ttlang-translate --allow-unregistered-dialect --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
+// RUN: FileCheck %s --input-file=%t.cpp
+
+// Purpose: verify that approximate exps with distinct scales reinitialize the
+// hardware and pass their respective BF16 scale values at execution.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: void kernel_main()
+// CHECK: exp_tile_init<true, 1073741824>();
+// CHECK: exp_tile<true, true>({{.*}}, VectorMode::RC, static_cast<uint16_t>(16384u));
+// CHECK: exp_tile_init<true, 1077936128>();
+// CHECK: exp_tile<true, true>({{.*}}, VectorMode::RC, static_cast<uint16_t>(16448u));
+func.func @approx_scaled_exps(%arg0: tensor<1x1x!ttcore.tile<32x32, f32>>)
+    -> tensor<1x1x!ttcore.tile<32x32, f32>>
+    attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  %output = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
+  %cb0 = ttl.bind_cb {cb_index = 0, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %cb1 = ttl.bind_cb {cb_index = 1, block_count = 1} : !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>
+  %input = ttl.cb_wait %cb0 : <[1, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %output_cb = ttl.attach_cb %output, %cb1 : (tensor<1x1x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 1>) -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %result_view = ttl.cb_reserve %cb1 : <[1, 1], !ttcore.tile<32x32, f32>, 1> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %first = ttl.exp %input {approx = true, scale = 2.000000e+00 : f32} : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  %second = ttl.exp %first {approx = true, scale = 3.000000e+00 : f32} : tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<1x1x!ttcore.tile<32x32, f32>>
+  ttl.store %second, %result_view : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<1x1x!ttcore.tile<32x32, f32>>
+  func.return %second : tensor<1x1x!ttcore.tile<32x32, f32>>
+}


### PR DESCRIPTION
### Problem description
There are no tests for ttl.exp.

### What's changed
Add device and lit tests for exp operation.
Ensure that both syntaxes are lowered into `scale` parameter:
1. `ttl.math.exp(x * EXP_SCALE, approx=True)`
2. `ttl.math.exp(x, approx=True, scale=EXP_SCALE)`

### Ticket
[[ttl.exp] Cover approximate scaling and assert lowering invariants](https://github.com/tenstorrent/tt-lang/issues/820)

### Checklist
- [X] New & Existing tests provide coverage for changes
