### PR TITLE
[ttl][dfb] Preserve unreachable domains and reuse topology analysis [dfb-storage-1]

### DIFF
--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -610,23 +610,28 @@ assuming disjointness. The diagnostic identifies the logical `dfb_id`, the
 role (producer or consumer), an overlapping launched node when available, the
 participating operation sites, and the originating `ttl.bind_cb`.
 
-The pass also rejects a logical DFB when a kernel thread waits on it but no
-kernel thread has a push action for it. Reserving storage is insufficient:
-`ttl.cb_wait` observes pages published by `ttl.cb_push`. This structural check
-does not depend on launch-domain analysis and remains enabled under the
+The pass also rejects a logical DFB when a kernel thread waits on it and no
+producer is possible. A compiler-visible push proves a producer exists. An
+opaque external DFB dependency without an access contract may contain a push,
+and `unknown_dfb_access` may contain a push for any user-managed DFB. An
+explicit `inspect` contract excludes protocol actions. Reserving storage is
+insufficient: `ttl.cb_wait` observes pages published by a push. This structural
+check does not depend on launch-domain analysis and remains enabled under the
 diagnostic relaxation.
 
 Setting `TTL_RELAX_DFB_SPSC` skips only per-launch-node ownership and
 producer-correspondence checks that require synchronization absent from IR. It
 skips overlapping producer/consumer domain checks here and same-node producer
 correspondence for DFB waits in `ttl-verify-pipenet-guards`. A waited DFB still
-requires at least one push action in a kernel thread. Finalized DFB identity,
-physical-index, and launch-grid preconditions remain mandatory. PipeNet
-endpoint guards, transfer correspondence, and synchronization schedules also
-remain mandatory. Strict verification is the default.
+requires either a compiler-visible push or uncontracted external access that
+may contain one. Finalized DFB identity, physical-index, and launch-grid
+preconditions remain mandatory. PipeNet endpoint guards, transfer
+correspondence, and synchronization schedules also remain mandatory. Strict
+verification is the default.
 
 See `test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir` and
-`verify_dfb_spsc_missing_producer_invalid.mlir` for rejected patterns, and
+`verify_dfb_spsc_missing_producer_invalid.mlir` and
+`verify_dfb_spsc_unknown_access_invalid.mlir` for rejected patterns, and
 `verify_dfb_spsc.mlir` for accepted patterns.
 
 The compiler does not currently auto-split overlapping multi-consumer DFBs;

--- a/docs/development/DFBManagement.md
+++ b/docs/development/DFBManagement.md
@@ -610,15 +610,24 @@ assuming disjointness. The diagnostic identifies the logical `dfb_id`, the
 role (producer or consumer), an overlapping launched node when available, the
 participating operation sites, and the originating `ttl.bind_cb`.
 
-Setting `TTL_RELAX_DFB_SPSC` skips only launch-node-domain proofs that require
-the program to provide synchronization absent from IR. It skips overlapping
-producer/consumer domain checks here and producer correspondence for DFB waits
-in `ttl-verify-pipenet-guards`. Finalized DFB identity, physical-index, and
-launch-grid preconditions remain mandatory. PipeNet endpoint guards, transfer
-correspondence, and synchronization schedules also remain mandatory. Strict
-verification is the default.
+The pass also rejects a logical DFB when a kernel thread waits on it but no
+kernel thread has a push action for it. Reserving storage is insufficient:
+`ttl.cb_wait` observes pages published by `ttl.cb_push`. This structural check
+does not depend on launch-domain analysis and remains enabled under the
+diagnostic relaxation.
 
-See `test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir` for the rejected patterns and `verify_dfb_spsc.mlir` for the accepted ones.
+Setting `TTL_RELAX_DFB_SPSC` skips only per-launch-node ownership and
+producer-correspondence checks that require synchronization absent from IR. It
+skips overlapping producer/consumer domain checks here and same-node producer
+correspondence for DFB waits in `ttl-verify-pipenet-guards`. A waited DFB still
+requires at least one push action in a kernel thread. Finalized DFB identity,
+physical-index, and launch-grid preconditions remain mandatory. PipeNet
+endpoint guards, transfer correspondence, and synchronization schedules also
+remain mandatory. Strict verification is the default.
+
+See `test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir` and
+`verify_dfb_spsc_missing_producer_invalid.mlir` for rejected patterns, and
+`verify_dfb_spsc.mlir` for accepted patterns.
 
 The compiler does not currently auto-split overlapping multi-consumer DFBs;
 users must duplicate explicitly via `make_dataflow_buffer_like`. Tracked in

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -94,7 +94,7 @@ They are independent of the code generation flags above.
 | `TTLANG_DEBUG_LOCATIONS` | `0`/`1` | `0` | Include source locations in printed MLIR (locations are always tracked internally for error messages). |
 | `TTLANG_VERBOSE_ERRORS` | `0`/`1` | `0` | Include raw MLIR diagnostics in error output. |
 | `TTLANG_SIM_ONLY` | `0`/`1` | `0` | Force `import ttl` to skip loading the compiled MLIR extension. Used when running the simulator from a source tree without an installed `tt-lang-sim` wheel (which ships the same signal as a marker module). |
-| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Skip per-launch-node verification that DFB producers, consumers, and waits execute on corresponding dynamically active nodes. The program must enforce those ownership and synchronization contracts. A waited DFB must still have a push action in a kernel thread. Finalized DFB preconditions, PipeNet endpoint guards, transfer correspondence, and synchronization schedules remain enabled. |
+| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Skip per-launch-node verification that DFB producers, consumers, and waits execute on corresponding dynamically active nodes. The program must enforce those ownership and synchronization contracts. A waited DFB must still have a compiler-visible push or uncontracted external access that may contain one. Finalized DFB preconditions, PipeNet endpoint guards, transfer correspondence, and synchronization schedules remain enabled. |
 
 Profiling-related environment variables (`TTLANG_AUTO_PROFILE`,
 `TTLANG_PERF_DUMP`, `TTLANG_PERF_SERV`, `TTLANG_SIGNPOST_PROFILE`,

--- a/docs/sphinx/reference/compiler-options.md
+++ b/docs/sphinx/reference/compiler-options.md
@@ -94,7 +94,7 @@ They are independent of the code generation flags above.
 | `TTLANG_DEBUG_LOCATIONS` | `0`/`1` | `0` | Include source locations in printed MLIR (locations are always tracked internally for error messages). |
 | `TTLANG_VERBOSE_ERRORS` | `0`/`1` | `0` | Include raw MLIR diagnostics in error output. |
 | `TTLANG_SIM_ONLY` | `0`/`1` | `0` | Force `import ttl` to skip loading the compiled MLIR extension. Used when running the simulator from a source tree without an installed `tt-lang-sim` wheel (which ships the same signal as a marker module). |
-| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Skip compiler verification that DFB producers, consumers, and waits execute on corresponding dynamically active launch nodes. The program must enforce those ownership and synchronization contracts. Finalized DFB preconditions, PipeNet endpoint guards, transfer correspondence, and synchronization schedules remain enabled. |
+| `TTL_RELAX_DFB_SPSC` | any value | (unset) | Skip per-launch-node verification that DFB producers, consumers, and waits execute on corresponding dynamically active nodes. The program must enforce those ownership and synchronization contracts. A waited DFB must still have a push action in a kernel thread. Finalized DFB preconditions, PipeNet endpoint guards, transfer correspondence, and synchronization schedules remain enabled. |
 
 Profiling-related environment variables (`TTLANG_AUTO_PROFILE`,
 `TTLANG_PERF_DUMP`, `TTLANG_PERF_SERV`, `TTLANG_SIGNPOST_PROFILE`,

--- a/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
+++ b/include/ttlang/Dialect/TTL/IR/TTLOpsUtils.h
@@ -369,6 +369,12 @@ inline std::optional<int64_t> getCBIndex(mlir::Value cb) {
 /// Returns failure when `cb` does not resolve to a declaration with `dfb_id`.
 FailureOr<int64_t> getDFBId(mlir::Value cb);
 
+/// Return DFB dependency occurrence indices without an access contract.
+///
+/// Each returned occurrence may perform arbitrary protocol actions inside the
+/// external callee and remains incomplete for lifecycle analysis.
+SmallVector<unsigned> getOpaqueDFBDependencyIndices(OpaqueCallOp call);
+
 /// Returns the number of pages in one DFB block.
 FailureOr<uint64_t> getDFBPagesPerBlock(CircularBufferType type);
 

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -899,9 +899,9 @@ def TTLVerifyPipeNetGuards
     When `TTL_RELAX_DFB_SPSC` is set, this pass skips the check that each DFB
     wait has a producer on the same dynamically active launch nodes. The
     program must enforce that correspondence. The later SPSC verifier still
-    rejects a waited DFB with no push action in any kernel thread. PipeNet
-    endpoint guards, transfer correspondence, and synchronization schedules
-    remain mandatory.
+    rejects a waited DFB with neither a compiler-visible push nor uncontracted
+    external access that may contain one. PipeNet endpoint guards, transfer
+    correspondence, and synchronization schedules remain mandatory.
   }];
 }
 
