### PR TITLE
Lower index unsigned division and remainder to EmitC

### DIFF
--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -2862,6 +2862,29 @@ public:
   }
 };
 
+template <typename SourceOp, typename EmitCOp>
+class ArithIndexUnsignedBinaryRewriter : public OpConversionPattern<SourceOp> {
+public:
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    if (!isa<IndexType>(op.getResult().getType())) {
+      return failure();
+    }
+    Type resultType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType) {
+      return failure();
+    }
+    ValueRange operands = adaptor.getOperands();
+    rewriter.replaceOpWithNewOp<EmitCOp>(op, resultType, operands[0],
+                                         operands[1]);
+    return success();
+  }
+};
+
 // Convert arith.bitcast to a call to float_to_bits helper.
 // This is needed for scalar tile ops that pass float values as integer params.
 // The helper function is defined in TTKernelToCpp.cpp during code generation.
@@ -3577,12 +3600,14 @@ public:
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalShardOp>>(
         typeConverter, context, state);
 
-    patterns
-        .add<ArithFloorDivRewriter, ArithBitcastRewriter, ArithMaxUIRewriter,
-             ArithMinUIRewriter, ArithMaxSIRewriter, ArithMinSIRewriter,
-             ArithBoolBinaryRewriter<arith::AndIOp, emitc::LogicalAndOp>,
-             ArithBoolBinaryRewriter<arith::OrIOp, emitc::LogicalOrOp>>(
-            typeConverter, context);
+    patterns.add<ArithFloorDivRewriter,
+                 ArithIndexUnsignedBinaryRewriter<arith::DivUIOp, emitc::DivOp>,
+                 ArithIndexUnsignedBinaryRewriter<arith::RemUIOp, emitc::RemOp>,
+                 ArithBitcastRewriter, ArithMaxUIRewriter, ArithMinUIRewriter,
+                 ArithMaxSIRewriter, ArithMinSIRewriter,
+                 ArithBoolBinaryRewriter<arith::AndIOp, emitc::LogicalAndOp>,
+                 ArithBoolBinaryRewriter<arith::OrIOp, emitc::LogicalOrOp>>(
+        typeConverter, context);
 
     return FrozenRewritePatternSet(std::move(patterns));
   }

--- a/test/ttlang/Conversion/TTKernelToEmitC/index_unsigned_divrem.mlir
+++ b/test/ttlang/Conversion/TTKernelToEmitC/index_unsigned_divrem.mlir
@@ -1,0 +1,28 @@
+// RUN: ttlang-opt --convert-ttkernel-to-emitc -o %t.emitc.mlir %s
+// RUN: FileCheck %s --input-file=%t.emitc.mlir --check-prefix=EMITC
+// RUN: ttlang-translate --ttkernel-to-cpp -o %t.cpp %t.emitc.mlir
+// RUN: FileCheck %s --input-file=%t.cpp --check-prefix=CPP
+
+// Verify unsigned division and remainder of index values lower to size_t C++
+// operators.
+
+// EMITC-LABEL: func.func @kernel_main
+// EMITC: %[[QUOTIENT:.*]] = emitc.div
+// EMITC: %[[REMAINDER:.*]] = emitc.rem
+// EMITC: emitc.add %[[QUOTIENT]], %[[REMAINDER]]
+
+// CPP-LABEL: void kernel_main()
+// CPP: size_t [[INDEX:.*]] = get_absolute_logical_x();
+// CPP: size_t [[DIVISOR:.*]] = 4;
+// CPP: size_t [[QUOTIENT:.*]] = [[INDEX]] / [[DIVISOR]];
+// CPP: size_t [[REMAINDER:.*]] = [[INDEX]] % [[DIVISOR]];
+// CPP: size_t {{.*}} = [[QUOTIENT]] + [[REMAINDER]];
+
+func.func @kernel_main() attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+  %index = "ttkernel.my_logical_x_"() : () -> index
+  %divisor = arith.constant 4 : index
+  %quotient = arith.divui %index, %divisor : index
+  %remainder = arith.remui %index, %divisor : index
+  %sum = arith.addi %quotient, %remainder : index
+  return
+}


### PR DESCRIPTION
### Problem description

TTKernel-to-EmitC conversion rejects `arith.divui` and `arith.remui` on index values, although index converts to unsigned C++ `size_t`. Compiler-generated index delinearization therefore fails after TTL lowering.

### What's changed

This PR lowers unsigned division and remainder on index values to `emitc.div` and `emitc.rem`, preserving unsigned semantics through the existing `index` to `size_t` conversion. Signless integer operations remain unchanged because their C++ signedness is not implied by the MLIR integer type.

The conversion test checks both EmitC IR and generated C++.

### Checklist
- [x] New/Existing tests provide coverage for changes
