### PR TITLE
Add missing negative tests for BindCBOp, AttachCBOp, and ComputeOp verifiers

### DIFF
--- a/test/ttlang/Dialect/TTL/IR/cb_ops_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/cb_ops_invalid.mlir
@@ -189,6 +189,54 @@ module {
   }
 }
 
+// -----
+
+// bind_cb cb_index must be non-negative.
+module {
+  func.func @bind_cb_negative_cb_index() {
+    // expected-error @below {{cb_index must be non-negative}}
+    %cb = ttl.bind_cb {cb_index = -1, block_count = 2}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// bind_cb block_count must be positive.
+module {
+  func.func @bind_cb_non_positive_block_count() {
+    // expected-error @below {{block_count must be > 0}}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 0}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// bind_cb block_count attribute must match the result type's block count.
+module {
+  func.func @bind_cb_block_count_mismatch() {
+    // expected-error @below {{block_count must match result type block count (2)}}
+    %cb = ttl.bind_cb {cb_index = 0, block_count = 3}
+        : !ttl.cb<[1, 1], !ttcore.tile<32x32, bf16>, 2>
+    return
+  }
+}
+
+// -----
+
+// attach_cb result type must equal the tensor operand type.
+module {
+  func.func @attach_cb_result_type_mismatch(%t: tensor<2x2xf32>, %cb: !ttl.cb<[2, 2], f32, 2>) {
+    // expected-error @below {{result type must equal tensor operand type}}
+    %r = ttl.attach_cb %t, %cb
+        : (tensor<2x2xf32>, !ttl.cb<[2, 2], f32, 2>) -> tensor<4x4xf32>
+    return
+  }
+}
+
 // tile_store tests moved to tile_store_invalid.mlir
 
 // -----

--- a/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
+++ b/test/ttlang/Dialect/TTL/IR/compute_invalid.mlir
@@ -515,6 +515,63 @@ func.func @compute_iterator_below_tensor_rank(
 
 // -----
 
+// Test: An indexing map's dim count must match the iterator domain, checked
+// per-map independently of the iterator_types-vs-max-tensor-rank check above.
+func.func @compute_indexing_map_dim_count_mismatch(
+    %a: tensor<2x2x!ttcore.tile<32x32, f32>>,
+    %cba: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+    %cbout: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_att = ttl.attach_cb %a, %cba
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %init_att = ttl.attach_cb %init, %cbout
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{indexing map expected 2 dims (iterator domain) but got 1}}
+  %0 = ttl.compute
+      ins(%a_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      outs(%init_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0) -> (d0, d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>):
+      ttl.yield
+  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
+// Test: An indexing map's result count must match the operand's rank.
+func.func @compute_indexing_map_result_count_mismatch(
+    %a: tensor<2x2x!ttcore.tile<32x32, f32>>,
+    %cba: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>,
+    %cbout: !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+    -> tensor<2x2x!ttcore.tile<32x32, f32>> {
+  %init = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+  %a_att = ttl.attach_cb %a, %cba
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  %init_att = ttl.attach_cb %init, %cbout
+      : (tensor<2x2x!ttcore.tile<32x32, f32>>, !ttl.cb<[1, 1], !ttcore.tile<32x32, f32>, 2>)
+        -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  // expected-error @below {{indexing map expected 2 results to match operand rank, but got 1}}
+  %0 = ttl.compute
+      ins(%a_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      outs(%init_att : tensor<2x2x!ttcore.tile<32x32, f32>>)
+      {indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]} {
+    ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>):
+      ttl.yield
+  } -> tensor<2x2x!ttcore.tile<32x32, f32>>
+  func.return %0 : tensor<2x2x!ttcore.tile<32x32, f32>>
+}
+
+// -----
+
 // Test: Result count does not match output count
 func.func @compute_result_count_mismatch(
     %a: tensor<2x2x!ttcore.tile<32x32, f32>>,


### PR DESCRIPTION
Closes #354.

Adds the negative-path lit tests the issue asks for, using the current error wording confirmed in the issue thread (`cb_index`/`block_count`, not the original `buffer_factor` naming):

- `BindCBOp::verify()`: negative `cb_index`, non-positive `block_count`, and `block_count` not matching the result type's block count.
- `AttachCBOp::verify()`: result type must equal the tensor operand type.
- `ComputeOp`'s `verifyMapCommon`: an indexing map's dim count must match the iterator domain, and its result count must match the operand rank — both checked independently of the `iterator_types`-vs-max-tensor-rank check that `compute_iterator_below_tensor_rank` already covers.

Each case is verified against the actual verifier source (`lib/Dialect/TTL/IR/TTLOps.cpp`) line by line, and each new test mirrors the exact syntax of an existing, already-passing sibling test in the same file (`negative_dfb_id` for the `bind_cb` cases, `compute_iterator_below_tensor_rank` for the `compute` cases) rather than being written from scratch.

**What I could not verify locally:** running these through `llvm-lit` needs the full IRD build environment (`TTLANG_USE_TOOLCHAIN=ON` against the `tt-lang-ird-ubuntu-24-04` container, ~5GB) or the published Python wheel with its own dependency chain, both of which exceeded what this environment's throttled network (measured ~140 KB/s) could complete in reasonable time — I let both run and confirmed the actual bottleneck was bandwidth, not a broken setup, before stopping. `pre-commit run` passes clean on both changed files (no MLIR-specific formatter in this repo's hooks). Happy to fix anything CI turns up.