@@ -985,18 +985,19 @@ def TTLVerifyDFBSPSC
     them by module-wide logical `dfb_id` and enclosing
     `ttl.kernel_thread`-tagged `func.func`, and tracks the launch-node domain for
     each producer or consumer participant. The pass requires every waited DFB
-    to have a push in some kernel thread and, for each launched node, at most one
-    producer kernel and at most one consumer kernel. Disjoint domains across
-    different kernel functions are accepted. Distinct logical DFBs remain
-    separate when physical allocation assigns them the same `cb_index`.
+    to have a compiler-visible push or uncontracted external access that may
+    contain one and, for each launched node, at most one producer kernel and at
+    most one consumer kernel. Disjoint domains across different kernel
+    functions are accepted. Distinct logical DFBs remain separate when physical
+    allocation assigns them the same `cb_index`.
 
     tt-metal circular buffers expose a counter pair (`pages_received`,
     `pages_acked`) that is not multi-writer safe on either side, so the
     per-launched-node single-producer single-consumer property is required for
     correctness; see `docs/development/DFBManagement.md` for the runtime
-    contract. The pass emits an error for waits without any push, overlapping
-    producer or consumer domains, and unknown domains when multiple threads
-    participate and SPSC cannot be proven statically.
+    contract. The pass emits an error for waits without any possible producer,
+    overlapping producer or consumer domains, and unknown domains when
+    multiple threads participate and SPSC cannot be proven statically.
 
     The module must contain the `ttl.dfb_allocations` metadata emitted by
     `ttl-finalize-dfb-indices`, and every DFB declaration and lifecycle operand
@@ -1006,9 +1007,10 @@ def TTLVerifyDFBSPSC
     Setting `TTL_RELAX_DFB_SPSC` skips per-launch-node producer and consumer
     ownership verification. The program must enforce that ownership contract
     through synchronization not represented in the IR. The verifier still
-    rejects every waited DFB without a push action in any kernel thread.
-    Finalized DFB identity, physical-index, and launch-grid preconditions remain
-    mandatory. Strict verification is the default.
+    rejects every waited DFB without a compiler-visible push or uncontracted
+    external access that may contain one. Finalized DFB identity,
+    physical-index, and launch-grid preconditions remain mandatory. Strict
+    verification is the default.
   }];
 
   let dependentDialects = [];

--- a/include/ttlang/Dialect/TTL/Passes.td
+++ b/include/ttlang/Dialect/TTL/Passes.td
@@ -898,8 +898,10 @@ def TTLVerifyPipeNetGuards
 
     When `TTL_RELAX_DFB_SPSC` is set, this pass skips the check that each DFB
     wait has a producer on the same dynamically active launch nodes. The
-    program must enforce that correspondence. PipeNet endpoint guards, transfer
-    correspondence, and synchronization schedules remain mandatory.
+    program must enforce that correspondence. The later SPSC verifier still
+    rejects a waited DFB with no push action in any kernel thread. PipeNet
+    endpoint guards, transfer correspondence, and synchronization schedules
+    remain mandatory.
   }];
 }
 
