### PR TITLE
Preserve user DFB bind lifetime anchors

### DIFF
--- a/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
+++ b/lib/Dialect/TTL/Transforms/TTLFinalizeDFBIndices.cpp
@@ -594,6 +594,15 @@ struct TTLFinalizeDFBIndicesPass
         }
       };
 
+      // A user DFB without an explicit acquire still has a live ring from
+      // bind onward (for example, a foreign operation may drive it). Anchor
+      // that interval here; the refinement below advances the start to the
+      // first acquire when one exists. Compiler DFB lifetimes are represented
+      // by their generated uses and need not be anchored.
+      if (!dfb.compilerAllocated) {
+        extendInterval(dfb, bindOp, func, *order);
+      }
+
       // Pipe destinations are slot-addressed (block_count == sender count)
       // and pipe sends read asynchronously, so pipe-attached DFBs keep
       // dedicated indices.


### PR DESCRIPTION
## Summary

- keep user-allocated DFB lifetimes anchored at their bind operation when no explicit acquire exists
- avoid extending compiler-allocated DFBs, whose lifetimes are already controlled by compiler epochs
- fix the DSpark fused metadata and accuracy regression introduced by the shared five-RISC reset barrier

## Validation

- TTLFinalizeDFBIndices safety lit test passed
- DSpark fused top device tests: 7 passed
- full stacked DSpark suite: 602 passed, 4 skipped

## Stack

Base: kostas/dspark_impl, compiler PR #945
Required by tenstorrent/tt-lang-ops-and-models PR #60