### PR TITLE
[test] Skip unsupported Galaxy fabric topologies

### DIFF
--- a/test/packaging/test_ttlang_test_utils.py
+++ b/test/packaging/test_ttlang_test_utils.py
@@ -79,9 +79,11 @@ def _load_ttlang_test_utils(
 def _create_fake_fabric_ttnn(
     discovered_shape: tuple[int, ...],
     configured_shapes: dict[object, tuple[int, ...]] | None = None,
+    configuration_errors: dict[object, RuntimeError] | None = None,
 ):
     events = []
     configured_shapes = configured_shapes or {}
+    configuration_errors = configuration_errors or {}
     active_config = None
 
     class MeshShape:
@@ -102,6 +104,8 @@ def _create_fake_fabric_ttnn(
         if kwargs:
             event += (kwargs,)
         events.append(event)
+        if config in configuration_errors:
+            raise configuration_errors[config]
 
     def open_mesh_device(shape):
         events.append(("open", shape.shape))
@@ -218,6 +222,45 @@ def test_fabric_mesh_discovers_shape_for_requested_config(monkeypatch) -> None:
     assert mesh_shape == (2, 2)
     assert events == [
         ("configure", "fabric-torus", {"reliability_mode": "relaxed"}),
+        ("configure", "disabled"),
+    ]
+
+
+def test_fabric_mesh_reports_unmappable_configuration(monkeypatch) -> None:
+    module = _load_ttlang_test_utils(monkeypatch)
+    mapping_error = RuntimeError(
+        "Graph specified in MGD could not fit in the discovered physical topology"
+    )
+    fake_ttnn, events, _mesh_device = _create_fake_fabric_ttnn(
+        (2, 4), configuration_errors={"fabric-torus": mapping_error}
+    )
+    monkeypatch.setattr(module, "_get_ttnn", lambda: fake_ttnn)
+
+    with pytest.raises(
+        module.FabricMeshUnavailable,
+        match="fabric configuration fabric-torus cannot be mapped",
+    ):
+        module.get_fabric_mesh_shape(fabric_config="fabric-torus")
+
+    assert events == [
+        ("configure", "fabric-torus"),
+        ("configure", "disabled"),
+    ]
+
+
+def test_fabric_mesh_preserves_other_configuration_errors(monkeypatch) -> None:
+    module = _load_ttlang_test_utils(monkeypatch)
+    fake_ttnn, events, _mesh_device = _create_fake_fabric_ttnn(
+        (2, 4),
+        configuration_errors={"fabric-torus": RuntimeError("configuration failed")},
+    )
+    monkeypatch.setattr(module, "_get_ttnn", lambda: fake_ttnn)
+
+    with pytest.raises(RuntimeError, match="configuration failed"):
+        module.get_fabric_mesh_shape(fabric_config="fabric-torus")
+
+    assert events == [
+        ("configure", "fabric-torus"),
         ("configure", "disabled"),
     ]
 

--- a/test/python/fabric/test_ccl.py
+++ b/test/python/fabric/test_ccl.py
@@ -19,6 +19,7 @@ ttnn = pytest.importorskip("ttnn", exc_type=ImportError)
 
 from examples.multidevice_all_reduce import make_structured_all_reduce_operation
 from ttlang_test_utils import (
+    FabricMeshUnavailable,
     get_fabric_mesh_shape,
     open_fabric_mesh,
     requires_forwarding_link_indices,
@@ -872,9 +873,12 @@ def _route_mesh_options(fabric_config):
 
 
 def _get_route_mesh_shape(fabric_config):
-    return get_fabric_mesh_shape(
-        fabric_config=fabric_config, **_route_mesh_options(fabric_config)
-    )
+    try:
+        return get_fabric_mesh_shape(
+            fabric_config=fabric_config, **_route_mesh_options(fabric_config)
+        )
+    except FabricMeshUnavailable as error:
+        pytest.skip(str(error))
 
 
 def _open_route_mesh(mesh_shape: tuple[int, ...], fabric_config):

--- a/test/ttlang_test_utils.py
+++ b/test/ttlang_test_utils.py
@@ -179,6 +179,11 @@ class FabricMeshUnavailable(RuntimeError):
     pass
 
 
+_UNMAPPABLE_FABRIC_TOPOLOGY = (
+    "Graph specified in MGD could not fit in the discovered physical topology"
+)
+
+
 def _get_current_fabric_mesh_shape(ttnn_module) -> tuple[int, ...]:
     return tuple(
         int(extent)
@@ -217,6 +222,14 @@ def get_fabric_mesh_shape(
             ),
         )
         return _get_current_fabric_mesh_shape(ttnn_module)
+    except RuntimeError as error:
+        # TTNN exposes topology support only by attempting configuration.
+        if _UNMAPPABLE_FABRIC_TOPOLOGY not in str(error):
+            raise
+        raise FabricMeshUnavailable(
+            f"fabric configuration {fabric_config} cannot be mapped to the "
+            "discovered physical topology"
+        ) from error
     finally:
         ttnn_module.set_fabric_config(ttnn_module.FabricConfig.DISABLED)
 


### PR DESCRIPTION
### Problem description

Galaxy runners do not all support the same torus orientations. The fabric route test currently treats a TT-Metal topology-mapping rejection as a TT-Lang failure, so a healthy runner can fail CI before any transfer is compiled or executed.

### What's changed

~20 LOC test infrastructure.

- Convert only TT-Metal's exact unsupported-topology diagnostic into `FabricMeshUnavailable`.
- Skip the affected route case while continuing to execute ordinary mesh and supported torus cases.
- Preserve every other fabric configuration error as a test failure.

### Checklist

- [x] New unit tests cover supported configuration, unsupported topology, cleanup, and unrelated runtime errors.
- [x] Job 78910 on `bh-glx-120-b07u08` executed ordinary mesh and torus-X and skipped unsupported torus-Y and torus-XY.