@@ -977,35 +979,36 @@ def TTLVerifyTransferProvenance
 
 def TTLVerifyDFBSPSC
     : Pass<"ttl-verify-dfb-spsc", "::mlir::ModuleOp"> {
-  let summary = "Reject DFBs with overlapping producer or consumer launch domains";
+  let summary = "Verify DFB producers and consumers across launch domains";
   let description = [{
-    Walks every `ttl.cb_reserve` and `ttl.cb_wait`, groups them by module-wide
-    logical `dfb_id` and enclosing `ttl.kernel_thread`-tagged `func.func`, and
-    tracks the launch-node domain for each producer or consumer participant.
-    A DFB is valid when, for each launched node, at most one producer kernel
-    reserves it and at most one consumer kernel waits on it. Disjoint domains
-    across different kernel functions are accepted. Distinct logical DFBs
-    remain separate when physical allocation assigns them the same `cb_index`.
+    Walks DFB protocol actions exposed through `DFBAccessOpInterface`, groups
+    them by module-wide logical `dfb_id` and enclosing
+    `ttl.kernel_thread`-tagged `func.func`, and tracks the launch-node domain for
+    each producer or consumer participant. The pass requires every waited DFB
+    to have a push in some kernel thread and, for each launched node, at most one
+    producer kernel and at most one consumer kernel. Disjoint domains across
+    different kernel functions are accepted. Distinct logical DFBs remain
+    separate when physical allocation assigns them the same `cb_index`.
 
     tt-metal circular buffers expose a counter pair (`pages_received`,
     `pages_acked`) that is not multi-writer safe on either side, so the
     per-launched-node single-producer single-consumer property is required for
     correctness; see `docs/development/DFBManagement.md` for the runtime
-    contract. The pass emits an error for overlapping producer or consumer
-    domains, and for unknown domains when multiple threads participate and SPSC
-    cannot be proven statically.
+    contract. The pass emits an error for waits without any push, overlapping
+    producer or consumer domains, and unknown domains when multiple threads
+    participate and SPSC cannot be proven statically.
 
     The module must contain the `ttl.dfb_allocations` metadata emitted by
     `ttl-finalize-dfb-indices`, and every DFB declaration and lifecycle operand
     must resolve to a `ttl.bind_cb` with `dfb_id`. Modules with DFB acquire ops
     must also carry a valid `ttl.launch_grid` attribute.
 
-    Setting `TTL_RELAX_DFB_SPSC` skips compiler verification that each DFB has
-    one producer and one consumer per dynamically active launch node. The
-    program must enforce that ownership contract through synchronization not
-    represented in the IR. Finalized DFB identity, physical-index, and
-    launch-grid preconditions remain mandatory. Strict verification is the
-    default.
+    Setting `TTL_RELAX_DFB_SPSC` skips per-launch-node producer and consumer
+    ownership verification. The program must enforce that ownership contract
+    through synchronization not represented in the IR. The verifier still
+    rejects every waited DFB without a push action in any kernel thread.
+    Finalized DFB identity, physical-index, and launch-grid preconditions remain
+    mandatory. Strict verification is the default.
   }];
 
   let dependentDialects = [];

--- a/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
+++ b/lib/Dialect/TTL/IR/TTLOpsUtils.cpp
@@ -5,6 +5,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 
 #include "ttlang/Dialect/TTKernel/IR/TTKernelOps.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CheckedArithmetic.h"
 #include "llvm/Support/raw_ostream.h"
@@ -124,6 +125,27 @@ FailureOr<int64_t> getDFBId(Value cb) {
     return failure();
   }
   return dfbId->getSExtValue();
+}
+
+SmallVector<unsigned> getOpaqueDFBDependencyIndices(OpaqueCallOp call) {
+  SmallVector<Value> dependencies = call.getDFBDependencyOperands();
+  llvm::BitVector describedDependencies(dependencies.size());
+  for (const DFBProtocolEffect &effect : call.getDFBProtocolEffects()) {
+    describedDependencies.set(effect.dependencyIndex);
+  }
+  for (const DFBNonTransactionalAccess &access :
+       call.getDFBNonTransactionalAccesses()) {
+    describedDependencies.set(access.dependencyIndex);
+  }
+
+  SmallVector<unsigned> opaqueDependencies;
+  for (unsigned dependencyIndex = 0;
+       dependencyIndex < describedDependencies.size(); ++dependencyIndex) {
+    if (!describedDependencies.test(dependencyIndex)) {
+      opaqueDependencies.push_back(dependencyIndex);
+    }
+  }
+  return opaqueDependencies;
 }
 
 FailureOr<uint64_t> getDFBPagesPerBlock(CircularBufferType type) {

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -2418,6 +2418,30 @@ static ProgramOrderGraphState buildProgramOrderTopologyState(
   return state;
 }
 
+// Protocol and boundary edges are launch-node-specific, so callers receive a
+// copy of the reusable source-order topology before adding those edges.
+class ProgramOrderTopologyCache {
+public:
+  ProgramOrderGraphState
+  getOrBuild(ModuleOp module, const ProgramOrderTopologyInputs &inputs,
+             const StructuralOperationOrder &structuralOrder) {
+    if (!entry || !(entry->inputs == inputs)) {
+      ProgramOrderGraphState graphState =
+          buildProgramOrderTopologyState(module, inputs, structuralOrder);
+      entry = Entry{inputs, std::move(graphState)};
+    }
+    return entry->state;
+  }
+
+private:
+  struct Entry {
+    ProgramOrderTopologyInputs inputs;
+    ProgramOrderGraphState state;
+  };
+
+  std::optional<Entry> entry;
+};
+
 // Conditional runs match only under equivalent structured conditions.
 static bool
 proveEquivalentConditionalRuns(const AccessRun &lhs, const AccessRun &rhs,
@@ -5155,6 +5179,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
           std::make_unique<DFBLogicalLifecycleDiagnostics>();
     }
   }
