### PR TITLE
[ci] Ignore pull request metadata edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,17 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event.action == 'edited' && github.event.changes.base == null && github.run_id || 'code' }}
   cancel-in-progress: true
 
 jobs:
   pre-commit:
-    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
+    if: ${{ github.event_name != 'pull_request' || (github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base != null)) }}
     uses: ./.github/workflows/call-pre-commit.yml
     secrets: inherit
 
   check-tt-metal-version:
-    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
+    if: ${{ github.event_name != 'pull_request' || (github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base != null)) }}
     name: Verify tt-metal version (third-party/tt-metal-version)
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -49,7 +49,7 @@ jobs:
       - run: .github/scripts/check-tt-metal-version.sh
 
   resolve-docker-tag:
-    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
+    if: ${{ github.event_name != 'pull_request' || (github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base != null)) }}
     name: Resolve docker tag for this branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -129,7 +129,7 @@ jobs:
     secrets: inherit
 
   changes:
-    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
+    if: ${{ github.event_name != 'pull_request' || (github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base != null)) }}
     name: Detect wheel/container-affecting changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -230,12 +230,12 @@ jobs:
       docker_tag: ${{ needs.resolve-docker-tag.outputs.docker_tag }}
 
   test-sim:
-    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
+    if: ${{ github.event_name != 'pull_request' || (github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base != null)) }}
     uses: ./.github/workflows/call-test-sim.yml
     secrets: inherit
 
   test-scripts:
-    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
+    if: ${{ github.event_name != 'pull_request' || (github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base != null)) }}
     uses: ./.github/workflows/call-test-scripts.yml
 
   test-dist-tutorials:
@@ -276,7 +276,8 @@ jobs:
         uses: actions/deploy-pages@v5
 
   check-all-green:
-    if: ${{ always() && (github.event_name != 'pull_request' || github.base_ref == 'main') }}
+    name: ${{ github.event.action == 'edited' && github.event.changes.base == null && 'metadata-edit' || 'check-all-green' }}
+    if: ${{ always() && (github.event_name != 'pull_request' || (github.base_ref == 'main' && (github.event.action != 'edited' || github.event.changes.base != null))) }}
     needs:
       - pre-commit
       - check-tt-metal-version

--- a/test/packaging/test_exabox_workflow.py
+++ b/test/packaging/test_exabox_workflow.py
@@ -24,11 +24,12 @@ INSTALL_EXABOX_WORKER = (
 UPLIFT_PATHS = REPO_ROOT / ".github" / "scripts" / "uplift-paths.sh"
 
 
-def test_pull_request_ci_targets_main_only() -> None:
+def test_pull_request_ci_distinguishes_base_and_metadata_edits() -> None:
     ci_workflow = CI_WORKFLOW.read_text()
     ci_jobs = yaml.safe_load(ci_workflow)["jobs"]
     pull_request_guard = (
-        "${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}"
+        "${{ github.event_name != 'pull_request' || (github.base_ref == 'main' && "
+        "(github.event.action != 'edited' || github.event.changes.base != null)) }}"
     )
 
     assert (
@@ -47,7 +48,16 @@ def test_pull_request_ci_targets_main_only() -> None:
             assert job["if"] == pull_request_guard
     assert ci_jobs["check-all-green"]["if"] == (
         "${{ always() && (github.event_name != 'pull_request' || "
-        "github.base_ref == 'main') }}"
+        "(github.base_ref == 'main' && (github.event.action != 'edited' || "
+        "github.event.changes.base != null))) }}"
+    )
+    assert ci_jobs["check-all-green"]["name"] == (
+        "${{ github.event.action == 'edited' && github.event.changes.base == null "
+        "&& 'metadata-edit' || 'check-all-green' }}"
+    )
+    assert yaml.safe_load(ci_workflow)["concurrency"]["group"].endswith(
+        "${{ github.event.action == 'edited' && github.event.changes.base == null "
+        "&& github.run_id || 'code' }}"
     )
 
 


### PR DESCRIPTION
### Problem description

CI subscribes to GitHub's `pull_request.edited` action so a stacked pull request runs CI when it is retargeted to `main`. GitHub uses the same action for title and description edits, which currently starts the complete workflow and cancels an in-progress code-validation run even though the commit is unchanged.

CI must retain automatic validation after a base-branch change without spending runners, cancelling code validation, or replacing the required check after a metadata-only edit.

### What's changed

~8 LOC implementation.

- Runs pull request CI jobs for normal code events and base-branch edits, but skips them for title and description edits.
- Gives metadata-only events an independent concurrency identity so they cannot cancel active code CI.
- Publishes metadata-only events under a different check name so they cannot replace the required `check-all-green` result.

### Checklist

- [x] The workflow contract test covers base changes, metadata edits, concurrency isolation, and required-check identity.