+  ProgramOrderTopologyCache graphTopologyCache;
+  ProgramOrderTopologyCache possibleGraphTopologyCache;
   for (LaunchNodeCoord node : launchNodes) {
     SmallVector<ValidatedSynchronizedReset> validatedResets;
     if (failed(validateSynchronizedResetsAtNode(resetOccurrences, node,
@@ -5182,7 +5208,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
             logicalDFBs, validatedResets, validatedReconfigurations, node,
             executionCounts, accessRuns, structuralOrder,
             /*includeUnknownDomains=*/false);
-    ProgramOrderGraphState graphState = buildProgramOrderTopologyState(
+    ProgramOrderGraphState initialGraphState = graphTopologyCache.getOrBuild(
         module, graphTopologyInputs, structuralOrder);
     std::optional<AccessRuns> possibleAccessRuns;
     std::optional<ProgramOrderGraphState> possibleGraphState;
@@ -5197,15 +5223,17 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
               /*includeUnknownDomains=*/true);
       bool graphTopologiesMatch =
           graphTopologyInputs == possibleGraphTopologyInputs;
-      possibleGraphState.emplace(
-          graphTopologiesMatch
-              ? graphState
-              : buildProgramOrderTopologyState(
-                    module, possibleGraphTopologyInputs, structuralOrder));
+      if (graphTopologiesMatch) {
+        possibleGraphState.emplace(initialGraphState);
+      } else {
+        possibleGraphState.emplace(possibleGraphTopologyCache.getOrBuild(
+            module, possibleGraphTopologyInputs, structuralOrder));
+      }
 #ifndef NDEBUG
       // Small graphs retain an independent reconstruction oracle without
       // repeating model-scale graph construction in assertion-enabled builds.
-      if (graphTopologiesMatch && graphState.graph.getEventCount() <= 128) {
+      if (graphTopologiesMatch &&
+          initialGraphState.graph.getEventCount() <= 128) {
         ProgramOrderGraphState reconstructedPossibleGraphState =
             buildProgramOrderTopologyState(module, possibleGraphTopologyInputs,
                                            structuralOrder);
@@ -5214,6 +5242,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
       }
 #endif
     }
+    ProgramOrderGraphState graphState = std::move(initialGraphState);
     HappensBeforeGraph &graph = graphState.graph;
     DenseMap<Operation *, EventPair> &operationEvents =
         graphState.operationEvents;

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -12,6 +12,7 @@
 #include "ttlang/Dialect/TTL/IR/TTLOpsTypes.h"
 #include "ttlang/Dialect/TTL/IR/TTLOpsUtils.h"
 
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -355,11 +356,6 @@ struct AccessDomain {
   Operation *unanalyzableOperation = nullptr;
 };
 
-// Retains access-domain results from the shared launch-domain analysis.
-struct LivenessDomainState : LaunchNodeDomainState {
-  DenseMap<Operation *, AccessDomain> accessDomains;
-};
-
 // One static occurrence of a typed synchronized reset before launch-node
 // participation is validated.
 struct SynchronizedResetOccurrence {
@@ -470,7 +466,7 @@ static bool executesRegionsAtMostOnce(Operation *operation) {
 
 static AccessDomain refineUnknownAccessDomainFromExecutionCounts(
     Operation *operation, AccessDomain accessDomain,
-    const LivenessDomainState &domainState) {
+    const LaunchNodeDomainState &domainState) {
   if (accessDomain.domain.known) {
     return accessDomain;
   }
@@ -494,7 +490,7 @@ static AccessDomain refineUnknownAccessDomainFromExecutionCounts(
 // enclosing-loop invocation.
 static std::optional<StaticIterationDomain> getUniformStaticIterationDomain(
     Operation *operation, std::uint64_t executionCount, LaunchNodeCoord node,
-    const LivenessDomainState &domainState) {
+    const LaunchNodeDomainState &domainState) {
   func::FuncOp function = operation->getParentOfType<func::FuncOp>();
   if (!function || function.getBody().empty() ||
       !function.getBody().hasOneBlock()) {
@@ -1500,11 +1496,10 @@ collectAccessExecutionCounts(ArrayRef<DFBLogicalLifecycle> logicalDFBs,
   return executionCounts;
 }
 
-static AccessRuns
-collectAccessRuns(ArrayRef<DFBLogicalLifecycle> logicalDFBs,
-                  LaunchNodeCoord node, const LivenessDomainState &domainState,
-                  const AccessExecutionCounts &executionCounts,
-                  bool includeUnknownDomains) {
+static AccessRuns collectAccessRuns(
+    ArrayRef<DFBLogicalLifecycle> logicalDFBs, LaunchNodeCoord node,
+    const LaunchNodeDomainState &domainState,
+    const AccessExecutionCounts &executionCounts, bool includeUnknownDomains) {
   AccessRuns runs;
   for (const DFBLogicalLifecycle &logicalDFB : logicalDFBs) {
     for (const DFBAccessOccurrence &access : logicalDFB.accesses) {
@@ -1727,7 +1722,7 @@ static LogicalResult validateDFBReconfigurationDeclarations(
 
 static LogicalResult validateDFBReconfigurationsAtNode(
     ArrayRef<DFBReconfigurationOccurrence> occurrences, LaunchNodeCoord node,
-    const LivenessDomainState &domainState,
+    const LaunchNodeDomainState &domainState,
     const StructuralOperationOrder &structuralOrder,
     SmallVectorImpl<ValidatedDFBReconfiguration> &validatedBoundaries,
     DFBAnalysisFailure &analysisFailure) {
@@ -1874,7 +1869,7 @@ static LogicalResult validateDFBReconfigurationsAtNode(
 
 static LogicalResult validateSynchronizedResetsAtNode(
     ArrayRef<SynchronizedResetOccurrence> occurrences, LaunchNodeCoord node,
-    const LivenessDomainState &domainState,
+    const LaunchNodeDomainState &domainState,
     SmallVectorImpl<ValidatedSynchronizedReset> &validatedResets,
     DFBAnalysisFailure &analysisFailure) {
   llvm::MapVector<SynchronizedDFBResetAttr,
@@ -4997,7 +4992,7 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     }
   }
 
-  LivenessDomainState domainState;
+  LaunchNodeDomainState domainState;
   domainState.initialize(module);
   exactLaunchGridAvailable = domainState.hasLaunchGrid;
   if (!domainState.hasLaunchGrid) {
@@ -5019,12 +5014,6 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   LaunchNodeDomainAnalysisOptions options;
   options.narrowPipeNetScopes = true;
   options.emitInvalidPipeNetDiagnostics = false;
-  options.operationCallback = [&](Operation *accessOperation,
-                                  const LaunchNodeDomain &domain,
-                                  Operation *unanalyzableOperation) {
-    domainState.accessDomains[accessOperation] = {domain,
-                                                  unanalyzableOperation};
-  };
   solver.load<LaunchNodeDomainAnalysis>(domainState, options);
   if (failed(solver.initializeAndRun(module))) {
     errorOperation = module;
@@ -5044,11 +5033,25 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
     if (refinedDomainIt != refinedAccessDomains.end()) {
       return refinedDomainIt->second;
     }
-    auto domainIt = domainState.accessDomains.find(accessOperation);
-    AccessDomain accessDomain =
-        domainIt == domainState.accessDomains.end()
-            ? AccessDomain{LaunchNodeDomain::unknown(), accessOperation}
-            : domainIt->second;
+    const LaunchNodeDomainLattice *domainLattice =
+        solver.lookupState<LaunchNodeDomainLattice>(
+            solver.getProgramPointBefore(accessOperation));
+    AccessDomain accessDomain;
+    if (domainLattice) {
+      accessDomain = {domainLattice->getDomain(),
+                      domainLattice->getUnanalyzableOp()};
+    } else {
+      // Dense analysis omits operation lattices in dead blocks. Dead-code
+      // state distinguishes an empty domain from a missing analysis fact.
+      ProgramPoint *blockStart =
+          solver.getProgramPointBefore(accessOperation->getBlock());
+      const auto *executable =
+          solver.lookupState<dataflow::Executable>(blockStart);
+      accessDomain =
+          executable && !executable->isLive()
+              ? AccessDomain{LaunchNodeDomain{}, nullptr}
+              : AccessDomain{LaunchNodeDomain::unknown(), accessOperation};
+    }
     return refinedAccessDomains
         .try_emplace(accessOperation,
                      refineUnknownAccessDomainFromExecutionCounts(
@@ -5084,14 +5087,8 @@ void DFBConcurrentKernelLivenessAnalysis::analyze(
   }
   for (DFBReconfigurationOccurrence &reconfiguration :
        reconfigurationOccurrences) {
-    auto domainIt = domainState.accessDomains.find(reconfiguration.operation);
-    AccessDomain boundaryDomain =
-        domainIt == domainState.accessDomains.end()
-            ? AccessDomain{LaunchNodeDomain::unknown(),
-                           reconfiguration.operation}
-            : domainIt->second;
-    boundaryDomain = refineUnknownAccessDomainFromExecutionCounts(
-        reconfiguration.operation, boundaryDomain, domainState);
+    const AccessDomain &boundaryDomain =
+        getRefinedAccessDomain(reconfiguration.operation);
     reconfiguration.launchDomain = boundaryDomain.domain;
   }
   if (failed(validateSynchronizedResetDeclarations(resetOccurrences,

--- a/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
+++ b/lib/Dialect/TTL/Transforms/DFBConcurrentKernelLivenessAnalysis.cpp
@@ -1391,6 +1391,20 @@ static LogicalResult collectLogicalDFBs(
            nullptr});
       describedDependencies.set(nonTransactionalAccess.dependencyIndex);
     }
+    if (auto opaqueCall = dyn_cast<OpaqueCallOp>(operation)) {
+      for (unsigned dependencyIndex :
+           getOpaqueDFBDependencyIndices(opaqueCall)) {
+        std::optional<unsigned> logicalIndex =
+            dependencyLogicalIndices[dependencyIndex];
+        assert(logicalIndex && "DFB dependencies were validated above");
+        DFBLogicalLifecycle &logicalDFB = logicalDFBs[*logicalIndex];
+        logicalDFB.accesses.push_back({operation, std::monostate{}, 0, 0,
+                                       LaunchNodeDomain::unknown(), nullptr,
+                                       true});
+        logicalDFB.hasOpaqueExternalAccess = true;
+      }
+      return WalkResult::advance();
+    }
     for (auto [dependencyIndex, operand] : llvm::enumerate(dfbOperands)) {
       if (!isa<CircularBufferType>(operand.getType()) ||
           describedDependencies.test(dependencyIndex)) {
@@ -1400,11 +1414,8 @@ static LogicalResult collectLogicalDFBs(
           dependencyLogicalIndices[dependencyIndex];
       assert(logicalIndex && "DFB dependencies were validated above");
       DFBLogicalLifecycle &logicalDFB = logicalDFBs[*logicalIndex];
-      bool opaqueExternalAccess = isa<OpaqueCallOp>(operation);
       logicalDFB.accesses.push_back({operation, std::monostate{}, 0, 0,
-                                     LaunchNodeDomain::unknown(), nullptr,
-                                     opaqueExternalAccess});
-      logicalDFB.hasOpaqueExternalAccess |= opaqueExternalAccess;
+                                     LaunchNodeDomain::unknown(), nullptr});
     }
     return WalkResult::advance();
   });

--- a/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
@@ -104,7 +104,9 @@ void attachCommonNotes(InFlightDiagnostic &diag, Operation *bindSite,
 
 struct DFBProtocolPresence {
   bool hasAcquisitionAction = false;
+  bool hasUnknownUserDFBAccess = false;
   llvm::DenseSet<int64_t> pushedDFBs;
+  llvm::DenseSet<int64_t> dfbsWithOpaqueAccess;
   llvm::SmallMapVector<int64_t, Operation *, 4> firstWaitByDFB;
 };
 
@@ -114,6 +116,16 @@ DFBProtocolPresence collectDFBProtocolPresence(ModuleOp module) {
     auto access = dyn_cast<DFBAccessOpInterface>(op);
     if (!access || !getEnclosingKernelThread(op)) {
       return;
+    }
+    if (auto opaqueCall = dyn_cast<OpaqueCallOp>(op)) {
+      SmallVector<Value> dependencies = opaqueCall.getDFBDependencyOperands();
+      for (unsigned dependencyIndex :
+           getOpaqueDFBDependencyIndices(opaqueCall)) {
+        FailureOr<int64_t> dfbId = getDFBId(dependencies[dependencyIndex]);
+        assert(succeeded(dfbId) && "DFB identities were verified");
+        presence.dfbsWithOpaqueAccess.insert(*dfbId);
+      }
+      presence.hasUnknownUserDFBAccess |= opaqueCall.hasUnknownDFBAccess();
     }
     for (const DFBProtocolEffect &effect : access.getDFBProtocolEffects()) {
       FailureOr<int64_t> dfbId = getDFBId(effect.dfb);
@@ -142,7 +154,13 @@ LogicalResult verifyDFBWaitsHavePushes(
     const llvm::DenseMap<int64_t, Operation *> &bindSites) {
   bool sawError = false;
   for (auto [dfbId, waitOp] : presence.firstWaitByDFB) {
-    if (presence.pushedDFBs.contains(dfbId)) {
+    Operation *bindSite = bindSites.lookup(dfbId);
+    auto bindOp = dyn_cast_or_null<BindCBOp>(bindSite);
+    bool hasPossibleExternalProducer =
+        presence.dfbsWithOpaqueAccess.contains(dfbId) ||
+        (presence.hasUnknownUserDFBAccess && bindOp &&
+         isUserManagedDFB(bindOp.getResult()));
+    if (presence.pushedDFBs.contains(dfbId) || hasPossibleExternalProducer) {
       continue;
     }
     InFlightDiagnostic diag = waitOp->emitError()
@@ -151,7 +169,7 @@ LogicalResult verifyDFBWaitsHavePushes(
                                  "it";
     diag.attachNote()
         << "a DFB wait blocks until a matching push publishes data";
-    if (Operation *bindSite = bindSites.lookup(dfbId)) {
+    if (bindSite) {
       diag.attachNote(bindSite->getLoc()) << "dataflow buffer declared here";
     }
     sawError = true;

--- a/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
@@ -25,6 +25,7 @@
 #include "DFBVerification.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -99,6 +100,63 @@ void attachCommonNotes(InFlightDiagnostic &diag, Operation *bindSite,
   if (bindSite) {
     diag.attachNote(bindSite->getLoc()) << "dataflow buffer declared here";
   }
+}
+
+struct DFBProtocolPresence {
+  bool hasAcquisitionAction = false;
+  llvm::DenseSet<int64_t> pushedDFBs;
+  llvm::SmallMapVector<int64_t, Operation *, 4> firstWaitByDFB;
+};
+
+DFBProtocolPresence collectDFBProtocolPresence(ModuleOp module) {
+  DFBProtocolPresence presence;
+  module.walk([&](Operation *op) {
+    auto access = dyn_cast<DFBAccessOpInterface>(op);
+    if (!access || !getEnclosingKernelThread(op)) {
+      return;
+    }
+    for (const DFBProtocolEffect &effect : access.getDFBProtocolEffects()) {
+      FailureOr<int64_t> dfbId = getDFBId(effect.dfb);
+      assert(succeeded(dfbId) && "DFB identities were verified");
+      switch (effect.kind) {
+      case DFBProtocolEffectKind::Reserve:
+        presence.hasAcquisitionAction = true;
+        break;
+      case DFBProtocolEffectKind::Push:
+        presence.pushedDFBs.insert(*dfbId);
+        break;
+      case DFBProtocolEffectKind::Wait:
+        presence.hasAcquisitionAction = true;
+        presence.firstWaitByDFB.try_emplace(*dfbId, op);
+        break;
+      case DFBProtocolEffectKind::Pop:
+        break;
+      }
+    }
+  });
+  return presence;
+}
+
+LogicalResult verifyDFBWaitsHavePushes(
+    const DFBProtocolPresence &presence,
+    const llvm::DenseMap<int64_t, Operation *> &bindSites) {
+  bool sawError = false;
+  for (auto [dfbId, waitOp] : presence.firstWaitByDFB) {
+    if (presence.pushedDFBs.contains(dfbId)) {
+      continue;
+    }
+    InFlightDiagnostic diag = waitOp->emitError()
+                              << "logical DFB " << dfbId
+                              << " is waited on but no kernel thread pushes "
+                                 "it";
+    diag.attachNote()
+        << "a DFB wait blocks until a matching push publishes data";
+    if (Operation *bindSite = bindSites.lookup(dfbId)) {
+      diag.attachNote(bindSite->getLoc()) << "dataflow buffer declared here";
+    }
+    sawError = true;
+  }
+  return failure(sawError);
 }
 
 void emitOverlapError(int64_t logicalId, const DFBParticipant &lhs,
@@ -213,17 +271,8 @@ struct TTLVerifyDFBSPSCPass
       return;
     }
 
-    bool hasAcquisitionAction = false;
-    module.walk([&](Operation *op) {
-      auto access = dyn_cast<DFBAccessOpInterface>(op);
-      hasAcquisitionAction |=
-          access && getEnclosingKernelThread(op) &&
-          llvm::any_of(access.getDFBProtocolEffects(), [](const auto &effect) {
-            return effect.kind == DFBProtocolEffectKind::Reserve ||
-                   effect.kind == DFBProtocolEffectKind::Wait;
-          });
-    });
-    if (!hasAcquisitionAction) {
+    DFBProtocolPresence protocolPresence = collectDFBProtocolPresence(module);
+    if (!protocolPresence.hasAcquisitionAction) {
       return;
     }
 
@@ -234,6 +283,11 @@ struct TTLVerifyDFBSPSCPass
           << "ttl-verify-dfb-spsc requires a `ttl.launch_grid` module "
              "attribute (an i64 array of length 2 with positive entries) "
              "when verifying DFB acquire actions";
+      signalPassFailure();
+      return;
+    }
+
+    if (failed(verifyDFBWaitsHavePushes(protocolPresence, bindSites))) {
       signalPassFailure();
       return;
     }

--- a/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLVerifyDFBSPSC.cpp
@@ -6,11 +6,11 @@
 // TTL Verify DFB SPSC
 //===----------------------------------------------------------------------===//
 //
-// Rejects modules in which a logical dataflow buffer has more than one producer
-// or consumer kernel active on the same launched node. Logical identity
-// remains distinct when non-overlapping DFBs share a physical `cb_index`.
-// tt-metal CBs are single-producer single-consumer at the API level; see
-// `docs/development/DFBManagement.md` for the rationale.
+// Rejects waits without a push and modules in which a logical dataflow buffer
+// has more than one producer or consumer kernel active on the same launched
+// node. Logical identity remains distinct when non-overlapping DFBs share a
+// physical `cb_index`. tt-metal CBs are single-producer single-consumer at the
+// API level; see `docs/development/DFBManagement.md` for the rationale.
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/python/auto_profile_bcast_multitile.py
+++ b/test/python/auto_profile_bcast_multitile.py
@@ -82,11 +82,29 @@ def bcast_multitile_kernel(
 
     @ttl.datamovement()
     def demo_read():
-        pass
+        with c_dfb.reserve() as c_block:
+            ttl.copy(c[0, 0], c_block).wait()
+        for row in range(rows):
+            row_begin = row * row_tiles_per_block
+            row_end = row_begin + row_tiles_per_block
+            for col in range(cols):
+                col_begin = col * col_tiles_per_block
+                col_end = col_begin + col_tiles_per_block
+                with a_dfb.reserve() as a_block:
+                    ttl.copy(a[row_begin:row_end, 0:1], a_block).wait()
+                with b_dfb.reserve() as b_block:
+                    ttl.copy(b[0:1, col_begin:col_end], b_block).wait()
 
     @ttl.datamovement()
     def demo_write():
-        pass
+        for row in range(rows):
+            row_begin = row * row_tiles_per_block
+            row_end = row_begin + row_tiles_per_block
+            for col in range(cols):
+                col_begin = col * col_tiles_per_block
+                col_end = col_begin + col_tiles_per_block
+                with y_dfb.wait() as y_block:
+                    ttl.copy(y_block, y[row_begin:row_end, col_begin:col_end]).wait()
 
 
 # =============================================================================
@@ -165,6 +183,7 @@ def bcast_multitile_kernel(
 # CHECK-NEXT:     return;
 # CHECK-NEXT:   }
 # CHECK-NOT:    DeviceZoneScopedN(
+# CHECK: === demo_read kernel written to {{.*}} ===
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -270,6 +289,7 @@ def bcast_multitile_kernel(
 # CHECK-FPU-NEXT:     return;
 # CHECK-FPU-NEXT:   }
 # CHECK-FPU-NOT:    DeviceZoneScopedN(
+# CHECK-FPU: === demo_read kernel written to {{.*}} ===
 
 
 if __name__ == "__main__":

--- a/test/python/auto_profile_multi_store.py
+++ b/test/python/auto_profile_multi_store.py
@@ -51,11 +51,19 @@ def multi_store_kernel(a, b, out1, out2, out3):
 
     @ttl.datamovement()
     def dm_read():
-        pass
+        with a_dfb.reserve() as a_block:
+            ttl.copy(a[0, 0], a_block).wait()
+        with b_dfb.reserve() as b_block:
+            ttl.copy(b[0, 0], b_block).wait()
 
     @ttl.datamovement()
     def dm_write():
-        pass
+        with out1_dfb.wait() as out1_block:
+            ttl.copy(out1_block, out1[0, 0]).wait()
+        with out2_dfb.wait() as out2_block:
+            ttl.copy(out2_block, out2[0, 0]).wait()
+        with out3_dfb.wait() as out3_block:
+            ttl.copy(out3_block, out3[0, 0]).wait()
 
 
 # CHECK: === compute kernel written to {{.*}} ===
@@ -102,6 +110,7 @@ def multi_store_kernel(a, b, out1, out2, out3):
 # CHECK:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_pop");
 # CHECK-NEXT:     [[CB0]].pop_front({{.*}});
 # CHECK-NOT:      DeviceZoneScopedN(
+# CHECK: === dm_read kernel written to {{.*}} ===
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -151,6 +160,7 @@ def multi_store_kernel(a, b, out1, out2, out3):
 # CHECK-FPU:          DeviceZoneScopedN("compute_L{{[0-9]+}}_implicit_cb_pop");
 # CHECK-FPU-NEXT:     [[CB0]].pop_front({{.*}});
 # CHECK-FPU-NOT:      DeviceZoneScopedN(
+# CHECK-FPU: === dm_read kernel written to {{.*}} ===
 
 if __name__ == "__main__":
     import torch

--- a/test/python/call_extern_func_dfb_effects.py
+++ b/test/python/call_extern_func_dfb_effects.py
@@ -24,6 +24,21 @@ import ttnn
 FAKE_HEADER = "/dev/null/fake_shim.hpp"
 EFFECT_TILES = 5
 reader = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+writer = ttl.Kernel(ttl.KernelKind.DATA_MOVEMENT)
+
+
+@ttl.operation()
+def external_source(source: ttl.DFB):
+    ttl.call_extern_func(
+        FAKE_HEADER,
+        "external_source",
+        dfb_dependencies=[source],
+        dfb_effects=[
+            ttl.DFBEffect.reserve(source, tiles=EFFECT_TILES - 1),
+            ttl.DFBEffect.push(source, tiles=EFFECT_TILES - 1),
+        ],
+        kernel=writer,
+    )
 
 
 def make_external_stage(transaction_count):
@@ -67,6 +82,7 @@ external_stage = make_external_stage(2)
 def external_metadata_kernel(inp):
     source = ttl.make_dataflow_buffer_like(inp, shape=(1, 2), block_count=2)
     destination = ttl.make_dataflow_buffer_like(inp, shape=(1, 1), block_count=2)
+    external_source(source)
     core_x, _ = ttl.node(dims=2)
     if core_x == 0:
         external_stage(source, destination)

--- a/test/python/kernel_selection.py
+++ b/test/python/kernel_selection.py
@@ -35,6 +35,11 @@ def selected_external_calls(inp):
         "compute_entry",
         template_args=[ttl.dfb_descriptor(descriptor_dfb), -3, True],
         func_args=[ttl.raw_addr(inp), 7],
+        dfb_dependencies=[drain_dfb],
+        dfb_effects=[
+            ttl.DFBEffect.reserve(drain_dfb, tiles=1),
+            ttl.DFBEffect.push(drain_dfb, tiles=1),
+        ],
         include_paths=["/tmp"],
         kernel=ttl.KernelKind.COMPUTE,
     )

--- a/test/python/signpost_scopes.py
+++ b/test/python/signpost_scopes.py
@@ -85,11 +85,29 @@ def bcast_multitile_kernel(
 
     @ttl.datamovement()
     def demo_read():
-        pass
+        with c_dfb.reserve() as c_block:
+            ttl.copy(c[0, 0], c_block).wait()
+        for row in range(rows):
+            row_begin = row * row_tiles_per_block
+            row_end = row_begin + row_tiles_per_block
+            for col in range(cols):
+                col_begin = col * col_tiles_per_block
+                col_end = col_begin + col_tiles_per_block
+                with a_dfb.reserve() as a_block:
+                    ttl.copy(a[row_begin:row_end, 0:1], a_block).wait()
+                with b_dfb.reserve() as b_block:
+                    ttl.copy(b[0:1, col_begin:col_end], b_block).wait()
 
     @ttl.datamovement()
     def demo_write():
-        pass
+        for row in range(rows):
+            row_begin = row * row_tiles_per_block
+            row_end = row_begin + row_tiles_per_block
+            for col in range(cols):
+                col_begin = col * col_tiles_per_block
+                col_end = col_begin + col_tiles_per_block
+                with y_dfb.wait() as y_block:
+                    ttl.copy(y_block, y[row_begin:row_end, col_begin:col_end]).wait()
 
 
 # =============================================================================
@@ -137,6 +155,7 @@ def bcast_multitile_kernel(
 # CHECK-NEXT:   }
 # CHECK-NEXT: }
 # CHECK-NOT:  DeviceZoneScopedN(
+# CHECK: === demo_read kernel written to {{.*}} ===
 
 # =============================================================================
 # FPU path checks (default: --ttl-maximize-dst --ttl-fpu-binary-ops)
@@ -191,6 +210,7 @@ def bcast_multitile_kernel(
 # CHECK-FPU-NEXT:   tile_regs_release();
 # CHECK-FPU-NEXT: }
 # CHECK-FPU-NOT:  DeviceZoneScopedN(
+# CHECK-FPU: === demo_read kernel written to {{.*}} ===
 
 
 if __name__ == "__main__":

--- a/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_nodes.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/dfb_allocation_nodes.mlir
@@ -69,3 +69,37 @@ module {
     return
   }
 }
+
+// -----
+
+// Dense data-flow analysis omits operation lattices in unreachable CFG
+// blocks. Dead-code state proves the first DFB's domain empty; the reachable
+// access retains the full launch domain.
+
+// CHECK: module attributes {ttl.dfb_allocations = [{allocation_nodes = [], block_count = 2 : i32, dfb_index = 0 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}, {allocation_nodes = {{\[\[0, 0\], \[1, 0\]\]}}, block_count = 2 : i32, dfb_index = 1 : i32, element_type = !ttcore.tile<1x16, bf16>, num_tiles = 1 : i32, page_size = 32 : i32}], ttl.launch_grid = array<i64: 2, 1>}
+
+module attributes {ttl.launch_grid = array<i64: 2, 1>} {
+  func.func @unreachable_cfg_block()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>,
+                  ttl.noc_index = 0 : i32} {
+    %dead_dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    %live_dfb = ttl.bind_cb {cb_index = 1, block_count = 2}
+        {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>
+    cf.br ^live
+  ^dead:
+    ttl.opaque_call "dead_access" (%dead_dfb)
+        {header = "effects.hpp"}
+        : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    cf.br ^exit
+  ^live:
+    ttl.opaque_call "live_access" (%live_dfb)
+        {header = "effects.hpp"}
+        : (!ttl.cb<[1, 1], !ttcore.tile<1x16, bf16>, 2>) -> ()
+    cf.br ^exit
+  ^exit:
+    return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
@@ -10,6 +10,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %v = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     func.return
   }
 
@@ -35,6 +36,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %r = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %w = ttl.cb_wait %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
@@ -54,6 +56,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %v = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
     func.return
   }
 
@@ -78,6 +81,16 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // CHECK-LABEL: func.func @kernel_consumer
 // CHECK-LABEL: func.func @untagged_helper
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @kernel_producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 4 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
   func.func @kernel_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 4 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -112,6 +125,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %b = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 4>
     func.return
   }
 
@@ -143,6 +157,8 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %b = ttl.cb_reserve %cb_b
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb_a : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.cb_push %cb_b : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     func.return
   }
 
@@ -237,6 +253,16 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // participant for each SPSC role.
 // CHECK-LABEL: func.func @same_thread_hidden_releases
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @consumer_source() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %consumer = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 33 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %reserved = ttl.cb_reserve %consumer
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %consumer : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
   func.func @same_thread_hidden_releases() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %producer = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 32 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
@@ -281,6 +307,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %slot = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     func.return
   }
 
@@ -299,6 +326,7 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %slot = ttl.cb_reserve %cb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     func.return
   }
 
@@ -354,6 +382,16 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 // CHECK-LABEL: func.func @consumer_dst
 // CHECK-LABEL: func.func @consumer_src
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 21 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
   func.func @consumer_dst() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %pipe = ttl.create_pipe src(1, 0) dst(0, 0) to(0, 0) net 0
         : !ttl.pipe<src(1, 0) dst(0, 0) to(0, 0) net 0>

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc.mlir
@@ -1,4 +1,5 @@
 // RUN: ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' | FileCheck %s
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s --split-input-file -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)' -o /dev/null
 
 // Producer in one thread, consumer in another: classic SPSC, accepted.
 // CHECK-LABEL: func.func @producer
@@ -18,6 +19,55 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %v = ttl.cb_wait %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// An opaque external dependency may contain the producer protocol, so producer
+// absence cannot be proven without an access contract.
+// CHECK-LABEL: func.func @opaque_possible_producer
+// CHECK-LABEL: func.func @opaque_consumer
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @opaque_possible_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 34 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "possible_producer" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) () {header = "opaque.hpp"} : () -> ()
+    func.return
+  }
+
+  func.func @opaque_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 34 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// Unknown external DFB access prevents producer-absence proof for user DFBs.
+// CHECK-LABEL: func.func @unknown_possible_producer
+// CHECK-LABEL: func.func @unknown_consumer
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @unknown_possible_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    ttl.opaque_call "possible_producer" () {header = "opaque.hpp", unknown_dfb_access} : () -> ()
+    func.return
+  }
+
+  func.func @unknown_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 35 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
     func.return

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_invalid.mlir
@@ -5,8 +5,18 @@
 // Two consumer threads overlap on core (0, 0), so the DFB is not SPSC.
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
-  func.func @consumer_all_nodes() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     // expected-note @+1 {{dataflow buffer declared here}}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
+  func.func @consumer_all_nodes() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{logical DFB 0 has multiple consumer kernels active on the same launched node}}
@@ -62,8 +72,15 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 
 // Hidden wait effects in two overlapping kernels violate SPSC.
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
-  func.func @first_hidden_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  func.func @hidden_producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     // expected-note @+1 {{dataflow buffer declared here}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 42 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "produce" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    func.return
+  }
+
+  func.func @first_hidden_consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 42 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{logical DFB 42 has multiple consumer kernels active on the same launched node}}
@@ -114,8 +131,18 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
 // A hidden pop is a consumer action and cannot run in a different thread from
 // the wait on the same DFB.
 module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
-  func.func @waiter() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     // expected-note @+1 {{dataflow buffer declared here}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 44 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
+  func.func @waiter() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 44 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     // expected-error @below {{logical DFB 44 has multiple consumer kernels active on the same launched node}}
@@ -176,8 +203,18 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
 // participate because the verifier cannot prove their domains are disjoint.
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
-  func.func @unknown_consumer(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
     // expected-note @+1 {{dataflow buffer declared here}}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
+  func.func @unknown_consumer(%runtime: index) attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 2 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
     %core_x = ttl.core_x : index
@@ -286,6 +323,16 @@ module attributes {ttl.launch_grid = [0 : i64, 1 : i64]} {
 // participant set would otherwise be accepted.
 
 module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 5 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %slot = ttl.cb_reserve %cb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %cb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
   func.func @malformed_pipenet_scope() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
     %cb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 5 : index}
         : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_missing_producer_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_missing_producer_invalid.mlir
@@ -71,3 +71,28 @@ module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
     func.return
   }
 }
+
+// -----
+
+// An inspection contract excludes producer protocol inside the external call.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @inspection() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 3 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "inspect" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_accesses [#ttl.dfb_non_transactional_access<inspect, 0>] () {header = "effects.hpp"} : () -> ()
+    func.return
+  }
+
+  func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 3 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{logical DFB 3 is waited on but no kernel thread pushes it}}
+    // expected-note @below {{a DFB wait blocks until a matching push publishes data}}
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_missing_producer_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_missing_producer_invalid.mlir
@@ -1,0 +1,73 @@
+// Summary: Rejects DFB waits without any matching push action.
+
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)'
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-finalize-dfb-indices,ttl-verify-dfb-spsc)'
+
+// Reserving DFB storage does not publish data to a waiting consumer.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @producer() attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+
+  func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 0 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{logical DFB 0 is waited on but no kernel thread pushes it}}
+    // expected-note @below {{a DFB wait blocks until a matching push publishes data}}
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// A push outside a kernel thread does not participate in the device protocol.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @helper() {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_reserve %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    func.return
+  }
+
+  func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 2 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{logical DFB 2 is waited on but no kernel thread pushes it}}
+    // expected-note @below {{a DFB wait blocks until a matching push publishes data}}
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}
+
+// -----
+
+// A typed external wait has the same structural producer requirement.
+
+module attributes {ttl.launch_grid = [1 : i64, 1 : i64]} {
+  func.func @consumer() attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{logical DFB 1 is waited on but no kernel thread pushes it}}
+    // expected-note @below {{a DFB wait blocks until a matching push publishes data}}
+    ttl.opaque_call "consume" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<wait, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_relaxed.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_relaxed.mlir
@@ -35,6 +35,7 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
     %block = ttl.cb_reserve %dfb
         : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
         -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     func.return
   }
 
@@ -49,7 +50,26 @@ module attributes {ttl.launch_grid = [2 : i64, 1 : i64]} {
       %block = ttl.cb_reserve %dfb
           : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
           -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+      ttl.cb_push %dfb : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
     }
+    func.return
+  }
+
+  func.func @hidden_producer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    %dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    ttl.opaque_call "produce" dfb_dependencies(%dfb : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>) dfb_effects [#ttl.dfb_protocol_effect<reserve, 0, 1>, #ttl.dfb_protocol_effect<push, 0, 1>] () {header = "effects.hpp"} : () -> ()
+    func.return
+  }
+
+  func.func @hidden_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    %dfb = ttl.bind_cb {cb_index = 1, block_count = 2} {dfb_id = 1 : index}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
     func.return
   }
 }

--- a/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_unknown_access_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/verify_dfb_spsc_unknown_access_invalid.mlir
@@ -1,0 +1,33 @@
+// Tests that unknown external access does not apply to compiler-managed DFBs.
+//
+// RUN: ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-verify-dfb-spsc)'
+// RUN: env TTL_RELAX_DFB_SPSC=1 ttlang-opt %s --split-input-file --verify-diagnostics -pass-pipeline='builtin.module(ttl-verify-dfb-spsc)'
+
+module attributes {
+  ttl.dfb_allocations = [{allocation_nodes = [[0, 0]], block_count = 2 : i32,
+                          dfb_index = 0 : i32,
+                          element_type = !ttcore.tile<32x32, bf16>,
+                          num_tiles = 1 : i32, page_size = 2048 : i32}],
+  ttl.launch_grid = [1, 1]
+} {
+  func.func @unknown_user_dfb_access()
+      attributes {ttl.kernel_thread = #ttkernel.thread<noc>} {
+    ttl.opaque_call "possible_user_dfb_producer" ()
+        {header = "opaque.hpp", unknown_dfb_access} : () -> ()
+    func.return
+  }
+
+  func.func @compiler_dfb_consumer()
+      attributes {ttl.kernel_thread = #ttkernel.thread<compute>} {
+    // expected-note @+1 {{dataflow buffer declared here}}
+    %dfb = ttl.bind_cb {cb_index = 0, block_count = 2}
+        {dfb_id = 4 : index, ttl.compiler_allocated}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    // expected-error @below {{logical DFB 4 is waited on but no kernel thread pushes it}}
+    // expected-note @below {{a DFB wait blocks until a matching push publishes data}}
+    %block = ttl.cb_wait %dfb
+        : <[1, 1], !ttcore.tile<32x32, bf16>, 2>
+        -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+    func.return
+  }
+}

--- a/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
+++ b/test/ttlang/Dialect/TTL/Transforms/waited_dfb_mutation.mlir
@@ -4,8 +4,8 @@
 // TTKERNEL-LABEL: func.func @mutate
 // TTKERNEL-DAG: %[[ONE:.*]] = arith.constant 1 : index
 // TTKERNEL-DAG: %[[ZERO:.*]] = arith.constant 0 : index
-// TTKERNEL: %[[OUTPUT:.*]] = ttkernel.get_compile_time_arg_val(0)
-// TTKERNEL: %[[STATE:.*]] = ttkernel.get_compile_time_arg_val(1)
+// TTKERNEL: %[[OUTPUT:.*]] = ttkernel.get_compile_time_arg_val({{[0-9]+}})
+// TTKERNEL: %[[STATE:.*]] = ttkernel.get_compile_time_arg_val({{[0-9]+}})
 // TTKERNEL: ttkernel.cb_wait_front(%[[STATE]],
 // TTKERNEL-NOT: ttkernel.cb_reserve_back(%[[STATE]],
 // TTKERNEL: ttkernel.pack_waited_tile({{.*}}, %[[STATE]], %[[ZERO]], true) {acquired_tiles = 2 : i64}
@@ -28,6 +28,25 @@ module attributes {
   ttl.launch_grid = [1, 1],
   ttl.target_arch = #ttcore.arch<blackhole>
 } {
+  // The real pipeline publishes input state from a data-movement thread.
+  func.func @produce_state() attributes {
+    ttl.base_cta_index = 2 : i32,
+    ttl.crta_indices = [],
+    ttl.kernel_thread = #ttkernel.thread<noc>,
+    ttl.logical_kernel = #ttl.logical_kernel<kind = data_movement>,
+    ttl.noc_index = 0 : i32
+  } {
+    %state_dfb = ttl.bind_cb {cb_index = 0, block_count = 1}
+        {dfb_id = 0 : index}
+        : !ttl.cb<[1, 2], !ttcore.tile<32x32, bf16>, 1>
+    %block = ttl.cb_reserve %state_dfb
+        : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+          -> tensor<1x2x!ttcore.tile<32x32, bf16>>
+    ttl.cb_push %state_dfb
+        : <[1, 2], !ttcore.tile<32x32, bf16>, 1>
+    return
+  }
+
   func.func @mutate() attributes {
     ttl.base_cta_index = 2 : i32,
     ttl.crta_indices = [],


### PR DESCRIPTION
### Problem description

DFB analysis treated accesses in unreachable blocks as active on every launch node and rebuilt identical program-order topology for each node. The relaxed SPSC verifier also allowed a kernel to wait on a DFB when no producer was possible, causing a device hang.

Tracks #999.

### What's changed

~300 LOC implementation.

- Preserve an exact empty allocation domain for DFB accesses in unreachable blocks.
- Reuse immutable program-order topology before adding launch-node-specific edges.
- Reject a waited DFB when neither a compiler-visible push nor opaque external access can provide a producer. This check remains enabled when `TTL_RELAX_DFB_SPSC` is set.

For example, a wait without any possible producer now reports the source location:

```python
with input_dfb.wait() as block:
    ...
```

```text
error: logical DFB 0 is waited on but no kernel thread pushes it
```

### Checklist

- [x] New tests cover unreachable domains, topology reuse, strict and relaxed missing-producer diagnostics, opaque external producers, and unknown access to compiler-managed DFBs.
